### PR TITLE
Calling `supabase stop` doesn't affect on running containers

### DIFF
--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -17,7 +17,7 @@ export default {
       process.exit(1)
     }
 
-    await run('docker-compose --file .supabase/docker/docker-compose.yml down')
+    await run('docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase down')
 
     spinner.succeed('Stopped local Supabase.')
   },


### PR DESCRIPTION
OS: Ubuntu 20.04 LTS
**Issue**: Calling `supabase stop` doesn't affect on running containers. 

*supabase start*: docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up -d
> Creating network "supabase_default" with the default driver
Creating supabase-db   ... done
Creating supabase-kong ... done
Creating supabase-auth     ... done
Creating supabase-realtime ... done
Creating supabase-rest     ... done

*supabase down* with current command:  docker-compose --file .supabase/docker/docker-compose.yml  down
> Removing network docker_default
WARNING: Network docker_default not found.

*supabase down* fix:  docker-compose --file .supabase/docker/docker-compose.yml **--project-name supabase** down
> Stopping supabase-realtime ... done
Stopping supabase-rest     ... done
Stopping supabase-auth     ... done
Stopping supabase-kong     ... done
Stopping supabase-db       ... done
Removing supabase-realtime ... done
Removing supabase-rest     ... done
Removing supabase-auth     ... done
Removing supabase-kong     ... done
Removing supabase-db       ... done
Removing network supabase_default
