### PR TITLE
fix: add `auth` to postgres's search_path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-latest]
+        platform: [ubuntu-latest]
         node: ['12']
 
     runs-on: ${{ matrix.platform }}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,4 +2,9 @@
 
 import { build } from 'gluegun'
 
+process.removeAllListeners('unhandledRejection')
+process.on('unhandledRejection', () => {
+  process.exit(1)
+})
+
 build('supabase').src(__dirname).create().run()

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -58,7 +58,10 @@ export default {
           },
         })
       )
-    )
+    ).catch(() => {
+      spinner.fail('Error writing Docker setup files.')
+      process.exit(1)
+    })
 
     spinner.succeed('Supabase Docker ejected.')
   },

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,9 +13,16 @@ export default {
       spin,
     },
     prompt: { ask },
+    system: { run, which },
   }: GluegunToolbox) => {
     if (exists('.supabase')) {
       error(`Project already initialized. Remove ${highlight('.supabase')} to reinitialize.`)
+      process.exit(1)
+    }
+
+    const dockerCompose = which('docker-compose')
+    if (!dockerCompose) {
+      error(`Cannot find ${highlight('docker-compose')} executable in PATH.`)
       process.exit(1)
     }
 
@@ -72,6 +79,10 @@ export default {
           },
         })
       )
+    )
+
+    await run(
+      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase build --no-cache --parallel --quiet'
     )
 
     spinner.succeed('Project initialized.')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -79,11 +79,17 @@ export default {
           },
         })
       )
-    )
+    ).catch(() => {
+      spinner.fail('Error writing Docker setup files.')
+      process.exit(1)
+    })
 
     await run(
       'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase build --no-cache --parallel --quiet'
-    )
+    ).catch(() => {
+      spinner.fail('Error running docker-compose.')
+      process.exit(1)
+    })
 
     spinner.succeed('Project initialized.')
     fancy(`Supabase URL: ${highlight(`http://localhost:${kongPort}`)}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -3,23 +3,37 @@ import { GluegunToolbox } from 'gluegun'
 export default {
   name: 'start',
   run: async ({
+    filesystem: { exists },
     print: {
       colors: { highlight },
+      error,
       spin,
     },
     system: { run, which },
   }: GluegunToolbox) => {
-    const spinner = spin('Starting local Supabase...')
-
-    const dockerCompose = which('docker-compose')
-    if (!dockerCompose) {
-      spinner.fail(`Cannot find ${highlight('docker-compose')} executable in PATH.`)
+    if (!exists('.supabase')) {
+      error(
+        `Cannot find ${highlight(
+          '.supabase'
+        )} in the current directory. Perhaps you meant to run ${highlight('supabase init')} first?`
+      )
       process.exit(1)
     }
 
+    const dockerCompose = which('docker-compose')
+    if (!dockerCompose) {
+      error(`Cannot find ${highlight('docker-compose')} executable in PATH.`)
+      process.exit(1)
+    }
+
+    const spinner = spin('Starting local Supabase...')
+
     await run(
       'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up --detach'
-    )
+    ).catch(() => {
+      spinner.fail('Error running docker-compose.')
+      process.exit(1)
+    })
 
     spinner.succeed('Started local Supabase.')
   },

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -17,7 +17,9 @@ export default {
       process.exit(1)
     }
 
-    await run('docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase down')
+    await run(
+      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase down'
+    )
 
     spinner.succeed('Stopped local Supabase.')
   },

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,23 +3,37 @@ import { GluegunToolbox } from 'gluegun'
 export default {
   name: 'stop',
   run: async ({
+    filesystem: { exists },
     print: {
       colors: { highlight },
+      error,
       spin,
     },
     system: { run, which },
   }: GluegunToolbox) => {
-    const spinner = spin('Stopping local Supabase...')
-
-    const dockerCompose = which('docker-compose')
-    if (!dockerCompose) {
-      spinner.fail(`Cannot find ${highlight('docker-compose')} executable in PATH.`)
+    if (!exists('.supabase')) {
+      error(
+        `Cannot find ${highlight(
+          '.supabase'
+        )} in the current directory. Perhaps you meant to run ${highlight('supabase init')} first?`
+      )
       process.exit(1)
     }
 
+    const dockerCompose = which('docker-compose')
+    if (!dockerCompose) {
+      error(`Cannot find ${highlight('docker-compose')} executable in PATH.`)
+      process.exit(1)
+    }
+
+    const spinner = spin('Stopping local Supabase...')
+
     await run(
       'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase down'
-    )
+    ).catch(() => {
+      spinner.fail('Error running docker-compose.')
+      process.exit(1)
+    })
 
     spinner.succeed('Stopped local Supabase.')
   },

--- a/src/templates/init/README.md
+++ b/src/templates/init/README.md
@@ -1,1 +1,12 @@
-Supabase instructions.
+> Why do I have a directory named ".supabase" in my project?
+
+The ".supabase" directory is created by the Supabase CLI.
+
+> What does the "docker" directory contain?
+
+It contains the Docker Compose file and build files for running Supabase locally.
+
+> Should I commit the ".supabase" directory?
+
+No, you should not share the ".supabase" directory with anyone.
+Upon creation, it will be automatically added to your ".gitignore" file.

--- a/src/templates/init/docker/postgres/auth-schema.sql
+++ b/src/templates/init/docker/postgres/auth-schema.sql
@@ -88,3 +88,4 @@ $$ language sql stable;
 GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
+ALTER ROLE postgres SET search_path = "$user", public, auth;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `auth` schema isn't included in the `postgres` role's `search_path`.

## What is the new behavior?

Include it in the `search_path`. Also:
- update `.supabase/README.md`,
- improve error handling.

## Additional context

Closes #9.
