### PR TITLE
Update stop.ts

### DIFF
--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -29,7 +29,7 @@ export default {
     const spinner = spin('Stopping local Supabase...')
 
     await run(
-      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase down'
+      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase stop'
     ).catch(() => {
       spinner.fail('Error running docker-compose.')
       process.exit(1)


### PR DESCRIPTION
Issue docker-compose stop command, instead of down command, to keep containers and data. (So any edits persist between supabase start and supabase stop, instead of wiping containers).

## What kind of change does this PR introduce?

Bug fix, so supabase stop doesn't destroy current docker containers.

## What is the current behavior?

supabase stop currently issues docker-compose down, which erases all docker containers. Issuing docker-compose stop will keep containers and allow for persisted data to be kept.

## What is the new behavior?

Docker containers are not destroyed.


