### PR TITLE
Fix `eject` apikeys

### DIFF
--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -9,6 +9,7 @@ export default {
     print: {
       colors: { highlight },
       error,
+      fancy,
       spin,
     },
     prompt: { ask },
@@ -33,8 +34,10 @@ export default {
       },
     ])
 
-    const apiKey =
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIiLCJSb2xlIjoicG9zdGdyZXMifQ.magCcozTMKNrl76Tj2dsM7XTl_YH0v0ilajzAvIlw3U'
+    const anonApiKey =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoiYW5vbiJ9.36fUebxgx1mcBo4s19v0SzqmzunP--hm_hep0uLX0ew'
+    const serviceRoleApiKey =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoic2VydmljZV9yb2xlIn0.necIJaiP7X2T2QjGeV-FhpkizcNTX8HjDDBAxpgQTEI'
 
     const spinner = spin('Ejecting...')
 
@@ -54,7 +57,7 @@ export default {
           props: {
             kongPort,
             dbPort,
-            apiKey,
+            anonApiKey,
           },
         })
       )
@@ -64,5 +67,10 @@ export default {
     })
 
     spinner.succeed('Supabase Docker ejected.')
+    fancy(`Supabase URL: ${highlight(`http://localhost:${kongPort}`)}
+Supabase Key (anon, public): ${highlight(anonApiKey)}
+Supabase Key (service_role, private): ${highlight(serviceRoleApiKey)}
+Database URL: ${highlight(`postgres://postgres:postgres@localhost:${dbPort}/postgres`)}
+`)
   },
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -75,7 +75,6 @@ export default {
             kongPort,
             dbPort,
             anonApiKey,
-            serviceRoleApiKey,
           },
         })
       )

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -85,7 +85,7 @@ export default {
     })
 
     await run(
-      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase build --no-cache --parallel --quiet'
+      'docker-compose --file .supabase/docker/docker-compose.yml build --no-cache && docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up --no-start --renew-anon-volumes'
     ).catch(() => {
       spinner.fail('Error running docker-compose.')
       process.exit(1)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -94,7 +94,7 @@ export default {
     spinner.succeed('Project initialized.')
     fancy(`Supabase URL: ${highlight(`http://localhost:${kongPort}`)}
 Supabase Key (anon, public): ${highlight(anonApiKey)}
-Supabase Key (service_role, private): ${highlight(anonApiKey)}
+Supabase Key (service_role, private): ${highlight(serviceRoleApiKey)}
 Database URL: ${highlight(`postgres://postgres:postgres@localhost:${dbPort}/postgres`)}
 
 Run ${highlight('supabase start')} to start local Supabase.

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -29,7 +29,7 @@ export default {
     const spinner = spin('Starting local Supabase...')
 
     await run(
-      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up --detach'
+      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase start'
     ).catch(() => {
       spinner.fail('Error running docker-compose.')
       process.exit(1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- fix: wrong printed apikey for service_role
- fix: build & create container on init
- fix: match `eject`'s apikeys with `init`

## Additional context

Fixes https://github.com/supabase/supabase/discussions/1029.
