### PR TITLE
fix: kong DNS delay on Docker on WSL2

### DIFF
--- a/src/templates/init/docker/docker-compose.yml
+++ b/src/templates/init/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       KONG_DECLARATIVE_CONFIG: /var/lib/kong/kong.yml
       KONG_PLUGINS: request-transformer,cors,key-auth,http-log
+      KONG_DNS_ORDER: LAST,A,CNAME
     ports:
       - <%= props.kongPort %>:8000/tcp
   auth:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Closes #14.

## What is the new behavior?

Add the suggested Kong config.