### PR TITLE
add serviceRoleApiKey to kong

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -82,6 +82,7 @@ export default {
             kongPort,
             dbPort,
             anonApiKey,
+            serviceRoleApiKey,
           },
         })
       )

--- a/src/templates/init/docker/kong/kong.yml
+++ b/src/templates/init/docker/kong/kong.yml
@@ -43,3 +43,4 @@ consumers:
   - username: 'private-key'
     keyauth_credentials:
       - key: <%= props.anonApiKey %>
+      - key: <%= props.serviceRoleApiKey %>


### PR DESCRIPTION
## What kind of change does this PR introduce?

bugfix

## What is the current behavior?

Only client key is available to use

## What is the new behavior?

service key is also available

## Additional context

https://github.com/supabase/supabase/discussions/1253

Not sure if this is the right kind of fix.
