### PR TITLE
Add email testing SMTP server

### DIFF
--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -58,6 +58,7 @@ export default {
             kongPort,
             dbPort,
             anonApiKey,
+            serviceRoleApiKey,
           },
         })
       )

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -19,7 +19,7 @@ export default {
       process.exit(1)
     }
 
-    const { kongPort, dbPort } = await ask([
+    const { kongPort, dbPort, mailPort } = await ask([
       {
         type: 'input',
         name: 'kongPort',
@@ -31,6 +31,12 @@ export default {
         name: 'dbPort',
         message: 'Port for PostgreSQL database:',
         initial: '5432',
+      },
+      {
+        type: 'input',
+        name: 'mailPort',
+        message: 'Port for email testing interface:',
+        initial: '9000',
       },
     ])
 
@@ -57,6 +63,7 @@ export default {
           props: {
             kongPort,
             dbPort,
+            mailPort,
             anonApiKey,
             serviceRoleApiKey,
           },
@@ -72,6 +79,7 @@ export default {
 Supabase Key (anon, public): ${highlight(anonApiKey)}
 Supabase Key (service_role, private): ${highlight(serviceRoleApiKey)}
 Database URL: ${highlight(`postgres://postgres:postgres@localhost:${dbPort}/postgres`)}
+Email testing interface URL: ${highlight(`http://localhost:${mailPort}`)}
 `)
   },
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -42,7 +42,7 @@ export default {
       }
     }
 
-    const { kongPort, dbPort } = await ask([
+    const { kongPort, dbPort, mailPort } = await ask([
       {
         type: 'input',
         name: 'kongPort',
@@ -54,6 +54,12 @@ export default {
         name: 'dbPort',
         message: 'Port for PostgreSQL database:',
         initial: '5432',
+      },
+      {
+        type: 'input',
+        name: 'mailPort',
+        message: 'Port for email testing interface:',
+        initial: '9000',
       },
     ])
 
@@ -81,6 +87,7 @@ export default {
           props: {
             kongPort,
             dbPort,
+            mailPort,
             anonApiKey,
             serviceRoleApiKey,
           },
@@ -106,6 +113,7 @@ export default {
 Supabase Key (anon, public): ${highlight(anonApiKey)}
 Supabase Key (service_role, private): ${highlight(serviceRoleApiKey)}
 Database URL: ${highlight(`postgres://postgres:postgres@localhost:${dbPort}/postgres`)}
+Email testing interface URL: ${highlight(`http://localhost:${mailPort}`)}
 
 Run ${highlight('supabase start')} to start local Supabase.
 `)

--- a/src/templates/init/docker/docker-compose.yml
+++ b/src/templates/init/docker/docker-compose.yml
@@ -20,17 +20,30 @@ services:
       GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
       GOTRUE_DB_DRIVER: postgres
       DB_NAMESPACE: auth
-      API_EXTERNAL_URL: localhost
-      GOTRUE_API_HOST: 0.0.0.0
+      API_EXTERNAL_URL: http://localhost:8000
+      GOTRUE_API_HOST: auth
       PORT: 9999
       GOTRUE_DISABLE_SIGNUP: 'false'
-      GOTRUE_SITE_URL: localhost
-      GOTRUE_MAILER_AUTOCONFIRM: 'true'
+      GOTRUE_SITE_URL: http://localhost:8000
+      GOTRUE_SMTP_HOST: mail
+      GOTRUE_SMTP_PORT: 2500
+      GOTRUE_SMTP_USER: GOTRUE_SMTP_USER
+      GOTRUE_SMTP_PASS: GOTRUE_SMTP_PASS
+      GOTRUE_SMTP_ADMIN_EMAIL: admin@email.com
+      GOTRUE_MAILER_AUTOCONFIRM: 'false'
+      GOTRUE_MAILER_SUBJECTS_CONFIRMATION: Confirm Your Signup
+      GOTRUE_MAILER_SUBJECTS_INVITE: You have been invited
+      GOTRUE_MAILER_SUBJECTS_MAGIC_LINK: Your Magic Link
+      GOTRUE_MAILER_SUBJECTS_RECOVERY: Reset Your Password
+      GOTRUE_MAILER_URLPATHS_CONFIRMATION: /auth/v1/verify
+      GOTRUE_MAILER_URLPATHS_INVITE: /auth/v1/verify
+      GOTRUE_MAILER_URLPATHS_RECOVERY: /auth/v1/verify
       GOTRUE_LOG_LEVEL: DEBUG
       GOTRUE_OPERATOR_TOKEN: super-secret-operator-token
-      DATABASE_URL: 'postgres://postgres:postgres@db:5432/postgres?sslmode=disable'
+      DATABASE_URL: postgres://postgres:postgres@db:5432/postgres?sslmode=disable
     depends_on:
       - db
+      - mail
   rest:
     container_name: supabase-rest
     image: postgrest/postgrest:latest
@@ -74,3 +87,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_PORT: 5432
+  mail:
+    container_name: supabase-mail
+    image: inbucket/inbucket:stable
+    ports:
+      - <%= props.mailPort %>:9000

--- a/src/templates/init/docker/kong/kong.yml
+++ b/src/templates/init/docker/kong/kong.yml
@@ -1,10 +1,20 @@
 _format_version: '1.1'
 services:
+  - name: auth-v1-open
+    _comment: 'GoTrue: /auth/v1/verify* -> http://auth:9999/verify*'
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
   - name: auth-v1
     _comment: 'GoTrue: /auth/v1/* -> http://auth:9999/*'
     url: http://auth:9999/
     routes:
-      - name: auth-v1-all
+      - name: auth-v1
         strip_path: true
         paths:
           - /auth/v1/


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

No SMTP server, so no way to check sent emails.

Fixes #22.

## What is the new behavior?

Adds an email testing server (inbucket). Can't do things like password reset yet, but at least we can now see sent emails for email confirmation, invitation, password reset, and magic link.