### PR TITLE
Replace docker-compose start with docker-compose up in start command

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -29,7 +29,7 @@ export default {
     const spinner = spin('Starting local Supabase...')
 
     await run(
-      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase start'
+      'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up'
     ).catch(() => {
       spinner.fail('Error running docker-compose.')
       process.exit(1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix or enhancement depending on your point of view

## What is the current behavior?

Currently the cli assumes the containers have already been created (via `supabase init`) so running `start` works but if you haven't run `supabase init` and have instead commited the `.supabase` directory, it doesn't work. Using `up` allows you to run it in this case. I can't run `supabase init` because I'm trying to run it in GitHub Actions and it has prompts that I don't see a way of bypassing, but that's a separate issue.

## What is the new behavior?

Using `up` instead of `start` is essentially the same thing as the existing functionality since if the containers have already been created it just runs `start`.
