### PR TITLE
Add more error informations for start command when docker-compose fail

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -30,9 +30,14 @@ export default {
 
     await run(
       'docker-compose --file .supabase/docker/docker-compose.yml --project-name supabase up --detach'
-    ).catch(() => {
-      spinner.fail('Error running docker-compose.')
-      process.exit(1)
+    ).catch((err: unknown) => {
+      if (err instanceof Error) {
+        spinner.fail(`Error running docker-compose: ${err.message}`)
+        process.exit(1)
+      } else {
+        spinner.fail('Error running docker-compose.')
+        process.exit(1)
+      }
     })
 
     spinner.succeed('Started local Supabase.')


### PR DESCRIPTION
## What kind of change does this PR introduce?

I was using the CLI to start the local env, but the `start` was failing, I had no idea why cause the error message was not very informative.

The error was because the port was already in use.

So, I added a more descriptive message to know about the error.

## What is the current behavior?

A simple error message:

`Error running docker-compose.`

## What is the new behavior?

It now displays the error message entirely.
