### PR TITLE
Add snapcrafts to goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,3 +33,9 @@ scoop:
   homepage: https://supabase.io
   description: Supabase CLI
   license: MIT
+snapcrafts:
+  -
+    publish: true
+    summary: Command Line Interface tool for managing a local Supabase instance.
+    confinement: strict 
+    grade: stable


### PR DESCRIPTION
Based on https://github.com/supabase/cli/issues/50, I believe these are the minimum changes required to publish the supabase-cli to the Ubuntu store. Happy to update as needed...just thought I'd take a quick stab at it in case it really is this easy.
