### PR TITLE
Upgrade realtime image to v0.19.0

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -44,7 +44,7 @@ const (
 	PgbouncerImage = "edoburu/pgbouncer:1.15.0"
 	KongImage      = "library/kong:2.1"
 	GotrueImage    = "supabase/gotrue:v2.2.6"
-	RealtimeImage  = "supabase/realtime:v0.18.0"
+	RealtimeImage  = "supabase/realtime:v0.19.0"
 	PostgrestImage = "postgrest/postgrest:v8.0.0"
 	StorageImage   = "supabase/storage-api:v0.9.3"
 	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.4"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrades realtime image tag to v0.19.0.

## What is the current behavior?

It is currently on v0.18.0, which gives a socket connection error.

## What is the new behavior?

The v0.19.0 resolves the socket connection error.
