### PR TITLE
fix: supabase init hang on windows

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -286,7 +286,7 @@ func GetGitRoot() (*string, error) {
 
 		if cwd, err := os.Getwd(); err != nil {
 			return nil, err
-		} else if cwd == "/" {
+		} else if IsRootDirectory(cwd) {
 			return nil, errors.New("Cannot find Git root. Are you in a Git repository?")
 		}
 

--- a/internal/utils/utils_unix.go
+++ b/internal/utils/utils_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package utils
+
+// IsRootDirectory reports whether the string dir is a root directory.
+func IsRootDirectory(dir string) bool {
+	return dir == "/"
+}

--- a/internal/utils/utils_windows.go
+++ b/internal/utils/utils_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package utils
+
+import (
+	"unicode"
+)
+
+// IsRootDirectory reports whether the string dir is a root directory.
+func IsRootDirectory(dir string) bool {
+	chars := []rune(dir)
+	return len(chars) == 3 && unicode.IsUpper(chars[0]) && chars[1] == ':' && chars[2] == '\\'
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `supabase init` command hangs within projects missing a .git folder on Windows devices due to a directory traversal loop. Root on Windows starts with an uppercase letter, followed by a colon and backslash instead of just a forward slash on Unix. The program was unable to determine root on Windows.

Fixes #89.

## What is the new behavior?

Build tags have been utilized to create platform independent functions to test whether a directory is root.

Tested on Ubuntu 16.04 and Windows 11.

## Additional context

N/A
