### PR TITLE
Update docker volume mount flags for SELinux compatibility.

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -696,8 +696,8 @@ EOSQL
 			},
 			&container.HostConfig{
 				Binds: []string{
-					cwd + "/supabase/.temp/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro",
-					cwd + "/supabase/.temp/userlist.txt:/etc/pgbouncer/userlist.txt:ro",
+					cwd + "/supabase/.temp/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:z",
+					cwd + "/supabase/.temp/userlist.txt:/etc/pgbouncer/userlist.txt:z",
 				},
 				PortBindings: nat.PortMap{"5432/tcp": []nat.PortBinding{{HostPort: utils.DbPort}}},
 				NetworkMode:  container.NetworkMode(utils.NetId),
@@ -735,7 +735,7 @@ EOSQL
 				},
 			},
 			&container.HostConfig{
-				Binds:        []string{(cwd + "/supabase/.temp/kong.yml:/var/lib/kong/kong.yml:ro")},
+				Binds:        []string{(cwd + "/supabase/.temp/kong.yml:/var/lib/kong/kong.yml:z")},
 				PortBindings: nat.PortMap{"8000/tcp": []nat.PortBinding{{HostPort: utils.ApiPort}}},
 				NetworkMode:  container.NetworkMode(utils.NetId),
 			},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature addition: SELinux compatible volume mounts, useful ie. when the host OS is Fedora. Fixes #106.

## What is the current behavior?

Mounts the `pgbouncer.ini`, `userlist.txt`, and `kong.yml` files with the read only (`:ro`) flag.

## What is the new behavior?

Mounts the `pgbouncer.ini`, `userlist.txt`, and `kong.yml` files with the SELinux compatible flag. I have chosen the lowercase z variant (indicating that the bind mount content is shared among multiple containers) just in case the user also uses their own docker containers alongside Supabase's (ie. VSCode devcontainer). This does mean the files are no longer mounted in a read-only way, unfortunately you can't use both flags at the same time. 

## Additional context

I had originally submitted the feature request as I am not familiar with Go development and wasn't sure if I could figure out how to locally build and test things if I made the changes myself, but as it turns out, building was super simple and I was able to test it locally to ensure it's working in my SELinux enabled environment. Go seems pretty cool :).

Thank you!
