### PR TITLE
fix: Ensure kong config is readable from the container after umask

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -572,6 +572,10 @@ EOSQL
 		if err := os.WriteFile("supabase/.temp/kong.yml", kongConfigBuf.Bytes(), 0644); err != nil {
 			return err
 		}
+		// Ensure the file is readable even after umask
+		if err := os.Chmod("supabase/.temp/kong.yml", 0644); err != nil {
+			return err
+		}
 
 		if _, err := utils.DockerRun(
 			ctx,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes the permissions of the `supabase/.temp/kong.yml` file after creating it to make sure it is readable from the Kong container.

Fixes #129 

## What is the current behavior?

`os.WriteFile` is used but as the doc states, the permissions mask that is given as an argument is applied *before* umask. If someone uses an umask where the `others` permission is more restrictive, the container won't start.

## What is the new behavior?

The start script manually calls `os.Chmod` after writing the file to ensure the right permission mask. The container successfully starts