### PR TITLE
feat: add external OAuth settings from .env

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -641,6 +641,14 @@ EOSQL
 			)
 		}
 
+		// Append external OAuth settings if exists.
+		envs := os.Environ()
+		for _, e := range envs {
+			if strings.HasPrefix(e, "GOTRUE_EXTERNAL") {
+				env = append(env, e)
+			}
+		}
+
 		if _, err := utils.DockerRun(
 			ctx,
 			utils.GotrueId,


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature.

## What is the current behavior?
Third Party Login feature cannot be enabled easily with cli.

This could be a workaround for #80.

## What is the new behavior?
Add an environment variable prefixed with `GOTRUE_EXTERNAL` from `supabase/.env` in local environment when starting a Docker container of GoTrue with cli. In this way, users can enable/disable the external OAuth service at the time of `supabase start` just by writing the following settings in `supabase/.env`.

```env:.env
# Google OAuth config
GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=000000000-01234567890abcdefghijk.apps.googleusercontent.com
GOTRUE_EXTERNAL_GOOGLE_SECRET=ABCDEFG-ABC-01234567890ABCDEFG
GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=http://localhost:54321/auth/v1/callback
GOTRUE_EXTERNAL_URI=https://accounts.google.com
```

See here for more information on environment variables that can be set.
[https://github.com/supabase/gotrue/blob/master/example.env](https://github.com/supabase/gotrue/blob/master/example.env)