### PR TITLE
Remove a check that normalized URL is equal to raw

### DIFF
--- a/internal/db/remote/set/set.go
+++ b/internal/db/remote/set/set.go
@@ -17,8 +17,6 @@ func Run(url string) error {
 	{
 		if parsedUrl, err := u.Parse(url); err != nil {
 			return err
-		} else if parsedUrl.String() != url {
-			return errors.New("Error parsing connection string: Make sure the URL is percent-encoded.")
 		}
 		if err := utils.LoadConfig(); err != nil {
 			return err


### PR DESCRIPTION
This check was problematic when using passwords with special characters.
Those must be encoded, and this check forced users to guess which exact characters Go would escape, otherwise the URL was considered invalid.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently URLs must be provided in the exact form they would be normalized to by net/url.

## What is the new behavior?

Any URL that could be parsed by net/url is accepted.