### PR TITLE
Update GotrueImage to latest 

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -41,7 +41,7 @@ type DiffEntry struct {
 const (
 	ShadowDbName           = "supabase_shadow"
 	KongImage              = "library/kong:2.1"
-	GotrueImage            = "supabase/gotrue:v2.3.8"
+	GotrueImage            = "supabase/gotrue:v2.5.0"
 	InbucketImage          = "inbucket/inbucket:stable"
 	RealtimeImage          = "supabase/realtime:v0.21.0"
 	PostgrestImage         = "postgrest/postgrest:v9.0.0"


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The current go true version (`2.3.8`) has a bug where refresh_token requests returns a `null` response -- see:

- https://github.com/supabase/gotrue/issues/348

## What is the new behavior?

The bug was fixed in version `2.3.9` -- see:

- https://github.com/supabase/gotrue/pull/349

This PR updates to the latest image (`2.5.0`)
