### PR TITLE
add new line in version template

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,5 +20,5 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.SetVersionTemplate("{{.Version}}")
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When calling `supabase --version` no newline is inserted  (zsh fixes for that by adding a `%` sign but bash/sh do not). 

<p align="center"><img width="705" alt="Screen Shot 2022-01-31 at 9 44 15 PM" src="https://user-images.githubusercontent.com/46427323/151853893-3d44e811-4726-4997-a83a-28670120f168.png"></p>


## What is the new behavior?

Adding a newline so the version is printed on its own line. 

<img width="735" alt="Screen Shot 2022-01-31 at 9 48 28 PM" src="https://user-images.githubusercontent.com/46427323/151854169-05a8a4f1-06f7-4657-8509-c417dd71f831.png">


