### PR TITLE
feat: Add dry-run flag to db push command

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -68,11 +68,13 @@ var (
 		},
 	}
 
+	dryRun bool
+
 	dbPushCmd = &cobra.Command{
 		Use:   "push",
 		Short: "Push new migrations to the remote database.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return push.Run()
+			return push.Run(dryRun)
 		},
 	}
 
@@ -130,6 +132,7 @@ func init() {
 	dbCmd.AddCommand(dbBranchCmd)
 	dbCmd.AddCommand(dbChangesCmd)
 	dbCmd.AddCommand(dbCommitCmd)
+	dbPushCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	dbCmd.AddCommand(dbPushCmd)
 	dbRemoteCmd.AddCommand(dbRemoteSetCmd)
 	dbRemoteCmd.AddCommand(dbRemoteChangesCmd)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new flag `--dry-run` on the `supabase db push` command. If enabled this will print out the migrations that would be applied **without** executing anything on the database. 

## What is the current behavior?

No support for this flag, AFAIK no way to view which migrations will be applied by `supabase db push`

## What is the new behavior?

Flag is added with the behaviour described above.

Updated help:

```
go run . db push --help                          
Push new migrations to the remote database.

Usage:
  supabase db push [flags]

Flags:
  -d, --dry-run   Print the migrations that would be applied, but don't actually apply them.
  -h, --help      help for push
```

Example with dry-run enabled:

```
go run . db push --dry-run
DRY RUN: migrations will *not* be pushed to the database.
Would apply migration 20220202121715_m1.sql:
CREATE TABLE films (
    code        char(5) CONSTRAINT firstkey PRIMARY KEY,
    title       varchar(40) NOT NULL,
    did         integer NOT NULL,
    date_prod   date,
    kind        varchar(10),
    len         interval hour to minute
);

---

Would apply migration 20220202121756_m2.sql:
CREATE TABLE distributors (
     did    integer PRIMARY KEY DEFAULT nextval('serial'),
     name   varchar(40) NOT NULL CHECK (name <> '')
);

---

Finished supabase db push.
```

Without the flag behaviour remains the same:

```
$ go run . db push
Applying unapplied migrations...
Finished supabase db push.
```

## Additional context

This will make my days less stressful :) 