### PR TITLE
docs: add error message hint when db push fails because of a prepared statement

### DIFF
--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/supabase/cli/internal/utils"
@@ -28,7 +29,14 @@ func Run() error {
 	// `schema_migrations` must be a "prefix" of `supabase/migrations`.
 
 	rows, err := conn.Query(ctx, "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version")
+
 	if err != nil {
+		error := err.Error()
+		if (strings.Contains(error, "prepared statement") && strings.Contains(error, "already exists"))	{
+			return fmt.Errorf(`Error querying remote database: %w.
+Try adding `+utils.Aqua("statement_cache_mode=describe")+" to your connection string.", err)
+		}
+
 		return fmt.Errorf(`Error querying remote database: %w.
 Try running `+utils.Aqua("supabase db remote set")+".", err)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This commit updates the error message when supabase db push fails to select migrations.

- If the error message contains "prepared statement" and "already exists", then the hint
suggests adding statement_cache_mode=describe to the connection string


## What is the current behavior?

I was seeing an error from supabase db push like:

```
Error: Error querying remote database: ERROR: prepared statement "lrupsc_1_0" already exists (SQLSTATE 42P05).
Try running supabase db remote set.
```

## What is the new behavior?

This error now looks like:

```
Error: Error querying remote database: ERROR: prepared statement "lrupsc_1_0" already exists (SQLSTATE 42P05).
Try adding statement_cache_mode=describe to your connection string.
```

## Additional context

Hopefully this will save future devs some debugging time!!

The error is thrown by the first conn.Query (which selects applied migrations)

I found that the cause of this is in pgx and it's caused by having pgbouncer in Transaction mode,
which is the recommended mode in supabase docs for serverless:
https://supabase.com/docs/guides/database/connecting-to-postgres#transaction

This can be resolved without any code changes by adding statement_cache_mode=describe to the connection string:
https://github.com/jackc/pgx/issues/602#issuecomment-532236718