### PR TITLE
Use simple text output if a tty is not available

### DIFF
--- a/internal/db/changes/changes.go
+++ b/internal/db/changes/changes.go
@@ -60,7 +60,7 @@ var (
 	diff string
 )
 
-func run(p *tea.Program) error {
+func run(p utils.Program) error {
 	p.Send(utils.StatusMsg("Creating shadow database..."))
 
 	// 1. Create shadow db and run migrations

--- a/internal/db/commit/commit.go
+++ b/internal/db/commit/commit.go
@@ -64,7 +64,7 @@ var (
 	ctx, cancelCtx = context.WithCancel(context.Background())
 )
 
-func run(p *tea.Program, name string) error {
+func run(p utils.Program, name string) error {
 	p.Send(utils.StatusMsg("Creating shadow database..."))
 
 	// 1. Create shadow db and run migrations

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -77,7 +77,7 @@ var (
 	diff string
 )
 
-func run(p *tea.Program, url string) error {
+func run(p utils.Program, url string) error {
 	_, _ = utils.Docker.NetworkCreate(
 		ctx,
 		netId,

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -75,7 +75,7 @@ const (
 
 var ctx, cancelCtx = context.WithCancel(context.Background())
 
-func run(p *tea.Program, url string) error {
+func run(p utils.Program, url string) error {
 	_, _ = utils.Docker.NetworkCreate(
 		ctx,
 		netId,

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -67,7 +67,7 @@ var (
 	currBranch string
 )
 
-func run(p *tea.Program) error {
+func run(p utils.Program) error {
 	// 1. Prevent new db connections to be established while db is recreated.
 	defer utils.Docker.NetworkConnect(ctx, utils.NetId, utils.DbId, &network.EndpointSettings{}) //nolint:errcheck
 	if err := utils.Docker.NetworkDisconnect(ctx, utils.NetId, utils.DbId, false); err != nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -91,7 +91,7 @@ var (
 	kongConfigTemplate, _ = template.New("kongConfig").Parse(kongConfigEmbed)
 )
 
-func run(p *tea.Program) error {
+func run(p utils.Program) error {
 	_, _ = utils.Docker.NetworkCreate(
 		ctx,
 		utils.NetId,

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -47,7 +47,7 @@ func Run() error {
 	s := spinner.NewModel()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-	p := tea.NewProgram(model{spinner: s})
+	p := utils.NewProgram(model{spinner: s})
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/utils/textTea.go
+++ b/internal/utils/textTea.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// An interface describing the parts of BubbleTea's Program that we actually use.
+type Program interface {
+	Start() error
+	Send(msg tea.Msg)
+	Quit()
+}

--- a/internal/utils/textTea.go
+++ b/internal/utils/textTea.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"os"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
 )
 
 // An interface describing the parts of BubbleTea's Program that we actually use.
@@ -9,4 +12,63 @@ type Program interface {
 	Start() error
 	Send(msg tea.Msg)
 	Quit()
+}
+
+// A dumb text implementation of BubbleTea's Program that allows
+// for output to be piped to another program.
+type FakeProgram struct {
+	model tea.Model
+}
+
+func NewProgram(model tea.Model, opts ...tea.ProgramOption) Program {
+	var p Program
+	if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) {
+		p = tea.NewProgram(model, opts...)
+	} else {
+		p = NewFakeProgram(model)
+	}
+	return p
+}
+
+func NewFakeProgram(model tea.Model) *FakeProgram {
+	p := &FakeProgram{
+		model: model,
+	}
+	return p
+}
+
+func (p *FakeProgram) Start() error {
+	initCmd := p.model.Init()
+	message := initCmd()
+	if message != nil {
+		p.model.Update(message)
+	}
+	return nil
+}
+
+func (p *FakeProgram) Send(msg tea.Msg) {
+	if msg == nil {
+		return
+	}
+
+	switch msg := msg.(type) {
+	case StatusMsg:
+		os.Stdout.Write([]byte(msg + "\n"))
+
+	case PsqlMsg:
+		if msg != nil {
+			os.Stdout.Write([]byte(*msg + "\n"))
+		}
+	}
+
+	model, cmd := p.model.Update(msg)
+	p.model = model
+
+	if cmd != nil {
+		cmd()
+	}
+}
+
+func (p *FakeProgram) Quit() {
+	p.Send(tea.Quit())
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -304,7 +303,7 @@ type (
 	PsqlMsg     *string
 )
 
-func ProcessPullOutput(out io.ReadCloser, p *tea.Program) error {
+func ProcessPullOutput(out io.ReadCloser, p Program) error {
 	dec := json.NewDecoder(out)
 
 	downloads := make(map[string]struct{ current, total int64 })
@@ -350,7 +349,7 @@ func ProcessPullOutput(out io.ReadCloser, p *tea.Program) error {
 	return nil
 }
 
-func ProcessDiffOutput(p *tea.Program, out io.Reader) ([]byte, error) {
+func ProcessDiffOutput(p Program, out io.Reader) ([]byte, error) {
 	var diffBytesBuf bytes.Buffer
 	r, w := io.Pipe()
 	doneCh := make(chan struct{}, 1)
@@ -460,7 +459,7 @@ func isSchemaIgnored(schema string) bool {
 	return false
 }
 
-func ProcessPsqlOutput(out io.Reader, p *tea.Program) error {
+func ProcessPsqlOutput(out io.Reader, p Program) error {
 	r, w := io.Pipe()
 	doneCh := make(chan struct{}, 1)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes supabase/cli#152.

## What is the current behavior?

Currently, if you run `supabase start` in a GitHub Action, or locally, piping output e.g. to a file, you get the following error:

```
Error: inappropriate ioctl for device
```

## What is the new behavior?

With this PR, if both stdin and stdout are not a terminal, the CLI bypasses BubbleTea's UI drawing methods and just logs status and progress messages to stdout.

```bash
supabase start | cat
Pulling images...
Starting database...
Restoring branches...
Setting up initial schema...
Applying supabase/extensions.sql...
Applying migration 20220201010915_add_shared_configs.sql...
Applying supabase/seed.sql...
Starting containers...
Started local development setup.

         API URL: http://localhost:54321
          DB URL: postgresql://postgres:postgres@localhost:54322/postgres
      Studio URL: http://localhost:54323
        anon key: ***
service_role key: ***
```

If running interactively, the behavior is unchanged.