### PR TITLE
Handle error for unknown migration files in supabase/migrations

### DIFF
--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -55,9 +55,14 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 
 	fmt.Println("Applying unapplied migrations...")
 
+	re := regexp.MustCompile(`([0-9]+)_.*\.sql`)
 	for i, migration := range migrations {
-		re := regexp.MustCompile(`([0-9]+)_.*\.sql`)
-		migrationTimestamp := re.FindStringSubmatch(migration.Name())[1]
+		matches := re.FindStringSubmatch(migration.Name())
+		if len(matches) == 0 {
+			return errors.New("Can't process file in supabase/migrations: " + migration.Name())
+		}
+
+		migrationTimestamp := matches[1]
 
 		if i >= len(versions) {
 			// skip


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix an issue where `supabase db push` would fail if there were files in `supabase/migrations` that don't aren't migrations.  e.g. MacOS might create `.DS_Store` files in the `supabase/migrations` filter.

## What is the current behavior?

```
❯ supabase db push      
Applying unapplied migrations...
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
github.com/supabase/cli/internal/db/push.Run()
        /home/runner/work/cli/cli/internal/db/push/push.go:60 +0x953
github.com/supabase/cli/cmd.glob..func6(0x1d201a0, {0x1763b66, 0x0, 0x0})
        /home/runner/work/cli/cli/cmd/db.go:75 +0x17
github.com/spf13/cobra.(*Command).execute(0x1d201a0, {0x1d5ce80, 0x0, 0x0})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0x1d1eda0)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
github.com/supabase/cli/cmd.Execute()
        /home/runner/work/cli/cli/cmd/root.go:19 +0x25
main.main()
        /home/runner/work/cli/cli/main.go:11 +0x4a
```

## What is the new behavior?

```
❯ ../../supabase/cli/cli db push   
Applying unapplied migrations...
Finished supabase db push.
```

