### PR TITLE
fix: don't include a period next to the generated fn filename

### DIFF
--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -19,12 +19,12 @@ func Run(slug string) error {
 
 	// 2. Validate Function slug.
 	{
-		matched, err := regexp.MatchString(`^[A-Za-z0-9_-]+$`, slug)
+		matched, err := regexp.MatchString(`^[A-Za-z][A-Za-z0-9_-]*$`, slug)
 		if err != nil {
 			return err
 		}
 		if !matched {
-			return errors.New("Invalid Function name. Must be `^[A-Za-z0-9_-]+$`.")
+			return errors.New("Invalid Function name. Must start with at least one letter, and only include alphanumeric characters, underscores, and hyphens. (^[A-Za-z][A-Za-z0-9_-]*$)")
 		}
 		if _, err := os.Stat("supabase/functions/" + slug + ".ts"); !errors.Is(err, os.ErrNotExist) {
 			return errors.New("Function " + utils.Aqua(slug) + " already exists locally.")

--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -48,6 +48,6 @@ serve(() => new Response("Hello World"));
 		}
 	}
 
-	fmt.Println("Created new Function at \"" + utils.Bold("supabase/functions/"+slug+".ts") + "\"")
+	fmt.Println("Created new Function at " + utils.Bold("supabase/functions/"+slug+".ts"))
 	return nil
 }

--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -48,6 +48,6 @@ serve(() => new Response("Hello World"));
 		}
 	}
 
-	fmt.Println("Created new Function at " + utils.Bold("supabase/functions/"+slug+".ts") + ".")
+	fmt.Println("Created new Function at \"" + utils.Bold("supabase/functions/"+slug+".ts") + "\"")
 	return nil
 }


### PR DESCRIPTION
Periods aren't usually a word break character in most terminals, so if
you double-click the name to copy it, the period will be selected as
well. The user would then need to erase the period quite
unnecessarily.

Additionally, impose further restrictions on what a valid function name can be.