### PR TITLE
Chore/move apikey location

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -55,11 +55,7 @@ func Run(slug string, projectRefArg string) error {
 	var newFunctionBody string
 	{
 		fmt.Println("Bundling " + utils.Bold("supabase/functions/"+slug))
-
-		denoPath, err := xdg.ConfigFile("supabase/deno")
-		if err != nil {
-			return err
-		}
+		denoPath := xdg.Home + "/.supabase/deno"
 
 		cmd := exec.Command(denoPath, "bundle", "--quiet", "supabase/functions/"+slug+"/index.ts")
 		var outBuf, errBuf bytes.Buffer

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -37,10 +37,10 @@ Enter your access token: `)
 
 	// 2. Save access token
 	{
-		accessTokenPath, err := xdg.ConfigFile("supabase/access-token")
-		if err != nil {
+		if err := utils.MkdirIfNotExist(xdg.Home + "/.supabase"); err != nil {
 			return err
 		}
+		accessTokenPath := xdg.Home + "/.supabase/access-token"
 
 		if err := os.WriteFile(accessTokenPath, []byte(accessToken), 0600); err != nil {
 			return err

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
-	"github.com/supabase/cli/internal/utils"
 )
 
 // Update initial schemas in internal/utils/templates/initial_schemas when
@@ -179,7 +178,7 @@ func AssertIsLinked() error {
 }
 
 func InstallOrUpgradeDeno() error {
-	if err := utils.MkdirIfNotExist(xdg.Home + "/.supabase"); err != nil {
+	if err := MkdirIfNotExist(xdg.Home + "/.supabase"); err != nil {
 		return err
 	}
 	denoPath := xdg.Home + "/.supabase/deno"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
+	"github.com/supabase/cli/internal/utils"
 )
 
 // Update initial schemas in internal/utils/templates/initial_schemas when
@@ -178,10 +179,10 @@ func AssertIsLinked() error {
 }
 
 func InstallOrUpgradeDeno() error {
-	denoPath, err := xdg.ConfigFile("supabase/deno")
-	if err != nil {
+	if err := utils.MkdirIfNotExist(xdg.Home + "/.supabase"); err != nil {
 		return err
 	}
+	denoPath := xdg.Home + "/.supabase/deno"
 
 	if _, err := os.Stat(denoPath); err == nil {
 		// Upgrade Deno.
@@ -269,10 +270,7 @@ func LoadAccessToken() (string, error) {
 		return accessToken, nil
 	}
 
-	accessTokenPath, err := xdg.ConfigFile("supabase/access-token")
-	if err != nil {
-		return "", err
-	}
+	accessTokenPath := xdg.Home + "/.supabase/access-token"
 	accessToken, err := os.ReadFile(accessTokenPath)
 	if errors.Is(err, os.ErrNotExist) || string(accessToken) == "" {
 		return "", errors.New("Access token not provided. Supply an access token by running " + Aqua("supabase login") + " or setting the SUPABASE_ACCESS_TOKEN environment variable.")


### PR DESCRIPTION
rationale is that devs are more likely to look for the apikey config inside `~/` than Application Support dir for dev tools

I'm not as concerned with the deno binary but probably makes sense to have all the config together so devs can check its version if they want to, so I moved it over as well (this one is also easier to move again later if we want since the state of it is managed fully automatically by the CLI)