### PR TITLE
fix: support passing of --project-ref in functions delete

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -17,9 +17,13 @@ var (
 	functionsDeleteCmd = &cobra.Command{
 		Use:   "delete <Function name>",
 		Short: "Delete a Function from the linked Supabase project. This does NOT remove the Function locally.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return delete.Run(args[0])
+			projectRef, err := cmd.Flags().GetString("project-ref")
+			if err != nil {
+				return err
+			}
+			return delete.Run(args[0], projectRef)
 		},
 	}
 
@@ -63,6 +67,7 @@ var (
 func init() {
 	functionsServeCmd.Flags().String("env-file", "", "Path to an env file to be populated to the Function environment")
 	functionsDeployCmd.Flags().String("project-ref", "", "Project ref of the Supabase project")
+	functionsDeleteCmd.Flags().String("project-ref", "", "Project ref of the Supabase project")
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)
 	functionsCmd.AddCommand(functionsNewCmd)

--- a/internal/functions/delete/delete.go
+++ b/internal/functions/delete/delete.go
@@ -74,9 +74,10 @@ func Run(slug string, projectRefArg string) error {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode == 404 { // Function doesn't exist
+		switch resp.StatusCode {
+		case http.StatusNotFound: // Function doesn't exist
 			return errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
-		} else if resp.StatusCode == 200 { // Function exists
+		case http.StatusOK: // Function exists
 			req, err := http.NewRequest("DELETE", "https://api.supabase.io/v1/projects/"+projectRef+"/functions/"+slug, nil)
 			if err != nil {
 				return err
@@ -95,7 +96,7 @@ func Run(slug string, projectRefArg string) error {
 
 				return errors.New("Failed to delete Function " + utils.Aqua(slug) + " on the Supabase project: " + string(body))
 			}
-		} else {
+		default:
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return fmt.Errorf("Unexpected error deleting Function: %w", err)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Now supports `supabase functions delete hello --project-ref <project-ref>` :) 