### PR TITLE
Add up-to-date minor version to supabase config for Major version 14

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -176,7 +176,7 @@ func LoadConfig() error {
 			DbImage = "supabase/postgres:13.3.0"
 			InitialSchemaSql = initialSchemaPg13Sql
 		case 14:
-			DbImage = "supabase/postgres:14.1.0"
+			DbImage = "supabase/postgres:14.1.0.19"
 			InitialSchemaSql = initialSchemaPg14Sql
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)


### PR DESCRIPTION
In order to enable `pg_graphql`, the major version 14 should be set to the most recent major version including `pg_graphql`.

Fixes: #231 

## What kind of change does this PR introduce?

Updates to the latest minor version [`14.1.0.19`](https://hub.docker.com/layers/postgres/supabase/postgres/14.1.0.19/images/sha256-85077f51095ca3372fa6b20fe8739b5cc72ac5240f2b6a25fb2a8ebd77a085fd?context=explore) for Major Version 14

## What is the current behavior?

Currently the local postgres that is installed is [`14.1.0`](https://hub.docker.com/layers/postgres/supabase/postgres/14.1.0/images/sha256-22d7f41a55cb7410d156ae357ce36d8f17d9b62d919e6ab479db9ba2a291c60c?context=explore)

Which does not contain graphql. The issue in #231 is caused by the local instance not having the graphql extension installed.

## What is the new behavior?

- 14.1.0.19 is now installed by `supabase start`
- graphql extensions (and other goodies from `...19`) are confirmed available


## Additional context

![Screen Shot 2022-04-02 at 5 11 27 PM](https://user-images.githubusercontent.com/2037165/161401379-eb600d16-bc79-41e2-935c-27450930754b.png)

