### PR TITLE
feature(cmd): add status|info|container (list|restart)

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/docker/containers/list"
+	"github.com/supabase/cli/internal/docker/containers/restart"
+)
+
+var (
+	containersCmd = &cobra.Command{
+		Use:   "containers",
+		Short: "Supabase docker containers",
+	}
+
+	containersListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all supabase docker containers.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list.Run()
+		},
+	}
+
+	containersRestartCmd = &cobra.Command{
+		Use:   "restart",
+		Short: "Restart all supabase docker containers.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return restart.Run()
+		},
+	}
+)
+
+func init() {
+	containersCmd.AddCommand(containersListCmd)
+	containersCmd.AddCommand(containersRestartCmd)
+	rootCmd.AddCommand(containersCmd)
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/info"
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get Supabase local development info.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return info.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,23 +9,10 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Get Supabase local development status.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		useShortId := true
-		showKeys := false
-
-		if useFullId, err := cmd.Flags().GetBool("full-id"); err == nil {
-			useShortId = !useFullId
-		}
-
-		if _showKeys, err := cmd.Flags().GetBool("show-keys"); err == nil {
-			showKeys = _showKeys
-		}
-
-		return status.Run(useShortId, showKeys)
+		return status.Run()
 	},
 }
 
 func init() {
-	statusCmd.Flags().Bool("full-id", false, "Display full id")
-	statusCmd.Flags().Bool("show-keys", false, "Display supabase keys")
 	rootCmd.AddCommand(statusCmd)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/status"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Get Supabase local development status.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useShortId := true
+
+		if showFullId, err := cmd.Flags().GetBool("full-id"); err == nil {
+			useShortId = !showFullId
+		}
+
+		return status.Run(useShortId)
+	},
+}
+
+func init() {
+	statusCmd.Flags().Bool("full-id", false, "Display full id")
+	rootCmd.AddCommand(statusCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,16 +10,22 @@ var statusCmd = &cobra.Command{
 	Short: "Get Supabase local development status.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useShortId := true
+		showKeys := false
 
-		if showFullId, err := cmd.Flags().GetBool("full-id"); err == nil {
-			useShortId = !showFullId
+		if useFullId, err := cmd.Flags().GetBool("full-id"); err == nil {
+			useShortId = !useFullId
 		}
 
-		return status.Run(useShortId)
+		if _showKeys, err := cmd.Flags().GetBool("show-keys"); err == nil {
+			showKeys = _showKeys
+		}
+
+		return status.Run(useShortId, showKeys)
 	},
 }
 
 func init() {
 	statusCmd.Flags().Bool("full-id", false, "Display full id")
+	statusCmd.Flags().Bool("show-keys", false, "Display supabase keys")
 	rootCmd.AddCommand(statusCmd)
 }

--- a/internal/docker/containers/list/list.go
+++ b/internal/docker/containers/list/list.go
@@ -1,0 +1,50 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/supabase/cli/internal/utils"
+)
+
+var ctx = context.Background()
+
+func Run() error {
+	// Sanity checks.
+	if err := utils.AssertDockerIsRunning(); err != nil {
+		return err
+	}
+	if err := utils.LoadConfig(); err != nil {
+		return err
+	}
+
+	containers, err := utils.GetProjectContainers(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(containers) == 0 {
+		fmt.Println(fmt.Sprintf("There aren't any containers for %s project", utils.Bold(utils.Config.ProjectId)))
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.TabIndent)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t", utils.Bold("ID"), utils.Bold("SERVICE"), utils.Bold("STATE"))
+		fmt.Fprintln(w)
+		for _, container := range containers {
+			state := utils.Aqua(container.State)
+
+			if container.State != "running" {
+				state = utils.Red(container.State)
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s", utils.Bold(container.ID[:6]), utils.Bold(utils.ContainerName(container.Names)), utils.Bold(state), utils.Bold(container.Image))
+			fmt.Fprintln(w)
+		}
+
+		w.Flush()
+	}
+
+	return nil
+}

--- a/internal/docker/containers/restart/restart.go
+++ b/internal/docker/containers/restart/restart.go
@@ -1,0 +1,167 @@
+package restart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/progress"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/docker/docker/api/types"
+	"github.com/muesli/reflow/wrap"
+	"github.com/supabase/cli/internal/utils"
+)
+
+var (
+	ctx, cancelCtx = context.WithCancel(context.Background())
+)
+
+func Run() error {
+	// Sanity checks.
+	if err := utils.AssertDockerIsRunning(); err != nil {
+		return err
+	}
+	if err := utils.LoadConfig(); err != nil {
+		return err
+	}
+
+	containers, err := utils.GetProjectContainers(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(containers) == 0 {
+		fmt.Println(fmt.Sprintf("There aren't any containers for %s project", utils.Bold(utils.Config.ProjectId)))
+	} else {
+		s := spinner.NewModel()
+		s.Spinner = spinner.Dot
+		s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+		p := utils.NewProgram(model{spinner: s})
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- run(p, containers)
+			p.Send(tea.Quit())
+		}()
+
+		if err := p.Start(); err != nil {
+			return err
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return errors.New("Aborted " + utils.Aqua("supabase containers restart") + ".")
+		}
+		if err := <-errCh; err != nil {
+			return err
+		}
+	}
+
+	fmt.Println(`Supabase containers restarted.`)
+
+	return nil
+}
+
+func run(p utils.Program, containers []types.Container) error {
+	p.Send(utils.StatusMsg("Restarting docker containers..."))
+
+	for _, container := range containers {
+		timeout := time.Second
+		status := fmt.Sprintf("Restaring %s", utils.Bold(utils.ContainerName(container.Names)))
+		p.Send(utils.PsqlMsg(&status))
+		err := utils.Docker.ContainerRestart(ctx, container.ID, &timeout)
+		if err != nil {
+			status := fmt.Sprintf("An error has ocurred trying to restart %s", utils.Bold(utils.Red(utils.ContainerName(container.Names))))
+			p.Send(utils.PsqlMsg(&status))
+		}
+	}
+
+	return nil
+}
+
+type model struct {
+	spinner     spinner.Model
+	status      string
+	progress    *progress.Model
+	psqlOutputs []string
+
+	width int
+}
+
+func (m model) Init() tea.Cmd {
+	return spinner.Tick
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			// Stop future runs
+			cancelCtx()
+			return m, tea.Quit
+		default:
+			return m, nil
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+	case spinner.TickMsg:
+		spinnerModel, cmd := m.spinner.Update(msg)
+		m.spinner = spinnerModel
+		return m, cmd
+	case progress.FrameMsg:
+		if m.progress == nil {
+			return m, nil
+		}
+
+		tmp, cmd := m.progress.Update(msg)
+		progressModel := tmp.(progress.Model)
+		m.progress = &progressModel
+		return m, cmd
+	case utils.StatusMsg:
+		m.status = string(msg)
+		return m, nil
+	case utils.ProgressMsg:
+		if msg == nil {
+			m.progress = nil
+			return m, nil
+		}
+
+		if m.progress == nil {
+			progressModel := progress.NewModel(progress.WithGradient("#1c1c1c", "#34b27b"))
+			m.progress = &progressModel
+		}
+
+		return m, m.progress.SetPercent(*msg)
+	case utils.PsqlMsg:
+		if msg == nil {
+			m.psqlOutputs = []string{}
+			return m, nil
+		}
+
+		m.psqlOutputs = append(m.psqlOutputs, *msg)
+		if len(m.psqlOutputs) > 5 {
+			m.psqlOutputs = m.psqlOutputs[1:]
+		}
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+func (m model) View() string {
+	var progress string
+	if m.progress != nil {
+		progress = "\n\n" + m.progress.View()
+	}
+
+	var psqlOutputs string
+	if len(m.psqlOutputs) > 0 {
+		psqlOutputs = "\n\n" + strings.Join(m.psqlOutputs, "\n")
+	}
+
+	return wrap.String(m.spinner.View()+m.status+progress+psqlOutputs, m.width)
+}

--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -54,7 +54,7 @@ serve(async (req) => {
 
 // To invoke:
 // curl -i --location --request POST 'http://localhost:54321/functions/v1/' \
-//   --header 'Authorization: Bearer `+utils.DEFAULT_ANON_KEY+`' \
+//   --header 'Authorization: Bearer `+utils.AnonKey+`' \
 //   --header 'Content-Type: application/json' \
 //   --data '{"name":"Functions"}'
 `),

--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -54,7 +54,7 @@ serve(async (req) => {
 
 // To invoke:
 // curl -i --location --request POST 'http://localhost:54321/functions/v1/' \
-//   --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs' \
+//   --header 'Authorization: Bearer `+utils.DEFAULT_ANON_KEY+`' \
 //   --header 'Content-Type: application/json' \
 //   --data '{"name":"Functions"}'
 `),

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -112,8 +112,8 @@ func Run(envFilePath string, slug string) error {
 
 		env := []string{
 			"SUPABASE_URL=http://" + utils.KongId + ":8000",
-			"SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs",
-			"SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.vI9obAHOGyVVKa3pD--kJlyxp-Z2zV9UUMAhKpNLAcU",
+			"SUPABASE_ANON_KEY=" + utils.AnonKey,
+			"SUPABASE_SERVICE_ROLE_KEY=" + utils.ServiceRoleKey,
 			"SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:" + strconv.FormatUint(uint64(utils.Config.Db.Port), 10) + "/postgres",
 		}
 

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -1,0 +1,24 @@
+package info
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/supabase/cli/internal/utils"
+)
+
+var ctx = context.Background()
+
+func Run() error {
+	// Sanity checks.
+	if err := utils.AssertDockerIsRunning(); err != nil {
+		return err
+	}
+	if err := utils.LoadConfig(); err != nil {
+		return err
+	}
+
+	fmt.Println(utils.GetProjectInfo())
+
+	return nil
+}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -42,7 +42,7 @@ func Run() error {
 		if err := utils.InterpolateEnvInConfig(); err != nil {
 			return err
 		}
-		projectInfo = utils.GetProjectInfo((true))
+		projectInfo = utils.GetProjectInfo()
 		if err := utils.AssertSupabaseStartIsRunning(); err == nil {
 			message := utils.Aqua("supabase start") + " is already running. " + fmt.Sprintln() + fmt.Sprintln() + projectInfo + fmt.Sprintln() + "Try running " + utils.Aqua("supabase stop") + " first."
 			return errors.New(message)
@@ -543,7 +543,7 @@ EOSQL
 			ProjectId     string
 			AnonKey       string
 			ServerRoleKey string
-		}{ProjectId: utils.Config.ProjectId, AnonKey: utils.DEFAULT_ANON_KEY, ServerRoleKey: utils.DEFAULT_SERVER_ROLE_KEY}); err != nil {
+		}{ProjectId: utils.Config.ProjectId, AnonKey: utils.AnonKey, ServerRoleKey: utils.ServiceRoleKey}); err != nil {
 			return err
 		}
 
@@ -732,8 +732,8 @@ EOF
 		&container.Config{
 			Image: utils.StorageImage,
 			Env: []string{
-				"ANON_KEY=" + utils.DEFAULT_ANON_KEY,
-				"SERVICE_KEY=" + utils.DEFAULT_SERVER_ROLE_KEY,
+				"ANON_KEY=" + utils.AnonKey,
+				"SERVICE_KEY=" + utils.ServiceRoleKey,
 				"POSTGREST_URL=http://" + utils.RestId + ":3000",
 				"PGRST_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long",
 				"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
@@ -813,8 +813,8 @@ EOF
 
 				"SUPABASE_URL=http://" + utils.KongId + ":8000",
 				fmt.Sprintf("SUPABASE_REST_URL=http://localhost:%v/rest/v1/", utils.Config.Api.Port),
-				"SUPABASE_ANON_KEY=" + utils.DEFAULT_ANON_KEY,
-				"SUPABASE_SERVICE_KEY=" + utils.DEFAULT_SERVER_ROLE_KEY,
+				"SUPABASE_ANON_KEY=" + utils.AnonKey,
+				"SUPABASE_SERVICE_KEY=" + utils.ServiceRoleKey,
 			},
 			Labels: map[string]string{
 				"com.supabase.cli.project":   utils.Config.ProjectId,

--- a/internal/start/templates/kong_config
+++ b/internal/start/templates/kong_config
@@ -98,7 +98,7 @@ services:
 consumers:
   - username: anon
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
+      - key: {{ .AnonKey }}
   - username: service_role
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.vI9obAHOGyVVKa3pD--kJlyxp-Z2zV9UUMAhKpNLAcU
+      - key: {{ .ServerRoleKey }}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -3,16 +3,13 @@ package status
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/supabase/cli/internal/utils"
 )
 
 var ctx = context.Background()
 
-func Run(useShortId bool, showKeys bool) error {
+func Run() error {
 	// Sanity checks.
 	if err := utils.AssertDockerIsRunning(); err != nil {
 		return err
@@ -21,55 +18,25 @@ func Run(useShortId bool, showKeys bool) error {
 		return err
 	}
 
-	// List containers.
+	// check containers status.
 	{
-		containers, err := utils.Docker.ContainerList(ctx, types.ContainerListOptions{
-			All:     true,
-			Filters: filters.NewArgs(filters.Arg("label", "com.supabase.cli.project="+utils.Config.ProjectId)),
-		})
+		containers, err := utils.GetProjectContainers(ctx)
 		if err != nil {
 			return err
 		}
 
-		fmt.Println("Project:", utils.Bold(utils.Config.ProjectId))
-		fmt.Println()
-		fmt.Println("Containers:")
-		fmt.Println("---")
+		allStopped := true
+		status := utils.Red("Stopped")
+
 		for _, container := range containers {
-			service := strings.Join(container.Names, " | ")
-
-			if len(service) > 0 && service[0] == '/' {
-				service = service[1:]
+			if allStopped && container.State == "running" {
+				allStopped = false
+				status = utils.Aqua("Running")
+				break
 			}
-
-			id := container.ID
-
-			if useShortId {
-				id = id[0:4]
-			}
-
-			fmt.Println("Name:", utils.Bold(service))
-			fmt.Println("ID:", utils.Bold(id))
-			fmt.Println("Image:", utils.Bold(container.Image))
-
-			state := utils.Aqua(container.State)
-
-			if container.State != "running" {
-				state = utils.Red(container.State)
-			}
-
-			fmt.Println("State:", utils.Bold(state))
-			fmt.Println("Status:", utils.Bold(container.Status))
-			fmt.Println("---")
 		}
 
-		if len(containers) == 0 {
-			fmt.Println(utils.Bold(utils.Red("Supabase stopped.")))
-			fmt.Println("---")
-		}
-		fmt.Println()
-		info := utils.GetProjectInfo(showKeys)
-		fmt.Println(info)
+		fmt.Println(fmt.Sprintf("Supabase local development: %s", utils.Bold(status)))
 	}
 
 	return nil

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,68 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/supabase/cli/internal/utils"
+)
+
+var ctx = context.Background()
+
+func Run(useShortId bool) error {
+	// Sanity checks.
+	if err := utils.AssertDockerIsRunning(); err != nil {
+		return err
+	}
+	if err := utils.LoadConfig(); err != nil {
+		return err
+	}
+
+	// List containers.
+	{
+		containers, err := utils.Docker.ContainerList(ctx, types.ContainerListOptions{
+			All:     true,
+			Filters: filters.NewArgs(filters.Arg("label", "com.supabase.cli.project="+utils.Config.ProjectId)),
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Project:", utils.Bold(utils.Config.ProjectId))
+
+		fmt.Println("Containers: ")
+		fmt.Println("---")
+		for _, container := range containers {
+			service := strings.Join(container.Names, " | ")
+
+			if len(service) > 0 && service[0] == '/' {
+				service = service[1:]
+			}
+
+			id := container.ID
+
+			if useShortId {
+				id = id[0:4]
+			}
+
+			fmt.Println("Name:", utils.Bold(service))
+			fmt.Println("ID:", utils.Bold(id))
+			fmt.Println("Image:", utils.Bold(container.Image))
+
+			state := utils.Aqua(container.State)
+
+			if container.State != "running" {
+				state = utils.Red(container.State)
+			}
+
+			fmt.Println("State:", utils.Bold(state))
+			fmt.Println("Status:", utils.Bold(container.Status))
+			fmt.Println("---")
+		}
+	}
+
+	return nil
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -12,7 +12,7 @@ import (
 
 var ctx = context.Background()
 
-func Run(useShortId bool) error {
+func Run(useShortId bool, showKeys bool) error {
 	// Sanity checks.
 	if err := utils.AssertDockerIsRunning(); err != nil {
 		return err
@@ -32,8 +32,8 @@ func Run(useShortId bool) error {
 		}
 
 		fmt.Println("Project:", utils.Bold(utils.Config.ProjectId))
-
-		fmt.Println("Containers: ")
+		fmt.Println()
+		fmt.Println("Containers:")
 		fmt.Println("---")
 		for _, container := range containers {
 			service := strings.Join(container.Names, " | ")
@@ -62,6 +62,14 @@ func Run(useShortId bool) error {
 			fmt.Println("Status:", utils.Bold(container.Status))
 			fmt.Println("---")
 		}
+
+		if len(containers) == 0 {
+			fmt.Println(utils.Bold(utils.Red("Supabase stopped.")))
+			fmt.Println("---")
+		}
+		fmt.Println()
+		info := utils.GetProjectInfo(showKeys)
+		fmt.Println(info)
 	}
 
 	return nil

--- a/internal/utils/colors.go
+++ b/internal/utils/colors.go
@@ -9,6 +9,10 @@ func Aqua(str string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render(str)
 }
 
+func Red(str string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(str)
+}
+
 // For paths & filenames.
 func Bold(str string) string {
 	return lipgloss.NewStyle().Bold(true).Render(str)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -16,6 +16,11 @@ import (
 )
 
 var (
+	DEFAULT_ANON_KEY        string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs"
+	DEFAULT_SERVER_ROLE_KEY string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.vI9obAHOGyVVKa3pD--kJlyxp-Z2zV9UUMAhKpNLAcU"
+)
+
+var (
 	DbImage     string
 	NetId       string
 	DbId        string

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -15,9 +15,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	DEFAULT_ANON_KEY        string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs"
-	DEFAULT_SERVER_ROLE_KEY string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.vI9obAHOGyVVKa3pD--kJlyxp-Z2zV9UUMAhKpNLAcU"
+const (
+	AnonKey        string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs"
+	ServiceRoleKey string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.vI9obAHOGyVVKa3pD--kJlyxp-Z2zV9UUMAhKpNLAcU"
 )
 
 var (

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 )
 
@@ -101,4 +103,21 @@ func DockerRemoveAll() {
 	}
 
 	wg.Wait()
+}
+
+func GetProjectContainers(ctx context.Context) ([]types.Container, error) {
+	return Docker.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("label", "com.supabase.cli.project="+Config.ProjectId)),
+	})
+}
+
+func ContainerName(names []string) string {
+	service := strings.Join(names, " | ")
+
+	if len(service) > 0 && service[0] == '/' {
+		service = service[1:]
+	}
+
+	return service
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -301,4 +302,24 @@ func ValidateFunctionSlug(slug string) error {
 	}
 
 	return nil
+}
+
+func GetProjectInfo(includeKeys bool) string {
+	writeLine := func(key string, value interface{}) string {
+		return fmt.Sprintln(fmt.Sprintf("  %s: %v", Aqua(key), value))
+	}
+
+	var projectInfo = fmt.Sprintln(Bold("Project Info:"))
+
+	projectInfo += writeLine("API URL", `http://localhost:`+strconv.FormatUint(uint64(Config.Api.Port), 10))
+	projectInfo += writeLine("DB URL", `postgresql://postgres:postgres@localhost:`+strconv.FormatUint(uint64(Config.Db.Port), 10)+`/postgres`)
+	projectInfo += writeLine("Studio URL", `http://localhost:`+strconv.FormatUint(uint64(Config.Studio.Port), 10))
+	projectInfo += writeLine("Inbucket URL", `http://localhost:`+strconv.FormatUint(uint64(Config.Inbucket.Port), 10))
+
+	if includeKeys {
+		projectInfo += writeLine("anon key", DEFAULT_ANON_KEY)
+		projectInfo += writeLine("service_role key", DEFAULT_SERVER_ROLE_KEY)
+	}
+
+	return projectInfo
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -304,7 +304,7 @@ func ValidateFunctionSlug(slug string) error {
 	return nil
 }
 
-func GetProjectInfo(includeKeys bool) string {
+func GetProjectInfo() string {
 	writeLine := func(key string, value interface{}) string {
 		return fmt.Sprintln(fmt.Sprintf("  %s: %v", Aqua(key), value))
 	}
@@ -315,11 +315,8 @@ func GetProjectInfo(includeKeys bool) string {
 	projectInfo += writeLine("DB URL", `postgresql://postgres:postgres@localhost:`+strconv.FormatUint(uint64(Config.Db.Port), 10)+`/postgres`)
 	projectInfo += writeLine("Studio URL", `http://localhost:`+strconv.FormatUint(uint64(Config.Studio.Port), 10))
 	projectInfo += writeLine("Inbucket URL", `http://localhost:`+strconv.FormatUint(uint64(Config.Inbucket.Port), 10))
-
-	if includeKeys {
-		projectInfo += writeLine("anon key", DEFAULT_ANON_KEY)
-		projectInfo += writeLine("service_role key", DEFAULT_SERVER_ROLE_KEY)
-	}
+	projectInfo += writeLine("anon key", AnonKey)
+	projectInfo += writeLine("service_role key", ServiceRoleKey)
 
 	return projectInfo
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

## What is the new behavior?

`supabase status`

<img width="547" alt="image" src="https://user-images.githubusercontent.com/969516/161760825-cbf036f4-3f33-4426-9c59-9c28fcaeb2ab.png">

<img width="523" alt="image" src="https://user-images.githubusercontent.com/969516/161761054-74e8bb4b-613a-4970-9666-d6ec7984b8de.png">

## Additional context

add status cmd #149

`supabase start` shows project info if project is started 

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/969516/161570104-002cefdf-f8b7-418d-9a13-9133ac20cc5b.png">

`supabase info`

<img width="784" alt="image" src="https://user-images.githubusercontent.com/969516/161761807-d6fa185d-2b07-4972-800e-5079f0c61265.png">

 `supabase containers list`

<img width="792" alt="image" src="https://user-images.githubusercontent.com/969516/161762137-eff18e95-930f-4673-9580-c160079d3222.png">

`supabase containers restart`

<img width="649" alt="image" src="https://user-images.githubusercontent.com/969516/161762257-75c08a74-cede-4a1a-9810-1ea5baae5952.png">


