### PR TITLE
feat: make GoTrue SMTP rate limit configurable

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -601,6 +601,7 @@ EOF
 			fmt.Sprintf("GOTRUE_EXTERNAL_EMAIL_ENABLED=%v", *utils.Config.Auth.Email.EnableSignup),
 			fmt.Sprintf("GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED=%v", *utils.Config.Auth.Email.DoubleConfirmChanges),
 			fmt.Sprintf("GOTRUE_MAILER_AUTOCONFIRM=%v", !*utils.Config.Auth.Email.EnableConfirmations),
+			fmt.Sprintf("GOTRUE_SMTP_MAX_FREQUENCY=%v", utils.Config.Auth.Email.MaxFrequency),
 
 			"GOTRUE_SMTP_HOST=" + utils.InbucketId,
 			"GOTRUE_SMTP_PORT=2500",

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -104,9 +104,10 @@ type (
 	}
 
 	email struct {
-		EnableSignup         *bool `toml:"enable_signup"`
-		DoubleConfirmChanges *bool `toml:"double_confirm_changes"`
-		EnableConfirmations  *bool `toml:"enable_confirmations"`
+		EnableSignup         *bool  `toml:"enable_signup"`
+		DoubleConfirmChanges *bool  `toml:"double_confirm_changes"`
+		EnableConfirmations  *bool  `toml:"enable_confirmations"`
+		MaxFrequency         string `toml:"max_frequency"`
 	}
 
 	provider struct {

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -51,6 +51,8 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# The minimum amount of time that must pass before sending another email.
+max_frequency = "1s"
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -51,6 +51,8 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# The minimum amount of time that must pass before sending another email.
+max_frequency = "1s"
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change makes the GoTrue SMTP rate limit configurable.

## What is the current behavior?

Currently the CLI tool starts up GoTrue without a SMTP rate limit configuration. Therefore it uses its one minute interval default, which is annoying for E2E testing involving authentication.

## What is the new behavior?

Now it is possible for a CLI user to adjust the rate limit by setting `max_frequency` in the `[auth.email]` block of `config.toml`.