### PR TITLE
feat (config.db): [logs] pass the min log level arg using commands

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -273,8 +273,15 @@ func run(p utils.Program) error {
 	// Start Postgres.
 	{
 		cmd := []string{}
+		var logMinMessagesCommand strings.Builder
+		logMinMessagesCommand.WriteString("log_min_messages=")
+		logMinMessagesCommand.WriteString(utils.Config.Db.LogMinMessages)
 		if utils.Config.Db.MajorVersion >= 14 {
-			cmd = []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"}
+			cmd = []string{
+				"postgres",
+				"-c", "config_file=/etc/postgresql/postgresql.conf",
+				"-c", logMinMessagesCommand.String(),
+			}
 		}
 
 		if _, err := utils.DockerRun(

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -333,7 +333,7 @@ port = %d
 # server_version; on the remote database to check.
 major_version = %d
 # The database minimun log level messages. This has to be changed to prevent csv files from growing too much.
-log_min_messages = %d
+log_min_messages = %s
 
 [studio]
 # Port to use for Supabase Studio.

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -20,6 +20,8 @@ port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 14
+# The database minimun log level messages. This has to be changed to prevent csv files from growing too much.
+log_min_messages = "warning"
 
 [studio]
 # Port to use for Supabase Studio.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -20,6 +20,8 @@ port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 14
+# The database minimun log level messages. This has to be changed to prevent csv files from growing too much.
+log_min_messages = "warning"
 
 [studio]
 # Port to use for Supabase Studio.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

when using `cli` to work with docker locally `postgres` container size growth wildly based on the current desired configuration as detailed below: 
- `log_statement='all'`
- `log_min_messages='warning'`

related: https://github.com/supabase/realtime/issues/231; https://github.com/supabase/supabase/pull/5481; https://github.com/supabase/supabase/issues/5505

## What is the new behavior?

- No new behavior by default. 
- Devs can opt to change min level of messages from configuration. 

## Additional context

### current version (configured with `warning`)
I've no screenshots but I've seen the container size growth up to `11GiBs` after a few days 

### configured with `fatal`

container size
<img width="547" alt="image" src="https://user-images.githubusercontent.com/158487/162357826-69747212-c2d8-402a-808d-e453d62e2280.png">

new command
<img width="355" alt="image" src="https://user-images.githubusercontent.com/158487/162357946-f36bddbe-bc12-4c67-8190-fe8d05aa5f3f.png">


