### PR TITLE
Add 'restart' command

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/start"
+	"github.com/supabase/cli/internal/stop"
+)
+
+var restartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the Supabase local development setup.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stopErr := stop.Run()
+		if stopErr != nil {
+			return stopErr
+		}
+		return start.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(restartCmd)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature! Requested in https://github.com/supabase/cli/issues/234

## What is the current behavior?

Doesn't exist

Please link any relevant issues here.

https://github.com/supabase/cli/issues/234

## What is the new behavior?

Specifying the `restart` command will bring down services, then bring them back up.

Feel free to include screenshots if it includes visual changes.

## Additional context

I also found myself restarting my stack a bit, so I added this feature and have found it useful.
