### PR TITLE
add more descriptive error messages for db push

### DIFF
--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -59,7 +59,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 	conflictErr := errors.New("supabase_migrations.schema_migrations table conflicts with the contents of " + utils.Bold("supabase/migrations") + ".")
 
 	if len(versions) > len(migrations) {
-		return fmt.Errorf("%w; Found " + len(versions) + " versions and " + len(migrations) + " migrations.", err)
+		return fmt.Errorf("%w; Found " + len(versions) + " versions and " + len(migrations) + " migrations.", conflictErr)
 	}
 
 	if !dryRun {
@@ -80,7 +80,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 		} else if versions[i] == migrationTimestamp {
 			continue
 		} else {
-			return fmt.Errorf("%w; Expected version" + versions[i] + " but found migration " + migrationTimestamp + " at index " + i + ".", err)
+			return fmt.Errorf("%w; Expected version" + versions[i] + " but found migration " + migrationTimestamp + " at index " + i + ".", conflictErr)
 		}
 
 		f, err := os.ReadFile("supabase/migrations/" + migration.Name())

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -59,7 +59,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 	conflictErr := errors.New("supabase_migrations.schema_migrations table conflicts with the contents of " + utils.Bold("supabase/migrations") + ".")
 
 	if len(versions) > len(migrations) {
-		return conflictErr
+		return fmt.Errorf("%w; Found " + len(versions) + " versions and " + len(migrations) + " migrations.", err)
 	}
 
 	if !dryRun {
@@ -80,7 +80,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 		} else if versions[i] == migrationTimestamp {
 			continue
 		} else {
-			return conflictErr
+			return fmt.Errorf("%w; Expected version" + versions[i] + " but found migration " + migrationTimestamp + " at index " + i + ".", err)
 		}
 
 		f, err := os.ReadFile("supabase/migrations/" + migration.Name())
@@ -91,7 +91,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 		if err := func() error {
 			tx, err := conn.Begin(ctx)
 			if err != nil {
-				return err
+				return fmt.Errorf("%w; while beginning migration " + migrationTimestamp, err)
 			}
 			defer tx.Rollback(context.Background()) //nolint:errcheck
 
@@ -99,14 +99,14 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 				fmt.Printf("Would apply migration %s:\n%s\n\n---\n\n", migration.Name(), f)
 			} else {
 				if _, err := tx.Exec(ctx, string(f)); err != nil {
-					return err
+					return fmt.Errorf("%w; while executing migration " + migrationTimestamp, err)
 				}
 				if _, err := tx.Exec(ctx, "INSERT INTO supabase_migrations.schema_migrations(version) VALUES('"+migrationTimestamp+"');"); err != nil {
-					return err
+					return fmt.Errorf("%w; while inserting migration " + migrationTimestamp, err)
 				}
 
 				if err := tx.Commit(ctx); err != nil {
-					return err
+					return fmt.Errorf("%w; while committing migration " + migrationTimestamp, err)
 				}
 			}
 

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -59,7 +59,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 	conflictErr := errors.New("supabase_migrations.schema_migrations table conflicts with the contents of " + utils.Bold("supabase/migrations") + ".")
 
 	if len(versions) > len(migrations) {
-		return fmt.Errorf("%w; Found " + len(versions) + " versions and " + len(migrations) + " migrations.", conflictErr)
+		return fmt.Errorf("%w; Found %d versions and %d migrations.", conflictErr, len(versions), len(migrations))
 	}
 
 	if !dryRun {
@@ -80,7 +80,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 		} else if versions[i] == migrationTimestamp {
 			continue
 		} else {
-			return fmt.Errorf("%w; Expected version" + versions[i] + " but found migration " + migrationTimestamp + " at index " + i + ".", conflictErr)
+			return fmt.Errorf("%w; Expected version %s but found migration %s at index %d.", conflictErr, versions[i], migrationTimestamp, i)
 		}
 
 		f, err := os.ReadFile("supabase/migrations/" + migration.Name())
@@ -91,7 +91,7 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 		if err := func() error {
 			tx, err := conn.Begin(ctx)
 			if err != nil {
-				return fmt.Errorf("%w; while beginning migration " + migrationTimestamp, err)
+				return fmt.Errorf("%w; while beginning migration %s", err, migrationTimestamp)
 			}
 			defer tx.Rollback(context.Background()) //nolint:errcheck
 
@@ -99,14 +99,14 @@ Try running `+utils.Aqua("supabase db remote set")+".", err)
 				fmt.Printf("Would apply migration %s:\n%s\n\n---\n\n", migration.Name(), f)
 			} else {
 				if _, err := tx.Exec(ctx, string(f)); err != nil {
-					return fmt.Errorf("%w; while executing migration " + migrationTimestamp, err)
+					return fmt.Errorf("%w; while executing migration %s",err, migrationTimestamp)
 				}
 				if _, err := tx.Exec(ctx, "INSERT INTO supabase_migrations.schema_migrations(version) VALUES('"+migrationTimestamp+"');"); err != nil {
-					return fmt.Errorf("%w; while inserting migration " + migrationTimestamp, err)
+					return fmt.Errorf("%w; while inserting migration %s", err, migrationTimestamp)
 				}
 
 				if err := tx.Commit(ctx); err != nil {
-					return fmt.Errorf("%w; while committing migration " + migrationTimestamp, err)
+					return fmt.Errorf("%w; while committing migration %s", err, migrationTimestamp)
 				}
 			}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - more detailed error messages for `db push`

## What is the current behavior?

It's difficult to tell which migration is causing a problem because the migration logs are overwritten each time.

## What is the new behavior?

Includes the actual error that happened and which migration timestamp it happened on.