### PR TITLE
fix: remove unnecessary exec start call

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -44,10 +44,6 @@ func DockerExec(ctx context.Context, container string, cmd []string) (io.Reader,
 		return nil, err
 	}
 
-	if err := Docker.ContainerExecStart(ctx, exec.ID, types.ExecStartCheck{}); err != nil {
-		return nil, err
-	}
-
 	return resp.Reader, nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: removes second call to start exec

## What is the current behavior?

Currently exec start is called twice in docker utils: once in `ExecAttach` and another one in `ExecStart`

## What is the new behavior?

`ExecStart` call is removed
