### PR TITLE
Support bigger seed.sql files using docker copy

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -206,9 +206,15 @@ EOSQL
 				// skip
 			} else if err != nil {
 				return err
+			}
+
+			err = utils.DockerAddFile(ctx, utils.DbId, "seed.sql", content)
+
+			if err != nil {
+				return err
 			} else {
 				out, err := utils.DockerExec(ctx, utils.DbId, []string{
-					"psql", "postgresql://postgres:postgres@localhost/postgres", "-f", string(content),
+					"psql", "postgresql://postgres:postgres@localhost/postgres", "-f", "/tmp/seed.sql",
 				})
 				if err != nil {
 					return err

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -208,7 +208,7 @@ EOSQL
 				return err
 			} else {
 				out, err := utils.DockerExec(ctx, utils.DbId, []string{
-					"psql", "postgresql://postgres:postgres@localhost/postgres", "-c", string(content),
+					"psql", "postgresql://postgres:postgres@localhost/postgres", "-f", string(content),
 				})
 				if err != nil {
 					return err

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -493,9 +493,15 @@ EOSQL
 						// skip
 					} else if err != nil {
 						return err
+					}
+
+					err = utils.DockerAddFile(ctx, utils.DbId, "seed.sql", content)
+
+					if err != nil {
+						return err
 					} else {
 						out, err := utils.DockerExec(ctx, utils.DbId, []string{
-							"psql", "postgresql://postgres:postgres@localhost/main", "-c", string(content),
+							"psql", "postgresql://postgres:postgres@localhost/main", "-f", "/tmp/seed.sql",
 						})
 						if err != nil {
 							return err

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -109,16 +109,26 @@ func DockerAddFile(ctx context.Context, container string, fileName string, conte
 		Mode: 0777,
 		Size: int64(len(content)),
 	})
+
+	if err != nil {
+		return fmt.Errorf("failed to copy file: %v", err)
+	}
+
 	_, err = tw.Write(content)
+
+	if err != nil {
+		return fmt.Errorf("failed to copy file: %v", err)
+	}
+
 	err = tw.Close()
 
 	if err != nil {
-		return fmt.Errorf("docker copy: %v", err)
+		return fmt.Errorf("failed to copy file: %v", err)
 	}
 
 	err = Docker.CopyToContainer(ctx, container, "/tmp", &buf, types.CopyToContainerOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to copy file: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

For seed.sql files that exceed the maximum argument length of the Linux distribution used to run the Postgres container the `postgres -c` command will fail. Supabase CLI will then silently fail to apply the seed file.

See related [StackOverflow Max size of string CMD that can be passed to Docker](https://stackoverflow.com/a/70738704) answer about command argument sizes. 

https://github.com/supabase/cli/issues/277 (See related comment)
https://github.com/supabase/cli/issues/274 (I think this might be related, but not sure)

## What is the new behavior?

A new Docker utility function DockerAddFile can be used to write a byte buffer to a container, in this case the seed.sql file. Then migrating the seed file is just a matter of using the file option of the `pgsql` command rather than the command option.

## Additional context

Let me know if the code needs some adjustments and if the selected approach is good or not.