### PR TITLE
Gitpod Support

### DIFF
--- a/internal/db/branch/delete/delete.go
+++ b/internal/db/branch/delete/delete.go
@@ -37,7 +37,7 @@ func Run(branch string) error {
 
 	{
 		out, err := utils.DockerExec(context.Background(), utils.DbId, []string{
-			"dropdb", "--username", "postgres", "--host", "localhost", branch,
+			"dropdb", "--username", "postgres", "--host", "127.0.0.1", branch,
 		})
 		if err != nil {
 			return err

--- a/internal/db/changes/changes.go
+++ b/internal/db/changes/changes.go
@@ -70,7 +70,7 @@ func run(p utils.Program) error {
 		out, err := utils.DockerExec(
 			ctx,
 			utils.DbId,
-			[]string{"createdb", "--username", "postgres", "--host", "localhost", utils.ShadowDbName},
+			[]string{"createdb", "--username", "postgres", "--host", "127.0.0.1", utils.ShadowDbName},
 		)
 		if err != nil {
 			return err
@@ -205,7 +205,7 @@ func cleanup() {
 	_, _ = utils.DockerExec(
 		context.Background(),
 		utils.DbId,
-		[]string{"dropdb", "--username", "postgres", "--host", "localhost", utils.ShadowDbName},
+		[]string{"dropdb", "--username", "postgres", "--host", "127.0.0.1", utils.ShadowDbName},
 	)
 }
 

--- a/internal/db/commit/commit.go
+++ b/internal/db/commit/commit.go
@@ -74,7 +74,7 @@ func run(p utils.Program, name string) error {
 		out, err := utils.DockerExec(
 			ctx,
 			utils.DbId,
-			[]string{"createdb", "--username", "postgres", "--host", "localhost", utils.ShadowDbName},
+			[]string{"createdb", "--username", "postgres", "--host", "127.0.0.1", utils.ShadowDbName},
 		)
 		if err != nil {
 			return err
@@ -211,7 +211,7 @@ func cleanup() {
 	_, _ = utils.DockerExec(
 		context.Background(),
 		utils.DbId,
-		[]string{"dropdb", "--username", "postgres", "--host", "localhost", utils.ShadowDbName},
+		[]string{"dropdb", "--username", "postgres", "--host", "127.0.0.1", utils.ShadowDbName},
 	)
 }
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -296,7 +296,7 @@ func run(p utils.Program) error {
 
 		out, err := utils.DockerExec(ctx, utils.DbId, []string{
 			"sh", "-c", "until pg_isready --host $(hostname --ip-address); do sleep 0.1; done " +
-				`&& psql --username postgres --host localhost <<'EOSQL'
+				`&& psql --username postgres --host 127.0.0.1 <<'EOSQL'
 BEGIN;
 ` + utils.GlobalsSql + `
 COMMIT;
@@ -306,6 +306,7 @@ EOSQL
 		if err != nil {
 			return err
 		}
+
 		var errBuf bytes.Buffer
 		if _, err := stdcopy.StdCopy(io.Discard, &errBuf, out); err != nil {
 			return err
@@ -334,7 +335,7 @@ EOSQL
 					}
 
 					out, err := utils.DockerExec(ctx, utils.DbId, []string{
-						"sh", "-c", `psql --set ON_ERROR_STOP=on postgresql://postgres:postgres@localhost/postgres <<'EOSQL'
+						"sh", "-c", `psql --set ON_ERROR_STOP=on --host 127.0.0.1 postgresql://postgres:postgres@localhost/postgres <<'EOSQL'
 CREATE DATABASE "` + branch.Name() + `";
 \connect ` + branch.Name() + `
 BEGIN;
@@ -376,7 +377,7 @@ EOSQL
 			if err := func() error {
 				{
 					out, err := utils.DockerExec(ctx, utils.DbId, []string{
-						"createdb", "--username", "postgres", "--host", "localhost", "main",
+						"createdb", "--username", "postgres", "--host", "127.0.0.1", "main",
 					})
 					if err != nil {
 						return err
@@ -393,7 +394,7 @@ EOSQL
 				p.Send(utils.StatusMsg("Setting up initial schema..."))
 				{
 					out, err := utils.DockerExec(ctx, utils.DbId, []string{
-						"sh", "-c", `PGOPTIONS='--client-min-messages=error' psql postgresql://postgres:postgres@localhost/main <<'EOSQL'
+						"sh", "-c", `PGOPTIONS='--client-min-messages=error' psql --host 127.0.0.1 postgresql://postgres:postgres@localhost/main <<'EOSQL'
 BEGIN;
 ` + utils.InitialSchemaSql + `
 COMMIT;

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -74,7 +74,7 @@ func DockerRun(
 	if err := Docker.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
 		return nil, err
 	}
-	
+
 	return resp.Reader, nil
 }
 

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -74,7 +74,7 @@ func DockerRun(
 	if err := Docker.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
 		return nil, err
 	}
-
+	
 	return resp.Reader, nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We use Gitpod internally and therefore we were eagerly searching for a solution of https://github.com/supabase/cli/issues/268. Due to the fact that we were able to run `supabase` in a Gitpod environment by using the official `docker-compose` [setup](https://github.com/supabase/supabase/tree/bc9992ff15a833b5bb0d9714f876eed668bf2757/docker), we had our Proof of Concept that running supabase within Gitpod is doable. Next, we thought it might be a good idea to look into the `cli` and see if we can make it work there too 🙂 

So, although Gitpod is a containerized environment, it turned out that the culprit is something else. Instead, it looks like the CLI is behaving differently when the environment is using Docker in [Rootless mode](https://docs.docker.com/engine/security/rootless/).

## What is the current behavior?

Using the `supabase` CLI within a Gitpod environment failed as described in https://github.com/supabase/cli/issues/268.

## What is the new behavior?

Compiling a CLI with the changes in this PR leads to a scenario in which all `supabase` commands, like `supabase start`, work as expected.

## Additional context

We also tested the change in a non-containerized environment and it behaves as expected there too. 