### PR TITLE
fix: Create docker client from env config

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -20,6 +20,12 @@ var Docker = func() *client.Client {
 		fmt.Fprintln(os.Stderr, "Failed to initialize Docker client:", err)
 		os.Exit(1)
 	}
+	// Support env (e.g. for mock setup or rootless docker)
+	err = client.FromEnv(docker)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to initialize Docker client:", err)
+		os.Exit(1)
+	}
 	return docker
 }()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Supabase CLI creates a Docker client without reading environment variable configuration such as `DOCKER_HOST`.

Fixes #275. 

## What is the new behavior?

Reads Docker client configuration from environment variables.

## Additional context

Cherrypick/patch client configuration code from  83b133e as suggested by @soedirgo.