### PR TITLE
Update Postgres14 image version

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -176,7 +176,7 @@ func LoadConfig() error {
 			DbImage = "supabase/postgres:13.3.0"
 			InitialSchemaSql = initialSchemaPg13Sql
 		case 14:
-			DbImage = "supabase/postgres:14.1.0.21"
+			DbImage = "supabase/postgres:14.1.0.34"
 			InitialSchemaSql = initialSchemaPg14Sql
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the image version used for Postgres v14 to use the [latest published tag](https://hub.docker.com/r/supabase/postgres/tags).

## Additional context

During local development I encountered a bug with the `pg_graphql` plugin that has already been [fixed upstream](https://github.com/supabase/pg_graphql/pull/154).
I imagine there are other fixes that would be nice to have during local development too.


Thanks, and let me know if this isn't the proper way to update image versions.