### PR TITLE
test: add unit tests for login command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
@@ -13,7 +15,7 @@ var (
 		Use:   "login",
 		Short: "Authenticate using an access token.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := login.Run(); err != nil {
+			if err := login.Run(os.Stdin, afero.NewOsFs()); err != nil {
 				return err
 			}
 

--- a/internal/functions/delete/delete.go
+++ b/internal/functions/delete/delete.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -20,7 +21,7 @@ func Run(slug string, projectRefArg string) error {
 			return err
 		}
 		if _, err := utils.LoadAccessToken(); err != nil && strings.HasPrefix(err.Error(), "Access token not provided. Supply an access token by running") {
-			if err := login.Run(); err != nil {
+			if err := login.Run(os.Stdin, afero.NewOsFs()); err != nil {
 				return err
 			}
 		} else if err != nil {

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -23,7 +24,7 @@ func Run(slug string, projectRefArg string, verifyJWT bool) error {
 	// 1. Sanity checks.
 	{
 		if _, err := utils.LoadAccessToken(); err != nil && strings.HasPrefix(err.Error(), "Access token not provided. Supply an access token by running") {
-			if err := login.Run(); err != nil {
+			if err := login.Run(os.Stdin, afero.NewOsFs()); err != nil {
 				return err
 			}
 		} else if err != nil {

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -43,7 +43,7 @@ func run(fsys afero.Fs) error {
 		}
 	}
 
-	if err := fsys.Mkdir("supabase", 0755); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := utils.MkdirIfNotExistFS(fsys, "supabase"); err != nil {
 		return err
 	}
 

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -48,8 +48,6 @@ func TestInitCommand(t *testing.T) {
 		assert.Error(t, Run(fsys))
 	})
 
-	// TODO: throws error on failure to find git root
-
 	t.Run("appends to git ignore", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
@@ -63,4 +61,6 @@ func TestInitCommand(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, initGitignore, content[1:])
 	})
+
+	// TODO: test all error edge cases around git ignore
 }

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -48,6 +48,8 @@ func TestInitCommand(t *testing.T) {
 		assert.Error(t, Run(fsys))
 	})
 
+	// TODO: throws error on failure to find git root
+
 	t.Run("appends to git ignore", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1,0 +1,79 @@
+package login
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func randomToken(t *testing.T) []byte {
+	data := make([]byte, 20)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	token := make([]byte, 44)
+	copy(token, "sbp_")
+	hex.Encode(token[4:], data)
+	return token
+}
+
+func TestLoginCommand(t *testing.T) {
+	t.Run("prompts and validates api token", func(t *testing.T) {
+		// Setup input with random token
+		token := randomToken(t)
+		stdin := bytes.NewBuffer(token)
+		fsys := afero.NewMemMapFs()
+		// Run test
+		assert.NoError(t, Run(stdin, fsys))
+		// Validate saved token
+		home, err := os.UserHomeDir()
+		assert.NoError(t, err)
+		accessToken := filepath.Join(home, ".supabase", "access-token")
+		content, err := afero.ReadFile(fsys, accessToken)
+		assert.NoError(t, err)
+		assert.Equal(t, token, content)
+	})
+
+	t.Run("cancels when no input", func(t *testing.T) {
+		// Setup dependencies
+		stdin := bytes.Buffer{}
+		fsys := afero.MemMapFs{}
+		// Run test
+		assert.NoError(t, Run(&stdin, &fsys))
+	})
+
+	t.Run("throws error on invalid token", func(t *testing.T) {
+		// Setup malformed token
+		stdin := bytes.NewBufferString("malformed")
+		fsys := afero.NewMemMapFs()
+		// Run test
+		assert.Error(t, Run(stdin, fsys))
+	})
+
+	t.Run("throws error on failure to create directory", func(t *testing.T) {
+		// Setup read-only fs
+		token := randomToken(t)
+		stdin := bytes.NewBuffer(token)
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Run test
+		assert.Error(t, Run(stdin, fsys))
+	})
+
+	t.Run("throws error on failure to get home", func(t *testing.T) {
+		// Setup empty home directory
+		token := randomToken(t)
+		stdin := bytes.NewBuffer(token)
+		fsys := afero.NewMemMapFs()
+		// Run test
+		t.Setenv("HOME", "")
+		assert.Error(t, Run(stdin, fsys))
+	})
+
+	// TODO: throws error on failure to save token
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/afero"
 )
 
 // Update initial schemas in internal/utils/templates/initial_schemas when
@@ -151,8 +153,17 @@ func IsBranchNameReserved(branch string) bool {
 	}
 }
 
+// Deprecated: use *FS version instead which allows mocking the filesystem in unit tests
 func MkdirIfNotExist(path string) error {
 	if err := os.Mkdir(path, 0755); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+
+	return nil
+}
+
+func MkdirIfNotExistFS(fsys afero.Fs, path string) error {
+	if err := fsys.Mkdir("supabase", 0755); err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
 

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -153,7 +153,6 @@ func IsBranchNameReserved(branch string) bool {
 	}
 }
 
-// Deprecated: use *FS version instead which allows mocking the filesystem in unit tests
 func MkdirIfNotExist(path string) error {
 	if err := os.Mkdir(path, 0755); err != nil && !errors.Is(err, os.ErrExist) {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

unit tests

## What is the current behavior?

login reads from `os.Stdin` and writes to `~/.supabase/access_token`

## What is the new behavior?

- dependency inject `io.Reader` and `afero.Fs` for unit testing
- refactor regex compilation to a global variable
- generate random token in test cases
- 94.7% coverage

## Additional context

Add any other context or screenshots.
