### PR TITLE
test: create and list project commands

### DIFF
--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -37,7 +37,13 @@ var (
 				return err
 			}
 
-			return create.Run(name, orgId, dbPassword, region, plan)
+			return create.Run(create.RequestParam{
+				Name:   name,
+				OrgId:  orgId,
+				DbPass: dbPassword,
+				Region: region,
+				Plan:   plan,
+			}, afero.NewOsFs())
 		},
 	}
 

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/projects/create"
 	"github.com/supabase/cli/internal/projects/list"
@@ -44,7 +45,7 @@ var (
 		Use:   "list",
 		Short: "List all projects.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list.Run()
+			return list.Run(afero.NewOsFs())
 		},
 	}
 )

--- a/internal/projects/create/create.go
+++ b/internal/projects/create/create.go
@@ -8,11 +8,21 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/projects/list"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(name string, orgId string, dbPassword string, region string, plan string) error {
-	accessToken, err := utils.LoadAccessToken()
+type RequestParam struct {
+	OrgId  string `json:"organization_id"`
+	Name   string `json:"name"`
+	DbPass string `json:"db_pass"`
+	Region string `json:"region"`
+	Plan   string `json:"plan"`
+}
+
+func Run(params RequestParam, fsys afero.Fs) error {
+	accessToken, err := utils.LoadAccessTokenFS(fsys)
 	if err != nil {
 		return err
 	}
@@ -22,18 +32,9 @@ func Run(name string, orgId string, dbPassword string, region string, plan strin
 	}
 
 	// POST request, check errors
-	var project struct {
-		Id   string `json:"id"`
-		Name string `json:"name"`
-	}
+	var project list.Project
 	{
-		jsonBytes, err := json.Marshal(map[string]interface{}{
-			"organization_id": orgId,
-			"name":            name,
-			"db_pass":         dbPassword,
-			"region":          region,
-			"plan":            plan,
-		})
+		jsonBytes, err := json.Marshal(params)
 		if err != nil {
 			return err
 		}

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -9,11 +9,20 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run() error {
-	accessToken, err := utils.LoadAccessToken()
+type Project struct {
+	OrgId     string `json:"organization_id"`
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	Region    string `json:"region"`
+	CreatedAt string `json:"created_at"`
+}
+
+func Run(fsys afero.Fs) error {
+	accessToken, err := utils.LoadAccessTokenFS(fsys)
 	if err != nil {
 		return err
 	}
@@ -43,13 +52,7 @@ func Run() error {
 		return err
 	}
 
-	var projects []struct {
-		OrgId     string `json:"organization_id"`
-		Id        string `json:"id"`
-		Name      string `json:"name"`
-		Region    string `json:"region"`
-		CreatedAt string `json:"created_at"`
-	}
+	var projects []Project
 	if err := json.Unmarshal(body, &projects); err != nil {
 		return err
 	}

--- a/internal/projects/list/list_test.go
+++ b/internal/projects/list/list_test.go
@@ -1,0 +1,88 @@
+package list
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestProjectListCommand(t *testing.T) {
+	t.Run("lists projects", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		// Flush pending mocks after test execution
+		defer gock.Off()
+		gock.New("https://api.supabase.io").
+			Get("/v1/projects").
+			Reply(200).
+			JSON([]Project{
+				{
+					Id:        "bcnzkuicchyuaswrezwk",
+					OrgId:     "combined-fuchsia-lion",
+					Name:      "Test Project",
+					Region:    "us-west-1",
+					CreatedAt: "2022-04-25T02:14:55.906498Z",
+				},
+			})
+		// Run test
+		assert.NoError(t, Run(fsys))
+	})
+
+	t.Run("throws error on failure to load token", func(t *testing.T) {
+		assert.Error(t, Run(afero.NewMemMapFs()))
+	})
+
+	t.Run("throws error on network error", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		// Flush pending mocks after test execution
+		defer gock.Off()
+		gock.New("https://api.supabase.io").
+			Get("/v1/projects").
+			ReplyError(errors.New("network error"))
+		// Run test
+		assert.Error(t, Run(fsys))
+	})
+
+	t.Run("throws error on server unavailable", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		// Flush pending mocks after test execution
+		defer gock.Off()
+		gock.New("https://api.supabase.io").
+			Get("/v1/projects").
+			Reply(500).
+			JSON(map[string]string{"message": "unavailable"})
+		// Run test
+		assert.Error(t, Run(fsys))
+	})
+
+	t.Run("throws error on malformed json", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		// Flush pending mocks after test execution
+		defer gock.Off()
+		gock.New("https://api.supabase.io").
+			Get("/v1/projects").
+			Reply(200).
+			JSON(map[string]string{})
+		// Run test
+		assert.Error(t, Run(fsys))
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

unit test

## What is the current behavior?

not tested

## What is the new behavior?

- 86.2% for create
- 84.8% for list

## Additional context

Might want to try codegen the supabase api client from openapi specs to reduce code and schema duplication. 
