### PR TITLE
fix: use dashboard URL instead of API URL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @soedirgo @sweatybridge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/internal/functions/delete/delete.go
+++ b/internal/functions/delete/delete.go
@@ -59,11 +59,7 @@ func Run(slug string, projectRefArg string) error {
 			return err
 		}
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
-		req, err := http.NewRequest("GET", supabaseAPI+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
+		req, err := http.NewRequest("GET", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
 		if err != nil {
 			return err
 		}
@@ -78,7 +74,7 @@ func Run(slug string, projectRefArg string) error {
 		case http.StatusNotFound: // Function doesn't exist
 			return errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
 		case http.StatusOK: // Function exists
-			req, err := http.NewRequest("DELETE", supabaseAPI+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
+			req, err := http.NewRequest("DELETE", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -122,11 +122,7 @@ Enter your project ref: `)
 			return err
 		}
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
-		req, err := http.NewRequest("GET", supabaseAPI+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
+		req, err := http.NewRequest("GET", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions/"+slug, nil)
 		if err != nil {
 			return err
 		}
@@ -151,7 +147,7 @@ Enter your project ref: `)
 			}
 
 			req, err := http.NewRequest(
-				"POST", supabaseAPI+"/v1/projects/"+projectRef+"/functions", bytes.NewReader(jsonBytes))
+				"POST", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions", bytes.NewReader(jsonBytes))
 			if err != nil {
 				return err
 			}
@@ -180,7 +176,7 @@ Enter your project ref: `)
 			}
 
 			req, err := http.NewRequest(
-				"PATCH", supabaseAPI+"/v1/projects/"+projectRef+"/functions/"+slug, bytes.NewReader(jsonBytes))
+				"PATCH", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions/"+slug, bytes.NewReader(jsonBytes))
 			if err != nil {
 				return err
 			}

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -208,11 +208,7 @@ Enter your project ref: `)
 
 	fmt.Println("Deployed Function " + utils.Aqua(slug) + " on project " + utils.Aqua(projectRef))
 
-	supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-	if supabaseAPI == "" {
-		supabaseAPI = "https://api.supabase.io"
-	}
-	url := fmt.Sprintf("%s/project/%v/functions/%v/details", supabaseAPI, projectRef, data.Id)
+	url := fmt.Sprintf("%s/project/%v/functions/%v/details", utils.GetSupabaseDashboardURL(), projectRef, data.Id)
 	fmt.Println("You can inspect your deployment in the Dashboard: " + url)
 
 	return nil

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -23,11 +22,7 @@ func Run(projectRef string, fsys afero.Fs) error {
 			return err
 		}
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
-		req, err := http.NewRequest("GET", supabaseAPI+"/v1/projects/"+projectRef+"/functions", nil)
+		req, err := http.NewRequest("GET", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/functions", nil)
 		if err != nil {
 			return err
 		}

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -14,8 +14,8 @@ import (
 )
 
 func Run(stdin io.Reader, fsys afero.Fs) error {
-	fmt.Print(`You can generate an access token from https://app.supabase.io/account/tokens.
-Enter your access token: `)
+	fmt.Printf(`You can generate an access token from %s/account/tokens.
+Enter your access token: `, utils.GetSupabaseDashboardURL())
 
 	scanner := bufio.NewScanner(stdin)
 	if !scanner.Scan() {

--- a/internal/secrets/list/list.go
+++ b/internal/secrets/list/list.go
@@ -38,11 +38,7 @@ func Run() error {
 			return err
 		}
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
-		req, err := http.NewRequest("GET", supabaseAPI+"/v1/projects/"+projectRef+"/secrets", nil)
+		req, err := http.NewRequest("GET", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/secrets", nil)
 		if err != nil {
 			return err
 		}

--- a/internal/secrets/set/set.go
+++ b/internal/secrets/set/set.go
@@ -79,11 +79,7 @@ func Run(envFilePath string, args []string) error {
 		}
 		reqBody := bytes.NewReader(secretsBytes)
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
-		req, err := http.NewRequest("POST", supabaseAPI+"/v1/projects/"+projectRef+"/secrets", reqBody)
+		req, err := http.NewRequest("POST", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/secrets", reqBody)
 		if err != nil {
 			return err
 		}

--- a/internal/secrets/unset/unset.go
+++ b/internal/secrets/unset/unset.go
@@ -42,12 +42,8 @@ func Run(args []string) error {
 		}
 		reqBody := bytes.NewReader(secretsNamesBytes)
 
-		supabaseAPI := os.Getenv("SUPABASE_INTERNAL_API_HOST")
-		if supabaseAPI == "" {
-			supabaseAPI = "https://api.supabase.io"
-		}
 		req, err := http.NewRequest(
-			"DELETE", supabaseAPI+"/v1/projects/"+projectRef+"/secrets", reqBody)
+			"DELETE", utils.GetSupabaseAPIHost()+"/v1/projects/"+projectRef+"/secrets", reqBody)
 		if err != nil {
 			return err
 		}

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -1,5 +1,7 @@
 package utils
 
+import "os"
+
 var RegionMap = map[string]string{
 	"ap-northeast-1": "Northeast Asia (Tokyo)",
 	"ap-northeast-2": "Northeast Asia (Seoul)",
@@ -13,4 +15,23 @@ var RegionMap = map[string]string{
 	"sa-east-1":      "South America (São Paulo)",
 	"us-east-1":      "East US (North Virginia)",
 	"us-west-1":      "West US (North California)",
+}
+
+func GetSupabaseAPIHost() string {
+	apiHost := os.Getenv("SUPABASE_INTERNAL_API_HOST")
+	if apiHost == "" {
+		apiHost = "https://api.supabase.io"
+	}
+	return apiHost
+}
+
+func GetSupabaseDashboardURL() string {
+	switch GetSupabaseAPIHost() {
+	case "https://api.supabase.com", "https://api.supabase.io":
+		return "https://app.supabase.com"
+	case "https://api.supabase.green":
+		return "https://app.supabase.green"
+	default:
+		return "http://localhost:8082"
+	}
 }


### PR DESCRIPTION
e.g.
```
❯ SUPABASE_INTERNAL_API_HOST=https://api.supabase.green supabase functions deploy hello
Bundling hello
Deployed Function hello on project [ref]
You can inspect your deployment in the Dashboard: https://api.supabase.green/project/[ref]/functions/[function-id]/details
```
Dashboard URL should be `app.supabase.green` instead of `api.supabase.green`, and `app.supabase.com` instead of `api.supabase.io`.

The API helpers refactor should've been in another PR, but can't resist