### PR TITLE
fix ci workflow run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

- ci workflow to run on main

## Additional context

ci workflow should run on push to main branch as well in order to get coverage badge
