### PR TITLE
chore: adds debug flag for printing postgres messages

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -96,15 +95,10 @@ var (
 		Short: "Set the remote database to push migrations to.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var opts []func(*pgx.ConnConfig)
 			if viper.GetBool("DEBUG") {
-				opts = append(opts, func(config *pgx.ConnConfig) {
-					proxy := debug.NewWithDialFunc(config.DialFunc)
-					config.DialFunc = proxy.DialFunc
-					config.TLSConfig = nil
-				})
+				return set.Run(args[0], afero.NewOsFs(), debug.SetupPGX)
 			}
-			return set.Run(args[0], afero.NewOsFs(), opts...)
+			return set.Run(args[0], afero.NewOsFs())
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 // Passed from `-ldflags`: https://stackoverflow.com/q/11354518.
@@ -20,6 +24,15 @@ func Execute() {
 }
 
 func init() {
+	cobra.OnInitialize(func() {
+		viper.SetEnvPrefix("SUPABASE")
+		viper.AutomaticEnv()
+	})
+	flags := rootCmd.PersistentFlags()
+	flags.Bool("debug", false, "enable debug mode")
+	flags.VisitAll(func(f *pflag.Flag) {
+		viper.BindPFlag(strings.ReplaceAll(f.Name, "-", "_"), flags.Lookup(f.Name))
+	})
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,8 @@ func init() {
 	flags := rootCmd.PersistentFlags()
 	flags.Bool("debug", false, "enable debug mode")
 	flags.VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(strings.ReplaceAll(f.Name, "-", "_"), flags.Lookup(f.Name))
+		key := strings.ReplaceAll(f.Name, "-", "_")
+		_ = viper.BindPFlag(key, flags.Lookup(f.Name))
 	})
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/yuin/goldmark v1.4.11 // indirect

--- a/internal/debug/postgres.go
+++ b/internal/debug/postgres.go
@@ -1,0 +1,155 @@
+package debug
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net"
+	"os"
+
+	"github.com/jackc/pgproto3/v2"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type Proxy struct {
+	dialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+	errChan     chan error
+}
+
+func NewProxy() Proxy {
+	dialer := net.Dialer{}
+	return Proxy{
+		dialContext: dialer.DialContext,
+		errChan:     make(chan error, 1),
+	}
+}
+
+func NewWithDialFunc(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) Proxy {
+	return Proxy{
+		dialContext: dialContext,
+		errChan:     make(chan error, 1),
+	}
+}
+
+func (p *Proxy) DialFunc(ctx context.Context, network, addr string) (net.Conn, error) {
+	serverConn, err := p.dialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	const bufSize = 1024 * 1024
+	ln := bufconn.Listen(bufSize)
+	go func() {
+		defer serverConn.Close()
+		clientConn, _ := ln.Accept()
+		defer clientConn.Close()
+
+		backend := NewBackend(clientConn)
+		frontend := NewFrontend(serverConn)
+		go backend.forward(frontend, p.errChan)
+		go frontend.forward(backend, p.errChan)
+
+		for {
+			if err := <-p.errChan; err != nil {
+				panic(err)
+			}
+		}
+	}()
+
+	return ln.DialContext(ctx)
+}
+
+type Backend struct {
+	*pgproto3.Backend
+	logger *log.Logger
+}
+
+func NewBackend(clientConn net.Conn) Backend {
+	return Backend{
+		pgproto3.NewBackend(pgproto3.NewChunkReader(clientConn), clientConn),
+		log.New(os.Stdout, "PG Recv: ", log.LstdFlags|log.Lmsgprefix),
+	}
+}
+
+func (b *Backend) forward(frontend Frontend, errChan chan error) {
+	startupMessage, err := b.ReceiveStartupMessage()
+	if err != nil {
+		errChan <- err
+		return
+	}
+
+	buf, err := json.Marshal(startupMessage)
+	if err != nil {
+		errChan <- err
+		return
+	}
+	frontend.logger.Println(string(buf))
+
+	if err = frontend.Send(startupMessage); err != nil {
+		errChan <- err
+		return
+	}
+
+	for {
+		msg, err := b.Receive()
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		buf, err := json.Marshal(msg)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		frontend.logger.Println(string(buf))
+
+		if err = frontend.Send(msg); err != nil {
+			errChan <- err
+			return
+		}
+	}
+}
+
+type Frontend struct {
+	*pgproto3.Frontend
+	logger *log.Logger
+}
+
+func NewFrontend(serverConn net.Conn) Frontend {
+	return Frontend{
+		pgproto3.NewFrontend(pgproto3.NewChunkReader(serverConn), serverConn),
+		log.New(os.Stdout, "PG Send: ", log.LstdFlags|log.Lmsgprefix),
+	}
+}
+
+func (f *Frontend) forward(backend Backend, errChan chan error) {
+	for {
+		msg, err := f.Receive()
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		buf, err := json.Marshal(msg)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		backend.logger.Println(string(buf))
+
+		if _, ok := msg.(pgproto3.AuthenticationResponseMessage); ok {
+			// Set the authentication type so the next backend.Receive() will
+			// properly decode the appropriate 'p' message.
+			if err := backend.SetAuthType(f.GetAuthType()); err != nil {
+				errChan <- err
+				return
+			}
+		}
+
+		if err := backend.Send(msg); err != nil {
+			errChan <- err
+			return
+		}
+	}
+}

--- a/internal/debug/postgres_test.go
+++ b/internal/debug/postgres_test.go
@@ -1,0 +1,31 @@
+package debug
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/pgtest"
+)
+
+func TestPostgresProxy(t *testing.T) {
+	const postgresUrl = "postgresql://postgres:password@localhost:5432/postgres"
+
+	t.Run("forwards messages between frontend and backend", func(t *testing.T) {
+		// Parse connection url
+		config, err := pgx.ParseConfig(postgresUrl)
+		require.NoError(t, err)
+		// Setup postgres mock
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Intercept(config)
+		// Run test
+		SetupPGX(config)
+		ctx := context.Background()
+		proxy, err := pgx.ConnectConfig(ctx, config)
+		assert.NoError(t, err)
+		assert.NoError(t, proxy.Close(ctx))
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

a global debug flag

## What is the current behavior?

no debug logging

## What is the new behavior?

- adds `SUPABASE_DEBUG=1` env var and `--debug` flag
- prints postgres messages to stderr when debugging

Example
```bash
$ supabase --debug db remote set "postgresql://postgres:password@localhost:5432/postgres"
...
2022/08/01 13:21:14 PG Recv: {"Type":"DataRow","Values":[{"text":"20220729102259"}]}
2022/08/01 13:21:14 PG Recv: {"Type":"CommandComplete","CommandTag":"SELECT 1"}
2022/08/01 13:21:14 PG Recv: {"Type":"ReadyForQuery","TxStatus":"I"}
Error: The remote database was set up with a different Supabase CLI project.
```

## Additional context

Add any other context or screenshots.
