### PR TITLE
fix(functions/deploy): pin deno version for now

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -89,7 +89,7 @@ Enter your project ref: `, utils.GetSupabaseDashboardURL())
 			}
 		}
 
-		cmd := exec.Command(denoPath, "bundle", "--quiet", functionPath+"/index.ts")
+		cmd := exec.Command(denoPath, "bundle", "--no-check=remote", "--quiet", functionPath+"/index.ts")
 		var outBuf, errBuf bytes.Buffer
 		cmd.Stdout = &outBuf
 		cmd.Stderr = &errBuf

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -226,7 +226,7 @@ func InstallOrUpgradeDeno() error {
 	if _, err := os.Stat(denoPath); err == nil {
 		// Upgrade Deno.
 
-		cmd := exec.Command(denoPath, "upgrade")
+		cmd := exec.Command(denoPath, "upgrade", "--version", "1.20.3")
 		if err := cmd.Run(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes: https://github.com/supabase/supabase/issues/7878

Latest Deno version's bundling is having some issues - downgrade to 1.20.3 for now, and later we can switch back to `latest` and use ESZip