### PR TITLE
feat: add db test command using pgtap

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -158,7 +158,8 @@ var (
 		Use:   "test",
 		Short: "Tests local database with pgTAP.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return test.Run(afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return test.Run(ctx, afero.NewOsFs())
 		},
 	}
 )

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -150,7 +150,8 @@ var (
 		Use:   "lint",
 		Short: "Checks local database for typing error",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return lint.Run(cmd.Context(), schema, level.Value, afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return lint.Run(ctx, schema, level.Value, afero.NewOsFs())
 		},
 	}
 

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/supabase/cli/internal/db/remote/changes"
 	"github.com/supabase/cli/internal/db/remote/commit"
 	"github.com/supabase/cli/internal/db/reset"
+	"github.com/supabase/cli/internal/db/test"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -151,6 +152,14 @@ var (
 			return lint.Run(cmd.Context(), schema, level.Value, afero.NewOsFs())
 		},
 	}
+
+	dbTestCmd = &cobra.Command{
+		Use:   "test",
+		Short: "Tests local database with pgTAP.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return test.Run(afero.NewOsFs())
+		},
+	}
 )
 
 func init() {
@@ -186,5 +195,7 @@ func init() {
 	lintFlags.StringSliceVarP(&schema, "schema", "s", []string{"public"}, "List of schema to include.")
 	lintFlags.Var(&level, "level", "Error level to emit.")
 	dbCmd.AddCommand(dbLintCmd)
+	// Build test command
+	dbCmd.AddCommand(dbTestCmd)
 	rootCmd.AddCommand(dbCmd)
 }

--- a/internal/db/branch/switch_/switch_.go
+++ b/internal/db/branch/switch_/switch_.go
@@ -65,7 +65,7 @@ func switchDatabase(ctx context.Context, source, target string, options ...func(
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(context.Background())
 	if err := reset.DisconnectClients(ctx, conn); err != nil {
 		return err
 	}

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -103,7 +103,7 @@ func ApplyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(context.Background())
 	// Apply migrations
 	if migrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil {
 		for i, migration := range migrations {

--- a/internal/db/lint/lint.go
+++ b/internal/db/lint/lint.go
@@ -51,7 +51,7 @@ func Run(ctx context.Context, schema []string, level string, fsys afero.Fs, opts
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(context.Background())
 	result, err := LintDatabase(ctx, conn, schema)
 	if err != nil {
 		return err

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -95,7 +95,7 @@ func SeedDatabase(ctx context.Context, url string, fsys afero.Fs, options ...fun
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(context.Background())
 	// Batch seed commands, safe to use statement cache
 	batch := pgx.Batch{}
 	lines, err := parser.Split(sql)
@@ -130,7 +130,7 @@ func ActivateDatabase(ctx context.Context, branch string, options ...func(*pgx.C
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(context.Background())
 	if err := DisconnectClients(ctx, conn); err != nil {
 		return err
 	}

--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -4,13 +4,13 @@
 apt-get -qq update && apt-get -qq install postgresql-14-pgtap
 
 # run postgres unit tests
-pg_prove -h localhost -U postgres "$TEST_DIR"
+pg_prove -h localhost -U postgres "$@"
 
 cleanup() {
     # save the return code of the script
     status=$?
     # clean up test files
-    rm -rf "$TEST_DIR"
+    rm -rf "$@"
     # actually quit
     exit $status
 }

--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -1,14 +1,25 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 
-# move this dependency to base image
-apt-get -qq update && apt-get -qq install postgresql-14-pgtap
+# TODO: move this dependency to base image
+if ! command -v pg_prove &> /dev/null; then
+    apt-get -qq update && apt-get -qq install postgresql-14-pgtap
+fi
+
+# temporarily enable pgtap
+enable="create extension if not exists pgtap with schema extensions"
+notice=$(psql -h localhost -U postgres -p 5432 -d postgres -c "$enable" 2>&1 >/dev/null)
 
 # run postgres unit tests
-pg_prove -h localhost -U postgres "$@"
+pg_prove -h localhost -U postgres -r "$@"
 
 cleanup() {
     # save the return code of the script
     status=$?
+    # disable pgtap
+    if [ -z "$notice" ]; then
+        psql -h localhost -U postgres -p 5432 -d postgres -c "drop extension if exists pgtap"
+    fi
     # clean up test files
     rm -rf "$@"
     # actually quit

--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # move this dependency to base image
-apt-get -qq install postgresql-14-pgtap
+apt-get -qq update && apt-get -qq install postgresql-14-pgtap
 
 # run postgres unit tests
 pg_prove -h localhost -U postgres "$TEST_DIR"

--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -16,7 +16,7 @@ pg_prove -h localhost -U postgres -r "$@"
 cleanup() {
     # save the return code of the script
     status=$?
-    # disable pgtap
+    # disable pgtap if previously not enabled
     if [ -z "$notice" ]; then
         psql -h localhost -U postgres -p 5432 -d postgres -c "drop extension if exists pgtap"
     fi

--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# move this dependency to base image
+apt-get -qq install postgresql-14-pgtap
+
+# run postgres unit tests
+pg_prove -h localhost -U postgres "$TEST_DIR"
+
+cleanup() {
+    # save the return code of the script
+    status=$?
+    # clean up test files
+    rm -rf "$TEST_DIR"
+    # actually quit
+    exit $status
+}
+
+trap cleanup EXIT

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -101,7 +101,7 @@ func compress(src string, buf io.Writer, fsys afero.Fs) error {
 	tw := tar.NewWriter(buf)
 
 	// walk through every file in the folder
-	afero.Walk(fsys, src, func(file string, fi os.FileInfo, err error) error {
+	if err := afero.Walk(fsys, src, func(file string, fi os.FileInfo, err error) error {
 		// return on any error
 		if err != nil {
 			fmt.Println(err)
@@ -145,7 +145,9 @@ func compress(src string, buf io.Writer, fsys afero.Fs) error {
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	// produce tar
 	if err := tw.Close(); err != nil {

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -101,9 +101,10 @@ func compress(src string, buf io.Writer, fsys afero.Fs) error {
 	tw := tar.NewWriter(buf)
 
 	// walk through every file in the folder
-	filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+	afero.Walk(fsys, src, func(file string, fi os.FileInfo, err error) error {
 		// return on any error
 		if err != nil {
+			fmt.Println(err)
 			return err
 		}
 

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -1,0 +1,154 @@
+package test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+)
+
+const (
+	testDir = "supabase/tests"
+)
+
+var (
+	//go:embed templates/test.sh
+	testScript string
+)
+
+func Run(fsys afero.Fs) error {
+	// Sanity checks.
+	{
+		if err := utils.AssertSupabaseStartIsRunning(); err != nil {
+			return err
+		}
+	}
+
+	ctx := context.Background()
+	// Trap Ctrl+C and call cancel on the context:
+	// https://medium.com/@matryer/make-ctrl-c-cancel-the-context-context-bd006a8ad6ff
+	ctx, cancel := context.WithCancel(ctx)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer func() {
+		signal.Stop(c)
+		cancel()
+	}()
+	go func() {
+		select {
+		case <-c:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	var buf bytes.Buffer
+	if err := compress(testDir, &buf, fsys); err != nil {
+		return err
+	}
+	dstPath := "/tmp"
+	if err := utils.Docker.CopyToContainer(ctx, utils.DbId, dstPath, &buf, types.CopyToContainerOptions{}); err != nil {
+		return err
+	}
+
+	exec, err := utils.Docker.ContainerExecCreate(ctx, utils.DbId, types.ExecConfig{
+		Cmd:          []string{"/bin/sh", "-c", testScript},
+		Env:          []string{"TEST_DIR=" + testDir},
+		WorkingDir:   dstPath,
+		AttachStderr: true,
+		AttachStdout: true,
+	})
+	if err != nil {
+		return err
+	}
+	// Read exec output
+	resp, err := utils.Docker.ContainerExecAttach(ctx, exec.ID, types.ExecStartCheck{})
+	if err != nil {
+		return err
+	}
+	// Capture error details
+	var errBuf bytes.Buffer
+	var outBuf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&outBuf, &errBuf, resp.Reader); err != nil {
+		return err
+	}
+	fmt.Println(outBuf.String())
+	// Get the exit code
+	iresp, err := utils.Docker.ContainerExecInspect(ctx, exec.ID)
+	if err != nil {
+		return err
+	}
+	if iresp.ExitCode > 0 {
+		return errors.New("unit tests failed " + errBuf.String())
+	}
+	return nil
+}
+
+// Ref 1: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07
+// Ref 2: https://gist.github.com/mimoo/25fc9716e0f1353791f5908f94d6e726
+func compress(src string, buf io.Writer, fsys afero.Fs) error {
+	tw := tar.NewWriter(buf)
+
+	// walk through every file in the folder
+	filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+		// return on any error
+		if err != nil {
+			return err
+		}
+
+		// return on non-regular files
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		// create a new dir/file header
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return err
+		}
+
+		// must provide real name
+		header.Name = filepath.ToSlash(file)
+
+		// write the header
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// open files for taring
+		f, err := fsys.Open(file)
+		if err != nil {
+			return err
+		}
+
+		// copy file data into tar writer
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+
+		// manually close here after each file operation; defering would cause each file close
+		// to wait until all operations have completed.
+		if err := f.Close(); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// produce tar
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/db/test/test_test.go
+++ b/internal/db/test/test_test.go
@@ -1,0 +1,9 @@
+package test
+
+import "testing"
+
+func TestPGTAP(t *testing.T) {
+	t.Run("unit tests run", func(t *testing.T) {
+
+	})
+}

--- a/internal/db/test/test_test.go
+++ b/internal/db/test/test_test.go
@@ -1,9 +1,23 @@
 package test
 
-import "testing"
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
 
-func TestPGTAP(t *testing.T) {
-	t.Run("unit tests run", func(t *testing.T) {
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
+func TestTarDirectory(t *testing.T) {
+	t.Run("tars a given directory", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		dir := "/tests"
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(dir, "order_test.pg"), []byte("SELECT 0;"), 0644))
+		// Run test
+		var buf bytes.Buffer
+		assert.NoError(t, compress(dir, &buf, fsys))
 	})
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -61,6 +61,7 @@ DO 'BEGIN WHILE (
 	CurrBranchPath = "supabase/.branches/_current_branch"
 	MigrationsDir  = "supabase/migrations"
 	FunctionsDir   = "supabase/functions"
+	DbTestsDir     = "supabase/tests"
 	SeedDataPath   = "supabase/seed.sql"
 )
 

--- a/internal/utils/templates/initial_schemas/14.sql
+++ b/internal/utils/templates/initial_schemas/14.sql
@@ -104,6 +104,20 @@ COMMENT ON EXTENSION pgjwt IS 'JSON Web Token API for Postgresql';
 
 
 --
+-- Name: pgtap; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+
+--
+-- Name: EXTENSION pgtap; Type: COMMENT; Schema: -; Owner:
+--
+
+COMMENT ON EXTENSION pgtap IS 'Unit testing for PostgreSQL';
+
+
+--
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 

--- a/internal/utils/templates/initial_schemas/14.sql
+++ b/internal/utils/templates/initial_schemas/14.sql
@@ -150,20 +150,6 @@ COMMENT ON EXTENSION pgjwt IS 'JSON Web Token API for Postgresql';
 
 
 --
--- Name: pgtap; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
-
-
---
--- Name: EXTENSION pgtap; Type: COMMENT; Schema: -; Owner:
---
-
-COMMENT ON EXTENSION pgtap IS 'Unit testing for PostgreSQL';
-
-
---
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: `supabase db test`

## What is the current behavior?

no cli native way to run tests

## What is the new behavior?

- installs `pg_prove` on `supabase_db_cli` container once
- copies `supabase/tests` into `supabase_db_cli` container
- enable pgtap extension temporarily
- runs `pg_prove` via docker exec and prints out results

## Additional context

Example `order_test.pg`
```sql
BEGIN;
SELECT plan(1);

SELECT has_column(
    'public',
    'order',
    'status',
    'status should exist'
);

SELECT * FROM finish();
ROLLBACK;
```

Output
```bash
$ supabase db test
supabase/tests/order_test.pg .. ok
supabase/tests/pet_test.pg .... ok
All tests successful.
Files=2, Tests=2,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.02 csys =  0.07 CPU)
Result: PASS
```