### PR TITLE
feat: allow configuring migra schema diff

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -63,6 +63,7 @@ var (
 	}
 
 	useMigra bool
+	schema   string
 
 	dbCommitCmd = &cobra.Command{
 		Use:   "commit <migration name>",
@@ -70,7 +71,7 @@ var (
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if useMigra {
-				return commit.RunMigra(args[0], afero.NewOsFs())
+				return commit.RunMigra(args[0], schema, afero.NewOsFs())
 			}
 			return commit.Run(args[0])
 		},
@@ -143,6 +144,7 @@ func init() {
 	dbCmd.AddCommand(dbBranchCmd)
 	dbCmd.AddCommand(dbChangesCmd)
 	dbCommitCmd.Flags().BoolVar(&useMigra, "migra", false, "Use migra to generate schema diff.")
+	dbCommitCmd.Flags().StringVarP(&schema, "schema", "s", "public", "The schema to diff (defaults to public).")
 	dbCmd.AddCommand(dbCommitCmd)
 	dbPushCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	dbCmd.AddCommand(dbPushCmd)

--- a/internal/db/commit/templates/migra.sh
+++ b/internal/db/commit/templates/migra.sh
@@ -9,4 +9,4 @@ sed -i 's/  and e.objid is null/  -- and e.objid is null/g' \
 /usr/local/lib/python3.9/site-packages/schemainspect/pg/sql/enums.sql
 
 # diff public schema only
-migra --unsafe --schema=public "$SOURCE" "$TARGET"
+migra --unsafe --schema="${SCHEMA:public}" "$SOURCE" "$TARGET"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

only `public` schema is diffed by migra

## What is the new behavior?

exposes a `-s` or `--schema` flag
```bash
$ supabase db commit --migra --schema extensions my_ext
```

## Additional context

Generates `20220804072957_my_ext.sql`

```sql
create extension if not exists "pgtap" with schema "extensions" version '1.1.0';

create type "extensions"."_time_trial_type" as ("a_time" numeric);
```
