### PR TITLE
fix: branch creation failure after init

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -33,7 +33,7 @@ var (
 		Short: "Create a branch.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return create.Run(args[0])
+			return create.Run(args[0], afero.NewOsFs())
 		},
 	}
 

--- a/internal/db/branch/create/create.go
+++ b/internal/db/branch/create/create.go
@@ -3,19 +3,25 @@ package create
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"regexp"
+	"path/filepath"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-var ctx = context.Background()
+var (
+	//go:embed templates/clone.sh
+	cloneScript string
+)
 
-func Run(branch string) error {
+func Run(branch string, fsys afero.Fs) error {
 	if err := utils.AssertSupabaseStartIsRunning(); err != nil {
 		return err
 	}
@@ -24,13 +30,12 @@ func Run(branch string) error {
 		return errors.New("Cannot create branch " + utils.Aqua(branch) + ": branch name is reserved.")
 	}
 
-	if valid, err := regexp.MatchString(`[[:word:]-]+`, branch); err != nil {
-		return err
-	} else if !valid {
+	if !utils.BranchNamePattern.MatchString(branch) {
 		return errors.New("Branch name " + utils.Aqua(branch) + " is invalid. Must match [0-9A-Za-z_-]+.")
 	}
 
-	if _, err := os.ReadDir("supabase/.branches/" + branch); errors.Is(err, os.ErrNotExist) {
+	branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
+	if _, err := afero.ReadDir(fsys, branchPath); errors.Is(err, os.ErrNotExist) {
 		// skip
 	} else if err != nil {
 		return err
@@ -38,56 +43,36 @@ func Run(branch string) error {
 		return errors.New("Branch " + utils.Aqua(branch) + " already exists.")
 	}
 
-	var dumpBuf bytes.Buffer
-	if err := func() error {
-		out, err := utils.DockerExec(ctx, utils.DbId, []string{
-			"pg_dump", "postgresql://postgres:postgres@localhost/postgres",
-		})
-		if err != nil {
-			return err
-		}
-
-		var errBuf bytes.Buffer
-		if _, err := stdcopy.StdCopy(&dumpBuf, &errBuf, out); err != nil {
-			return err
-		}
-		if errBuf.Len() > 0 {
-			return errors.New(errBuf.String())
-		}
-
-		return nil
-	}(); err != nil {
-		return fmt.Errorf("Error creating branch: %w", err)
+	var ctx = context.Background()
+	exec, err := utils.Docker.ContainerExecCreate(ctx, utils.DbId, types.ExecConfig{
+		Cmd:          []string{"/bin/bash", "-c", cloneScript},
+		Env:          []string{"DB_NAME=" + branch},
+		AttachStderr: true,
+		AttachStdout: true,
+	})
+	if err != nil {
+		return err
+	}
+	// Read exec output
+	resp, err := utils.Docker.ContainerExecAttach(ctx, exec.ID, types.ExecStartCheck{})
+	if err != nil {
+		return err
+	}
+	// Capture error details
+	var errBuf bytes.Buffer
+	if _, err := stdcopy.StdCopy(io.Discard, &errBuf, resp.Reader); err != nil {
+		return err
+	}
+	// Get the exit code
+	iresp, err := utils.Docker.ContainerExecInspect(ctx, exec.ID)
+	if err != nil {
+		return err
+	}
+	if iresp.ExitCode > 0 {
+		return errors.New("Error creating branch: " + errBuf.String())
 	}
 
-	if err := func() error {
-		out, err := utils.DockerExec(ctx, utils.DbId, []string{
-			"sh", "-c", `psql --set ON_ERROR_STOP=on postgresql://postgres:postgres@localhost/postgres <<'EOSQL'
-CREATE DATABASE "` + branch + `";
-\connect ` + branch + `
-BEGIN;
-` + dumpBuf.String() + `
-COMMIT;
-EOSQL
-`,
-		})
-		if err != nil {
-			return err
-		}
-		var errBuf bytes.Buffer
-		if _, err := stdcopy.StdCopy(io.Discard, &errBuf, out); err != nil {
-			return err
-		}
-		if errBuf.Len() > 0 {
-			return errors.New(errBuf.String())
-		}
-
-		return nil
-	}(); err != nil {
-		return fmt.Errorf("Error creating branch %s: %w", utils.Aqua(branch), err)
-	}
-
-	if err := os.Mkdir("supabase/.branches/"+branch, 0755); err != nil {
+	if err := fsys.MkdirAll(branchPath, 0755); err != nil {
 		return err
 	}
 

--- a/internal/db/branch/create/create_test.go
+++ b/internal/db/branch/create/create_test.go
@@ -1,0 +1,113 @@
+package create
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestBranchValidation(t *testing.T) {
+	t.Run("branch name is valid", func(t *testing.T) {
+		assert.NoError(t, assertNewBranchIsValid("test-branch", afero.NewMemMapFs()))
+	})
+
+	t.Run("branch name is reserved", func(t *testing.T) {
+		assert.Error(t, assertNewBranchIsValid("main", afero.NewMemMapFs()))
+	})
+
+	t.Run("branch name is invalid", func(t *testing.T) {
+		assert.Error(t, assertNewBranchIsValid("@", afero.NewMemMapFs()))
+	})
+
+	t.Run("branch not a directory", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		path := "/supabase/.branches/test-branch"
+		_, err := fsys.Create(path)
+		require.NoError(t, err)
+		// Run test
+		assert.Error(t, assertNewBranchIsValid(path, fsys))
+	})
+
+	t.Run("branch already exists", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		path := "/supabase/.branches/test-branch"
+		require.NoError(t, fsys.MkdirAll(path, 0755))
+		// Run test
+		assert.Error(t, assertNewBranchIsValid(path, fsys))
+	})
+}
+
+func TestBranchCreation(t *testing.T) {
+	const version = "1.41"
+	utils.DbId = "test-db"
+
+	t.Run("docker exec failure", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.Off()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers/" + utils.DbId + "/exec").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		assert.Error(t, createBranch(context.Background(), "test-branch"))
+	})
+
+	t.Run("docker attach failure", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.Off()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers/" + utils.DbId + "/exec").
+			Reply(http.StatusCreated).
+			JSON(types.ContainerJSON{})
+		// Run test
+		assert.Error(t, createBranch(context.Background(), "test-branch"))
+	})
+}
+
+func TestCreateCommand(t *testing.T) {
+	const (
+		version = "v1.41"
+		branch  = "test-branch"
+	)
+
+	t.Run("throws error on missing config", func(t *testing.T) {
+		assert.Error(t, Run(branch, afero.NewMemMapFs()))
+	})
+
+	t.Run("throws error on stopped db", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := &afero.MemMapFs{}
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.Off()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		// Run test
+		assert.Error(t, Run(branch, fsys))
+	})
+}

--- a/internal/db/branch/create/templates/clone.sh
+++ b/internal/db/branch/create/templates/clone.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+createdb --username postgres --host 127.0.0.1 "$DB_NAME"
+pg_dump --username postgres --host 127.0.0.1 postgres | psql --username postgres --host 127.0.0.1 "$DB_NAME"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -64,6 +64,7 @@ var (
 	ProjectRefPattern  = regexp.MustCompile(`^[a-z]{20}$`)
 	PostgresUrlPattern = regexp.MustCompile(`^postgres(?:ql)?://postgres:(.+)@(.+?)(:\d+)?/postgres$`)
 	MigrateFilePattern = regexp.MustCompile(`([0-9]+)_.*\.sql`)
+	BranchNamePattern  = regexp.MustCompile(`[[:word:]-]+`)
 )
 
 func GetCurrentTimestamp() string {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -127,6 +127,14 @@ func AssertSupabaseStartIsRunning() error {
 	return nil
 }
 
+func AssertSupabaseDbIsRunning() error {
+	if _, err := Docker.ContainerInspect(context.Background(), DbId); err != nil {
+		return errors.New(Aqua("supabase start") + " is not running.")
+	}
+
+	return nil
+}
+
 func GetGitRoot() (*string, error) {
 	origWd, err := os.Getwd()
 	if err != nil {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -120,11 +120,7 @@ func AssertSupabaseStartIsRunning() error {
 		return err
 	}
 
-	if _, err := Docker.ContainerInspect(context.Background(), DbId); err != nil {
-		return errors.New(Aqua("supabase start") + " is not running.")
-	}
-
-	return nil
+	return AssertSupabaseDbIsRunning()
 }
 
 func AssertSupabaseDbIsRunning() error {

--- a/test/branch_test.go
+++ b/test/branch_test.go
@@ -1,8 +1,10 @@
 package integration
 
 import (
+	"encoding/json"
 	"os"
 
+	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,10 +31,9 @@ func (suite *DBTestSuite) TestBranchCreate() {
 	require.ElementsMatch(suite.T(), suite.params, ids)
 
 	// check commands in exec calls
-	require.ElementsMatch(suite.T(), suite.bodies, []string{
-		"{\"User\":\"\",\"Privileged\":false,\"Tty\":false,\"AttachStdin\":false,\"AttachStderr\":true,\"AttachStdout\":true,\"Detach\":false,\"DetachKeys\":\"\",\"Env\":null,\"WorkingDir\":\"\",\"Cmd\":[\"pg_dump\",\"postgresql://postgres:postgres@localhost/postgres\"]}\n",
-		"{\"Detach\":false,\"Tty\":false}\n",
-		"{\"User\":\"\",\"Privileged\":false,\"Tty\":false,\"AttachStdin\":false,\"AttachStderr\":true,\"AttachStdout\":true,\"Detach\":false,\"DetachKeys\":\"\",\"Env\":null,\"WorkingDir\":\"\",\"Cmd\":[\"sh\",\"-c\",\"psql --set ON_ERROR_STOP=on postgresql://postgres:postgres@localhost/postgres \\u003c\\u003c'EOSQL'\\nCREATE DATABASE \\\"" + branch + "\\\";\\n\\\\connect " + branch + "\\nBEGIN;\\nexit code 0\\nCOMMIT;\\nEOSQL\\n\"]}\n",
-		"{\"Detach\":false,\"Tty\":false}\n",
-	})
+	require.Equal(suite.T(), 2, len(suite.bodies))
+	var execBody types.ExecConfig
+	require.NoError(suite.T(), json.Unmarshal([]byte(suite.bodies[0]), &execBody))
+	var startBody types.ExecStartCheck
+	require.NoError(suite.T(), json.Unmarshal([]byte(suite.bodies[1]), &startBody))
 }

--- a/test/mocks/docker/server.go
+++ b/test/mocks/docker/server.go
@@ -49,6 +49,7 @@ func (s *Server) NewRouter() *gin.Engine {
 
 	exec := router.Group("/exec")
 	exec.POST("/:id/start", s.startExec)
+	exec.GET("/:id/json", s.inspectContainer)
 
 	return root
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

part 1 for fixing https://github.com/supabase/cli/issues/321

## What is the current behavior?

branch create fails if `supabase start` is not run.

## What is the new behavior?

- allow `supabase db branch create` to succeed by using `MkdirAll`.

## Additional context

Add any other context or screenshots.
