### PR TITLE
feat(db remote commit): pg_dump special case

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -12,11 +12,6 @@ import (
 )
 
 var (
-	// pg_dumpall --globals-only --no-role-passwords --dbname $DB_URL \
-	// | sed '/^CREATE ROLE postgres;/d' \
-	// | sed '/^ALTER ROLE postgres WITH /d' \
-	// | sed "/^ALTER ROLE .* WITH .* LOGIN /s/;$/ PASSWORD 'postgres';/"
-	// pg_dump --dbname $DB_URL
 	//go:embed templates/init_gitignore
 	initGitignore []byte
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -526,7 +526,7 @@ EOSQL
 		// Set up current branch.
 		{
 			out, err := utils.DockerExec(ctx, utils.DbId, []string{
-				"sh", "-c", `psql --set ON_ERROR_STOP=on postgresql://postgres:postgres@localhost/template1 <<'EOSQL'
+				"sh", "-c", `PGOPTIONS='--client-min-messages=error' psql --set ON_ERROR_STOP=on postgresql://postgres:postgres@localhost/template1 <<'EOSQL'
 BEGIN;
 ` + fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres") + `
 COMMIT;

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -184,7 +184,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 			DbImage = "supabase/postgres:13.3.0"
 			InitialSchemaSql = initialSchemaPg13Sql
 		case 14:
-			DbImage = "supabase/postgres:14.1.0.21"
+			DbImage = "supabase/postgres:14.1.0.34"
 			InitialSchemaSql = initialSchemaPg14Sql
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)

--- a/internal/utils/container_output.go
+++ b/internal/utils/container_output.go
@@ -162,8 +162,7 @@ func filterDiffOutput(diffBytes []byte) ([]byte, error) {
 		}
 
 		isSchemaIgnored := func(schema string) bool {
-			ignoredSchemas := []string{"auth", "extensions", "pgbouncer", "realtime", "storage", "supabase_functions", "supabase_migrations"}
-			for _, s := range ignoredSchemas {
+			for _, s := range InternalSchemas {
 				if s == schema {
 					return true
 				}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -69,6 +69,9 @@ var (
 	PostgresUrlPattern = regexp.MustCompile(`^postgres(?:ql)?://postgres:(.+)@(.+?)(:\d+)?/postgres$`)
 	MigrateFilePattern = regexp.MustCompile(`([0-9]+)_.*\.sql`)
 	BranchNamePattern  = regexp.MustCompile(`[[:word:]-]+`)
+
+	// These schemas are ignored from schema diffs
+	InternalSchemas = []string{"auth", "extensions", "graphql_public", "pgbouncer", "realtime", "storage", "supabase_functions", "supabase_migrations", "pg_catalog", "pg_toast", "information_schema"}
 )
 
 func GetCurrentTimestamp() string {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -57,6 +57,10 @@ DO 'BEGIN WHILE (SELECT COUNT(*) FROM pg_replication_slots) > 0 LOOP END LOOP; E
 )
 
 var (
+	// pg_dumpall --globals-only --no-role-passwords --dbname $DB_URL \
+	// | sed '/^CREATE ROLE postgres;/d' \
+	// | sed '/^ALTER ROLE postgres WITH /d' \
+	// | sed "/^ALTER ROLE .* WITH .* LOGIN /s/;$/ PASSWORD 'postgres';/"
 	//go:embed templates/globals.sql
 	GlobalsSql string
 

--- a/internal/utils/templates/globals.sql
+++ b/internal/utils/templates/globals.sql
@@ -107,6 +107,8 @@ GRANT anon TO authenticator GRANTED BY postgres;
 GRANT authenticated TO authenticator GRANTED BY postgres;
 GRANT service_role TO authenticator GRANTED BY postgres;
 GRANT supabase_admin TO authenticator GRANTED BY postgres;
+GRANT supabase_auth_admin TO postgres GRANTED BY supabase_admin;
+GRANT supabase_storage_admin TO postgres GRANTED BY supabase_admin;
 
 
 


### PR DESCRIPTION
Use pg_dump instead of schema diff for `db remote commit` if it's the first migration.

This is to handle the common case of users wanting to use the CLI midway after developing their schemas using the dashboard. At that point the schema diff is likely very large and prone to errors.