### PR TITLE
fix(typegen): only include specified schemas

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -16,9 +16,9 @@ var (
 
 	genTypesTypescriptCmd = &cobra.Command{
 		Use:   "typescript",
-		Short: "Generate types for TypeScript. Must either specify --local, or --db-url, or be in a linked project (with supabase link)",
+		Short: "Generate types for TypeScript. Must specify either --local or --db-url",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			isLocal, err := cmd.Flags().GetBool("local")
+			useLocal, err := cmd.Flags().GetBool("local")
 			if err != nil {
 				return err
 			}
@@ -27,7 +27,7 @@ var (
 				return err
 			}
 
-			return typescript.Run(isLocal, dbUrl)
+			return typescript.Run(useLocal, dbUrl)
 		},
 	}
 )

--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -23,6 +24,10 @@ func Run(useLocal bool, dbUrl string) error {
 		return errors.New("Must specify either --local or --db-url")
 	}
 
+	if err := utils.LoadConfig(); err != nil {
+		return err
+	}
+
 	if useLocal {
 		if err := utils.AssertSupabaseStartIsRunning(); err != nil {
 			return err
@@ -36,7 +41,7 @@ func Run(useLocal bool, dbUrl string) error {
 					"PG_META_DB_HOST=" + utils.DbId,
 				},
 				Cmd: []string{
-					"node", "bin/src/server/app.js", "gen", "types", "typescript", "--exclude-schemas", "auth,extensions,graphql,graphql_public,realtime,storage,supabase_functions,supabase_migrations",
+					"node", "bin/src/server/app.js", "gen", "types", "typescript", "--include-schemas", strings.Join(append([]string{"public"}, utils.Config.Api.Schemas...), ","),
 				},
 				AttachStderr: true,
 				AttachStdout: true,
@@ -98,7 +103,7 @@ func Run(useLocal bool, dbUrl string) error {
 					"PG_META_DB_URL=" + dbUrl,
 				},
 				Cmd: []string{
-					"node", "bin/src/server/app.js", "gen", "types", "typescript", "--exclude-schemas", "auth,extensions,graphql,graphql_public,realtime,storage,supabase_functions,supabase_migrations",
+					"node", "bin/src/server/app.js", "gen", "types", "typescript", "--include-schemas", strings.Join(append([]string{"public"}, utils.Config.Api.Schemas...), ","),
 				},
 			},
 			&container.HostConfig{},

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -35,7 +35,7 @@ const (
 	InbucketImage  = "inbucket/inbucket:stable"
 	PostgrestImage = "postgrest/postgrest:v9.0.0.20220211"
 	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.4"
-	PgmetaImage    = "supabase/postgres-meta:v0.40.0"
+	PgmetaImage    = "supabase/postgres-meta:v0.42.1"
 	// TODO: Hardcode version once provided upstream.
 	StudioImage    = "supabase/studio:latest"
 	DenoRelayImage = "supabase/deno-relay:v1.2.0"


### PR DESCRIPTION
Previously it included unintended schemas (e.g. `net` from the `pg_net` extension). Since the typegen is only used for supabase/postgrest-js, only include schemas according to the PostgREST config `DB_SCHEMAS`, reflected on `api.schemas` in `config.toml`.

Also remove support for generating types from linked project, since we removed `db_pass` from API.