### PR TITLE
fix: assume source branch is main when not set

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -233,11 +233,13 @@ EOSQL
 		{
 			// Need to connect for PostgREST to connect.
 			if err := utils.Docker.NetworkConnect(ctx, utils.NetId, utils.DbId, &network.EndpointSettings{}); err != nil {
-				return fmt.Errorf("Error reconnecting database: %w", err)
+				fmt.Fprintf(os.Stderr, "Error reconnecting database: %v", err)
+				return nil
 			}
 
 			if err := utils.Docker.ContainerKill(ctx, utils.RestId, "SIGUSR1"); err != nil {
-				return fmt.Errorf("Error reloading PostgREST schema cache: %w", err)
+				fmt.Fprintf(os.Stderr, "Error reloading PostgREST schema cache: %v", err)
+				return nil
 			}
 		}
 

--- a/internal/db/switch_/switch_.go
+++ b/internal/db/switch_/switch_.go
@@ -35,7 +35,7 @@ func Run(target string) error {
 		if branch.Name() == target {
 			currBranch, err := utils.GetCurrentBranch()
 			if err != nil {
-				return err
+				currBranch = "main"
 			}
 
 			if err := os.WriteFile(utils.CurrBranchPath, []byte(target), 0644); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes https://github.com/supabase/cli/issues/321

## What is the current behavior?

unable to switch branch if current branch is unset

## What is the new behavior?

assume we are switching from `main` branch if unset

caveat: if `main` database already exists, `switch` will write to `_current_branch` file but fail to rename db. User will have to manually edit `_current_branch` or drop `main` database to fix.

## Additional context

Add any other context or screenshots.
