### PR TITLE
feat: support stdin when creating new migration

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/migration/new"
@@ -18,7 +20,7 @@ var (
 		Short: "Create an empty migration.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return new.Run(args[0], afero.NewOsFs())
+			return new.Run(args[0], os.Stdin, afero.NewOsFs())
 		},
 	}
 )

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/utils"
@@ -17,7 +18,7 @@ var (
 		Short: "Create an empty migration.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return new.Run(args[0])
+			return new.Run(args[0], afero.NewOsFs())
 		},
 	}
 )

--- a/internal/db/commit/migra.go
+++ b/internal/db/commit/migra.go
@@ -27,9 +27,8 @@ import (
 )
 
 const (
-	migraId    = "supabase_migra_cli"
-	diffImage  = "djrobstep/migra:3.0.1621480950"
-	migrateDir = "supabase/migrations"
+	migraId   = "supabase_migra_cli"
+	diffImage = "djrobstep/migra:3.0.1621480950"
 )
 
 var (
@@ -101,7 +100,7 @@ func RunMigra(name, schema string, fsys afero.Fs) error {
 	}
 
 	filename := utils.GetCurrentTimestamp() + "_" + name + ".sql"
-	if err := afero.WriteFile(fsys, filepath.Join(migrateDir, filename), []byte(diff), 0644); err != nil {
+	if err := afero.WriteFile(fsys, filepath.Join(utils.MigrationsDir, filename), []byte(diff), 0644); err != nil {
 		return err
 	}
 
@@ -191,7 +190,7 @@ func applyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 	}
 	defer conn.Close(ctx)
 	// Apply migrations
-	if migrations, err := afero.ReadDir(fsys, migrateDir); err == nil {
+	if migrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil {
 		for i, migration := range migrations {
 			// NOTE: To handle backward-compatibility. `<timestamp>_init.sql` as
 			// the first migration (prev versions of the CLI) is deprecated.
@@ -207,7 +206,7 @@ func applyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 				}
 			}
 			fmt.Println("Applying migration " + utils.Bold(migration.Name()) + "...")
-			contents, err := afero.ReadFile(fsys, filepath.Join(migrateDir, migration.Name()))
+			contents, err := afero.ReadFile(fsys, filepath.Join(utils.MigrationsDir, migration.Name()))
 			if err != nil {
 				return err
 			}

--- a/internal/db/commit/migra_test.go
+++ b/internal/db/commit/migra_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/pgtest"
+	"github.com/supabase/cli/internal/utils"
 )
 
 func TestApplyMigrations(t *testing.T) {
@@ -20,8 +21,8 @@ func TestApplyMigrations(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup initial migration
 		migrations := map[string]string{
-			filepath.Join(migrateDir, "20220727064247_init.sql"): "create table test",
-			filepath.Join(migrateDir, "20220727064248_drop.sql"): "drop table test;\n-- ignore me",
+			filepath.Join(utils.MigrationsDir, "20220727064247_init.sql"): "create table test",
+			filepath.Join(utils.MigrationsDir, "20220727064248_drop.sql"): "drop table test;\n-- ignore me",
 		}
 		for path, query := range migrations {
 			require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
@@ -52,7 +53,7 @@ func TestApplyMigrations(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup initial migration
 		name := "20211208000000_init.sql"
-		path := filepath.Join(migrateDir, name)
+		path := filepath.Join(utils.MigrationsDir, name)
 		query := "create table test"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
 		// Setup mock postgres
@@ -75,7 +76,7 @@ func TestApplyMigrations(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup initial migration
 		name := "20220727064247_create_table.sql"
-		path := filepath.Join(migrateDir, name)
+		path := filepath.Join(utils.MigrationsDir, name)
 		query := "create table test"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
 		// Setup mock postgres

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -23,7 +23,9 @@ func Run(migrationName string, stdin afero.File, fsys afero.Fs) error {
 	}
 	defer f.Close()
 
-	if fi, err := stdin.Stat(); err == nil && fi.Size() > 0 {
+	if fi, err := stdin.Stat(); err != nil {
+		return err
+	} else if fi.Size() > 0 {
 		if _, err := io.Copy(f, stdin); err != nil {
 			return err
 		}

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -2,20 +2,29 @@ package new
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(migrationName string, fsys afero.Fs) error {
+func Run(migrationName string, stdin io.Reader, fsys afero.Fs) error {
 	if err := utils.MkdirIfNotExistFS(fsys, utils.MigrationsDir); err != nil {
 		return err
 	}
 
 	name := utils.GetCurrentTimestamp() + "_" + migrationName + ".sql"
 	path := filepath.Join(utils.MigrationsDir, name)
-	if err := afero.WriteFile(fsys, path, []byte{}, 0644); err != nil {
+	f, err := fsys.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, stdin); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -2,25 +2,23 @@ package new
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(migrationName string) error {
-	if err := utils.AssertSupabaseCliIsSetUp(); err != nil {
+func Run(migrationName string, fsys afero.Fs) error {
+	if err := utils.MkdirIfNotExistFS(fsys, utils.MigrationsDir); err != nil {
 		return err
 	}
 
-	if err := utils.MkdirIfNotExist("supabase/migrations"); err != nil {
+	name := utils.GetCurrentTimestamp() + "_" + migrationName + ".sql"
+	path := filepath.Join(utils.MigrationsDir, name)
+	if err := afero.WriteFile(fsys, path, []byte{}, 0644); err != nil {
 		return err
 	}
 
-	timestamp := utils.GetCurrentTimestamp()
-	if err := os.WriteFile("supabase/migrations/"+timestamp+"_"+migrationName+".sql", []byte{}, 0644); err != nil {
-		return err
-	}
-
-	fmt.Println("Created new migration at " + utils.Bold("supabase/migrations/"+timestamp+"_"+migrationName+".sql") + ".")
+	fmt.Println("Created new migration at " + utils.Bold(path) + ".")
 	return nil
 }

--- a/internal/migration/new/new_test.go
+++ b/internal/migration/new/new_test.go
@@ -1,21 +1,54 @@
 package new
 
 import (
+	"bytes"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/utils"
 )
 
 func TestNewCommand(t *testing.T) {
 	t.Run("creates new migration file", func(t *testing.T) {
-		assert.NoError(t, Run("test_migrate", afero.NewMemMapFs()))
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup empty stdin
+		stdin := &bytes.Buffer{}
+		// Run test
+		assert.NoError(t, Run("test_migrate", stdin, fsys))
+		// Validate output
+		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		match, err := regexp.MatchString(`([0-9]{14})_test_migrate\.sql`, files[0].Name())
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("creates new file with contents", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup stdin
+		script := "create table pet;\ndrop table pet;\n"
+		// Run test
+		assert.NoError(t, Run("test_migrate", bytes.NewBufferString(script), fsys))
+		// Validate output
+		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		path := filepath.Join(utils.MigrationsDir, files[0].Name())
+		contents, err := afero.ReadFile(fsys, path)
+		assert.NoError(t, err)
+		assert.Equal(t, script, contents)
 	})
 
 	t.Run("throws error on failure to create directory", func(t *testing.T) {
 		// Setup read-only fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Setup empty stdin
+		stdin := &bytes.Buffer{}
 		// Run test
-		assert.Error(t, Run("test_migrate", fsys))
+		assert.Error(t, Run("test_migrate", stdin, fsys))
 	})
 }

--- a/internal/migration/new/new_test.go
+++ b/internal/migration/new/new_test.go
@@ -1,0 +1,21 @@
+package new
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCommand(t *testing.T) {
+	t.Run("creates new migration file", func(t *testing.T) {
+		assert.NoError(t, Run("test_migrate", afero.NewMemMapFs()))
+	})
+
+	t.Run("throws error on failure to create directory", func(t *testing.T) {
+		// Setup read-only fs
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Run test
+		assert.Error(t, Run("test_migrate", fsys))
+	})
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -54,6 +54,7 @@ DO 'BEGIN WHILE (SELECT COUNT(*) FROM pg_replication_slots) > 0 LOOP END LOOP; E
 	ProjectRefPath = "supabase/.temp/project-ref"
 	RemoteDbPath   = "supabase/.temp/remote-db-url"
 	CurrBranchPath = "supabase/.branches/_current_branch"
+	MigrationsDir  = "supabase/migrations"
 )
 
 var (


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

`supabase migration new <name>` only creates a new file

## What is the new behavior?

supports reading from stdin so pipe works, for eg.
```bash
echo "create table pet;" | supabase migration new create_pet_table
supabase db changes | supabase migration new my_diff
```

## Additional context

Add any other context or screenshots.
