### PR TITLE
feat: move gitignore to supabase directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,3 @@
 
 # IDE
 .vscode
-
-# Supabase
-**/supabase/.branches
-**/supabase/.temp

--- a/internal/init/templates/init_gitignore
+++ b/internal/init/templates/init_gitignore
@@ -1,3 +1,3 @@
 # Supabase
-**/supabase/.branches
-**/supabase/.temp
+.branches
+.temp

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -409,6 +409,10 @@ func WriteConfig(fsys afero.Fs, test bool) error {
 		return err
 	}
 
+	if err := MkdirIfNotExistFS(fsys, filepath.Dir(ConfigPath)); err != nil {
+		return err
+	}
+
 	if err := afero.WriteFile(fsys, ConfigPath, initConfigBuf.Bytes(), 0644); err != nil {
 		return err
 	}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -138,14 +138,14 @@ func AssertSupabaseDbIsRunning() error {
 	return nil
 }
 
-func GetGitRoot() (*string, error) {
+func GetGitRoot(fsys afero.Fs) (*string, error) {
 	origWd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 
 	for {
-		_, err := os.ReadDir(".git")
+		_, err := afero.ReadDir(fsys, ".git")
 
 		if err == nil {
 			gitRoot, err := os.Getwd()


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Root level gitignore is modified by `supabase init`. The CLI should be agnostic to what users store outside of the generated `supabase` directory.

## What is the new behavior?

- creates `supabase/.gitignore`
- do not remove `supabase` directory on failure as it may contain migration files
- use `afero.FileContainsBytes` instead of reading the entire gitignore file

## Additional context

Add any other context or screenshots.
