### PR TITLE
fix: init exits 0 when config file exists

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -3,6 +3,7 @@ package init
 import (
 	_ "embed"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -13,15 +14,14 @@ import (
 var (
 	//go:embed templates/init_gitignore
 	initGitignore []byte
-
-	errAlreadyInitialized = errors.New("Project already initialized. Remove " + utils.Bold("supabase") + " to reinitialize.")
 )
 
 func Run(fsys afero.Fs) error {
 	// Sanity checks.
 	{
 		if _, err := fsys.Stat(utils.ConfigPath); err == nil {
-			return errAlreadyInitialized
+			fmt.Fprintln(os.Stderr, "Project already initialized. Remove "+utils.Bold("supabase")+" to reinitialize.")
+			return nil
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -44,13 +44,13 @@ func TestInitCommand(t *testing.T) {
 		assert.False(t, exists)
 	})
 
-	t.Run("throws error when config file exists", func(t *testing.T) {
+	t.Run("returns early when config file exists", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
 		_, err := fsys.Create(utils.ConfigPath)
 		require.NoError(t, err)
 		// Run test
-		assert.Error(t, Run(fsys))
+		assert.NoError(t, Run(fsys))
 	})
 
 	t.Run("throws error on failure to write config", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

patch

## What is the current behavior?

return 1 when config file exists

## What is the new behavior?

return 0 so that ci works more gracefully

## Additional context

Add any other context or screenshots.
