### PR TITLE
fix: move signal handling to specific commands

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/signal"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -72,7 +73,8 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if useMigra {
-				return diff.RunMigra(cmd.Context(), schema, file, fsys)
+				ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+				return diff.RunMigra(ctx, schema, file, fsys)
 			}
 			return diff.Run(file, fsys)
 		},
@@ -87,7 +89,8 @@ var (
 			if password == "" {
 				password = PromptPassword(os.Stdin)
 			}
-			return push.Run(cmd.Context(), dryRun, username, password, database, afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return push.Run(ctx, dryRun, username, password, database, afero.NewOsFs())
 		},
 	}
 
@@ -111,7 +114,8 @@ var (
 			if password == "" {
 				password = PromptPassword(os.Stdin)
 			}
-			return commit.Run(cmd.Context(), username, password, database, afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return commit.Run(ctx, username, password, database, afero.NewOsFs())
 		},
 	}
 

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/signal"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -31,7 +32,8 @@ var (
 			}
 
 			fsys := afero.NewOsFs()
-			if err := link.Run(cmd.Context(), projectRef, username, password, database, fsys); err != nil {
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			if err := link.Run(ctx, projectRef, username, password, database, fsys); err != nil {
 				return err
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -23,21 +20,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	ctx := context.Background()
-	// Trap Ctrl+C and call cancel on the context:
-	// https://medium.com/@matryer/make-ctrl-c-cancel-the-context-context-bd006a8ad6ff
-	ctx, cancel := context.WithCancel(ctx)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	defer signal.Stop(c)
-	go func() {
-		select {
-		case <-c:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	cobra.CheckErr(rootCmd.ExecuteContext(ctx))
+	cobra.CheckErr(rootCmd.Execute())
 }
 
 func init() {

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"os/signal"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/secrets/list"
@@ -18,7 +21,8 @@ var (
 		Use:   "list",
 		Short: "List all secrets in the linked project",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list.Run(cmd.Context(), afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return list.Run(ctx, afero.NewOsFs())
 		},
 	}
 
@@ -30,8 +34,8 @@ var (
 			if err != nil {
 				return err
 			}
-
-			return set.Run(cmd.Context(), envFilePath, args, afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return set.Run(ctx, envFilePath, args, afero.NewOsFs())
 		},
 	}
 
@@ -39,7 +43,8 @@ var (
 		Use:   "unset <NAME> ...",
 		Short: "Unset a secret(s) from the linked Supabase project",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return unset.Run(cmd.Context(), args, afero.NewOsFs())
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return unset.Run(ctx, args, afero.NewOsFs())
 		},
 	}
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug

## What is the current behavior?

ctrl+c is intercepted at root command, causing stdin to not abort (have to use ctrl+d)

## What is the new behavior?

proper way seems to be scanning stdin in a goroutine that also selects on the cancel context.
since we don't have many commands which use signal yet, decided move the signal part instead.

## Additional context

Add any other context or screenshots.
