### PR TITLE
feat: add command to list migrations

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/new"
 )
 
@@ -12,6 +13,17 @@ var (
 	migrationCmd = &cobra.Command{
 		Use:   "migration",
 		Short: "Manage database migration scripts",
+	}
+
+	migrationListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List local and remote migrations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if password == "" {
+				password = PromptPassword(os.Stdin)
+			}
+			return list.Run(cmd.Context(), username, password, database, afero.NewOsFs())
+		},
 	}
 
 	migrationNewCmd = &cobra.Command{
@@ -25,6 +37,8 @@ var (
 )
 
 func init() {
+	migrationListCmd.Flags().StringVarP(&password, "password", "p", "", "Password to your remote Postgres database.")
+	migrationCmd.AddCommand(migrationListCmd)
 	migrationCmd.AddCommand(migrationNewCmd)
 	rootCmd.AddCommand(migrationCmd)
 }

--- a/internal/migration/list/list.go
+++ b/internal/migration/list/list.go
@@ -1,0 +1,103 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/db/remote/commit"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, username, password, database string, fsys afero.Fs) error {
+	// Sanity checks.
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
+	}
+	// Connect to remote db
+	projectRef, err := utils.LoadProjectRef(fsys)
+	if err != nil {
+		return err
+	}
+	conn, err := commit.ConnectRemotePostgres(ctx, username, password, database, projectRef)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(context.Background())
+	// Load remote migrations
+	rows, err := conn.Query(ctx, commit.LIST_MIGRATION_VERSION)
+	if err != nil {
+		return err
+	}
+	remoteMigrations := []string{}
+	for rows.Next() {
+		var version string
+		if err := rows.Scan(&version); err != nil {
+			return err
+		}
+		remoteMigrations = append(remoteMigrations, version)
+	}
+	// Load local migrations
+	if err := utils.MkdirIfNotExistFS(fsys, utils.MigrationsDir); err != nil {
+		return err
+	}
+	localMigrations, err := afero.ReadDir(fsys, utils.MigrationsDir)
+	if err != nil {
+		return err
+	}
+	// Render table
+	layoutVersion := "20060102150405"
+	layoutHuman := "2006-01-02 15:04:05"
+	table := "|Local|Remote|Time (UTC)|\n|-|-|-|\n"
+	for i, j := 0, 0; i < len(remoteMigrations) || j < len(localMigrations); {
+		var timestamp time.Time
+		remoteTimestamp := math.MaxInt
+		if i < len(remoteMigrations) {
+			if parsed, err := strconv.Atoi(remoteMigrations[i]); err == nil {
+				remoteTimestamp = parsed
+				timestamp, _ = time.Parse(layoutVersion, remoteMigrations[i])
+			}
+		}
+		localTimestamp := math.MaxInt
+		if j < len(localMigrations) {
+			matches := utils.MigrateFilePattern.FindStringSubmatch(localMigrations[j].Name())
+			if len(matches) > 1 {
+				if parsed, err := strconv.Atoi(matches[1]); err == nil {
+					localTimestamp = parsed
+					timestamp, _ = time.Parse(layoutVersion, matches[1])
+				}
+			}
+		}
+		// Top to bottom chronological order
+		if localTimestamp < remoteTimestamp {
+			table += fmt.Sprintf("|`%d`|` `|`%s`|\n", localTimestamp, timestamp.Format(layoutHuman))
+			j++
+		} else if remoteTimestamp < localTimestamp {
+			table += fmt.Sprintf("|` `|`%d`|`%s`|\n", remoteTimestamp, timestamp.Format(layoutHuman))
+			i++
+		} else {
+			table += fmt.Sprintf("|`%d`|`%d`|`%s`|\n", localTimestamp, remoteTimestamp, timestamp.Format(layoutHuman))
+			i++
+			j++
+		}
+	}
+
+	r, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(-1),
+	)
+	if err != nil {
+		return err
+	}
+	out, err := r.Render(table)
+	if err != nil {
+		return err
+	}
+	fmt.Print(out)
+
+	return nil
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

no visibility on migration history table

## What is the new behavior?

```bash
$ supabase migration list

        LOCAL      │     REMOTE     │     TIME (UTC)
  ─────────────────┼────────────────┼──────────────────────
    20220809084034 │                │ 2022-08-09 08:40:34
                   │ 20220810154537 │ 2022-08-10 15:45:37
```

## Additional context

Add any other context or screenshots.
