### PR TITLE
feat(functions): add support for deno on arm64 Linux

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -265,6 +265,7 @@ func InstallOrUpgradeDeno() error {
 
 	// 1. Determine OS triple
 	var assetFilename string
+	assetsUrl := "https://github.com/denoland/deno/releases/latest/download/"
 	{
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 			assetFilename = "deno-x86_64-apple-darwin.zip"
@@ -272,6 +273,9 @@ func InstallOrUpgradeDeno() error {
 			assetFilename = "deno-aarch64-apple-darwin.zip"
 		} else if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
 			assetFilename = "deno-x86_64-unknown-linux-gnu.zip"
+		} else if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+			assetsUrl = "https://github.com/LukeChannings/deno-arm64/releases/latest/download/"
+			assetFilename = "deno-linux-arm64.zip"
 		} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
 			assetFilename = "deno-x86_64-pc-windows-msvc.zip"
 		} else {
@@ -281,7 +285,7 @@ func InstallOrUpgradeDeno() error {
 
 	// 2. Download & install Deno binary.
 	{
-		resp, err := http.Get("https://github.com/denoland/deno/releases/latest/download/" + assetFilename)
+		resp, err := http.Get(assetsUrl + assetFilename)
 		if err != nil {
 			return err
 		}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -279,6 +279,7 @@ func InstallOrUpgradeDeno() error {
 		} else if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
 			assetFilename = "deno-x86_64-unknown-linux-gnu.zip"
 		} else if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+			// TODO: version pin to official release once available https://github.com/denoland/deno/issues/1846
 			assetsUrl = "https://github.com/LukeChannings/deno-arm64/releases/latest/download/"
 			assetFilename = "deno-linux-arm64.zip"
 		} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {


### PR DESCRIPTION
This adds support for linux/arm64 to the Supabase functions CLI by utilizing the unofficial arm64 builds of Deno from https://github.com/LukeChannings/deno-arm64