### PR TITLE
fix: batched query with variable fails

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -126,6 +126,7 @@ func applyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 		return err
 	}
 	// Apply config overrides
+	config.PreferSimpleProtocol = true
 	for _, op := range options {
 		op(config)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

splits migration script into batched statements

## What is the new behavior?

sends the whole script as a string

## Additional context

Add any other context or screenshots.
