### PR TITLE
fix: remove registry prefix from docker hub image

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -146,8 +146,10 @@ func DockerAddFile(ctx context.Context, container string, fileName string, conte
 }
 
 func GetRegistryImageUrl(imageName string) string {
+	const hub = "docker.io"
 	const ecr = "public.ecr.aws/t3w2s2c9"
 	registry := viper.GetString("INTERNAL_IMAGE_REGISTRY")
+	registry = strings.ToLower(registry)
 	if registry == "" {
 		// Defaults to Supabase public ECR for faster image pull
 		registry = ecr
@@ -155,6 +157,9 @@ func GetRegistryImageUrl(imageName string) string {
 	if registry == ecr {
 		parts := strings.Split(imageName, "/")
 		imageName = parts[len(parts)-1]
+	}
+	if registry == hub {
+		return imageName
 	}
 	return registry + "/" + imageName
 }

--- a/internal/utils/docker_test.go
+++ b/internal/utils/docker_test.go
@@ -37,7 +37,7 @@ func TestPullImage(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusNotFound)
 		gock.New("http:///var/run/docker.sock").
 			Post("/v"+version+"/images/create").
@@ -60,7 +60,7 @@ func TestPullImage(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		// Run test
@@ -79,7 +79,7 @@ func TestPullImage(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
 		assert.Error(t, DockerPullImageIfNotCached(context.Background(), imageId))
@@ -97,7 +97,7 @@ func TestPullImage(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusNotFound)
 		gock.New("http:///var/run/docker.sock").
 			Post("/v"+version+"/images/create").
@@ -124,7 +124,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -171,7 +171,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -198,7 +198,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -229,7 +229,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -270,7 +270,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -306,7 +306,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").
@@ -350,7 +350,7 @@ func TestRunOnce(t *testing.T) {
 			SetHeader("API-Version", version).
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
-			Get("/v" + version + "/images/docker.io/" + imageId + "/json").
+			Get("/v" + version + "/images/" + imageId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ImageInspect{})
 		gock.New("http:///var/run/docker.sock").


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

fails to pull docker hub image

## What is the new behavior?

pulls locally

## Additional context

Add any other context or screenshots.
