### PR TITLE
fix: bump pgadmin schema diff to 0.0.5

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -23,13 +23,13 @@ import (
 )
 
 func SaveDiff(out, file string, fsys afero.Fs) error {
-	if len(diff) < 2 {
+	if len(out) < 2 {
 		fmt.Fprintln(os.Stderr, "No changes found")
 	} else if len(file) > 0 {
 		path := new.GetMigrationPath(file)
-		return afero.WriteFile(fsys, path, []byte(diff), 0644)
+		return afero.WriteFile(fsys, path, []byte(out), 0644)
 	} else {
-		fmt.Println(diff)
+		fmt.Println(out)
 	}
 	return nil
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	KongImage      = "library/kong:2.1"
 	InbucketImage  = "inbucket/inbucket:stable"
 	PostgrestImage = "postgrest/postgrest:v9.0.1.20220802"
-	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.4"
+	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	PgmetaImage    = "supabase/postgres-meta:v0.42.1"
 	// TODO: Hardcode version once provided upstream.
 	StudioImage    = "supabase/studio:latest"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/369

## What is the current behavior?

unable to diff with pgadmin

## What is the new behavior?

updated pgadmin image to 0.0.5

## Additional context

Add any other context or screenshots.
