### PR TITLE
fix: pin dependency images to hosted version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - id: semantic-release
         uses: cycjimmy/semantic-release-action@v2
         with:
-          semantic_version: 17
+          semantic_version: 18
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -181,10 +181,10 @@ func LoadConfigFS(fsys afero.Fs) error {
 		case 12:
 			return errors.New("Postgres version 12.x is unsupported. To use the CLI, either start a new project or follow project migration steps here: https://supabase.com/docs/guides/database#migrating-between-projects.")
 		case 13:
-			DbImage = "supabase/postgres:13.3.0"
+			DbImage = Pg13Image
 			InitialSchemaSql = initialSchemaPg13Sql
 		case 14:
-			DbImage = "supabase/postgres:14.1.0.34"
+			DbImage = Pg14Image
 			InitialSchemaSql = initialSchemaPg14Sql
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -21,25 +21,27 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Update initial schemas in internal/utils/templates/initial_schemas when
-// updating any one of these.
+// Update tools/listdep/main.go when adding new docker images
 const (
+	Pg13Image      = "supabase/postgres:13.3.0"
+	Pg14Image      = "supabase/postgres:14.1.0.34"
+	KongImage      = "library/kong:2.8.1"
+	InbucketImage  = "inbucket/inbucket:3.0.3"
+	PostgrestImage = "postgrest/postgrest:v9.0.1.20220717"
+	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.5"
+	MigraImage     = "djrobstep/migra:3.0.1621480950"
+	PgmetaImage    = "supabase/postgres-meta:v0.42.2"
+	StudioImage    = "supabase/studio:v0.1.0"
+	DenoRelayImage = "supabase/deno-relay:v1.2.1"
+	// Update initial schemas in internal/utils/templates/initial_schemas when
+	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.10.3"
 	RealtimeImage = "supabase/realtime:v0.22.7"
 	StorageImage  = "supabase/storage-api:v0.18.7"
 )
 
 const (
-	ShadowDbName   = "supabase_shadow"
-	KongImage      = "library/kong:2.1"
-	InbucketImage  = "inbucket/inbucket:stable"
-	PostgrestImage = "postgrest/postgrest:v9.0.1.20220802"
-	DifferImage    = "supabase/pgadmin-schema-diff:cli-0.0.5"
-	MigraImage     = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage    = "supabase/postgres-meta:v0.42.1"
-	// TODO: Hardcode version once provided upstream.
-	StudioImage    = "supabase/studio:latest"
-	DenoRelayImage = "supabase/deno-relay:v1.2.1"
+	ShadowDbName = "supabase_shadow"
 
 	// https://dba.stackexchange.com/a/11895
 	// Args: dbname

--- a/tools/listdep/main.go
+++ b/tools/listdep/main.go
@@ -11,6 +11,8 @@ import (
 
 func main() {
 	images := []string{
+		utils.Pg13Image,
+		utils.Pg14Image,
 		utils.GotrueImage,
 		utils.RealtimeImage,
 		utils.StorageImage,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

some images are not version pinned

## What is the new behavior?

pin all images to latest https://github.com/supabase/kps/blob/master/ansible/arm64_vars.yml

## Additional context

Add any other context or screenshots.
