### PR TITLE
fix: remove docker network when supabase start is interrupted

### DIFF
--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -92,7 +92,7 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 			},
 		},
 	)
-	defer cleanup()
+	defer utils.DockerRemoveAll(context.Background(), netId)
 
 	p.Send(utils.StatusMsg("Pulling images..."))
 
@@ -277,10 +277,6 @@ EOSQL
 	return nil
 }
 
-func cleanup() {
-	_ = utils.DockerRemoveAll(context.Background(), netId)
-}
-
 type model struct {
 	cancel      context.CancelFunc
 	spinner     spinner.Model
@@ -303,7 +299,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Stop future runs
 			m.cancel()
 			// Stop current runs
-			cleanup()
+			utils.DockerRemoveAll(context.Background(), netId)
 			return m, tea.Quit
 		default:
 			return m, nil

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -278,8 +278,7 @@ EOSQL
 }
 
 func cleanup() {
-	utils.DockerRemoveAll()
-	_ = utils.Docker.NetworkRemove(context.Background(), netId)
+	_ = utils.DockerRemoveAll(context.Background(), netId)
 }
 
 type model struct {

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -110,7 +110,7 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 			},
 		},
 	)
-	defer cleanup()
+	defer utils.DockerRemoveAll(context.Background(), netId)
 
 	p.Send(utils.StatusMsg("Pulling images..."))
 
@@ -367,10 +367,6 @@ type model struct {
 	width int
 }
 
-func cleanup() {
-	_ = utils.DockerRemoveAll(context.Background(), netId)
-}
-
 func (m model) Init() tea.Cmd {
 	return spinner.Tick
 }
@@ -383,7 +379,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Stop future runs
 			m.cancel()
 			// Stop current runs
-			cleanup()
+			utils.DockerRemoveAll(context.Background(), netId)
 			return m, tea.Quit
 		default:
 			return m, nil

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -368,8 +368,7 @@ type model struct {
 }
 
 func cleanup() {
-	utils.DockerRemoveAll()
-	_ = utils.Docker.NetworkRemove(context.Background(), netId)
+	_ = utils.DockerRemoveAll(context.Background(), netId)
 }
 
 func (m model) Init() tea.Cmd {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -61,8 +61,7 @@ func Run(ctx context.Context) error {
 		return errors.New("Aborted " + utils.Aqua("supabase start") + ".")
 	}
 	if err := <-errCh; err != nil {
-		utils.DockerRemoveAll()
-		_ = utils.Docker.NetworkRemove(context.Background(), utils.NetId)
+		_ = utils.DockerRemoveAll(context.Background(), utils.NetId)
 		return err
 	}
 
@@ -819,7 +818,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Stop future runs
 			m.cancel()
 			// Stop current runs
-			utils.DockerRemoveAll()
+			utils.DockerRemoveAll(context.Background(), utils.NetId)
 			return m, tea.Quit
 		default:
 			return m, nil

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -61,7 +61,7 @@ func Run(ctx context.Context) error {
 		return errors.New("Aborted " + utils.Aqua("supabase start") + ".")
 	}
 	if err := <-errCh; err != nil {
-		_ = utils.DockerRemoveAll(context.Background(), utils.NetId)
+		utils.DockerRemoveAll(context.Background(), utils.NetId)
 		return err
 	}
 

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -90,14 +90,14 @@ func DockerRun(
 	return resp.Reader, nil
 }
 
-func DockerRemoveAll() {
+func DockerRemoveContainers(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	for _, container := range containers {
 		wg.Add(1)
 
 		go func(container string) {
-			if err := Docker.ContainerRemove(context.Background(), container, types.ContainerRemoveOptions{
+			if err := Docker.ContainerRemove(ctx, container, types.ContainerRemoveOptions{
 				RemoveVolumes: true,
 				Force:         true,
 			}); err != nil {
@@ -111,6 +111,11 @@ func DockerRemoveAll() {
 	}
 
 	wg.Wait()
+}
+
+func DockerRemoveAll(ctx context.Context, netId string) error {
+	DockerRemoveContainers(ctx)
+	return Docker.NetworkRemove(ctx, netId)
 }
 
 func DockerAddFile(ctx context.Context, container string, fileName string, content []byte) error {

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -113,9 +113,9 @@ func DockerRemoveContainers(ctx context.Context) {
 	wg.Wait()
 }
 
-func DockerRemoveAll(ctx context.Context, netId string) error {
+func DockerRemoveAll(ctx context.Context, netId string) {
 	DockerRemoveContainers(ctx)
-	return Docker.NetworkRemove(ctx, netId)
+	_ = Docker.NetworkRemove(ctx, netId)
 }
 
 func DockerAddFile(ctx context.Context, container string, fileName string, content []byte) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studying the codebase I've noticed the function `DockerRemoveAll` used as a cleanup function always paired with another function to remove the docker network.

I've refactored the function having a misleading name `DockerRemoveAll` to `DockerRemoveContainers` as `DockerRemoveAll` only removes containers I renamed it to `DockerRemoveContainers` and replaces the usage of the old functions (always used together) to the new version of `DockerRemoveAll` which now calls both.

A spot where the old `DockerRemoveAll` were used lacked the removal of network, is was a bug and is not handler properly.

fixes #425 
