### PR TITLE
chore: clearer error message when project already initialized

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -14,7 +14,7 @@ var (
 	//go:embed templates/init_gitignore
 	initGitignore []byte
 
-	errAlreadyInitialized = errors.New("Project already initialized. To allow reinitialization remove the directory " + utils.Bold("./supabase"))
+	errAlreadyInitialized = errors.New("Project already initialized. Remove " + utils.Bold(utils.ConfigPath) + " to reinitialize.")
 )
 
 func Run(fsys afero.Fs) error {

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -14,7 +14,7 @@ var (
 	//go:embed templates/init_gitignore
 	initGitignore []byte
 
-	errAlreadyInitialized = errors.New("Project already initialized. Remove " + utils.Bold("supabase") + " to reinitialize.")
+	errAlreadyInitialized = errors.New("Project already initialized. To allow reinitialization remove the directory " + utils.Bold("./supabase"))
 )
 
 func Run(fsys afero.Fs) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

With current error it may seems like the supabase cli needs to be reinstalled intead of the directory removed

## What is the current behavior?
Current:

`Error: Project already initialized. Remove supabase to reinitialize.`

## What is the new behavior?
New:
`Error: Project already initialized. To allow reinitialization remove the directory ./supabase`
