### PR TITLE
fix: delimiter slice may be overwritten

### DIFF
--- a/internal/utils/parser/state.go
+++ b/internal/utils/parser/state.go
@@ -118,7 +118,13 @@ type TagState struct {
 
 func (s *TagState) Next(r rune, data []byte) State {
 	if r == '$' {
-		return &DollarState{delimiter: data[s.offset:]}
+		// Make a copy since the data slice may be overwritten
+		tag := data[s.offset:]
+		dollar := DollarState{
+			delimiter: make([]byte, len(tag)),
+		}
+		copy(dollar.delimiter, tag)
+		return &dollar
 	}
 	// Valid tag: https://www.postgresql.org/docs/current/sql-syntax-lexical.html
 	if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Byte slices are not copied by value. As a result, buffered reader could overwrite delimiter when scanning more tokens.

## What is the new behavior?

Make a copy of the delimiter byte slice.

## Additional context

Add any other context or screenshots.
