### PR TITLE
show migration new help when called without arguments

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -31,7 +31,13 @@ var (
 	migrationNewCmd = &cobra.Command{
 		Use:   "new <migration name>",
 		Short: "Create an empty migration script",
-		Args:  cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				cmd.Help()
+				os.Exit(0)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return new.Run(args[0], os.Stdin, afero.NewOsFs())
 		},

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -33,7 +33,7 @@ var (
 		Short: "Create an empty migration script",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				cmd.Help()
+				_ = cmd.Help()
 				os.Exit(0)
 			}
 			return nil


### PR DESCRIPTION
print help instead of validation error when passing 0 or more than 1 arguments to `migration new`

## What kind of change does this PR introduce?

feature

## What is the current behavior?

![image](https://user-images.githubusercontent.com/4562878/187241061-53942b4b-996a-4a51-b93f-84704efc505d.png)


## What is the new behavior?

![image](https://user-images.githubusercontent.com/4562878/187241113-a0b6adc7-55d7-40a6-b8e4-83b5bf372f16.png)

