### PR TITLE
fix: add log rotation to postgres

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -234,6 +234,7 @@ func run(p utils.Program, ctx context.Context) error {
 		if utils.Config.Db.MajorVersion >= 14 {
 			cmd = []string{"postgres",
 				"-c", "config_file=/etc/postgresql/postgresql.conf",
+				// One log file per hour, 24 hours retention
 				"-c", "log_filename=server_%H00_UTC.log",
 				"-c", "log_rotation_age=60",
 				"-c", "log_truncate_on_rotation=on",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -232,7 +232,12 @@ func run(p utils.Program, ctx context.Context) error {
 	{
 		cmd := []string{}
 		if utils.Config.Db.MajorVersion >= 14 {
-			cmd = []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"}
+			cmd = []string{"postgres",
+				"-c", "config_file=/etc/postgresql/postgresql.conf",
+				"-c", "log_filename=server_%H00_UTC.log",
+				"-c", "log_rotation_age=60",
+				"-c", "log_truncate_on_rotation=on",
+			}
 		}
 
 		if _, err := utils.DockerRun(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supersedes https://github.com/supabase/cli/pull/245

## What is the current behavior?

Postgres logs grow indefinitely 

## What is the new behavior?

Keeps last 24 hours of logs, one log file per hour
total size ~4GB at `log_statement='all'` level

Ref: https://www.postgresql.org/docs/current/runtime-config-logging.html

## Additional context

```bash
root@202b693ee8da:/# ls -la /var/log/postgresql/
total 23112
drwxrwxr-t 1 root     postgres     4096 Aug 30 17:00 .
drwxr-xr-x 1 root     root         4096 Jan 27  2022 ..
-rw-r----- 1 postgres postgres 23455571 Aug 30 17:00 server_1600_UTC.csv
-rw-r----- 1 postgres postgres      406 Aug 30 16:52 server_1600_UTC.log
-rw-r----- 1 postgres postgres   190377 Aug 30 17:00 server_1700_UTC.csv
-rw-r----- 1 postgres postgres        0 Aug 30 17:00 server_1700_UTC.log
```
