### PR TITLE
fix: use dns over https as fallback resolver

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,11 +13,6 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
-    overrides:
-      - goos: darwin
-        env:
-          # https://github.com/golang/go/issues/12524
-          - CGO_ENABLED=1
 changelog:
   skip: true
 brews:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,11 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
+    overrides:
+      - goos: darwin
+        env:
+          # https://github.com/golang/go/issues/12524
+          - CGO_ENABLED=1
 changelog:
   skip: true
 brews:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/utils"
 )
 
 // Passed from `-ldflags`: https://stackoverflow.com/q/11354518.
@@ -17,6 +18,11 @@ var rootCmd = &cobra.Command{
 	Version:       version,
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if viper.GetBool("DEBUG") {
+			cmd.SetContext(utils.WithTraceContext(cmd.Context()))
+		}
+	},
 }
 
 func Execute() {

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -54,7 +54,7 @@ func fallbackLookupIP(ctx context.Context, address string) string {
 		return ""
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return ""
 	}
 	// Parses response

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -1,8 +1,12 @@
 package utils
 
 import (
+	"context"
 	"log"
+	"net"
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/spf13/viper"
@@ -13,6 +17,35 @@ var (
 	clientOnce sync.Once
 	apiClient  *supabase.ClientWithResponses
 )
+
+func withFallbackResolver(c *supabase.Client) error {
+	dialer := &net.Dialer{Timeout: 15 * time.Second}
+	dialer.Resolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			// Go resolver may not work on macOS https://github.com/golang/go/issues/12524
+			conn, err := dialer.DialContext(ctx, network, address)
+			if err != nil {
+				// Retry with CloudFlare DNS resolver
+				return dialer.DialContext(ctx, "udp", "1.1.1.1:53")
+			}
+			return conn, err
+		},
+	}
+	c.Client = &http.Client{
+		// Other settings are the same as http.DefaultTransport
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dialer.DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	return nil
+}
 
 func GetSupabase() *supabase.ClientWithResponses {
 	clientOnce.Do(func() {
@@ -27,6 +60,7 @@ func GetSupabase() *supabase.ClientWithResponses {
 		apiClient, err = supabase.NewClientWithResponses(
 			GetSupabaseAPIHost(),
 			supabase.WithRequestEditorFn(provider.Intercept),
+			withFallbackResolver,
 		)
 		if err != nil {
 			log.Fatalln(err)

--- a/internal/utils/api_test.go
+++ b/internal/utils/api_test.go
@@ -1,0 +1,119 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestFallbackDNS(t *testing.T) {
+	const host = "api.supabase.io"
+
+	t.Run("resolves IPv4 with CloudFlare", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", host).
+			MatchHeader("accept", "application/dns-json").
+			Reply(http.StatusOK).
+			JSON(&dnsResponse{Answer: []dnsAnswer{
+				{Type: dnsIPv4Type, Data: "127.0.0.1"},
+			}})
+		// Run test
+		ip := fallbackLookupIP(context.Background(), host+":443")
+		// Validate output
+		assert.Equal(t, "127.0.0.1:443", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("resolves IPv6 recursively", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", "api.supabase.com").
+			MatchHeader("accept", "application/dns-json").
+			Reply(http.StatusOK).
+			JSON(&dnsResponse{Answer: []dnsAnswer{
+				{Type: 5, Data: "supabase-api.fly.dev."},
+				{Type: dnsIPv6Type, Data: "2606:2800:220:1:248:1893:25c8:1946"},
+			}})
+		// Run test
+		ip := fallbackLookupIP(context.Background(), "api.supabase.com:443")
+		// Validate output
+		assert.Equal(t, "[2606:2800:220:1:248:1893:25c8:1946]:443", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("empty on malformed address", func(t *testing.T) {
+		assert.Equal(t, "", fallbackLookupIP(context.Background(), "bad?url"))
+	})
+
+	t.Run("empty on network failure", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", host).
+			MatchHeader("accept", "application/dns-json").
+			ReplyError(errors.New("network error"))
+		// Run test
+		ip := fallbackLookupIP(context.Background(), host+":443")
+		// Validate output
+		assert.Equal(t, "", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("empty on service unavailable", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", host).
+			MatchHeader("accept", "application/dns-json").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		ip := fallbackLookupIP(context.Background(), host+":443")
+		// Validate output
+		assert.Equal(t, "", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("empty on malformed json", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", host).
+			MatchHeader("accept", "application/dns-json").
+			Reply(http.StatusOK).
+			JSON("malformed")
+		// Run test
+		ip := fallbackLookupIP(context.Background(), host+":443")
+		// Validate output
+		assert.Equal(t, "", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("empty on no answer", func(t *testing.T) {
+		// Setup http mock
+		defer gock.OffAll()
+		gock.New("https://1.1.1.1").
+			Get("/dns-query").
+			MatchParam("name", host).
+			MatchHeader("accept", "application/dns-json").
+			Reply(http.StatusOK).
+			JSON(&dnsResponse{})
+		// Run test
+		ip := fallbackLookupIP(context.Background(), host+":443")
+		// Validate output
+		assert.Equal(t, "", ip)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

netgo dns resolver is bugged on macOS

https://go.dev/src/net/net.go?s=16228:16259
https://github.com/golang/go/issues/12524

## What is the new behavior?

Adds cloudflare dns as a fallback. This avoids compiling with cgo enabled.

## Additional context

```bash
$ GODEBUG=netdns=go+2 go run main.go projects list
go package net: GODEBUG setting forcing use of Go's resolver
go package net: hostLookupOrder(api.supabase.io) = files,dns
```
