### PR TITLE
fix: hard link to binary on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Supabase](https://supabase.io) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
 
-This repository contains all the functionality for our CLI.
+This repository contains all the functionality for Supabase CLI.
 
 - [x] Running Supabase locally
 - [x] Managing database migrations
@@ -18,6 +18,20 @@ This repository contains all the functionality for our CLI.
 ## Getting started
 
 ### Install the CLI
+
+#### NodeJS
+
+Available via [NPM](https://www.npmjs.com). To install:
+
+```bash
+npm i supabase
+```
+
+To run:
+
+```bash
+npx supabase -h
+```
 
 #### macOS
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #441 

## What is the current behavior?

npm could not find `bin/supabase` specified in package.json because windows binary has `.exe` extension.

## What is the new behavior?

windows only:
- creates a [hard link](https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions) in the download directory
- symlink results in permission denied

## Additional context


