### PR TITLE
fix: support remote commit of pg13 database

### DIFF
--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -296,7 +295,13 @@ EOSQL
 			return err
 		}
 
-		if err := differ.SaveDiff(string(diffBytes), "remote_commit", fsys); err != nil {
+		// Ignore header comments
+		if len(diffBytes) <= 350 {
+			return nil
+		}
+
+		path := filepath.Join(utils.MigrationsDir, timestamp+"_remote_commit.sql")
+		if err := afero.WriteFile(fsys, path, diffBytes, 0644); err != nil {
 			return err
 		}
 	}

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -107,6 +107,7 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 	timestamp := utils.GetCurrentTimestamp()
 
 	// 2. Special case if this is the first migration
+	// MigrationsDir should exist and be readable after AssertRemoteInSync call
 	if localMigrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil && len(localMigrations) == 0 {
 		p.Send(utils.StatusMsg("Committing initial migration on remote database..."))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #440 

## What is the current behavior?

- runs pg_dump from db container

## What is the new behavior?

- always use pg14 container for creating dump

## Additional context

Add any other context or screenshots.
