### PR TITLE
fix: set search_path from postgres config

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -242,6 +242,8 @@ func run(p utils.Program, ctx context.Context) error {
 				"-c", "log_rotation_age=60",
 				"-c", "log_rotation_size=0",
 				"-c", "log_truncate_on_rotation=on",
+				// Ref: https://postgrespro.com/list/thread-id/2448092
+				"-c", `search_path="$user",public,extensions`,
 			}
 		}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #453 

## What is the current behavior?

search_path intentionally not included in pg_dump to prevent abuse https://postgrespro.com/list/thread-id/2448092

## What is the new behavior?

sets the default search_path for postgres user via config flag
although it is possible to include alter 

## Additional context

- [x] tested db reset
- [x] tested db push
