### PR TITLE
fix: supabase login redirects to wrong link

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Run(stdin io.Reader, fsys afero.Fs) error {
-	fmt.Printf(`You can generate an access token from %s/account/tokens.
+	fmt.Printf(`You can generate an access token from %s/account/tokens
 Enter your access token: `, utils.GetSupabaseDashboardURL())
 
 	scanner := bufio.NewScanner(stdin)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #457

## What is the current behavior?

`supabase login` redirects to `https://app.supabase.com/account/tokens.` on control clicking the link. 
The link has "." at the end.

## What is the new behavior?

`supabase login` redirects to `https://app.supabase.com/account/tokens`

## Additional context

Some terminal applications like konsole allows control clicking on the link to open it on the browser and it considers everything as part of url if there is no gap between the characters. In this case it was the period / dot.
