### PR TITLE
fix: restart database after issuing pg_terminate_backend

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -63,7 +63,8 @@ var (
 		Short: "Switch the active branch",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return switch_.Run(args[0])
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return switch_.Run(ctx, args[0], afero.NewOsFs())
 		},
 	}
 

--- a/internal/db/branch/list/list.go
+++ b/internal/db/branch/list/list.go
@@ -21,7 +21,7 @@ func Run(fsys afero.Fs, out io.Writer) error {
 
 	currBranch, _ := utils.GetCurrentBranchFS(fsys)
 	for _, branch := range branches {
-		if branch.Name() == "_current_branch" {
+		if branch.Name() == filepath.Base(utils.CurrBranchPath) {
 			continue
 		}
 

--- a/internal/db/branch/switch_/switch_.go
+++ b/internal/db/branch/switch_/switch_.go
@@ -69,7 +69,7 @@ func switchDatabase(ctx context.Context, source, target string, options ...func(
 	if err := reset.DisconnectClients(ctx, conn); err != nil {
 		return err
 	}
-	defer reset.RestartDatabase(ctx)
+	defer reset.RestartDatabase(context.Background())
 	backup := "ALTER DATABASE postgres RENAME TO " + source + ";"
 	if _, err := conn.Exec(ctx, backup); err != nil {
 		return err

--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -45,7 +45,7 @@ func TestSwitchCommand(t *testing.T) {
 			JSON(types.ContainerJSON{})
 		gock.New("http:///var/run/docker.sock").
 			Post("/v" + version + "/containers").
-			Reply(http.StatusOK)
+			Reply(http.StatusServiceUnavailable)
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -289,7 +289,7 @@ func TestSwitchDatabase(t *testing.T) {
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
 			Post("/v" + version + "/containers/" + utils.DbId + "/restart").
-			Reply(http.StatusOK)
+			Reply(http.StatusServiceUnavailable)
 		// Run test
 		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
 		// Check error
@@ -325,7 +325,7 @@ func TestSwitchDatabase(t *testing.T) {
 			SetHeader("OSType", "linux")
 		gock.New("http:///var/run/docker.sock").
 			Post("/v" + version + "/containers/" + utils.DbId + "/restart").
-			Reply(http.StatusOK)
+			Reply(http.StatusServiceUnavailable)
 		// Run test
 		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
 		// Check error

--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -1,0 +1,335 @@
+package switch_
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/jackc/pgerrcode"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/testing/pgtest"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestSwitchCommand(t *testing.T) {
+	const version = "1.41"
+
+	t.Run("switches local branch", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup target branch
+		branch := "target"
+		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
+		require.NoError(t, fsys.Mkdir(branchPath, 0755))
+		require.NoError(t, afero.WriteFile(fsys, utils.CurrBranchPath, []byte("main"), 0644))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers").
+			Reply(http.StatusOK)
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Reply("DO").
+			Query("ALTER DATABASE postgres RENAME TO main;").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE " + branch + " RENAME TO postgres;").
+			Reply("ALTER DATABASE")
+		// Run test
+		assert.NoError(t, Run(context.Background(), branch, fsys, conn.Intercept))
+		// Validate output
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+		contents, err := afero.ReadFile(fsys, utils.CurrBranchPath)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(branch), contents)
+	})
+
+	t.Run("throws error on missing config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		err := Run(context.Background(), "target", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Have you set up the project with supabase init?")
+	})
+
+	t.Run("throws error on malformed config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
+		// Run test
+		err := Run(context.Background(), "target", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Failed to read config: toml")
+	})
+
+	t.Run("throws error on missing database", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := Run(context.Background(), "target", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "supabase start is not running.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on reserved branch", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Run test
+		err := Run(context.Background(), utils.ShadowDbName, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "branch name is reserved.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on missing branch", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Run test
+		err := Run(context.Background(), "main", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Branch main does not exist.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("noop on current branch", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Setup target branch
+		branch := "main"
+		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
+		require.NoError(t, fsys.Mkdir(branchPath, 0755))
+		// Run test
+		assert.NoError(t, Run(context.Background(), branch, fsys))
+		// Check error
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+		contents, err := afero.ReadFile(fsys, utils.CurrBranchPath)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(branch), contents)
+	})
+
+	t.Run("throws error on failure to switch", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Setup target branch
+		branch := "target"
+		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
+		require.NoError(t, fsys.Mkdir(branchPath, 0755))
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		// Run test
+		err := Run(context.Background(), branch, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "Error switching to branch target: conn closed")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to write", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Setup target branch
+		branch := "main"
+		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
+		require.NoError(t, fsys.Mkdir(branchPath, 0755))
+		// Run test
+		err := Run(context.Background(), branch, afero.NewReadOnlyFs(fsys))
+		// Check error
+		assert.ErrorContains(t, err, "Unable to update local branch file.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestSwitchDatabase(t *testing.T) {
+	const version = "1.41"
+
+	t.Run("throws error on failure to connect", func(t *testing.T) {
+		// Setup invalid port
+		utils.Config.Db.Port = 0
+		// Run test
+		err := switchDatabase(context.Background(), "main", "target")
+		// Check error
+		assert.ErrorContains(t, err, "invalid port")
+	})
+
+	t.Run("throws error on failure to disconnect", func(t *testing.T) {
+		// Setup valid config
+		utils.Config.Db.Port = 54322
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
+		// Run test
+		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, pgerrcode.InvalidParameterValue)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to backup", func(t *testing.T) {
+		// Setup valid config
+		utils.DbId = "test-switch"
+		utils.Config.Db.Port = 54322
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Reply("DO").
+			Query("ALTER DATABASE postgres RENAME TO main;").
+			ReplyError(pgerrcode.DuplicateDatabase, `database "main" already exists`)
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers/" + utils.DbId + "/restart").
+			Reply(http.StatusOK)
+		// Run test
+		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, pgerrcode.DuplicateDatabase)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to rename", func(t *testing.T) {
+		// Setup valid config
+		utils.DbId = "test-switch"
+		utils.Config.Db.Port = 54322
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Reply("DO").
+			Query("ALTER DATABASE postgres RENAME TO main;").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE target RENAME TO postgres;").
+			ReplyError(pgerrcode.InvalidCatalogName, `database "target" does not exist`).
+			// Attempt to rollback
+			Query("ALTER DATABASE main RENAME TO postgres;").
+			ReplyError(pgerrcode.DuplicateDatabase, `database "postgres" already exists`)
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers/" + utils.DbId + "/restart").
+			Reply(http.StatusOK)
+		// Run test
+		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, pgerrcode.InvalidCatalogName)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -125,9 +125,7 @@ func ActivateDatabase(ctx context.Context, branch string, options ...func(*pgx.C
 	if err := DisconnectClients(ctx, conn); err != nil {
 		return err
 	}
-	// Some extensions must be manually restarted after pg_terminate_backend
-	// Ref: https://github.com/citusdata/pg_cron/issues/99
-	defer RestartDatabase(ctx)
+	defer RestartDatabase(context.Background())
 	drop := "DROP DATABASE IF EXISTS postgres WITH (FORCE);"
 	if _, err := conn.Exec(ctx, drop); err != nil {
 		return err
@@ -156,6 +154,8 @@ func DisconnectClients(ctx context.Context, conn *pgx.Conn) error {
 }
 
 func RestartDatabase(ctx context.Context) {
+	// Some extensions must be manually restarted after pg_terminate_backend
+	// Ref: https://github.com/citusdata/pg_cron/issues/99
 	if err := utils.Docker.ContainerRestart(ctx, utils.DbId, nil); err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to restart database:", err)
 	}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -492,7 +492,7 @@ EOSQL
 			if err != nil {
 				return err
 			}
-			defer reset.RestartDatabase(ctx)
+			defer reset.RestartDatabase(context.Background())
 			var errBuf bytes.Buffer
 			if _, err := stdcopy.StdCopy(io.Discard, &errBuf, out); err != nil {
 				return err

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/muesli/reflow/wrap"
+	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -269,7 +270,7 @@ func run(p utils.Program, ctx context.Context) error {
 		}
 
 		out, err := utils.DockerExec(ctx, utils.DbId, []string{
-			"sh", "-c", "until pg_isready --host $(hostname --ip-address); do sleep 0.1; done " +
+			"sh", "-c", "until pg_isready --username postgres --host $(hostname --ip-address); do sleep 0.1; done " +
 				`&& psql --username postgres --host 127.0.0.1 <<'EOSQL'
 BEGIN;
 ` + utils.GlobalsSql + `
@@ -491,6 +492,7 @@ EOSQL
 			if err != nil {
 				return err
 			}
+			defer reset.RestartDatabase(ctx)
 			var errBuf bytes.Buffer
 			if _, err := stdcopy.StdCopy(io.Discard, &errBuf, out); err != nil {
 				return err

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -255,6 +256,12 @@ func run(p utils.Program, ctx context.Context) error {
 				Image: utils.GetRegistryImageUrl(utils.DbImage),
 				Env:   []string{"POSTGRES_PASSWORD=postgres"},
 				Cmd:   cmd,
+				Healthcheck: &container.HealthConfig{
+					Test:     []string{"CMD", "pg_isready", "-h", "localhost", "-p", "5432"},
+					Interval: 2 * time.Second,
+					Timeout:  2 * time.Second,
+					Retries:  10,
+				},
 				Labels: map[string]string{
 					"com.supabase.cli.project":   utils.Config.ProjectId,
 					"com.docker.compose.project": utils.Config.ProjectId,

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -257,7 +257,7 @@ func run(p utils.Program, ctx context.Context) error {
 				Env:   []string{"POSTGRES_PASSWORD=postgres"},
 				Cmd:   cmd,
 				Healthcheck: &container.HealthConfig{
-					Test:     []string{"CMD", "pg_isready", "-h", "localhost", "-p", "5432"},
+					Test:     []string{"CMD", "pg_isready", "-u", "postgres", "-h", "localhost", "-p", "5432"},
 					Interval: 2 * time.Second,
 					Timeout:  2 * time.Second,
 					Retries:  10,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

pg_terminate_backend induces pg_cron scheduler to shutdown

## What is the new behavior?

- restart postgres as recommended https://github.com/citusdata/pg_cron/issues/99 
- refactors branch switch to use pgx
- add unit tests
- adds health probe 

## Additional context

Add any other context or screenshots.
