### PR TITLE
fix: expose jwt signing secret in status message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
 
       - run: |
           if [ ! -z $(gofmt -l .) ]; then echo 'Make sure to run "go fmt ./..." before commit!' && exit 1; fi
-          mkdir  /home/runner/.supabase && chown -R runner /home/runner/.supabase
           go test ./... -race -v -count=1 -coverpkg ./cmd/...,./internal/... -coverprofile=coverage.out
           go tool cover -func coverage.out | grep total
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"os/signal"
+
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/status"
 )
@@ -9,7 +13,8 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of local Supabase containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return status.Run()
+		ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		return status.Run(ctx, afero.NewOsFs())
 	},
 }
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -257,7 +257,7 @@ func run(p utils.Program, ctx context.Context) error {
 				Env:   []string{"POSTGRES_PASSWORD=postgres"},
 				Cmd:   cmd,
 				Healthcheck: &container.HealthConfig{
-					Test:     []string{"CMD", "pg_isready", "-u", "postgres", "-h", "localhost", "-p", "5432"},
+					Test:     []string{"CMD", "pg_isready", "-U", "postgres", "-h", "localhost", "-p", "5432"},
 					Interval: 2 * time.Second,
 					Timeout:  2 * time.Second,
 					Retries:  10,

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,26 +1,50 @@
 package status
 
 import (
+	"context"
 	"fmt"
+	"os"
 
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run() error {
+func Run(ctx context.Context, fsys afero.Fs) error {
 	// Sanity checks.
-	if err := utils.AssertDockerIsRunning(); err != nil {
-		return err
-	}
-	if err := utils.LoadConfig(); err != nil {
-		return err
-	}
-
-	if err := utils.AssertSupabaseStartIsRunning(); err == nil {
-		fmt.Println(utils.Aqua("supabase") + " local development setup is running.")
-		utils.ShowStatus()
-	} else {
-		fmt.Println(utils.Aqua("supabase") + " local development setup is not running.")
+	{
+		if err := utils.AssertSupabaseCliIsSetUpFS(fsys); err != nil {
+			return err
+		}
+		if err := utils.LoadConfigFS(fsys); err != nil {
+			return err
+		}
+		if err := utils.AssertDockerIsRunning(); err != nil {
+			return err
+		}
 	}
 
+	services := []string{
+		utils.DbId,
+		utils.KongId,
+		utils.GotrueId,
+		utils.InbucketId,
+		utils.RealtimeId,
+		utils.RestId,
+		utils.StorageId,
+		utils.PgmetaId,
+		utils.StudioId,
+	}
+	for _, name := range services {
+		resp, err := utils.Docker.ContainerInspect(ctx, name)
+		if err != nil {
+			return fmt.Errorf("container %s not found. Have your run %s?", name, utils.Aqua("supabase start"))
+		}
+		if !resp.State.Running {
+			fmt.Fprintln(os.Stderr, name, "container is not running:", resp.State.Status)
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, utils.Aqua("supabase"), "local development setup is running.")
+	utils.ShowStatus()
 	return nil
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -42,7 +42,7 @@ func showServiceHealth(ctx context.Context, services []string, stderr io.Writer)
 	for _, name := range services {
 		resp, err := utils.Docker.ContainerInspect(ctx, name)
 		if err != nil {
-			return fmt.Errorf("container %s not found. Have your run %s?", name, utils.Aqua("supabase start"))
+			return fmt.Errorf("%s container not found. Have your run %s?", name, utils.Aqua("supabase start"))
 		}
 		if !resp.State.Running {
 			fmt.Fprintln(stderr, name, "container is not running:", resp.State.Status)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/afero"
@@ -34,17 +35,21 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		utils.PgmetaId,
 		utils.StudioId,
 	}
+	return showServiceHealth(ctx, services, os.Stderr)
+}
+
+func showServiceHealth(ctx context.Context, services []string, stderr io.Writer) error {
 	for _, name := range services {
 		resp, err := utils.Docker.ContainerInspect(ctx, name)
 		if err != nil {
 			return fmt.Errorf("container %s not found. Have your run %s?", name, utils.Aqua("supabase start"))
 		}
 		if !resp.State.Running {
-			fmt.Fprintln(os.Stderr, name, "container is not running:", resp.State.Status)
+			fmt.Fprintln(stderr, name, "container is not running:", resp.State.Status)
 		}
 	}
 
-	fmt.Fprintln(os.Stderr, utils.Aqua("supabase"), "local development setup is running.")
+	fmt.Fprintln(stderr, utils.Aqua("supabase"), "local development setup is running.")
 	utils.ShowStatus()
 	return nil
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,0 +1,123 @@
+package status
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestStatusCommand(t *testing.T) {
+	const version = "1.41"
+
+	t.Run("throws error on missing config", func(t *testing.T) {
+		err := Run(context.Background(), afero.NewMemMapFs())
+		assert.ErrorContains(t, err, "Have you set up the project with supabase init?")
+	})
+
+	t.Run("throws error on invalid config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Failed to read config: toml")
+	})
+
+	t.Run("throws error on missing docker", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			ReplyError(errors.New("network error"))
+		gock.New("http:///var/run/docker.sock").
+			Get("/_ping").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on missing container", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusNotFound)
+		// Run test
+		Run(context.Background(), fsys)
+		// Check error
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestServiceHealth(t *testing.T) {
+	const version = "1.41"
+
+	t.Run("checks all services", func(t *testing.T) {
+		services := []string{"supabase_db", "supabase_auth"}
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + services[0] + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Running: true},
+			}})
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + services[1] + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Status: "exited"},
+			}})
+		// Run test
+		var stderr bytes.Buffer
+		assert.NoError(t, showServiceHealth(context.Background(), services, &stderr))
+		// Check error
+		assert.Contains(t, stderr.String(), "supabase_auth container is not running: exited")
+		assert.Contains(t, stderr.String(), "supabase local development setup is running.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -81,8 +81,9 @@ func TestStatusCommand(t *testing.T) {
 			Get("/v" + version + "/containers").
 			Reply(http.StatusNotFound)
 		// Run test
-		Run(context.Background(), fsys)
+		err := Run(context.Background(), fsys)
 		// Check error
+		assert.ErrorContains(t, err, "container not found. Have your run supabase start?")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -391,6 +391,7 @@ func ShowStatus() {
           ` + Aqua("DB URL") + `: postgresql://postgres:postgres@localhost:` + strconv.FormatUint(uint64(Config.Db.Port), 10) + `/postgres
       ` + Aqua("Studio URL") + `: http://localhost:` + strconv.FormatUint(uint64(Config.Studio.Port), 10) + `
     ` + Aqua("Inbucket URL") + `: http://localhost:` + strconv.FormatUint(uint64(Config.Inbucket.Port), 10) + `
+      ` + Aqua("JWT secret") + `: ` + JWTSecret + `
         ` + Aqua("anon key") + `: ` + AnonKey + `
 ` + Aqua("service_role key") + `: ` + ServiceRoleKey)
 }

--- a/test/link_test.go
+++ b/test/link_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	clicmd "github.com/supabase/cli/cmd"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/test/mocks/supabase"
 )
 
@@ -37,8 +38,7 @@ func (suite *LinkTestSuite) TestLink() {
 	link, _, err := suite.cmd.Find([]string{"link"})
 	link.SetContext(context.Background())
 	require.NoError(suite.T(), err)
-	key := "sbp_" + gonanoid.MustGenerate(supabase.KeyAlphabet, supabase.KeyLength)
-	os.Setenv("SUPABASE_ACCESS_TOKEN", key)
+
 	id := gonanoid.MustGenerate(supabase.IDAlphabet, supabase.IDLength)
 	require.NoError(suite.T(), link.Flags().Set("project-ref", id))
 	require.NoError(suite.T(), link.Flags().Set("password", "postgres"))
@@ -50,7 +50,7 @@ func (suite *LinkTestSuite) TestLink() {
 	defer suite.mtx.RUnlock()
 	require.Contains(suite.T(), suite.ids, id)
 	require.Contains(suite.T(), suite.headers, http.Header{
-		"Authorization":   []string{fmt.Sprintf("Bearer %s", key)},
+		"Authorization":   []string{fmt.Sprintf("Bearer %s", supabase.AccessToken)},
 		"Accept-Encoding": []string{"gzip"},
 		"User-Agent":      []string{"Go-http-client/1.1"},
 	})
@@ -77,7 +77,7 @@ func (suite *LinkTestSuite) SetupTest() {
 		suite.addHeaders(c.Request.Header)
 		suite.addID(c.Params.ByName("id"))
 
-		c.JSON(http.StatusOK, gin.H{})
+		c.JSON(http.StatusOK, []api.FunctionResponse{})
 	}
 }
 

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -42,6 +42,8 @@ func TestMain(m *testing.M) {
 		Logger.Fatal(err)
 	}
 	viper.Set("INTERNAL_API_HOST", "http://127.0.0.1"+SupabasePort)
+	os.Setenv("SUPABASE_ACCESS_TOKEN", supabase.AccessToken)
+	os.Setenv("HOME", TempDir)
 
 	// run tests
 	exitVal := m.Run()

--- a/test/mocks/supabase/server.go
+++ b/test/mocks/supabase/server.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	gonanoid "github.com/matoous/go-nanoid/v2"
 )
 
 const (
@@ -12,6 +13,8 @@ const (
 	KeyAlphabet = "abcdef0123456789"
 	KeyLength   = 40
 )
+
+var AccessToken = "sbp_" + gonanoid.MustGenerate(KeyAlphabet, KeyLength)
 
 // Server struct with route handlers
 type Server struct {

--- a/test/secrets_test.go
+++ b/test/secrets_test.go
@@ -38,8 +38,6 @@ func (suite *SecretsTestSuite) TestList() {
 	list.SetContext(context.Background())
 	require.NoError(suite.T(), err)
 
-	key := "sbp_" + gonanoid.MustGenerate(supabase.KeyAlphabet, supabase.KeyLength)
-	os.Setenv("SUPABASE_ACCESS_TOKEN", key)
 	ref := gonanoid.MustGenerate(supabase.IDAlphabet, supabase.IDLength)
 	require.NoError(suite.T(), ioutil.WriteFile(utils.ProjectRefPath, []byte(ref), os.FileMode(0755)))
 
@@ -58,7 +56,7 @@ func (suite *SecretsTestSuite) TestList() {
 	defer suite.mtx.RUnlock()
 	require.Contains(suite.T(), suite.ids, ref)
 	require.Contains(suite.T(), suite.headers, http.Header{
-		"Authorization":   []string{fmt.Sprintf("Bearer %s", key)},
+		"Authorization":   []string{fmt.Sprintf("Bearer %s", supabase.AccessToken)},
 		"Accept-Encoding": []string{"gzip"},
 		"User-Agent":      []string{"Go-http-client/1.1"},
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #468 

## What is the current behavior?

JWT secret is hard coded

## What is the new behavior?

```bash
$ supabase status
supabase local development setup is running.

         API URL: http://localhost:54321
          DB URL: postgresql://postgres:postgres@localhost:54322/postgres
      Studio URL: http://localhost:54323
    Inbucket URL: http://localhost:54324
      JWT secret: <redacted>
        anon key: <redacted>
service_role key: <redacted>
```

## Additional context

Also fixes:
- misspelt health check flag
- status checks all service containers are running
- add unit tests
