### PR TITLE
fix: retry connecting to remote postgres

### DIFF
--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/muesli/reflow/wrap"
 	"github.com/spf13/afero"
@@ -431,10 +432,10 @@ func ConnectRemotePostgres(ctx context.Context, username, password, database, ho
 	// Build connection string
 	pgUrl := fmt.Sprintf(
 		// Use port 6543 for connection pooling
-		"postgresql://%s:%s@db.%s.supabase.co:6543/%s",
+		"postgresql://%s:%s@%s:6543/%s?connect_timeout=3",
 		url.QueryEscape(username),
 		url.QueryEscape(password),
-		url.QueryEscape(host),
+		utils.GetSupabaseDbHost(url.QueryEscape(host)),
 		url.QueryEscape(database),
 	)
 	// Parse connection url
@@ -453,6 +454,13 @@ func ConnectRemotePostgres(ctx context.Context, username, password, database, ho
 	if viper.GetBool("DEBUG") {
 		debug.SetupPGX(config)
 	}
+	conn, err := pgx.ConnectConfig(ctx, config)
+	if !pgconn.Timeout(err) {
+		return conn, err
+	}
+	// Fallback to postgres when pgbouncer is unavailable
+	config.Port = 5432
+	fmt.Println("Retrying...", config.Host, config.Port)
 	return pgx.ConnectConfig(ctx, config)
 }
 

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -460,7 +461,7 @@ func ConnectRemotePostgres(ctx context.Context, username, password, database, ho
 	}
 	// Fallback to postgres when pgbouncer is unavailable
 	config.Port = 5432
-	fmt.Println("Retrying...", config.Host, config.Port)
+	fmt.Fprintln(os.Stderr, "Retrying...", config.Host, config.Port)
 	return pgx.ConnectConfig(ctx, config)
 }
 

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -190,5 +191,17 @@ func GetSupabaseDashboardURL() string {
 		return "https://app.supabase.green"
 	default:
 		return "http://localhost:8082"
+	}
+}
+
+func GetSupabaseDbHost(projectRef string) string {
+	// TODO: query projects api for db_host
+	switch GetSupabaseAPIHost() {
+	case "https://api.supabase.com", "https://api.supabase.io":
+		return fmt.Sprintf("db.%s.supabase.co", projectRef)
+	case "https://api.supabase.green":
+		return fmt.Sprintf("db.%s.supabase.red", projectRef)
+	default:
+		return "http://localhost:5432"
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

improves availability

## What is the current behavior?

cannot link project if pgbouncer is down

## What is the new behavior?

- retries on postgres port if pgbouncer times out
- times out connect after 3 seconds (previously no timeout)
- supports staging red url (previously hardcoded to supabase.co)

## Additional context

Add any other context or screenshots.
