### PR TITLE
fix: allow for long lines in SQL migrations

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -128,7 +128,11 @@ func ApplyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 			defer sql.Close()
 			// Batch migration commands, without using statement cache
 			batch := pgconn.Batch{}
-			for _, line := range parser.Split(sql) {
+			lines, err := parser.Split(sql)
+			if err != nil {
+				return err
+			}
+			for _, line := range lines {
 				trim := strings.TrimSpace(strings.TrimRight(line, ";"))
 				if len(trim) > 0 {
 					batch.ExecParams(trim, nil, nil, nil, nil)

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -98,7 +98,11 @@ func SeedDatabase(ctx context.Context, url string, fsys afero.Fs, options ...fun
 	defer conn.Close(ctx)
 	// Batch seed commands, safe to use statement cache
 	batch := pgx.Batch{}
-	for _, line := range parser.Split(sql) {
+	lines, err := parser.Split(sql)
+	if err != nil {
+		return err
+	}
+	for _, line := range lines {
 		trim := strings.TrimSpace(strings.TrimRight(line, ";"))
 		if len(trim) > 0 {
 			batch.Queue(trim)

--- a/internal/utils/parser/state_test.go
+++ b/internal/utils/parser/state_test.go
@@ -5,30 +5,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLineComment(t *testing.T) {
 	t.Run("after separator", func(t *testing.T) {
 		sql := "END;-- comment"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"END;", "-- comment"}, stats)
 	})
 
 	t.Run("before separator", func(t *testing.T) {
 		sql := "SELECT --; 1"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT --; 1"}, stats)
 	})
 
 	t.Run("not started", func(t *testing.T) {
 		sql := "- ;END"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"- ;", "END"}, stats)
 	})
 
 	t.Run("between lines", func(t *testing.T) {
 		sql := "-- /* \n; */ END"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"-- /* \n;", " */ END"}, stats)
 	})
 }
@@ -36,19 +41,22 @@ func TestLineComment(t *testing.T) {
 func TestBlockComment(t *testing.T) {
 	t.Run("contains separator", func(t *testing.T) {
 		sql := "SELECT /* ; */ 1;"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT /* ; */ 1;"}, stats)
 	})
 
 	t.Run("nested block", func(t *testing.T) {
 		sql := "SELECT /*; /*;*/ ;*/ 1"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT /*; /*;*/ ;*/ 1"}, stats)
 	})
 
 	t.Run("not started", func(t *testing.T) {
 		sql := "/ * ; */ END"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"/ * ;", " */ END"}, stats)
 	})
 }
@@ -56,19 +64,22 @@ func TestBlockComment(t *testing.T) {
 func TestSeparator(t *testing.T) {
 	t.Run("no spaces", func(t *testing.T) {
 		sql := ";END;;"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{";", "END;", ";"}, stats)
 	})
 
 	t.Run("between spaces", func(t *testing.T) {
 		sql := "BEGIN   ;  END"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"BEGIN   ;", "  END"}, stats)
 	})
 
 	t.Run("backslash escaped", func(t *testing.T) {
 		sql := "\\;;\\;"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"\\;;", "\\;"}, stats)
 	})
 }
@@ -76,19 +87,22 @@ func TestSeparator(t *testing.T) {
 func TestDollarQuote(t *testing.T) {
 	t.Run("named tag", func(t *testing.T) {
 		sql := "$tag$ any ; string$tag$"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"$tag$ any ; string$tag$"}, stats)
 	})
 
 	t.Run("anonymous tag", func(t *testing.T) {
 		sql := "$$\"Dane's horse\"$$"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"$$\"Dane's horse\"$$"}, stats)
 	})
 
 	t.Run("not started", func(t *testing.T) {
 		sql := "SELECT \"$\"; $$"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT \"$\";", " $$"}, stats)
 	})
 }
@@ -96,19 +110,22 @@ func TestDollarQuote(t *testing.T) {
 func TestSingleQuote(t *testing.T) {
 	t.Run("escapes separator", func(t *testing.T) {
 		sql := "SELECT ';' 1"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT ';' 1"}, stats)
 	})
 
 	t.Run("preserves single quote", func(t *testing.T) {
 		sql := "SELECT ';'';' 1"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT ';'';' 1"}, stats)
 	})
 
 	t.Run("literal backslash", func(t *testing.T) {
 		sql := "SELECT '\\'; 1'"
-		stats := Split(strings.NewReader(sql))
+		stats, err := Split(strings.NewReader(sql))
+		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"SELECT '\\';", " 1'"}, stats)
 	})
 }

--- a/internal/utils/parser/token.go
+++ b/internal/utils/parser/token.go
@@ -6,6 +6,15 @@ import (
 	"unicode/utf8"
 )
 
+const (
+	// Default max capacity is 64 * 1024 which is not enough for certain lines
+	// containing e.g. geographical data.
+	// 256K ought to be enough for anybody...
+	maxScannerCapacity = 256 * 1024
+	// Equal to `startBufSize` from `bufio/scan.go`
+	startBufSize = 4096
+)
+
 // State transition table for tokenizer:
 //
 //   Ready -> Ready (default)
@@ -70,6 +79,11 @@ func (t *tokenizer) ScanToken(data []byte, atEOF bool) (advance int, token []byt
 func Split(sql io.Reader) (stats []string, err error) {
 	t := tokenizer{state: &ReadyState{}}
 	scanner := bufio.NewScanner(sql)
+
+	// Increase scanner capacity to support very long lines containing e.g. geodata
+	buf := make([]byte, startBufSize)
+	scanner.Buffer(buf, maxScannerCapacity)
+
 	scanner.Split(t.ScanToken)
 	for scanner.Scan() {
 		token := scanner.Text()

--- a/internal/utils/parser/token.go
+++ b/internal/utils/parser/token.go
@@ -67,7 +67,7 @@ func (t *tokenizer) ScanToken(data []byte, atEOF bool) (advance int, token []byt
 // token can be parsed as statement separator.
 //
 // Each statement is split as it is, without removing comments or white spaces.
-func Split(sql io.Reader) (stats []string) {
+func Split(sql io.Reader) (stats []string, err error) {
 	t := tokenizer{state: &ReadyState{}}
 	scanner := bufio.NewScanner(sql)
 	scanner.Split(t.ScanToken)
@@ -75,5 +75,5 @@ func Split(sql io.Reader) (stats []string) {
 		token := scanner.Text()
 		stats = append(stats, token)
 	}
-	return stats
+	return stats, scanner.Err()
 }

--- a/internal/utils/parser/token_test.go
+++ b/internal/utils/parser/token_test.go
@@ -34,7 +34,8 @@ func TestSplit(t *testing.T) {
 
 	sql, err := os.Open(filepath.Join(testdata, "all.sql"))
 	require.NoError(t, err)
-	stats := Split(sql)
+	stats, err := Split(sql)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, fixture, stats[:len(fixture)])
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When lines that are too long are encountered, the scanner in `internal/utils/parser/token.go#Split` fails, but the `.Err()` is not checked, causing the error to be suppressed and the `internal/utils/parser/token.go#Split` func to return partial data.

See #470 

## What is the new behavior?

* Errors produced by the scanner used in `internal/utils/parser/token.go#Split` are propagated to the caller.
* Lines up to 256K can now be read by `internal/utils/parser/token.go#Split`.