### PR TITLE
feat: support configuring arbitrary OIDC provider url for gotrue

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -535,6 +535,7 @@ EOSQL
 					"KONG_PLUGINS=request-transformer,cors,key-auth",
 					// Need to increase the nginx buffers in kong to avoid it rejecting the rather
 					// sizeable response headers azure can generate
+					// Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126
 					"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
 					"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
 				},

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -533,6 +533,10 @@ EOSQL
 					"KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml",
 					"KONG_DNS_ORDER=LAST,A,CNAME", // https://github.com/supabase/cli/issues/14
 					"KONG_PLUGINS=request-transformer,cors,key-auth",
+					// Need to increase the nginx buffers in kong to avoid it rejecting the rather
+					// sizeable response headers azure can generate
+					"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
+					"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
 				},
 				Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /home/kong/kong.yml && ./docker-entrypoint.sh kong docker-start
 ` + kongConfigBuf.String() + `

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -599,6 +599,12 @@ EOF
 				fmt.Sprintf("GOTRUE_EXTERNAL_%s_SECRET=%s", strings.ToUpper(name), config.Secret),
 				fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=http://localhost:%v/auth/v1/callback", strings.ToUpper(name), utils.Config.Api.Port),
 			)
+
+			if config.Url != "" {
+				env = append(env,
+					fmt.Sprintf("GOTRUE_EXTERNAL_%s_URL=%s", strings.ToUpper(name), config.Url),
+				)
+			}
 		}
 
 		if _, err := utils.DockerRun(

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -114,6 +114,7 @@ type (
 		Enabled  bool
 		ClientId string `toml:"client_id"`
 		Secret   string
+		Url      string
 	}
 
 	// TODO
@@ -231,7 +232,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 					return value, nil
 				}
 
-				var clientId, secret string
+				var clientId, secret, url string
 
 				if Config.Auth.External[ext].ClientId == "" {
 					return fmt.Errorf("Missing required field in config: auth.external.%s.client_id", ext)
@@ -252,10 +253,20 @@ func LoadConfigFS(fsys afero.Fs) error {
 					secret = v
 				}
 
+				if Config.Auth.External[ext].Url != "" {
+
+					v, err := maybeLoadEnv(Config.Auth.External[ext].Url)
+					if err != nil {
+						return err
+					}
+					url = v
+				}
+
 				Config.Auth.External[ext] = provider{
 					Enabled:  true,
 					ClientId: clientId,
 					Secret:   secret,
+					Url:      url,
 				}
 			}
 		}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -254,7 +254,6 @@ func LoadConfigFS(fsys afero.Fs) error {
 				}
 
 				if Config.Auth.External[ext].Url != "" {
-
 					v, err := maybeLoadEnv(Config.Auth.External[ext].Url)
 					if err != nil {
 						return err

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -60,3 +60,6 @@ enable_confirmations = false
 enabled = true
 client_id = "env(AZURE_CLIENT_ID)"
 secret = "env(AZURE_SECRET)"
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = "https://login.microsoftonline.com/tenant"

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -60,3 +60,6 @@ enable_confirmations = false
 enabled = false
 client_id = ""
 secret = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature


## What is the current behavior?

You have to use multi-tenant azure application to enable sign-in with azure. which is impractical if you are making an org specific URL. 

## What is the new behavior?

This allows specifying a `url` property on external auth providers which will be passed along to GoTrue:
```toml
[auth.external.azure]
enabled = true
client_id = "****"
secret = "****"
url = "https://login.microsoftonline.com/****"
```

The property is optional and will not be passed along if not specified. 


## Additional context

Add any other context or screenshots.

Related ticket in gotrue: https://github.com/supabase/gotrue/issues/292 
