### PR TITLE
feat: add storage.file_size_limit_bytes config

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -708,38 +708,36 @@ EOF
 	}
 
 	// Start Storage.
-	{
-		if _, err := utils.DockerRun(
-			ctx,
-			utils.StorageId,
-			&container.Config{
-				Image: utils.GetRegistryImageUrl(utils.StorageImage),
-				Env: []string{
-					"ANON_KEY=" + utils.AnonKey,
-					"SERVICE_KEY=" + utils.ServiceRoleKey,
-					"POSTGREST_URL=http://" + utils.RestId + ":3000",
-					"PGRST_JWT_SECRET=" + utils.JWTSecret,
-					"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
-					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit.Value),
-					"STORAGE_BACKEND=file",
-					"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
-					"TENANT_ID=stub",
-					// TODO: https://github.com/supabase/storage-api/issues/55
-					"REGION=stub",
-					"GLOBAL_S3_BUCKET=stub",
-				},
-				Labels: map[string]string{
-					"com.supabase.cli.project":   utils.Config.ProjectId,
-					"com.docker.compose.project": utils.Config.ProjectId,
-				},
+	if _, err := utils.DockerRun(
+		ctx,
+		utils.StorageId,
+		&container.Config{
+			Image: utils.GetRegistryImageUrl(utils.StorageImage),
+			Env: []string{
+				"ANON_KEY=" + utils.AnonKey,
+				"SERVICE_KEY=" + utils.ServiceRoleKey,
+				"POSTGREST_URL=http://" + utils.RestId + ":3000",
+				"PGRST_JWT_SECRET=" + utils.JWTSecret,
+				"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
+				fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit.Value),
+				"STORAGE_BACKEND=file",
+				"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
+				"TENANT_ID=stub",
+				// TODO: https://github.com/supabase/storage-api/issues/55
+				"REGION=stub",
+				"GLOBAL_S3_BUCKET=stub",
 			},
-			&container.HostConfig{
-				NetworkMode:   container.NetworkMode(utils.NetId),
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+			Labels: map[string]string{
+				"com.supabase.cli.project":   utils.Config.ProjectId,
+				"com.docker.compose.project": utils.Config.ProjectId,
 			},
-		); err != nil {
-			return err
-		}
+		},
+		&container.HostConfig{
+			NetworkMode:   container.NetworkMode(utils.NetId),
+			RestartPolicy: container.RestartPolicy{Name: "always"},
+		},
+	); err != nil {
+		return err
 	}
 
 	// Start diff tool.

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
-	"github.com/docker/go-units"
 	"github.com/muesli/reflow/wrap"
 	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/utils"
@@ -710,11 +709,6 @@ EOF
 
 	// Start Storage.
 	{
-		file_size_limit_bytes, err := units.FromHumanSize(utils.Config.Storage.FileSizeLimit)
-		if err != nil {
-			return err
-		}
-
 		if _, err := utils.DockerRun(
 			ctx,
 			utils.StorageId,
@@ -726,7 +720,7 @@ EOF
 					"POSTGREST_URL=http://" + utils.RestId + ":3000",
 					"PGRST_JWT_SECRET=" + utils.JWTSecret,
 					"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
-					fmt.Sprintf("FILE_SIZE_LIMIT=%v", file_size_limit_bytes),
+					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit.Value),
 					"STORAGE_BACKEND=file",
 					"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
 					"TENANT_ID=stub",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -719,7 +719,7 @@ EOF
 				"POSTGREST_URL=http://" + utils.RestId + ":3000",
 				"PGRST_JWT_SECRET=" + utils.JWTSecret,
 				"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
-				fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit.Value),
+				fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 				"STORAGE_BACKEND=file",
 				"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
 				"TENANT_ID=stub",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -719,7 +719,7 @@ EOF
 				"POSTGREST_URL=http://" + utils.RestId + ":3000",
 				"PGRST_JWT_SECRET=" + utils.JWTSecret,
 				"DATABASE_URL=postgresql://supabase_storage_admin:postgres@" + utils.DbId + ":5432/postgres",
-				"FILE_SIZE_LIMIT=52428800",
+				fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 				"STORAGE_BACKEND=file",
 				"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
 				"TENANT_ID=stub",

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -61,13 +61,13 @@ var (
 )
 
 // Type for turning human-friendly bytes string ("5MB", "32kB") into an int64 during toml decoding.
-type sizeInBytes struct {
-	Value int64
-}
+type sizeInBytes int64
 
-func (a *sizeInBytes) UnmarshalText(text []byte) error {
-	var err error
-	a.Value, err = units.FromHumanSize(string(text))
+func (s *sizeInBytes) UnmarshalText(text []byte) error {
+	size, err := units.RAMInBytes(string(text))
+	if err == nil {
+		*s = sizeInBytes(size)
+	}
 	return err
 }
 
@@ -200,8 +200,8 @@ func LoadConfigFS(fsys afero.Fs) error {
 		if Config.Inbucket.Port == 0 {
 			return errors.New("Missing required field in config: inbucket.port")
 		}
-		if Config.Storage.FileSizeLimit.Value == 0 {
-			Config.Storage.FileSizeLimit.Value = 5 * units.MB
+		if Config.Storage.FileSizeLimit == 0 {
+			Config.Storage.FileSizeLimit = 50 * units.MiB
 		}
 		if Config.Auth.SiteUrl == "" {
 			return errors.New("Missing required field in config: auth.site_url")

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -68,6 +68,7 @@ type (
 		Db        db
 		Studio    studio
 		Inbucket  inbucket
+		Storage   storage
 		Auth      auth
 		// TODO
 		// Scripts   scripts
@@ -93,6 +94,10 @@ type (
 		Port     uint
 		SmtpPort uint `toml:"smtp_port"`
 		Pop3Port uint `toml:"pop3_port"`
+	}
+
+	storage struct {
+		FileSizeLimit uint `toml:"file_size_limit_bytes"`
 	}
 
 	auth struct {
@@ -182,6 +187,9 @@ func LoadConfigFS(fsys afero.Fs) error {
 		}
 		if Config.Inbucket.Port == 0 {
 			return errors.New("Missing required field in config: inbucket.port")
+		}
+		if Config.Storage.FileSizeLimit == 0 {
+			Config.Storage.FileSizeLimit = 52428800
 		}
 		if Config.Auth.SiteUrl == "" {
 			return errors.New("Missing required field in config: auth.site_url")

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/BurntSushi/toml"
+	"github.com/docker/go-units"
 	"github.com/spf13/afero"
 )
 
@@ -97,7 +98,7 @@ type (
 	}
 
 	storage struct {
-		FileSizeLimit uint `toml:"file_size_limit_bytes"`
+		FileSizeLimit string `toml:"file_size_limit"`
 	}
 
 	auth struct {
@@ -188,8 +189,8 @@ func LoadConfigFS(fsys afero.Fs) error {
 		if Config.Inbucket.Port == 0 {
 			return errors.New("Missing required field in config: inbucket.port")
 		}
-		if Config.Storage.FileSizeLimit == 0 {
-			Config.Storage.FileSizeLimit = 52428800
+		if Config.Storage.FileSizeLimit == "" {
+			Config.Storage.FileSizeLimit = 5 * units.MB
 		}
 		if Config.Auth.SiteUrl == "" {
 			return errors.New("Missing required field in config: auth.site_url")

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -36,48 +36,55 @@ func TestConfigParsing(t *testing.T) {
 
 func TestFileSizeLimitConfigParsing(t *testing.T) {
 	t.Run("test file size limit parsing number", func(t *testing.T) {
+		var testConfig config
 		_, err := toml.Decode(`
 		[storage]
 		file_size_limit = 5000000
-		`, &Config)
+		`, &testConfig)
 		if assert.NoError(t, err) {
-			assert.Equal(t, int64(5000000), Config.Storage.FileSizeLimit.Value)
+			assert.Equal(t, sizeInBytes(5000000), testConfig.Storage.FileSizeLimit)
 		}
 	})
 
 	t.Run("test file size limit parsing bytes unit", func(t *testing.T) {
+		var testConfig config
 		_, err := toml.Decode(`
 		[storage]
 		file_size_limit = "5MB"
-		`, &Config)
+		`, &testConfig)
 		if assert.NoError(t, err) {
-			assert.Equal(t, int64(5000000), Config.Storage.FileSizeLimit.Value)
+			assert.Equal(t, sizeInBytes(5242880), testConfig.Storage.FileSizeLimit)
 		}
 	})
 
 	t.Run("test file size limit parsing string number", func(t *testing.T) {
+		var testConfig config
 		_, err := toml.Decode(`
 		[storage]
 		file_size_limit = "5000000"
-		`, &Config)
+		`, &testConfig)
 		if assert.NoError(t, err) {
-			assert.Equal(t, int64(5000000), Config.Storage.FileSizeLimit.Value)
+			assert.Equal(t, sizeInBytes(5000000), testConfig.Storage.FileSizeLimit)
 		}
 	})
 
 	t.Run("test file size limit parsing bad datatype", func(t *testing.T) {
+		var testConfig config
 		_, err := toml.Decode(`
 		[storage]
 		file_size_limit = []
-		`, &Config)
+		`, &testConfig)
 		assert.Error(t, err)
+		assert.Equal(t, sizeInBytes(0), testConfig.Storage.FileSizeLimit)
 	})
 
 	t.Run("test file size limit parsing bad string data", func(t *testing.T) {
+		var testConfig config
 		_, err := toml.Decode(`
 		[storage]
 		file_size_limit = "foobar"
-		`, &Config)
+		`, &testConfig)
 		assert.Error(t, err)
+		assert.Equal(t, sizeInBytes(0), testConfig.Storage.FileSizeLimit)
 	})
 }

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -57,6 +57,17 @@ func TestFileSizeLimitConfigParsing(t *testing.T) {
 		}
 	})
 
+	t.Run("test file size limit parsing binary bytes unit", func(t *testing.T) {
+		var testConfig config
+		_, err := toml.Decode(`
+		[storage]
+		file_size_limit = "5MiB"
+		`, &testConfig)
+		if assert.NoError(t, err) {
+			assert.Equal(t, sizeInBytes(5242880), testConfig.Storage.FileSizeLimit)
+		}
+	})
+
 	t.Run("test file size limit parsing string number", func(t *testing.T) {
 		var testConfig config
 		_, err := toml.Decode(`

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -33,6 +33,10 @@ port = 54324
 smtp_port = 54325
 pop3_port = 54326
 
+[storage]
+# The maximum file size allowed.
+file_size_limit_bytes = 52428800
+
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -35,7 +35,7 @@ pop3_port = 54326
 
 [storage]
 # The maximum file size allowed (e.g. "5MB", "500KB").
-file_size_limit = "5MB"
+file_size_limit = "50MiB"
 
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -34,8 +34,8 @@ smtp_port = 54325
 pop3_port = 54326
 
 [storage]
-# The maximum file size allowed.
-file_size_limit_bytes = 52428800
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "5MB"
 
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -33,6 +33,10 @@ port = 54324
 smtp_port = 54325
 pop3_port = 54326
 
+[storage]
+# The maximum file size allowed.
+file_size_limit_bytes = 52428800
+
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -35,7 +35,7 @@ pop3_port = 54326
 
 [storage]
 # The maximum file size allowed (e.g. "5MB", "500KB").
-file_size_limit = "5MB"
+file_size_limit = "50MiB"
 
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -34,8 +34,8 @@ smtp_port = 54325
 pop3_port = 54326
 
 [storage]
-# The maximum file size allowed.
-file_size_limit_bytes = 52428800
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "5MB"
 
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used


### PR DESCRIPTION


## What kind of change does this PR introduce?

Feature

Adds [storage] table to config.toml with a file_size_limit_bytes value that defaults to 50 MiB. This config value becomes the FILE_SIZE_LIMIT env var for the storage docker container.

## What is the current behavior?

The storage-api's file size limit is hard-coded to 50 MiB and is not configurable.

This PR fixes #489

## What is the new behavior?

The storage-api's file size limit can be configured in config.toml like below:

```
[storage]
# The maximum file size allowed, in bytes.
file_size_limit_bytes = 52428800
```

If the storage table or the file_size_limit_bytes key are not specified, the limit defaults to 50 MiB.

## Additional context

I'm unfamiliar with Go, so please let me know if I did anything wrong! :grinning: 