### PR TITLE
fix: check image exists after docker pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,10 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "*/10 * * * *"
-  workflow_dispatch:
 
 jobs:
   test:
     name: Test
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +28,6 @@ jobs:
 
   lint:
     name: Lint
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:
   test:
     name: Test
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -29,6 +33,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -41,3 +46,13 @@ jobs:
         with:
           version: v1.47
           args: --timeout 3m --verbose
+
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - run: go run main.go init
+      - run: go run main.go start

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           args: --timeout 3m --verbose
 
   start:
+    name: Start
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - run: go run main.go init
-      - run: go run main.go start
+      - run: go build main.go
+      - run: ./main init
+      - run: ./main start

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -80,6 +80,27 @@ var (
 	kongConfigTemplate, _ = template.New("kongConfig").Parse(kongConfigEmbed)
 )
 
+func pullImage(p utils.Program, ctx context.Context, image string) error {
+	imageUrl := utils.GetRegistryImageUrl(image)
+	_, _, err := utils.Docker.ImageInspectWithRaw(ctx, imageUrl)
+	for i := 0; i < 3; i++ {
+		if err == nil {
+			break
+		}
+		var out io.ReadCloser
+		out, err = utils.DockerImagePullWithRetry(ctx, imageUrl, 2)
+		if err != nil {
+			break
+		}
+		defer out.Close()
+		if err := utils.ProcessPullOutput(out, p); err != nil {
+			p.Send(utils.ProgressMsg(nil))
+		}
+		_, _, err = utils.Docker.ImageInspectWithRaw(ctx, imageUrl)
+	}
+	return err
+}
+
 func run(p utils.Program, ctx context.Context) error {
 	_, _ = utils.Docker.NetworkCreate(
 		ctx,
@@ -115,146 +136,11 @@ func run(p utils.Program, ctx context.Context) error {
 
 	// Pull images.
 	{
-		dbImage := utils.GetRegistryImageUrl(utils.DbImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, dbImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, dbImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
+		if err := pullImage(p, ctx, utils.DbImage); err != nil {
+			return err
 		}
-		kongImage := utils.GetRegistryImageUrl(utils.KongImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, kongImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, kongImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		gotrueImage := utils.GetRegistryImageUrl(utils.GotrueImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, gotrueImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, gotrueImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		inbucketImage := utils.GetRegistryImageUrl(utils.InbucketImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, inbucketImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, inbucketImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		realtimeImage := utils.GetRegistryImageUrl(utils.RealtimeImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, realtimeImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, realtimeImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		restImage := utils.GetRegistryImageUrl(utils.PostgrestImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, restImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, restImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		storageImage := utils.GetRegistryImageUrl(utils.StorageImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, storageImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, storageImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		diffImage := utils.GetRegistryImageUrl(utils.DifferImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, diffImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, diffImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		metaImage := utils.GetRegistryImageUrl(utils.PgmetaImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, metaImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, metaImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		studioImage := utils.GetRegistryImageUrl(utils.StudioImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, studioImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, studioImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-		}
-		denoImage := utils.GetRegistryImageUrl(utils.DenoRelayImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, denoImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, denoImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-			if err := out.Close(); err != nil {
+		for _, image := range utils.ServiceImages {
+			if err := pullImage(p, ctx, image); err != nil {
 				return err
 			}
 		}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -124,6 +124,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		kongImage := utils.GetRegistryImageUrl(utils.KongImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, kongImage); err != nil {
@@ -132,6 +135,9 @@ func run(p utils.Program, ctx context.Context) error {
 				return err
 			}
 			if err := utils.ProcessPullOutput(out, p); err != nil {
+				return err
+			}
+			if err := out.Close(); err != nil {
 				return err
 			}
 		}
@@ -144,6 +150,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		inbucketImage := utils.GetRegistryImageUrl(utils.InbucketImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, inbucketImage); err != nil {
@@ -152,6 +161,9 @@ func run(p utils.Program, ctx context.Context) error {
 				return err
 			}
 			if err := utils.ProcessPullOutput(out, p); err != nil {
+				return err
+			}
+			if err := out.Close(); err != nil {
 				return err
 			}
 		}
@@ -164,6 +176,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		restImage := utils.GetRegistryImageUrl(utils.PostgrestImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, restImage); err != nil {
@@ -172,6 +187,9 @@ func run(p utils.Program, ctx context.Context) error {
 				return err
 			}
 			if err := utils.ProcessPullOutput(out, p); err != nil {
+				return err
+			}
+			if err := out.Close(); err != nil {
 				return err
 			}
 		}
@@ -184,6 +202,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		diffImage := utils.GetRegistryImageUrl(utils.DifferImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, diffImage); err != nil {
@@ -192,6 +213,9 @@ func run(p utils.Program, ctx context.Context) error {
 				return err
 			}
 			if err := utils.ProcessPullOutput(out, p); err != nil {
+				return err
+			}
+			if err := out.Close(); err != nil {
 				return err
 			}
 		}
@@ -204,6 +228,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		studioImage := utils.GetRegistryImageUrl(utils.StudioImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, studioImage); err != nil {
@@ -214,6 +241,9 @@ func run(p utils.Program, ctx context.Context) error {
 			if err := utils.ProcessPullOutput(out, p); err != nil {
 				return err
 			}
+			if err := out.Close(); err != nil {
+				return err
+			}
 		}
 		denoImage := utils.GetRegistryImageUrl(utils.DenoRelayImage)
 		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, denoImage); err != nil {
@@ -222,6 +252,9 @@ func run(p utils.Program, ctx context.Context) error {
 				return err
 			}
 			if err := utils.ProcessPullOutput(out, p); err != nil {
+				return err
+			}
+			if err := out.Close(); err != nil {
 				return err
 			}
 		}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -23,8 +23,9 @@ import (
 
 // Update tools/listdep/main.go when adding new docker images
 const (
-	Pg13Image      = "supabase/postgres:13.3.0"
-	Pg14Image      = "supabase/postgres:14.1.0.71"
+	Pg13Image = "supabase/postgres:13.3.0"
+	Pg14Image = "supabase/postgres:14.1.0.71"
+	// Append to ServiceImages when adding new dependencies below
 	KongImage      = "library/kong:2.8.1"
 	InbucketImage  = "inbucket/inbucket:3.0.3"
 	PostgrestImage = "postgrest/postgrest:v9.0.1.20220717"
@@ -39,6 +40,20 @@ const (
 	RealtimeImage = "supabase/realtime:v0.22.7"
 	StorageImage  = "supabase/storage-api:v0.20.1"
 )
+
+var ServiceImages = []string{
+	GotrueImage,
+	RealtimeImage,
+	StorageImage,
+	KongImage,
+	InbucketImage,
+	PostgrestImage,
+	DifferImage,
+	MigraImage,
+	PgmetaImage,
+	StudioImage,
+	DenoRelayImage,
+}
 
 const (
 	ShadowDbName = "supabase_shadow"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Update tools/listdep/main.go when adding new docker images
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.71"

--- a/tools/listdep/main.go
+++ b/tools/listdep/main.go
@@ -10,24 +10,8 @@ import (
 )
 
 func main() {
-	images := []string{
-		utils.Pg13Image,
-		utils.Pg14Image,
-		utils.GotrueImage,
-		utils.RealtimeImage,
-		utils.StorageImage,
-		utils.KongImage,
-		utils.InbucketImage,
-		utils.PostgrestImage,
-		utils.DifferImage,
-		utils.MigraImage,
-		utils.PgmetaImage,
-		utils.StudioImage,
-		utils.DenoRelayImage,
-	}
-
 	external := make([]string, 0)
-	for _, img := range images {
+	for _, img := range utils.ServiceImages {
 		if !strings.HasPrefix(img, "supabase/") {
 			external = append(external, img)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #493 

## What is the current behavior?

log stream from image pull may return `io.EOF` when download isn't complete
happens mostly on public ECR, possibly due to rate limits

## What is the new behavior?

check that image exists after pulling, otherwise retry

## Additional context

Add any other context or screenshots.
