### PR TITLE
fix: refactor supabase start to use pgx

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/start"
 )
@@ -9,7 +10,7 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start containers for Supabase local development",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return start.Run(cmd.Context())
+		return start.Run(cmd.Context(), afero.NewOsFs())
 	},
 }
 

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -105,6 +105,10 @@ func ApplyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 		return err
 	}
 	defer conn.Close(context.Background())
+	return MigrateDatabase(ctx, conn, fsys)
+}
+
+func MigrateDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 	// Apply migrations
 	if migrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil {
 		for i, migration := range migrations {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -36,10 +36,10 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		if err := utils.AssertSupabaseCliIsSetUpFS(fsys); err != nil {
 			return err
 		}
-		if err := utils.AssertDockerIsRunning(); err != nil {
+		if err := utils.LoadConfigFS(fsys); err != nil {
 			return err
 		}
-		if err := utils.LoadConfigFS(fsys); err != nil {
+		if err := utils.AssertDockerIsRunning(); err != nil {
 			return err
 		}
 		if err := utils.AssertSupabaseDbIsRunning(); err == nil {

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -5,16 +5,20 @@ import (
 	"errors"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/parser"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -226,6 +230,212 @@ func TestDatabaseStart(t *testing.T) {
 		err := run(p, context.Background(), fsys)
 		// Check error
 		assert.ErrorContains(t, err, "unable to upgrade to tcp, received 404")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestInitDatabase(t *testing.T) {
+	const version = "1.41"
+	p := utils.NewProgram(model{})
+
+	t.Run("init main branch", func(t *testing.T) {
+		utils.DbId = "supabase_db_test"
+		utils.Config.Db.Port = 5432
+		utils.InitialSchemaSql = "CREATE SCHEMA public"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+			}})
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		globals, err := parser.Split(strings.NewReader(utils.GlobalsSql))
+		require.NoError(t, err)
+		for _, line := range globals {
+			trim := strings.TrimSpace(strings.TrimRight(line, ";"))
+			if len(trim) > 0 {
+				conn.Query(trim)
+			}
+		}
+		conn.Query(utils.InitialSchemaSql).Reply("CREATE SCHEMA")
+		// Run test
+		err = initDatabase(p, context.Background(), fsys, conn.Intercept)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+		// Check current branch
+		contents, err := afero.ReadFile(fsys, utils.CurrBranchPath)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("main"), contents)
+		// Check branch dir
+		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), "main")
+		exists, err := afero.DirExists(fsys, branchPath)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+		// Check migrations
+		exists, err = afero.DirExists(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("throws error on connect failure", func(t *testing.T) {
+		utils.DbId = "supabase_db_test"
+		utils.Config.Db.Port = 0
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+			}})
+		// Run test
+		err := initDatabase(p, context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "invalid port")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on exec failure", func(t *testing.T) {
+		utils.DbId = "supabase_db_test"
+		utils.Config.Db.Port = 5432
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+			}})
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		globals, err := parser.Split(strings.NewReader(utils.GlobalsSql))
+		require.NoError(t, err)
+		for _, line := range globals {
+			trim := strings.TrimSpace(strings.TrimRight(line, ";"))
+			if len(trim) > 0 {
+				conn.Query(trim)
+			}
+		}
+		conn.ReplyError(pgerrcode.DuplicateObject, `role "postgres" already exists`)
+		// Run test
+		err = initDatabase(p, context.Background(), fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: role "postgres" already exists (SQLSTATE 42710)`)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on permission denied", func(t *testing.T) {
+		utils.DbId = "supabase_db_test"
+		utils.Config.Db.Port = 5432
+		// Setup in-memory fs
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+			}})
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		globals, err := parser.Split(strings.NewReader(utils.GlobalsSql))
+		require.NoError(t, err)
+		for _, line := range globals {
+			trim := strings.TrimSpace(strings.TrimRight(line, ";"))
+			if len(trim) > 0 {
+				conn.Query(trim)
+			}
+		}
+		// Run test
+		err = initDatabase(p, context.Background(), fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "operation not permitted")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("restore dumped branches", func(t *testing.T) {
+		utils.DbId = "supabase_db_test"
+		utils.Config.Db.Port = 5432
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.CurrBranchPath, []byte("develop"), 0644))
+		branchDir := filepath.Dir(utils.CurrBranchPath)
+		dumpPath := filepath.Join(branchDir, "develop", "dump.sql")
+		dumpSql := "CREATE SCHEMA public"
+		require.NoError(t, afero.WriteFile(fsys, dumpPath, []byte(dumpSql), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(branchDir, "postgres", "dump.sql"), []byte(dumpSql), 0644))
+		require.NoError(t, fsys.Mkdir(filepath.Join(branchDir, "invalid"), 0755))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+			}})
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		globals, err := parser.Split(strings.NewReader(utils.GlobalsSql))
+		require.NoError(t, err)
+		for _, line := range globals {
+			trim := strings.TrimSpace(strings.TrimRight(line, ";"))
+			if len(trim) > 0 {
+				conn.Query(trim)
+			}
+		}
+		conn.Query(dumpSql).
+			Reply("CREATE SCHEMA").
+			Query(`CREATE DATABASE "postgres";`).
+			ReplyError(pgerrcode.DuplicateDatabase, `database "postgres" already exists`)
+		// Run test
+		err = initDatabase(p, context.Background(), fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: database "postgres" already exists (SQLSTATE 42P04)`)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -123,6 +125,107 @@ func TestStartCommand(t *testing.T) {
 		err := Run(context.Background(), fsys)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestPullImage(t *testing.T) {
+	const version = "1.41"
+	const image = "postgres"
+	p := utils.NewProgram(model{})
+
+	t.Run("inspects image before pull", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/images/public.ecr.aws/t3w2s2c9/" + image + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ImageInspect{})
+		// Run test
+		err := pullImage(p, context.Background(), image)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("pulls missing image", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/images/public.ecr.aws/t3w2s2c9/" + image + "/json").
+			Reply(http.StatusNotFound)
+		gock.New("http:///var/run/docker.sock").
+			Post("/v"+version+"/images/create").
+			MatchParam("fromImage", image).
+			MatchParam("tag", "latest").
+			Reply(http.StatusAccepted).
+			BodyString("progress")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/images/public.ecr.aws/t3w2s2c9/" + image + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ImageInspect{})
+		// Run test
+		err := pullImage(p, context.Background(), image)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	// TODO: test for transient error
+}
+
+func TestDatabaseStart(t *testing.T) {
+	const version = "1.41"
+	p := utils.NewProgram(model{})
+
+	t.Run("starts database locally", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/networks/create").
+			Reply(http.StatusCreated).
+			JSON(types.NetworkCreateResponse{})
+		// Caches all dependencies
+		utils.DbImage = "postgres"
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/images/public.ecr.aws/t3w2s2c9/" + utils.DbImage + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ImageInspect{})
+		for _, image := range utils.ServiceImages {
+			service := filepath.Base(image)
+			gock.New("http:///var/run/docker.sock").
+				Get("/v" + version + "/images/public.ecr.aws/t3w2s2c9/" + service + "/json").
+				Reply(http.StatusOK).
+				JSON(types.ImageInspect{})
+		}
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/containers/create").
+			Reply(http.StatusCreated).
+			JSON(container.ContainerCreateCreatedBody{})
+		// Run test
+		err := run(p, context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "unable to upgrade to tcp, received 404")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -1,0 +1,128 @@
+package start
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestStartCommand(t *testing.T) {
+	const version = "1.41"
+
+	t.Run("throws error on missing config", func(t *testing.T) {
+		err := Run(context.Background(), afero.NewMemMapFs())
+		assert.ErrorContains(t, err, "Have you set up the project with supabase init?")
+	})
+
+	t.Run("throws error on invalid config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Failed to read config: toml")
+	})
+
+	t.Run("throws error on missing docker", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			ReplyError(errors.New("network error"))
+		gock.New("http:///var/run/docker.sock").
+			Get("/_ping").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on running database", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "supabase start is already running. Try running supabase stop first.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to create network", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, client.WithHTTPClient(http.DefaultClient)(utils.Docker))
+		defer gock.OffAll()
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Head("/_ping").
+			Reply(http.StatusOK).
+			SetHeader("API-Version", version).
+			SetHeader("OSType", "linux")
+		gock.New("http:///var/run/docker.sock").
+			Get("/v" + version + "/containers").
+			Reply(http.StatusNotFound)
+		gock.New("http:///var/run/docker.sock").
+			Post("/v" + version + "/networks/create").
+			ReplyError(errors.New("network error"))
+		// Cleans up network on error
+		gock.New("http:///var/run/docker.sock").
+			Delete("/v" + version + "/networks/supabase_network_").
+			Reply(http.StatusOK)
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -222,10 +222,6 @@ func MkdirIfNotExistFS(fsys afero.Fs, path string) error {
 	return nil
 }
 
-func AssertSupabaseCliIsSetUp() error {
-	return AssertSupabaseCliIsSetUpFS(afero.NewOsFs())
-}
-
 func AssertSupabaseCliIsSetUpFS(fsys afero.Fs) error {
 	if _, err := fsys.Stat(ConfigPath); errors.Is(err, os.ErrNotExist) {
 		return errors.New("Cannot find " + Bold(ConfigPath) + " in the current directory. Have you set up the project with " + Aqua("supabase init") + "?")

--- a/internal/utils/templates/initial_schemas/14.sql
+++ b/internal/utils/templates/initial_schemas/14.sql
@@ -20,7 +20,7 @@ SET row_security = off;
 -- Name: auth; Type: SCHEMA; Schema: -; Owner: supabase_admin
 --
 
-CREATE SCHEMA auth;
+CREATE SCHEMA IF NOT EXISTS auth;
 
 
 ALTER SCHEMA auth OWNER TO supabase_admin;
@@ -29,7 +29,7 @@ ALTER SCHEMA auth OWNER TO supabase_admin;
 -- Name: extensions; Type: SCHEMA; Schema: -; Owner: postgres
 --
 
-CREATE SCHEMA extensions;
+CREATE SCHEMA IF NOT EXISTS extensions;
 
 
 ALTER SCHEMA extensions OWNER TO postgres;
@@ -52,7 +52,7 @@ COMMENT ON EXTENSION pg_graphql IS 'GraphQL support';
 -- Name: graphql_public; Type: SCHEMA; Schema: -; Owner: supabase_admin
 --
 
-CREATE SCHEMA graphql_public;
+CREATE SCHEMA IF NOT EXISTS graphql_public;
 
 
 ALTER SCHEMA graphql_public OWNER TO supabase_admin;
@@ -61,7 +61,7 @@ ALTER SCHEMA graphql_public OWNER TO supabase_admin;
 -- Name: pgbouncer; Type: SCHEMA; Schema: -; Owner: pgbouncer
 --
 
-CREATE SCHEMA pgbouncer;
+CREATE SCHEMA IF NOT EXISTS pgbouncer;
 
 
 ALTER SCHEMA pgbouncer OWNER TO pgbouncer;
@@ -70,7 +70,7 @@ ALTER SCHEMA pgbouncer OWNER TO pgbouncer;
 -- Name: pgsodium; Type: SCHEMA; Schema: -; Owner: postgres
 --
 
-CREATE SCHEMA pgsodium;
+CREATE SCHEMA IF NOT EXISTS pgsodium;
 
 
 ALTER SCHEMA pgsodium OWNER TO postgres;
@@ -93,7 +93,7 @@ COMMENT ON EXTENSION pgsodium IS 'Pgsodium is a modern cryptography library for 
 -- Name: realtime; Type: SCHEMA; Schema: -; Owner: supabase_admin
 --
 
-CREATE SCHEMA realtime;
+CREATE SCHEMA IF NOT EXISTS realtime;
 
 
 ALTER SCHEMA realtime OWNER TO supabase_admin;
@@ -102,7 +102,7 @@ ALTER SCHEMA realtime OWNER TO supabase_admin;
 -- Name: storage; Type: SCHEMA; Schema: -; Owner: supabase_admin
 --
 
-CREATE SCHEMA storage;
+CREATE SCHEMA IF NOT EXISTS storage;
 
 
 ALTER SCHEMA storage OWNER TO supabase_admin;
@@ -241,7 +241,7 @@ ALTER TYPE realtime.wal_rls OWNER TO supabase_admin;
 -- Name: email(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE FUNCTION auth.email() RETURNS text
+CREATE OR REPLACE FUNCTION auth.email() RETURNS text
     LANGUAGE sql STABLE
     AS $$
   select 
@@ -265,7 +265,7 @@ COMMENT ON FUNCTION auth.email() IS 'Deprecated. Use auth.jwt() -> ''email'' ins
 -- Name: jwt(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE FUNCTION auth.jwt() RETURNS jsonb
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb
     LANGUAGE sql STABLE
     AS $$
   select 
@@ -282,7 +282,7 @@ ALTER FUNCTION auth.jwt() OWNER TO supabase_auth_admin;
 -- Name: role(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE FUNCTION auth.role() RETURNS text
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text
     LANGUAGE sql STABLE
     AS $$
   select 
@@ -306,7 +306,7 @@ COMMENT ON FUNCTION auth.role() IS 'Deprecated. Use auth.jwt() -> ''role'' inste
 -- Name: uid(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE FUNCTION auth.uid() RETURNS uuid
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
     LANGUAGE sql STABLE
     AS $$
   select 
@@ -330,7 +330,7 @@ COMMENT ON FUNCTION auth.uid() IS 'Deprecated. Use auth.jwt() -> ''sub'' instead
 -- Name: grant_pg_cron_access(); Type: FUNCTION; Schema: extensions; Owner: postgres
 --
 
-CREATE FUNCTION extensions.grant_pg_cron_access() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.grant_pg_cron_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -379,7 +379,7 @@ COMMENT ON FUNCTION extensions.grant_pg_cron_access() IS 'Grants access to pg_cr
 -- Name: grant_pg_graphql_access(); Type: FUNCTION; Schema: extensions; Owner: supabase_admin
 --
 
-CREATE FUNCTION extensions.grant_pg_graphql_access() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.grant_pg_graphql_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $_$
 DECLARE
@@ -443,7 +443,7 @@ COMMENT ON FUNCTION extensions.grant_pg_graphql_access() IS 'Grants access to pg
 -- Name: grant_pg_net_access(); Type: FUNCTION; Schema: extensions; Owner: postgres
 --
 
-CREATE FUNCTION extensions.grant_pg_net_access() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -499,7 +499,7 @@ COMMENT ON FUNCTION extensions.grant_pg_net_access() IS 'Grants access to pg_net
 -- Name: pgrst_ddl_watch(); Type: FUNCTION; Schema: extensions; Owner: supabase_admin
 --
 
-CREATE FUNCTION extensions.pgrst_ddl_watch() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.pgrst_ddl_watch() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -534,7 +534,7 @@ ALTER FUNCTION extensions.pgrst_ddl_watch() OWNER TO supabase_admin;
 -- Name: pgrst_drop_watch(); Type: FUNCTION; Schema: extensions; Owner: supabase_admin
 --
 
-CREATE FUNCTION extensions.pgrst_drop_watch() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.pgrst_drop_watch() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -567,7 +567,7 @@ ALTER FUNCTION extensions.pgrst_drop_watch() OWNER TO supabase_admin;
 -- Name: set_graphql_placeholder(); Type: FUNCTION; Schema: extensions; Owner: supabase_admin
 --
 
-CREATE FUNCTION extensions.set_graphql_placeholder() RETURNS event_trigger
+CREATE OR REPLACE FUNCTION extensions.set_graphql_placeholder() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $_$
     DECLARE
@@ -633,7 +633,7 @@ COMMENT ON FUNCTION extensions.set_graphql_placeholder() IS 'Reintroduces placeh
 -- Name: get_auth(text); Type: FUNCTION; Schema: pgbouncer; Owner: postgres
 --
 
-CREATE FUNCTION pgbouncer.get_auth(p_usename text) RETURNS TABLE(username text, password text)
+CREATE OR REPLACE FUNCTION pgbouncer.get_auth(p_usename text) RETURNS TABLE(username text, password text)
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 BEGIN
@@ -652,7 +652,7 @@ ALTER FUNCTION pgbouncer.get_auth(p_usename text) OWNER TO postgres;
 -- Name: apply_rls(jsonb, integer); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.apply_rls(wal jsonb, max_record_bytes integer DEFAULT (1024 * 1024)) RETURNS SETOF realtime.wal_rls
+CREATE OR REPLACE FUNCTION realtime.apply_rls(wal jsonb, max_record_bytes integer DEFAULT (1024 * 1024)) RETURNS SETOF realtime.wal_rls
     LANGUAGE plpgsql
     AS $$
       declare
@@ -940,7 +940,7 @@ ALTER FUNCTION realtime.apply_rls(wal jsonb, max_record_bytes integer) OWNER TO 
 -- Name: build_prepared_statement_sql(text, regclass, realtime.wal_column[]); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.build_prepared_statement_sql(prepared_statement_name text, entity regclass, columns realtime.wal_column[]) RETURNS text
+CREATE OR REPLACE FUNCTION realtime.build_prepared_statement_sql(prepared_statement_name text, entity regclass, columns realtime.wal_column[]) RETURNS text
     LANGUAGE sql
     AS $$
       /*
@@ -975,7 +975,7 @@ ALTER FUNCTION realtime.build_prepared_statement_sql(prepared_statement_name tex
 -- Name: cast(text, regtype); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime."cast"(val text, type_ regtype) RETURNS jsonb
+CREATE OR REPLACE FUNCTION realtime."cast"(val text, type_ regtype) RETURNS jsonb
     LANGUAGE plpgsql IMMUTABLE
     AS $$
     declare
@@ -993,7 +993,7 @@ ALTER FUNCTION realtime."cast"(val text, type_ regtype) OWNER TO supabase_admin;
 -- Name: check_equality_op(realtime.equality_op, regtype, text, text); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.check_equality_op(op realtime.equality_op, type_ regtype, val_1 text, val_2 text) RETURNS boolean
+CREATE OR REPLACE FUNCTION realtime.check_equality_op(op realtime.equality_op, type_ regtype, val_1 text, val_2 text) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE
     AS $$
     /*
@@ -1025,7 +1025,7 @@ ALTER FUNCTION realtime.check_equality_op(op realtime.equality_op, type_ regtype
 -- Name: is_visible_through_filters(realtime.wal_column[], realtime.user_defined_filter[]); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[]) RETURNS boolean
+CREATE OR REPLACE FUNCTION realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[]) RETURNS boolean
     LANGUAGE sql IMMUTABLE
     AS $$
         /*
@@ -1061,7 +1061,7 @@ ALTER FUNCTION realtime.is_visible_through_filters(columns realtime.wal_column[]
 -- Name: quote_wal2json(regclass); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.quote_wal2json(entity regclass) RETURNS text
+CREATE OR REPLACE FUNCTION realtime.quote_wal2json(entity regclass) RETURNS text
     LANGUAGE sql IMMUTABLE STRICT
     AS $$
       select
@@ -1101,7 +1101,7 @@ ALTER FUNCTION realtime.quote_wal2json(entity regclass) OWNER TO supabase_admin;
 -- Name: subscription_check_filters(); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.subscription_check_filters() RETURNS trigger
+CREATE OR REPLACE FUNCTION realtime.subscription_check_filters() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
     /*
@@ -1165,7 +1165,7 @@ ALTER FUNCTION realtime.subscription_check_filters() OWNER TO supabase_admin;
 -- Name: to_regrole(text); Type: FUNCTION; Schema: realtime; Owner: supabase_admin
 --
 
-CREATE FUNCTION realtime.to_regrole(role_name text) RETURNS regrole
+CREATE OR REPLACE FUNCTION realtime.to_regrole(role_name text) RETURNS regrole
     LANGUAGE sql IMMUTABLE
     AS $$ select role_name::regrole $$;
 
@@ -1176,7 +1176,7 @@ ALTER FUNCTION realtime.to_regrole(role_name text) OWNER TO supabase_admin;
 -- Name: extension(text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.extension(name text) RETURNS text
+CREATE OR REPLACE FUNCTION storage.extension(name text) RETURNS text
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -1197,7 +1197,7 @@ ALTER FUNCTION storage.extension(name text) OWNER TO supabase_storage_admin;
 -- Name: filename(text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.filename(name text) RETURNS text
+CREATE OR REPLACE FUNCTION storage.filename(name text) RETURNS text
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -1215,7 +1215,7 @@ ALTER FUNCTION storage.filename(name text) OWNER TO supabase_storage_admin;
 -- Name: foldername(text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.foldername(name text) RETURNS text[]
+CREATE OR REPLACE FUNCTION storage.foldername(name text) RETURNS text[]
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -1233,7 +1233,7 @@ ALTER FUNCTION storage.foldername(name text) OWNER TO supabase_storage_admin;
 -- Name: get_size_by_bucket(); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.get_size_by_bucket() RETURNS TABLE(size bigint, bucket_id text)
+CREATE OR REPLACE FUNCTION storage.get_size_by_bucket() RETURNS TABLE(size bigint, bucket_id text)
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -1251,7 +1251,7 @@ ALTER FUNCTION storage.get_size_by_bucket() OWNER TO supabase_storage_admin;
 -- Name: search(text, text, integer, integer, integer, text, text, text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.search(prefix text, bucketname text, limits integer DEFAULT 100, levels integer DEFAULT 1, offsets integer DEFAULT 0, search text DEFAULT ''::text, sortcolumn text DEFAULT 'name'::text, sortorder text DEFAULT 'asc'::text) RETURNS TABLE(name text, id uuid, updated_at timestamp with time zone, created_at timestamp with time zone, last_accessed_at timestamp with time zone, metadata jsonb)
+CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits integer DEFAULT 100, levels integer DEFAULT 1, offsets integer DEFAULT 0, search text DEFAULT ''::text, sortcolumn text DEFAULT 'name'::text, sortorder text DEFAULT 'asc'::text) RETURNS TABLE(name text, id uuid, updated_at timestamp with time zone, created_at timestamp with time zone, last_accessed_at timestamp with time zone, metadata jsonb)
     LANGUAGE plpgsql STABLE
     AS $_$
 declare
@@ -1322,7 +1322,7 @@ ALTER FUNCTION storage.search(prefix text, bucketname text, limits integer, leve
 -- Name: update_updated_at_column(); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE FUNCTION storage.update_updated_at_column() RETURNS trigger
+CREATE OR REPLACE FUNCTION storage.update_updated_at_column() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #497
Bug fix #498

## What is the new behavior?

- updates initial schema such that it can be applied on `postgres` database (will update db reset in another PR)
- uses pgx to initialise globals and apply migrations (avoids size limit of docker exec arg)
- uses pgx to seed data (avoids copying seed file to `/tmp/seed.sql` inside container)
- failure to restore `dump.sql` will not clear branch directory (user may fix the error and restart)

## Additional context

Add any other context or screenshots.
