### PR TITLE
fix: disable graphql on pg13

### DIFF
--- a/internal/utils/templates/initial_schemas/13.sql
+++ b/internal/utils/templates/initial_schemas/13.sql
@@ -2938,5 +2938,3 @@ ALTER EVENT TRIGGER pgrst_drop_watch OWNER TO supabase_admin;
 --
 -- PostgreSQL database dump complete
 --
-
-drop extension pg_graphql; create extension pg_graphql schema extensions;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #460

## What is the current behavior?

pg_graphql is not available on pg13 docker image

## What is the new behavior?

don't call pg_graphql extensions

## Additional context

Add any other context or screenshots.
