### PR TITLE
fix: improper url-escaping of db password

### DIFF
--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -95,7 +95,7 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 	if err != nil {
 		return err
 	}
-	conn, err := ConnectRemotePostgres(ctx, username, password, database, projectRef)
+	conn, err := ConnectRemotePostgres(ctx, username, password, database, utils.GetSupabaseDbHost(projectRef))
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,7 @@ func ConnectRemotePostgres(ctx context.Context, username, password, database, ho
 		"postgresql://%s:%s@%s:6543/%s?connect_timeout=3",
 		url.QueryEscape(username),
 		url.QueryEscape(password),
-		utils.GetSupabaseDbHost(url.QueryEscape(host)),
+		url.QueryEscape(host),
 		url.QueryEscape(database),
 	)
 	// Parse connection url

--- a/internal/db/remote/commit/commit_test.go
+++ b/internal/db/remote/commit/commit_test.go
@@ -1,0 +1,36 @@
+package commit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/pgtest"
+)
+
+func TestConnectRemotePostgres(t *testing.T) {
+	t.Run("connects to remote postgres successfully", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+
+		// Run test
+		c, err := ConnectRemotePostgres(context.Background(), "username", "password", "database", "localhost", conn.Intercept)
+		defer c.Close(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("preserves db password", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+
+		// Run test
+		password := "pass word"
+		c, err := ConnectRemotePostgres(context.Background(), "username", password, "database", "localhost", conn.Intercept)
+		defer c.Close(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, password, c.Config().Password)
+	})
+}

--- a/internal/db/remote/commit/commit_test.go
+++ b/internal/db/remote/commit/commit_test.go
@@ -17,6 +17,7 @@ func TestConnectRemotePostgres(t *testing.T) {
 
 		// Run test
 		c, err := ConnectRemotePostgres(context.Background(), "username", "password", "database", "localhost", conn.Intercept)
+		require.NoError(t, err)
 		defer c.Close(context.Background())
 		assert.NoError(t, err)
 	})
@@ -29,8 +30,8 @@ func TestConnectRemotePostgres(t *testing.T) {
 		// Run test
 		password := "pass word"
 		c, err := ConnectRemotePostgres(context.Background(), "username", password, "database", "localhost", conn.Intercept)
-		defer c.Close(context.Background())
 		require.NoError(t, err)
+		defer c.Close(context.Background())
 		assert.Equal(t, password, c.Config().Password)
 	})
 }

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -21,7 +21,7 @@ func Run(ctx context.Context, projectRef, username, password, database string, f
 
 	// 2. Check database connection
 	{
-		conn, err := commit.ConnectRemotePostgres(ctx, username, password, database, projectRef)
+		conn, err := commit.ConnectRemotePostgres(ctx, username, password, database, utils.GetSupabaseDbHost(projectRef))
 		if err != nil {
 			return err
 		}

--- a/internal/migration/list/list.go
+++ b/internal/migration/list/list.go
@@ -23,7 +23,7 @@ func Run(ctx context.Context, username, password, database string, fsys afero.Fs
 	if err != nil {
 		return err
 	}
-	conn, err := commit.ConnectRemotePostgres(ctx, username, password, database, projectRef)
+	conn, err := commit.ConnectRemotePostgres(ctx, username, password, database, utils.GetSupabaseDbHost(projectRef))
 	if err != nil {
 		return err
 	}

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -202,6 +202,6 @@ func GetSupabaseDbHost(projectRef string) string {
 	case "https://api.supabase.green":
 		return fmt.Sprintf("db.%s.supabase.red", projectRef)
 	default:
-		return "http://localhost:5432"
+		return fmt.Sprintf("db.%s.supabase.red", projectRef)
 	}
 }

--- a/internal/utils/parser/token.go
+++ b/internal/utils/parser/token.go
@@ -17,30 +17,29 @@ const (
 
 // State transition table for tokenizer:
 //
-//   Ready -> Ready (default)
-//   Ready -> Error (on invalid syntax)
-//   Ready -> Done (on ;, emit token)
-//   Ready -> Done (on EOF, emit token)
+//	Ready -> Ready (default)
+//	Ready -> Error (on invalid syntax)
+//	Ready -> Done (on ;, emit token)
+//	Ready -> Done (on EOF, emit token)
 //
-//   Ready -> Comment (on --)
-//   Comment -> Comment (default)
-//   Comment -> Ready (on \n)
+//	Ready -> Comment (on --)
+//	Comment -> Comment (default)
+//	Comment -> Ready (on \n)
 //
-//   Ready -> Block (on /*)
-//   Block -> Block (on /*, +-depth)
-//   Block -> Ready (on */, depth 0)
+//	Ready -> Block (on /*)
+//	Block -> Block (on /*, +-depth)
+//	Block -> Ready (on */, depth 0)
 //
-//   Ready -> Quote (on ')
-//   Quote -> Quote (on '', default)
-//   Quote -> Ready (on ')
+//	Ready -> Quote (on ')
+//	Quote -> Quote (on '', default)
+//	Quote -> Ready (on ')
 //
-//   Ready -> Dollar (on $tag$)
-//   Dollar -> Dollar (default)
-//   Dollar -> Ready (on $tag$)
+//	Ready -> Dollar (on $tag$)
+//	Dollar -> Dollar (default)
+//	Dollar -> Ready (on $tag$)
 //
-//   Ready -> Escape (on \)
-//   Escape -> Ready (on next)
-//
+//	Ready -> Escape (on \)
+//	Escape -> Ready (on next)
 type tokenizer struct {
 	state State
 	last  int

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -2,7 +2,7 @@ package integration
 
 // Basic imports
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -43,7 +43,7 @@ func (suite *DBTestSuite) SetupTest() {
 	// add docker mock handlers
 	DockerMock.ExecCreateHandler = func(c *gin.Context) {
 		suite.addParams(c.Copy())
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"message": "error reading body",
@@ -61,7 +61,7 @@ func (suite *DBTestSuite) SetupTest() {
 
 	DockerMock.ExecStartHandler = func(c *gin.Context) {
 		suite.addParams(c.Copy())
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"message": "error reading body",

--- a/test/link_test.go
+++ b/test/link_test.go
@@ -4,7 +4,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -56,7 +55,7 @@ func (suite *LinkTestSuite) TestLink() {
 	})
 	_, err = os.Stat(utils.ProjectRefPath)
 	require.NoError(suite.T(), err)
-	ref, err := ioutil.ReadFile(utils.ProjectRefPath)
+	ref, err := os.ReadFile(utils.ProjectRefPath)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), id, string(ref))
 }

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -2,7 +2,6 @@ package integration
 
 // Basic imports
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func (suite *LoginTestSuite) TestLink() {
 
 	// change stdin to read from a file
 	content := []byte(key)
-	tmpfile, err := ioutil.TempFile(suite.tempDir, "key")
+	tmpfile, err := os.CreateTemp(suite.tempDir, "key")
 	require.NoError(suite.T(), err)
 	defer os.Remove(tmpfile.Name()) // clean up
 
@@ -58,7 +57,7 @@ func (suite *LoginTestSuite) TestLink() {
 	require.NoError(suite.T(), err)
 	_, err = os.Stat(filepath.Join(home, ".supabase/access-token"))
 	require.NoError(suite.T(), err)
-	token, err := ioutil.ReadFile(filepath.Join(home, ".supabase/access-token"))
+	token, err := os.ReadFile(filepath.Join(home, ".supabase/access-token"))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), key, string(token))
 }

--- a/test/secrets_test.go
+++ b/test/secrets_test.go
@@ -4,7 +4,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -39,10 +38,10 @@ func (suite *SecretsTestSuite) TestList() {
 	require.NoError(suite.T(), err)
 
 	ref := gonanoid.MustGenerate(supabase.IDAlphabet, supabase.IDLength)
-	require.NoError(suite.T(), ioutil.WriteFile(utils.ProjectRefPath, []byte(ref), os.FileMode(0755)))
+	require.NoError(suite.T(), os.WriteFile(utils.ProjectRefPath, []byte(ref), os.FileMode(0755)))
 
 	// set stdout to write into file so we can capture cmd output
-	tmpfile, err := ioutil.TempFile(suite.tempDir, "output")
+	tmpfile, err := os.CreateTemp(suite.tempDir, "output")
 	require.NoError(suite.T(), err)
 	defer os.Remove(tmpfile.Name()) // clean up
 	oldStdout := os.Stdout
@@ -61,7 +60,7 @@ func (suite *SecretsTestSuite) TestList() {
 		"User-Agent":      []string{"Go-http-client/1.1"},
 	})
 
-	contents, err := ioutil.ReadFile(tmpfile.Name())
+	contents, err := os.ReadFile(tmpfile.Name())
 	require.NoError(suite.T(), err)
 	require.Contains(suite.T(), string(contents), "some-key")
 	require.Contains(suite.T(), string(contents), "another")

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -3,7 +3,6 @@ package integration
 // Basic imports
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ func (suite *StatusTestSuite) TestStatus() {
 	require.NoError(suite.T(), err)
 
 	// set stdout to write into file so we can capture cmd output
-	tmpfile, err := ioutil.TempFile(suite.tempDir, "output")
+	tmpfile, err := os.CreateTemp(suite.tempDir, "output")
 	require.NoError(suite.T(), err)
 	defer os.Remove(tmpfile.Name()) // clean up
 	oldStdout := os.Stdout
@@ -55,7 +54,7 @@ func (suite *StatusTestSuite) TestStatus() {
 		},
 	})
 
-	contents, err := ioutil.ReadFile(tmpfile.Name())
+	contents, err := os.ReadFile(tmpfile.Name())
 	require.NoError(suite.T(), err)
 	require.Contains(suite.T(), string(contents), "API URL: http://localhost:54321")
 	require.Contains(suite.T(), string(contents), "DB URL: postgresql://postgres:postgres@localhost:54322/postgres")

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -107,17 +107,17 @@ func GenYamlDoc(cmd *cobra.Command, root *SpecDoc) CmdDoc {
 
 // Wraps a command string in markdown style code block, ie.
 //
-//   ```sh
-//   echo "hello world"
-//   ```
+//	```sh
+//	echo "hello world"
+//	```
 func mdCodeBlock(script string, language string) string {
 	return "```" + language + "\n" + strings.Trim(script, "\n") + "\n```"
 }
 
 // Yaml lib generates incorrect yaml with long strings that do not contain \n.
 //
-//   example: 'a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-//     a a a a a a '
+//	example: 'a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+//	  a a a a a a '
 func forceMultiLine(s string) string {
 	if len(s) > 60 && !strings.Contains(s, "\n") {
 		s = s + "\n"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

db password `pass word` is parsed as `pass+word` because of `url.QueryEscape()`

## What is the new behavior?

db password `pass word` is parsed as `pass word`
