### PR TITLE
fix: allow CLI to work within any sub-directory of a supabase project

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ var rootCmd = &cobra.Command{
 		if viper.GetBool("DEBUG") {
 			cmd.SetContext(utils.WithTraceContext(cmd.Context()))
 		}
+		
+		utils.TryChangeWorkDirToProjectRoot()
 	},
 }
 

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -219,7 +219,7 @@ func GetProjectRoot(fsys afero.Fs) (string, error) {
 			break
 		}
 	}
-	return origWd, nil
+	return origWd, err
 }
 
 func IsBranchNameReserved(branch string) bool {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -207,8 +207,8 @@ func GetGitRoot(fsys afero.Fs) (*string, error) {
 }
 
 // If the `os.Getwd()` is within a supabase project, this will change
-// the current working directory to the root of the given project. 
-// Otherwise, the `os.Getwd()` is kept as is. 
+// the current working directory to the root of the given project.
+// Otherwise, the `os.Getwd()` is kept as is.
 func TryChangeWorkDirToProjectRoot() {
 	fsys := afero.NewOsFs()
 	origWd, err := os.Getwd()

--- a/internal/utils/misc_test.go
+++ b/internal/utils/misc_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectRoot(t *testing.T) {
+	t.Run("searches project root recursively", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		_, err := fsys.Create(filepath.Join("/", ConfigPath))
+		require.NoError(t, err)
+		// Run test
+		path, err := GetProjectRoot(fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, "/", path)
+	})
+
+	t.Run("stops at root dir", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		path, err := GetProjectRoot(fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, cwd, path)
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes #329 and closes #517 

## What is the current behavior?
- Cannot execute cli commands in subdirectories. 
- Cannot specify working directory 

## What is the new behavior?

- The CLI now will try to find the root of the project upon initialization. 
  - If root project is found, then the working directory is changed to it (i.e. for `status`, `start`, `stop` and such).
  - If no root project was found, the directory will be kept as is (i.e. for `init` and such).

- The CLI now accepts a new flag `--workdir` that allows users to specify the desired working directory as shown in the help menu:

  <p align="center"><img width="816" alt="Screen Shot 2022-10-12 at 10 35 18 PM" src="https://user-images.githubusercontent.com/46427323/195432185-599ef875-fc95-43b4-bb1a-c1942daf4d48.png"></p>

The second change was minimal so I thought it was okay to add it to the same PR. Please let me know if you want me to split it. 