### PR TITLE
fix: handle single quote in identifier name

### DIFF
--- a/internal/utils/parser/state.go
+++ b/internal/utils/parser/state.go
@@ -76,7 +76,7 @@ func (s *BlockState) Next(r rune, data []byte) State {
 	return s
 }
 
-// Opened a single quote '
+// Opened a single quote ' or double quote "
 type QuoteState struct {
 	delimiter rune
 	escape    bool


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #527 

## What is the current behavior?

single quotes in identifiers causes split error

## What is the new behavior?

handles double quote state

## Additional context

Add any other context or screenshots.
