### PR TITLE
feat: add `--experimental`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,11 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-// Passed from `-ldflags`: https://stackoverflow.com/q/11354518.
-var version string
+var (
+	// Passed from `-ldflags`: https://stackoverflow.com/q/11354518.
+	version      string
+	experimental bool
+)
 
 var rootCmd = &cobra.Command{
 	Use:           "supabase",
@@ -64,6 +67,9 @@ func init() {
 		key := strings.ReplaceAll(f.Name, "-", "_")
 		cobra.CheckErr(viper.BindPFlag(key, flags.Lookup(f.Name)))
 	})
+
+	flags.BoolVar(&experimental, "experimental", false, "enable experimental features")
+
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No way to specify which commands are experimental.

## What is the new behavior?

Experimental commands can do:

```go
myExperimentalCmd.MarkFlagRequired("experimental")
```

to make sure the flag is explicitly set

## Additional context

To be used for https://github.com/supabase/cli/pull/534