### PR TITLE
fix: initialise seed.sql as documented

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -32,18 +32,19 @@ func Run(fsys afero.Fs) error {
 		return err
 	}
 
-	// 2. Append to `.gitignore`.
+	// 2. Create `seed.sql`.
+	if _, err := fsys.Create(utils.SeedDataPath); err != nil {
+		return err
+	}
+
+	// 3. Append to `.gitignore`.
 	if gitRoot, _ := utils.GetGitRoot(fsys); gitRoot == nil {
 		// User not using git
 		return nil
 	}
 
 	ignorePath := filepath.Join(filepath.Dir(utils.ConfigPath), ".gitignore")
-	if err := updateGitIgnore(ignorePath, fsys); err != nil {
-		return err
-	}
-
-	return nil
+	return updateGitIgnore(ignorePath, fsys)
 }
 
 func updateGitIgnore(ignorePath string, fsys afero.Fs) error {

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -26,6 +26,10 @@ func TestInitCommand(t *testing.T) {
 		exists, err = afero.Exists(fsys, ignorePath)
 		assert.NoError(t, err)
 		assert.True(t, exists)
+		// Validate generated seed.sql
+		exists, err = afero.Exists(fsys, utils.SeedDataPath)
+		assert.NoError(t, err)
+		assert.True(t, exists)
 	})
 
 	t.Run("does not generate gitignore if no git", func(t *testing.T) {
@@ -42,6 +46,10 @@ func TestInitCommand(t *testing.T) {
 		exists, err = afero.Exists(fsys, ignorePath)
 		assert.NoError(t, err)
 		assert.False(t, exists)
+		// Validate generated seed.sql
+		exists, err = afero.Exists(fsys, utils.SeedDataPath)
+		assert.NoError(t, err)
+		assert.True(t, exists)
 	})
 
 	t.Run("throws error when config file exists", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #277

## What is the current behavior?

no seed.sql generated after init

## What is the new behavior?

generates seed.sql as [documented](https://supabase.com/docs/guides/cli/local-development#add-sample-data)

## Additional context

Add any other context or screenshots.
