### PR TITLE
Allow Redirect URI Overrides from config.toml

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -376,18 +376,12 @@ EOF
 			)
 
 			if config.RedirectUri != "" {
-				fmt.Fprintln(os.Stderr, "Going to use custom redirect URI ")
-
 				env = append(env,
 					fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=%s", strings.ToUpper(name), config.RedirectUri),
 				)
 			} else {
-				fmt.Fprintln(os.Stderr, "Going to use default redirect URI ")
-				// env = append(env,
-				// 	fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=http://localhost:%v/auth/v1/callback", strings.ToUpper(name), utils.Config.Api.Port),
-				// )
 				env = append(env,
-					fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=https://reviewcorralauth.ngrok.io/auth/v1/callback", strings.ToUpper(name)),
+					fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=http://localhost:%v/auth/v1/callback", strings.ToUpper(name), utils.Config.Api.Port),
 				)
 			}
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -373,8 +373,23 @@ EOF
 				fmt.Sprintf("GOTRUE_EXTERNAL_%s_ENABLED=%v", strings.ToUpper(name), config.Enabled),
 				fmt.Sprintf("GOTRUE_EXTERNAL_%s_CLIENT_ID=%s", strings.ToUpper(name), config.ClientId),
 				fmt.Sprintf("GOTRUE_EXTERNAL_%s_SECRET=%s", strings.ToUpper(name), config.Secret),
-				fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=http://localhost:%v/auth/v1/callback", strings.ToUpper(name), utils.Config.Api.Port),
 			)
+
+			if config.RedirectUri != "" {
+				fmt.Fprintln(os.Stderr, "Going to use custom redirect URI ")
+
+				env = append(env,
+					fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=%s", strings.ToUpper(name), config.RedirectUri),
+				)
+			} else {
+				fmt.Fprintln(os.Stderr, "Going to use default redirect URI ")
+				// env = append(env,
+				// 	fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=http://localhost:%v/auth/v1/callback", strings.ToUpper(name), utils.Config.Api.Port),
+				// )
+				env = append(env,
+					fmt.Sprintf("GOTRUE_EXTERNAL_%s_REDIRECT_URI=https://reviewcorralauth.ngrok.io/auth/v1/callback", strings.ToUpper(name)),
+				)
+			}
 
 			if config.Url != "" {
 				env = append(env,

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -128,10 +128,11 @@ type (
 	}
 
 	provider struct {
-		Enabled  bool
-		ClientId string `toml:"client_id"`
-		Secret   string
-		Url      string
+		Enabled     bool
+		ClientId    string `toml:"client_id"`
+		Secret      string
+		Url         string
+		RedirectUri string
 	}
 
 	// TODO
@@ -252,7 +253,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 					return value, nil
 				}
 
-				var clientId, secret, url string
+				var clientId, secret, redirectUri, url string
 
 				if Config.Auth.External[ext].ClientId == "" {
 					return fmt.Errorf("Missing required field in config: auth.external.%s.client_id", ext)
@@ -273,6 +274,14 @@ func LoadConfigFS(fsys afero.Fs) error {
 					secret = v
 				}
 
+				if Config.Auth.External[ext].RedirectUri != "" {
+					v, err := maybeLoadEnv(Config.Auth.External[ext].RedirectUri)
+					if err != nil {
+						return err
+					}
+					redirectUri = v
+				}
+
 				if Config.Auth.External[ext].Url != "" {
 					v, err := maybeLoadEnv(Config.Auth.External[ext].Url)
 					if err != nil {
@@ -282,10 +291,11 @@ func LoadConfigFS(fsys afero.Fs) error {
 				}
 
 				Config.Auth.External[ext] = provider{
-					Enabled:  true,
-					ClientId: clientId,
-					Secret:   secret,
-					Url:      url,
+					Enabled:     true,
+					ClientId:    clientId,
+					Secret:      secret,
+					RedirectUri: redirectUri,
+					Url:         url,
 				}
 			}
 		}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -132,7 +132,7 @@ type (
 		ClientId    string `toml:"client_id"`
 		Secret      string
 		Url         string
-		RedirectUri string
+		RedirectUri string `toml:"redirect_uri"`
 	}
 
 	// TODO

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -64,6 +64,8 @@ enable_confirmations = false
 enabled = false
 client_id = ""
 secret = ""
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
 # Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
 # or any other third-party OIDC providers.
 url = ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Feature]
Allows users to override the `redirect_uri` for an auth provider. This is particularly useful when wanting to run the cli locally and needing to tunnel the redirect uri from some public url to localhost (eg: using Ngrok). 

## Additional context

Closes https://github.com/supabase/cli/issues/543