### PR TITLE
fix: diff against linked project using migra

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -170,6 +170,7 @@ func MigrateDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 	if migrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil {
 		for i, migration := range migrations {
 			if i == 0 && shouldSkip(migration.Name()) {
+				fmt.Fprintln(os.Stderr, "Skipping migration "+utils.Bold(migration.Name())+`... (replace "init" with a different file name to apply this migration)`)
 				continue
 			}
 			fmt.Fprintln(os.Stderr, "Applying migration "+utils.Bold(migration.Name())+"...")

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -45,7 +45,7 @@ func RunMigra(ctx context.Context, schema []string, file string, password string
 	if err != nil {
 		return err
 	}
-	defer utils.Docker.ContainerStop(context.Background(), shadow, nil)
+	defer utils.DockerStop(shadow)
 	if err := migrateShadowDatabase(ctx, fsys, options...); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func createShadowDatabase(ctx context.Context) (string, error) {
 	return utils.DockerStart(ctx, utils.DbImage, []string{"POSTGRES_PASSWORD=postgres"}, cmd, ports)
 }
 
-func connectShadowPostgres(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {
+func connectShadowDatabase(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {
 	now := time.Now()
 	expiry := now.Add(timeout)
 	ticker := time.NewTicker(time.Second)
@@ -118,7 +118,7 @@ func connectShadowPostgres(ctx context.Context, timeout time.Duration, options .
 }
 
 func migrateShadowDatabase(ctx context.Context, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
-	conn, err := connectShadowPostgres(ctx, 10*time.Second, options...)
+	conn, err := connectShadowDatabase(ctx, 10*time.Second, options...)
 	if err != nil {
 		return err
 	}

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -6,17 +6,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
-	"github.com/spf13/viper"
-	"github.com/supabase/cli/internal/debug"
+	"github.com/supabase/cli/internal/db/lint"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/parser"
 )
@@ -25,67 +27,110 @@ var (
 	initSchemaPattern = regexp.MustCompile(`([0-9]{14})_init\.sql`)
 	//go:embed templates/migra.sh
 	diffSchemaScript string
-	//go:embed templates/reset.sh
-	resetShadowScript string
 )
 
-func RunMigra(ctx context.Context, schema []string, file string, fsys afero.Fs) error {
+func RunMigra(ctx context.Context, schema []string, file string, password string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	// Sanity checks.
-	{
-		if err := utils.LoadConfigFS(fsys); err != nil {
-			return err
-		}
-		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
-			return err
-		}
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
 	}
-
-	var opts []func(*pgx.ConnConfig)
-	if viper.GetBool("DEBUG") {
-		opts = append(opts, debug.SetupPGX)
+	// 1. Determine local or remote target
+	target, err := buildTargetUrl(password, fsys)
+	if err != nil {
+		return err
 	}
-
+	// 2. Create shadow database
 	fmt.Fprintln(os.Stderr, "Creating shadow database...")
-	if err := ResetDatabase(ctx, utils.DbId, utils.ShadowDbName); err != nil {
+	shadow, err := createShadowDatabase(ctx)
+	if err != nil {
 		return err
 	}
-
-	fmt.Fprintln(os.Stderr, "Initialising schema...")
-	url := fmt.Sprintf("postgresql://postgres:postgres@localhost:%d/%s", utils.Config.Db.Port, utils.ShadowDbName)
-	if err := ApplyMigrations(ctx, url, fsys, opts...); err != nil {
+	defer utils.Docker.ContainerStop(context.Background(), shadow, nil)
+	if err := migrateShadowDatabase(ctx, fsys, options...); err != nil {
 		return err
 	}
-
-	fmt.Fprintln(os.Stderr, "Diffing local database...")
-	source := "postgresql://postgres:postgres@" + utils.DbId + ":5432/" + utils.ShadowDbName
-	target := "postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres"
+	// 3. Run migra to diff schema
+	progress := "Diffing local database..."
+	if len(password) > 0 {
+		progress = "Diffing linked project..."
+	}
+	fmt.Fprintln(os.Stderr, progress)
+	source := "postgresql://postgres:postgres@" + shadow[:12] + ":5432/postgres"
 	out, err := diffSchema(ctx, source, target, schema)
 	if err != nil {
 		return err
 	}
-
-	if errors.Is(ctx.Err(), context.Canceled) {
-		return errors.New("Aborted " + utils.Aqua("supabase db diff") + ".")
-	}
-
 	branch, err := utils.GetCurrentBranchFS(fsys)
 	if err != nil {
-		branch = "<unknown>"
+		branch = "main"
 	}
 	fmt.Fprintln(os.Stderr, "Finished "+utils.Aqua("supabase db diff")+" on branch "+utils.Aqua(branch)+".\n")
-
 	return SaveDiff(out, file, fsys)
 }
 
-// Creates a fresh database inside a Postgres container.
-func ResetDatabase(ctx context.Context, container, shadow string) error {
-	// Our initial schema should not exceed the maximum size of an env var, ~32KB
-	env := []string{"DB_NAME=" + shadow, "SCHEMA=" + utils.InitialSchemaSql}
-	cmd := []string{"/bin/bash", "-c", resetShadowScript}
-	if _, err := utils.DockerExecOnce(ctx, container, env, cmd); err != nil {
-		return errors.New("error creating shadow database")
+// Builds a postgres connection string for local or remote database
+func buildTargetUrl(password string, fsys afero.Fs) (target string, err error) {
+	if len(password) > 0 {
+		ref, err := utils.LoadProjectRef(fsys)
+		if err != nil {
+			return target, err
+		}
+		target = fmt.Sprintf(
+			"postgresql://%s@%s:6543/postgres",
+			url.UserPassword("postgres", password),
+			utils.GetSupabaseDbHost(ref),
+		)
+	} else {
+		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
+			return target, err
+		}
+		target = "postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres"
 	}
-	return nil
+	return target, err
+}
+
+func createShadowDatabase(ctx context.Context) (string, error) {
+	var cmd []string
+	if utils.Config.Db.MajorVersion >= 14 {
+		cmd = []string{"postgres",
+			"-c", "config_file=/etc/postgresql/postgresql.conf",
+			// Ref: https://postgrespro.com/list/thread-id/2448092
+			"-c", `search_path="$user",public,extensions`,
+		}
+	}
+	ports := nat.PortMap{"5432/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Db.ShadowPort), 10)}}}
+	return utils.DockerStart(ctx, utils.DbImage, []string{"POSTGRES_PASSWORD=postgres"}, cmd, ports)
+}
+
+func connectShadowPostgres(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {
+	now := time.Now()
+	expiry := now.Add(timeout)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	// Retry until connected, cancelled, or timeout
+	for t := now; t.Before(expiry); t = <-ticker.C {
+		conn, err = lint.ConnectLocalPostgres(ctx, "localhost", utils.Config.Db.ShadowPort, "postgres", options...)
+		if err == nil || errors.Is(ctx.Err(), context.Canceled) {
+			break
+		}
+	}
+	return conn, err
+}
+
+func migrateShadowDatabase(ctx context.Context, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := connectShadowPostgres(ctx, 10*time.Second, options...)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(context.Background())
+	fmt.Fprintln(os.Stderr, "Initialising schema...")
+	if err := BatchExecDDL(ctx, conn, strings.NewReader(utils.GlobalsSql)); err != nil {
+		return err
+	}
+	if err := BatchExecDDL(ctx, conn, strings.NewReader(utils.InitialSchemaSql)); err != nil {
+		return err
+	}
+	return MigrateDatabase(ctx, conn, fsys)
 }
 
 // Applies local migration scripts to a database.
@@ -108,22 +153,24 @@ func ApplyMigrations(ctx context.Context, url string, fsys afero.Fs, options ...
 	return MigrateDatabase(ctx, conn, fsys)
 }
 
+func shouldSkip(name string) bool {
+	// NOTE: To handle backward-compatibility. `<timestamp>_init.sql` as
+	// the first migration (prev versions of the CLI) is deprecated.
+	matches := initSchemaPattern.FindStringSubmatch(name)
+	if len(matches) == 2 {
+		if timestamp, err := strconv.ParseUint(matches[1], 10, 64); err == nil && timestamp < 20211209000000 {
+			return true
+		}
+	}
+	return false
+}
+
 func MigrateDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 	// Apply migrations
 	if migrations, err := afero.ReadDir(fsys, utils.MigrationsDir); err == nil {
 		for i, migration := range migrations {
-			// NOTE: To handle backward-compatibility. `<timestamp>_init.sql` as
-			// the first migration (prev versions of the CLI) is deprecated.
-			if i == 0 {
-				matches := initSchemaPattern.FindStringSubmatch(migration.Name())
-				if len(matches) == 2 {
-					if timestamp, err := strconv.ParseUint(matches[1], 10, 64); err != nil {
-						// Unreachable due to regex valdiation, but return just in case
-						return err
-					} else if timestamp < 20211209000000 {
-						continue
-					}
-				}
+			if i == 0 && shouldSkip(migration.Name()) {
+				continue
 			}
 			fmt.Fprintln(os.Stderr, "Applying migration "+utils.Bold(migration.Name())+"...")
 			sql, err := fsys.Open(filepath.Join(utils.MigrationsDir, migration.Name()))

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -2,16 +2,217 @@ package diff
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/parser"
+	"gopkg.in/h2non/gock.v1"
 )
+
+func TestRunMigra(t *testing.T) {
+	t.Run("runs migra diff", func(t *testing.T) {
+		utils.GlobalsSql = "create schema public"
+		utils.InitialSchemaPg14Sql = "create schema private"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		project := apitest.RandomProjectRef()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
+			Reply(http.StatusOK)
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.MigraImage), "test-migra")
+		diff := "create table test();"
+		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-migra", diff))
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(utils.GlobalsSql).
+			Reply("CREATE SCHEMA").
+			Query(utils.InitialSchemaPg14Sql).
+			Reply("CREATE SCHEMA")
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "file", "password", fsys, conn.Intercept)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+		// Check diff file
+		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(files))
+		diffPath := filepath.Join(utils.MigrationsDir, files[0].Name())
+		contents, err := afero.ReadFile(fsys, diffPath)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(diff), contents)
+	})
+
+	t.Run("throws error on missing config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "", "", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Missing config: open supabase/config.toml: file does not exist")
+	})
+
+	t.Run("throws error on missing project", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "", "password", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Cannot find project ref. Have you run supabase link?")
+	})
+
+	t.Run("throws error on missing database", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "", "", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "supabase start is not running.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to create shadow", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		project := apitest.RandomProjectRef()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/images/" + utils.GetRegistryImageUrl(utils.Pg14Image) + "/json").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "", "password", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to migrate shadow", func(t *testing.T) {
+		utils.GlobalsSql = "create schema public"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		project := apitest.RandomProjectRef()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
+			Reply(http.StatusOK)
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(utils.GlobalsSql).
+			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`)
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "", "password", fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: schema "public" already exists (SQLSTATE 42P06)
+At statement 0: create schema public`)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to diff target", func(t *testing.T) {
+		utils.GlobalsSql = "create schema public"
+		utils.InitialSchemaPg14Sql = "create schema private"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		project := apitest.RandomProjectRef()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
+			Reply(http.StatusOK)
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.MigraImage), "test-migra")
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-migra/logs").
+			ReplyError(errors.New("network error"))
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(utils.GlobalsSql).
+			Reply("CREATE SCHEMA").
+			Query(utils.InitialSchemaPg14Sql).
+			Reply("CREATE SCHEMA")
+		// Run test
+		err := RunMigra(context.Background(), []string{"public"}, "file", "password", fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "error diffing scheam")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+		// Check diff file
+		exists, err := afero.DirExists(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestBuildTarget(t *testing.T) {
+	t.Run("builds remote url", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		project := apitest.RandomProjectRef()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		// Run test
+		url, err := buildTargetUrl("password", fsys)
+		// Check output
+		assert.NoError(t, err)
+		assert.Equal(t, "postgresql://postgres:password@db."+project+".supabase.co:6543/postgres", url)
+	})
+
+	t.Run("builds local url", func(t *testing.T) {
+		utils.DbId = "postgres"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Run test
+		url, err := buildTargetUrl("", fsys)
+		// Check output
+		assert.NoError(t, err)
+		assert.Equal(t, "postgresql://postgres:postgres@postgres:5432/postgres", url)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
 
 func TestApplyMigrations(t *testing.T) {
 	const postgresUrl = "postgresql://postgres:password@localhost:5432/postgres"
@@ -40,31 +241,6 @@ func TestApplyMigrations(t *testing.T) {
 		assert.NoError(t, ApplyMigrations(context.Background(), postgresUrl, fsys, conn.Intercept))
 	})
 
-	t.Run("ignores empty local directory", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		// Run test
-		assert.NoError(t, ApplyMigrations(context.Background(), postgresUrl, fsys, conn.Intercept))
-	})
-
-	t.Run("ignores outdated migrations", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup initial migration
-		name := "20211208000000_init.sql"
-		path := filepath.Join(utils.MigrationsDir, name)
-		query := "create table test"
-		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		// Run test
-		assert.NoError(t, ApplyMigrations(context.Background(), postgresUrl, fsys, conn.Intercept))
-	})
-
 	t.Run("throws error on invalid postgres url", func(t *testing.T) {
 		assert.Error(t, ApplyMigrations(context.Background(), "invalid", afero.NewMemMapFs()))
 	})
@@ -88,5 +264,89 @@ func TestApplyMigrations(t *testing.T) {
 			ReplyError(pgerrcode.DuplicateTable, `relation "test" already exists`)
 		// Run test
 		assert.Error(t, ApplyMigrations(context.Background(), postgresUrl, fsys, conn.Intercept))
+	})
+}
+
+func TestMigrateDatabase(t *testing.T) {
+	t.Run("ignores empty local directory", func(t *testing.T) {
+		assert.NoError(t, MigrateDatabase(context.Background(), nil, afero.NewMemMapFs()))
+	})
+
+	t.Run("ignores outdated migrations", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup initial migration
+		name := "20211208000000_init.sql"
+		path := filepath.Join(utils.MigrationsDir, name)
+		query := "create table test"
+		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
+		// Run test
+		err := MigrateDatabase(context.Background(), nil, fsys)
+		// Check error
+		assert.NoError(t, err)
+	})
+
+	t.Run("throws error on failture to scan token", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup initial migration
+		name := "20220727064247_create_table.sql"
+		path := filepath.Join(utils.MigrationsDir, name)
+		query := "BEGIN; " + strings.Repeat("a", parser.MaxScannerCapacity)
+		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
+		// Run test
+		err := MigrateDatabase(context.Background(), nil, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "bufio.Scanner: token too long\nAfter statement 1: BEGIN;")
+	})
+}
+
+func TestMigrateShadow(t *testing.T) {
+	t.Run("throws error on timeout", func(t *testing.T) {
+		utils.Config.Db.ShadowPort = 54320
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup cancelled context
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		// Run test
+		err := migrateShadowDatabase(ctx, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "operation was canceled")
+	})
+
+	t.Run("throws error on globals schema", func(t *testing.T) {
+		utils.Config.Db.ShadowPort = 54320
+		utils.GlobalsSql = "create schema public"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(utils.GlobalsSql).
+			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`)
+		// Run test
+		err := migrateShadowDatabase(ctx, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: schema "public" already exists (SQLSTATE 42P06)`)
+	})
+
+	t.Run("throws error on initial schema", func(t *testing.T) {
+		utils.Config.Db.ShadowPort = 54320
+		utils.GlobalsSql = "create schema public"
+		utils.InitialSchemaSql = "create schema private"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(utils.GlobalsSql).
+			Reply("CREATE SCHEMA").
+			Query(utils.InitialSchemaSql).
+			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`)
+		// Run test
+		err := migrateShadowDatabase(ctx, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: schema "public" already exists (SQLSTATE 42P06)`)
 	})
 }

--- a/internal/db/diff/templates/migra.sh
+++ b/internal/db/diff/templates/migra.sh
@@ -10,5 +10,8 @@ trap 'kill -9 %1' TERM
 # accepts command line args as a list of schema to generate
 for i in "$@"; do
     # migra exits 2 when differences are found
-    migra --unsafe --schema="$i" "$SOURCE" "$TARGET" || true
+    migra --unsafe --schema="$i" "$SOURCE" "$TARGET" || status=$?
+    if [ ${status:-2} -ne 2 ]; then
+        exit $status
+    fi
 done

--- a/internal/db/lint/lint.go
+++ b/internal/db/lint/lint.go
@@ -87,7 +87,7 @@ func printResultJSON(result []Result, minLevel LintLevel, stdout io.Writer) erro
 
 // Connnect to local Postgres with optimised settings. The caller is responsible for closing the connection returned.
 func ConnectLocalPostgres(ctx context.Context, host string, port uint, database string, options ...func(*pgx.ConnConfig)) (*pgx.Conn, error) {
-	url := fmt.Sprintf("postgresql://postgres:postgres@%s:%d/%s", host, port, database)
+	url := fmt.Sprintf("postgresql://postgres:postgres@%s:%d/%s?connect_timeout=2", host, port, database)
 	// Parse connection url
 	config, err := pgx.ParseConfig(url)
 	if err != nil {

--- a/internal/testing/apitest/helper.go
+++ b/internal/testing/apitest/helper.go
@@ -1,10 +1,69 @@
 package apitest
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
 
+	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"gopkg.in/h2non/gock.v1"
 )
+
+const mockHost = "http://localhost"
+
+func MockDocker(docker *client.Client) error {
+	// Skip setup if docker is already mocked
+	if docker.DaemonHost() == mockHost {
+		return nil
+	}
+	if err := client.WithVersion(api.DefaultVersion)(docker); err != nil {
+		return err
+	}
+	if err := client.WithHost(mockHost)(docker); err != nil {
+		return err
+	}
+	return client.WithHTTPClient(http.DefaultClient)(docker)
+}
+
+// Ref: internal/utils/docker.go::DockerStart
+func MockDockerStart(docker *client.Client, image, containerID string) {
+	gock.New(docker.DaemonHost()).
+		Get("/v" + docker.ClientVersion() + "/images/" + image + "/json").
+		Reply(http.StatusOK).
+		JSON(types.ImageInspect{})
+	gock.New(docker.DaemonHost()).
+		Get("/v" + docker.ClientVersion() + "/networks").
+		Reply(http.StatusOK).
+		JSON(types.NetworkResource{})
+	gock.New(docker.DaemonHost()).
+		Post("/v" + docker.ClientVersion() + "/containers/create").
+		Reply(http.StatusOK).
+		JSON(container.ContainerCreateCreatedBody{ID: containerID})
+	gock.New(docker.DaemonHost()).
+		Post("/v" + docker.ClientVersion() + "/containers/" + containerID + "/start").
+		Reply(http.StatusAccepted)
+}
+
+// Ref: internal/utils/docker.go::DockerRunOnce
+func MockDockerLogs(docker *client.Client, containerID, stdout string) error {
+	var body bytes.Buffer
+	writer := stdcopy.NewStdWriter(&body, stdcopy.Stdout)
+	_, err := writer.Write([]byte(stdout))
+	gock.New(docker.DaemonHost()).
+		Get("/v"+docker.ClientVersion()+"/containers/"+containerID+"/logs").
+		Reply(http.StatusOK).
+		SetHeader("Content-Type", "application/vnd.docker.raw-stream").
+		Body(&body)
+	gock.New(docker.DaemonHost()).
+		Get("/v" + docker.ClientVersion() + "/containers/" + containerID + "/json").
+		Reply(http.StatusOK).
+		JSON(types.ContainerJSONBase{State: &types.ContainerState{ExitCode: 0}})
+	return err
+}
 
 func ListUnmatchedRequests() []string {
 	result := make([]string, len(gock.GetUnmatchedRequests()))

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -32,9 +32,9 @@ var (
 
 	InitialSchemaSql string
 	//go:embed templates/initial_schemas/13.sql
-	initialSchemaPg13Sql string
+	InitialSchemaPg13Sql string
 	//go:embed templates/initial_schemas/14.sql
-	initialSchemaPg14Sql string
+	InitialSchemaPg14Sql string
 
 	authExternalProviders = []string{
 		"apple",
@@ -95,6 +95,7 @@ type (
 
 	db struct {
 		Port         uint
+		ShadowPort   uint `toml:"shadow_port"`
 		MajorVersion uint `toml:"major_version"`
 	}
 
@@ -181,6 +182,9 @@ func LoadConfigFS(fsys afero.Fs) error {
 		if Config.Db.Port == 0 {
 			return errors.New("Missing required field in config: db.port")
 		}
+		if Config.Db.ShadowPort == 0 {
+			Config.Db.ShadowPort = 54320
+		}
 		switch Config.Db.MajorVersion {
 		case 0:
 			return errors.New("Missing required field in config: db.major_version")
@@ -188,10 +192,10 @@ func LoadConfigFS(fsys afero.Fs) error {
 			return errors.New("Postgres version 12.x is unsupported. To use the CLI, either start a new project or follow project migration steps here: https://supabase.com/docs/guides/database#migrating-between-projects.")
 		case 13:
 			DbImage = Pg13Image
-			InitialSchemaSql = initialSchemaPg13Sql
+			InitialSchemaSql = InitialSchemaPg13Sql
 		case 14:
 			DbImage = Pg14Image
-			InitialSchemaSql = initialSchemaPg14Sql
+			InitialSchemaSql = InitialSchemaPg14Sql
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)
 		}

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
 	"github.com/spf13/viper"
 )
 
@@ -205,8 +206,7 @@ func DockerPullImageIfNotCached(ctx context.Context, imageName string) error {
 	return err
 }
 
-// Runs a container image exactly once, returning stdout and throwing error on non-zero exit code.
-func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string) (string, error) {
+func DockerStart(ctx context.Context, image string, env []string, cmd []string, ports nat.PortMap) (string, error) {
 	// Pull container image
 	if err := DockerPullImageIfNotCached(ctx, image); err != nil {
 		return "", err
@@ -226,8 +226,9 @@ func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string
 			"com.docker.compose.project": Config.ProjectId,
 		},
 	}, &container.HostConfig{
-		NetworkMode: container.NetworkMode(network.ID),
-		AutoRemove:  true,
+		NetworkMode:  container.NetworkMode(network.ID),
+		PortBindings: ports,
+		AutoRemove:   true,
 	}, nil, nil, "")
 	if err != nil {
 		return "", err
@@ -244,8 +245,17 @@ func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string
 			}
 		}
 	}()
+	return resp.ID, nil
+}
+
+// Runs a container image exactly once, returning stdout and throwing error on non-zero exit code.
+func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string) (string, error) {
+	container, err := DockerStart(ctx, image, env, cmd, nil)
+	if err != nil {
+		return "", err
+	}
 	// Stream logs
-	logs, err := Docker.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{
+	logs, err := Docker.ContainerLogs(ctx, container, types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: viper.GetBool("DEBUG"),
 		Follow:     true,
@@ -259,11 +269,11 @@ func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string
 		return "", err
 	}
 	// Check exit code
-	iresp, err := Docker.ContainerInspect(ctx, resp.ID)
+	resp, err := Docker.ContainerInspect(ctx, container)
 	if err != nil {
 		return "", err
 	}
-	if iresp.State.ExitCode > 0 {
+	if resp.State.ExitCode > 0 {
 		return "", errors.New("error running container")
 	}
 	return out.String(), nil

--- a/internal/utils/parser/token.go
+++ b/internal/utils/parser/token.go
@@ -12,7 +12,7 @@ const (
 	// Default max capacity is 64 * 1024 which is not enough for certain lines
 	// containing e.g. geographical data.
 	// 256K ought to be enough for anybody...
-	maxScannerCapacity = 256 * 1024
+	MaxScannerCapacity = 256 * 1024
 	// Equal to `startBufSize` from `bufio/scan.go`
 	startBufSize = 4096
 )
@@ -85,7 +85,7 @@ func Split(sql io.Reader) (stats []string, err error) {
 	buf := make([]byte, startBufSize)
 	maxbuf := viper.GetSizeInBytes("SCANNER_BUFFER_SIZE")
 	if maxbuf == 0 {
-		maxbuf = maxScannerCapacity
+		maxbuf = MaxScannerCapacity
 	}
 	scanner.Buffer(buf, int(maxbuf))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #479

## What is the current behavior?

- creates shadow database in the same container as postgres
- cannot use migra to diff remote project

## What is the new behavior?

- adds `db diff --linked` flag
- adds apitest helpers for mocking docker
- sets local pg connect timeout to 2 seconds
- fixes `migra.sh` reporting success on error code 1
- creates shadow database in a new container to accommodate pg_cron

## Additional context

Add any other context or screenshots.
