### PR TITLE
fix: error in getting project root

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -210,9 +210,9 @@ func GetGitRoot(fsys afero.Fs) (*string, error) {
 func GetProjectRoot(fsys afero.Fs) (string, error) {
 	origWd, err := os.Getwd()
 	for cwd := origWd; err == nil; cwd = filepath.Dir(cwd) {
-		var isSupaProj bool
 		path := filepath.Join(cwd, ConfigPath)
-		if isSupaProj, err = afero.Exists(fsys, path); isSupaProj {
+		// Treat all errors as file not exists
+		if isSupaProj, _ := afero.Exists(fsys, path); isSupaProj {
 			return cwd, nil
 		}
 		if isRootDirectory(cwd) {

--- a/internal/utils/misc_test.go
+++ b/internal/utils/misc_test.go
@@ -1,14 +1,28 @@
 package utils
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type MockFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *MockFs) Stat(name string) (fs.FileInfo, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.Stat(name)
+}
 
 func TestProjectRoot(t *testing.T) {
 	t.Run("searches project root recursively", func(t *testing.T) {
@@ -28,6 +42,18 @@ func TestProjectRoot(t *testing.T) {
 		require.NoError(t, err)
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		// Run test
+		path, err := GetProjectRoot(fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, cwd, path)
+	})
+
+	t.Run("ignores error if path is not directory", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		// Setup in-memory fs
+		fsys := &MockFs{DenyPath: filepath.Join(cwd, "supabase")}
 		// Run test
 		path, err := GetProjectRoot(fsys)
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #554

## What is the current behavior?

introduced in https://github.com/supabase/cli/pull/522

## What is the new behavior?

silently ignore errors from `fs.Exists`, such as permission denied, or path not a directory.

## Additional context

Add any other context or screenshots.
