### PR TITLE
chore: add supabase test command alias

### DIFF
--- a/cmd/customHostname.go
+++ b/cmd/customHostname.go
@@ -17,7 +17,7 @@ import (
 var (
 	customHostnamesCmd = &cobra.Command{
 		Use:   "custom-hostname",
-		Short: "Manage custom hostnames for Supabase projects.",
+		Short: "Manage custom hostnames for Supabase projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if !experimental {
 				return errors.New("must set the --experimental flag to run this command")

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -164,7 +164,7 @@ var (
 
 	dbTestCmd = &cobra.Command{
 		Use:   "test",
-		Short: "Tests local database with pgTAP.",
+		Short: "Tests local database with pgTAP",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return test.Run(ctx, afero.NewOsFs())

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -7,7 +7,7 @@ import (
 var (
 	testCmd = &cobra.Command{
 		Use:   "test",
-		Short: "Manage Supabase tests",
+		Short: "Run tests for local project",
 	}
 
 	testDbCmd = &cobra.Command{

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	testCmd = &cobra.Command{
+		Use:   "test",
+		Short: "Manage Supabase tests",
+	}
+
+	testDbCmd = &cobra.Command{
+		Use:   "db",
+		Short: dbTestCmd.Short,
+		RunE:  dbTestCmd.RunE,
+	}
+)
+
+func init() {
+	testCmd.AddCommand(testDbCmd)
+	rootCmd.AddCommand(testCmd)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

command alias

## What is the current behavior?

`supabase db test`

## What is the new behavior?

adds alias for `supabase test db` in preparation for more test types

## Additional context

Add any other context or screenshots.
