### PR TITLE
fix: group cli commands help text

### DIFF
--- a/cmd/customHostname.go
+++ b/cmd/customHostname.go
@@ -16,8 +16,9 @@ import (
 
 var (
 	customHostnamesCmd = &cobra.Command{
-		Use:   "custom-hostname",
-		Short: "Manage custom hostnames for Supabase projects",
+		GroupID: "hosted",
+		Use:     "custom-hostname",
+		Short:   "Manage custom hostnames for Supabase projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if !experimental {
 				return errors.New("must set the --experimental flag to run this command")

--- a/cmd/customHostname.go
+++ b/cmd/customHostname.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	customHostnamesCmd = &cobra.Command{
-		GroupID: "hosted",
+		GroupID: "management-api",
 		Use:     "custom-hostname",
 		Short:   "Manage custom hostnames for Supabase projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	dbCmd = &cobra.Command{
-		GroupID: "admin",
+		GroupID: "local-dev",
 		Use:     "db",
 		Short:   "Manage local Postgres databases",
 	}

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -23,8 +23,9 @@ import (
 
 var (
 	dbCmd = &cobra.Command{
-		Use:   "db",
-		Short: "Manage local Postgres databases",
+		GroupID: "admin",
+		Use:     "db",
+		Short:   "Manage local Postgres databases",
 	}
 
 	dbBranchCmd = &cobra.Command{

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	dbCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "db",
 		Short:   "Manage local Postgres databases",
 	}

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	customHostnamesCmd = &cobra.Command{
-		GroupID: "management-api",
+		GroupID: groupManagementAPI,
 		Use:     "domains",
 		Short:   "Manage custom domain names for Supabase projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -17,8 +17,8 @@ import (
 var (
 	customHostnamesCmd = &cobra.Command{
 		GroupID: "management-api",
-		Use:     "custom-hostname",
-		Short:   "Manage custom hostnames for Supabase projects",
+		Use:     "domains",
+		Short:   "Manage custom domain names for Supabase projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if !experimental {
 				return errors.New("must set the --experimental flag to run this command")

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	functionsCmd = &cobra.Command{
-		GroupID: "hosted",
+		GroupID: "management-api",
 		Use:     "functions",
 		Short:   "Manage Supabase Edge functions",
 	}

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -20,8 +20,9 @@ import (
 
 var (
 	functionsCmd = &cobra.Command{
-		Use:   "functions",
-		Short: "Manage Supabase Edge functions",
+		GroupID: "hosted",
+		Use:     "functions",
+		Short:   "Manage Supabase Edge functions",
 	}
 
 	projectRef string

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	functionsCmd = &cobra.Command{
-		GroupID: "management-api",
+		GroupID: groupManagementAPI,
 		Use:     "functions",
 		Short:   "Manage Supabase Edge functions",
 	}

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	genCmd = &cobra.Command{
-		Use:   "gen",
-		Short: "Run code generation tools",
+		GroupID: "local-dev",
+		Use:     "gen",
+		Short:   "Run code generation tools",
 	}
 
 	genTypesCmd = &cobra.Command{

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	genCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "gen",
 		Short:   "Run code generation tools",
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,7 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	GroupID: "local-dev",
+	GroupID: groupLocalDev,
 	Use:     "init",
 	Short:   "Initialize a local project",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,8 +10,9 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a local project",
+	GroupID: "setup",
+	Use:     "init",
+	Short:   "Initialize a local project",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fsys := afero.NewOsFs()
 		if err := _init.Run(fsys); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,7 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	GroupID: "setup",
+	GroupID: "local-dev",
 	Use:     "init",
 	Short:   "Initialize a local project",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -19,7 +19,7 @@ var (
 	username = "postgres"
 
 	linkCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "link",
 		Short:   "Link to a Supabase project",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -19,7 +19,7 @@ var (
 	username = "postgres"
 
 	linkCmd = &cobra.Command{
-		GroupID: "admin",
+		GroupID: "local-dev",
 		Use:     "link",
 		Short:   "Link to a Supabase project",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -19,8 +19,9 @@ var (
 	username = "postgres"
 
 	linkCmd = &cobra.Command{
-		Use:   "link",
-		Short: "Link to a Supabase project",
+		GroupID: "admin",
+		Use:     "link",
+		Short:   "Link to a Supabase project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectRef, err := cmd.Flags().GetString("project-ref")
 			if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	loginCmd = &cobra.Command{
-		Use:   "login",
-		Short: "Authenticate using an access token",
+		GroupID: "setup",
+		Use:     "login",
+		Short:   "Authenticate using an access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.Run(os.Stdin, afero.NewOsFs()); err != nil {
 				return err

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	loginCmd = &cobra.Command{
-		GroupID: "setup",
+		GroupID: "local-dev",
 		Use:     "login",
 		Short:   "Authenticate using an access token",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	loginCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "login",
 		Short:   "Authenticate using an access token",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	migrationCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "migration",
 		Short:   "Manage database migration scripts",
 	}

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	migrationCmd = &cobra.Command{
-		GroupID: "admin",
+		GroupID: "local-dev",
 		Use:     "migration",
 		Short:   "Manage database migration scripts",
 	}

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	migrationCmd = &cobra.Command{
-		Use:   "migration",
-		Short: "Manage database migration scripts",
+		GroupID: "admin",
+		Use:     "migration",
+		Short:   "Manage database migration scripts",
 	}
 
 	migrationListCmd = &cobra.Command{

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	orgsCmd = &cobra.Command{
-		GroupID: "management-api",
+		GroupID: groupManagementAPI,
 		Use:     "orgs",
 		Short:   "Manage Supabase organizations",
 	}

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -8,8 +8,9 @@ import (
 
 var (
 	orgsCmd = &cobra.Command{
-		Use:   "orgs",
-		Short: "Manage Supabase organizations",
+		GroupID: "hosted",
+		Use:     "orgs",
+		Short:   "Manage Supabase organizations",
 	}
 
 	orgsListCmd = &cobra.Command{

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	orgsCmd = &cobra.Command{
-		GroupID: "hosted",
+		GroupID: "management-api",
 		Use:     "orgs",
 		Short:   "Manage Supabase organizations",
 	}

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	projectsCmd = &cobra.Command{
-		GroupID: "hosted",
+		GroupID: "management-api",
 		Use:     "projects",
 		Short:   "Manage Supabase projects",
 	}

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	projectsCmd = &cobra.Command{
-		GroupID: "management-api",
+		GroupID: groupManagementAPI,
 		Use:     "projects",
 		Short:   "Manage Supabase projects",
 	}

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -17,8 +17,9 @@ import (
 
 var (
 	projectsCmd = &cobra.Command{
-		Use:   "projects",
-		Short: "Manage Supabase projects",
+		GroupID: "hosted",
+		Use:     "projects",
+		Short:   "Manage Supabase projects",
 	}
 
 	interactive bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,10 @@ func init() {
 	flags.BoolVar(&experimental, "experimental", false, "enable experimental features")
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.AddGroup(&cobra.Group{ID: "setup", Title: "Configuration:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "local-dev", Title: "Local Development:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "hosted", Title: "Hosted Project:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "admin", Title: "Database Admin:"})
 }
 
 // instantiate new rootCmd is a bit tricky with cobra, but it can be done later with the following

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,11 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
+const (
+	groupLocalDev      = "local-dev"
+	groupManagementAPI = "management-api"
+)
+
 var (
 	// Passed from `-ldflags`: https://stackoverflow.com/q/11354518.
 	version      string
@@ -68,8 +73,8 @@ func init() {
 	flags.BoolVar(&experimental, "experimental", false, "enable experimental features")
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
-	rootCmd.AddGroup(&cobra.Group{ID: "local-dev", Title: "Local Development:"})
-	rootCmd.AddGroup(&cobra.Group{ID: "management-api", Title: "Management APIs:"})
+	rootCmd.AddGroup(&cobra.Group{ID: groupLocalDev, Title: "Local Development:"})
+	rootCmd.AddGroup(&cobra.Group{ID: groupManagementAPI, Title: "Management APIs:"})
 }
 
 // instantiate new rootCmd is a bit tricky with cobra, but it can be done later with the following

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func init() {
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddGroup(&cobra.Group{ID: "local-dev", Title: "Local Development:"})
-	rootCmd.AddGroup(&cobra.Group{ID: "management-api", Title: "Management API:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "management-api", Title: "Management APIs:"})
 }
 
 // instantiate new rootCmd is a bit tricky with cobra, but it can be done later with the following

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,10 +68,8 @@ func init() {
 	flags.BoolVar(&experimental, "experimental", false, "enable experimental features")
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
-	rootCmd.AddGroup(&cobra.Group{ID: "setup", Title: "Configuration:"})
 	rootCmd.AddGroup(&cobra.Group{ID: "local-dev", Title: "Local Development:"})
-	rootCmd.AddGroup(&cobra.Group{ID: "hosted", Title: "Hosted Project:"})
-	rootCmd.AddGroup(&cobra.Group{ID: "admin", Title: "Database Admin:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "management-api", Title: "Management API:"})
 }
 
 // instantiate new rootCmd is a bit tricky with cobra, but it can be done later with the following

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	secretsCmd = &cobra.Command{
-		GroupID: "management-api",
+		GroupID: groupManagementAPI,
 		Use:     "secrets",
 		Short:   "Manage Supabase secrets",
 	}

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	secretsCmd = &cobra.Command{
-		GroupID: "hosted",
+		GroupID: "management-api",
 		Use:     "secrets",
 		Short:   "Manage Supabase secrets",
 	}

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -13,8 +13,9 @@ import (
 
 var (
 	secretsCmd = &cobra.Command{
-		Use:   "secrets",
-		Short: "Manage Supabase secrets",
+		GroupID: "hosted",
+		Use:     "secrets",
+		Short:   "Manage Supabase secrets",
 	}
 
 	secretsListCmd = &cobra.Command{

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,8 +7,9 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start containers for Supabase local development",
+	GroupID: "local-dev",
+	Use:     "start",
+	Short:   "Start containers for Supabase local development",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return start.Run(cmd.Context(), afero.NewOsFs())
 	},

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,7 +7,7 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	GroupID: "local-dev",
+	GroupID: groupLocalDev,
 	Use:     "start",
 	Short:   "Start containers for Supabase local development",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,8 +10,9 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show status of local Supabase containers",
+	GroupID: "local-dev",
+	Use:     "status",
+	Short:   "Show status of local Supabase containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 		return status.Run(ctx, afero.NewOsFs())

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,7 +10,7 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	GroupID: "local-dev",
+	GroupID: groupLocalDev,
 	Use:     "status",
 	Short:   "Show status of local Supabase containers",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -13,8 +13,9 @@ var (
 	backup bool
 
 	stopCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "Stop all local Supabase containers",
+		GroupID: "local-dev",
+		Use:     "stop",
+		Short:   "Stop all local Supabase containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return stop.Run(ctx, backup, afero.NewOsFs())

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -13,7 +13,7 @@ var (
 	backup bool
 
 	stopCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "stop",
 		Short:   "Stop all local Supabase containers",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	testCmd = &cobra.Command{
-		GroupID: "local-dev",
+		GroupID: groupLocalDev,
 		Use:     "test",
 		Short:   "Run tests on local Supabase containers",
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -6,8 +6,9 @@ import (
 
 var (
 	testCmd = &cobra.Command{
-		Use:   "test",
-		Short: "Run tests for local project",
+		GroupID: "local-dev",
+		Use:     "test",
+		Short:   "Run tests on local Supabase containers",
 	}
 
 	testDbCmd = &cobra.Command{


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

too many commands in root, making help text look messy

## What is the new behavior?

group commands by their use case

## Additional context

```
$ supabase help
Supabase CLI

Usage:
  supabase [command]

Local Development:
  db                Manage local Postgres databases
  gen               Run code generation tools
  init              Initialize a local project
  link              Link to a Supabase project
  login             Authenticate using an access token
  migration         Manage database migration scripts
  start             Start containers for Supabase local development
  status            Show status of local Supabase containers
  stop              Stop all local Supabase containers
  test              Run tests on local Supabase containers

Management APIs:
  domains           Manage custom domain names for Supabase projects
  functions         Manage Supabase Edge functions
  orgs              Manage Supabase organizations
  projects          Manage Supabase projects
  secrets           Manage Supabase secrets

Additional Commands:
  completion        Generate the autocompletion script for the specified shell
  help              Help about any command

Flags:
      --debug            output debug logs to stderr
      --experimental     enable experimental features
  -h, --help             help for supabase
      --workdir string   path to a Supabase project directory

Use "supabase [command] --help" for more information about a command.
```
