### PR TITLE
Allow smtp overrides from config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # NPM
 node_modules
 package-lock.json
+
+# Generated supabase folder (from `go run . init` command)
+supabase

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -354,9 +354,6 @@ EOF
 			fmt.Sprintf("GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED=%v", *utils.Config.Auth.Email.DoubleConfirmChanges),
 			fmt.Sprintf("GOTRUE_MAILER_AUTOCONFIRM=%v", !*utils.Config.Auth.Email.EnableConfirmations),
 
-			"GOTRUE_SMTP_HOST=" + utils.InbucketId,
-			"GOTRUE_SMTP_PORT=2500",
-			"GOTRUE_SMTP_ADMIN_EMAIL=admin@email.com",
 			"GOTRUE_SMTP_MAX_FREQUENCY=1s",
 			"GOTRUE_MAILER_URLPATHS_INVITE=/auth/v1/verify",
 			"GOTRUE_MAILER_URLPATHS_CONFIRMATION=/auth/v1/verify",
@@ -365,6 +362,69 @@ EOF
 
 			"GOTRUE_EXTERNAL_PHONE_ENABLED=true",
 			"GOTRUE_SMS_AUTOCONFIRM=true",
+		}
+
+		var smtpHost = utils.Config.Auth.Email.SmtpHost
+		if smtpHost != "" {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_HOST=%s", smtpHost),
+			)
+		} else {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_HOST=%s", utils.InbucketId),
+			)
+		}
+
+		var smtpPort = utils.Config.Auth.Email.SmtpPort
+		if smtpPort != 0 {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_PORT=%v", smtpPort),
+			)
+		} else {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_PORT=%v", 2500),
+			)
+		}
+
+		var smtpAdminEmail = utils.Config.Auth.Email.SmtpAdminEmail
+		if smtpAdminEmail != "" {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", smtpAdminEmail),
+			)
+		} else {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", "admin@email.com"),
+			)
+		}
+
+		var smtpUser = utils.Config.Auth.Email.SmtpUser
+		if smtpUser != "" {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_USER=%s", smtpUser),
+			)
+		}
+
+		var smtpPass = utils.Config.Auth.Email.SmtpPass
+		if smtpPass != "" {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_PASS=%s", smtpPass),
+			)
+		}
+
+		var smtpSenderName = utils.Config.Auth.Email.SmtpSenderName
+		if smtpSenderName != "" {
+			env = append(
+				env,
+				fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", smtpSenderName),
+			)
 		}
 
 		for name, config := range utils.Config.Auth.External {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -126,6 +126,13 @@ type (
 		EnableSignup         *bool `toml:"enable_signup"`
 		DoubleConfirmChanges *bool `toml:"double_confirm_changes"`
 		EnableConfirmations  *bool `toml:"enable_confirmations"`
+
+		SmtpPort       uint   `toml:"smtp_port"`
+		SmtpAdminEmail string `toml:"smtp_admin_email"`
+		SmtpHost       string `toml:"smtp_host"`
+		SmtpUser       string `toml:"smtp_user"`
+		SmtpPass       string `toml:"smtp_pass"`
+		SmtpSenderName string `toml:"smtp_sender_name"`
 	}
 
 	provider struct {

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -57,6 +57,15 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# SMTP configurations, uncomment what is needed.
+#smtp_admin_email="admin@email.com"
+# [WARNING] The line below (smtp_host) will override InbucketId
+#smtp_host="mail"
+# smtp_port defaults to 2500 (no need to uncomment if this is the case)
+#smtp_port=2500
+#smtp_user="fake_mail_user"
+#smtp_pass="fake_mail_password"
+#smtp_sender_name="fake_sender"
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Feature]
Allows users to override the `smtp_admin_email`, `smtp_host`, `smtp_port`, `smtp_user`, `smtp_pass` and `smtp_sender_name` to enable sending emails while clients signups using their emails from a local development environment (or self host).

## What is the current behavior?

Sign up from supabase (e.g supabase.js) or invite button from dashboard users UI does not send verification email when `enable_confirmations = true`

## What is the new behavior?

if `smtp_admin_email`, `smtp_host`, `smtp_port`, `smtp_user`, `smtp_pass` and `smtp_sender_name` are set correctly, sending emails should work.
