### PR TITLE
fix: support tests in .sql extension

### DIFF
--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -10,9 +10,7 @@ fi
 enable="create extension if not exists pgtap with schema extensions"
 notice=$(psql -h localhost -U postgres -p 5432 -d postgres -c "$enable" 2>&1 >/dev/null)
 
-# run postgres unit tests
-pg_prove -h localhost -U postgres -r "$@"
-
+files=$1
 cleanup() {
     # save the return code of the script
     status=$?
@@ -21,9 +19,12 @@ cleanup() {
         psql -h localhost -U postgres -p 5432 -d postgres -c "drop extension if exists pgtap"
     fi
     # clean up test files
-    rm -rf "$@"
+    rm -rf "$files"
     # actually quit
     exit $status
 }
 
 trap cleanup EXIT
+
+# run postgres unit tests
+pg_prove -h localhost -U postgres --ext .pg --ext .sql -r "$files"

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -41,8 +41,10 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		return err
 	}
 
+	// Passing in script string means command line args must be set manually, ie. "$@"
+	args := "set -- " + dstPath + "/" + utils.DbTestsDir + ";"
 	// Requires unix path inside container
-	cmd := []string{"/bin/bash", "-c", testScript, dstPath + "/" + utils.DbTestsDir}
+	cmd := []string{"/bin/bash", "-c", args + testScript}
 	out, err := utils.DockerExecOnce(ctx, utils.DbId, nil, cmd)
 	if err != nil {
 		return err

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -32,11 +32,15 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		}
 	}
 
+	return pgProve(ctx, "/tmp", fsys)
+}
+
+func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
+	// Copy tests into database container
 	var buf bytes.Buffer
 	if err := compress(utils.DbTestsDir, &buf, fsys); err != nil {
 		return err
 	}
-	dstPath := "/tmp"
 	if err := utils.Docker.CopyToContainer(ctx, utils.DbId, dstPath, &buf, types.CopyToContainerOptions{}); err != nil {
 		return err
 	}
@@ -63,7 +67,6 @@ func compress(src string, buf io.Writer, fsys afero.Fs) error {
 	if err := afero.Walk(fsys, src, func(file string, fi os.FileInfo, err error) error {
 		// return on any error
 		if err != nil {
-			fmt.Println(err)
 			return err
 		}
 

--- a/internal/db/test/test_test.go
+++ b/internal/db/test/test_test.go
@@ -2,22 +2,138 @@ package test
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
 )
+
+type MockFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *MockFs) Open(name string) (afero.File, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.Open(name)
+}
 
 func TestTarDirectory(t *testing.T) {
 	t.Run("tars a given directory", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		dir := "/tests"
-		require.NoError(t, afero.WriteFile(fsys, filepath.Join(dir, "order_test.pg"), []byte("SELECT 0;"), 0644))
+		pgtap := "/tests/order_test.sql"
+		require.NoError(t, afero.WriteFile(fsys, pgtap, []byte("SELECT 0;"), 0644))
 		// Run test
 		var buf bytes.Buffer
-		assert.NoError(t, compress(dir, &buf, fsys))
+		assert.NoError(t, compress(filepath.Dir(pgtap), &buf, fsys))
+	})
+
+	t.Run("throws error on permission denied", func(t *testing.T) {
+		// Setup in-memory fs
+		pgtap := "/tests/order_test.sql"
+		fsys := &MockFs{DenyPath: pgtap}
+		require.NoError(t, afero.WriteFile(fsys, pgtap, []byte("SELECT 0;"), 0644))
+		// Run test
+		var buf bytes.Buffer
+		err := compress(filepath.Dir(pgtap), &buf, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "permission denied")
+	})
+}
+
+func TestPgProve(t *testing.T) {
+	t.Run("throws error on copy failure", func(t *testing.T) {
+		utils.DbId = "test_db"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, fsys.Mkdir(utils.DbTestsDir, 0755))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		gock.New(utils.Docker.DaemonHost()).
+			Put("/v" + utils.Docker.ClientVersion() + "/containers/test_db/archive").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := pgProve(context.Background(), "/tmp", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on exec failure", func(t *testing.T) {
+		utils.DbId = "test_db"
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, fsys.Mkdir(utils.DbTestsDir, 0755))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		gock.New(utils.Docker.DaemonHost()).
+			Put("/v" + utils.Docker.ClientVersion() + "/containers/test_db/archive").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/test_db/exec").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := pgProve(context.Background(), "/tmp", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestRunCommand(t *testing.T) {
+	t.Run("throws error on missing config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Missing config: open supabase/config.toml: file does not exist")
+	})
+
+	t.Run("throws error on missing database", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "supabase start is not running.")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on missing tests", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{})
+		// Run test
+		err := Run(context.Background(), fsys)
+		// Check error
+		assert.ErrorContains(t, err, "open supabase/tests: file does not exist")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix #571 

## What is the current behavior?

`.sql` not supported

## What is the new behavior?

- match documented behaviour

## Additional context

Add any other context or screenshots.
