### PR TITLE
fix: show pg_prove failing test results

### DIFF
--- a/internal/db/test/templates/test.sh
+++ b/internal/db/test/templates/test.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # TODO: move this dependency to base image
 if ! command -v pg_prove &> /dev/null; then
-    apt-get -qq update && apt-get -qq install postgresql-14-pgtap
+    apt-get -qq update
+    apt-get -qq install postgresql-14-pgtap &> /dev/null
 fi
 
 # temporarily enable pgtap
@@ -16,7 +17,7 @@ cleanup() {
     status=$?
     # disable pgtap if previously not enabled
     if [ -z "$notice" ]; then
-        psql -h localhost -U postgres -p 5432 -d postgres -c "drop extension if exists pgtap"
+        psql -h localhost -U postgres -p 5432 -d postgres -c "drop extension if exists pgtap" 2>&1 >/dev/null
     fi
     # clean up test files
     rm -rf "$files"

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -51,6 +51,7 @@ func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
 	cmd := []string{"/bin/bash", "-c", args + testScript}
 	out, err := utils.DockerExecOnce(ctx, utils.DbId, nil, cmd)
 	if err != nil {
+		fmt.Println(out)
 		return err
 	}
 

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -50,13 +50,8 @@ func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
 	// Requires unix path inside container
 	cmd := []string{"/bin/bash", "-c", args + testScript}
 	out, err := utils.DockerExecOnce(ctx, utils.DbId, nil, cmd)
-	if err != nil {
-		fmt.Println(out)
-		return err
-	}
-
 	fmt.Print(out)
-	return nil
+	return err
 }
 
 // Ref 1: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -314,7 +314,7 @@ func DockerExecOnce(ctx context.Context, container string, env []string, cmd []s
 		return "", err
 	}
 	if iresp.ExitCode > 0 {
-		return "", errors.New("error executing command")
+		return out.String(), errors.New("error executing command")
 	}
 	return out.String(), nil
 }

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -314,7 +314,7 @@ func DockerExecOnce(ctx context.Context, container string, env []string, cmd []s
 		return "", err
 	}
 	if iresp.ExitCode > 0 {
-		return out.String(), errors.New("error executing command")
+		err = errors.New("error executing command")
 	}
-	return out.String(), nil
+	return out.String(), err
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / enhancement

## What is the current behavior?

See #578 

The `supabase db test` command does not print the `pg_prove` test results if any of the tests fail. This of course makes it difficult to identify the failing test.

## What is the new behavior?

The command will now print the stdout results from the `pg_prove` command if it exits with a non-zero exit code.

The new output looks like what I shared in the "Expected behavior" section of the referenced issue.

## Additional context

This makes a small change to a shared function in `internal/utils/docker.go`. It's not clear to me if this will have undesired side effects for other commands. Let me know if you think this could be handled differently.

Thanks!
