### PR TITLE
chore: update gotrue to v2.27.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -35,7 +35,7 @@ const (
 	DenoRelayImage = "supabase/deno-relay:v1.2.4"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
-	GotrueImage   = "supabase/gotrue:v2.15.3"
+	GotrueImage   = "supabase/gotrue:v2.27.0"
 	RealtimeImage = "supabase/realtime:v0.25.1"
 	StorageImage  = "supabase/storage-api:v0.20.1"
 )

--- a/internal/utils/templates/initial_schemas/README.md
+++ b/internal/utils/templates/initial_schemas/README.md
@@ -33,7 +33,7 @@ services:
 
   auth:
     container_name: supabase-auth
-    image: supabase/gotrue:v2.10.3
+    image: supabase/gotrue:v2.27.0
     depends_on:
       - db
     restart: unless-stopped


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hi 👋  I am building an app that requires fetching a refresh token from Google. I found this related issue https://github.com/supabase/gotrue-js/issues/131 and luckily it was recently fixed in GoTrue v2.19.1.  

I'm still blocked developing locally because `supabase start` runs GoTrue v2.15.3. This PR updates it to the lastest GoTrue version. 

I don't know what the processes is for upgrading service versions in the Supabase CLI, so let me know if I should change to different version. 

## What is the current behavior?

GoTrue v2.15.3

## What is the new behavior?

GoTrue v2.27.0

## Additional context

- Related feature: https://github.com/supabase/gotrue/pull/757
- Related issue: https://github.com/supabase/gotrue-js/issues/131 