### PR TITLE
fix: temporarily silence migrate.sh error

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -271,6 +271,7 @@ func run(p utils.Program, ctx context.Context, fsys afero.Fs) error {
 				NetworkMode:   container.NetworkMode(utils.NetId),
 				PortBindings:  nat.PortMap{"5432/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Db.Port), 10)}}},
 				RestartPolicy: container.RestartPolicy{Name: "always"},
+				Binds:         []string{"/dev/null:/docker-entrypoint-initdb.d/migrate.sh:ro"},
 			},
 		); err != nil {
 			return err

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -239,6 +239,7 @@ func DockerStart(ctx context.Context, image string, env []string, cmd []string, 
 		NetworkMode:  container.NetworkMode(network.ID),
 		PortBindings: ports,
 		AutoRemove:   true,
+		Binds:        []string{"/dev/null:/docker-entrypoint-initdb.d/migrate.sh:ro"},
 	}, nil, nil, "")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #595

## What is the new behavior?

temporary fix as we replace initial schema with migrate.sh

## Additional context

Add any other context or screenshots.
