### PR TITLE
feat: enable ESZIPs for functions

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -90,7 +90,7 @@ func init() {
 	functionsDeleteCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDeployCmd.Flags().BoolVar(&noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsDeployCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
-	functionsDeployCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", true, "Use legacy bundling mechanism.")
+	functionsDeployCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")
 	functionsServeCmd.Flags().BoolVar(&noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsCmd.AddCommand(functionsDeleteCmd)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	MigraImage     = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage    = "supabase/postgres-meta:v0.50.2"
 	StudioImage    = "supabase/studio:0.22.08"
-	DenoRelayImage = "supabase/deno-relay:v1.4.0"
+	DenoRelayImage = "supabase/deno-relay:v1.5.0"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.25.1"
@@ -304,7 +304,7 @@ func InstallOrUpgradeDeno(ctx context.Context, fsys afero.Fs) error {
 
 	if _, err := fsys.Stat(denoPath); err == nil {
 		// Upgrade Deno.
-		cmd := exec.CommandContext(ctx, denoPath, "upgrade", "--version", "1.27.1")
+		cmd := exec.CommandContext(ctx, denoPath, "upgrade", "--version", "1.28.0")
 		return cmd.Run()
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enable ESZIP format for deploying functions by default. Also, updates Deno to 1.28.0.

## What is the current behavior?

Currently, ESZIP format is disabled and can be enabled via `--legacy-bundle=false` flag.

## What is the new behavior?

ESZIPs are enabled by default and if you need legacy bundling you will need to add `--legacy-bundle=true` flag.

