### PR TITLE
fix: disable npm resolution in deno serve

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -136,7 +136,7 @@ func Run(ctx context.Context, slug string, envFilePath string, verifyJWT bool, f
 			types.ExecConfig{
 				Env: env,
 				Cmd: []string{
-					"deno", "run", "--no-check=remote", "--allow-all", "--watch", "--no-clear-screen", dockerFuncPath,
+					"deno", "run", "--no-check=remote", "--allow-all", "--watch", "--no-clear-screen", "--no-npm", dockerFuncPath,
 				},
 				AttachStderr: true,
 				AttachStdout: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Disable `npm` specifiers in `functions serve` since it's not supported in Deno Deploy yet.
