### PR TITLE
fix: bump connect timeout to 10 seconds

### DIFF
--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -434,7 +434,7 @@ func AssertPostgresVersionMatch(conn *pgx.Conn) error {
 func ConnectRemotePostgres(ctx context.Context, username, password, database, host string, options ...func(*pgx.ConnConfig)) (*pgx.Conn, error) {
 	// Build connection string
 	// Use port 6543 for connection pooling
-	pgUrl := "postgresql://:@:6543/?connect_timeout=3"
+	pgUrl := "postgresql://:@:6543/?connect_timeout=10"
 	// Parse connection url
 	config, err := pgx.ParseConfig(pgUrl)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

3 seconds may be too short if the RTT is around 1 second

## What is the new behavior?

10 seconds should be enough...

## Additional context

Add any other context or screenshots.
