### PR TITLE
fix: update Realtime tenant id to realtime-demo

### DIFF
--- a/internal/start/templates/kong_config
+++ b/internal/start/templates/kong_config
@@ -76,7 +76,7 @@ services:
               - "Content-Profile: graphql_public"
   - name: realtime-v1
     _comment: "Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*"
-    url: http://realtime.supabase_realtime_{{ .ProjectId }}:4000/socket
+    url: http://realtime-demo.supabase_realtime_{{ .ProjectId }}:4000/socket
     routes:
       - name: realtime-v1-all
         strip_path: true

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -24,7 +24,7 @@ func TestStatusCommand(t *testing.T) {
 			"supabase_kong_",
 			"supabase_auth_",
 			"supabase_inbucket_",
-			"realtime.supabase_realtime_",
+			"realtime-demo.supabase_realtime_",
 			"supabase_rest_",
 			"supabase_storage_",
 			"supabase_pg_meta_",

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -165,7 +165,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 			KongId = "supabase_kong_" + Config.ProjectId
 			GotrueId = "supabase_auth_" + Config.ProjectId
 			InbucketId = "supabase_inbucket_" + Config.ProjectId
-			RealtimeId = "realtime.supabase_realtime_" + Config.ProjectId
+			RealtimeId = "realtime-demo.supabase_realtime_" + Config.ProjectId
 			RestId = "supabase_rest_" + Config.ProjectId
 			StorageId = "supabase_storage_" + Config.ProjectId
 			DifferId = "supabase_differ_" + Config.ProjectId

--- a/internal/utils/templates/initial_schemas/13.sql
+++ b/internal/utils/templates/initial_schemas/13.sql
@@ -1072,7 +1072,7 @@ INSERT INTO _realtime.schema_migrations (version, inserted_at)
 --
 
 INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent_users, max_events_per_second, postgres_cdc_default, inserted_at, updated_at)
-    VALUES ('98d09d90-612d-4a69-8c84-e8e5ecbaed6d', 'realtime', 'realtime', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 300, 100, 'postgres_cdc_rls', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
+    VALUES ('98d09d90-612d-4a69-8c84-e8e5ecbaed6d', 'realtime-demo', 'realtime-demo', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 300, 100, 'postgres_cdc_rls', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
 
 
 --
@@ -1080,7 +1080,7 @@ INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent
 --
 
 INSERT INTO _realtime.extensions (id, settings, type, tenant_external_id, inserted_at, updated_at)
-    VALUES ('935b3773-e37c-4b3e-baa1-2309ddb697cf', '{"region":"us-east-1","db_host":"e96tXstkn+jtFWJi0eBr+m3INdFm15wSEW0bMvP2ryY=","db_name":"sWBpZNdjggEPTQVlI52Zfw==","db_port":"MqmbZ5ZiXXFlSy8FeFYPAQ==","db_user":"sWBpZNdjggEPTQVlI52Zfw==","slot_name":"supabase_realtime_replication_slot","ip_version":4,"db_password":"sWBpZNdjggEPTQVlI52Zfw==","publication":"supabase_realtime","poll_interval_ms":100,"poll_max_changes":100,"poll_max_record_bytes":1048576}', 'postgres_cdc_rls', 'realtime', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
+    VALUES ('935b3773-e37c-4b3e-baa1-2309ddb697cf', '{"region":"us-east-1","db_host":"e96tXstkn+jtFWJi0eBr+m3INdFm15wSEW0bMvP2ryY=","db_name":"sWBpZNdjggEPTQVlI52Zfw==","db_port":"MqmbZ5ZiXXFlSy8FeFYPAQ==","db_user":"sWBpZNdjggEPTQVlI52Zfw==","slot_name":"supabase_realtime_replication_slot","ip_version":4,"db_password":"sWBpZNdjggEPTQVlI52Zfw==","publication":"supabase_realtime","poll_interval_ms":100,"poll_max_changes":100,"poll_max_record_bytes":1048576}', 'postgres_cdc_rls', 'realtime-demo', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
 
 
 --

--- a/internal/utils/templates/initial_schemas/14.sql
+++ b/internal/utils/templates/initial_schemas/14.sql
@@ -1463,7 +1463,7 @@ INSERT INTO _realtime.schema_migrations (version, inserted_at)
 --
 
 INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent_users, max_events_per_second, postgres_cdc_default, inserted_at, updated_at)
-    VALUES ('98d09d90-612d-4a69-8c84-e8e5ecbaed6d', 'realtime', 'realtime', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 300, 100, 'postgres_cdc_rls', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
+    VALUES ('98d09d90-612d-4a69-8c84-e8e5ecbaed6d', 'realtime-demo', 'realtime-demo', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 300, 100, 'postgres_cdc_rls', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
 
 
 --
@@ -1471,7 +1471,7 @@ INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent
 --
 
 INSERT INTO _realtime.extensions (id, settings, type, tenant_external_id, inserted_at, updated_at)
-    VALUES ('935b3773-e37c-4b3e-baa1-2309ddb697cf', '{"region":"us-east-1","db_host":"e96tXstkn+jtFWJi0eBr+m3INdFm15wSEW0bMvP2ryY=","db_name":"sWBpZNdjggEPTQVlI52Zfw==","db_port":"MqmbZ5ZiXXFlSy8FeFYPAQ==","db_user":"sWBpZNdjggEPTQVlI52Zfw==","slot_name":"supabase_realtime_replication_slot","ip_version":4,"db_password":"sWBpZNdjggEPTQVlI52Zfw==","publication":"supabase_realtime","poll_interval_ms":100,"poll_max_changes":100,"poll_max_record_bytes":1048576}', 'postgres_cdc_rls', 'realtime', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
+    VALUES ('935b3773-e37c-4b3e-baa1-2309ddb697cf', '{"region":"us-east-1","db_host":"e96tXstkn+jtFWJi0eBr+m3INdFm15wSEW0bMvP2ryY=","db_name":"sWBpZNdjggEPTQVlI52Zfw==","db_port":"MqmbZ5ZiXXFlSy8FeFYPAQ==","db_user":"sWBpZNdjggEPTQVlI52Zfw==","slot_name":"supabase_realtime_replication_slot","ip_version":4,"db_password":"sWBpZNdjggEPTQVlI52Zfw==","publication":"supabase_realtime","poll_interval_ms":100,"poll_max_changes":100,"poll_max_record_bytes":1048576}', 'postgres_cdc_rls', 'realtime-demo', '2022-11-14 23:04:49', '2022-11-14 23:04:49');
 
 
 --


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime Broadcast and Presence don't work b/c the channel begins with `realtime:` and having the tenant id / external_id as `realtime` causes conflict internally.

## What is the new behavior?

Realtime Broadcast and Presence works as expected.

## Additional context

- Issue: https://github.com/supabase/realtime/issues/353
