### PR TITLE
chore: mirror dependencies to ghcr

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -25,6 +25,9 @@ jobs:
     strategy:
       matrix:
         src: ${{ fromJson(needs.setup.outputs.tags) }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - id: strip
         run: |
@@ -35,7 +38,14 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.PROD_ACCESS_KEY_ID }}
           password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: docker.io/${{ matrix.src }}
-          dst: public.ecr.aws/supabase/${{ steps.strip.outputs.dst }}
+          dst: |
+            public.ecr.aws/supabase/${{ steps.strip.outputs.dst }}
+            ghcr.io/supabase/${{ steps.strip.outputs.dst }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

docker images

## What is the new behavior?

more than 30 seconds faster image pull when run from GHA: https://github.com/supabase/supabase-action-example/pull/15

## Additional context

Add any other context or screenshots.
