### PR TITLE
fix: use escaped pg url for connecting on windows

### DIFF
--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -59,9 +59,9 @@ func TestMigrationPush(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), false, user, pass, database, host+":0", fsys)
+		err := Run(context.Background(), false, user, pass, database, "0", fsys)
 		// Check error
-		assert.ErrorContains(t, err, "hostname resolving error (lookup localhost:0: no such host)")
+		assert.ErrorContains(t, err, "dial error (dial tcp 0.0.0.0:6543: connect: connection refused)")
 	})
 
 	t.Run("throws error on remote load failure", func(t *testing.T) {

--- a/internal/utils/connect_test.go
+++ b/internal/utils/connect_test.go
@@ -38,8 +38,8 @@ func TestConnectRemotePostgres(t *testing.T) {
 func TestConnectLocal(t *testing.T) {
 	t.Run("connects with debug log", func(t *testing.T) {
 		viper.Set("DEBUG", true)
-		_, err := ConnectLocalPostgres(context.Background(), "localhost", 5432, "postgres")
-		assert.ErrorContains(t, err, "dial error (dial tcp 127.0.0.1:5432: connect: connection refused)")
+		_, err := ConnectLocalPostgres(context.Background(), "0", 5432, "postgres")
+		assert.ErrorContains(t, err, "dial error (dial tcp 0.0.0.0:5432: connect: connection refused)")
 	})
 
 	t.Run("throws error on invalid port", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #646 

## What is the current behavior?

Setting config object does not work on windows

## What is the new behavior?

Use dsn format which treats all params as string literal

## Additional context

Add any other context or screenshots.
