### PR TITLE
fix: copy binary on postinstall

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -116,6 +116,13 @@ async function main() {
     await fs.promises.link(bin + ext, bin);
   }
 
+  // Copy binary because yarn runs as postinstall
+  if (process.env.npm_config_user_agent.startsWith("yarn/")) {
+    const bin = path.join(opts.binPath, opts.binName);
+    const link = path.join("..", ".bin", opts.binName);
+    await fs.promises.symlink(bin, link);
+  }
+
   // TODO: verify checksums
   console.info("Installed Supabase CLI successfully");
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -59,10 +59,11 @@ async function parsePackageJson() {
   }
 
   // We have validated the config. It exists in all its glory
-  let binName = path.basename(packageJson.bin);
-  const binPath = path.dirname(packageJson.bin);
-  let url = packageJson.url;
-  let version = packageJson.version;
+  const bin = packageJson.bin.toString();
+  const binName = path.basename(bin);
+  const binPath = path.dirname(bin);
+  let url = packageJson.url.toString();
+  let version = packageJson.version.toString();
 
   // strip the 'v' if necessary v0.0.1 => 0.0.1
   if (version[0] === "v") version = version.substr(1);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #620 

## What is the current behavior?

According to [yarn lifecycle](https://yarnpkg.com/advanced/lifecycle-scripts):

> For backwards compatibility, preinstall and install are called as part of postinstall.

As a result, yarn tries to symlink a binary that is not yet downloaded.

## What is the new behavior?

Detect if yarn is being used and symlink the binary to `.bin`

## Additional context

supersedes #634 
