### PR TITLE
fix: show script size after function deploy

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -12,12 +12,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/go-units"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
 
-const MB float64 = 1 << (10 * 2)
 const EszipContentType = "application/vnd.denoland.eszip"
 
 func Run(ctx context.Context, slug string, projectRefArg string, verifyJWT bool, useLegacyBundle bool, fsys afero.Fs) error {
@@ -85,7 +85,8 @@ func Run(ctx context.Context, slug string, projectRefArg string, verifyJWT bool,
 	}
 
 	// 3. Deploy new Function.
-	return deployFunction(ctx, projectRef, slug, functionBody, verifyJWT, useLegacyBundle, functionSize)
+	fmt.Println("Deploying " + utils.Bold(slug) + " (script size: " + utils.Bold(units.HumanSize(float64(functionSize))) + ")")
+	return deployFunction(ctx, projectRef, slug, functionBody, verifyJWT, useLegacyBundle)
 }
 
 func makeLegacyFunctionBody(functionBody io.Reader) (string, error) {
@@ -98,10 +99,7 @@ func makeLegacyFunctionBody(functionBody io.Reader) (string, error) {
 	return buf.String(), nil
 }
 
-func deployFunction(ctx context.Context, projectRef, slug string, functionBody io.Reader, verifyJWT, useLegacyBundle bool, functionSize int) error {
-	functionSizeFmt := fmt.Sprintf("%.2fMB", float64(functionSize)/MB)
-	fmt.Println("Deploying " + utils.Bold(slug) + " (script size: " + utils.Bold(functionSizeFmt) + ")")
-
+func deployFunction(ctx context.Context, projectRef, slug string, functionBody io.Reader, verifyJWT, useLegacyBundle bool) error {
 	var deployedFuncId string
 	{
 		resp, err := utils.GetSupabase().GetFunctionWithResponse(ctx, projectRef, slug)

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -264,7 +264,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -276,7 +276,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "Unexpected error deploying Function:")
 	})
@@ -291,7 +291,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -306,7 +306,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to create a new Function on the Supabase project:")
 	})
@@ -322,7 +322,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -338,7 +338,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to update an existing Function's body on the Supabase project:")
 	})

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -264,7 +264,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -276,7 +276,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "Unexpected error deploying Function:")
 	})
@@ -291,7 +291,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -306,7 +306,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to create a new Function on the Supabase project:")
 	})
@@ -322,7 +322,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -338,7 +338,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true)
+		err := deployFunction(context.Background(), project, slug, strings.NewReader("body"), true, true, 0)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to update an existing Function's body on the Supabase project:")
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, users don't have an easy way to find their function's size when deploying. Supabase checks and returns an error in the API layer if the script is above the permitted limit. However, the error is not very user-friendly since users don't know the size of their script.

This PR prints another line when deploying a function (ie. `deploying {name} (script size: X.XMB)`)

![Screen Shot 2022-12-07 at 9 25 42 pm](https://user-images.githubusercontent.com/5358/206155370-56cdfa22-12d5-413a-977f-47410bdc197f.png)

This should also work when `--legacy-bundle` flag is set.
