### PR TITLE
feat: allow providing custom import-map paths to function serve/deploy

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -44,6 +44,7 @@ var (
 
 	noVerifyJWT     bool
 	useLegacyBundle bool
+	importMapPath   string
 
 	functionsDeployCmd = &cobra.Command{
 		Use:   "deploy <Function name>",
@@ -59,7 +60,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return deploy.Run(ctx, args[0], projectRef, !noVerifyJWT, useLegacyBundle, fsys)
+			return deploy.Run(ctx, args[0], projectRef, !noVerifyJWT, useLegacyBundle, importMapPath, fsys)
 		},
 	}
 
@@ -81,7 +82,7 @@ var (
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return serve.Run(ctx, args[0], envFilePath, !noVerifyJWT, afero.NewOsFs())
+			return serve.Run(ctx, args[0], envFilePath, !noVerifyJWT, importMapPath, afero.NewOsFs())
 		},
 	}
 )
@@ -91,8 +92,10 @@ func init() {
 	functionsDeployCmd.Flags().BoolVar(&noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsDeployCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDeployCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")
+	functionsDeployCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
 	functionsServeCmd.Flags().BoolVar(&noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
+	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)
 	functionsCmd.AddCommand(functionsNewCmd)

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -19,7 +19,7 @@ import (
 
 const EszipContentType = "application/vnd.denoland.eszip"
 
-func Run(ctx context.Context, slug string, projectRefArg string, verifyJWT bool, useLegacyBundle bool, fsys afero.Fs) error {
+func Run(ctx context.Context, slug string, projectRefArg string, verifyJWT bool, useLegacyBundle bool, importMapPath string, fsys afero.Fs) error {
 	// 1. Sanity checks.
 	projectRef := projectRefArg
 	var buildScriptPath string
@@ -66,7 +66,7 @@ func Run(ctx context.Context, slug string, projectRefArg string, verifyJWT bool,
 			}
 		}
 
-		args := []string{"run", "-A", buildScriptPath, filepath.Join(functionPath, "index.ts")}
+		args := []string{"run", "-A", buildScriptPath, filepath.Join(functionPath, "index.ts"), importMapPath}
 		if useLegacyBundle {
 			args = []string{"bundle", "--no-check=remote", "--quiet", filepath.Join(functionPath, "index.ts")}
 		}

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -63,7 +63,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusCreated).
 			JSON(api.FunctionResponse{Id: "1"})
 		// Run test
-		assert.NoError(t, Run(context.Background(), slug, project, false, true, fsys))
+		assert.NoError(t, Run(context.Background(), slug, project, false, true, "", fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -90,7 +90,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusCreated).
 			JSON(api.FunctionResponse{Id: "1"})
 		// Run test
-		assert.NoError(t, Run(context.Background(), slug, project, false, false, fsys))
+		assert.NoError(t, Run(context.Background(), slug, project, false, false, "", fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -119,7 +119,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(api.FunctionResponse{Id: "1"})
 		// Run test
-		assert.NoError(t, Run(context.Background(), slug, "", true, true, fsys))
+		assert.NoError(t, Run(context.Background(), slug, "", true, true, "", fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -148,7 +148,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(api.FunctionResponse{Id: "1"})
 		// Run test
-		assert.NoError(t, Run(context.Background(), slug, "", true, false, fsys))
+		assert.NoError(t, Run(context.Background(), slug, "", true, false, "", fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -159,7 +159,7 @@ func TestDeployCommand(t *testing.T) {
 		// Setup invalid project ref
 		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte("test-project"), 0644))
 		// Run test
-		err := Run(context.Background(), "test-func", "", false, true, fsys)
+		err := Run(context.Background(), "test-func", "", false, true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Invalid project ref format.")
 	})
@@ -168,7 +168,7 @@ func TestDeployCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), "test-func", "test-project", false, true, fsys)
+		err := Run(context.Background(), "test-func", "test-project", false, true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Invalid project ref format.")
 	})
@@ -179,7 +179,7 @@ func TestDeployCommand(t *testing.T) {
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Run test
-		err := Run(context.Background(), "@", project, false, true, fsys)
+		err := Run(context.Background(), "@", project, false, true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Invalid Function name.")
 	})
@@ -190,7 +190,7 @@ func TestDeployCommand(t *testing.T) {
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Run test
-		err := Run(context.Background(), "test-func", project, false, true, fsys)
+		err := Run(context.Background(), "test-func", project, false, true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "operation not permitted")
 	})
@@ -216,7 +216,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			Body(&body)
 		// Run test
-		err = Run(context.Background(), "test-func", project, false, true, fsys)
+		err = Run(context.Background(), "test-func", project, false, true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Error bundling function: exit status 1\nbundle failed\n")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -243,7 +243,7 @@ func TestDeployCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			Body(&body)
 
-		err = Run(context.Background(), "test-func", project, false, false, fsys)
+		err = Run(context.Background(), "test-func", project, false, false, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Error bundling function: exit status 1\neszip failed\n")
 	})

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -35,7 +35,7 @@ func TestServeCommand(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), "test-func", "", true, fsys)
+		err := Run(context.Background(), "test-func", "", true, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version http://localhost/v1.41/containers/supabase_deno_relay_serve/exec")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/utils/eszip/build.ts
+++ b/internal/utils/eszip/build.ts
@@ -7,7 +7,7 @@ import { load } from "https://deno.land/x/eszip@v0.30.0/loader.ts";
 
 const virtualBasePath = "file:///src/";
 
-async function buildAndWrite(p: string) {
+async function buildAndWrite(p: string, importMapPath: string) {
   const funcDirPath = path.dirname(p);
   const entrypoint = new URL("index.ts", virtualBasePath).href;
 
@@ -20,6 +20,12 @@ async function buildAndWrite(p: string) {
       // if the path is `file:///src/*`, treat it as a relative path from current dir
       if (specifier.startsWith(virtualBasePath)) {
         actualPath = specifier.replace(virtualBasePath, `./${funcDirPath}/`);
+      }
+
+      // If an import map path is set read file from the given path.
+      // Otherwise default to `import_map.json` in functions directory.
+      if (specifier.endsWith('import_map.json') && importMapPath != "") {
+        actualPath = importMapPath
       }
       try {
         const content = await Deno.readTextFile(actualPath);
@@ -57,4 +63,4 @@ async function buildAndWrite(p: string) {
   await writeAll(Deno.stdout, combinedPayload);
 }
 
-buildAndWrite(Deno.args[0]);
+buildAndWrite(Deno.args[0], Deno.args[1]);

--- a/internal/utils/eszip/build.ts
+++ b/internal/utils/eszip/build.ts
@@ -24,7 +24,7 @@ async function buildAndWrite(p: string, importMapPath: string) {
 
       // If an import map path is set read file from the given path.
       // Otherwise default to `import_map.json` in functions directory.
-      if (specifier.endsWith('import_map.json') && importMapPath != "") {
+      if (specifier.endsWith('import_map.json') && importMapPath) {
         actualPath = importMapPath
       }
       try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allows users to set a custom `--import-map` flag with relative path to an import map. 

This covers following use cases:
* Creating a project-level import_map.json outside of `supabase/functions` to be shared across all functions in the project.
* If you run `deno vendor`, those vendored dependencies needs to be linked using `vendor/import_map.json`
