### PR TITLE
fix: load project ref after parsing workdir

### DIFF
--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -27,7 +27,7 @@ Use of custom domains and vanity subdomains is mutually exclusive.
 			if !experimental {
 				return errors.New("must set the --experimental flag to run this command")
 			}
-			return nil
+			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 	}
 

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -25,15 +25,11 @@ var (
 	migrationListCmd = &cobra.Command{
 		Use:   "list",
 		Short: "List local and remote migrations",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if err := loadLinkedProject(fsys); err != nil {
 				return err
 			}
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fsys := afero.NewOsFs()
 			host := utils.GetSupabaseDbHost(projectRef)
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return list.Run(ctx, username, dbPassword, database, host, fsys)
@@ -60,14 +56,11 @@ var (
 		Use:   "repair <version>",
 		Short: "Repairs the migration history table",
 		Args:  cobra.ExactArgs(1),
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if err := loadLinkedProject(fsys); err != nil {
 				return err
 			}
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
 			host := utils.GetSupabaseDbHost(projectRef)
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return repair.Run(ctx, username, dbPassword, database, host, args[0], targetStatus.Value)

--- a/cmd/restrictions.go
+++ b/cmd/restrictions.go
@@ -20,7 +20,7 @@ var (
 			if !experimental {
 				return errors.New("must set the --experimental flag to run this command")
 			}
-			return nil
+			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #680

## What is the current behavior?

workdir is parsed before project ref, resulting in ref not found

## What is the new behavior?

always parse workdir before loading project ref

## Additional context

Add any other context or screenshots.
