### PR TITLE
fix: mirror local DENO_* variables on function serve container

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -66,6 +66,13 @@ func Run(ctx context.Context, slug string, envFilePath string, verifyJWT bool, i
 			env = append(env, "VERIFY_JWT=false")
 		}
 
+		// mirror local DENO_* env variables to the Docker container.
+		env = append(env,
+			"DENO_TLS_CA_STORE="+os.Getenv("DENO_TLS_CA_STORE"),
+			"DENO_CERT="+os.Getenv("DENO_CERT"),
+			"DENO_AUTH_TOKENS="+os.Getenv("DENO_AUTH_TOKENS"),
+		)
+
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

This will mirror the following DENO env variables to the `functions serve` container.

`DENO_TLS_CA_STORE`
`DENO_CERT`
`DENO_AUTH_TOKENS`

https://deno.land/manual@v1.29.0/getting_started/setup_your_environment#environment-variables