### PR TITLE
fix: prefer saving access token to credentials store

### DIFF
--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/zalando/go-keyring"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -96,6 +97,8 @@ func TestLinkCommand(t *testing.T) {
 	// Setup valid access token
 	token := apitest.RandomAccessToken(t)
 	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+	// Mock credentials store
+	keyring.MockInit()
 
 	// Reset global variable
 	t.Cleanup(func() {

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -4,13 +4,18 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/credentials"
+	"github.com/zalando/go-keyring"
 )
 
 func randomToken(t *testing.T) []byte {
@@ -24,56 +29,98 @@ func randomToken(t *testing.T) []byte {
 }
 
 func TestLoginCommand(t *testing.T) {
+	keyring.MockInit()
+
 	t.Run("prompts and validates api token", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Setup input with random token
 		token := randomToken(t)
 		stdin := bytes.NewBuffer(token)
-		fsys := afero.NewMemMapFs()
 		// Run test
 		assert.NoError(t, Run(stdin, fsys))
 		// Validate saved token
-		home, err := os.UserHomeDir()
+		saved, err := credentials.Get(utils.AccessTokenKey)
 		assert.NoError(t, err)
-		accessToken := filepath.Join(home, ".supabase", "access-token")
-		content, err := afero.ReadFile(fsys, accessToken)
-		assert.NoError(t, err)
-		assert.Equal(t, token, content)
+		assert.Equal(t, string(token), saved)
 	})
 
 	t.Run("cancels when no input", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Setup dependencies
-		stdin := bytes.Buffer{}
-		fsys := afero.MemMapFs{}
+		stdin := &bytes.Buffer{}
 		// Run test
-		assert.NoError(t, Run(&stdin, &fsys))
+		assert.NoError(t, Run(stdin, fsys))
 	})
 
 	t.Run("throws error on invalid token", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Setup malformed token
 		stdin := bytes.NewBufferString("malformed")
-		fsys := afero.NewMemMapFs()
 		// Run test
 		assert.Error(t, Run(stdin, fsys))
 	})
+}
 
-	t.Run("throws error on failure to create directory", func(t *testing.T) {
-		// Setup read-only fs
-		token := randomToken(t)
-		stdin := bytes.NewBuffer(token)
+func TestSaveToken(t *testing.T) {
+	const token = "test-token"
+
+	t.Run("fallback saves to file", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		assert.NoError(t, fallbackSaveToken(token, fsys))
+		// Validate saved token
+		home, err := os.UserHomeDir()
+		assert.NoError(t, err)
+		path := filepath.Join(home, ".supabase", utils.AccessTokenKey)
+		contents, err := afero.ReadFile(fsys, path)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(token), contents)
+	})
+
+	t.Run("throws error on home dir failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Setup empty home directory
+		t.Setenv("HOME", "")
+		// Run test
+		err := fallbackSaveToken(token, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "$HOME is not defined")
+	})
+
+	t.Run("throws error on permission denied", func(t *testing.T) {
+		// Setup in-memory fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
-		assert.Error(t, Run(stdin, fsys))
+		err := fallbackSaveToken(token, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "operation not permitted")
 	})
 
-	t.Run("throws error on failure to get home", func(t *testing.T) {
-		// Setup empty home directory
-		token := randomToken(t)
-		stdin := bytes.NewBuffer(token)
-		fsys := afero.NewMemMapFs()
+	t.Run("throws error on write failure", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		assert.NoError(t, err)
+		// Setup in-memory fs
+		fsys := &MockFs{DenyPath: home}
 		// Run test
-		t.Setenv("HOME", "")
-		assert.Error(t, Run(stdin, fsys))
+		err = fallbackSaveToken(token, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "permission denied")
 	})
+}
 
-	// TODO: throws error on failure to save token
+type MockFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *MockFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.OpenFile(name, flag, perm)
 }

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -4,7 +4,6 @@ package integration
 import (
 	"net/http"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 
@@ -14,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clicmd "github.com/supabase/cli/cmd"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/supabase/cli/test/mocks/supabase"
 )
 
@@ -53,11 +54,7 @@ func (suite *LoginTestSuite) TestLink() {
 	require.NoError(suite.T(), login.RunE(login, []string{}))
 
 	// check token is saved
-	home, err := os.UserHomeDir()
-	require.NoError(suite.T(), err)
-	_, err = os.Stat(filepath.Join(home, ".supabase/access-token"))
-	require.NoError(suite.T(), err)
-	token, err := os.ReadFile(filepath.Join(home, ".supabase/access-token"))
+	token, err := credentials.Get(utils.AccessTokenKey)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), key, string(token))
 }

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -4,6 +4,7 @@ package integration
 import (
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -13,8 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clicmd "github.com/supabase/cli/cmd"
-	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/supabase/cli/test/mocks/supabase"
 )
 
@@ -54,7 +53,11 @@ func (suite *LoginTestSuite) TestLink() {
 	require.NoError(suite.T(), login.RunE(login, []string{}))
 
 	// check token is saved
-	token, err := credentials.Get(utils.AccessTokenKey)
+	home, err := os.UserHomeDir()
+	require.NoError(suite.T(), err)
+	_, err = os.Stat(filepath.Join(home, ".supabase/access-token"))
+	require.NoError(suite.T(), err)
+	token, err := os.ReadFile(filepath.Join(home, ".supabase/access-token"))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), key, string(token))
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

part one of #267 

## What is the current behavior?

access token is saved to `~/.supabase/access-token`

## What is the new behavior?

prefer saving to native credentials store
fallback to home directory if not available

## Additional context

Add any other context or screenshots.
