### PR TITLE
fix: print pull logs by default

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -84,6 +84,7 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string) error 
 }
 
 var (
+	pullRetry = 2
 	// TODO: Unhardcode keys
 	//go:embed templates/kong_config
 	kongConfigEmbed    string
@@ -98,7 +99,7 @@ func pullImage(p utils.Program, ctx context.Context, image string) error {
 			break
 		}
 		var out io.ReadCloser
-		out, err = utils.DockerImagePullWithRetry(ctx, imageUrl, 2)
+		out, err = utils.DockerImagePullWithRetry(ctx, imageUrl, pullRetry)
 		if err != nil {
 			break
 		}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -16,7 +16,9 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
 	"github.com/jackc/pgx/v4"
 	"github.com/muesli/reflow/wrap"
@@ -101,8 +103,9 @@ func pullImage(p utils.Program, ctx context.Context, image string) error {
 			break
 		}
 		defer out.Close()
-		if err := utils.ProcessPullOutput(out, p); err != nil {
-			p.Send(utils.ProgressMsg(nil))
+		err = jsonmessage.DisplayJSONMessagesToStream(out, streams.NewOut(os.Stderr), nil)
+		if err != nil {
+			break
 		}
 		_, _, err = utils.Docker.ImageInspectWithRaw(ctx, imageUrl)
 	}

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	dockerConfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -253,12 +254,7 @@ func DockerPullImageIfNotCached(ctx context.Context, imageName string) error {
 		return err
 	}
 	defer out.Close()
-	fmt.Fprintln(os.Stderr, "Pulling docker image:", imageUrl)
-	if viper.GetBool("DEBUG") {
-		return jsonmessage.DisplayJSONMessagesStream(out, os.Stderr, os.Stderr.Fd(), true, nil)
-	}
-	_, err = io.Copy(io.Discard, out)
-	return err
+	return jsonmessage.DisplayJSONMessagesToStream(out, streams.NewOut(os.Stderr), nil)
 }
 
 func DockerStop(containerID string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #707 

also related #687, #665, #142, #118

## What is the current behavior?

image pull logs are hidden behind debug flag, resulting in confusing errors

## What is the new behavior?

Print pull logs by default. Once the image has been downloaded locally, these logs won't be printed.

## Additional context

```bash
$ supabase start
15.1.0.11: Pulling from supabase/postgres
025c56f98b67: Pull complete
26dc25c16f4e: Pull complete
a032d8a894de: Pull complete
40dba7d35750: Pull complete
8ebb44a56070: Pull complete
813fd6cf203b: Pull complete
7024f61bf8f5: Pull complete
23f986b322e8: Pull complete
1fb05ff7a8d6: Pull complete
74afc7d9bc5c: Pull complete
7c2c7eebef2f: Pull complete
bdd9df7f1d37: Pull complete
33d269a3a052: Pull complete
0e60f1aa369a: Pull complete
6746734d6cc0: Pull complete
976e3d3274d5: Pull complete
b685a82d955c: Extracting [==================================================>]  1.117GB/1.117GB
d3b1fb74dfd6: Download complete
ad176c4c8ba8: Download complete
51b00fa7dce5: Download complete
Error: failed to register layer: Error processing tar file(exit status 1): write /usr/lib/postgresql/lib/wrappers-0.1.6.so: no space left on device
Try rerunning the command with --debug to troubleshoot the error.
exit status 1
```

in progress:
```bash
20221214-4eecc99: Pulling from supabase/studio
6eab20599fab: Pull complete
26757b0b9512: Pull complete
a524d549ab5b: Pull complete
190235e6ea57: Pull complete
863b806c23e5: Pull complete
519637545aa1: Extracting [=============================================>     ]  154.3MB/169MB
4f4fb700ef54: Download complete
⣻ Pulling images... (10/13)
```
