### PR TITLE
chore: skip publishing to chocolatey

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,7 @@ chocolateys:
     release_notes: "https://github.com/supabase/cli/releases/tag/v{{ .Version }}"
     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
+    skip_publish: true
 nfpms:
   - vendor: Supabase
     description: Supabase CLI

--- a/README.md
+++ b/README.md
@@ -49,25 +49,7 @@ brew upgrade supabase
 
 #### Windows
 
-Available via [Scoop](https://scoop.sh) and [Chocolatey](https://chocolatey.org).
-
-##### via Chocolatey
-
-To install:
-
-```powershell
-choco install supabase
-```
-
-To upgrade:
-
-```powershell
-choco upgrade supabase
-```
-
-##### via Scoop
-
-To install:
+Available via [Scoop](https://scoop.sh). To install:
 
 ```powershell
 scoop bucket add supabase https://github.com/supabase/scoop-bucket.git


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the current behavior?

chocolatey package is blocked because goreleaser doesn't support `.tar.gz` format https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/chocolatey/template.go#L37

According to the package reviewer, we need to call `Get-ChocolateyUnzip` on the resulting `.tar` file.
> Hi,
>
> Unfortunately, `Install-ChocolateyZipPackage` is not able to extract .tar.gz files in one step.
> It is caused because of a limitation in 7zip, see this issue: https://github.com/chocolatey/choco/issues/386
>
> You can a call to `Get-ChocolateyUnzip` to extract the resulting .tar file from Install-ChocolateyZipPackage
>
> Regards, TheCakeIsNaOH

## What is the new behavior?

skips publishing for now

## Additional context

Add any other context or screenshots.
