### PR TITLE
fix: unify image pull with retry implementation

### DIFF
--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -99,26 +99,9 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 	p.Send(utils.StatusMsg("Pulling images..."))
 
 	// Pull images.
-	{
-		dbImage := utils.GetRegistryImageUrl(utils.DbImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, dbImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, dbImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-		}
-		diffImage := utils.GetRegistryImageUrl(utils.DifferImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, diffImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, diffImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
+	for _, image := range []string{utils.DbImage, utils.DifferImage} {
+		if err := utils.DockerPullImageIfNotCached(ctx, image); err != nil {
+			return err
 		}
 	}
 

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -140,26 +140,9 @@ func run(p utils.Program, ctx context.Context, username, password, database stri
 	p.Send(utils.StatusMsg("Pulling images..."))
 
 	// Pull images.
-	{
-		dbImage := utils.GetRegistryImageUrl(utils.DbImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, dbImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, dbImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
-		}
-		diffImage := utils.GetRegistryImageUrl(utils.DifferImage)
-		if _, _, err := utils.Docker.ImageInspectWithRaw(ctx, diffImage); err != nil {
-			out, err := utils.DockerImagePullWithRetry(ctx, diffImage, 2)
-			if err != nil {
-				return err
-			}
-			if err := utils.ProcessPullOutput(out, p); err != nil {
-				return err
-			}
+	for _, image := range []string{utils.DbImage, utils.DifferImage} {
+		if err := utils.DockerPullImageIfNotCached(ctx, image); err != nil {
+			return err
 		}
 	}
 

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,95 +111,6 @@ func TestStartCommand(t *testing.T) {
 		err := Run(context.Background(), fsys, []string{})
 		// Check error
 		assert.ErrorContains(t, err, "network error")
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-}
-
-func TestPullImage(t *testing.T) {
-	const image = "postgres"
-	imageUrl := utils.GetRegistryImageUrl(image)
-	p := utils.NewProgram(model{})
-
-	t.Run("inspects image before pull", func(t *testing.T) {
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusOK).
-			JSON(types.ImageInspect{})
-		// Run test
-		err := pullImage(p, context.Background(), image)
-		// Check error
-		assert.NoError(t, err)
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("pulls missing image", func(t *testing.T) {
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusNotFound)
-		gock.New(utils.Docker.DaemonHost()).
-			Post("/v"+utils.Docker.ClientVersion()+"/images/create").
-			MatchParam("fromImage", image).
-			MatchParam("tag", "latest").
-			Reply(http.StatusAccepted).
-			BodyString("")
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusOK).
-			JSON(types.ImageInspect{})
-		// Run test
-		err := pullImage(p, context.Background(), image)
-		// Check error
-		assert.NoError(t, err)
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on pull failure", func(t *testing.T) {
-		pullRetry = 0
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusNotFound)
-		gock.New(utils.Docker.DaemonHost()).
-			Post("/v"+utils.Docker.ClientVersion()+"/images/create").
-			MatchParam("fromImage", image).
-			MatchParam("tag", "latest").
-			Reply(http.StatusServiceUnavailable)
-		// Run test
-		err := pullImage(p, context.Background(), image)
-		// Check error
-		assert.ErrorContains(t, err, "request returned Service Unavailable")
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on no space left", func(t *testing.T) {
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusNotFound)
-		gock.New(utils.Docker.DaemonHost()).
-			Post("/v"+utils.Docker.ClientVersion()+"/images/create").
-			MatchParam("fromImage", image).
-			MatchParam("tag", "latest").
-			Reply(http.StatusAccepted).
-			JSON(jsonmessage.JSONMessage{Error: &jsonmessage.JSONError{Message: "no space left on device"}})
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
-			Reply(http.StatusOK).
-			JSON(types.ImageInspect{})
-		// Run test
-		err := pullImage(p, context.Background(), image)
-		// Check error
-		assert.ErrorContains(t, err, "no space left on device")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -232,7 +232,7 @@ func DockerImagePullWithRetry(ctx context.Context, image string, retries int) (i
 			break
 		}
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintf(os.Stderr, "Retrying after %d seconds...\n", i)
+		fmt.Fprintf(os.Stderr, "Retrying after %d seconds: %s\n", i, image)
 		time.Sleep(i * time.Second)
 		out, err = Docker.ImagePull(ctx, image, types.ImagePullOptions{
 			RegistryAuth: GetRegistryAuth(),

--- a/internal/utils/docker_test.go
+++ b/internal/utils/docker_test.go
@@ -72,6 +72,7 @@ func TestPullImage(t *testing.T) {
 	})
 
 	t.Run("throws error on failure to pull image", func(t *testing.T) {
+		timeUnit = time.Duration(0)
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(Docker))
 		defer gock.OffAll()

--- a/internal/utils/docker_test.go
+++ b/internal/utils/docker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -89,15 +90,18 @@ func TestPullImage(t *testing.T) {
 			Post("/v"+Docker.ClientVersion()+"/images/create").
 			MatchParam("fromImage", imageId).
 			MatchParam("tag", "latest").
-			Reply(http.StatusServiceUnavailable)
+			Reply(http.StatusAccepted).
+			JSON(jsonmessage.JSONMessage{Error: &jsonmessage.JSONError{Message: "toomanyrequests"}})
 		gock.New(Docker.DaemonHost()).
 			Post("/v"+Docker.ClientVersion()+"/images/create").
 			MatchParam("fromImage", imageId).
 			MatchParam("tag", "latest").
-			Reply(http.StatusServiceUnavailable)
+			Reply(http.StatusAccepted).
+			JSON(jsonmessage.JSONMessage{Error: &jsonmessage.JSONError{Message: "no space left on device"}})
 		// Run test
-		assert.Error(t, DockerPullImageIfNotCached(context.Background(), imageId))
+		err := DockerPullImageIfNotCached(context.Background(), imageId)
 		// Validate api
+		assert.ErrorContains(t, err, "no space left on device")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

regression from #709 

## What is the current behavior?

Rate limit bug reappeared https://github.com/supabase/setup-cli/actions/runs/3717908241/jobs/6305704807

## What is the new behavior?

Use a single pull with retry method

## Additional context

Add any other context or screenshots.
