### PR TITLE
fix: initialise pg15 project by default

### DIFF
--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -23,7 +23,7 @@ import (
 func TestRunMigra(t *testing.T) {
 	t.Run("runs migra diff", func(t *testing.T) {
 		utils.GlobalsSql = "create schema public"
-		utils.InitialSchemaPg14Sql = "create schema private"
+		utils.InitialSchemaPg15Sql = "create schema private"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
@@ -32,7 +32,7 @@ func TestRunMigra(t *testing.T) {
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-shadow-db")
 		gock.New(utils.Docker.DaemonHost()).
 			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
 			Reply(http.StatusOK)
@@ -44,7 +44,7 @@ func TestRunMigra(t *testing.T) {
 		defer conn.Close(t)
 		conn.Query(utils.GlobalsSql).
 			Reply("CREATE SCHEMA").
-			Query(utils.InitialSchemaPg14Sql).
+			Query(utils.InitialSchemaPg15Sql).
 			Reply("CREATE SCHEMA")
 		// Run test
 		err := RunMigra(context.Background(), []string{"public"}, "file", "password", fsys, conn.Intercept)
@@ -107,7 +107,7 @@ func TestRunMigra(t *testing.T) {
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images/" + utils.GetRegistryImageUrl(utils.Pg14Image) + "/json").
+			Get("/v" + utils.Docker.ClientVersion() + "/images/" + utils.GetRegistryImageUrl(utils.Pg15Image) + "/json").
 			ReplyError(errors.New("network error"))
 		// Run test
 		err := RunMigra(context.Background(), []string{"public"}, "", "password", fsys)
@@ -126,7 +126,7 @@ func TestRunMigra(t *testing.T) {
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-shadow-db")
 		gock.New(utils.Docker.DaemonHost()).
 			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
 			Reply(http.StatusOK)
@@ -145,7 +145,7 @@ At statement 0: create schema public`)
 
 	t.Run("throws error on failure to diff target", func(t *testing.T) {
 		utils.GlobalsSql = "create schema public"
-		utils.InitialSchemaPg14Sql = "create schema private"
+		utils.InitialSchemaPg15Sql = "create schema private"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
@@ -154,7 +154,7 @@ At statement 0: create schema public`)
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg14Image), "test-shadow-db")
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-shadow-db")
 		gock.New(utils.Docker.DaemonHost()).
 			Post("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/stop").
 			Reply(http.StatusOK)
@@ -167,7 +167,7 @@ At statement 0: create schema public`)
 		defer conn.Close(t)
 		conn.Query(utils.GlobalsSql).
 			Reply("CREATE SCHEMA").
-			Query(utils.InitialSchemaPg14Sql).
+			Query(utils.InitialSchemaPg15Sql).
 			Reply("CREATE SCHEMA")
 		// Run test
 		err := RunMigra(context.Background(), []string{"public"}, "file", "password", fsys, conn.Intercept)

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -129,7 +129,7 @@ func TestDatabaseStart(t *testing.T) {
 			Reply(http.StatusCreated).
 			JSON(types.NetworkCreateResponse{})
 		// Caches all dependencies
-		utils.DbImage = utils.Pg14Image
+		utils.DbImage = utils.Pg15Image
 		imageUrl := utils.GetRegistryImageUrl(utils.DbImage)
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
@@ -205,7 +205,7 @@ func TestDatabaseStart(t *testing.T) {
 			Reply(http.StatusCreated).
 			JSON(types.NetworkCreateResponse{})
 		// Caches all dependencies
-		utils.DbImage = utils.Pg14Image
+		utils.DbImage = utils.Pg15Image
 		imageUrl := utils.GetRegistryImageUrl(utils.DbImage)
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -62,7 +62,7 @@ func Run(ctx context.Context, backup bool, fsys afero.Fs) error {
 }
 
 func backupDatabase(ctx context.Context, fsys afero.Fs) error {
-	out, err := utils.DockerRunOnce(ctx, utils.Pg14Image, []string{
+	out, err := utils.DockerRunOnce(ctx, utils.Pg15Image, []string{
 		"EXCLUDED_SCHEMAS=" + strings.Join(ignoreSchemas, "|"),
 		"DB_URL=postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres",
 	}, []string{"bash", "-c", dumpScript})

--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -187,7 +187,7 @@ func TestStopServices(t *testing.T) {
 func TestBackupDatabase(t *testing.T) {
 	const containerId = "test-db"
 	const dumped = "create schema public"
-	imageUrl := utils.GetRegistryImageUrl(utils.Pg14Image)
+	imageUrl := utils.GetRegistryImageUrl(utils.Pg15Image)
 
 	t.Run("backup main branch", func(t *testing.T) {
 		// Setup in-memory fs

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -19,7 +19,7 @@ max_rows = 1000
 port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 14
+major_version = 15
 
 [studio]
 # Port to use for Supabase Studio.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -19,7 +19,7 @@ max_rows = 1000
 port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 14
+major_version = 15
 
 [studio]
 # Port to use for Supabase Studio.


### PR DESCRIPTION
## What kind of change does this PR introduce?

related #715

## What is the current behavior?

pg_dump 14 cannot be used on pg15 project, breaking `--backup` flag

## What is the new behavior?

use pg15 image for backup
updates supabase init to pg15 for new projects

## Additional context

Add any other context or screenshots.
