### PR TITLE
fix: declare placeholder bin for npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js"
   },
+  "bin": {
+    "supabase": "bin/supabase"
+  },
   "dependencies": {
     "bin-links": "^4.0.1",
     "node-fetch": "^3.2.10",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #717 

## What is the current behavior?

npx determines bin path from package.json

## What is the new behavior?

links are still created postinstall. non-existent bin path won't cause failure

## Additional context

Add any other context or screenshots.
