### PR TITLE
fix: inject user envs to all deno commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
           cache: true
 
       - run: |
@@ -35,7 +35,8 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          # Linter requires no cache
+          go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v3
         with:
@@ -49,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
           cache: true
       - run: go build main.go
       - run: ./main init
@@ -65,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
           cache: true
 
       - run: go generate tools/codegen/main.go

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
           cache: true
       - id: list
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
           cache: true
 
       - name: Install chocolatey


### PR DESCRIPTION
## What kind of change does this PR introduce?

supersedes #722 
supersedes #700 

## What is the current behavior?

user defined envs are only available to functions

## What is the new behavior?

pass user defined envs to all deno commands

## Additional context

Add any other context or screenshots.
