### PR TITLE
fix: use upstream imgproxy image from docker hub

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	PgmetaImage     = "supabase/postgres-meta:v0.54.1"
 	StudioImage     = "supabase/studio:20221214-4eecc99"
 	DenoRelayImage  = "supabase/deno-relay:v1.5.0"
-	ImageProxyImage = "supabase/imgproxy:v1.0.4"
+	ImageProxyImage = "darthsim/imgproxy:v3.8.0"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.25.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #743 

## What is the new behavior?

switch to the official mirror

## Additional context

Add any other context or screenshots.
