### PR TITLE
fix: bump gotrue image version to match hosted

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -27,7 +27,7 @@ import (
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.89"
-	Pg15Image = "supabase/postgres:15.1.0.11"
+	Pg15Image = "supabase/postgres:15.1.0.18"
 	// Append to ServiceImages when adding new dependencies below
 	KongImage       = "library/kong:2.8.1"
 	InbucketImage   = "inbucket/inbucket:3.0.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	ImageProxyImage = "darthsim/imgproxy:v3.8.0"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
-	GotrueImage   = "supabase/gotrue:v2.25.1"
+	GotrueImage   = "supabase/gotrue:v2.36.1"
 	RealtimeImage = "supabase/realtime:v1.0.0-rc.11"
 	StorageImage  = "supabase/storage-api:v0.26.1"
 	// Should be kept in-sync with DenoRelayImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #726

## What is the current behavior?

vault was released prematurely

## What is the new behavior?

- use latest postgres image without vault
- update gotrue to match hosted platform

## Additional context

Add any other context or screenshots.
