### PR TITLE
Update list of supported OAuth providers

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -48,10 +48,15 @@ var (
 		"github",
 		"gitlab",
 		"google",
+		"keycloak",
+		"linkedin",
+		"notion",
 		"twitch",
 		"twitter",
 		"slack",
 		"spotify",
+		"workos",
+		"zoom",
 	}
 
 	//go:embed templates/init_config.toml

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -59,7 +59,8 @@ double_confirm_changes = true
 enable_confirmations = false
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
-# `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
 [auth.external.azure]
 enabled = true
 client_id = "env(AZURE_CLIENT_ID)"

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -59,7 +59,8 @@ double_confirm_changes = true
 enable_confirmations = false
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
-# `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
 [auth.external.apple]
 enabled = false
 client_id = ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The template for new config.toml files does not include all the currently implemented OAuth providers.

## What is the new behavior?

All currently available OAuth providers are listed when initializing a supabase project.

## Additional context

-
