### PR TITLE
fix: clean up containers and network with stop

### DIFF
--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -28,14 +28,8 @@ var (
 
 func Run(ctx context.Context, backup bool, fsys afero.Fs) error {
 	// Sanity checks.
-	{
-		if err := utils.LoadConfigFS(fsys); err != nil {
-			return err
-		}
-		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
-			fmt.Println(utils.Aqua("supabase") + " local development setup is already stopped.")
-			return nil
-		}
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
 	}
 
 	if backup {

--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -26,10 +26,6 @@ func TestStopCommand(t *testing.T) {
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{})
-		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
 			Reply(http.StatusOK).
 			JSON([]types.Container{})
@@ -57,23 +53,6 @@ func TestStopCommand(t *testing.T) {
 		assert.ErrorContains(t, err, "Missing config: open supabase/config.toml: file does not exist")
 	})
 
-	t.Run("ignores stopped database", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(http.StatusServiceUnavailable)
-		// Run test
-		err := Run(context.Background(), false, fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
 	t.Run("throws error on backup failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -81,10 +60,6 @@ func TestStopCommand(t *testing.T) {
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{})
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			ReplyError(errors.New("network error"))
@@ -103,10 +78,6 @@ func TestStopCommand(t *testing.T) {
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{})
-		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
@@ -123,10 +94,6 @@ func TestStopCommand(t *testing.T) {
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{})
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
 			Reply(http.StatusOK).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #729

## What is the new behavior?

allow `supabase stop` to clean up all containers and networks even when db is no longer running

## Additional context

Add any other context or screenshots.
