### PR TITLE
fix: report excluded containers with status command

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/diff"
+	"github.com/supabase/cli/internal/status"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/parser"
 )
@@ -164,14 +165,9 @@ func RetryEverySecond(callback func() bool, timeout time.Duration) bool {
 	return false
 }
 
-func IsContainerHealthy(ctx context.Context, container string) bool {
-	resp, err := utils.Docker.ContainerInspect(ctx, container)
-	return err == nil && resp.State.Health != nil && resp.State.Health.Status == "healthy"
-}
-
 func WaitForHealthyService(ctx context.Context, container string, timeout time.Duration) bool {
 	probe := func() bool {
-		return IsContainerHealthy(ctx, container)
+		return status.AssertContainerHealthy(ctx, container) == nil
 	}
 	return RetryEverySecond(probe, timeout)
 }

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -280,9 +280,8 @@ func TestRestartDatabase(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
 				State: &types.ContainerState{
-					Health: &types.Health{
-						Status: "healthy",
-					},
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
 				},
 			}})
 		utils.StorageId = "test-storage"

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -34,7 +34,10 @@ func TestInitDatabase(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Setup mock postgres
 		conn := pgtest.NewConn()
@@ -80,7 +83,10 @@ func TestInitDatabase(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Run test
 		err := initDatabase(context.Background(), fsys, io.Discard)
@@ -101,7 +107,10 @@ func TestInitDatabase(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Setup mock postgres
 		conn := pgtest.NewConn()
@@ -134,7 +143,10 @@ func TestInitDatabase(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Setup mock postgres
 		conn := pgtest.NewConn()
@@ -173,7 +185,10 @@ func TestInitDatabase(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Setup mock postgres
 		conn := pgtest.NewConn()

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -189,7 +189,10 @@ func TestDatabaseStart(t *testing.T) {
 				Get("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/json").
 				Reply(http.StatusOK).
 				JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-					State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+					State: &types.ContainerState{
+						Running: true,
+						Health:  &types.Health{Status: "healthy"},
+					},
 				}})
 		}
 		gock.New("localhost").
@@ -229,7 +232,10 @@ func TestDatabaseStart(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Health: &types.Health{Status: "healthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
 			}})
 		// Setup mock postgres
 		utils.GlobalsSql = "create schema public"

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -108,6 +108,7 @@ func checkServiceHealth(ctx context.Context, services []string, w io.Writer) (st
 			if client.IsErrNotFound(err) {
 				stopped = append(stopped, name)
 			} else {
+				// Log unhealthy containers instead of failing
 				fmt.Fprintln(w, err)
 			}
 		}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"reflect"
 
 	"github.com/BurntSushi/toml"
+	"github.com/docker/docker/client"
 	"github.com/joho/godotenv"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -27,19 +30,39 @@ type CustomName struct {
 	DbURL          string `env:"db.url,default=DB_URL"`
 	StudioURL      string `env:"studio.url,default=STUDIO_URL"`
 	InbucketURL    string `env:"inbucket.url,default=INBUCKET_URL"`
+	JWTSecret      string `env:"auth.jwt_secret,default=JWT_SECRET"`
 	AnonKey        string `env:"auth.anon_key,default=ANON_KEY"`
 	ServiceRoleKey string `env:"auth.service_role_key,default=SERVICE_ROLE_KEY"`
 }
 
-func (c *CustomName) toValues() map[string]string {
-	return map[string]string{
-		c.ApiURL:         fmt.Sprintf("http://localhost:%d", utils.Config.Api.Port),
-		c.DbURL:          fmt.Sprintf("postgresql://postgres:postgres@localhost:%d/postgres", utils.Config.Db.Port),
-		c.StudioURL:      fmt.Sprintf("http://localhost:%d", utils.Config.Studio.Port),
-		c.InbucketURL:    fmt.Sprintf("http://localhost:%d", utils.Config.Inbucket.Port),
-		c.AnonKey:        utils.AnonKey,
-		c.ServiceRoleKey: utils.ServiceRoleKey,
+func (c *CustomName) toValues(exclude ...string) map[string]string {
+	values := map[string]string{
+		c.DbURL: fmt.Sprintf("postgresql://postgres:postgres@localhost:%d/postgres", utils.Config.Db.Port),
 	}
+	if !sliceContains(exclude, utils.RestId) && !sliceContains(exclude, utils.ShortContainerImageName(utils.PostgrestImage)) {
+		values[c.ApiURL] = fmt.Sprintf("http://localhost:%d", utils.Config.Api.Port)
+	}
+	if !sliceContains(exclude, utils.StudioId) && !sliceContains(exclude, utils.ShortContainerImageName(utils.StudioImage)) {
+		values[c.StudioURL] = fmt.Sprintf("http://localhost:%d", utils.Config.Studio.Port)
+	}
+	if !sliceContains(exclude, utils.GotrueId) && !sliceContains(exclude, utils.ShortContainerImageName(utils.GotrueImage)) {
+		values[c.JWTSecret] = utils.JWTSecret
+		values[c.AnonKey] = utils.AnonKey
+		values[c.ServiceRoleKey] = utils.ServiceRoleKey
+	}
+	if !sliceContains(exclude, utils.InbucketId) && !sliceContains(exclude, utils.ShortContainerImageName(utils.InbucketImage)) {
+		values[c.InbucketURL] = fmt.Sprintf("http://localhost:%d", utils.Config.Inbucket.Port)
+	}
+	return values
+}
+
+func sliceContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }
 
 func Run(ctx context.Context, names CustomName, format string, fsys afero.Fs) error {
@@ -51,42 +74,79 @@ func Run(ctx context.Context, names CustomName, format string, fsys afero.Fs) er
 		if err := utils.LoadConfigFS(fsys); err != nil {
 			return err
 		}
-		if err := utils.AssertDockerIsRunning(); err != nil {
+		if err := AssertContainerHealthy(ctx, utils.DbId); err != nil {
 			return err
 		}
 	}
 
 	services := []string{
-		utils.DbId,
 		utils.KongId,
 		utils.GotrueId,
 		utils.InbucketId,
 		utils.RealtimeId,
 		utils.RestId,
 		utils.StorageId,
+		utils.ImgProxyId,
 		utils.PgmetaId,
 		utils.StudioId,
 	}
-	if err := checkServiceHealth(ctx, services, os.Stderr); err != nil {
-		return err
+	stopped := checkServiceHealth(ctx, services, os.Stderr)
+	if len(stopped) > 0 {
+		fmt.Fprintln(os.Stderr, "Stopped services:", stopped)
 	}
-	return printStatus(names.toValues(), format, os.Stdout)
+	if format == OutputPretty {
+		fmt.Fprintf(os.Stderr, "%s local development setup is running.\n\n", utils.Aqua("supabase"))
+		PrettyPrint(os.Stdout, stopped...)
+		return nil
+	}
+	return printStatus(names, format, os.Stdout, stopped...)
 }
 
-func checkServiceHealth(ctx context.Context, services []string, w io.Writer) error {
+func checkServiceHealth(ctx context.Context, services []string, w io.Writer) (stopped []string) {
 	for _, name := range services {
-		resp, err := utils.Docker.ContainerInspect(ctx, name)
-		if err != nil {
-			return fmt.Errorf("%s container not found. Have you run %s?", name, utils.Aqua("supabase start"))
+		if err := AssertContainerHealthy(ctx, name); err != nil {
+			if client.IsErrNotFound(err) {
+				stopped = append(stopped, name)
+			} else {
+				fmt.Fprintln(w, err)
+			}
 		}
-		if !resp.State.Running {
-			fmt.Fprintln(w, name, "container is not running:", resp.State.Status)
-		}
+	}
+	return stopped
+}
+
+func AssertContainerHealthy(ctx context.Context, container string) error {
+	if resp, err := utils.Docker.ContainerInspect(ctx, container); err != nil {
+		return err
+	} else if !resp.State.Running {
+		return fmt.Errorf("%s container is not running: %s", container, resp.State.Status)
+	} else if resp.State.Health != nil && resp.State.Health.Status != "healthy" {
+		return fmt.Errorf("%s container is not ready: %s", container, resp.State.Health.Status)
 	}
 	return nil
 }
 
-func printStatus(values map[string]string, format string, w io.Writer) (err error) {
+func IsServiceReady(ctx context.Context, container string) bool {
+	if container == utils.RestId {
+		return isPostgRESTHealthy(ctx)
+	}
+	return AssertContainerHealthy(ctx, container) == nil
+}
+
+func isPostgRESTHealthy(ctx context.Context) bool {
+	// PostgREST does not support native health checks
+	restUrl := fmt.Sprintf("http://localhost:%d/rest/v1/", utils.Config.Api.Port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, restUrl, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Add("apikey", utils.AnonKey)
+	resp, err := http.DefaultClient.Do(req)
+	return err == nil && resp.StatusCode == http.StatusOK
+}
+
+func printStatus(names CustomName, format string, w io.Writer, exclude ...string) (err error) {
+	values := names.toValues(exclude...)
 	switch format {
 	case OutputEnv:
 		var out string
@@ -101,9 +161,27 @@ func printStatus(values map[string]string, format string, w io.Writer) (err erro
 	case OutputToml:
 		enc := toml.NewEncoder(w)
 		err = enc.Encode(values)
-	default:
-		fmt.Fprintln(os.Stderr, utils.Aqua("supabase"), "local development setup is running.")
-		utils.ShowStatus()
 	}
 	return err
+}
+
+func PrettyPrint(w io.Writer, exclude ...string) {
+	names := CustomName{
+		ApiURL:         "         " + utils.Aqua("API URL"),
+		DbURL:          "          " + utils.Aqua("DB URL"),
+		StudioURL:      "      " + utils.Aqua("Studio URL"),
+		InbucketURL:    "    " + utils.Aqua("Inbucket URL"),
+		JWTSecret:      "      " + utils.Aqua("JWT secret"),
+		AnonKey:        "        " + utils.Aqua("anon key"),
+		ServiceRoleKey: "" + utils.Aqua("service_role key"),
+	}
+	values := names.toValues(exclude...)
+	// Iterate through map in order of declared struct fields
+	val := reflect.ValueOf(names)
+	for i := 0; i < val.NumField(); i++ {
+		k := val.Field(i).String()
+		if v, ok := values[k]; ok {
+			fmt.Fprintf(w, "%s: %s\n", k, v)
+		}
+	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -96,7 +96,10 @@ func TestServiceHealth(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + services[0] + "/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Running: true, Health: &types.Health{Status: "Unhealthy"}},
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "Unhealthy"},
+				},
 			}})
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + services[1] + "/json").
@@ -138,11 +141,12 @@ func TestServiceHealth(t *testing.T) {
 }
 
 func TestPrintStatus(t *testing.T) {
+	utils.Config.Db.Port = 0
 	exclude := []string{
 		utils.ShortContainerImageName(utils.PostgrestImage),
 		utils.ShortContainerImageName(utils.StudioImage),
-		utils.ShortContainerImageName(utils.GotrueId),
-		utils.ShortContainerImageName(utils.InbucketId),
+		utils.GotrueId,
+		utils.InbucketId,
 	}
 
 	t.Run("outputs env var", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`supabase status` errors if a container is excluded from start

## What is the new behavior?

since `supabase start` now waits for services to be healthy, we can change `supabase status` to print stopped services to stderr

## Additional context

Add any other context or screenshots.
