### PR TITLE
feat: support `verify_jwt` functions config

### DIFF
--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -271,8 +271,6 @@ verify_jwt = false
 `)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
-		b, e := afero.ReadFile(fsys, "supabase/config.toml")
-		fmt.Println(string(b), e)
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token
@@ -294,7 +292,6 @@ verify_jwt = false
 					return false, err
 				}
 
-				fmt.Println(string(body))
 				var bodyJson map[string]interface{}
 				err = json.Unmarshal(body, &bodyJson)
 				if err != nil {
@@ -324,8 +321,6 @@ verify_jwt = false
 `)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
-		b, e := afero.ReadFile(fsys, "supabase/config.toml")
-		fmt.Println(string(b), e)
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token
@@ -347,7 +342,6 @@ verify_jwt = false
 					return false, err
 				}
 
-				fmt.Println(string(body))
 				var bodyJson map[string]interface{}
 				err = json.Unmarshal(body, &bodyJson)
 				if err != nil {

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -35,7 +35,7 @@ func TestServeCommand(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), "test-func", "", true, "", fsys)
+		err := Run(context.Background(), "test-func", "", nil, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version http://localhost/v1.41/containers/supabase_deno_relay_serve/exec")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -83,13 +83,14 @@ var Config config
 
 type (
 	config struct {
-		ProjectId string   `toml:"project_id"`
-		Api       api      `toml:"api"`
-		Db        db       `toml:"db"`
-		Studio    studio   `toml:"studio"`
-		Inbucket  inbucket `toml:"inbucket"`
-		Storage   storage  `toml:"storage"`
-		Auth      auth     `toml:"auth"`
+		ProjectId string              `toml:"project_id"`
+		Api       api                 `toml:"api"`
+		Db        db                  `toml:"db"`
+		Studio    studio              `toml:"studio"`
+		Inbucket  inbucket            `toml:"inbucket"`
+		Storage   storage             `toml:"storage"`
+		Auth      auth                `toml:"auth"`
+		Functions map[string]function `toml:"functions"`
 		// TODO
 		// Scripts   scripts
 	}
@@ -142,6 +143,10 @@ type (
 		Secret      string `toml:"secret"`
 		Url         string `toml:"url"`
 		RedirectUri string `toml:"redirect_uri"`
+	}
+
+	function struct {
+		VerifyJWT *bool `toml:"verify_jwt"`
 	}
 
 	// TODO
@@ -320,6 +325,22 @@ func LoadConfigFS(fsys afero.Fs) error {
 					Url:         url,
 				}
 			}
+		}
+	}
+
+	if Config.Functions == nil {
+		Config.Functions = map[string]function{}
+	}
+	for name, functionConfig := range Config.Functions {
+		verifyJWT := functionConfig.VerifyJWT
+
+		if verifyJWT == nil {
+			x := true
+			verifyJWT = &x
+		}
+
+		Config.Functions[name] = function{
+			VerifyJWT: verifyJWT,
 		}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Need to set `--no-verify-jwt` flag every time `functions serve` and `functions deploy` commands are run.

## What is the new behavior?

Add per-function config to allow setting `verify_jwt`. `verify_jwt` value falls back to the config is the flag is not set - if it's set, it overrides the config.

## Additional context

Closes https://github.com/supabase/cli/issues/280
