### PR TITLE
feat(functions): fallback import_map.json to FunctionsDir

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -60,12 +60,16 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 				return fmt.Errorf("Failed to read env file: %w", err)
 			}
 		}
-		if functionConfig, ok := utils.Config.Functions[slug]; ok && importMapPath == "" && functionConfig.ImportMap != "" {
+		if importMapPath != "" {
+			// skip
+		} else if functionConfig, ok := utils.Config.Functions[slug]; ok && functionConfig.ImportMap != "" {
 			if filepath.IsAbs(functionConfig.ImportMap) {
 				importMapPath = functionConfig.ImportMap
 			} else {
 				importMapPath = filepath.Join(utils.SupabaseDirPath, functionConfig.ImportMap)
 			}
+		} else if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {
+			importMapPath = utils.FallbackImportMapPath
 		}
 		if importMapPath != "" {
 			if _, err := fsys.Stat(importMapPath); err != nil {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -130,15 +130,16 @@ var (
 		"supabase_migrations",
 	}, SystemSchemas...)
 
-	SupabaseDirPath = "supabase"
-	ConfigPath      = filepath.Join(SupabaseDirPath, "config.toml")
-	ProjectRefPath  = filepath.Join(SupabaseDirPath, ".temp", "project-ref")
-	RemoteDbPath    = filepath.Join(SupabaseDirPath, ".temp", "remote-db-url")
-	CurrBranchPath  = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
-	MigrationsDir   = filepath.Join(SupabaseDirPath, "migrations")
-	FunctionsDir    = filepath.Join(SupabaseDirPath, "functions")
-	DbTestsDir      = filepath.Join(SupabaseDirPath, "tests")
-	SeedDataPath    = filepath.Join(SupabaseDirPath, "seed.sql")
+	SupabaseDirPath       = "supabase"
+	ConfigPath            = filepath.Join(SupabaseDirPath, "config.toml")
+	ProjectRefPath        = filepath.Join(SupabaseDirPath, ".temp", "project-ref")
+	RemoteDbPath          = filepath.Join(SupabaseDirPath, ".temp", "remote-db-url")
+	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
+	MigrationsDir         = filepath.Join(SupabaseDirPath, "migrations")
+	FunctionsDir          = filepath.Join(SupabaseDirPath, "functions")
+	FallbackImportMapPath = filepath.Join(FunctionsDir, "import_map.json")
+	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
+	SeedDataPath          = filepath.Join(SupabaseDirPath, "seed.sql")
 )
 
 // Used by unit tests


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

For each function, `import_map.json` is implicitly used from `supabase/functions/my_func/import_map.json`.

## What is the new behavior?

Implicitly fall back to `supabase/functions/import_map.json` if the per-function import map doesn't exist. The priority becomes (in decreasing order):
- `--import-map` flag
- `import_map` per-function config
- `supabase/functions/<function name>/import_map.json`
- `supabase/functions/import_map.json`

## Additional context

[Context](https://supabase.slack.com/archives/C02KMRX22NR/p1673582728382819?thread_ts=1673233215.735009&cid=C02KMRX22NR)
