### PR TITLE
fix: upgrade postgres-meta to v0.58.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PostgrestImage  = "postgrest/postgrest:v10.1.1.20221215"
 	DifferImage     = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage      = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage     = "supabase/postgres-meta:v0.54.1"
+	PgmetaImage     = "supabase/postgres-meta:v0.58.0"
 	StudioImage     = "supabase/studio:20221214-4eecc99"
 	DenoRelayImage  = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage = "darthsim/imgproxy:v3.8.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`supabase/postgres-meta` docker image is currently at v0.54.1.

## What is the new behavior?

Upgrades `supabase/postgres-meta` docker image to latest v0.58.0.

## Additional context

Specifically I'm interested in some recent updates to the TypeScript generation logic.
