### PR TITLE
fix: print interactive prompts to stderr

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -145,7 +145,7 @@ func PromptProjectRef(fsys afero.Fs) error {
 	} else if err := utils.AssertIsLinkedFS(fsys); err == nil {
 		return nil
 	} else if strings.HasPrefix(err.Error(), "Cannot find project ref. Have you run") {
-		fmt.Printf(`You can find your project ref from the project's dashboard home page, e.g. %s/project/<project-ref>.
+		fmt.Fprintf(os.Stderr, `You can find your project ref from the project's dashboard home page, e.g. %s/project/<project-ref>.
 Enter your project ref: `, utils.GetSupabaseDashboardURL())
 
 		scanner := bufio.NewScanner(os.Stdin)

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -151,7 +151,7 @@ func updatePostgresConfig(conn *pgx.Conn) {
 }
 
 func PromptPassword(stdin *os.File) string {
-	fmt.Print("Enter your database password: ")
+	fmt.Fprint(os.Stderr, "Enter your database password: ")
 	bytepw, err := term.ReadPassword(int(stdin.Fd()))
 	fmt.Println()
 	if err != nil {

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Run(stdin io.Reader, fsys afero.Fs) error {
-	fmt.Printf(`You can generate an access token from %s/account/tokens
+	fmt.Fprintf(os.Stderr, `You can generate an access token from %s/account/tokens
 Enter your access token: `, utils.GetSupabaseDashboardURL())
 
 	scanner := bufio.NewScanner(stdin)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`Enter your password:` is printed to stdout, causing wrong content to be piped.

## What is the new behavior?

Print interactive prompts to stderr. This seems to be standard practice accepted by posix shell https://unix.stackexchange.com/questions/380012/why-does-bash-interactive-shell-by-default-write-its-prompt-and-echoes-its-inter.

## Additional context

Add any other context or screenshots.
