### PR TITLE
fix: Correct type generation script path.

### DIFF
--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -62,7 +62,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			"PG_META_DB_URL=" + escaped,
 		}, []string{
 			"node",
-			"bin/src/server/app.js",
+			"dist/server/app.js",
 			"gen",
 			"types",
 			"typescript",
@@ -91,7 +91,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			"PG_META_DB_HOST=" + utils.DbId,
 		}, []string{
 			"node",
-			"bin/src/server/app.js",
+			"dist/server/app.js",
 			"gen",
 			"types",
 			"typescript",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Get an error. #797 

## What is the new behavior?

No changes.

## Additional context

The path was changed since `supabase/postgres-meta:v0.56.0`

Current version is v0.58.0, So that makes an error.
https://github.com/supabase/cli/blob/main/internal/utils/misc.go#L36
