### PR TITLE
fix: bypass non-fatal errors when running supabase start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,13 +11,14 @@ import (
 var (
 	allowedContainers  = start.ExcludableContainers()
 	excludedContainers []string
+	ignoreHealthCheck  bool
 
 	startCmd = &cobra.Command{
 		GroupID: groupLocalDev,
 		Use:     "start",
 		Short:   "Start containers for Supabase local development",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers)
+			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers, ignoreHealthCheck)
 		},
 	}
 )
@@ -26,5 +27,6 @@ func init() {
 	flags := startCmd.Flags()
 	names := strings.Join(allowedContainers, ", ")
 	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. ["+names+"]")
+	flags.BoolVar(&ignoreHealthCheck, "ignore-health-check", false, "Ignore unhealthy services and exit 0")
 	rootCmd.AddCommand(startCmd)
 }

--- a/docs/supabase/start.md
+++ b/docs/supabase/start.md
@@ -5,3 +5,5 @@ Starts the Supabase local development stack.
 Requires `supabase/config.toml` to be created in your current working directory by running `supabase init`.
 
 All service containers are started by default. You can exclude those not needed by passing in `-x` flag.
+
+Health checks are automatically added to verify the started containers. Use `--ignore-health-check` flag to ignore these errors.

--- a/docs/templates/examples.yaml
+++ b/docs/templates/examples.yaml
@@ -43,6 +43,13 @@ supabase-start:
       Excluding container: supabase/studio:20221214-4eecc99
       Seeding data supabase/seed.sql...
       Started supabase local development setup.
+  - id: ignore-health-check
+    name: Ignore service health checks
+    code: supabase start --ignore-health-check
+    response: |
+      Seeding data supabase/seed.sql...
+      service not healthy: [supabase_storage_cli]
+      Started supabase local development setup.
 supabase-stop:
   - id: basic-usage
     name: Basic usage

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -15,7 +15,7 @@ var output string
 func Run(ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
 	// Sanity checks.
 	{
-		if err := utils.AssertDockerIsRunning(); err != nil {
+		if err := utils.AssertDockerIsRunning(ctx); err != nil {
 			return err
 		}
 		if err := utils.LoadConfigFS(fsys); err != nil {

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -20,7 +20,7 @@ import (
 func Run(ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
 	// Sanity checks.
 	{
-		if err := utils.AssertDockerIsRunning(); err != nil {
+		if err := utils.AssertDockerIsRunning(ctx); err != nil {
 			return err
 		}
 		if err := utils.LoadConfigFS(fsys); err != nil {

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -28,7 +28,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	if err := utils.LoadConfigFS(fsys); err != nil {
 		return err
 	}
-	if err := utils.AssertDockerIsRunning(); err != nil {
+	if err := utils.AssertDockerIsRunning(ctx); err != nil {
 		return err
 	}
 	if _, err := utils.Docker.ContainerInspect(ctx, utils.DbId); err == nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string) error 
 		if err := utils.LoadConfigFS(fsys); err != nil {
 			return err
 		}
-		if err := utils.AssertDockerIsRunning(); err != nil {
+		if err := utils.AssertDockerIsRunning(ctx); err != nil {
 			return err
 		}
 		if err := utils.AssertSupabaseDbIsRunning(); err == nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -34,8 +34,9 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string) error 
 		if err := utils.AssertDockerIsRunning(ctx); err != nil {
 			return err
 		}
-		if err := utils.AssertSupabaseDbIsRunning(); err == nil {
-			return errors.New(utils.Aqua("supabase start") + " is already running. Try running " + utils.Aqua("supabase stop") + " first.")
+		if _, err := utils.Docker.ContainerInspect(ctx, utils.DbId); err == nil {
+			fmt.Fprintln(os.Stderr, utils.Aqua("supabase start")+" is already running.")
+			return nil
 		}
 	}
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -60,10 +60,6 @@ var (
 )
 
 func run(p utils.Program, ctx context.Context, fsys afero.Fs, excludedContainers []string, options ...func(*pgx.ConnConfig)) error {
-	if err := utils.DockerNetworkCreateIfNotExists(ctx, utils.NetId); err != nil {
-		return err
-	}
-
 	excluded := make(map[string]bool)
 	for _, name := range excludedContainers {
 		excluded[name] = true

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -43,8 +43,8 @@ func NewDocker() *client.Client {
 	return docker
 }
 
-func AssertDockerIsRunning() error {
-	if _, err := Docker.Ping(context.Background()); err != nil {
+func AssertDockerIsRunning(ctx context.Context) error {
+	if _, err := Docker.Ping(ctx); err != nil {
 		return NewError(err.Error())
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes #787
relates to #778

## What is the current behavior?

If supabase is already started, throws error.
If any service is unhealthy, throws error.

## What is the new behavior?

- exit 0 instead (consistent with `db start`)
- adds `--ignore-health-check` flag to exit 0 when services are unhealthy

## Additional context

Add any other context or screenshots.
