### PR TITLE
fix: healthcheck printf returns 0

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -280,7 +280,7 @@ EOF
 					"/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server",
 				},
 				Healthcheck: &container.HealthConfig{
-					Test:     []string{"CMD", "printf", "\\0", ">", "/dev/tcp/localhost/4000"},
+					Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/4000"},
 					Interval: 2 * time.Second,
 					Timeout:  2 * time.Second,
 					Retries:  10,

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -309,6 +309,12 @@ EOF
 					"PGRST_DB_ANON_ROLE=anon",
 					"PGRST_JWT_SECRET=" + utils.JWTSecret,
 				},
+				Healthcheck: &container.HealthConfig{
+					Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/3000"},
+					Interval: 2 * time.Second,
+					Timeout:  2 * time.Second,
+					Retries:  10,
+				},
 			},
 			container.HostConfig{
 				RestartPolicy: container.RestartPolicy{Name: "always"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and feature

## What is the current behavior?

Currently healthchecks based on `printf` return always 0 and are false-positive.

Healthcheck config (the port is wrong in order to test, rest has 3000 open, 4000 is closed):
```sh
$ docker inspect -f '{{json .Config.Healthcheck }}' supabase-rest
{"Test":["CMD","printf","\\0",">","/dev/tcp/localhost/4000"],"Interval":5000000000,"Timeout":5000000000,"Retries":3}
```

```sh
$ docker inspect -f '{{json .State.Health.Log }}' supabase-rest
[{"Start":"2023-01-20T17:51:21.136686444Z","End":"2023-01-20T17:51:21.203277311Z","ExitCode":0,"Output":"\u0000printf: warning: ignoring excess arguments, starting with '>'\n"},{"Start":"2023-01-20T17:51:26.211514237Z","End":"2023-01-20T17:51:26.279377587Z","ExitCode":0,"Output":"\u0000printf: warning: ignoring excess arguments, starting with '>'\n"},{"Start":"2023-01-20T17:51:31.286512431Z","End":"2023-01-20T17:51:31.350657173Z","ExitCode":0,"Output":"\u0000printf: warning: ignoring excess arguments, starting with '>'\n"},{"Start":"2023-01-20T17:51:36.362020785Z","End":"2023-01-20T17:51:36.424323443Z","ExitCode":0,"Output":"\u0000printf: warning: ignoring excess arguments, starting with '>'\n"},{"Start":"2023-01-20T17:51:41.43299977Z","End":"2023-01-20T17:51:41.50987106Z","ExitCode":0,"Output":"printf: warning: ignoring excess arguments, starting with '>'\n\u0000"}]
```

Exit code is always 0

## What is the new behavior?

```sh
$ docker inspect -f '{{json .Config.Healthcheck }}' supabase-rest
{"Test":["CMD","bash","-c","printf \\0 > /dev/tcp/localhost/4000"],"Interval":5000000000,"Timeout":5000000000,"Retries":3}
```

```sh
$ docker inspect -f '{{json .State.Health.Log }}' supabase-rest
[{"Start":"2023-01-20T18:01:32.979767241Z","End":"2023-01-20T18:01:33.042339059Z","ExitCode":1,"Output":"bash: connect: Cannot assign requested address\nbash: /dev/tcp/localhost/4000: Cannot assign requested address\n"},{"Start":"2023-01-20T18:01:38.04912028Z","End":"2023-01-20T18:01:38.094944501Z","ExitCode":1,"Output":"bash: connect: Cannot assign requested address\nbash: /dev/tcp/localhost/4000: Cannot assign requested address\n"}]
```

## Additional context

Added Healthcheck to PostgREST also
