### PR TITLE
fix: allow deno functions to reach host OS

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -120,6 +120,8 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 			},
 			container.HostConfig{
 				Binds: binds,
+				// Allows containerized functions on Linux to reach host OS
+				ExtraHosts: []string{"host.docker.internal:host-gateway"},
 			},
 			utils.DenoRelayId,
 		); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

no consistent way for locally served functions to reach host OS

## What is the new behavior?

Starting from Docker Engine `20.04`, it's now possible to use `host.docker.internal` consistently across platforms https://stackoverflow.com/a/61424570

## Additional context

https://github.com/supabase/supabase/discussions/9837#discussioncomment-4805370

- [x] tested on codespaces
