### PR TITLE
fix: close migration file immediately after executing

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -45,11 +45,6 @@ func Run(ctx context.Context, fsys afero.Fs, options ...func(*pgx.ConnConfig)) e
 		}
 	}
 
-	// Reload PostgREST schema cache.
-	if err := utils.Docker.ContainerKill(ctx, utils.RestId, "SIGUSR1"); err != nil {
-		fmt.Fprintln(os.Stderr, "Error reloading PostgREST schema cache:", err)
-	}
-
 	branch, err := utils.GetCurrentBranchFS(fsys)
 	if err != nil {
 		// Assume we are on main branch
@@ -149,6 +144,10 @@ func RestartDatabase(ctx context.Context) {
 	// TODO: update storage-api to handle postgres restarts
 	if err := utils.Docker.ContainerRestart(ctx, utils.StorageId, nil); err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to restart storage-api:", err)
+	}
+	// Reload PostgREST schema cache.
+	if err := utils.Docker.ContainerKill(ctx, utils.RestId, "SIGUSR1"); err != nil {
+		fmt.Fprintln(os.Stderr, "Error reloading PostgREST schema cache:", err)
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #822 

## What is the current behavior?

Deferred statements are run before function returns, not when out of scope.

## What is the new behavior?

Close migration files immediately to release resources back to the host OS.

## Additional context

Tested locally with

```bash
ulimit -n 200
for i in {1..250}; do supabase migration new "$i"; done
supabase db start
```

Checked all other usage of `defer` keyword and found an issue where postgREST may be restarted before database is fully up. Fixed it in this PR as well.