### PR TITLE
feat: Allow serving all edge functions using edge runtime

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -95,18 +95,23 @@ var (
 	}
 
 	envFilePath string
+	serveAll    bool
 
 	functionsServeCmd = &cobra.Command{
 		Use:   "serve <Function name>",
 		Short: "Serve a Function locally",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			// Fallback to config if user did not set the flag.
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return serve.Run(ctx, args[0], envFilePath, noVerifyJWT, importMapPath, afero.NewOsFs())
+			slug := ""
+			if len(args) > 1 {
+				slug = args[0]
+			}
+			return serve.Run(ctx, slug, envFilePath, noVerifyJWT, importMapPath, serveAll, afero.NewOsFs())
 		},
 	}
 )
@@ -120,6 +125,7 @@ func init() {
 	functionsServeCmd.Flags().BoolVar(noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
+	functionsServeCmd.Flags().BoolVar(&serveAll, "all", false, "Serve all functions (caution: Experimental feature)")
 	functionsDownloadCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -82,6 +82,7 @@ func DiffSchema(ctx context.Context, source, target string, schema []string, p u
 			utils.DifferImage,
 			nil,
 			args,
+			nil,
 			stream.Stdout(),
 			stream.Stderr(),
 		); err != nil {
@@ -95,6 +96,7 @@ func DiffSchema(ctx context.Context, source, target string, schema []string, p u
 			utils.DifferImage,
 			nil,
 			append([]string{"--schema", s}, args...),
+			nil,
 			stream.Stdout(),
 			stream.Stderr(),
 		); err != nil {

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -285,12 +285,8 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 			binds = append(binds, filepath.Join(cwd, importMapPath)+":"+customDockerImportMapPath+":ro,z")
 		}
 
-		// bind deno cache directory
-		cachePath, err := utils.GetDenoCachePath()
-		if err != nil {
-			return err
-		}
-		binds = append(binds, cachePath+":/root/.cache/deno:rw,z")
+		// bind deno cache volume
+		binds = append(binds, utils.DenoRelayId+":/root/.cache/deno:rw,z")
 
 		containerID, err := utils.DockerStart(
 			ctx,

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,7 +41,11 @@ func ParseEnvFile(envFilePath string) ([]string, error) {
 	return env, nil
 }
 
-func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
+func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool, importMapPath string, serveAll bool, fsys afero.Fs) error {
+	if serveAll {
+		return runServeAll(ctx, envFilePath, noVerifyJWT, importMapPath, fsys)
+	}
+
 	// 1. Sanity checks.
 	{
 		if err := utils.LoadConfigFS(fsys); err != nil {
@@ -215,4 +220,135 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 
 	fmt.Println("Stopped serving " + utils.Bold(localFuncDir))
 	return nil
+}
+
+func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
+	// 1. Sanity checks.
+	{
+		if err := utils.LoadConfigFS(fsys); err != nil {
+			return err
+		}
+		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
+			return err
+		}
+		if envFilePath != "" {
+			if _, err := fsys.Stat(envFilePath); err != nil {
+				return fmt.Errorf("Failed to read env file: %w", err)
+			}
+		}
+		if importMapPath != "" {
+			// skip
+		} else if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {
+			importMapPath = utils.FallbackImportMapPath
+		}
+		if importMapPath != "" {
+			if _, err := fsys.Stat(importMapPath); err != nil {
+				return fmt.Errorf("Failed to read import map: %w", err)
+			}
+		}
+	}
+
+	// 2. Parse user defined env
+	userEnv, err := ParseEnvFile(envFilePath)
+	if err != nil {
+		return err
+	}
+
+	// 3. Start container
+	{
+		_ = utils.Docker.ContainerRemove(ctx, utils.DenoRelayId, types.ContainerRemoveOptions{
+			RemoveVolumes: true,
+			Force:         true,
+		})
+
+		env := []string{
+			"JWT_SECRET=" + utils.JWTSecret,
+			"SUPABASE_URL=http://" + utils.KongId + ":8000",
+			"SUPABASE_ANON_KEY=" + utils.AnonKey,
+			"SUPABASE_SERVICE_ROLE_KEY=" + utils.ServiceRoleKey,
+			"SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:" + strconv.FormatUint(uint64(utils.Config.Db.Port), 10) + "/postgres",
+		}
+		verifyJWTEnv := "VERIFY_JWT=true"
+		if noVerifyJWT != nil {
+			verifyJWTEnv = "VERIFY_JWT=false"
+		}
+		env = append(env, verifyJWTEnv)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		binds := []string{filepath.Join(cwd, utils.FunctionsDir) + ":" + relayFuncDir + ":ro,z"}
+		// If a import map path is explcitly provided, mount it as a separate file
+		if importMapPath != "" {
+			binds = append(binds, filepath.Join(cwd, importMapPath)+":"+customDockerImportMapPath+":ro,z")
+		}
+
+		// bind deno cache directory
+		cachePath, err := utils.GetDenoCachePath()
+		if err != nil {
+			return err
+		}
+		binds = append(binds, cachePath+":/root/.cache/deno:rw,z")
+
+		containerID, err := utils.DockerStart(
+			ctx,
+			container.Config{
+				Image:        utils.EdgeRuntimeImage,
+				Env:          append(env, userEnv...),
+				Cmd:          []string{"start", "--dir", relayFuncDir, "-p", "8081"},
+				OpenStdin:    true,
+				AttachStdin:  true,
+				AttachStderr: true,
+				AttachStdout: true,
+				Tty:          true,
+			},
+			container.HostConfig{
+				Binds: binds,
+			},
+			utils.DenoRelayId,
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Serving " + utils.Bold(utils.FunctionsDir))
+
+		// TODO: pipe the OS signals to the container
+		resp, err := utils.Docker.ContainerAttach(ctx, containerID, types.ContainerAttachOptions{
+			Stream: true,
+			Stdin:  true,
+			Stdout: true,
+			Stderr: true,
+			Logs:   true,
+		})
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			_, _ = io.Copy(os.Stdout, resp.Reader)
+		}()
+
+		statusCh, errCh := utils.Docker.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
+		select {
+		case err := <-errCh:
+			if err != nil {
+				return err
+			}
+		case <-statusCh:
+		}
+
+		go func() {
+			<-ctx.Done()
+			if ctx.Err() != nil {
+				utils.DockerRemove(utils.DenoRelayId)
+			}
+		}()
+	}
+
+	fmt.Println("Stopped serving " + utils.Bold(utils.FunctionsDir))
+	return nil
+
 }

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -35,7 +35,7 @@ func TestServeCommand(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), "test-func", "", nil, "", fsys)
+		err := Run(context.Background(), "test-func", "", nil, "", false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version http://localhost/v1.41/containers/supabase_deno_relay_serve/exec")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	StudioImage      = "supabase/studio:20230127-6bfd87b"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:latest"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.7"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.40.1"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -323,18 +323,6 @@ func GetDenoPath() (string, error) {
 	return denoPath, nil
 }
 
-func GetDenoCachePath() (string, error) {
-	if len(DenoPathOverride) > 0 {
-		return DenoPathOverride, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	cachePath := filepath.Join(home, ".supabase", "deno_cache")
-	return cachePath, nil
-}
-
 func InstallOrUpgradeDeno(ctx context.Context, fsys afero.Fs) error {
 	denoPath, err := GetDenoPath()
 	if err != nil {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -28,15 +28,16 @@ const (
 	Pg14Image = "supabase/postgres:14.1.0.89"
 	Pg15Image = "supabase/postgres:15.1.0.33"
 	// Append to ServiceImages when adding new dependencies below
-	KongImage       = "library/kong:2.8.1"
-	InbucketImage   = "inbucket/inbucket:3.0.3"
-	PostgrestImage  = "postgrest/postgrest:v10.1.1.20221215"
-	DifferImage     = "supabase/pgadmin-schema-diff:cli-0.0.5"
-	MigraImage      = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage     = "supabase/postgres-meta:v0.60.3"
-	StudioImage     = "supabase/studio:20230127-6bfd87b"
-	DenoRelayImage  = "supabase/deno-relay:v1.5.0"
-	ImageProxyImage = "darthsim/imgproxy:v3.8.0"
+	KongImage        = "library/kong:2.8.1"
+	InbucketImage    = "inbucket/inbucket:3.0.3"
+	PostgrestImage   = "postgrest/postgrest:v10.1.1.20221215"
+	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
+	MigraImage       = "djrobstep/migra:3.0.1621480950"
+	PgmetaImage      = "supabase/postgres-meta:v0.60.3"
+	StudioImage      = "supabase/studio:20230127-6bfd87b"
+	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
+	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
+	EdgeRuntimeImage = "supabase/edge-runtime:latest"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.40.1"
@@ -320,6 +321,18 @@ func GetDenoPath() (string, error) {
 	}
 	denoPath := filepath.Join(home, ".supabase", denoBinName)
 	return denoPath, nil
+}
+
+func GetDenoCachePath() (string, error) {
+	if len(DenoPathOverride) > 0 {
+		return DenoPathOverride, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	cachePath := filepath.Join(home, ".supabase", "deno_cache")
+	return cachePath, nil
 }
 
 func InstallOrUpgradeDeno(ctx context.Context, fsys afero.Fs) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces **experimental** `functions serve --all` option, which would use edge-runtime to serve all edge functions in a project locally.

Please note this is still experimental and missing several key features:
- `verify-jwt` option doesn't work
- `import-maps` doesn't work

TODO:

[x] Update the edge-runtime image tag
