### PR TITLE
fix: set container name when calling DockerRunOnceWithStream

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -83,6 +83,7 @@ func DiffSchema(ctx context.Context, source, target string, schema []string, p u
 			nil,
 			args,
 			nil,
+			"",
 			stream.Stdout(),
 			stream.Stderr(),
 		); err != nil {
@@ -97,6 +98,7 @@ func DiffSchema(ctx context.Context, source, target string, schema []string, p u
 			nil,
 			append([]string{"--schema", s}, args...),
 			nil,
+			"",
 			stream.Stdout(),
 			stream.Stderr(),
 		); err != nil {

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -295,6 +295,7 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 			append(env, userEnv...),
 			[]string{"start", "--dir", relayFuncDir, "-p", "8081"},
 			binds,
+			utils.DenoRelayId,
 			os.Stdout,
 			os.Stderr,
 		); err != nil {

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -302,11 +302,11 @@ func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string
 		stderr = os.Stderr
 	}
 	var out bytes.Buffer
-	err := DockerRunOnceWithStream(ctx, image, env, cmd, nil, &out, stderr)
+	err := DockerRunOnceWithStream(ctx, image, env, cmd, nil, "", &out, stderr)
 	return out.String(), err
 }
 
-func DockerRunOnceWithStream(ctx context.Context, image string, env, cmd, binds []string, stdout, stderr io.Writer) error {
+func DockerRunOnceWithStream(ctx context.Context, image string, env, cmd, binds []string, containerName string, stdout, stderr io.Writer) error {
 	// Cannot rely on docker's auto remove because
 	//   1. We must inspect exit code after container stops
 	//   2. Context cancellation may happen after start
@@ -318,7 +318,7 @@ func DockerRunOnceWithStream(ctx context.Context, image string, env, cmd, binds 
 		Binds: binds,
 		// Allows containerized functions on Linux to reach host OS
 		ExtraHosts: []string{"host.docker.internal:host-gateway"},
-	}, "")
+	}, containerName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

If we don't set the container name, the kong proxying to the container wouldn't work.
