### PR TITLE
fix: match db locale of Supabase cloud in local development

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -45,6 +45,7 @@ func StartDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 		Env: []string{
 			"POSTGRES_PASSWORD=postgres",
 			"POSTGRES_HOST=/var/run/postgresql",
+			"LC_ALL=C.UTF-8",
 		},
 		Healthcheck: &container.HealthConfig{
 			Test:     []string{"CMD", "pg_isready", "-U", "postgres", "-h", "localhost", "-p", "5432"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #825 

## What is the current behavior?

The locale of the Postgres database is inherited from the host system.

## What is the new behavior?

The locale of the Postgres database matches that of Supabase cloud.

## Additional context

None.
