### PR TITLE
Update edge runtime

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/joho/godotenv"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -289,11 +290,15 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 
 		fmt.Println("Serving " + utils.Bold(utils.FunctionsDir))
 
+		verboseFlag := ""
+		if viper.GetBool("DEBUG") {
+			verboseFlag = "--verbose"
+		}
 		if err := utils.DockerRunOnceWithStream(
 			ctx,
 			utils.EdgeRuntimeImage,
 			append(env, userEnv...),
-			[]string{"start", "--dir", relayFuncDir, "-p", "8081"},
+			[]string{"start", "--dir", relayFuncDir, "-p", "8081", verboseFlag},
 			binds,
 			utils.DenoRelayId,
 			os.Stdout,

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	StudioImage      = "supabase/studio:20230127-6bfd87b"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.7"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.8"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.40.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates edge-runtime to v1.0.8, which includes a critical bug fix. Also, I've updated the serve command to pass the `--debug` flag to the container.