### PR TITLE
Update postgres-meta to 0.60.6

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v10.1.1.20221215"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage      = "supabase/postgres-meta:v0.60.3"
+	PgmetaImage      = "supabase/postgres-meta:v0.60.6"
 	StudioImage      = "supabase/studio:20230127-6bfd87b"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"


### PR DESCRIPTION
Hi! This is a follow-up to this comment:
https://github.com/supabase/postgres-meta/pull/483#issuecomment-1409562603

I am proposing an update of postgres-meta to version 0.60.6. I am hoping to make use of https://github.com/supabase/postgres-meta/pull/492 through the Supabase CLI.

As per the above linked comment, I am aware that in general, the postgres-meta version is kept at the same version as what is used on the hosted platform. This is a minor changes from the current version 0.60.3 so perhaps it will quality for an exception? I am not sure how I can check what version is live on the hosted platform.

Thanks for considering!