### PR TITLE
fix: disable refresh token security

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -175,6 +175,8 @@ EOF
 
 			"GOTRUE_EXTERNAL_PHONE_ENABLED=true",
 			"GOTRUE_SMS_AUTOCONFIRM=true",
+
+			"GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=false",
 		}
 
 		for name, config := range utils.Config.Auth.External {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Local auth server is invalidating refresh token - see `GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED` in https://github.com/supabase/gotrue/blob/master/README.md, which is enabled by default.

## What is the new behavior?

Disable this security feature, since it's not relevant within a local dev context.