### PR TITLE
feat: adds support for enabling SSL enforcement on DB conns

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var experimental = []*cobra.Command{
 	bansCmd,
 	restrictionsCmd,
 	vanityCmd,
+	sslEnforcementCmd,
 }
 
 func IsExperimental(cmd *cobra.Command) bool {

--- a/cmd/sslEnforcement.go
+++ b/cmd/sslEnforcement.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/ssl_enforcement/get"
+	"github.com/supabase/cli/internal/ssl_enforcement/update"
+)
+
+var (
+	sslEnforcementCmd = &cobra.Command{
+		GroupID: groupManagementAPI,
+		Use:     "ssl-enforcement",
+		Short:   "Manage SSL enforcement configuration",
+	}
+
+	dbEnforceSsl bool
+	dbDisableSsl bool
+
+	sslEnforcementUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update SSL enforcement configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := PromptLogin(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			if !dbEnforceSsl && !dbDisableSsl {
+				return fmt.Errorf("enable/disable not specified")
+			}
+			return update.Run(ctx, projectRef, dbEnforceSsl, fsys)
+		},
+	}
+
+	sslEnforcementGetCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get the current SSL enforcement configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := PromptLogin(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return get.Run(ctx, projectRef, fsys)
+		},
+	}
+)
+
+func init() {
+	sslEnforcementCmd.PersistentFlags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
+	sslEnforcementUpdateCmd.Flags().BoolVar(&dbEnforceSsl, "enable-db-ssl-enforcement", false, "Whether the DB should enable SSL enforcement for all external connections.")
+	sslEnforcementUpdateCmd.Flags().BoolVar(&dbDisableSsl, "disable-db-ssl-enforcement", false, "Whether the DB should disable SSL enforcement for all external connections.")
+	sslEnforcementUpdateCmd.MarkFlagsMutuallyExclusive("enable-db-ssl-enforcement", "disable-db-ssl-enforcement")
+	sslEnforcementCmd.AddCommand(sslEnforcementUpdateCmd)
+	sslEnforcementCmd.AddCommand(sslEnforcementGetCmd)
+
+	rootCmd.AddCommand(sslEnforcementCmd)
+}

--- a/internal/ssl_enforcement/get/get.go
+++ b/internal/ssl_enforcement/get/get.go
@@ -1,0 +1,47 @@
+package get
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, projectRefArg string, fsys afero.Fs) error {
+	// 1. Sanity checks.
+	projectRef := projectRefArg
+	{
+		if len(projectRefArg) == 0 {
+			ref, err := utils.LoadProjectRef(fsys)
+			if err != nil {
+				return err
+			}
+			projectRef = ref
+		} else if !utils.ProjectRefPattern.MatchString(projectRef) {
+			return errors.New("Invalid project ref format. Must be like `abcdefghijklmnopqrst`.")
+		}
+	}
+
+	// 2. get ssl enforcement config
+	{
+		resp, err := utils.GetSupabase().GetSslEnforcementConfigWithResponse(ctx, projectRef)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve SSL enforcement config: %w", err)
+		}
+		if resp.JSON200 == nil {
+			return errors.New("failed to retrieve SSL enforcement config; received: " + string(resp.Body))
+		}
+
+		if err != nil {
+			return err
+		}
+		if resp.JSON200.CurrentConfig.Database && resp.JSON200.AppliedSuccessfully {
+			fmt.Println("SSL is being enforced.")
+		} else {
+			fmt.Println("SSL is *NOT* being enforced.")
+		}
+		return nil
+	}
+}

--- a/internal/ssl_enforcement/update/update.go
+++ b/internal/ssl_enforcement/update/update.go
@@ -1,0 +1,50 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+)
+
+func Run(ctx context.Context, projectRefArg string, enforceDbSsl bool, fsys afero.Fs) error {
+	// 1. Sanity checks.
+	projectRef := projectRefArg
+
+	// 1. sanity checks
+	{
+		if len(projectRefArg) == 0 {
+			ref, err := utils.LoadProjectRef(fsys)
+			if err != nil {
+				return err
+			}
+			projectRef = ref
+		} else if !utils.ProjectRefPattern.MatchString(projectRef) {
+			return errors.New("Invalid project ref format. Must be like `abcdefghijklmnopqrst`.")
+		}
+	}
+
+	// 2. update restrictions
+	{
+		resp, err := utils.GetSupabase().UpdateSslEnforcementConfigWithResponse(ctx, projectRef, api.UpdateSslEnforcementConfigJSONRequestBody{
+			RequestedConfig: api.SslEnforcements{
+				Database: enforceDbSsl,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		if resp.JSON200 == nil {
+			return errors.New("failed to update SSL enforcement confnig: " + string(resp.Body))
+		}
+		if resp.JSON200.CurrentConfig.Database && resp.JSON200.AppliedSuccessfully {
+			fmt.Println("SSL is now being enforced.")
+		} else {
+			fmt.Println("SSL is *NOT* being enforced.")
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Experimental commands for enabling/disabling SSL enforcement for
connections to the DB (PG+pooler).