### PR TITLE
fix: defaults to serve all functions

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -95,7 +95,6 @@ var (
 	}
 
 	envFilePath string
-	serveAll    bool
 
 	functionsServeCmd = &cobra.Command{
 		Use:   "serve <Function name>",
@@ -111,7 +110,7 @@ var (
 			if len(args) > 0 {
 				slug = args[0]
 			}
-			return serve.Run(ctx, slug, envFilePath, noVerifyJWT, importMapPath, serveAll, afero.NewOsFs())
+			return serve.Run(ctx, slug, envFilePath, noVerifyJWT, importMapPath, afero.NewOsFs())
 		},
 	}
 )
@@ -125,7 +124,8 @@ func init() {
 	functionsServeCmd.Flags().BoolVar(noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
-	functionsServeCmd.Flags().BoolVar(&serveAll, "all", false, "Serve all functions (caution: Experimental feature)")
+	functionsServeCmd.Flags().Bool("all", true, "Serve all functions (caution: Experimental feature)")
+	functionsServeCmd.Flags().MarkHidden("all")
 	functionsDownloadCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -125,7 +125,7 @@ func init() {
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
 	functionsServeCmd.Flags().Bool("all", true, "Serve all functions (caution: Experimental feature)")
-	functionsServeCmd.Flags().MarkHidden("all")
+	cobra.CheckErr(functionsServeCmd.Flags().MarkHidden("all"))
 	functionsDownloadCmd.Flags().StringVar(&projectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -46,8 +46,8 @@ func ParseEnvFile(envFilePath string, fsys afero.Fs) ([]string, error) {
 	return env, nil
 }
 
-func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool, importMapPath string, serveAll bool, fsys afero.Fs) error {
-	if serveAll {
+func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
+	if len(slug) == 0 {
 		return runServeAll(ctx, envFilePath, noVerifyJWT, importMapPath, fsys)
 	}
 

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -35,7 +35,7 @@ func TestServeCommand(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), "test-func", "", nil, "", false, fsys)
+		err := Run(context.Background(), "test-func", "", nil, "", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version http://localhost/v1.41/containers/supabase_deno_relay_serve/exec")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -60,7 +60,7 @@ func TestServeCommand(t *testing.T) {
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/" + containerId).
 			Reply(http.StatusOK)
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.EdgeRuntimeImage), containerId)
-		apitest.MockDockerLogs(utils.Docker, containerId, "success")
+		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "success"))
 		// Run test
 		noVerifyJWT := true
 		err := Run(context.Background(), "", ".env", &noVerifyJWT, "", fsys)


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

`functions serve` errors without `--all` arg

## What is the new behavior?

`supabase functions serve` defaults to serving all functions

## Additional context

Add any other context or screenshots.
