### PR TITLE
fix: bump edge-runtime to 1.0.15

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	StudioImage      = "supabase/studio:20230127-6bfd87b"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.9"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.15"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.40.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps edge-runtime to v1.0.15 which included bug fix for #869 
