### PR TITLE
fix: bump postgres image to latest slim

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -29,7 +29,7 @@ var Version string
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.89"
-	Pg15Image = "supabase/postgres:15.1.0.33"
+	Pg15Image = "supabase/postgres:15.1.0.42-rc2"
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.60.7"
-	StudioImage      = "supabase/studio:20230127-6bfd87b"
+	StudioImage      = "supabase/studio:20230216-e731b77"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.15"


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes https://github.com/supabase/cli/issues/870

## What is the new behavior?

updates postgres and studio image

## Additional context

Add any other context or screenshots.
