### PR TITLE
fix: update edge-runtime to support import maps

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -285,14 +285,17 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 			filepath.Join(cwd, utils.FunctionsDir) + ":" + relayFuncDir + ":rw,z",
 			utils.DenoRelayId + ":/root/.cache/deno:rw,z",
 		}
-		// If a import map path is explcitly provided, mount it as a separate file
+		dockerImportMapPath := relayFuncDir + "/import_map.json"
 		if importMapPath != "" {
-			binds = append(binds, filepath.Join(cwd, importMapPath)+":"+customDockerImportMapPath+":ro,z")
+			binds = append(binds, filepath.Join(cwd, importMapPath)+":"+dockerImportMapPath+":ro,z")
 		}
 
 		fmt.Println("Serving " + utils.Bold(utils.FunctionsDir))
 
 		cmd := []string{"start", "--dir", relayFuncDir, "-p", "8081"}
+		if importMapPath != "" {
+			cmd = append(cmd, "--import-map", dockerImportMapPath)
+		}
 		if viper.GetBool("DEBUG") {
 			cmd = append(cmd, "--verbose")
 		}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	StudioImage      = "supabase/studio:20230216-e731b77"
 	DenoRelayImage   = "supabase/deno-relay:v1.5.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.15"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.0.20"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.40.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR bumps edge-runtime to 1.0.20, which adds import maps support.