### PR TITLE
fix: exclude temporary schemas from db diff

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -23,7 +23,7 @@ import (
 	"github.com/supabase/cli/internal/utils/parser"
 )
 
-const LIST_SCHEMAS = "SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name = ANY($1) ORDER BY schema_name"
+const LIST_SCHEMAS = "SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name LIKE ANY($1) ORDER BY schema_name"
 
 var (
 	//go:embed templates/migra.sh
@@ -106,6 +106,9 @@ func LoadUserSchemas(ctx context.Context, conn *pgx.Conn, exclude ...string) ([]
 			// Exclude functions because Webhooks support is early alpha
 			"supabase_functions",
 			"supabase_migrations",
+			// Exclude postgres temporary schemas
+			"pg_temp_%",
+			"pg_toast_temp_%",
 		}, utils.SystemSchemas...)
 	}
 	rows, err := conn.Query(ctx, LIST_SCHEMAS, exclude)

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -108,7 +108,7 @@ func TestRunMigra(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name LIKE ANY('{pgbouncer,realtime,_realtime,supabase_functions,supabase_migrations,pg_temp_%,pg_toast_temp_%,information_schema,pg_catalog,pg_toast,cron,graphql,graphql_public,net,pgsodium,pgsodium_masks,vault}') ORDER BY schema_name").
+		conn.Query(`SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name LIKE ANY('{pgbouncer,realtime,"\\_realtime","supabase\\_functions","supabase\\_migrations","information\\_schema","pg\\_%",cron,graphql,"graphql\\_public",net,pgsodium,"pgsodium\\_masks",vault}') ORDER BY schema_name`).
 			ReplyError(pgerrcode.DuplicateTable, `relation "test" already exists`)
 		// Run test
 		err := RunMigra(context.Background(), []string{}, "", "password", fsys, conn.Intercept)

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -108,7 +108,7 @@ func TestRunMigra(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name = ANY('{pgbouncer,realtime,_realtime,supabase_functions,supabase_migrations,information_schema,pg_catalog,pg_toast,cron,graphql,graphql_public,net,pgsodium,pgsodium_masks,vault}') ORDER BY schema_name").
+		conn.Query("SELECT schema_name FROM information_schema.schemata WHERE NOT schema_name LIKE ANY('{pgbouncer,realtime,_realtime,supabase_functions,supabase_migrations,pg_temp_%,pg_toast_temp_%,information_schema,pg_catalog,pg_toast,cron,graphql,graphql_public,net,pgsodium,pgsodium_masks,vault}') ORDER BY schema_name").
 			ReplyError(pgerrcode.DuplicateTable, `relation "test" already exists`)
 		// Run test
 		err := RunMigra(context.Background(), []string{}, "", "password", fsys, conn.Intercept)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -109,11 +109,10 @@ var (
 	FuncSlugPattern    = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
 	ImageNamePattern   = regexp.MustCompile(`\/(.*):`)
 
-	// These schemas are ignored from schema diffs
+	// These schemas are ignored from db diff and db dump
 	SystemSchemas = []string{
 		"information_schema",
-		"pg_catalog",
-		"pg_toast",
+		"pg_*", // Wildcard pattern follows pg_dump
 		// Owned by extensions
 		"cron",
 		"graphql",

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -114,8 +114,6 @@ var (
 		"information_schema",
 		"pg_catalog",
 		"pg_toast",
-		// "pg_temp_1",
-		// "pg_toast_temp_1",
 		// Owned by extensions
 		"cron",
 		"graphql",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://gist.github.com/tmcw/6f43e433bae38fffacec6d2aa5c9345a

## What is the new behavior?

- removes all temporary schemas from being diffed by default
- uses `pg_*` wildcard pattern to support both diff and dump

## Additional context

Add any other context or screenshots.
