### PR TITLE
fix: fallback to dns over http on timeout

### DIFF
--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -180,7 +180,7 @@ func GetSupabase() *supabase.ClientWithResponses {
 			t.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 				conn, err := dialContext(ctx, network, address)
 				// Workaround when pure Go DNS resolver fails https://github.com/golang/go/issues/12524
-				if err, ok := err.(*net.OpError); ok && err.Op == "dial" {
+				if err, ok := err.(net.Error); ok && err.Timeout() {
 					if ip := fallbackLookupIP(ctx, address); ip != "" {
 						return dialContext(ctx, network, ip)
 					}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There have been more reported cases where dns timed out locally but the fallback resolver was not used.

## What is the new behavior?

Use dns over https to handle more cases where native go resolver fails.

## Additional context

tested locally by setting a bogus dns
