### PR TITLE
feat: support overriding dns resolver with flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func init() {
 	flags.Bool("debug", false, "output debug logs to stderr")
 	flags.String("workdir", "", "path to a Supabase project directory")
 	flags.Bool("experimental", false, "enable experimental features")
+	flags.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
 	cobra.CheckErr(viper.BindPFlags(flags))
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- `supabase link --dns-resolver=https` will use dns-over-https resolver for both api and db hostname

## Additional context

Add any other context or screenshots.
