### PR TITLE
feat: support self hosted urls with db commands

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -205,13 +205,13 @@ var (
 )
 
 func init() {
+	dbCmd.PersistentFlags().StringVar(&dbUrl, "db-url", "", "connect using the specified database url")
 	// Build branch command
 	dbBranchCmd.AddCommand(dbBranchCreateCmd)
 	dbBranchCmd.AddCommand(dbBranchDeleteCmd)
 	dbBranchCmd.AddCommand(dbBranchListCmd)
 	dbBranchCmd.AddCommand(dbSwitchCmd)
 	dbCmd.AddCommand(dbBranchCmd)
-	dbCmd.PersistentFlags().StringVar(&dbUrl, "db-url", "", "connect using the specified database url")
 	// Build diff command
 	diffFlags := dbDiffCmd.Flags()
 	diffFlags.BoolVar(&useMigra, "use-migra", true, "Use migra to generate schema diff.")

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -83,16 +83,16 @@ var (
 		Short: "Diffs the local database for schema changes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
-			if linked {
-				if err := loadLinkedProject(fsys); err != nil {
+			if linked || len(dbUrl) > 0 {
+				if err := parseDatabaseConfig(fsys); err != nil {
 					return err
 				}
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			if usePgAdmin {
-				return diff.Run(ctx, schema, file, dbPassword, fsys)
+				return diff.Run(ctx, schema, file, dbConfig, fsys)
 			}
-			return diff.RunMigra(ctx, schema, file, dbPassword, fsys)
+			return diff.RunMigra(ctx, schema, file, dbConfig, fsys)
 		},
 	}
 

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -108,7 +108,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return dump.Run(ctx, file, dbConfig.User, dbConfig.Password, dbConfig.Database, dbConfig.Host, dataOnly, roleOnly, fsys)
+			return dump.Run(ctx, file, dbConfig, dataOnly, roleOnly, fsys)
 		},
 	}
 
@@ -123,7 +123,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return push.Run(ctx, dryRun, dbConfig.User, dbConfig.Password, dbConfig.Database, dbConfig.Host, fsys)
+			return push.Run(ctx, dryRun, dbConfig, fsys)
 		},
 	}
 
@@ -147,7 +147,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return changes.Run(ctx, schema, dbConfig.User, dbConfig.Password, dbConfig.Database, dbConfig.Host, fsys)
+			return changes.Run(ctx, schema, dbConfig, fsys)
 		},
 	}
 
@@ -157,7 +157,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return commit.Run(ctx, schema, dbConfig.User, dbConfig.Password, dbConfig.Database, dbConfig.Host, fsys)
+			return commit.Run(ctx, schema, dbConfig, fsys)
 		},
 	}
 

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -74,8 +72,6 @@ var (
 			return switch_.Run(ctx, args[0], afero.NewOsFs())
 		},
 	}
-
-	dbConfig pgconn.Config
 
 	useMigra   bool
 	usePgAdmin bool
@@ -263,22 +259,4 @@ func init() {
 	// Build test command
 	dbCmd.AddCommand(dbTestCmd)
 	rootCmd.AddCommand(dbCmd)
-}
-
-func parseDatabaseConfig(fsys afero.Fs) error {
-	if len(dbUrl) > 0 {
-		conn, err := pgx.ParseConfig(dbUrl)
-		if err == nil {
-			dbConfig = conn.Config
-		}
-		return err
-	}
-	if err := loadLinkedProject(fsys); err != nil {
-		return err
-	}
-	dbConfig.Host = utils.GetSupabaseDbHost(projectRef)
-	dbConfig.User = "postgres"
-	dbConfig.Password = dbPassword
-	dbConfig.Database = "postgres"
-	return nil
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -11,10 +11,6 @@ import (
 )
 
 var (
-	// TODO: allow switching roles on backend
-	database = "postgres"
-	username = "postgres"
-
 	linkCmd = &cobra.Command{
 		GroupID: groupLocalDev,
 		Use:     "link",
@@ -29,7 +25,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return link.Run(ctx, projectRef, username, dbPassword, database, fsys)
+			return link.Run(ctx, projectRef, dbPassword, fsys)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return link.PostRun(projectRef, os.Stdout, afero.NewOsFs())

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -70,6 +70,7 @@ var (
 )
 
 func init() {
+	migrationCmd.PersistentFlags().StringVar(&dbUrl, "db-url", "", "connect using the specified database url")
 	// Build list command
 	listFlags := migrationListCmd.Flags()
 	listFlags.StringVarP(&dbPassword, "password", "p", "", "Password to your remote Postgres database.")

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/utils"
@@ -29,7 +30,7 @@ func SaveDiff(out, file string, fsys afero.Fs) error {
 	return nil
 }
 
-func Run(ctx context.Context, schema []string, file, password string, fsys afero.Fs) error {
+func Run(ctx context.Context, schema []string, file string, config pgconn.Config, fsys afero.Fs) error {
 	// Sanity checks.
 	{
 		if err := utils.LoadConfigFS(fsys); err != nil {
@@ -41,7 +42,7 @@ func Run(ctx context.Context, schema []string, file, password string, fsys afero
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
-		return run(p, ctx, schema, fsys)
+		return run(p, ctx, schema, config, fsys)
 	}); err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func Run(ctx context.Context, schema []string, file, password string, fsys afero
 
 var output string
 
-func run(p utils.Program, ctx context.Context, schema []string, fsys afero.Fs) error {
+func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Config, fsys afero.Fs) error {
 	p.Send(utils.StatusMsg("Creating shadow database..."))
 
 	// 1. Create shadow db and run migrations
@@ -68,7 +69,14 @@ func run(p utils.Program, ctx context.Context, schema []string, fsys afero.Fs) e
 
 	// 2. Diff local db (source) with shadow db (target), print it.
 	source := "postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres"
-	target := "postgresql://postgres:postgres@" + shadow[:12] + ":5432/postgres"
+	if len(config.Password) == 0 {
+		config.Host = shadow[:12]
+		config.Port = 5432
+		config.User = "postgres"
+		config.Password = "postgres"
+		config.Database = "postgres"
+	}
+	target := utils.ToPostgresURL(config)
 	output, err = DiffSchema(ctx, source, target, schema, p)
 	return err
 }

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -396,7 +397,13 @@ func TestUserSchema(t *testing.T) {
 		Reply("SELECT 1", []interface{}{"test"})
 	// Connect to mock
 	ctx := context.Background()
-	mock, err := utils.ConnectRemotePostgres(ctx, "admin", "pass", "postgres", "localhost", conn.Intercept)
+	mock, err := utils.ConnectRemotePostgres(ctx, pgconn.Config{
+		Host:     "localhost",
+		Port:     5432,
+		User:     "admin",
+		Password: "pass",
+		Database: "postgres",
+	}, conn.Intercept)
 	require.NoError(t, err)
 	defer mock.Close(ctx)
 	// Run test

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -20,11 +20,11 @@ var (
 	errConflict = errors.New("supabase_migrations.schema_migrations table conflicts with the contents of " + utils.Bold(utils.MigrationsDir) + ".")
 )
 
-func Run(ctx context.Context, dryRun bool, username, password, database, host string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, dryRun bool, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	if dryRun {
 		fmt.Fprintln(os.Stderr, "DRY RUN: migrations will *not* be pushed to the database.")
 	}
-	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host, options...)
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return err
 	}

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -12,7 +12,7 @@ import (
 
 var output string
 
-func Run(ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
+func Run(ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) error {
 	// Sanity checks.
 	{
 		if err := utils.AssertDockerIsRunning(ctx); err != nil {
@@ -24,7 +24,7 @@ func Run(ctx context.Context, schema []string, username, password, database stri
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
-		return run(p, ctx, schema, username, password, database, fsys)
+		return run(p, ctx, schema, username, password, database, host, fsys)
 	}); err != nil {
 		return err
 	}
@@ -32,13 +32,7 @@ func Run(ctx context.Context, schema []string, username, password, database stri
 	return diff.SaveDiff(output, "", fsys)
 }
 
-func run(p utils.Program, ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
-	projectRef, err := utils.LoadProjectRef(fsys)
-	if err != nil {
-		return err
-	}
-	host := utils.GetSupabaseDbHost(projectRef)
-
+func run(p utils.Program, ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) (err error) {
 	// 1. Assert `supabase/migrations` and `schema_migrations` are in sync.
 	{
 		p.Send(utils.StatusMsg("Connecting to remote database..."))

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -50,7 +50,6 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 
 	w := utils.StatusWriter{Program: p}
 	// 2. Diff remote db (source) & shadow db (target) and print it.
-	target := utils.ToPostgresURL(config)
-	output, err = diff.DiffDatabase(ctx, schema, target, w, fsys)
+	output, err = diff.DiffDatabase(ctx, schema, config, w, fsys)
 	return err
 }

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -17,7 +17,7 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
+func Run(ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) error {
 	// Sanity checks.
 	{
 		if err := utils.AssertDockerIsRunning(ctx); err != nil {
@@ -29,7 +29,7 @@ func Run(ctx context.Context, schema []string, username, password, database stri
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
-		return run(p, ctx, schema, username, password, database, fsys)
+		return run(p, ctx, schema, username, password, database, host, fsys)
 	}); err != nil {
 		return err
 	}
@@ -38,13 +38,7 @@ func Run(ctx context.Context, schema []string, username, password, database stri
 	return nil
 }
 
-func run(p utils.Program, ctx context.Context, schema []string, username, password, database string, fsys afero.Fs) error {
-	projectRef, err := utils.LoadProjectRef(fsys)
-	if err != nil {
-		return err
-	}
-	host := utils.GetSupabaseDbHost(projectRef)
-
+func run(p utils.Program, ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) error {
 	// 1. Assert `supabase/migrations` and `schema_migrations` are in sync.
 	p.Send(utils.StatusMsg("Connecting to remote database..."))
 	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host)

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -5,9 +5,9 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"net/url"
 	"path/filepath"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/diff"
@@ -17,7 +17,7 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) error {
+func Run(ctx context.Context, schema []string, config pgconn.Config, fsys afero.Fs) error {
 	// Sanity checks.
 	{
 		if err := utils.AssertDockerIsRunning(ctx); err != nil {
@@ -29,7 +29,7 @@ func Run(ctx context.Context, schema []string, username, password, database, hos
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
-		return run(p, ctx, schema, username, password, database, host, fsys)
+		return run(p, ctx, schema, config, fsys)
 	}); err != nil {
 		return err
 	}
@@ -38,10 +38,10 @@ func Run(ctx context.Context, schema []string, username, password, database, hos
 	return nil
 }
 
-func run(p utils.Program, ctx context.Context, schema []string, username, password, database, host string, fsys afero.Fs) error {
+func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Config, fsys afero.Fs) error {
 	// 1. Assert `supabase/migrations` and `schema_migrations` are in sync.
 	p.Send(utils.StatusMsg("Connecting to remote database..."))
-	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host)
+	conn, err := utils.ConnectRemotePostgres(ctx, config)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func run(p utils.Program, ctx context.Context, schema []string, username, passwo
 		}
 	}
 	timestamp := utils.GetCurrentTimestamp()
-	if err := fetchRemote(p, ctx, schema, timestamp, username, password, database, host, fsys); err != nil {
+	if err := fetchRemote(p, ctx, schema, timestamp, config, fsys); err != nil {
 		return err
 	}
 
@@ -67,19 +67,19 @@ func run(p utils.Program, ctx context.Context, schema []string, username, passwo
 	return err
 }
 
-func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestamp, username, password, database, host string, fsys afero.Fs) error {
+func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestamp string, config pgconn.Config, fsys afero.Fs) error {
 	path := filepath.Join(utils.MigrationsDir, timestamp+"_remote_commit.sql")
 	// Special case if this is the first migration
 	if migrations, err := list.LoadLocalMigrations(fsys); err != nil {
 		return err
 	} else if len(migrations) == 0 {
 		p.Send(utils.StatusMsg("Committing initial migration on remote database..."))
-		return dump.Run(ctx, path, username, password, database, host, false, false, fsys)
+		return dump.Run(ctx, path, config, false, false, fsys)
 	}
 
 	w := utils.StatusWriter{Program: p}
 	// Diff remote db (source) & shadow db (target) and write it as a new migration.
-	target := fmt.Sprintf("postgresql://%s@%s:6543/postgres", url.UserPassword(database, password), host)
+	target := utils.ToPostgresURL(config)
 	output, err := diff.DiffDatabase(ctx, schema, target, w, fsys)
 	if err != nil {
 		return err

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -79,8 +79,7 @@ func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestam
 
 	w := utils.StatusWriter{Program: p}
 	// Diff remote db (source) & shadow db (target) and write it as a new migration.
-	target := utils.ToPostgresURL(config)
-	output, err := diff.DiffDatabase(ctx, schema, target, w, fsys)
+	output, err := diff.DiffDatabase(ctx, schema, config, w, fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -120,7 +120,13 @@ func sliceEqual(a, b []string) bool {
 }
 
 func linkDatabase(ctx context.Context, username, password, database, host string, options ...func(*pgx.ConnConfig)) error {
-	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host, options...)
+	conn, err := utils.ConnectRemotePostgres(ctx, pgconn.Config{
+		Host:     host,
+		Port:     6543,
+		User:     username,
+		Password: password,
+		Database: database,
+	}, options...)
 	if err != nil {
 		return err
 	}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -31,7 +31,7 @@ func PreRun(projectRef string, fsys afero.Fs) error {
 	return utils.LoadConfigFS(fsys)
 }
 
-func Run(ctx context.Context, projectRef, username, password, database string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, projectRef, password string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	// 1. Check postgrest config
 	if err := linkPostgrest(ctx, projectRef); err != nil {
 		return err
@@ -39,8 +39,13 @@ func Run(ctx context.Context, projectRef, username, password, database string, f
 
 	// 2. Check database connection
 	if len(password) > 0 {
-		host := utils.GetSupabaseDbHost(projectRef)
-		if err := linkDatabase(ctx, username, password, database, host, options...); err != nil {
+		if err := linkDatabase(ctx, pgconn.Config{
+			Host:     utils.GetSupabaseDbHost(projectRef),
+			Port:     6543,
+			User:     "postgres",
+			Password: password,
+			Database: "postgres",
+		}, options...); err != nil {
 			return err
 		}
 		// Save database password
@@ -119,14 +124,8 @@ func sliceEqual(a, b []string) bool {
 	return true
 }
 
-func linkDatabase(ctx context.Context, username, password, database, host string, options ...func(*pgx.ConnConfig)) error {
-	conn, err := utils.ConnectRemotePostgres(ctx, pgconn.Config{
-		Host:     host,
-		Port:     6543,
-		User:     username,
-		Password: password,
-		Database: database,
-	}, options...)
+func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return err
 	}

--- a/internal/migration/list/list.go
+++ b/internal/migration/list/list.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -19,8 +20,8 @@ const LIST_MIGRATION_VERSION = "SELECT version FROM supabase_migrations.schema_m
 
 var initSchemaPattern = regexp.MustCompile(`([0-9]{14})_init\.sql`)
 
-func Run(ctx context.Context, username, password, database, host string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
-	remoteVersions, err := loadRemoteVersions(ctx, username, password, database, host, options...)
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	remoteVersions, err := loadRemoteVersions(ctx, config, options...)
 	if err != nil {
 		return err
 	}
@@ -31,8 +32,8 @@ func Run(ctx context.Context, username, password, database, host string, fsys af
 	return RenderTable(remoteVersions, localVersions)
 }
 
-func loadRemoteVersions(ctx context.Context, username, password, database, host string, options ...func(*pgx.ConnConfig)) ([]string, error) {
-	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host, options...)
+func loadRemoteVersions(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) ([]string, error) {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -21,7 +21,6 @@ const (
 	CREATE_VERSION_TABLE     = "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text NOT NULL PRIMARY KEY)"
 	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version) VALUES($1)"
 	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = $1"
-	CREATE_MIGRATION_TABLE   = CREATE_VERSION_SCHEMA + ";" + CREATE_VERSION_TABLE
 )
 
 func Run(ctx context.Context, config pgconn.Config, version, status string, options ...func(*pgx.ConnConfig)) error {
@@ -46,6 +45,14 @@ func Run(ctx context.Context, config pgconn.Config, version, status string, opti
 	}
 	fmt.Fprintln(os.Stderr, "Repaired migration history:", version, "=>", status)
 	return nil
+}
+
+func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
+	batch := pgconn.Batch{}
+	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
+	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
+	_, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll()
+	return err
 }
 
 func InsertVersionSQL(batch *pgconn.Batch, version string) {

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -24,8 +24,8 @@ const (
 	CREATE_MIGRATION_TABLE   = CREATE_VERSION_SCHEMA + ";" + CREATE_VERSION_TABLE
 )
 
-func Run(ctx context.Context, username, password, database, host, version, status string, options ...func(*pgx.ConnConfig)) error {
-	conn, err := utils.ConnectRemotePostgres(ctx, username, password, database, host, options...)
+func Run(ctx context.Context, config pgconn.Config, version, status string, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return err
 	}

--- a/internal/migration/repair/repair_test.go
+++ b/internal/migration/repair/repair_test.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/supabase/cli/internal/testing/pgtest"
 )
 
-const (
-	user     = "admin"
-	pass     = "password"
-	database = "postgres"
-	host     = "localhost"
-)
+var dbConfig = pgconn.Config{
+	Host:     "localhost",
+	Port:     5432,
+	User:     "admin",
+	Password: "password",
+	Database: "postgres",
+}
 
 func TestRepairCommand(t *testing.T) {
 	t.Run("applies new version", func(t *testing.T) {
@@ -28,7 +30,7 @@ func TestRepairCommand(t *testing.T) {
 			Query(INSERT_MIGRATION_VERSION, "0").
 			Reply("INSERT 0 1")
 		// Run test
-		err := Run(context.Background(), user, pass, database, host, "0", Applied, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Applied, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -44,16 +46,16 @@ func TestRepairCommand(t *testing.T) {
 			Query(DELETE_MIGRATION_VERSION, "0").
 			Reply("DELETE 1")
 		// Run test
-		err := Run(context.Background(), user, pass, database, host, "0", Reverted, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Reverted, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
 
 	t.Run("throws error on connect failure", func(t *testing.T) {
 		// Run test
-		err := Run(context.Background(), user, pass, database, "0", "0", Applied)
+		err := Run(context.Background(), pgconn.Config{}, "0", Applied)
 		// Check error
-		assert.ErrorContains(t, err, "connect: connection refused")
+		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
 	t.Run("throws error on insert failure", func(t *testing.T) {
@@ -67,7 +69,7 @@ func TestRepairCommand(t *testing.T) {
 			Query(INSERT_MIGRATION_VERSION, "0").
 			ReplyError(pgerrcode.DuplicateObject, `relation "supabase_migrations.schema_migrations" does not exist`)
 		// Run test
-		err := Run(context.Background(), user, pass, database, host, "0", Applied, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Applied, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42710)`)
 	})

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -103,7 +103,7 @@ var (
 
 	AccessTokenPattern = regexp.MustCompile(`^sbp_[a-f0-9]{40}$`)
 	ProjectRefPattern  = regexp.MustCompile(`^[a-z]{20}$`)
-	PostgresUrlPattern = regexp.MustCompile(`^postgres(?:ql)?:\/\/postgres:(.*)@(.+)\/postgres$`)
+	ProjectHostPattern = regexp.MustCompile(`^(db\.)[a-z]{20}\.supabase\.(co|red)$`)
 	MigrateFilePattern = regexp.MustCompile(`^([0-9]+)_.*\.sql$`)
 	BranchNamePattern  = regexp.MustCompile(`[[:word:]-]+`)
 	FuncSlugPattern    = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

closes https://github.com/supabase/cli/issues/753

## What is the new behavior?

support migrations for self-hosted database via `--db-url` flag, including
- [x] `supabase migration list [--db-url]`
- [x] `supabase migration repair [--db-url]`
- [x] `supabase db dump [--db-url]`
- [x] `supabase db push [--db-url]`
- [x] `supabase db remote commit [--db-url]`
- [x] `supabase db diff [--linked | --db-url]`

## Additional context

Add any other context or screenshots.
