### PR TITLE
fix: flag validation order when linking project

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -19,15 +19,15 @@ var (
 		GroupID: groupLocalDev,
 		Use:     "link",
 		Short:   "Link to a Supabase project",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := link.PreRun(projectRef, fsys); err != nil {
+				return err
+			}
 			dbPassword = viper.GetString("DB_PASSWORD")
 			if dbPassword == "" {
 				dbPassword = link.PromptPassword(os.Stdin)
 			}
-			return link.PreRun(projectRef, afero.NewOsFs())
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fsys := afero.NewOsFs()
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return link.Run(ctx, projectRef, username, dbPassword, database, fsys)
 		},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/878

## What is the current behavior?

Required arg validation is processed after PreRun callback, causing confusing errors.

## What is the new behavior?

Move project ref validation to RunE

```bash
$ supabase link
Error: required flag(s) "project-ref" not set
Try rerunning the command with --debug to troubleshoot the error.
exit status 1

$ supabase link --project-ref invalid
Error: Invalid project ref format. Must be like `abcdefghijklmnopqrst`.
exit status 1
```

database password is only prompted after ref validation

## Additional context

Add any other context or screenshots.
