### PR TITLE
chore: update docs for excluding multiple container images from start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,8 +25,8 @@ var (
 
 func init() {
 	flags := startCmd.Flags()
-	names := strings.Join(allowedContainers, ", ")
-	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. Multiple excludes should be comma seperated, without spaces, such as `-x studio,imgproxy`. ["+names+"]")
+	names := strings.Join(allowedContainers, ",")
+	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. ["+names+"]")
 	flags.BoolVar(&ignoreHealthCheck, "ignore-health-check", false, "Ignore unhealthy services and exit 0")
 	rootCmd.AddCommand(startCmd)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -26,7 +26,7 @@ var (
 func init() {
 	flags := startCmd.Flags()
 	names := strings.Join(allowedContainers, ", ")
-	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. ["+names+"]")
+	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. Multiple excludes should be comma seperated, without spaces, such as `-x studio,imgproxy`. ["+names+"]")
 	flags.BoolVar(&ignoreHealthCheck, "ignore-health-check", false, "Ignore unhealthy services and exit 0")
 	rootCmd.AddCommand(startCmd)
 }

--- a/docs/supabase/start.md
+++ b/docs/supabase/start.md
@@ -4,7 +4,7 @@ Starts the Supabase local development stack.
 
 Requires `supabase/config.toml` to be created in your current working directory by running `supabase init`.
 
-All service containers are started by default. You can exclude those not needed by passing in `-x` flag.
+All service containers are started by default. You can exclude those not needed by passing in `-x` flag. To pass multiple containers to be excluded, pass a comma seperated string without spaces, such as: `-x gotrue,imgproxy`.
 
 > It is recommended to have at least 7GB of RAM to start all services.
 

--- a/docs/supabase/start.md
+++ b/docs/supabase/start.md
@@ -4,7 +4,7 @@ Starts the Supabase local development stack.
 
 Requires `supabase/config.toml` to be created in your current working directory by running `supabase init`.
 
-All service containers are started by default. You can exclude those not needed by passing in `-x` flag. To pass multiple containers to be excluded, pass a comma seperated string without spaces, such as: `-x gotrue,imgproxy`.
+All service containers are started by default. You can exclude those not needed by passing in `-x` flag. To exclude multiple containers, either pass in a comma separated string, such as `-x gotrue,imgproxy`, or specify `-x` flag multiple times.
 
 > It is recommended to have at least 7GB of RAM to start all services.
 

--- a/docs/templates/examples.yaml
+++ b/docs/templates/examples.yaml
@@ -37,10 +37,11 @@ supabase-start:
       Seeding data supabase/seed.sql...
       Started supabase local development setup.
   - id: without-studio
-    name: Start containers without studio
-    code: supabase start -x studio
+    name: Start containers without studio and without imgproxy
+    code: supabase start -x studio,imgproxy
     response: |
       Excluding container: supabase/studio:20221214-4eecc99
+      Excluding container: darthsim/imgproxy:v3.8.0
       Seeding data supabase/seed.sql...
       Started supabase local development setup.
   - id: ignore-health-check

--- a/docs/templates/examples.yaml
+++ b/docs/templates/examples.yaml
@@ -37,7 +37,7 @@ supabase-start:
       Seeding data supabase/seed.sql...
       Started supabase local development setup.
   - id: without-studio
-    name: Start containers without studio and without imgproxy
+    name: Start containers without studio and imgproxy
     code: supabase start -x studio,imgproxy
     response: |
       Excluding container: supabase/studio:20221214-4eecc99


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation change to better describe the comma seperated string for excluding multiple containers from starting.

...docs update, ...

## What is the current behavior?

Docs for start --exclude describe it as able to exclude multiple containers but only describe excluding one and the syntax is non-obvious.

Please link any relevant issues here.

## What is the new behavior?

More documentation is present across manual and docs.

## Additional context


