### PR TITLE
fix: db tests path in windows container

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
@@ -46,7 +47,8 @@ func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
 	}
 
 	// Passing in script string means command line args must be set manually, ie. "$@"
-	args := "set -- " + dstPath + "/" + utils.DbTestsDir + ";"
+	testsPath := path.Join(dstPath, filepath.Dir(utils.DbTestsDir), filepath.Base(utils.DbTestsDir))
+	args := "set -- " + testsPath + ";"
 	// Requires unix path inside container
 	cmd := []string{"/bin/bash", "-c", args + testScript}
 	out, err := utils.DockerExecOnce(ctx, utils.DbId, nil, cmd)

--- a/internal/utils/connect.go
+++ b/internal/utils/connect.go
@@ -52,7 +52,10 @@ func ConnectRemotePostgres(ctx context.Context, config pgconn.Config, options ..
 	})
 	// Use port 6543 for connection pooling
 	conn, err := ConnectByUrl(ctx, ToPostgresURL(config), opts...)
-	if !pgconn.Timeout(err) && !isDialError(err) && !ProjectHostPattern.MatchString(config.Host) {
+	if !pgconn.Timeout(err) && !isDialError(err) {
+		return conn, err
+	}
+	if !ProjectHostPattern.MatchString(config.Host) || config.Port != 6543 {
 		return conn, err
 	}
 	// Fallback to 5432 when pgbouncer is unavailable

--- a/internal/utils/connect_test.go
+++ b/internal/utils/connect_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 var dbConfig = pgconn.Config{
-	Host:     "localhost",
-	Port:     5432,
+	Host:     GetSupabaseDbHost(apitest.RandomProjectRef()),
+	Port:     6543,
 	User:     "admin",
 	Password: "password",
 	Database: "postgres",
@@ -49,12 +49,11 @@ func TestConnectRemotePostgres(t *testing.T) {
 
 	t.Run("fallback to postgres port on timeout", func(t *testing.T) {
 		DNSResolver.Value = DNS_OVER_HTTPS
-		const host = "localhost"
 		// Setup http mock
 		defer gock.OffAll()
 		gock.New("https://1.1.1.1").
 			Get("/dns-query").
-			MatchParam("name", host).
+			MatchParam("name", dbConfig.Host).
 			MatchHeader("accept", "application/dns-json").
 			Reply(http.StatusOK).
 			JSON(&dnsResponse{Answer: []dnsAnswer{
@@ -62,7 +61,7 @@ func TestConnectRemotePostgres(t *testing.T) {
 			}})
 		gock.New("https://1.1.1.1").
 			Get("/dns-query").
-			MatchParam("name", host).
+			MatchParam("name", dbConfig.Host).
 			MatchHeader("accept", "application/dns-json").
 			Reply(http.StatusOK).
 			JSON(&dnsResponse{Answer: []dnsAnswer{
@@ -71,7 +70,7 @@ func TestConnectRemotePostgres(t *testing.T) {
 		// pgx makes 2 calls to resolve ip for each connect request
 		gock.New("https://1.1.1.1").
 			Get("/dns-query").
-			MatchParam("name", host).
+			MatchParam("name", dbConfig.Host).
 			MatchHeader("accept", "application/dns-json").
 			Reply(http.StatusOK).
 			JSON(&dnsResponse{Answer: []dnsAnswer{
@@ -79,7 +78,7 @@ func TestConnectRemotePostgres(t *testing.T) {
 			}})
 		gock.New("https://1.1.1.1").
 			Get("/dns-query").
-			MatchParam("name", host).
+			MatchParam("name", dbConfig.Host).
 			MatchHeader("accept", "application/dns-json").
 			Reply(http.StatusOK).
 			JSON(&dnsResponse{Answer: []dnsAnswer{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/843

## What is the current behavior?

`filepath.Join` returns back slash on windows

## What is the new behavior?

Always construct path using forward slash inside container.

## Additional context

Add any other context or screenshots.
