### PR TITLE
fix: use db container url for functions serve

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -184,7 +183,7 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 			"SUPABASE_URL=http://" + utils.KongId + ":8000",
 			"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
 			"SUPABASE_SERVICE_ROLE_KEY=" + utils.Config.Auth.ServiceRoleKey,
-			"SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:" + strconv.FormatUint(uint64(utils.Config.Db.Port), 10) + "/postgres",
+			"SUPABASE_DB_URL=postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres",
 		}
 
 		denoRunCmd := []string{"deno", "run", "--no-check=remote", "--allow-all", "--watch", "--no-clear-screen", "--no-npm"}
@@ -268,7 +267,7 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 			"SUPABASE_URL=http://" + utils.KongId + ":8000",
 			"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
 			"SUPABASE_SERVICE_ROLE_KEY=" + utils.Config.Auth.ServiceRoleKey,
-			"SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:" + strconv.FormatUint(uint64(utils.Config.Db.Port), 10) + "/postgres",
+			"SUPABASE_DB_URL=postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres",
 		}
 		verifyJWTEnv := "VERIFY_JWT=true"
 		if noVerifyJWT != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/944

## What is the new behavior?

`SUPABASE_URL` already points to an internal ip via kong_id, make db_url consistent by using db_id.

## Additional context

Add any other context or screenshots.
