### PR TITLE
fix: host network identification on windows

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -262,7 +262,7 @@ func DockerStart(ctx context.Context, config container.Config, hostConfig contai
 		hostConfig.NetworkMode = container.NetworkMode(NetId)
 	}
 	// Create network with name
-	if hostConfig.NetworkMode.IsUserDefined() {
+	if hostConfig.NetworkMode.IsUserDefined() && hostConfig.NetworkMode.UserDefined() != "host" {
 		if err := DockerNetworkCreateIfNotExists(ctx, hostConfig.NetworkMode.NetworkName()); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #928 

## What is the new behavior?

Docker's [IsUserDefined](https://github.com/moby/moby/blob/master/api/types/container/hostconfig_windows.go#L16) is implemented differently on windows. Unify it with unix.

## Additional context

tested in win10 bootcamp
