### PR TITLE
fix: update to edge-runtime 1.1.7

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	StudioImage      = "supabase/studio:20230216-e731b77"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.1.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.1.7"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.51.4"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps edge-runtime to 1.1.7 (contains couple of minor fixes, no changes to public API)