### PR TITLE
feat: add sso info cmd

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -72,7 +72,7 @@ var (
 			if err := PromptLogin(fsys); err != nil {
 				return err
 			}
-			if err := PromptProjectRef(fsys); err != nil {
+			if err := PromptProjectRef(fsys, cmd); err != nil {
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
@@ -145,7 +145,9 @@ func PromptLogin(fsys afero.Fs) error {
 	}
 }
 
-func PromptProjectRef(fsys afero.Fs) error {
+// PromptProjectRef prompts for the project ref if there is no project ref provided
+// or if there is no linked project
+func PromptProjectRef(fsys afero.Fs, cmd *cobra.Command) error {
 	if len(projectRef) > 0 {
 		return nil
 	} else if err := utils.AssertIsLinkedFS(fsys); err == nil {
@@ -156,7 +158,7 @@ Enter your project ref: `, utils.GetSupabaseDashboardURL())
 
 		scanner := bufio.NewScanner(os.Stdin)
 		if !scanner.Scan() {
-			return errors.New("Cancelled " + utils.Aqua("supabase functions deploy") + ".")
+			return errors.New("Cancelled " + utils.Aqua(cmd.UseLine()) + ".")
 		}
 
 		projectRef = strings.TrimSpace(scanner.Text())

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -29,7 +29,8 @@ var (
 		Use:     "sso",
 		Short:   "Manage Single Sign-On (SSO) authentication for projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			signal.NotifyContext(cmd.Context(), os.Interrupt)
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			cmd.SetContext(ctx)
 
 			fsys := afero.NewOsFs()
 			if err := PromptProjectRef(fsys, cmd); err != nil {

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -29,6 +29,9 @@ var (
 		Use:     "sso",
 		Short:   "Manage Single Sign-On (SSO) authentication for projects",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.Root().PersistentPreRunE(cmd, args); err != nil {
+				return err
+			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			cmd.SetContext(ctx)
 

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/supabase/cli/internal/sso/create"
 	"github.com/supabase/cli/internal/sso/get"
+	"github.com/supabase/cli/internal/sso/info"
 	"github.com/supabase/cli/internal/sso/list"
 	"github.com/supabase/cli/internal/sso/remove"
 	"github.com/supabase/cli/internal/sso/update"
@@ -169,6 +170,18 @@ var (
 			return list.Run(cmd.Context(), ssoProjectRef, ssoOutput.Value)
 		},
 	}
+
+	ssoInfoCmd = &cobra.Command{
+		Use:     "info",
+		Short:   "Returns the SAML SSO settings required for the identity provider",
+		Example: `  supabase sso info --project-ref b5ae62f9-ef1d-4f11-a02b-731c8bbb11e8`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			cobra.CheckErr(cmd.MarkFlagRequired("project-ref"))
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return info.Run(cmd.Context(), ssoProjectRef, ssoOutput.Value)
+		},
+	}
 )
 
 func init() {
@@ -211,11 +224,16 @@ func init() {
 	ssoListFlags.VarP(&ssoOutput, "output", "o", "Output format")
 	ssoListFlags.StringVar(&ssoProjectRef, "project-ref", "", "Project on which to list identity providers.")
 
+	ssoInfoFlags := ssoInfoCmd.Flags()
+	ssoInfoFlags.VarP(&ssoOutput, "output", "o", "Output format")
+	ssoInfoFlags.StringVar(&ssoProjectRef, "project-ref", "", "Project on which to show project SAML SSO settings.")
+
 	ssoCmd.AddCommand(ssoAddCmd)
 	ssoCmd.AddCommand(ssoRemoveCmd)
 	ssoCmd.AddCommand(ssoUpdateCmd)
 	ssoCmd.AddCommand(ssoShowCmd)
 	ssoCmd.AddCommand(ssoListCmd)
+	ssoCmd.AddCommand(ssoInfoCmd)
 
 	rootCmd.AddCommand(ssoCmd)
 }

--- a/internal/sso/info/info.go
+++ b/internal/sso/info/info.go
@@ -1,0 +1,24 @@
+package info
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/supabase/cli/internal/sso/internal/render"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, ref string, format string) error {
+	switch format {
+	case utils.OutputPretty:
+		return render.InfoMarkdown(ref)
+
+	default:
+		return utils.EncodeOutput(format, os.Stdout, map[string]interface{}{
+			"Single sign-on URL (ACS URL)": fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/acs", ref),
+			"Audience URI (SP Entity ID)":  fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/metadata", ref),
+			"Default Relaystate":           fmt.Sprintf("https://%s.supabase.co", ref),
+		})
+	}
+}

--- a/internal/sso/info/info.go
+++ b/internal/sso/info/info.go
@@ -16,9 +16,9 @@ func Run(ctx context.Context, ref string, format string) error {
 
 	default:
 		return utils.EncodeOutput(format, os.Stdout, map[string]interface{}{
-			"Single sign-on URL (ACS URL)": fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/acs", ref),
-			"Audience URI (SP Entity ID)":  fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/metadata", ref),
-			"Default Relaystate":           fmt.Sprintf("https://%s.supabase.co", ref),
+			"acs_url":    fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/acs", ref),
+			"entity_id":  fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/metadata", ref),
+			"relaystate": fmt.Sprintf("https://%s.supabase.co", ref),
 		})
 	}
 }

--- a/internal/sso/internal/render/render.go
+++ b/internal/sso/internal/render/render.go
@@ -168,3 +168,41 @@ func SingleMarkdown(provider api.Provider) error {
 	fmt.Print(out)
 	return nil
 }
+
+func InfoMarkdown(ref string) error {
+	markdownTable := []string{
+		"|PROPERTY|VALUE|",
+		"|-|-|",
+	}
+
+	markdownTable = append(markdownTable, fmt.Sprintf(
+		"|Single sign-on URL (ACS URL) |`%s`|",
+		fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/acs", ref),
+	))
+
+	markdownTable = append(markdownTable, fmt.Sprintf(
+		"|Audience URI (SP Entity ID)|`%s`|",
+		fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/metadata", ref),
+	))
+
+	markdownTable = append(markdownTable, fmt.Sprintf(
+		"|Default Relaystate|`%s`|",
+		fmt.Sprintf("https://%s.supabase.co", ref),
+	))
+
+	r, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(-1),
+	)
+	if err != nil {
+		return err
+	}
+
+	out, err := r.Render(strings.Join(markdownTable, "\n"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(out)
+	return nil
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the info cmd which returns the service provider (gotrue) SAML settings to be added to the identity provider 

## Example

* `supabase sso info --project-ref <project_ref>`

```
            PROPERTY             │                               VALUE
  ───────────────────────────────┼─────────────────────────────────────────────────────────────────────
    Single sign-on URL (ACS URL) │ https://projectref.supabase.co/auth/v1/sso/saml/acs
    Audience URI (SP Entity ID)  │ https://projectref.supabase.co/auth/v1/sso/saml/metadata
    Default Relaystate           │ https://projectref.supabase.co

```