### PR TITLE
fix: Provide a better error message for non-existing function

### DIFF
--- a/internal/utils/denos/build.ts
+++ b/internal/utils/denos/build.ts
@@ -9,6 +9,13 @@ const virtualBasePath = "file:///src/";
 
 async function buildAndWrite(p: string, importMapPath: string) {
   const funcDirPath = path.dirname(p);
+  try {
+    await Deno.lstat(funcDirPath);
+  } catch (e) {
+    console.error(`Error: Cannot access "${funcDirPath}". Check if directory exists or has read permissions.`);
+    Deno.exit(1);
+  }
+
   const entrypoint = new URL("index.ts", virtualBasePath).href;
 
   const eszip = await build([entrypoint], async (specifier: string) => {
@@ -64,3 +71,4 @@ async function buildAndWrite(p: string, importMapPath: string) {
 }
 
 buildAndWrite(Deno.args[0], Deno.args[1]);
+

--- a/internal/utils/denos/build.ts
+++ b/internal/utils/denos/build.ts
@@ -12,7 +12,7 @@ async function buildAndWrite(p: string, importMapPath: string) {
   try {
     await Deno.lstat(funcDirPath);
   } catch (e) {
-    console.error(`Error: Cannot access "${funcDirPath}". Check if directory exists or has read permissions.`);
+    console.error(`Error: Cannot access "${funcDirPath}". Check if directory exists and has read permissions.`);
     Deno.exit(1);
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Show a more descriptive and easy-to-understand error when a user tries to deploy a function that doesn't exist.

## Current behavior

<img width="646" alt="image" src="https://user-images.githubusercontent.com/5358/228395163-a7247b30-4636-43bc-8cf0-9fa5513d6ece.png">

## New behavior

![Screen Shot 2023-03-29 at 11 22 20 am](https://user-images.githubusercontent.com/5358/228395384-a971aa6d-bd00-454f-84b0-989eba7b08d6.png)

## Additional details

Ideally, this should be fixed in the Go code that handles the deploy command. However, we currently do some deduction of paths when a directory doesn't exist (eg: traversing down `supabase/functions`). We can refactor that logic and account for true non-existing functions in a future iteration.