### PR TITLE
fix: make add-domains and remove-domains work

### DIFF
--- a/internal/sso/update/update.go
+++ b/internal/sso/update/update.go
@@ -74,7 +74,7 @@ func Run(ctx context.Context, params RunParams) error {
 		body.AttributeMapping = data
 	}
 
-	if params.Domains != nil {
+	if len(params.Domains) != 0 {
 		body.Domains = &params.Domains
 	} else if params.AddDomains != nil || params.RemoveDomains != nil {
 		domainsSet := make(map[string]bool)

--- a/internal/sso/update/update.go
+++ b/internal/sso/update/update.go
@@ -95,7 +95,7 @@ func Run(ctx context.Context, params RunParams) error {
 			domainsSet[addDomain] = true
 		}
 
-		var domains []string
+		domains := make([]string, 0)
 		for domain := range domainsSet {
 			domains = append(domains, domain)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `--add-domains` wasn't adding the domain because `params.Domains` always defaults to an empty slice and will never by `nil`
* `--remove-domains` wasn't removing the domain because `var domains []string` defaults to nil instead of an empty slice. When the `domainsSet` is empty, `domains` will remain `nil` and thus, no domains will be removed.