### PR TITLE
fix: seed database after all services are up

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -19,6 +19,8 @@ import (
 	"github.com/supabase/cli/internal/utils/parser"
 )
 
+const SET_POSTGRES_ROLE = "SET ROLE postgres;"
+
 var (
 	healthTimeout = 5 * time.Second
 )
@@ -65,6 +67,9 @@ func resetDatabase(ctx context.Context, fsys afero.Fs, options ...func(*pgx.Conn
 	defer conn.Close(context.Background())
 	fmt.Fprintln(os.Stderr, "Initialising schema...")
 	if err := apply.BatchExecDDL(ctx, conn, strings.NewReader(utils.InitialSchemaSql)); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(ctx, SET_POSTGRES_ROLE); err != nil {
 		return err
 	}
 	return InitialiseDatabase(ctx, conn, fsys)

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -78,7 +78,9 @@ func TestResetDatabase(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		conn.Query(utils.InitialSchemaSql).
-			Reply("CREATE SCHEMA")
+			Reply("CREATE SCHEMA").
+			Query(SET_POSTGRES_ROLE).
+			Reply("SET ROLE")
 		// Run test
 		assert.NoError(t, resetDatabase(context.Background(), fsys, conn.Intercept))
 	})
@@ -122,6 +124,8 @@ func TestResetDatabase(t *testing.T) {
 		defer conn.Close(t)
 		conn.Query(utils.InitialSchemaSql).
 			Reply("CREATE SCHEMA").
+			Query(SET_POSTGRES_ROLE).
+			Reply("SET ROLE").
 			Query(sql).
 			ReplyError(pgerrcode.DuplicateObject, `table "example" already exists`)
 		// Run test

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -605,7 +605,12 @@ EOF
 		started = append(started, utils.StudioId)
 	}
 
-	return waitForServiceReady(ctx, started)
+	if err := waitForServiceReady(ctx, started); err != nil {
+		return err
+	}
+
+	// Setup database after all services are up
+	return start.SetupDatabase(ctx, fsys, w, options...)
 }
 
 func isContainerExcluded(imageName string, excluded map[string]bool) bool {

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -145,6 +145,7 @@ func TestDatabaseStart(t *testing.T) {
 		// Start postgres
 		utils.DbId = "test-postgres"
 		utils.Config.Db.Port = 54322
+		utils.Config.Db.MajorVersion = 15
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/volumes/" + utils.DbId).
 			Reply(http.StatusNotFound)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Seeding can only happen after all service migrations have been run.

## Additional context

Add any other context or screenshots.
