### PR TITLE
chore: bump logflare version

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -240,15 +240,9 @@ EOF
 		); err != nil {
 			return err
 		}
-		startTime := time.Now()
-		timeout := 30 * time.Second
-		// TODO: logflare needs more time to initialise after passing health check
-		_ = reset.RetryEverySecond(ctx, func() bool {
-			progress := time.Since(startTime).Seconds() / timeout.Seconds() * 100
-			p.Send(utils.StatusMsg(fmt.Sprintf("Initialising logflare... %d%%", int(progress))))
-			return false
-		}, timeout)
-		started = append(started, utils.LogflareId)
+		if err := waitForServiceReady(ctx, []string{utils.LogflareId}); err != nil {
+			return err
+		}
 	}
 
 	// Start Kong.

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -47,7 +47,7 @@ const (
 	GotrueImage   = "supabase/gotrue:v2.51.4"
 	RealtimeImage = "supabase/realtime:v2.10.1"
 	StorageImage  = "supabase/storage-api:v0.29.1"
-	LogflareImage = "supabase/logflare:1.0.0"
+	LogflareImage = "supabase/logflare:1.0.1"
 	// Should be kept in-sync with DenoRelayImage
 	DenoVersion = "1.30.3"
 )


### PR DESCRIPTION
Bumps logflare version to 1.0.1, which has improved health checks and data seeding flow for supabase mode.