### PR TITLE
feat: serve all functions on supabase start

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -252,7 +252,7 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 
 func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
 	// 1. Load default values
-	if envFilePath != "" {
+	if envFilePath == "" {
 		if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
 			envFilePath = utils.FallbackEnvFilePath
 		}

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -236,9 +236,11 @@ func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, imp
 			return err
 		}
 		if envFilePath != "" {
-			if _, err := fsys.Stat(envFilePath); err != nil {
-				return fmt.Errorf("Failed to read env file: %w", err)
+			if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
+				envFilePath = utils.FallbackEnvFilePath
 			}
+		} else if _, err := fsys.Stat(envFilePath); err != nil {
+			return fmt.Errorf("Failed to read env file: %w", err)
 		}
 		if importMapPath == "" {
 			if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -312,10 +313,10 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 			Env:   append(env, userEnv...),
 			Cmd:   cmd,
 		},
-		container.HostConfig{
+		start.WithSyslogConfig(container.HostConfig{
 			Binds:      binds,
 			ExtraHosts: []string{"host.docker.internal:host-gateway"},
-		},
+		}),
 		utils.DenoRelayId,
 	)
 	return err

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -228,97 +228,95 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 
 func runServeAll(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
 	// 1. Sanity checks.
-	{
-		if err := utils.LoadConfigFS(fsys); err != nil {
-			return err
-		}
-		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
-			return err
-		}
-		if envFilePath != "" {
-			if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
-				envFilePath = utils.FallbackEnvFilePath
-			}
-		} else if _, err := fsys.Stat(envFilePath); err != nil {
-			return fmt.Errorf("Failed to read env file: %w", err)
-		}
-		if importMapPath == "" {
-			if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {
-				importMapPath = utils.FallbackImportMapPath
-			}
-		} else if _, err := fsys.Stat(importMapPath); err != nil {
-			return fmt.Errorf("Failed to read import map: %w", err)
-		}
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
 	}
+	if err := utils.AssertSupabaseDbIsRunning(); err != nil {
+		return err
+	}
+	// 2. Remove existing container.
+	_ = utils.Docker.ContainerRemove(ctx, utils.DenoRelayId, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+		Force:         true,
+	})
+	// 3. Serve and log to console
+	if err := ServeFunctions(ctx, envFilePath, noVerifyJWT, importMapPath, fsys); err != nil {
+		return err
+	}
+	if err := utils.DockerStreamLogs(ctx, utils.DenoRelayId, os.Stdout, os.Stderr); err != nil {
+		return err
+	}
+	fmt.Println("Stopped serving " + utils.Bold(utils.FunctionsDir))
+	return nil
+}
 
+func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
+	// 1. Load default values
+	if envFilePath != "" {
+		if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
+			envFilePath = utils.FallbackEnvFilePath
+		}
+	} else if _, err := fsys.Stat(envFilePath); err != nil {
+		return fmt.Errorf("Failed to read env file: %w", err)
+	}
+	if importMapPath == "" {
+		if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {
+			importMapPath = utils.FallbackImportMapPath
+		}
+	} else if _, err := fsys.Stat(importMapPath); err != nil {
+		return fmt.Errorf("Failed to read import map: %w", err)
+	}
 	// 2. Parse user defined env
 	userEnv, err := ParseEnvFile(envFilePath, fsys)
 	if err != nil {
 		return err
 	}
-
-	// 3. Start container
-	{
-		_ = utils.Docker.ContainerRemove(ctx, utils.DenoRelayId, types.ContainerRemoveOptions{
-			RemoveVolumes: true,
-			Force:         true,
-		})
-
-		env := []string{
-			"JWT_SECRET=" + utils.Config.Auth.JwtSecret,
-			"SUPABASE_URL=http://" + utils.KongId + ":8000",
-			"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
-			"SUPABASE_SERVICE_ROLE_KEY=" + utils.Config.Auth.ServiceRoleKey,
-			"SUPABASE_DB_URL=postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres",
-		}
-		verifyJWTEnv := "VERIFY_JWT=true"
-		if noVerifyJWT != nil {
-			verifyJWTEnv = "VERIFY_JWT=false"
-		}
-		env = append(env, verifyJWTEnv)
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-
-		binds := []string{
-			filepath.Join(cwd, utils.FunctionsDir) + ":" + relayFuncDir + ":rw,z",
-			utils.DenoRelayId + ":/root/.cache/deno:rw,z",
-		}
-		dockerImportMapPath := relayFuncDir + "/import_map.json"
-		if importMapPath != "" {
-			binds = append(binds, filepath.Join(cwd, importMapPath)+":"+dockerImportMapPath+":ro,z")
-		}
-
-		fmt.Println("Serving " + utils.Bold(utils.FunctionsDir))
-
-		cmd := []string{"start", "--dir", relayFuncDir, "-p", "8081"}
-		if importMapPath != "" {
-			cmd = append(cmd, "--import-map", dockerImportMapPath)
-		}
-		if viper.GetBool("DEBUG") {
-			cmd = append(cmd, "--verbose")
-		}
-		if err := utils.DockerRunOnceWithConfig(
-			ctx,
-			container.Config{
-				Image: utils.EdgeRuntimeImage,
-				Env:   append(env, userEnv...),
-				Cmd:   cmd,
-			},
-			container.HostConfig{
-				Binds:      binds,
-				ExtraHosts: []string{"host.docker.internal:host-gateway"},
-			},
-			utils.DenoRelayId,
-			os.Stdout,
-			os.Stderr,
-		); err != nil {
-			return err
-		}
+	env := []string{
+		"JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+		"SUPABASE_URL=http://" + utils.KongId + ":8000",
+		"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
+		"SUPABASE_SERVICE_ROLE_KEY=" + utils.Config.Auth.ServiceRoleKey,
+		"SUPABASE_DB_URL=postgresql://postgres:postgres@" + utils.DbId + ":5432/postgres",
 	}
-
-	fmt.Println("Stopped serving " + utils.Bold(utils.FunctionsDir))
-	return nil
+	verifyJWTEnv := "VERIFY_JWT=true"
+	if noVerifyJWT != nil {
+		verifyJWTEnv = "VERIFY_JWT=false"
+	}
+	env = append(env, verifyJWTEnv)
+	// 3. Parse custom import map
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	binds := []string{
+		filepath.Join(cwd, utils.FunctionsDir) + ":" + relayFuncDir + ":rw,z",
+		utils.DenoRelayId + ":/root/.cache/deno:rw,z",
+	}
+	dockerImportMapPath := relayFuncDir + "/import_map.json"
+	if importMapPath != "" {
+		binds = append(binds, filepath.Join(cwd, importMapPath)+":"+dockerImportMapPath+":ro,z")
+	}
+	// 4. Start container
+	fmt.Println("Serving " + utils.Bold(utils.FunctionsDir))
+	cmd := []string{"start", "--dir", relayFuncDir, "-p", "8081"}
+	if importMapPath != "" {
+		cmd = append(cmd, "--import-map", dockerImportMapPath)
+	}
+	if viper.GetBool("DEBUG") {
+		cmd = append(cmd, "--verbose")
+	}
+	_, err = utils.DockerStart(
+		ctx,
+		container.Config{
+			Image: utils.EdgeRuntimeImage,
+			Env:   append(env, userEnv...),
+			Cmd:   cmd,
+		},
+		container.HostConfig{
+			Binds:      binds,
+			ExtraHosts: []string{"host.docker.internal:host-gateway"},
+		},
+		utils.DenoRelayId,
+	)
+	return err
 }

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -93,14 +93,15 @@ func NewKongConfig() kongConfig {
 }
 
 type vectorConfig struct {
-	ApiKey     string
-	LogflareId string
-	KongId     string
-	GotrueId   string
-	RestId     string
-	RealtimeId string
-	StorageId  string
-	DbId       string
+	ApiKey      string
+	LogflareId  string
+	KongId      string
+	GotrueId    string
+	RestId      string
+	RealtimeId  string
+	StorageId   string
+	DenoRelayId string
+	DbId        string
 }
 
 var (
@@ -138,14 +139,15 @@ func run(p utils.Program, ctx context.Context, fsys afero.Fs, excludedContainers
 	if utils.Config.Analytics.Enabled && !isContainerExcluded(utils.VectorImage, excluded) {
 		var vectorConfigBuf bytes.Buffer
 		if err := vectorConfigTemplate.Execute(&vectorConfigBuf, vectorConfig{
-			ApiKey:     utils.Config.Analytics.ApiKey,
-			LogflareId: utils.LogflareId,
-			KongId:     utils.KongId,
-			GotrueId:   utils.GotrueId,
-			RestId:     utils.RestId,
-			RealtimeId: utils.RealtimeId,
-			StorageId:  utils.StorageId,
-			DbId:       utils.DbId,
+			ApiKey:      utils.Config.Analytics.ApiKey,
+			LogflareId:  utils.LogflareId,
+			KongId:      utils.KongId,
+			GotrueId:    utils.GotrueId,
+			RestId:      utils.RestId,
+			RealtimeId:  utils.RealtimeId,
+			StorageId:   utils.StorageId,
+			DenoRelayId: utils.DenoRelayId,
+			DbId:        utils.DbId,
 		}); err != nil {
 			return err
 		}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/db/start"
+	"github.com/supabase/cli/internal/functions/serve"
 	"github.com/supabase/cli/internal/status"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -534,6 +535,14 @@ EOF
 			return err
 		}
 		started = append(started, utils.ImgProxyId)
+	}
+
+	// Start all functions.
+	if !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
+		if err := serve.ServeFunctions(ctx, "", nil, "", fsys); err != nil {
+			return err
+		}
+		started = append(started, utils.DenoRelayId)
 	}
 
 	// Start pg-meta.

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -172,6 +172,8 @@ func TestDatabaseStart(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.ImageProxyImage), utils.ImgProxyId)
 		utils.DifferId = "test-differ"
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.DifferImage), utils.DifferId)
+		utils.DenoRelayId = "test-edge-runtime"
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.EdgeRuntimeImage), utils.DenoRelayId)
 		utils.PgmetaId = "test-pgmeta"
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.PgmetaImage), utils.PgmetaId)
 		utils.StudioId = "test-studio"
@@ -184,7 +186,8 @@ func TestDatabaseStart(t *testing.T) {
 		// Setup health probes
 		started := []string{
 			utils.DbId, utils.KongId, utils.GotrueId, utils.InbucketId, utils.RealtimeId,
-			utils.StorageId, utils.ImgProxyId, utils.PgmetaId, utils.StudioId, utils.LogflareId,
+			utils.StorageId, utils.ImgProxyId, utils.DenoRelayId, utils.PgmetaId, utils.StudioId,
+			utils.LogflareId,
 		}
 		for _, container := range started {
 			gock.New(utils.Docker.DaemonHost()).

--- a/internal/start/templates/vector.yaml
+++ b/internal/start/templates/vector.yaml
@@ -33,6 +33,7 @@ transforms:
       rest: '.appname == "{{ .RestId }}"'
       realtime: '.appname == "{{ .RealtimeId }}"'
       storage: '.appname == "{{ .StorageId }}"'
+      functions: '.appname == "{{ .DenoRelayId }}"'
       db: '.appname == "{{ .DbId }}"'
   # Kong logs only include api requests
   kong_logs:
@@ -189,6 +190,16 @@ sinks:
     request:
       retry_max_duration_secs: 10
     uri: "http://{{ .LogflareId }}:4000/api/logs?source_name=storage.logs.prod.2&api_key={{ .ApiKey }}"
+  logflare_functions:
+    type: "http"
+    inputs:
+      - router.functions
+    encoding:
+      codec: "json"
+    method: "post"
+    request:
+      retry_max_duration_secs: 10
+    uri: "http://{{ .LogflareId }}:4000/api/logs?source_name=deno-relay-logs&api_key={{ .ApiKey }}"
   logflare_kong:
     type: "http"
     inputs:

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -325,6 +325,10 @@ func DockerRunOnceWithConfig(ctx context.Context, config container.Config, hostC
 		return err
 	}
 	defer DockerRemove(container)
+	return DockerStreamLogs(ctx, container, stdout, stderr)
+}
+
+func DockerStreamLogs(ctx context.Context, container string, stdout, stderr io.Writer) error {
 	// Stream logs
 	logs, err := Docker.ContainerLogs(ctx, container, types.ContainerLogsOptions{
 		ShowStdout: true,

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -64,7 +64,7 @@ var ServiceImages = []string{
 	MigraImage,
 	PgmetaImage,
 	StudioImage,
-	DenoRelayImage,
+	EdgeRuntimeImage,
 	LogflareImage,
 	VectorImage,
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -178,6 +178,7 @@ var (
 	MigrationsDir         = filepath.Join(SupabaseDirPath, "migrations")
 	FunctionsDir          = filepath.Join(SupabaseDirPath, "functions")
 	FallbackImportMapPath = filepath.Join(FunctionsDir, "import_map.json")
+	FallbackEnvFilePath   = filepath.Join(FunctionsDir, ".env")
 	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
 	SeedDataPath          = filepath.Join(SupabaseDirPath, "seed.sql")
 	CustomRolesPath       = filepath.Join(SupabaseDirPath, "roles.sql")


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

serving functions locally require a separate command

## What is the new behavior?

- `supabase start` will also serve all functions locally
- loads env vars from `supabase/functions/.env` by default
- logs are ingested to logflare and viewable at http://localhost:54327/sources/3
- running `supabase functions serve` after `supabase start` will restart edge runtime

## Additional context

<img width="1140" alt="Screenshot 2023-04-06 at 9 55 50 AM" src="https://user-images.githubusercontent.com/1639722/230253565-1a8a8c6c-b9c9-4bf0-8b3f-c1de8761bbfb.png">
