### PR TITLE
fix: Bump up Logflare image

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -47,7 +47,7 @@ const (
 	GotrueImage   = "supabase/gotrue:v2.51.4"
 	RealtimeImage = "supabase/realtime:v2.10.1"
 	StorageImage  = "supabase/storage-api:v0.29.1"
-	LogflareImage = "supabase/logflare:1.0.1"
+	LogflareImage = "supabase/logflare:1.0.2"
 	// Should be kept in-sync with DenoRelayImage
 	DenoVersion = "1.30.3"
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

New Logflare image was released, bumping up from 1.0.1 to 1.0.2