### PR TITLE
fix: use supabase admin role for realtime

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -407,7 +407,7 @@ EOF
 					"PORT=4000",
 					"DB_HOST=" + utils.DbId,
 					"DB_PORT=5432",
-					"DB_USER=postgres",
+					"DB_USER=supabase_admin",
 					"DB_PASSWORD=postgres",
 					"DB_NAME=postgres",
 					"DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/997

## What is the new behavior?

`realtime` schema is owned by `supabase_admin` so migrations have to be run as the same user

## Additional context

Add any other context or screenshots.
