### PR TITLE
fix: update storage api image

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -46,7 +46,7 @@ const (
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.51.4"
 	RealtimeImage = "supabase/realtime:v2.10.1"
-	StorageImage  = "supabase/storage-api:v0.34.0"
+	StorageImage  = "supabase/storage-api:v0.35.1"
 	LogflareImage = "supabase/logflare:1.0.2"
 	// Should be kept in-sync with DenoRelayImage
 	DenoVersion = "1.30.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -46,7 +46,7 @@ const (
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.51.4"
 	RealtimeImage = "supabase/realtime:v2.10.1"
-	StorageImage  = "supabase/storage-api:v0.35.1"
+	StorageImage  = "supabase/storage-api:v0.37.4"
 	LogflareImage = "supabase/logflare:1.0.2"
 	// Should be kept in-sync with DenoRelayImage
 	DenoVersion = "1.30.3"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump storage image version from 0.34.0 to 0.35.1

## What is the current behavior?

I recently ran into this issue https://github.com/supabase/storage-api/issues/255 (can't read a 2+GB file from disk), which is fixed in storage-api version 0.35.0

## What is the new behavior?

I'm curious to try out the new version so I can read large files from disk.