### PR TITLE
upgrade eszip in the build from 0.30.0 to 0.35.0

### DIFF
--- a/internal/utils/denos/build.ts
+++ b/internal/utils/denos/build.ts
@@ -2,7 +2,7 @@ import { encode } from "https://deno.land/std@0.127.0/encoding/base64.ts";
 import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
 import { writeAll } from "https://deno.land/std@0.162.0/streams/conversion.ts";
 import { compress } from "https://deno.land/x/brotli@0.1.7/mod.ts";
-import { build } from "https://deno.land/x/eszip@v0.30.0/mod.ts";
+import { build } from "https://deno.land/x/eszip@v0.35.0/mod.ts";
 
 const virtualBasePath = "file:///src/";
 


### PR DESCRIPTION
eszip at 0.30.0 - 0.34.0 incorrectly handles some npm packages.

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The current version of eszip does not correctly handle some npm packages (example: https://esm.sh/ethers@5.7.2 ). See discord: https://discord.com/channels/839993398554656828/1098545559926739098/1098545559926739098

## What is the new behavior?

The upgrade allows ethers to deploy without a problem and the edge functions are correctly run on the server.

## Additional context

eszip is now at 0.40.0 though so maybe it makes sense to jump up to there.