### PR TITLE
fix: handle missing migration history table as empty

### DIFF
--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -38,6 +38,11 @@ func Run(ctx context.Context, dryRun bool, config pgconn.Config, fsys afero.Fs, 
 		return nil
 	}
 	// Push pending migrations
+	if !dryRun {
+		if err := repair.CreateMigrationTable(ctx, conn); err != nil {
+			return err
+		}
+	}
 	for _, filename := range pending {
 		if dryRun {
 			fmt.Fprintln(os.Stderr, "Would push migration "+utils.Bold(filename)+"...")

--- a/internal/migration/list/list_test.go
+++ b/internal/migration/list/list_test.go
@@ -84,16 +84,17 @@ func TestRemoteMigrations(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
-	t.Run("throws error on missing schema", func(t *testing.T) {
+	t.Run("loads empty migrations on missing table", func(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		conn.Query(LIST_MIGRATION_VERSION).
 			ReplyError(pgerrcode.UndefinedTable, "relation \"supabase_migrations.schema_migrations\" does not exist")
 		// Run test
-		_, err := loadRemoteVersions(context.Background(), dbConfig, conn.Intercept)
+		versions, err := loadRemoteVersions(context.Background(), dbConfig, conn.Intercept)
 		// Check error
-		assert.ErrorContains(t, err, `ERROR: relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42P01)`)
+		assert.NoError(t, err)
+		assert.Empty(t, versions)
 	})
 
 	t.Run("throws error on invalid row", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When running `supabase migration list --db-url` on fresh self-hosted projects, a missing table error is thrown.

## What is the new behavior?

```bash
$ supabase migration list --db-url 'postgres://self-hosted'


        LOCAL      │ REMOTE │     TIME (UTC)
  ─────────────────┼────────┼──────────────────────
    20230410135622 │        │ 2023-04-10 13:56:22
```

## Additional context

Add any other context or screenshots.
