### PR TITLE
fix: sanitize project id based on directory name

### DIFF
--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -118,3 +118,14 @@ func TestFileSizeLimitConfigParsing(t *testing.T) {
 		assert.Equal(t, sizeInBytes(0), testConfig.Storage.FileSizeLimit)
 	})
 }
+
+func TestSanitizeProjectI(t *testing.T) {
+	// Preserves valid consecutive characters
+	assert.Equal(t, "abc", sanitizeProjectId("abc"))
+	assert.Equal(t, "a..b_c", sanitizeProjectId("a..b_c"))
+	// Removes leading special characters
+	assert.Equal(t, "abc", sanitizeProjectId("_abc"))
+	assert.Equal(t, "abc", sanitizeProjectId("_@abc"))
+	// Replaces consecutive invalid characters with a single _
+	assert.Equal(t, "a_bc-", sanitizeProjectId("a@@bc-"))
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/483

## What is the new behavior?

only use project ids containing valid characters

## Additional context

Add any other context or screenshots.
