### PR TITLE
feat: resolve relative deno import paths for mounting in docker

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -292,17 +292,28 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		utils.DenoRelayId + ":/root/.cache/deno:rw,z",
 	}
 	if importMapPath != "" {
-		binds = append(binds, importMapPath+":"+dockerFlagImportMapPath+":ro,z")
+		modules, err := bindImportMap(importMapPath, dockerFlagImportMapPath, fsys)
+		if err != nil {
+			return err
+		}
+		binds = append(binds, modules...)
 	}
 
-	fallbackImportMapString := `{"imports":{}}`
-	if fallbackImportMapBytes, err := afero.ReadFile(fsys, utils.FallbackImportMapPath); errors.Is(err, os.ErrNotExist) {
-		// skip
-	} else if err != nil {
+	fallbackImportMapPath := utils.FallbackImportMapPath
+	if exists, err := afero.Exists(fsys, fallbackImportMapPath); err != nil {
 		return fmt.Errorf("Failed to read fallback import map: %w", err)
-	} else {
-		fallbackImportMapString = string(fallbackImportMapBytes)
+	} else if !exists {
+		name := utils.GetPathHash(fallbackImportMapPath) + ".json"
+		fallbackImportMapPath = filepath.Join(utils.ImportMapsDir, name)
+		if err := afero.WriteFile(fsys, fallbackImportMapPath, []byte(`{"imports":{}}`), 0644); err != nil {
+			return err
+		}
 	}
+	modules, err := bindImportMap(fallbackImportMapPath, dockerFallbackImportMapPath, fsys)
+	if err != nil {
+		return err
+	}
+	binds = append(binds, modules...)
 
 	if err := utils.MkdirIfNotExistFS(fsys, utils.FunctionsDir); err != nil {
 		return err
@@ -325,10 +336,8 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		cmdString = strings.Join(cmd, " ")
 	}
 
-	entrypoint := []string{"sh", "-c", `mkdir /home/deno/main && cat <<'EOF' > /home/deno/main/index.ts && cat <<'EOF' > /home/deno/fallback_import_map.json && ` + cmdString + `
+	entrypoint := []string{"sh", "-c", `mkdir /home/deno/main && cat <<'EOF' > /home/deno/main/index.ts && ` + cmdString + `
 ` + mainFuncEmbed + `
-EOF
-` + fallbackImportMapString + `
 EOF
 `}
 	_, err = utils.DockerStart(
@@ -404,7 +413,12 @@ func populatePerFunctionConfigs(binds []string, importMapPath string, noVerifyJW
 			dockerImportMapPath = dockerFlagImportMapPath
 		} else if functionConfig, ok := utils.Config.Functions[functionName]; ok && functionConfig.ImportMap != "" {
 			dockerImportMapPath = "/home/deno/import_maps/" + functionName + "/import_map.json"
-			binds = append(binds, filepath.Join(cwd, utils.SupabaseDirPath, functionConfig.ImportMap)+":"+dockerImportMapPath+":ro,z")
+			hostImportMapPath := filepath.Join(cwd, utils.SupabaseDirPath, functionConfig.ImportMap)
+			modules, err := bindImportMap(hostImportMapPath, dockerImportMapPath, fsys)
+			if err != nil {
+				return nil, "", err
+			}
+			binds = append(binds, modules...)
 		}
 
 		verifyJWT := true
@@ -426,4 +440,28 @@ func populatePerFunctionConfigs(binds []string, importMapPath string, noVerifyJW
 	}
 
 	return binds, string(functionsConfigBytes), nil
+}
+
+func bindImportMap(hostImportMapPath, dockerImportMapPath string, fsys afero.Fs) ([]string, error) {
+	importMap, err := utils.NewImportMap(hostImportMapPath, fsys)
+	if err != nil {
+		return nil, err
+	}
+	resolved := importMap.Resolve(fsys)
+	binds := importMap.BindModules(resolved)
+	if len(binds) > 0 {
+		// Rewrite import map to temporary host path
+		name := utils.GetPathHash(hostImportMapPath) + ".json"
+		hostImportMapPath = filepath.Join(utils.ImportMapsDir, name)
+		f, err := fsys.Create(hostImportMapPath)
+		if err != nil {
+			return nil, err
+		}
+		enc := json.NewEncoder(f)
+		if err := enc.Encode(resolved); err != nil {
+			return nil, err
+		}
+	}
+	binds = append(binds, hostImportMapPath+":"+dockerImportMapPath+":ro,z")
+	return binds, nil
 }

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	dockerFuncDirPath = "/home/deno/functions"
+	dockerFuncDirPath = utils.DockerDenoDir + "/functions"
 	// Import Map from CLI flag, i.e. --import-map, takes priority over config.toml & fallback.
-	dockerFlagImportMapPath     = "/home/deno/flag_import_map.json"
-	dockerFallbackImportMapPath = "/home/deno/fallback_import_map.json"
+	dockerFlagImportMapPath     = utils.DockerDenoDir + "/flag_import_map.json"
+	dockerFallbackImportMapPath = utils.DockerDenoDir + "/fallback_import_map.json"
 )
 
 var (

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -1,0 +1,313 @@
+package utils
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+var (
+	//go:embed denos/*
+	denoEmbedDir embed.FS
+	// Used by unit tests
+	DenoPathOverride string
+)
+
+func GetDenoPath() (string, error) {
+	if len(DenoPathOverride) > 0 {
+		return DenoPathOverride, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	denoBinName := "deno"
+	if runtime.GOOS == "windows" {
+		denoBinName = "deno.exe"
+	}
+	denoPath := filepath.Join(home, ".supabase", denoBinName)
+	return denoPath, nil
+}
+
+func InstallOrUpgradeDeno(ctx context.Context, fsys afero.Fs) error {
+	denoPath, err := GetDenoPath()
+	if err != nil {
+		return err
+	}
+
+	if _, err := fsys.Stat(denoPath); err == nil {
+		// Upgrade Deno.
+		cmd := exec.CommandContext(ctx, denoPath, "upgrade", "--version", DenoVersion)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		return cmd.Run()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// Install Deno.
+	if err := MkdirIfNotExistFS(fsys, filepath.Dir(denoPath)); err != nil {
+		return err
+	}
+
+	// 1. Determine OS triple
+	var assetFilename string
+	assetRepo := "denoland/deno"
+	{
+		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+			assetFilename = "deno-x86_64-apple-darwin.zip"
+		} else if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+			assetFilename = "deno-aarch64-apple-darwin.zip"
+		} else if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+			assetFilename = "deno-x86_64-unknown-linux-gnu.zip"
+		} else if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+			// TODO: version pin to official release once available https://github.com/denoland/deno/issues/1846
+			assetRepo = "LukeChannings/deno-arm64"
+			assetFilename = "deno-linux-arm64.zip"
+		} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
+			assetFilename = "deno-x86_64-pc-windows-msvc.zip"
+		} else {
+			return errors.New("Platform " + runtime.GOOS + "/" + runtime.GOARCH + " is currently unsupported for Functions.")
+		}
+	}
+
+	// 2. Download & install Deno binary.
+	{
+		assetUrl := fmt.Sprintf("https://github.com/%s/releases/download/v%s/%s", assetRepo, DenoVersion, assetFilename)
+		req, err := http.NewRequestWithContext(ctx, "GET", assetUrl, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			return errors.New("Failed installing Deno binary.")
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		r, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+		// There should be only 1 file: the deno binary
+		if len(r.File) != 1 {
+			return err
+		}
+		denoContents, err := r.File[0].Open()
+		if err != nil {
+			return err
+		}
+		defer denoContents.Close()
+
+		denoBytes, err := io.ReadAll(denoContents)
+		if err != nil {
+			return err
+		}
+
+		if err := afero.WriteFile(fsys, denoPath, denoBytes, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isScriptModified(fsys afero.Fs, destPath string, src []byte) (bool, error) {
+	dest, err := afero.ReadFile(fsys, destPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	// compare the md5 checksum of src bytes with user's copy.
+	// if the checksums doesn't match, script is modified.
+	return md5.Sum(dest) != md5.Sum(src), nil
+}
+
+type DenoScriptDir struct {
+	ExtractPath string
+	BuildPath   string
+}
+
+// Copy Deno scripts needed for function deploy and downloads, returning a DenoScriptDir struct or an error.
+func CopyDenoScripts(ctx context.Context, fsys afero.Fs) (*DenoScriptDir, error) {
+	denoPath, err := GetDenoPath()
+	if err != nil {
+		return nil, err
+	}
+
+	denoDirPath := filepath.Dir(denoPath)
+	scriptDirPath := filepath.Join(denoDirPath, "denos")
+
+	// make the script directory if not exist
+	if err := MkdirIfNotExistFS(fsys, scriptDirPath); err != nil {
+		return nil, err
+	}
+
+	// copy embed files to script directory
+	err = fs.WalkDir(denoEmbedDir, "denos", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// skip copying the directory
+		if d.IsDir() {
+			return nil
+		}
+
+		destPath := filepath.Join(denoDirPath, path)
+
+		contents, err := fs.ReadFile(denoEmbedDir, path)
+		if err != nil {
+			return err
+		}
+
+		// check if the script should be copied
+		modified, err := isScriptModified(fsys, destPath, contents)
+		if err != nil {
+			return err
+		}
+		if !modified {
+			return nil
+		}
+
+		if err := afero.WriteFile(fsys, filepath.Join(denoDirPath, path), contents, 0666); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sd := DenoScriptDir{
+		ExtractPath: filepath.Join(scriptDirPath, "extract.ts"),
+		BuildPath:   filepath.Join(scriptDirPath, "build.ts"),
+	}
+
+	return &sd, nil
+}
+
+type ImportMap struct {
+	Imports map[string]string
+	Scopes  map[string]map[string]string
+}
+
+func NewImportMap(path string, fsys afero.Fs) (*ImportMap, error) {
+	contents, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer contents.Close()
+	return NewFromReader(contents)
+}
+
+func NewFromReader(r io.Reader) (*ImportMap, error) {
+	decoder := json.NewDecoder(r)
+	importMap := &ImportMap{}
+	if err := decoder.Decode(importMap); err != nil {
+		return nil, err
+	}
+	return importMap, nil
+}
+
+func (m *ImportMap) Resolve(fsys afero.Fs) ImportMap {
+	result := ImportMap{
+		Imports: make(map[string]string, len(m.Imports)),
+		Scopes:  make(map[string]map[string]string, len(m.Scopes)),
+	}
+	for k, v := range m.Imports {
+		result.Imports[k] = resolveHostPath(v, fsys)
+	}
+	for module, mapping := range m.Scopes {
+		result.Scopes[module] = map[string]string{}
+		for k, v := range mapping {
+			result.Scopes[module][k] = resolveHostPath(v, fsys)
+		}
+	}
+	return result
+}
+
+func (m *ImportMap) BindModules(resolved ImportMap) []string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	var binds []string
+	for k, dockerPath := range resolved.Imports {
+		if strings.HasPrefix(dockerPath, DockerModsDir) {
+			hostPath := filepath.Join(cwd, FunctionsDir, m.Imports[k])
+			binds = append(binds, hostPath+":"+dockerPath+":ro,z")
+		}
+	}
+	for module, mapping := range resolved.Scopes {
+		for k, dockerPath := range mapping {
+			if strings.HasPrefix(dockerPath, DockerModsDir) {
+				hostPath := filepath.Join(cwd, FunctionsDir, m.Scopes[module][k])
+				binds = append(binds, hostPath+":"+dockerPath+":ro,z")
+			}
+		}
+	}
+	return binds
+}
+
+const (
+	DockerDenoDir = "/home/deno"
+	DockerModsDir = DockerDenoDir + "/modules"
+)
+
+func resolveHostPath(hostPath string, fsys afero.Fs) string {
+	// All local fs imports will be mounted to /home/deno/modules
+	if filepath.IsAbs(hostPath) {
+		return getModulePath(hostPath)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return hostPath
+	}
+	rel := filepath.Join(FunctionsDir, hostPath)
+	if strings.HasPrefix(rel, FunctionsDir) {
+		return hostPath
+	}
+	rebased := filepath.Join(cwd, rel)
+	if exists, _ := afero.Exists(fsys, rebased); !exists {
+		return hostPath
+	}
+	return getModulePath(rel)
+}
+
+func getModulePath(hostPath string) string {
+	return path.Join(DockerModsDir, GetPathHash(hostPath))
+}
+
+func GetPathHash(path string) string {
+	digest := sha256.Sum256([]byte(path))
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveImports(t *testing.T) {
+	t.Run("resolves relative directory", func(t *testing.T) {
+		importMap := &ImportMap{
+			Imports: map[string]string{
+				"abs":     "/tmp",
+				"root":    "../../common",
+				"parent":  "../tests",
+				"child":   "child",
+				"missing": "../missing",
+			},
+		}
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, "common"), 0755))
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, DbTestsDir), 0755))
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, FunctionsDir, "child"), 0755))
+		// Run test
+		resolved := importMap.Resolve(fsys)
+		// Check error
+		assert.Equal(t, "/home/deno/modules/e9671acd244849c57167c658fa2f969752048f7ab184a3dcf5c46cb4d56ae124", resolved.Imports["abs"])
+		assert.Equal(t, "/home/deno/modules/92a5dc04bd6f9fb8f29f8066fed8a5c1e81bc59ad48a11283b63736867e4f2a8", resolved.Imports["root"])
+		assert.Equal(t, "/home/deno/modules/faaed96206118cf98625ea8065b6b3864f8cf9484814c423b58ebaa9b2d1e47b", resolved.Imports["parent"])
+		assert.Equal(t, "child", resolved.Imports["child"])
+		assert.Equal(t, "../missing", resolved.Imports["missing"])
+	})
+
+	t.Run("resolves parent scopes", func(t *testing.T) {
+		importMap := &ImportMap{
+			Scopes: map[string]map[string]string{
+				"my-scope": {
+					"my-mod": "https://deno.land",
+				},
+			},
+		}
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		resolved := importMap.Resolve(fsys)
+		// Check error
+		assert.Equal(t, "https://deno.land", resolved.Scopes["my-scope"]["my-mod"])
+	})
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -300,6 +300,13 @@ func MkdirIfNotExistFS(fsys afero.Fs, path string) error {
 	return nil
 }
 
+func WriteFile(path string, contents []byte, fsys afero.Fs) error {
+	if err := MkdirIfNotExistFS(fsys, filepath.Dir(path)); err != nil {
+		return err
+	}
+	return afero.WriteFile(fsys, path, contents, 0644)
+}
+
 func AssertSupabaseCliIsSetUpFS(fsys afero.Fs) error {
 	if _, err := fsys.Stat(ConfigPath); errors.Is(err, os.ErrNotExist) {
 		return errors.New("Cannot find " + Bold(ConfigPath) + " in the current directory. Have you set up the project with " + Aqua("supabase init") + "?")

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -1,18 +1,12 @@
 package utils
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
-	"crypto/md5"
-	"embed"
+	_ "embed"
 	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -97,9 +91,6 @@ var (
 	//go:embed templates/globals.sql
 	GlobalsSql string
 
-	//go:embed denos/*
-	denoEmbedDir embed.FS
-
 	ProjectRefPattern  = regexp.MustCompile(`^[a-z]{20}$`)
 	UUIDPattern        = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 	ProjectHostPattern = regexp.MustCompile(`^(db\.)[a-z]{20}\.supabase\.(co|red)$`)
@@ -171,6 +162,7 @@ var (
 	SupabaseDirPath       = "supabase"
 	ConfigPath            = filepath.Join(SupabaseDirPath, "config.toml")
 	GitIgnorePath         = filepath.Join(SupabaseDirPath, ".gitignore")
+	ImportMapsDir         = filepath.Join(SupabaseDirPath, ".temp", "import_maps")
 	ProjectRefPath        = filepath.Join(SupabaseDirPath, ".temp", "project-ref")
 	RemoteDbPath          = filepath.Join(SupabaseDirPath, ".temp", "remote-db-url")
 	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
@@ -181,11 +173,6 @@ var (
 	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
 	SeedDataPath          = filepath.Join(SupabaseDirPath, "seed.sql")
 	CustomRolesPath       = filepath.Join(SupabaseDirPath, "roles.sql")
-)
-
-// Used by unit tests
-var (
-	DenoPathOverride string
 )
 
 func GetCurrentTimestamp() string {
@@ -343,190 +330,6 @@ func LoadProjectRef(fsys afero.Fs) (string, error) {
 		return "", errors.New("Invalid project ref format. Must be like `abcdefghijklmnopqrst`.")
 	}
 	return projectRef, nil
-}
-
-func GetDenoPath() (string, error) {
-	if len(DenoPathOverride) > 0 {
-		return DenoPathOverride, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	denoBinName := "deno"
-	if runtime.GOOS == "windows" {
-		denoBinName = "deno.exe"
-	}
-	denoPath := filepath.Join(home, ".supabase", denoBinName)
-	return denoPath, nil
-}
-
-func InstallOrUpgradeDeno(ctx context.Context, fsys afero.Fs) error {
-	denoPath, err := GetDenoPath()
-	if err != nil {
-		return err
-	}
-
-	if _, err := fsys.Stat(denoPath); err == nil {
-		// Upgrade Deno.
-		cmd := exec.CommandContext(ctx, denoPath, "upgrade", "--version", DenoVersion)
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		return cmd.Run()
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-
-	// Install Deno.
-	if err := MkdirIfNotExistFS(fsys, filepath.Dir(denoPath)); err != nil {
-		return err
-	}
-
-	// 1. Determine OS triple
-	var assetFilename string
-	assetRepo := "denoland/deno"
-	{
-		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
-			assetFilename = "deno-x86_64-apple-darwin.zip"
-		} else if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-			assetFilename = "deno-aarch64-apple-darwin.zip"
-		} else if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
-			assetFilename = "deno-x86_64-unknown-linux-gnu.zip"
-		} else if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
-			// TODO: version pin to official release once available https://github.com/denoland/deno/issues/1846
-			assetRepo = "LukeChannings/deno-arm64"
-			assetFilename = "deno-linux-arm64.zip"
-		} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
-			assetFilename = "deno-x86_64-pc-windows-msvc.zip"
-		} else {
-			return errors.New("Platform " + runtime.GOOS + "/" + runtime.GOARCH + " is currently unsupported for Functions.")
-		}
-	}
-
-	// 2. Download & install Deno binary.
-	{
-		assetUrl := fmt.Sprintf("https://github.com/%s/releases/download/v%s/%s", assetRepo, DenoVersion, assetFilename)
-		req, err := http.NewRequestWithContext(ctx, "GET", assetUrl, nil)
-		if err != nil {
-			return err
-		}
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			return errors.New("Failed installing Deno binary.")
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		r, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
-		// There should be only 1 file: the deno binary
-		if len(r.File) != 1 {
-			return err
-		}
-		denoContents, err := r.File[0].Open()
-		if err != nil {
-			return err
-		}
-		defer denoContents.Close()
-
-		denoBytes, err := io.ReadAll(denoContents)
-		if err != nil {
-			return err
-		}
-
-		if err := afero.WriteFile(fsys, denoPath, denoBytes, 0755); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func isScriptModified(fsys afero.Fs, destPath string, src []byte) (bool, error) {
-	dest, err := afero.ReadFile(fsys, destPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return true, nil
-		}
-		return false, err
-	}
-
-	// compare the md5 checksum of src bytes with user's copy.
-	// if the checksums doesn't match, script is modified.
-	return md5.Sum(dest) != md5.Sum(src), nil
-}
-
-type DenoScriptDir struct {
-	ExtractPath string
-	BuildPath   string
-}
-
-// Copy Deno scripts needed for function deploy and downloads, returning a DenoScriptDir struct or an error.
-func CopyDenoScripts(ctx context.Context, fsys afero.Fs) (*DenoScriptDir, error) {
-	denoPath, err := GetDenoPath()
-	if err != nil {
-		return nil, err
-	}
-
-	denoDirPath := filepath.Dir(denoPath)
-	scriptDirPath := filepath.Join(denoDirPath, "denos")
-
-	// make the script directory if not exist
-	if err := MkdirIfNotExistFS(fsys, scriptDirPath); err != nil {
-		return nil, err
-	}
-
-	// copy embed files to script directory
-	err = fs.WalkDir(denoEmbedDir, "denos", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// skip copying the directory
-		if d.IsDir() {
-			return nil
-		}
-
-		destPath := filepath.Join(denoDirPath, path)
-
-		contents, err := fs.ReadFile(denoEmbedDir, path)
-		if err != nil {
-			return err
-		}
-
-		// check if the script should be copied
-		modified, err := isScriptModified(fsys, destPath, contents)
-		if err != nil {
-			return err
-		}
-		if !modified {
-			return nil
-		}
-
-		if err := afero.WriteFile(fsys, filepath.Join(denoDirPath, path), contents, 0666); err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	sd := DenoScriptDir{
-		ExtractPath: filepath.Join(scriptDirPath, "extract.ts"),
-		BuildPath:   filepath.Join(scriptDirPath, "build.ts"),
-	}
-
-	return &sd, nil
 }
 
 func ValidateFunctionSlug(slug string) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature
fixes https://github.com/supabase/cli/issues/1040

## What is the current behavior?

- unable to import modules relative to parent directories

## What is the new behavior?

- rewrites import map to a `supabase/.temp/import_maps/<hash>.json`
- bind mounts imported directories to `/home/deno/modules/<hash>` in edge runtime container
- relative paths to parent directories are solved to absolute paths inside container

## Additional context

Add any other context or screenshots.
