### PR TITLE
fix: skip migrations when backup volume exists

### DIFF
--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -92,7 +92,7 @@ func TestResetDatabase(t *testing.T) {
 		// Run test
 		err := resetDatabase(context.Background(), fsys)
 		// Check error
-		assert.ErrorContains(t, err, "invalid port")
+		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
 	t.Run("throws error on duplicate schema", func(t *testing.T) {

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -89,12 +89,13 @@ func TestInitDatabase(t *testing.T) {
 }
 
 func TestStartDatabase(t *testing.T) {
-	t.Cleanup(func() {
+	teardown := func() {
 		utils.Containers = []string{}
 		utils.Volumes = []string{}
-	})
+	}
 
 	t.Run("initialise main branch", func(t *testing.T) {
+		defer teardown()
 		utils.DbImage = utils.Pg15Image
 		utils.Config.Db.MajorVersion = 15
 		utils.DbId = "supabase_db_test"
@@ -130,6 +131,7 @@ func TestStartDatabase(t *testing.T) {
 	})
 
 	t.Run("recover from backup volume", func(t *testing.T) {
+		defer teardown()
 		utils.DbImage = utils.Pg15Image
 		utils.Config.Db.MajorVersion = 15
 		utils.DbId = "supabase_db_test"
@@ -164,6 +166,7 @@ func TestStartDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on start failure", func(t *testing.T) {
+		defer teardown()
 		utils.DbImage = utils.Pg15Image
 		utils.Config.Db.MajorVersion = 15
 		utils.DbId = "supabase_db_test"

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -247,14 +247,11 @@ func TestDatabaseStart(t *testing.T) {
 					Health:  &types.Health{Status: "healthy"},
 				},
 			}})
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
 		// Run test
 		exclude := ExcludableContainers()
 		exclude = append(exclude, "invalid", exclude[0])
 		err := utils.RunProgram(context.Background(), func(p utils.Program, ctx context.Context) error {
-			return run(p, context.Background(), fsys, exclude, conn.Intercept)
+			return run(p, context.Background(), fsys, exclude)
 		})
 		// Check error
 		assert.NoError(t, err)

--- a/internal/testing/fstest/open.go
+++ b/internal/testing/fstest/open.go
@@ -1,0 +1,28 @@
+package fstest
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+type OpenErrorFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *OpenErrorFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.OpenFile(name, flag, perm)
+}
+
+func (m *OpenErrorFs) Open(name string) (afero.File, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.Open(name)
+}

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -19,17 +19,19 @@ var (
 func TestConfigParsing(t *testing.T) {
 	// Reset global variable
 	copy := initConfigTemplate
-	t.Cleanup(func() {
+	teardown := func() {
 		initConfigTemplate = copy
-	})
+	}
 
 	t.Run("classic config file", func(t *testing.T) {
+		defer teardown()
 		fsys := afero.NewMemMapFs()
 		assert.NoError(t, WriteConfig(fsys, false))
 		assert.NoError(t, LoadConfigFS(fsys))
 	})
 
 	t.Run("config file with environment variables", func(t *testing.T) {
+		defer teardown()
 		initConfigTemplate = testInitConfigTemplate
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -44,6 +46,7 @@ func TestConfigParsing(t *testing.T) {
 	})
 
 	t.Run("config file with environment variables fails when unset", func(t *testing.T) {
+		defer teardown()
 		initConfigTemplate = testInitConfigTemplate
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1055

## What is the new behavior?

- introduced a scoped variable for checking if backup exists
- refactors common error fs for testing

## Additional context

Add any other context or screenshots.
