### PR TITLE
fix: buffer size override

### DIFF
--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -66,7 +65,9 @@ func NewMigrationFromFile(path string, fsys afero.Fs) (*MigrationFile, error) {
 	// Unless explicitly specified, Use file length as max buffer size
 	if !viper.IsSet("SCANNER_BUFFER_SIZE") {
 		if fi, err := sql.Stat(); err == nil {
-			viper.Set("SCANNER_BUFFER_SIZE", strconv.FormatInt(fi.Size(), 10))
+			if size := int(fi.Size()); size > parser.MaxScannerCapacity {
+				parser.MaxScannerCapacity = size
+			}
 		}
 	}
 	file, err := NewMigrationFromReader(sql)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1058

## What is the new behavior?

The first file size was carried over due to the use of `viper.Set`. Switch to use a variable instead. 

## Additional context

Add any other context or screenshots.
