### PR TITLE
fix: deno import map resolved directory paths

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -462,7 +462,7 @@ func bindImportMap(hostImportMapPath, dockerImportMapPath string, fsys afero.Fs)
 		if err != nil {
 			return nil, err
 		}
-		contents, err := json.Marshal(resolved)
+		contents, err := json.MarshalIndent(resolved, "", "    ")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -348,8 +348,9 @@ EOF
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.GotrueImage,
-				Env:   env,
+				Image:        utils.GotrueImage,
+				Env:          env,
+				ExposedPorts: nat.PortSet{"9999/tcp": {}},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9999/health"},
 					Interval: 2 * time.Second,
@@ -420,6 +421,7 @@ EOF
 					"/bin/sh", "-c",
 					"/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server",
 				},
+				ExposedPorts: nat.PortSet{"4000/tcp": {}},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/4000"},
 					Interval: 2 * time.Second,

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -300,6 +300,8 @@ func resolveHostPath(hostPath string, fsys afero.Fs) string {
 	if exists, _ := afero.Exists(fsys, rebased); !exists {
 		return hostPath
 	}
+	// Directory imports need to be suffixed with /
+	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
 	if strings.HasSuffix(hostPath, "/") {
 		rel += "/"
 	}

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -216,8 +216,8 @@ func CopyDenoScripts(ctx context.Context, fsys afero.Fs) (*DenoScriptDir, error)
 }
 
 type ImportMap struct {
-	Imports map[string]string
-	Scopes  map[string]map[string]string
+	Imports map[string]string            `json:"imports"`
+	Scopes  map[string]map[string]string `json:"scopes"`
 }
 
 func NewImportMap(path string, fsys afero.Fs) (*ImportMap, error) {
@@ -300,11 +300,18 @@ func resolveHostPath(hostPath string, fsys afero.Fs) string {
 	if exists, _ := afero.Exists(fsys, rebased); !exists {
 		return hostPath
 	}
+	if strings.HasSuffix(hostPath, "/") {
+		rel += "/"
+	}
 	return getModulePath(rel)
 }
 
 func getModulePath(hostPath string) string {
-	return path.Join(DockerModsDir, GetPathHash(hostPath))
+	mod := path.Join(DockerModsDir, GetPathHash(hostPath))
+	if strings.HasSuffix(hostPath, "/") {
+		mod += "/"
+	}
+	return mod
 }
 
 func GetPathHash(path string) string {

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -14,7 +14,7 @@ func TestResolveImports(t *testing.T) {
 	t.Run("resolves relative directory", func(t *testing.T) {
 		importMap := &ImportMap{
 			Imports: map[string]string{
-				"abs":     "/tmp",
+				"abs/":    "/tmp/",
 				"root":    "../../common",
 				"parent":  "../tests",
 				"child":   "child",
@@ -31,7 +31,7 @@ func TestResolveImports(t *testing.T) {
 		// Run test
 		resolved := importMap.Resolve(fsys)
 		// Check error
-		assert.Equal(t, "/home/deno/modules/e9671acd244849c57167c658fa2f969752048f7ab184a3dcf5c46cb4d56ae124", resolved.Imports["abs"])
+		assert.Equal(t, "/home/deno/modules/ac351c7174c8f47a9a9056bd96bcd71cfb980c906daee74ab9bce8308c68b811/", resolved.Imports["abs/"])
 		assert.Equal(t, "/home/deno/modules/92a5dc04bd6f9fb8f29f8066fed8a5c1e81bc59ad48a11283b63736867e4f2a8", resolved.Imports["root"])
 		assert.Equal(t, "/home/deno/modules/faaed96206118cf98625ea8065b6b3864f8cf9484814c423b58ebaa9b2d1e47b", resolved.Imports["parent"])
 		assert.Equal(t, "child", resolved.Imports["child"])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow up https://github.com/supabase/cli/issues/1040

## What is the new behavior?

- serialized import map should have have lowercase fields, ie. `imports`
- unlike files, imported directories should end with `/`

unrelated
- added health checks so that `docker ps -a` is more informative

## Additional context

Tested with the following config

- `supabase/functions/import_map.json`
```json
{
  "imports": {
    "http-server": "https://deno.land/std@0.168.0/http/server.ts",
    "shared/": "../../shared/"
  }
}
```

- `supabase/functions/hello_world/index.ts`
```typescript
import { serve } from "http-server";
import { handler } from "shared/index.ts";

serve(handler, { port: 8081 });
```

- `shared/index.ts`
```typescript
export const handler = async (req) => {
  const { name } = await req.json();
  const data = {
    message: `Hello World ${name}!`,
  };

  return new Response(JSON.stringify(data), {
    headers: { "Content-Type": "application/json" },
  });
};
```