### PR TITLE
fix: use external health check for edge runtime

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -348,12 +347,6 @@ EOF
 			Env:          append(env, userEnv...),
 			Entrypoint:   entrypoint,
 			ExposedPorts: nat.PortSet{"8081/tcp": {}},
-			Healthcheck: &container.HealthConfig{
-				Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/8081"},
-				Interval: 2 * time.Second,
-				Timeout:  2 * time.Second,
-				Retries:  10,
-			},
 		},
 		start.WithSyslogConfig(container.HostConfig{
 			Binds:      binds,

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -187,7 +187,7 @@ func TestDatabaseStart(t *testing.T) {
 		started := []string{
 			utils.DbId, utils.KongId, utils.GotrueId, utils.InbucketId, utils.RealtimeId,
 			utils.StorageId, utils.ImgProxyId, utils.DenoRelayId, utils.PgmetaId, utils.StudioId,
-			utils.LogflareId,
+			utils.LogflareId, utils.RestId,
 		}
 		for _, container := range started {
 			gock.New(utils.Docker.DaemonHost()).
@@ -202,6 +202,9 @@ func TestDatabaseStart(t *testing.T) {
 		}
 		gock.New("localhost").
 			Head("/rest/v1/").
+			Reply(http.StatusOK)
+		gock.New("localhost").
+			Head("/functions/v1/_internal/health").
 			Reply(http.StatusOK)
 		// Run test
 		err := utils.RunProgram(context.Background(), func(p utils.Program, ctx context.Context) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #1061 

## What is the current behavior?

container health check is logging too much error

## What is the new behavior?

switch to external http health check from host

## Additional context

Add any other context or screenshots.
