### PR TITLE
chore: remove auth and storage from initial schemas

### DIFF
--- a/internal/utils/templates/initial_schemas/15.sql
+++ b/internal/utils/templates/initial_schemas/15.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 15.1 (Debian 15.1-1.pgdg110+1)
--- Dumped by pg_dump version 15.2 (Homebrew)
+-- Dumped by pg_dump version 15.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -246,94 +246,17 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
 
 
 --
--- Name: aal_level; Type: TYPE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TYPE auth.aal_level AS ENUM (
-    'aal1',
-    'aal2',
-    'aal3'
-);
-
-
-ALTER TYPE auth.aal_level OWNER TO supabase_auth_admin;
-
---
--- Name: code_challenge_method; Type: TYPE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TYPE auth.code_challenge_method AS ENUM (
-    's256',
-    'plain'
-);
-
-
-ALTER TYPE auth.code_challenge_method OWNER TO supabase_auth_admin;
-
---
--- Name: factor_status; Type: TYPE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TYPE auth.factor_status AS ENUM (
-    'unverified',
-    'verified'
-);
-
-
-ALTER TYPE auth.factor_status OWNER TO supabase_auth_admin;
-
---
--- Name: factor_type; Type: TYPE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TYPE auth.factor_type AS ENUM (
-    'totp',
-    'webauthn'
-);
-
-
-ALTER TYPE auth.factor_type OWNER TO supabase_auth_admin;
-
---
 -- Name: email(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
 --
 
 CREATE OR REPLACE FUNCTION auth.email() RETURNS text
     LANGUAGE sql STABLE
     AS $$
-  select 
-  coalesce(
-    nullif(current_setting('request.jwt.claim.email', true), ''),
-    (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email')
-  )::text
+  select nullif(current_setting('request.jwt.claim.email', true), '')::text;
 $$;
 
 
 ALTER FUNCTION auth.email() OWNER TO supabase_auth_admin;
-
---
--- Name: FUNCTION email(); Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON FUNCTION auth.email() IS 'Deprecated. Use auth.jwt() -> ''email'' instead.';
-
-
---
--- Name: jwt(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb
-    LANGUAGE sql STABLE
-    AS $$
-  select 
-    coalesce(
-        nullif(current_setting('request.jwt.claim', true), ''),
-        nullif(current_setting('request.jwt.claims', true), '')
-    )::jsonb
-$$;
-
-
-ALTER FUNCTION auth.jwt() OWNER TO supabase_auth_admin;
 
 --
 -- Name: role(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
@@ -342,22 +265,11 @@ ALTER FUNCTION auth.jwt() OWNER TO supabase_auth_admin;
 CREATE OR REPLACE FUNCTION auth.role() RETURNS text
     LANGUAGE sql STABLE
     AS $$
-  select 
-  coalesce(
-    nullif(current_setting('request.jwt.claim.role', true), ''),
-    (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role')
-  )::text
+  select nullif(current_setting('request.jwt.claim.role', true), '')::text;
 $$;
 
 
 ALTER FUNCTION auth.role() OWNER TO supabase_auth_admin;
-
---
--- Name: FUNCTION role(); Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON FUNCTION auth.role() IS 'Deprecated. Use auth.jwt() -> ''role'' instead.';
-
 
 --
 -- Name: uid(); Type: FUNCTION; Schema: auth; Owner: supabase_auth_admin
@@ -366,22 +278,11 @@ COMMENT ON FUNCTION auth.role() IS 'Deprecated. Use auth.jwt() -> ''role'' inste
 CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
     LANGUAGE sql STABLE
     AS $$
-  select 
-  coalesce(
-    nullif(current_setting('request.jwt.claim.sub', true), ''),
-    (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')
-  )::uuid
+  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
 $$;
 
 
 ALTER FUNCTION auth.uid() OWNER TO supabase_auth_admin;
-
---
--- Name: FUNCTION uid(); Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON FUNCTION auth.uid() IS 'Deprecated. Use auth.jwt() -> ''sub'' instead.';
-
 
 --
 -- Name: grant_pg_cron_access(); Type: FUNCTION; Schema: extensions; Owner: postgres
@@ -692,25 +593,6 @@ $$;
 ALTER FUNCTION pgbouncer.get_auth(p_usename text) OWNER TO postgres;
 
 --
--- Name: can_insert_object(text, text, uuid, jsonb); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
---
-
-CREATE OR REPLACE FUNCTION storage.can_insert_object(bucketid text, name text, owner uuid, metadata jsonb) RETURNS void
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-  INSERT INTO "storage"."objects" ("bucket_id", "name", "owner", "metadata") VALUES (bucketid, name, owner, metadata);
-  -- hack to rollback the successful insert
-  RAISE sqlstate 'PT200' using
-  message = 'ROLLBACK',
-  detail = 'rollback successful insert';
-END
-$$;
-
-
-ALTER FUNCTION storage.can_insert_object(bucketid text, name text, owner uuid, metadata jsonb) OWNER TO supabase_storage_admin;
-
---
 -- Name: extension(text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
@@ -768,109 +650,22 @@ $$;
 ALTER FUNCTION storage.foldername(name text) OWNER TO supabase_storage_admin;
 
 --
--- Name: get_size_by_bucket(); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
+-- Name: search(text, text, integer, integer, integer); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
 --
 
-CREATE OR REPLACE FUNCTION storage.get_size_by_bucket() RETURNS TABLE(size bigint, bucket_id text)
+CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits integer DEFAULT 100, levels integer DEFAULT 1, offsets integer DEFAULT 0) RETURNS TABLE(name text, id uuid, updated_at timestamp with time zone, created_at timestamp with time zone, last_accessed_at timestamp with time zone, metadata jsonb)
     LANGUAGE plpgsql
     AS $$
+DECLARE
+_bucketId text;
 BEGIN
-    return query
-        select sum((metadata->>'size')::int) as size, obj.bucket_id
-        from "storage".objects as obj
-        group by obj.bucket_id;
+    -- will be replaced by migrations when server starts
+    -- saving space for cloud-init
 END
 $$;
 
 
-ALTER FUNCTION storage.get_size_by_bucket() OWNER TO supabase_storage_admin;
-
---
--- Name: search(text, text, integer, integer, integer, text, text, text); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
---
-
-CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits integer DEFAULT 100, levels integer DEFAULT 1, offsets integer DEFAULT 0, search text DEFAULT ''::text, sortcolumn text DEFAULT 'name'::text, sortorder text DEFAULT 'asc'::text) RETURNS TABLE(name text, id uuid, updated_at timestamp with time zone, created_at timestamp with time zone, last_accessed_at timestamp with time zone, metadata jsonb)
-    LANGUAGE plpgsql STABLE
-    AS $_$
-declare
-  v_order_by text;
-  v_sort_order text;
-begin
-  case
-    when sortcolumn = 'name' then
-      v_order_by = 'name';
-    when sortcolumn = 'updated_at' then
-      v_order_by = 'updated_at';
-    when sortcolumn = 'created_at' then
-      v_order_by = 'created_at';
-    when sortcolumn = 'last_accessed_at' then
-      v_order_by = 'last_accessed_at';
-    else
-      v_order_by = 'name';
-  end case;
-
-  case
-    when sortorder = 'asc' then
-      v_sort_order = 'asc';
-    when sortorder = 'desc' then
-      v_sort_order = 'desc';
-    else
-      v_sort_order = 'asc';
-  end case;
-
-  v_order_by = v_order_by || ' ' || v_sort_order;
-
-  return query execute
-    'with folders as (
-       select path_tokens[$1] as folder
-       from storage.objects
-         where objects.name ilike $2 || $3 || ''%''
-           and bucket_id = $4
-           and array_length(regexp_split_to_array(objects.name, ''/''), 1) <> $1
-       group by folder
-       order by folder ' || v_sort_order || '
-     )
-     (select folder as "name",
-            null as id,
-            null as updated_at,
-            null as created_at,
-            null as last_accessed_at,
-            null as metadata from folders)
-     union all
-     (select path_tokens[$1] as "name",
-            id,
-            updated_at,
-            created_at,
-            last_accessed_at,
-            metadata
-     from storage.objects
-     where objects.name ilike $2 || $3 || ''%''
-       and bucket_id = $4
-       and array_length(regexp_split_to_array(objects.name, ''/''), 1) = $1
-     order by ' || v_order_by || ')
-     limit $5
-     offset $6' using levels, prefix, search, bucketname, limits, offsets;
-end;
-$_$;
-
-
-ALTER FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer, search text, sortcolumn text, sortorder text) OWNER TO supabase_storage_admin;
-
---
--- Name: update_updated_at_column(); Type: FUNCTION; Schema: storage; Owner: supabase_storage_admin
---
-
-CREATE OR REPLACE FUNCTION storage.update_updated_at_column() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    NEW.updated_at = now();
-    RETURN NEW; 
-END;
-$$;
-
-
-ALTER FUNCTION storage.update_updated_at_column() OWNER TO supabase_storage_admin;
+ALTER FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) OWNER TO supabase_storage_admin;
 
 --
 -- Name: http_request(); Type: FUNCTION; Schema: supabase_functions; Owner: supabase_functions_admin
@@ -1041,8 +836,7 @@ CREATE TABLE IF NOT EXISTS auth.audit_log_entries (
     instance_id uuid,
     id uuid NOT NULL,
     payload json,
-    created_at timestamp with time zone,
-    ip_address character varying(64) DEFAULT ''::character varying NOT NULL
+    created_at timestamp with time zone
 );
 
 
@@ -1053,66 +847,6 @@ ALTER TABLE auth.audit_log_entries OWNER TO supabase_auth_admin;
 --
 
 COMMENT ON TABLE auth.audit_log_entries IS 'Auth: Audit trail for user actions.';
-
-
---
--- Name: flow_state; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.flow_state (
-    id uuid NOT NULL,
-    user_id uuid,
-    auth_code text NOT NULL,
-    code_challenge_method auth.code_challenge_method NOT NULL,
-    code_challenge text NOT NULL,
-    provider_type text NOT NULL,
-    provider_access_token text,
-    provider_refresh_token text,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    authentication_method text NOT NULL
-);
-
-
-ALTER TABLE auth.flow_state OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE flow_state; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.flow_state IS 'stores metadata for pkce logins';
-
-
---
--- Name: identities; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.identities (
-    id text NOT NULL,
-    user_id uuid NOT NULL,
-    identity_data jsonb NOT NULL,
-    provider text NOT NULL,
-    last_sign_in_at timestamp with time zone,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    email text GENERATED ALWAYS AS (lower((identity_data ->> 'email'::text))) STORED
-);
-
-
-ALTER TABLE auth.identities OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE identities; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.identities IS 'Auth: Stores identities associated to a user.';
-
-
---
--- Name: COLUMN identities.email; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON COLUMN auth.identities.email IS 'Auth: Email is a generated column that references the optional email property in the identity_data';
 
 
 --
@@ -1138,75 +872,6 @@ COMMENT ON TABLE auth.instances IS 'Auth: Manages users across multiple sites.';
 
 
 --
--- Name: mfa_amr_claims; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.mfa_amr_claims (
-    session_id uuid NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    authentication_method text NOT NULL,
-    id uuid NOT NULL
-);
-
-
-ALTER TABLE auth.mfa_amr_claims OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE mfa_amr_claims; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.mfa_amr_claims IS 'auth: stores authenticator method reference claims for multi factor authentication';
-
-
---
--- Name: mfa_challenges; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.mfa_challenges (
-    id uuid NOT NULL,
-    factor_id uuid NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    verified_at timestamp with time zone,
-    ip_address inet NOT NULL
-);
-
-
-ALTER TABLE auth.mfa_challenges OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE mfa_challenges; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.mfa_challenges IS 'auth: stores metadata about challenge requests made';
-
-
---
--- Name: mfa_factors; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.mfa_factors (
-    id uuid NOT NULL,
-    user_id uuid NOT NULL,
-    friendly_name text,
-    factor_type auth.factor_type NOT NULL,
-    status auth.factor_status NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    secret text
-);
-
-
-ALTER TABLE auth.mfa_factors OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE mfa_factors; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.mfa_factors IS 'auth: stores metadata about factors';
-
-
---
 -- Name: refresh_tokens; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
 --
 
@@ -1217,9 +882,7 @@ CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
     user_id character varying(255),
     revoked boolean,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    parent character varying(255),
-    session_id uuid
+    updated_at timestamp with time zone
 );
 
 
@@ -1254,60 +917,6 @@ ALTER SEQUENCE auth.refresh_tokens_id_seq OWNED BY auth.refresh_tokens.id;
 
 
 --
--- Name: saml_providers; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.saml_providers (
-    id uuid NOT NULL,
-    sso_provider_id uuid NOT NULL,
-    entity_id text NOT NULL,
-    metadata_xml text NOT NULL,
-    metadata_url text,
-    attribute_mapping jsonb,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    CONSTRAINT "entity_id not empty" CHECK ((char_length(entity_id) > 0)),
-    CONSTRAINT "metadata_url not empty" CHECK (((metadata_url = NULL::text) OR (char_length(metadata_url) > 0))),
-    CONSTRAINT "metadata_xml not empty" CHECK ((char_length(metadata_xml) > 0))
-);
-
-
-ALTER TABLE auth.saml_providers OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE saml_providers; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.saml_providers IS 'Auth: Manages SAML Identity Provider connections.';
-
-
---
--- Name: saml_relay_states; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.saml_relay_states (
-    id uuid NOT NULL,
-    sso_provider_id uuid NOT NULL,
-    request_id text NOT NULL,
-    for_email text,
-    redirect_to text,
-    from_ip_address inet,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    CONSTRAINT "request_id not empty" CHECK ((char_length(request_id) > 0))
-);
-
-
-ALTER TABLE auth.saml_relay_states OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE saml_relay_states; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.saml_relay_states IS 'Auth: Contains SAML Relay State information for each Service Provider initiated login.';
-
-
---
 -- Name: schema_migrations; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
 --
 
@@ -1326,89 +935,6 @@ COMMENT ON TABLE auth.schema_migrations IS 'Auth: Manages updates to the auth sy
 
 
 --
--- Name: sessions; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.sessions (
-    id uuid NOT NULL,
-    user_id uuid NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    factor_id uuid,
-    aal auth.aal_level,
-    not_after timestamp with time zone
-);
-
-
-ALTER TABLE auth.sessions OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE sessions; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.sessions IS 'Auth: Stores session data associated to a user.';
-
-
---
--- Name: COLUMN sessions.not_after; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON COLUMN auth.sessions.not_after IS 'Auth: Not after is a nullable column that contains a timestamp after which the session should be regarded as expired.';
-
-
---
--- Name: sso_domains; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.sso_domains (
-    id uuid NOT NULL,
-    sso_provider_id uuid NOT NULL,
-    domain text NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    CONSTRAINT "domain not empty" CHECK ((char_length(domain) > 0))
-);
-
-
-ALTER TABLE auth.sso_domains OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE sso_domains; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.sso_domains IS 'Auth: Manages SSO email address domain mapping to an SSO Identity Provider.';
-
-
---
--- Name: sso_providers; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE TABLE IF NOT EXISTS auth.sso_providers (
-    id uuid NOT NULL,
-    resource_id text,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    CONSTRAINT "resource_id not empty" CHECK (((resource_id = NULL::text) OR (char_length(resource_id) > 0)))
-);
-
-
-ALTER TABLE auth.sso_providers OWNER TO supabase_auth_admin;
-
---
--- Name: TABLE sso_providers; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON TABLE auth.sso_providers IS 'Auth: Manages SSO identity provider information; see saml_providers for SAML.';
-
-
---
--- Name: COLUMN sso_providers.resource_id; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON COLUMN auth.sso_providers.resource_id IS 'Auth: Uniquely identifies a SSO provider according to a user-chosen resource ID (case insensitive), useful in infrastructure as code.';
-
-
---
 -- Name: users; Type: TABLE; Schema: auth; Owner: supabase_auth_admin
 --
 
@@ -1419,13 +945,13 @@ CREATE TABLE IF NOT EXISTS auth.users (
     role character varying(255),
     email character varying(255),
     encrypted_password character varying(255),
-    email_confirmed_at timestamp with time zone,
+    confirmed_at timestamp with time zone,
     invited_at timestamp with time zone,
     confirmation_token character varying(255),
     confirmation_sent_at timestamp with time zone,
     recovery_token character varying(255),
     recovery_sent_at timestamp with time zone,
-    email_change_token_new character varying(255),
+    email_change_token character varying(255),
     email_change character varying(255),
     email_change_sent_at timestamp with time zone,
     last_sign_in_at timestamp with time zone,
@@ -1433,21 +959,7 @@ CREATE TABLE IF NOT EXISTS auth.users (
     raw_user_meta_data jsonb,
     is_super_admin boolean,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone,
-    phone text DEFAULT NULL::character varying,
-    phone_confirmed_at timestamp with time zone,
-    phone_change text DEFAULT ''::character varying,
-    phone_change_token character varying(255) DEFAULT ''::character varying,
-    phone_change_sent_at timestamp with time zone,
-    confirmed_at timestamp with time zone GENERATED ALWAYS AS (LEAST(email_confirmed_at, phone_confirmed_at)) STORED,
-    email_change_token_current character varying(255) DEFAULT ''::character varying,
-    email_change_confirm_status smallint DEFAULT 0,
-    banned_until timestamp with time zone,
-    reauthentication_token character varying(255) DEFAULT ''::character varying,
-    reauthentication_sent_at timestamp with time zone,
-    is_sso_user boolean DEFAULT false NOT NULL,
-    deleted_at timestamp with time zone,
-    CONSTRAINT users_email_change_confirm_status_check CHECK (((email_change_confirm_status >= 0) AND (email_change_confirm_status <= 2)))
+    updated_at timestamp with time zone
 );
 
 
@@ -1461,13 +973,6 @@ COMMENT ON TABLE auth.users IS 'Auth: Stores user login data within a secure sch
 
 
 --
--- Name: COLUMN users.is_sso_user; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON COLUMN auth.users.is_sso_user IS 'Auth: Set this column to true when the account comes from SSO. These accounts can have duplicate emails.';
-
-
---
 -- Name: buckets; Type: TABLE; Schema: storage; Owner: supabase_storage_admin
 --
 
@@ -1476,11 +981,7 @@ CREATE TABLE IF NOT EXISTS storage.buckets (
     name text NOT NULL,
     owner uuid,
     created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    public boolean DEFAULT false,
-    avif_autodetection boolean DEFAULT false,
-    file_size_limit bigint,
-    allowed_mime_types text[]
+    updated_at timestamp with time zone DEFAULT now()
 );
 
 
@@ -1512,9 +1013,7 @@ CREATE TABLE IF NOT EXISTS storage.objects (
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
     last_accessed_at timestamp with time zone DEFAULT now(),
-    metadata jsonb,
-    path_tokens text[] GENERATED ALWAYS AS (string_to_array(name, '/'::text)) STORED,
-    version text
+    metadata jsonb
 );
 
 
@@ -1619,48 +1118,36 @@ ALTER TABLE ONLY supabase_functions.hooks ALTER COLUMN id SET DEFAULT nextval('s
 -- Data for Name: extensions; Type: TABLE DATA; Schema: _realtime; Owner: supabase_admin
 --
 
-INSERT INTO _realtime.extensions (id, type, settings, tenant_external_id, inserted_at, updated_at) VALUES ('0bf3859e-9d2f-4490-a611-22b938249f45', 'postgres_cdc_rls', '{"region": "us-east-1", "db_host": "ABK7kBu27y/PVdL10i/b+A==", "db_name": "sWBpZNdjggEPTQVlI52Zfw==", "db_port": "+enMDFi1J/3IrrquHHwUmA==", "db_user": "uxbEq/zz8DXVD53TOI1zmw==", "slot_name": "supabase_realtime_replication_slot", "ip_version": 4, "db_password": "sWBpZNdjggEPTQVlI52Zfw==", "publication": "supabase_realtime", "poll_interval_ms": 100, "poll_max_changes": 100, "poll_max_record_bytes": 1048576}', 'realtime-dev', '2023-04-26 13:46:10', '2023-04-26 13:46:10');
+INSERT INTO _realtime.extensions (id, type, settings, tenant_external_id, inserted_at, updated_at) VALUES ('457de1fb-df64-45d6-9fe0-28775c7c9ad8', 'postgres_cdc_rls', '{"region": "us-east-1", "db_host": "ABK7kBu27y/PVdL10i/b+A==", "db_name": "sWBpZNdjggEPTQVlI52Zfw==", "db_port": "+enMDFi1J/3IrrquHHwUmA==", "db_user": "uxbEq/zz8DXVD53TOI1zmw==", "slot_name": "supabase_realtime_replication_slot", "ip_version": 4, "db_password": "sWBpZNdjggEPTQVlI52Zfw==", "publication": "supabase_realtime", "poll_interval_ms": 100, "poll_max_changes": 100, "poll_max_record_bytes": 1048576}', 'realtime-dev', '2023-05-05 04:18:20', '2023-05-05 04:18:20');
 
 
 --
 -- Data for Name: schema_migrations; Type: TABLE DATA; Schema: _realtime; Owner: supabase_admin
 --
 
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20210706140551, '2023-04-26 13:46:08');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220329161857, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220410212326, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220506102948, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220527210857, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220815211129, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220815215024, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220818141501, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221018173709, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221102172703, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221223010058, '2023-04-26 13:46:09');
-INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20230110180046, '2023-04-26 13:46:09');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20210706140551, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220329161857, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220410212326, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220506102948, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220527210857, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220815211129, '2023-05-05 04:18:18');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220815215024, '2023-05-05 04:18:19');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20220818141501, '2023-05-05 04:18:19');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221018173709, '2023-05-05 04:18:19');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221102172703, '2023-05-05 04:18:19');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20221223010058, '2023-05-05 04:18:19');
+INSERT INTO _realtime.schema_migrations (version, inserted_at) VALUES (20230110180046, '2023-05-05 04:18:19');
 
 
 --
 -- Data for Name: tenants; Type: TABLE DATA; Schema: _realtime; Owner: supabase_admin
 --
 
-INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent_users, inserted_at, updated_at, max_events_per_second, postgres_cdc_default, max_bytes_per_second, max_channels_per_client, max_joins_per_second) VALUES ('746f7d92-617e-4cdc-a605-d1dac4e74c9c', 'realtime-dev', 'realtime-dev', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 200, '2023-04-26 13:46:10', '2023-04-26 13:46:10', 100, 'postgres_cdc_rls', 100000, 100, 500);
+INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent_users, inserted_at, updated_at, max_events_per_second, postgres_cdc_default, max_bytes_per_second, max_channels_per_client, max_joins_per_second) VALUES ('158d4660-a9aa-422b-b5f2-60158a2e4ab2', 'realtime-dev', 'realtime-dev', 'iNjicxc4+llvc9wovDvqymwfnj9teWMlyOIbJ8Fh6j2WNU8CIJ2ZgjR6MUIKqSmeDmvpsKLsZ9jgXJmQPpwL8w==', 200, '2023-05-05 04:18:20', '2023-05-05 04:18:20', 100, 'postgres_cdc_rls', 100000, 100, 500);
 
 
 --
 -- Data for Name: audit_log_entries; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: flow_state; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: identities; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
 --
 
 
@@ -1672,37 +1159,7 @@ INSERT INTO _realtime.tenants (id, name, external_id, jwt_secret, max_concurrent
 
 
 --
--- Data for Name: mfa_amr_claims; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: mfa_challenges; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: mfa_factors; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
 -- Data for Name: refresh_tokens; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: saml_providers; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: saml_relay_states; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
 --
 
 
@@ -1718,61 +1175,6 @@ INSERT INTO auth.schema_migrations (version) VALUES ('20180103212743');
 INSERT INTO auth.schema_migrations (version) VALUES ('20180108183307');
 INSERT INTO auth.schema_migrations (version) VALUES ('20180119214651');
 INSERT INTO auth.schema_migrations (version) VALUES ('20180125194653');
-INSERT INTO auth.schema_migrations (version) VALUES ('00');
-INSERT INTO auth.schema_migrations (version) VALUES ('20210710035447');
-INSERT INTO auth.schema_migrations (version) VALUES ('20210722035447');
-INSERT INTO auth.schema_migrations (version) VALUES ('20210730183235');
-INSERT INTO auth.schema_migrations (version) VALUES ('20210909172000');
-INSERT INTO auth.schema_migrations (version) VALUES ('20210927181326');
-INSERT INTO auth.schema_migrations (version) VALUES ('20211122151130');
-INSERT INTO auth.schema_migrations (version) VALUES ('20211124214934');
-INSERT INTO auth.schema_migrations (version) VALUES ('20211202183645');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220114185221');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220114185340');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220224000811');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220323170000');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220429102000');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220531120530');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220614074223');
-INSERT INTO auth.schema_migrations (version) VALUES ('20220811173540');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221003041349');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221003041400');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221011041400');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221020193600');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221021073300');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221021082433');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221027105023');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221114143122');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221114143410');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221125140132');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221208132122');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221215195500');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221215195800');
-INSERT INTO auth.schema_migrations (version) VALUES ('20221215195900');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230116124310');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230116124412');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230131181311');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230322519590');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230402418590');
-INSERT INTO auth.schema_migrations (version) VALUES ('20230411005111');
-
-
---
--- Data for Name: sessions; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: sso_domains; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
-
-
---
--- Data for Name: sso_providers; Type: TABLE DATA; Schema: auth; Owner: supabase_auth_admin
---
-
 
 
 --
@@ -1791,22 +1193,6 @@ INSERT INTO auth.schema_migrations (version) VALUES ('20230411005111');
 -- Data for Name: migrations; Type: TABLE DATA; Schema: storage; Owner: supabase_storage_admin
 --
 
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (0, 'create-migrations-table', 'e18db593bcde2aca2a408c4d1100f6abba2195df', '2023-04-06 08:00:54.875113');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (1, 'initialmigration', '6ab16121fbaa08bbd11b712d05f358f9b555d777', '2023-04-06 08:00:54.893123');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (2, 'pathtoken-column', '49756be03be4c17bb85fe70d4a861f27de7e49ad', '2023-04-06 08:00:54.903069');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (3, 'add-migrations-rls', 'bb5d124c53d68635a883e399426c6a5a25fc893d', '2023-04-06 08:00:54.977572');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (4, 'add-size-functions', '6d79007d04f5acd288c9c250c42d2d5fd286c54d', '2023-04-06 08:00:55.007177');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (5, 'change-column-name-in-get-size', 'fd65688505d2ffa9fbdc58a944348dd8604d688c', '2023-04-06 08:00:55.017454');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (6, 'add-rls-to-buckets', '63e2bab75a2040fee8e3fb3f15a0d26f3380e9b6', '2023-04-06 08:00:55.03386');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (7, 'add-public-to-buckets', '82568934f8a4d9e0a85f126f6fb483ad8214c418', '2023-04-06 08:00:55.041908');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (8, 'fix-search-function', '1a43a40eddb525f2e2f26efd709e6c06e58e059c', '2023-04-06 08:00:55.052594');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (9, 'search-files-search-function', '34c096597eb8b9d077fdfdde9878c88501b2fafc', '2023-04-06 08:00:55.058769');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (10, 'add-trigger-to-auto-update-updated_at-column', '37d6bb964a70a822e6d37f22f457b9bca7885928', '2023-04-06 08:00:55.068775');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (11, 'add-automatic-avif-detection-flag', 'bd76c53a9c564c80d98d119c1b3a28e16c8152db', '2023-04-06 08:00:55.07397');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (12, 'add-bucket-custom-limits', 'cbe0a4c32a0e891554a21020433b7a4423c07ee7', '2023-04-06 08:00:55.083113');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (13, 'use-bytes-for-max-size', '7a158ebce8a0c2801c9c65b7e9b2f98f68b3874e', '2023-04-06 08:00:55.090631');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (14, 'add-can-insert-object-function', '273193826bca7e0990b458d1ba72f8aa27c0d825', '2023-04-06 08:00:55.108943');
-INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (15, 'add-version', 'e821a779d26612899b8c2dfe20245f904a327c4f', '2023-04-06 08:00:55.116335');
 
 
 --
@@ -1825,8 +1211,8 @@ INSERT INTO storage.migrations (id, name, hash, executed_at) VALUES (15, 'add-ve
 -- Data for Name: migrations; Type: TABLE DATA; Schema: supabase_functions; Owner: supabase_functions_admin
 --
 
-INSERT INTO supabase_functions.migrations (version, inserted_at) VALUES ('initial', '2023-03-08 06:28:46.163363+00');
-INSERT INTO supabase_functions.migrations (version, inserted_at) VALUES ('20210809183423_update_grants', '2023-03-08 06:28:46.163363+00');
+INSERT INTO supabase_functions.migrations (version, inserted_at) VALUES ('initial', '2023-05-05 04:18:13.418929+00');
+INSERT INTO supabase_functions.migrations (version, inserted_at) VALUES ('20210809183423_update_grants', '2023-05-05 04:18:13.418929+00');
 
 
 --
@@ -1881,35 +1267,11 @@ ALTER TABLE ONLY _realtime.tenants
 
 
 --
--- Name: mfa_amr_claims amr_id_pk; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_amr_claims
-    ADD CONSTRAINT amr_id_pk PRIMARY KEY (id);
-
-
---
 -- Name: audit_log_entries audit_log_entries_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
 --
 
 ALTER TABLE ONLY auth.audit_log_entries
     ADD CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id);
-
-
---
--- Name: flow_state flow_state_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.flow_state
-    ADD CONSTRAINT flow_state_pkey PRIMARY KEY (id);
-
-
---
--- Name: identities identities_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.identities
-    ADD CONSTRAINT identities_pkey PRIMARY KEY (provider, id);
 
 
 --
@@ -1921,67 +1283,11 @@ ALTER TABLE ONLY auth.instances
 
 
 --
--- Name: mfa_amr_claims mfa_amr_claims_session_id_authentication_method_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_amr_claims
-    ADD CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey UNIQUE (session_id, authentication_method);
-
-
---
--- Name: mfa_challenges mfa_challenges_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_challenges
-    ADD CONSTRAINT mfa_challenges_pkey PRIMARY KEY (id);
-
-
---
--- Name: mfa_factors mfa_factors_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_factors
-    ADD CONSTRAINT mfa_factors_pkey PRIMARY KEY (id);
-
-
---
 -- Name: refresh_tokens refresh_tokens_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
 --
 
 ALTER TABLE ONLY auth.refresh_tokens
     ADD CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id);
-
-
---
--- Name: refresh_tokens refresh_tokens_token_unique; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.refresh_tokens
-    ADD CONSTRAINT refresh_tokens_token_unique UNIQUE (token);
-
-
---
--- Name: saml_providers saml_providers_entity_id_key; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.saml_providers
-    ADD CONSTRAINT saml_providers_entity_id_key UNIQUE (entity_id);
-
-
---
--- Name: saml_providers saml_providers_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.saml_providers
-    ADD CONSTRAINT saml_providers_pkey PRIMARY KEY (id);
-
-
---
--- Name: saml_relay_states saml_relay_states_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.saml_relay_states
-    ADD CONSTRAINT saml_relay_states_pkey PRIMARY KEY (id);
 
 
 --
@@ -1993,35 +1299,11 @@ ALTER TABLE ONLY auth.schema_migrations
 
 
 --
--- Name: sessions sessions_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.sessions
-    ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);
-
-
---
--- Name: sso_domains sso_domains_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.sso_domains
-    ADD CONSTRAINT sso_domains_pkey PRIMARY KEY (id);
-
-
---
--- Name: sso_providers sso_providers_pkey; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.sso_providers
-    ADD CONSTRAINT sso_providers_pkey PRIMARY KEY (id);
-
-
---
--- Name: users users_phone_key; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
+-- Name: users users_email_key; Type: CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
 --
 
 ALTER TABLE ONLY auth.users
-    ADD CONSTRAINT users_phone_key UNIQUE (phone);
+    ADD CONSTRAINT users_email_key UNIQUE (email);
 
 
 --
@@ -2102,90 +1384,6 @@ CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (i
 
 
 --
--- Name: confirmation_token_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE ((confirmation_token)::text !~ '^[0-9 ]*$'::text);
-
-
---
--- Name: email_change_token_current_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE ((email_change_token_current)::text !~ '^[0-9 ]*$'::text);
-
-
---
--- Name: email_change_token_new_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE ((email_change_token_new)::text !~ '^[0-9 ]*$'::text);
-
-
---
--- Name: factor_id_created_at_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX factor_id_created_at_idx ON auth.mfa_factors USING btree (user_id, created_at);
-
-
---
--- Name: identities_email_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX identities_email_idx ON auth.identities USING btree (email text_pattern_ops);
-
-
---
--- Name: INDEX identities_email_idx; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON INDEX auth.identities_email_idx IS 'Auth: Ensures indexed queries on the email column';
-
-
---
--- Name: identities_user_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX identities_user_id_idx ON auth.identities USING btree (user_id);
-
-
---
--- Name: idx_auth_code; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX idx_auth_code ON auth.flow_state USING btree (auth_code);
-
-
---
--- Name: idx_user_id_auth_method; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX idx_user_id_auth_method ON auth.flow_state USING btree (user_id, authentication_method);
-
-
---
--- Name: mfa_factors_user_friendly_name_unique; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX mfa_factors_user_friendly_name_unique ON auth.mfa_factors USING btree (friendly_name, user_id) WHERE (TRIM(BOTH FROM friendly_name) <> ''::text);
-
-
---
--- Name: reauthentication_token_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE ((reauthentication_token)::text !~ '^[0-9 ]*$'::text);
-
-
---
--- Name: recovery_token_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX recovery_token_idx ON auth.users USING btree (recovery_token) WHERE ((recovery_token)::text !~ '^[0-9 ]*$'::text);
-
-
---
 -- Name: refresh_tokens_instance_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
 --
 
@@ -2200,94 +1398,17 @@ CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING
 
 
 --
--- Name: refresh_tokens_parent_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
+-- Name: refresh_tokens_token_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE INDEX refresh_tokens_parent_idx ON auth.refresh_tokens USING btree (parent);
-
-
---
--- Name: refresh_tokens_session_id_revoked_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX refresh_tokens_session_id_revoked_idx ON auth.refresh_tokens USING btree (session_id, revoked);
-
-
---
--- Name: saml_providers_sso_provider_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX saml_providers_sso_provider_id_idx ON auth.saml_providers USING btree (sso_provider_id);
-
-
---
--- Name: saml_relay_states_for_email_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX saml_relay_states_for_email_idx ON auth.saml_relay_states USING btree (for_email);
-
-
---
--- Name: saml_relay_states_sso_provider_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX saml_relay_states_sso_provider_id_idx ON auth.saml_relay_states USING btree (sso_provider_id);
-
-
---
--- Name: sessions_user_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX sessions_user_id_idx ON auth.sessions USING btree (user_id);
-
-
---
--- Name: sso_domains_domain_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX sso_domains_domain_idx ON auth.sso_domains USING btree (lower(domain));
-
-
---
--- Name: sso_domains_sso_provider_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX sso_domains_sso_provider_id_idx ON auth.sso_domains USING btree (sso_provider_id);
-
-
---
--- Name: sso_providers_resource_id_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX sso_providers_resource_id_idx ON auth.sso_providers USING btree (lower(resource_id));
-
-
---
--- Name: user_id_created_at_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE INDEX user_id_created_at_idx ON auth.sessions USING btree (user_id, created_at);
-
-
---
--- Name: users_email_partial_key; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
---
-
-CREATE UNIQUE INDEX users_email_partial_key ON auth.users USING btree (email) WHERE (is_sso_user = false);
-
-
---
--- Name: INDEX users_email_partial_key; Type: COMMENT; Schema: auth; Owner: supabase_auth_admin
---
-
-COMMENT ON INDEX auth.users_email_partial_key IS 'Auth: A partial unique index that applies only when is_sso_user is false';
+CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 
 
 --
 -- Name: users_instance_id_email_idx; Type: INDEX; Schema: auth; Owner: supabase_auth_admin
 --
 
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, lower((email)::text));
+CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
 
 
 --
@@ -2333,90 +1454,11 @@ CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks
 
 
 --
--- Name: objects update_objects_updated_at; Type: TRIGGER; Schema: storage; Owner: supabase_storage_admin
---
-
-CREATE TRIGGER update_objects_updated_at BEFORE UPDATE ON storage.objects FOR EACH ROW EXECUTE FUNCTION storage.update_updated_at_column();
-
-
---
 -- Name: extensions extensions_tenant_external_id_fkey; Type: FK CONSTRAINT; Schema: _realtime; Owner: supabase_admin
 --
 
 ALTER TABLE ONLY _realtime.extensions
     ADD CONSTRAINT extensions_tenant_external_id_fkey FOREIGN KEY (tenant_external_id) REFERENCES _realtime.tenants(external_id) ON DELETE CASCADE;
-
-
---
--- Name: identities identities_user_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.identities
-    ADD CONSTRAINT identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: mfa_amr_claims mfa_amr_claims_session_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_amr_claims
-    ADD CONSTRAINT mfa_amr_claims_session_id_fkey FOREIGN KEY (session_id) REFERENCES auth.sessions(id) ON DELETE CASCADE;
-
-
---
--- Name: mfa_challenges mfa_challenges_auth_factor_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_challenges
-    ADD CONSTRAINT mfa_challenges_auth_factor_id_fkey FOREIGN KEY (factor_id) REFERENCES auth.mfa_factors(id) ON DELETE CASCADE;
-
-
---
--- Name: mfa_factors mfa_factors_user_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.mfa_factors
-    ADD CONSTRAINT mfa_factors_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: refresh_tokens refresh_tokens_session_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.refresh_tokens
-    ADD CONSTRAINT refresh_tokens_session_id_fkey FOREIGN KEY (session_id) REFERENCES auth.sessions(id) ON DELETE CASCADE;
-
-
---
--- Name: saml_providers saml_providers_sso_provider_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.saml_providers
-    ADD CONSTRAINT saml_providers_sso_provider_id_fkey FOREIGN KEY (sso_provider_id) REFERENCES auth.sso_providers(id) ON DELETE CASCADE;
-
-
---
--- Name: saml_relay_states saml_relay_states_sso_provider_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.saml_relay_states
-    ADD CONSTRAINT saml_relay_states_sso_provider_id_fkey FOREIGN KEY (sso_provider_id) REFERENCES auth.sso_providers(id) ON DELETE CASCADE;
-
-
---
--- Name: sessions sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.sessions
-    ADD CONSTRAINT sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: sso_domains sso_domains_sso_provider_id_fkey; Type: FK CONSTRAINT; Schema: auth; Owner: supabase_auth_admin
---
-
-ALTER TABLE ONLY auth.sso_domains
-    ADD CONSTRAINT sso_domains_sso_provider_id_fkey FOREIGN KEY (sso_provider_id) REFERENCES auth.sso_providers(id) ON DELETE CASCADE;
 
 
 --
@@ -2442,18 +1484,6 @@ ALTER TABLE ONLY storage.objects
 ALTER TABLE ONLY storage.objects
     ADD CONSTRAINT objects_owner_fkey FOREIGN KEY (owner) REFERENCES auth.users(id);
 
-
---
--- Name: buckets; Type: ROW SECURITY; Schema: storage; Owner: supabase_storage_admin
---
-
-ALTER TABLE storage.buckets ENABLE ROW LEVEL SECURITY;
-
---
--- Name: migrations; Type: ROW SECURITY; Schema: storage; Owner: supabase_storage_admin
---
-
-ALTER TABLE storage.migrations ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: objects; Type: ROW SECURITY; Schema: storage; Owner: supabase_storage_admin
@@ -2557,14 +1587,6 @@ GRANT ALL ON SCHEMA supabase_functions TO supabase_functions_admin;
 --
 
 GRANT ALL ON FUNCTION auth.email() TO dashboard_user;
-
-
---
--- Name: FUNCTION jwt(); Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON FUNCTION auth.jwt() TO postgres;
-GRANT ALL ON FUNCTION auth.jwt() TO dashboard_user;
 
 
 --
@@ -3253,6 +2275,17 @@ GRANT ALL ON FUNCTION storage.foldername(name text) TO postgres;
 
 
 --
+-- Name: FUNCTION search(prefix text, bucketname text, limits integer, levels integer, offsets integer); Type: ACL; Schema: storage; Owner: supabase_storage_admin
+--
+
+GRANT ALL ON FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) TO anon;
+GRANT ALL ON FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) TO authenticated;
+GRANT ALL ON FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) TO service_role;
+GRANT ALL ON FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) TO dashboard_user;
+GRANT ALL ON FUNCTION storage.search(prefix text, bucketname text, limits integer, levels integer, offsets integer) TO postgres;
+
+
+--
 -- Name: FUNCTION http_request(); Type: ACL; Schema: supabase_functions; Owner: supabase_functions_admin
 --
 
@@ -3272,51 +2305,11 @@ GRANT ALL ON TABLE auth.audit_log_entries TO postgres;
 
 
 --
--- Name: TABLE flow_state; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.flow_state TO postgres;
-GRANT ALL ON TABLE auth.flow_state TO dashboard_user;
-
-
---
--- Name: TABLE identities; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.identities TO postgres;
-GRANT ALL ON TABLE auth.identities TO dashboard_user;
-
-
---
 -- Name: TABLE instances; Type: ACL; Schema: auth; Owner: supabase_auth_admin
 --
 
 GRANT ALL ON TABLE auth.instances TO dashboard_user;
 GRANT ALL ON TABLE auth.instances TO postgres;
-
-
---
--- Name: TABLE mfa_amr_claims; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.mfa_amr_claims TO postgres;
-GRANT ALL ON TABLE auth.mfa_amr_claims TO dashboard_user;
-
-
---
--- Name: TABLE mfa_challenges; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.mfa_challenges TO postgres;
-GRANT ALL ON TABLE auth.mfa_challenges TO dashboard_user;
-
-
---
--- Name: TABLE mfa_factors; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.mfa_factors TO postgres;
-GRANT ALL ON TABLE auth.mfa_factors TO dashboard_user;
 
 
 --
@@ -3336,51 +2329,11 @@ GRANT ALL ON SEQUENCE auth.refresh_tokens_id_seq TO postgres;
 
 
 --
--- Name: TABLE saml_providers; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.saml_providers TO postgres;
-GRANT ALL ON TABLE auth.saml_providers TO dashboard_user;
-
-
---
--- Name: TABLE saml_relay_states; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.saml_relay_states TO postgres;
-GRANT ALL ON TABLE auth.saml_relay_states TO dashboard_user;
-
-
---
 -- Name: TABLE schema_migrations; Type: ACL; Schema: auth; Owner: supabase_auth_admin
 --
 
 GRANT ALL ON TABLE auth.schema_migrations TO dashboard_user;
 GRANT ALL ON TABLE auth.schema_migrations TO postgres;
-
-
---
--- Name: TABLE sessions; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.sessions TO postgres;
-GRANT ALL ON TABLE auth.sessions TO dashboard_user;
-
-
---
--- Name: TABLE sso_domains; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.sso_domains TO postgres;
-GRANT ALL ON TABLE auth.sso_domains TO dashboard_user;
-
-
---
--- Name: TABLE sso_providers; Type: ACL; Schema: auth; Owner: supabase_auth_admin
---
-
-GRANT ALL ON TABLE auth.sso_providers TO postgres;
-GRANT ALL ON TABLE auth.sso_providers TO dashboard_user;
 
 
 --

--- a/internal/utils/templates/initial_schemas/README.md
+++ b/internal/utils/templates/initial_schemas/README.md
@@ -14,7 +14,7 @@ Because Realtime, GoTrue, Logflare, and Storage have their own migrations, and t
 
 ```bash
 go run . init
-go run . start
+go run . start -x gotrue,storage-api,imgproxy
 ```
 
 2. Run the initial dump script and pipe output to `15.sql`
@@ -27,7 +27,7 @@ go run . start
 
 - `INSERT INTO _realtime.extensions` and `_realtime.tenants` usually do not require updating.
 - `INSERT INTO *.schema_migrations` statements are only required if there are new migrations.
-- `ALTER EVENT TRIGGER issue_pg_cron_access OWNER TO` should be followed by supabase_admin.
+- `ALTER EVENT TRIGGER issue_pg_cron_access OWNER TO` should be followed by `supabase_admin`.
 
 4. Set `major_version = 14` in `supabase/config.toml` and repeat steps 1-3 to update `14.sql`
 5. Set `major_version = 13` in `supabase/config.toml` and repeat steps 1-3 to update `13.sql`

--- a/tools/dump_initial_schema.sh
+++ b/tools/dump_initial_schema.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 # Explanation of special flags:
 #
 #   --column-inserts  include migration history, but not pgsodium key
-#   --no-comments     only object owner can set comment, omit to allow restore by non-superuser
 pg_dump \
     --column-inserts \
     --exclude-table-data 'pgsodium.key' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Since we are restarting auth and storage containers after db reset, it's better to let those services run their own migrations. This simplifies the upgrade process as only image version bump is needed for pg15.

pg14 and pg13 still require updating initial schema.

## Additional context

Add any other context or screenshots.
