### PR TITLE
fix: bump edge-runtime to v1.2.19

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	StudioImage      = "supabase/studio:20230509-af8eb1e"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.2.18"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.2.19"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
Fixes https://github.com/supabase/cli/issues/1071