### PR TITLE
fix: default to save backup on stop

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	backup bool
+	noBackup bool
 
 	stopCmd = &cobra.Command{
 		GroupID: groupLocalDev,
@@ -18,12 +18,15 @@ var (
 		Short:   "Stop all local Supabase containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return stop.Run(ctx, backup, afero.NewOsFs())
+			return stop.Run(ctx, !noBackup, afero.NewOsFs())
 		},
 	}
 )
 
 func init() {
-	stopCmd.Flags().BoolVar(&backup, "backup", false, "Backs up the current database before stopping.")
+	flags := stopCmd.Flags()
+	flags.Bool("backup", true, "Backs up the current database before stopping.")
+	cobra.CheckErr(flags.MarkHidden("backup"))
+	flags.BoolVar(&noBackup, "no-backup", false, "Deletes all data volumes after stopping.")
 	rootCmd.AddCommand(stopCmd)
 }

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -87,10 +87,14 @@ func StartDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 		config.Entrypoint = nil
 		hostConfig.Tmpfs = map[string]string{"/docker-entrypoint-initdb.d": ""}
 	}
-	fmt.Fprintln(w, "Starting database...")
 	// Creating volume will not override existing volume, so we must inspect explicitly
 	_, err := utils.Docker.VolumeInspect(ctx, utils.DbId)
 	noBackupVolume = client.IsErrNotFound(err)
+	if noBackupVolume {
+		fmt.Fprintln(w, "Starting database...")
+	} else {
+		fmt.Fprintln(w, "Starting database from backup...")
+	}
 	if _, err := utils.DockerStart(ctx, config, hostConfig, utils.DbId); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://supabase.slack.com/archives/C03S3SW9485/p1683767717245129?thread_ts=1683749208.015289&cid=C03S3SW9485

## What is the new behavior?

- `supabase stop` will save the backup volume by default
- adds `supabase stop --no-backup` flag to delete volumes

## Additional context

Add any other context or screenshots.
