### PR TITLE
fix: support linting remote database by url

### DIFF
--- a/internal/db/lint/lint.go
+++ b/internal/db/lint/lint.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/diff"
@@ -37,20 +38,14 @@ func toEnum(level string) LintLevel {
 	return -1
 }
 
-func Run(ctx context.Context, schema []string, level string, fsys afero.Fs, opts ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, schema []string, level string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	// Sanity checks.
-	if err := utils.LoadConfigFS(fsys); err != nil {
-		return err
-	}
-	if err := utils.AssertSupabaseDbIsRunning(); err != nil {
-		return err
-	}
-	// Run lint script
-	conn, err := utils.ConnectLocalPostgres(ctx, "localhost", utils.Config.Db.Port, "postgres", opts...)
+	conn, err := connect(ctx, config, fsys, options...)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(context.Background())
+	// Run lint script
 	result, err := LintDatabase(ctx, conn, schema)
 	if err != nil {
 		return err
@@ -60,6 +55,21 @@ func Run(ctx context.Context, schema []string, level string, fsys afero.Fs, opts
 		return nil
 	}
 	return printResultJSON(result, toEnum(level), os.Stdout)
+}
+
+func connect(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) (*pgx.Conn, error) {
+	if len(config.Password) > 0 {
+		fmt.Fprintln(os.Stderr, "Connecting to remote database...")
+		return utils.ConnectRemotePostgres(ctx, config, options...)
+	}
+	fmt.Fprintln(os.Stderr, "Connecting to local database...")
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return nil, err
+	}
+	if err := utils.AssertSupabaseDbIsRunning(); err != nil {
+		return nil, err
+	}
+	return utils.ConnectLocalPostgres(ctx, "localhost", utils.Config.Db.Port, "postgres", options...)
 }
 
 func filterResult(result []Result, minLevel LintLevel) (filtered []Result) {

--- a/internal/db/lint/lint_test.go
+++ b/internal/db/lint/lint_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func TestLintCommand(t *testing.T) {
 		Reply("SELECT 1", []interface{}{"f1", string(data)}).
 		Query("rollback").Reply("ROLLBACK")
 	// Run test
-	assert.NoError(t, Run(context.Background(), []string{"public"}, "warning", fsys, conn.Intercept))
+	assert.NoError(t, Run(context.Background(), []string{"public"}, "warning", pgconn.Config{}, fsys, conn.Intercept))
 	// Validate api
 	assert.Empty(t, apitest.ListUnmatchedRequests())
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -321,16 +321,6 @@ func AssertSupabaseCliIsSetUpFS(fsys afero.Fs) error {
 	return nil
 }
 
-func AssertIsLinkedFS(fsys afero.Fs) error {
-	if _, err := fsys.Stat(ProjectRefPath); errors.Is(err, os.ErrNotExist) {
-		return ErrNotLinked
-	} else if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func AssertProjectRefIsValid(projectRef string) error {
 	if !ProjectRefPattern.MatchString(projectRef) {
 		return ErrInvalidRef
@@ -340,8 +330,10 @@ func AssertProjectRefIsValid(projectRef string) error {
 
 func LoadProjectRef(fsys afero.Fs) (string, error) {
 	projectRefBytes, err := afero.ReadFile(fsys, ProjectRefPath)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", ErrNotLinked
+	} else if err != nil {
+		return "", err
 	}
 	projectRef := string(bytes.TrimSpace(projectRefBytes))
 	if !ProjectRefPattern.MatchString(projectRef) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1096

## What is the new behavior?

- parses `--db-url` and `--linked` flag so that `db lint` works against remote db

## Additional context

Add any other context or screenshots.
