### PR TITLE
fix: account for github head ref env var

### DIFF
--- a/internal/gen/keys/keys.go
+++ b/internal/gen/keys/keys.go
@@ -87,6 +87,10 @@ func GenerateSecrets(ctx context.Context, projectRef, branch string, fsys afero.
 }
 
 func GetGitBranch(fsys afero.Fs) string {
+	head := os.Getenv("GITHUB_HEAD_REF")
+	if len(head) > 0 {
+		return head
+	}
 	branch := "main"
 	if gitRoot, err := utils.GetGitRoot(fsys); err == nil {
 		if repo, err := git.PlainOpen(*gitRoot); err == nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -438,7 +438,7 @@ EOF
 					"DB_USER=supabase_admin",
 					"DB_PASSWORD=" + dbConfig.Password,
 					"DB_NAME=" + dbConfig.Database,
-					"DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime",
+					"DB_AFTER_CONNECT_QUERY=CREATE SCHEMA IF NOT EXISTS _realtime; SET search_path TO _realtime",
 					"DB_ENC_KEY=supabaserealtime",
 					"API_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
 					"FLY_ALLOC_ID=abc123",


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #1081 

## What is the new behavior?

- GHA only checks out the head ref of branch by default. To get the branch name, we need to allow env var override.
- connecting realtime to preview branch errors due to missing `_realtime` schema. Let the container initialise itself.

## Additional context

Add any other context or screenshots.
