### PR TITLE
feat: support deploying functions that imports from parent directory

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -391,27 +391,33 @@ paths:
           schema:
             pattern: /^[A-Za-z0-9_-]+$/
             type: string
-        - name: import_map_path
+        - name: slug
+          required: false
+          in: query
+          schema:
+            pattern: /^[A-Za-z0-9_-]+$/
+            type: string
+        - name: name
           required: false
           in: query
           schema:
             type: string
-        - name: entrypoint_path
-          required: false
-          in: query
-          schema:
-            type: string
-        - name: import_map
-          required: false
-          in: query
-          schema:
-            type: boolean
         - name: verify_jwt
           required: false
           in: query
           schema:
             type: boolean
-        - name: name
+        - name: import_map
+          required: false
+          in: query
+          schema:
+            type: boolean
+        - name: entrypoint_path
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: import_map_path
           required: false
           in: query
           schema:

--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -271,6 +271,16 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: entrypoint_path
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: import_map_path
+          required: false
+          in: query
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -402,6 +412,16 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: entrypoint_path
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: import_map_path
+          required: false
+          in: query
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -1758,6 +1778,10 @@ components:
           type: boolean
         import_map:
           type: boolean
+        entrypoint_path:
+          type: string
+        import_map_path:
+          type: string
       required:
         - id
         - slug
@@ -1788,6 +1812,10 @@ components:
           type: boolean
         import_map:
           type: boolean
+        entrypoint_path:
+          type: string
+        import_map_path:
+          type: string
       required:
         - id
         - slug

--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -391,33 +391,27 @@ paths:
           schema:
             pattern: /^[A-Za-z0-9_-]+$/
             type: string
-        - name: slug
-          required: false
-          in: query
-          schema:
-            pattern: /^[A-Za-z0-9_-]+$/
-            type: string
-        - name: name
+        - name: import_map_path
           required: false
           in: query
           schema:
             type: string
-        - name: verify_jwt
-          required: false
-          in: query
-          schema:
-            type: boolean
-        - name: import_map
-          required: false
-          in: query
-          schema:
-            type: boolean
         - name: entrypoint_path
           required: false
           in: query
           schema:
             type: string
-        - name: import_map_path
+        - name: import_map
+          required: false
+          in: query
+          schema:
+            type: boolean
+        - name: verify_jwt
+          required: false
+          in: query
+          schema:
+            type: boolean
+        - name: name
           required: false
           in: query
           schema:

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -57,7 +57,7 @@ var (
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return deploy.Run(cmd.Context(), args[0], flags.ProjectRef, noVerifyJWT, useLegacyBundle, importMapPath, afero.NewOsFs())
+			return deploy.Run(cmd.Context(), args[0], flags.ProjectRef, noVerifyJWT, false, importMapPath, afero.NewOsFs())
 		},
 	}
 
@@ -106,6 +106,7 @@ func init() {
 	functionsDeployCmd.Flags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDeployCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")
 	functionsDeployCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
+	cobra.CheckErr(functionsDeployCmd.Flags().MarkHidden("legacy-bundle"))
 	functionsServeCmd.Flags().BoolVar(noVerifyJWT, "no-verify-jwt", false, "Disable JWT verification for the Function.")
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -57,7 +57,7 @@ var (
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return deploy.Run(cmd.Context(), args[0], flags.ProjectRef, noVerifyJWT, false, importMapPath, afero.NewOsFs())
+			return deploy.Run(cmd.Context(), args[0], flags.ProjectRef, noVerifyJWT, importMapPath, afero.NewOsFs())
 		},
 	}
 

--- a/internal/functions/delete/delete.go
+++ b/internal/functions/delete/delete.go
@@ -19,26 +19,17 @@ func Run(ctx context.Context, slug string, projectRef string, fsys afero.Fs) err
 	}
 
 	// 2. Delete Function.
-	{
-		resp, err := utils.GetSupabase().GetFunctionWithResponse(ctx, projectRef, slug)
-		if err != nil {
-			return err
-		}
-
-		switch resp.StatusCode() {
-		case http.StatusNotFound: // Function doesn't exist
-			return errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
-		case http.StatusOK: // Function exists
-			resp, err := utils.GetSupabase().DeleteFunctionWithResponse(ctx, projectRef, slug)
-			if err != nil {
-				return err
-			}
-			if resp.StatusCode() != http.StatusOK {
-				return errors.New("Failed to delete Function " + utils.Aqua(slug) + " on the Supabase project: " + string(resp.Body))
-			}
-		default:
-			return errors.New("Unexpected error deleting Function: " + string(resp.Body))
-		}
+	resp, err := utils.GetSupabase().DeleteFunctionWithResponse(ctx, projectRef, slug)
+	if err != nil {
+		return err
+	}
+	switch resp.StatusCode() {
+	case http.StatusNotFound:
+		return errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
+	case http.StatusOK:
+		break
+	default:
+		return errors.New("Failed to delete Function " + utils.Aqua(slug) + " on the Supabase project: " + string(resp.Body))
 	}
 
 	fmt.Println("Deleted Function " + utils.Aqua(slug) + " from project " + utils.Aqua(projectRef) + ".")

--- a/internal/functions/delete/delete_test.go
+++ b/internal/functions/delete/delete_test.go
@@ -15,11 +15,15 @@ import (
 
 func TestDeleteCommand(t *testing.T) {
 	const slug = "test-func"
+	// Setup valid project ref
+	project := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
 	t.Run("deletes function from project", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -45,8 +49,6 @@ func TestDeleteCommand(t *testing.T) {
 	t.Run("throws error on network failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -62,8 +64,6 @@ func TestDeleteCommand(t *testing.T) {
 	t.Run("throws error on missing function", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -80,8 +80,6 @@ func TestDeleteCommand(t *testing.T) {
 	t.Run("throws error on service unavailable", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -65,13 +65,15 @@ func Run(ctx context.Context, slug string, projectRef string, noVerifyJWT *bool,
 	// Note: eszip created will always contain a `import_map.json`.
 	importMap := true
 	verifyJWT := !*noVerifyJWT
+	importMapUrl := "file://" + importMapPath
+	entrypointUrl := "file://" + entrypointPath
 	return deployFunction(ctx, projectRef, api.CreateFunctionParams{
 		Slug:           &slug,
 		Name:           &slug,
 		VerifyJwt:      &verifyJWT,
 		ImportMap:      &importMap,
-		ImportMapPath:  &importMapPath,
-		EntrypointPath: &entrypointPath,
+		ImportMapPath:  &importMapUrl,
+		EntrypointPath: &entrypointUrl,
 	}, functionBody)
 }
 

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -35,6 +35,13 @@ func Run(ctx context.Context, slug string, projectRef string, noVerifyJWT *bool,
 		if err != nil {
 			return err
 		}
+		// Upstream server expects import map to be always defined
+		if importMapPath == "" {
+			resolved, err = filepath.Abs(utils.FallbackImportMapPath)
+			if err != nil {
+				return err
+			}
+		}
 		importMapPath = resolved
 		if err := utils.ValidateFunctionSlug(slug); err != nil {
 			return err

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/go-units"
 	"github.com/spf13/afero"
@@ -19,7 +18,7 @@ import (
 
 const eszipContentType = "application/vnd.denoland.eszip"
 
-func Run(ctx context.Context, slug string, projectRef string, noVerifyJWT *bool, useLegacyBundle bool, importMapPath string, fsys afero.Fs) error {
+func Run(ctx context.Context, slug string, projectRef string, noVerifyJWT *bool, importMapPath string, fsys afero.Fs) error {
 	// 1. Sanity checks.
 	{
 		// Load function config if any for fallbacks for some flags, but continue on error.
@@ -50,24 +49,34 @@ func Run(ctx context.Context, slug string, projectRef string, noVerifyJWT *bool,
 	if err != nil {
 		return err
 	}
-	functionBody, err := bundleFunction(ctx, slug, importMapPath, scriptDir.BuildPath, fsys)
+	entrypointPath, err := filepath.Abs(filepath.Join(utils.FunctionsDir, slug, "index.ts"))
 	if err != nil {
 		return err
 	}
-	functionSize := functionBody.Len()
+	fmt.Println("Bundling " + utils.Bold(slug))
+	functionBody, err := bundleFunction(ctx, entrypointPath, importMapPath, scriptDir.BuildPath, fsys)
+	if err != nil {
+		return err
+	}
 
 	// 3. Deploy new Function.
-	fmt.Println("Deploying " + utils.Bold(slug) + " (script size: " + utils.Bold(units.HumanSize(float64(functionSize))) + ")")
-	return deployFunction(ctx, projectRef, slug, functionBody, !*noVerifyJWT, useLegacyBundle)
+	functionSize := units.HumanSize(float64(functionBody.Len()))
+	fmt.Println("Deploying " + utils.Bold(slug) + " (script size: " + utils.Bold(functionSize) + ")")
+	// Note: eszip created will always contain a `import_map.json`.
+	importMap := true
+	verifyJWT := !*noVerifyJWT
+	return deployFunction(ctx, projectRef, api.CreateFunctionParams{
+		Slug:           &slug,
+		Name:           &slug,
+		VerifyJwt:      &verifyJWT,
+		ImportMap:      &importMap,
+		ImportMapPath:  &importMapPath,
+		EntrypointPath: &entrypointPath,
+	}, functionBody)
 }
 
-func bundleFunction(ctx context.Context, slug, importMapPath, buildScriptPath string, fsys afero.Fs) (*bytes.Buffer, error) {
-	fmt.Println("Bundling " + utils.Bold(slug))
+func bundleFunction(ctx context.Context, entrypointPath, importMapPath, buildScriptPath string, fsys afero.Fs) (*bytes.Buffer, error) {
 	denoPath, err := utils.GetDenoPath()
-	if err != nil {
-		return nil, err
-	}
-	entrypointPath, err := filepath.Abs(filepath.Join(utils.FunctionsDir, slug, "index.ts"))
 	if err != nil {
 		return nil, err
 	}
@@ -83,89 +92,41 @@ func bundleFunction(ctx context.Context, slug, importMapPath, buildScriptPath st
 	return &outBuf, nil
 }
 
-func makeLegacyFunctionBody(functionBody io.Reader) (string, error) {
-	buf := new(strings.Builder)
-	_, err := io.Copy(buf, functionBody)
+func deployFunction(ctx context.Context, projectRef string, params api.CreateFunctionParams, functionBody io.Reader) error {
+	slug := *params.Slug
+	resp, err := utils.GetSupabase().GetFunctionWithResponse(ctx, projectRef, slug)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return buf.String(), nil
-}
-
-// TODO: Remove `useLegacyBundle` after 2023-06-01
-func deployFunction(ctx context.Context, projectRef, slug string, functionBody io.Reader, verifyJWT, useLegacyBundle bool) error {
-	{
-		resp, err := utils.GetSupabase().GetFunctionWithResponse(ctx, projectRef, slug)
+	switch resp.StatusCode() {
+	case http.StatusNotFound: // Function doesn't exist yet, so do a POST
+		resp, err := utils.GetSupabase().CreateFunctionWithBodyWithResponse(ctx, projectRef, &params, eszipContentType, functionBody)
 		if err != nil {
 			return err
 		}
-
-		var functionBodyStr string
-		if useLegacyBundle {
-			functionBodyStr, err = makeLegacyFunctionBody(functionBody)
-			if err != nil {
-				return err
-			}
+		if resp.JSON201 == nil {
+			return errors.New("Failed to create a new Function on the Supabase project: " + string(resp.Body))
 		}
-
-		// Note: imageMap is always set to true, since eszip created will always contain a `import_map.json`.
-		importMap := true
-
-		switch resp.StatusCode() {
-		case http.StatusNotFound: // Function doesn't exist yet, so do a POST
-			var resp *api.CreateFunctionResponse
-			var err error
-			if useLegacyBundle {
-				resp, err = utils.GetSupabase().CreateFunctionWithResponse(ctx, projectRef, &api.CreateFunctionParams{}, api.CreateFunctionJSONRequestBody{
-					Body:      functionBodyStr,
-					Name:      slug,
-					Slug:      slug,
-					VerifyJwt: &verifyJWT,
-				})
-			} else {
-				resp, err = utils.GetSupabase().CreateFunctionWithBodyWithResponse(ctx, projectRef, &api.CreateFunctionParams{
-					Slug:      &slug,
-					Name:      &slug,
-					VerifyJwt: &verifyJWT,
-					ImportMap: &importMap,
-				}, eszipContentType, functionBody)
-			}
-			if err != nil {
-				return err
-			}
-			if resp.JSON201 == nil {
-				return errors.New("Failed to create a new Function on the Supabase project: " + string(resp.Body))
-			}
-		case http.StatusOK: // Function already exists, so do a PATCH
-			var resp *api.UpdateFunctionResponse
-			var err error
-			if useLegacyBundle {
-				resp, err = utils.GetSupabase().UpdateFunctionWithResponse(ctx, projectRef, slug, &api.UpdateFunctionParams{}, api.UpdateFunctionJSONRequestBody{
-					Body:      &functionBodyStr,
-					VerifyJwt: &verifyJWT,
-				})
-			} else {
-				resp, err = utils.GetSupabase().UpdateFunctionWithBodyWithResponse(ctx, projectRef, slug, &api.UpdateFunctionParams{
-					VerifyJwt: &verifyJWT,
-					ImportMap: &importMap,
-				}, eszipContentType, functionBody)
-			}
-			if err != nil {
-				return err
-			}
-			if resp.JSON200 == nil {
-				return errors.New("Failed to update an existing Function's body on the Supabase project: " + string(resp.Body))
-			}
-		default:
-			return errors.New("Unexpected error deploying Function: " + string(resp.Body))
+	case http.StatusOK: // Function already exists, so do a PATCH
+		resp, err := utils.GetSupabase().UpdateFunctionWithBodyWithResponse(ctx, projectRef, slug, &api.UpdateFunctionParams{
+			VerifyJwt:      params.VerifyJwt,
+			ImportMap:      params.ImportMap,
+			ImportMapPath:  params.ImportMapPath,
+			EntrypointPath: params.EntrypointPath,
+		}, eszipContentType, functionBody)
+		if err != nil {
+			return err
 		}
+		if resp.JSON200 == nil {
+			return errors.New("Failed to update an existing Function's body on the Supabase project: " + string(resp.Body))
+		}
+	default:
+		return errors.New("Unexpected error deploying Function: " + string(resp.Body))
 	}
 
 	fmt.Println("Deployed Function " + utils.Aqua(slug) + " on project " + utils.Aqua(projectRef))
-
 	url := fmt.Sprintf("%s/project/%v/functions/%v/details", utils.GetSupabaseDashboardURL(), projectRef, slug)
 	fmt.Println("You can inspect your deployment in the Dashboard: " + url)
-
 	return nil
 }

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -340,14 +341,17 @@ verify_jwt = false
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
-		require.NoError(t, afero.WriteFile(fsys, "supabase/functions/import_map.json", []byte(""), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte(""), 0644))
+		absPath, err := filepath.Abs(utils.FallbackImportMapPath)
+		require.NoError(t, err)
+		require.NoError(t, afero.WriteFile(fsys, absPath, []byte("{}"), 0644))
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)
 		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Setup valid deno path
-		_, err := fsys.Create(utils.DenoPathOverride)
+		_, err = fsys.Create(utils.DenoPathOverride)
 		require.NoError(t, err)
 		// Setup mock api
 		defer gock.OffAll()

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -42,8 +42,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestDeployCommand(t *testing.T) {
+	const slug = "test-func"
+
 	t.Run("deploys new function (ESZIP)", func(t *testing.T) {
-		const slug = "test-func"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup valid project ref
@@ -71,7 +72,6 @@ func TestDeployCommand(t *testing.T) {
 	})
 
 	t.Run("updates deployed function (ESZIP)", func(t *testing.T) {
-		const slug = "test-func"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup valid project ref
@@ -178,7 +178,6 @@ func TestDeployCommand(t *testing.T) {
 	})
 
 	t.Run("verify_jwt param falls back to config", func(t *testing.T) {
-		const slug = "test-func"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
@@ -215,7 +214,6 @@ verify_jwt = false
 	})
 
 	t.Run("verify_jwt flag overrides config", func(t *testing.T) {
-		const slug = "test-func"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
@@ -253,7 +251,6 @@ verify_jwt = false
 	})
 
 	t.Run("uses fallback import map", func(t *testing.T) {
-		const slug = "test-func"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -276,7 +276,7 @@ verify_jwt = false
 			Reply(http.StatusNotFound)
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/projects/"+project+"/functions").
-			MatchParam("import_map", "true").
+			MatchParam("import_map_path", absPath).
 			Reply(http.StatusCreated).
 			JSON(api.FunctionResponse{Id: "1"})
 		// Run test
@@ -288,13 +288,7 @@ verify_jwt = false
 }
 
 func TestDeployFunction(t *testing.T) {
-	slug := "test-func"
-	verifyJwt := true
-	params := api.CreateFunctionParams{
-		Slug:      &slug,
-		Name:      &slug,
-		VerifyJwt: &verifyJwt,
-	}
+	const slug = "test-func"
 	// Setup valid project ref
 	project := apitest.RandomProjectRef()
 	// Setup valid access token
@@ -308,7 +302,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -320,7 +314,7 @@ func TestDeployFunction(t *testing.T) {
 			Get("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "Unexpected error deploying Function:")
 	})
@@ -335,7 +329,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -350,7 +344,7 @@ func TestDeployFunction(t *testing.T) {
 			Post("/v1/projects/" + project + "/functions").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "Failed to create a new Function on the Supabase project:")
 	})
@@ -366,7 +360,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 	})
@@ -382,7 +376,7 @@ func TestDeployFunction(t *testing.T) {
 			Patch("/v1/projects/" + project + "/functions/" + slug).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := deployFunction(context.Background(), project, params, strings.NewReader("body"))
+		err := deployFunction(context.Background(), project, slug, "", "", true, strings.NewReader("body"))
 		// Check error
 		assert.ErrorContains(t, err, "Failed to update an existing Function's body on the Supabase project:")
 	})

--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -37,43 +37,8 @@ func Run(ctx context.Context, slug string, projectRef string, fsys afero.Fs) err
 	}
 
 	// 2. Download Function.
-	{
-		fmt.Println("Downloading " + utils.Bold(slug))
-		denoPath, err := utils.GetDenoPath()
-		if err != nil {
-			return err
-		}
-
-		meta, err := getFunctionMetadata(ctx, projectRef, slug)
-		if err != nil {
-			return err
-		}
-
-		resp, err := utils.GetSupabase().GetFunctionBodyWithResponse(ctx, projectRef, slug)
-		if err != nil {
-			return err
-		}
-
-		switch resp.StatusCode() {
-		case http.StatusNotFound: // Function doesn't exist
-			return errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
-		case http.StatusOK: // Function exists
-			resBuf := bytes.NewReader(resp.Body)
-
-			extractScriptPath := scriptDir.ExtractPath
-			funcDir := filepath.Join(utils.FunctionsDir, slug)
-			var errBuf bytes.Buffer
-			args := []string{"run", "-A", extractScriptPath, funcDir, *meta.EntrypointPath}
-			cmd := exec.CommandContext(ctx, denoPath, args...)
-			cmd.Stdin = resBuf
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = &errBuf
-			if err := cmd.Run(); err != nil {
-				return fmt.Errorf("Error downloading function: %w\n%v", err, errBuf.String())
-			}
-		default:
-			return errors.New("Unexpected error downloading Function: " + string(resp.Body))
-		}
+	if err := downloadFunction(ctx, projectRef, slug, scriptDir.ExtractPath); err != nil {
+		return err
 	}
 
 	fmt.Println("Downloaded Function " + utils.Aqua(slug) + " from project " + utils.Aqua(projectRef) + ".")
@@ -85,7 +50,13 @@ func getFunctionMetadata(ctx context.Context, projectRef, slug string) (*api.Fun
 	if err != nil {
 		return nil, err
 	}
-	if resp.JSON200 == nil {
+
+	switch resp.StatusCode() {
+	case http.StatusNotFound:
+		return nil, errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
+	case http.StatusOK:
+		break
+	default:
 		return nil, errors.New("Failed to download Function " + utils.Aqua(slug) + " on the Supabase project: " + string(resp.Body))
 	}
 
@@ -96,4 +67,38 @@ func getFunctionMetadata(ctx context.Context, projectRef, slug string) (*api.Fun
 		resp.JSON200.ImportMapPath = &legacyImportMapPath
 	}
 	return resp.JSON200, nil
+}
+
+func downloadFunction(ctx context.Context, projectRef, slug, extractScriptPath string) error {
+	fmt.Println("Downloading " + utils.Bold(slug))
+	denoPath, err := utils.GetDenoPath()
+	if err != nil {
+		return err
+	}
+
+	meta, err := getFunctionMetadata(ctx, projectRef, slug)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.GetSupabase().GetFunctionBodyWithResponse(ctx, projectRef, slug)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return errors.New("Unexpected error downloading Function: " + string(resp.Body))
+	}
+
+	resBuf := bytes.NewReader(resp.Body)
+	funcDir := filepath.Join(utils.FunctionsDir, slug)
+	args := []string{"run", "-A", extractScriptPath, funcDir, *meta.EntrypointPath}
+	cmd := exec.CommandContext(ctx, denoPath, args...)
+	var errBuf bytes.Buffer
+	cmd.Stdin = resBuf
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Error downloading function: %w\n%v", err, errBuf.String())
+	}
+	return nil
 }

--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -86,7 +86,7 @@ func getFunctionMetadata(ctx context.Context, projectRef, slug string) (*api.Fun
 		return nil, err
 	}
 	if resp.JSON200 == nil {
-		return nil, errors.New("Failed to fetch Function metadata on the Supabase project: " + string(resp.Body))
+		return nil, errors.New("Failed to download Function " + utils.Aqua(slug) + " on the Supabase project: " + string(resp.Body))
 	}
 
 	if resp.JSON200.EntrypointPath == nil {

--- a/internal/functions/download/download_test.go
+++ b/internal/functions/download/download_test.go
@@ -47,6 +47,9 @@ func TestDownloadCommand(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Setup valid deno path
 		_, err := fsys.Create(utils.DenoPathOverride)
 		require.NoError(t, err)
@@ -107,6 +110,9 @@ func TestDownloadCommand(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Setup valid deno path
 		_, err := fsys.Create(utils.DenoPathOverride)
 		require.NoError(t, err)
@@ -125,10 +131,13 @@ func TestDownloadCommand(t *testing.T) {
 
 func TestDownloadFunction(t *testing.T) {
 	const slug = "test-func"
+	// Setup valid project ref
+	project := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 
 	t.Run("throws error on network error", func(t *testing.T) {
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -145,8 +154,6 @@ func TestDownloadFunction(t *testing.T) {
 	})
 
 	t.Run("throws error on service unavailable", func(t *testing.T) {
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -163,8 +170,6 @@ func TestDownloadFunction(t *testing.T) {
 	})
 
 	t.Run("throws error on extract failure", func(t *testing.T) {
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
 		// Setup deno error
 		t.Setenv("TEST_DENO_ERROR", "extract failed")
 		var body bytes.Buffer
@@ -194,6 +199,9 @@ func TestDownloadFunction(t *testing.T) {
 func TestGetMetadata(t *testing.T) {
 	const slug = "test-func"
 	project := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 
 	t.Run("fallback to default paths", func(t *testing.T) {
 		// Setup mock api

--- a/internal/functions/download/download_test.go
+++ b/internal/functions/download/download_test.go
@@ -1,0 +1,238 @@
+package download
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestMain(m *testing.M) {
+	// Setup fake deno binary
+	if len(os.Args) > 1 && (os.Args[1] == "bundle" || os.Args[1] == "upgrade" || os.Args[1] == "run") {
+		msg := os.Getenv("TEST_DENO_ERROR")
+		if msg != "" {
+			fmt.Fprintln(os.Stderr, msg)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	denoPath, err := os.Executable()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	utils.DenoPathOverride = denoPath
+	// Run test suite
+	os.Exit(m.Run())
+}
+
+func TestDownloadCommand(t *testing.T) {
+	const slug = "test-func"
+
+	t.Run("downloads eszip bundle", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup valid deno path
+		_, err := fsys.Create(utils.DenoPathOverride)
+		require.NoError(t, err)
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Id: "1"})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug + "/body").
+			Reply(http.StatusOK)
+		// Run test
+		err = Run(context.Background(), slug, project, fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on malformed slug", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Run test
+		err := Run(context.Background(), "@", project, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Invalid Function name.")
+	})
+
+	t.Run("throws error on failure to install deno", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Run test
+		err := Run(context.Background(), slug, project, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "operation not permitted")
+	})
+
+	t.Run("throws error on copy failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup valid deno path
+		_, err := fsys.Create(utils.DenoPathOverride)
+		require.NoError(t, err)
+		// Run test
+		err = Run(context.Background(), slug, project, afero.NewReadOnlyFs(fsys))
+		// Check error
+		assert.ErrorContains(t, err, "operation not permitted")
+	})
+
+	t.Run("throws error on missing function", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup valid deno path
+		_, err := fsys.Create(utils.DenoPathOverride)
+		require.NoError(t, err)
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusNotFound).
+			JSON(map[string]string{"message": "Function not found"})
+		// Run test
+		err = Run(context.Background(), slug, project, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Function test-func does not exist on the Supabase project.")
+	})
+}
+
+func TestDownloadFunction(t *testing.T) {
+	const slug = "test-func"
+
+	t.Run("throws error on network error", func(t *testing.T) {
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Id: "1"})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug + "/body").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := downloadFunction(context.Background(), project, slug, "")
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+	})
+
+	t.Run("throws error on service unavailable", func(t *testing.T) {
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Id: "1"})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug + "/body").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := downloadFunction(context.Background(), project, slug, "")
+		// Check error
+		assert.ErrorContains(t, err, "Unexpected error downloading Function:")
+	})
+
+	t.Run("throws error on extract failure", func(t *testing.T) {
+		// Setup valid project ref
+		project := apitest.RandomProjectRef()
+		// Setup deno error
+		t.Setenv("TEST_DENO_ERROR", "extract failed")
+		var body bytes.Buffer
+		archive := zip.NewWriter(&body)
+		w, err := archive.Create("deno")
+		require.NoError(t, err)
+		_, err = w.Write([]byte("binary"))
+		require.NoError(t, err)
+		require.NoError(t, archive.Close())
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Id: "1"})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug + "/body").
+			Reply(http.StatusOK)
+		// Run test
+		err = downloadFunction(context.Background(), project, slug, "")
+		// Check error
+		assert.ErrorContains(t, err, "Error downloading function: exit status 1\nextract failed\n")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestGetMetadata(t *testing.T) {
+	const slug = "test-func"
+	project := apitest.RandomProjectRef()
+
+	t.Run("fallback to default paths", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Id: "1"})
+		// Run test
+		meta, err := getFunctionMetadata(context.Background(), project, slug)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, legacyEntrypointPath, *meta.EntrypointPath)
+		assert.Equal(t, legacyImportMapPath, *meta.ImportMapPath)
+	})
+
+	t.Run("throws error on network error", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			ReplyError(errors.New("network error"))
+		// Run test
+		meta, err := getFunctionMetadata(context.Background(), project, slug)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+		assert.Nil(t, meta)
+	})
+
+	t.Run("throws error on service unavailable", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/functions/" + slug).
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		meta, err := getFunctionMetadata(context.Background(), project, slug)
+		// Check error
+		assert.ErrorContains(t, err, "Failed to download Function test-func on the Supabase project:")
+		assert.Nil(t, meta)
+	})
+}

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -55,32 +55,11 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 				return fmt.Errorf("Failed to read env file: %w", err)
 			}
 		}
-		cwd, err := os.Getwd()
+		resolved, err := utils.AbsImportMapPath(importMapPath, slug, fsys)
 		if err != nil {
 			return err
 		}
-		if importMapPath != "" {
-			if !filepath.IsAbs(importMapPath) {
-				importMapPath = filepath.Join(cwd, importMapPath)
-			}
-		} else if functionConfig, ok := utils.Config.Functions[slug]; ok && functionConfig.ImportMap != "" {
-			if filepath.IsAbs(functionConfig.ImportMap) {
-				importMapPath = functionConfig.ImportMap
-			} else {
-				importMapPath = filepath.Join(cwd, utils.SupabaseDirPath, functionConfig.ImportMap)
-			}
-		} else if f, err := fsys.Stat(utils.FallbackImportMapPath); err == nil && !f.IsDir() {
-			if filepath.IsAbs(utils.FallbackImportMapPath) {
-				importMapPath = utils.FallbackImportMapPath
-			} else {
-				importMapPath = filepath.Join(cwd, utils.FallbackImportMapPath)
-			}
-		}
-		if importMapPath != "" {
-			if _, err := fsys.Stat(importMapPath); err != nil {
-				return fmt.Errorf("Failed to read import map: %w", err)
-			}
-		}
+		importMapPath = resolved
 	}
 
 	// 2. Parse user defined env

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -320,3 +320,28 @@ func GetPathHash(path string) string {
 	digest := sha256.Sum256([]byte(path))
 	return hex.EncodeToString(digest[:])
 }
+
+func AbsImportMapPath(importMapPath, slug string, fsys afero.Fs) (string, error) {
+	if importMapPath == "" {
+		if functionConfig, ok := Config.Functions[slug]; ok && functionConfig.ImportMap != "" {
+			importMapPath = functionConfig.ImportMap
+			if !filepath.IsAbs(importMapPath) {
+				importMapPath = filepath.Join(SupabaseDirPath, importMapPath)
+			}
+		} else if exists, _ := afero.Exists(fsys, FallbackImportMapPath); exists {
+			importMapPath = FallbackImportMapPath
+		} else {
+			return importMapPath, nil
+		}
+	}
+	resolved, err := filepath.Abs(importMapPath)
+	if err != nil {
+		return "", err
+	}
+	if f, err := fsys.Stat(resolved); err != nil {
+		return "", fmt.Errorf("Failed to read import map: %w", err)
+	} else if f.IsDir() {
+		return "", errors.New("Importing directory is unsupported: " + resolved)
+	}
+	return resolved, nil
+}

--- a/internal/utils/denos/build.ts
+++ b/internal/utils/denos/build.ts
@@ -1,40 +1,19 @@
 import { encode } from "https://deno.land/std@0.127.0/encoding/base64.ts";
-import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
 import { writeAll } from "https://deno.land/std@0.162.0/streams/conversion.ts";
 import { compress } from "https://deno.land/x/brotli@0.1.7/mod.ts";
 import { build } from "https://deno.land/x/eszip@v0.35.0/mod.ts";
 
-const virtualBasePath = "file:///src/";
-
 async function buildAndWrite(p: string, importMapPath: string) {
-  const funcDirPath = path.dirname(p);
-  try {
-    await Deno.lstat(funcDirPath);
-  } catch (e) {
-    console.error(
-      `Error: Cannot access "${funcDirPath}". Check if directory exists and has read permissions.`,
-    );
-    Deno.exit(1);
-  }
-
-  const entrypoint = new URL("index.ts", virtualBasePath).href;
+  const cwd = `file://${Deno.cwd()}/`
+  const entrypoint = new URL(p, cwd).href;
+  const importMap = new URL(importMapPath || "supabase/functions/import_map.json", cwd).href
 
   const eszip = await build([entrypoint], async (specifier: string) => {
     const url = new URL(specifier);
     if (url.protocol === "file:") {
       console.error(specifier);
-      // if the path is `file:///*`, treat it as a path from parent directory
-      let actualPath = specifier.replace("file:///", `./${funcDirPath}/../`);
-      // if the path is `file:///src/*`, treat it as a relative path from current dir
-      if (specifier.startsWith(virtualBasePath)) {
-        actualPath = specifier.replace(virtualBasePath, `./${funcDirPath}/`);
-      }
+      const actualPath = url.pathname;
 
-      // If an import map path is set read file from the given path.
-      // Otherwise default to `import_map.json` in functions directory.
-      if (specifier.endsWith("import_map.json") && importMapPath) {
-        actualPath = importMapPath;
-      }
       try {
         const content = await Deno.readTextFile(actualPath);
         return {
@@ -60,7 +39,7 @@ async function buildAndWrite(p: string, importMapPath: string) {
     }
 
     return load(specifier);
-  }, "file:///src/import_map.json");
+  }, importMap);
   // compress ESZIP payload using Brotli
   const compressed = compress(eszip);
 

--- a/internal/utils/denos/extract.ts
+++ b/internal/utils/denos/extract.ts
@@ -1,13 +1,7 @@
 import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
 import { readAll } from "https://deno.land/std@0.162.0/streams/conversion.ts";
 import { decompress } from "https://deno.land/x/brotli@0.1.7/mod.ts";
-
 import { Parser } from "https://deno.land/x/eszip@v0.30.0/mod.ts";
-
-function url2path(url: string) {
-  const srcPath = new URL(url).pathname.replace("/src", "");
-  return path.join(...srcPath.split("/").filter(Boolean));
-}
 
 async function write(p: string, content: string) {
   await Deno.mkdir(path.dirname(p), { recursive: true });
@@ -21,25 +15,33 @@ async function loadEszip(bytes: Uint8Array) {
   return { parser, specifiers };
 }
 
-async function extractEszip(dest: string, parser, specifiers) {
-  const imports = {};
-
+async function extractEszip(
+  destPath: string,
+  entrypointUrl: string,
+  parser: Parser,
+  specifiers: string[]
+) {
+  const entrypointPath = path.fromFileUrl(entrypointUrl);
+  const basePath = path.dirname(entrypointPath);
   for (const specifier of specifiers) {
     // skip remote dependencies
     if (!specifier.startsWith("file:")) {
       continue;
     }
+    console.error(specifier);
     const module = await parser.getModuleSource(specifier);
-    await write(path.join(dest, url2path(specifier)), module);
+    const absPath = path.fromFileUrl(specifier);
+    const relPath = path.relative(basePath, absPath);
+    await write(path.join(destPath, relPath), module);
   }
 }
 
-async function extractSource(dest: string) {
+async function extractSource(destPath: string, entrypointUrl: string) {
   const buf = await readAll(Deno.stdin);
   // response is compressed with Brotli
   const decompressed = decompress(buf);
   const { parser, specifiers } = await loadEszip(decompressed);
-  await extractEszip(dest, parser, specifiers);
+  await extractEszip(destPath, entrypointUrl, parser, specifiers);
 }
 
-extractSource(Deno.args[0]);
+extractSource(...Deno.args);

--- a/internal/utils/denos/extract.ts
+++ b/internal/utils/denos/extract.ts
@@ -32,7 +32,9 @@ async function extractEszip(
     const module = await parser.getModuleSource(specifier);
     const absPath = path.fromFileUrl(specifier);
     const relPath = path.relative(basePath, absPath);
-    await write(path.join(destPath, relPath), module);
+    const dest = path.join(destPath, relPath);
+    console.info(path.resolve(dest));
+    await write(dest, module);
   }
 }
 

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -2589,57 +2589,9 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 
 	queryValues := queryURL.Query()
 
-	if params.Slug != nil {
+	if params.ImportMapPath != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "slug", runtime.ParamLocationQuery, *params.Slug); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.Name != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.VerifyJwt != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "verify_jwt", runtime.ParamLocationQuery, *params.VerifyJwt); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.ImportMap != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map", runtime.ParamLocationQuery, *params.ImportMap); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -2669,9 +2621,41 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 
 	}
 
-	if params.ImportMapPath != nil {
+	if params.ImportMap != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map", runtime.ParamLocationQuery, *params.ImportMap); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.VerifyJwt != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "verify_jwt", runtime.ParamLocationQuery, *params.VerifyJwt); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Name != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -2417,6 +2417,38 @@ func NewCreateFunctionRequestWithBody(server string, ref string, params *CreateF
 
 	}
 
+	if params.EntrypointPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entrypoint_path", runtime.ParamLocationQuery, *params.EntrypointPath); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.ImportMapPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -2608,6 +2640,38 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 	if params.ImportMap != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map", runtime.ParamLocationQuery, *params.ImportMap); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.EntrypointPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entrypoint_path", runtime.ParamLocationQuery, *params.EntrypointPath); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.ImportMapPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -2589,9 +2589,9 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 
 	queryValues := queryURL.Query()
 
-	if params.ImportMapPath != nil {
+	if params.Slug != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "slug", runtime.ParamLocationQuery, *params.Slug); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -2605,25 +2605,9 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 
 	}
 
-	if params.EntrypointPath != nil {
+	if params.Name != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entrypoint_path", runtime.ParamLocationQuery, *params.EntrypointPath); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.ImportMap != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map", runtime.ParamLocationQuery, *params.ImportMap); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -2653,9 +2637,41 @@ func NewUpdateFunctionRequestWithBody(server string, ref string, functionSlug st
 
 	}
 
-	if params.Name != nil {
+	if params.ImportMap != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map", runtime.ParamLocationQuery, *params.ImportMap); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.EntrypointPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entrypoint_path", runtime.ParamLocationQuery, *params.EntrypointPath); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.ImportMapPath != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "import_map_path", runtime.ParamLocationQuery, *params.ImportMapPath); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -749,12 +749,11 @@ type CreateFunctionParams struct {
 
 // UpdateFunctionParams defines parameters for UpdateFunction.
 type UpdateFunctionParams struct {
-	Slug           *string `form:"slug,omitempty" json:"slug,omitempty"`
-	Name           *string `form:"name,omitempty" json:"name,omitempty"`
-	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
-	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
-	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
 	ImportMapPath  *string `form:"import_map_path,omitempty" json:"import_map_path,omitempty"`
+	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
+	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
+	Name           *string `form:"name,omitempty" json:"name,omitempty"`
 }
 
 // DeleteSecretsJSONBody defines parameters for DeleteSecrets.

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -353,15 +353,17 @@ type Domain struct {
 
 // FunctionResponse defines model for FunctionResponse.
 type FunctionResponse struct {
-	CreatedAt float32                `json:"created_at"`
-	Id        string                 `json:"id"`
-	ImportMap *bool                  `json:"import_map,omitempty"`
-	Name      string                 `json:"name"`
-	Slug      string                 `json:"slug"`
-	Status    FunctionResponseStatus `json:"status"`
-	UpdatedAt float32                `json:"updated_at"`
-	VerifyJwt *bool                  `json:"verify_jwt,omitempty"`
-	Version   float32                `json:"version"`
+	CreatedAt      float32                `json:"created_at"`
+	EntrypointPath *string                `json:"entrypoint_path,omitempty"`
+	Id             string                 `json:"id"`
+	ImportMap      *bool                  `json:"import_map,omitempty"`
+	ImportMapPath  *string                `json:"import_map_path,omitempty"`
+	Name           string                 `json:"name"`
+	Slug           string                 `json:"slug"`
+	Status         FunctionResponseStatus `json:"status"`
+	UpdatedAt      float32                `json:"updated_at"`
+	VerifyJwt      *bool                  `json:"verify_jwt,omitempty"`
+	Version        float32                `json:"version"`
 }
 
 // FunctionResponseStatus defines model for FunctionResponse.Status.
@@ -369,15 +371,17 @@ type FunctionResponseStatus string
 
 // FunctionSlugResponse defines model for FunctionSlugResponse.
 type FunctionSlugResponse struct {
-	CreatedAt float32                    `json:"created_at"`
-	Id        string                     `json:"id"`
-	ImportMap *bool                      `json:"import_map,omitempty"`
-	Name      string                     `json:"name"`
-	Slug      string                     `json:"slug"`
-	Status    FunctionSlugResponseStatus `json:"status"`
-	UpdatedAt float32                    `json:"updated_at"`
-	VerifyJwt *bool                      `json:"verify_jwt,omitempty"`
-	Version   float32                    `json:"version"`
+	CreatedAt      float32                    `json:"created_at"`
+	EntrypointPath *string                    `json:"entrypoint_path,omitempty"`
+	Id             string                     `json:"id"`
+	ImportMap      *bool                      `json:"import_map,omitempty"`
+	ImportMapPath  *string                    `json:"import_map_path,omitempty"`
+	Name           string                     `json:"name"`
+	Slug           string                     `json:"slug"`
+	Status         FunctionSlugResponseStatus `json:"status"`
+	UpdatedAt      float32                    `json:"updated_at"`
+	VerifyJwt      *bool                      `json:"verify_jwt,omitempty"`
+	Version        float32                    `json:"version"`
 }
 
 // FunctionSlugResponseStatus defines model for FunctionSlugResponse.Status.
@@ -735,18 +739,22 @@ type TokenParamsGrantType string
 
 // CreateFunctionParams defines parameters for CreateFunction.
 type CreateFunctionParams struct {
-	Slug      *string `form:"slug,omitempty" json:"slug,omitempty"`
-	Name      *string `form:"name,omitempty" json:"name,omitempty"`
-	VerifyJwt *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
-	ImportMap *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	Slug           *string `form:"slug,omitempty" json:"slug,omitempty"`
+	Name           *string `form:"name,omitempty" json:"name,omitempty"`
+	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
+	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
+	ImportMapPath  *string `form:"import_map_path,omitempty" json:"import_map_path,omitempty"`
 }
 
 // UpdateFunctionParams defines parameters for UpdateFunction.
 type UpdateFunctionParams struct {
-	Slug      *string `form:"slug,omitempty" json:"slug,omitempty"`
-	Name      *string `form:"name,omitempty" json:"name,omitempty"`
-	VerifyJwt *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
-	ImportMap *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	Slug           *string `form:"slug,omitempty" json:"slug,omitempty"`
+	Name           *string `form:"name,omitempty" json:"name,omitempty"`
+	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
+	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
+	ImportMapPath  *string `form:"import_map_path,omitempty" json:"import_map_path,omitempty"`
 }
 
 // DeleteSecretsJSONBody defines parameters for DeleteSecrets.

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -749,11 +749,12 @@ type CreateFunctionParams struct {
 
 // UpdateFunctionParams defines parameters for UpdateFunction.
 type UpdateFunctionParams struct {
-	ImportMapPath  *string `form:"import_map_path,omitempty" json:"import_map_path,omitempty"`
-	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
-	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
-	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
+	Slug           *string `form:"slug,omitempty" json:"slug,omitempty"`
 	Name           *string `form:"name,omitempty" json:"name,omitempty"`
+	VerifyJwt      *bool   `form:"verify_jwt,omitempty" json:"verify_jwt,omitempty"`
+	ImportMap      *bool   `form:"import_map,omitempty" json:"import_map,omitempty"`
+	EntrypointPath *string `form:"entrypoint_path,omitempty" json:"entrypoint_path,omitempty"`
+	ImportMapPath  *string `form:"import_map_path,omitempty" json:"import_map_path,omitempty"`
 }
 
 // DeleteSecretsJSONBody defines parameters for DeleteSecrets.


### PR DESCRIPTION
Reverts supabase/cli#1102

draft PR to continue testing https://github.com/supabase/cli/issues/1028

blocked on upstream changes
- [x] https://github.com/supabase/functions/pull/56
- [x] https://github.com/supabase/infrastructure/pull/12917

TODO:
- [x] update download / extract.ts
- [x] wait for api prod release

What's new
---

- `functions deploy`
  - drops legacy json bundle support by defaulting to eszip
  - always sets the `entrypointUrl` and `importMapUrl` for upstream server
- `functions download`
  - passes in the `entrypointPath` so that files are extracted relative to dest
  - tested that `download` works for functions both with and without explicit entrypoint
  - logs extracted file paths to stdout
- `functions delete`
  - no need to get function first as delete will return 404 on missing function
- `functions serve`
  - refactored `import-map` flag parsing so it's reused by deploy command
