### PR TITLE
chore: print suggestion when serving with legacy deno relay

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -92,6 +92,7 @@ var (
 				noVerifyJWT = nil
 			}
 			slug := ""
+			// TODO: Make `functions serve <function-name>` do `functions serve` under the hood and remove deno relay code.
 			if len(args) > 0 {
 				slug = args[0]
 			}

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -40,6 +40,7 @@ func Run(ctx context.Context, slug string, envFilePath string, noVerifyJWT *bool
 	}
 
 	// 1. Sanity checks.
+	fmt.Fprintf(os.Stderr, "Serving functions with legacy %s... Run %s instead to use Edge Runtime.\n", utils.Yellow(utils.DenoRelayImage), utils.Aqua("functions serve"))
 	{
 		if err := utils.LoadConfigFS(fsys); err != nil {
 			return err

--- a/internal/utils/colors.go
+++ b/internal/utils/colors.go
@@ -9,6 +9,10 @@ func Aqua(str string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render(str)
 }
 
+func Yellow(str string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render(str)
+}
+
 // For paths & filenames.
 func Bold(str string) string {
 	return lipgloss.NewStyle().Bold(true).Render(str)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1093

## What is the new behavior?

Clearer logs when deno relay is used.

## Additional context

Add any other context or screenshots.
