### PR TITLE
feat: support reseting remote database

### DIFF
--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
@@ -267,7 +268,7 @@ func TestUserSchema(t *testing.T) {
 	// Setup mock postgres
 	conn := pgtest.NewConn()
 	defer conn.Close(t)
-	conn.Query(strings.ReplaceAll(LIST_SCHEMAS, "$1", "'{public}'")).
+	conn.Query(strings.ReplaceAll(reset.LIST_SCHEMAS, "$1", "'{public}'")).
 		Reply("SELECT 1", []interface{}{"test"})
 	// Connect to mock
 	ctx := context.Background()

--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -1,0 +1,35 @@
+do $$ declare
+  rec record;
+begin
+  -- functions
+  for rec in
+    select *
+    from pg_proc p
+    where p.pronamespace::regnamespace::name = 'public'
+  loop
+    -- supports aggregate, function, and procedure
+    execute format('drop routine if exists %I.%I(%s) cascade', rec.pronamespace::regnamespace::name, rec.proname, pg_catalog.pg_get_function_identity_arguments(rec.oid));
+  end loop;
+
+  -- in order: tables (cascade to views), sequences
+  for rec in
+    select *
+    from pg_class c
+    where
+      c.relnamespace::regnamespace::name = 'public'
+      and c.relkind not in ('c', 'v', 'm')
+    order by c.relkind desc
+  loop
+    -- supports all kinds of relations, except views and complex types
+    execute format('drop table if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
+  end loop;
+
+  -- types
+  for rec in
+    select *
+    from pg_type t
+    where t.typnamespace::regnamespace::name = 'public'
+  loop
+    execute format('drop type if exists %I.%I cascade', rec.typnamespace::regnamespace::name, rec.typname);
+  end loop;
+end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

closes https://github.com/supabase/cli/issues/480
closes https://github.com/supabase/cli/issues/1099

## What is the new behavior?

Conservatively resets the remote database.
- ignores all supabase managed schemas, including auth, storage, extensions, etc.
- only drop objects in `public` schema to preserve default schema privileges for `supabase_admin`
- applies all location migrations and seeds remote database

```bash
$ supabase db reset --db-url 'postgres://postgres:postgres@localhost:54322/postgres'
Resetting remote database...
Applying migration 20220810154537_full.sql...
Seeding data supabase/seed.sql...
```

## Additional context

Add any other context or screenshots.
