### PR TITLE
feat: support deploying all functions

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -51,13 +51,12 @@ var (
 		Use:   "deploy <Function name>",
 		Short: "Deploy a Function to Supabase",
 		Long:  "Deploy a Function to the linked Supabase project.",
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Fallback to config if user did not set the flag.
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return deploy.Run(cmd.Context(), args[0], flags.ProjectRef, noVerifyJWT, importMapPath, afero.NewOsFs())
+			return deploy.Run(cmd.Context(), args, flags.ProjectRef, noVerifyJWT, importMapPath, afero.NewOsFs())
 		},
 	}
 

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -176,7 +175,7 @@ func deployAll(ctx context.Context, slugs []string, projectRef, importMapPath st
 	for _, slug := range slugs {
 		// Log all errors and proceed
 		if err := <-errCh; err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			return err
 		}
 		go func(slug string) {
 			errCh <- deployOne(ctx, slug, projectRef, importMapPath, scriptDir.BuildPath, noVerifyJWT, fsys)

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -35,16 +35,15 @@ func Run(ctx context.Context, slugs []string, projectRef string, noVerifyJWT *bo
 }
 
 func getFunctionSlugs(fsys afero.Fs) ([]string, error) {
-	functions, err := afero.ReadDir(fsys, utils.FunctionsDir)
+	pattern := filepath.Join(utils.FunctionsDir, "*", "index.ts")
+	paths, err := afero.Glob(fsys, pattern)
 	if err != nil {
 		return nil, err
 	}
 	var slugs []string
-	for _, fi := range functions {
-		if !fi.IsDir() {
-			continue
-		}
-		slugs = append(slugs, fi.Name())
+	for _, path := range paths {
+		slug := filepath.Base(filepath.Dir(path))
+		slugs = append(slugs, slug)
 	}
 	return slugs, nil
 }

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -260,8 +260,8 @@ func TestDeployCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, afero.WriteFile(fsys, importMapPath, []byte("{}"), 0644))
 		// Setup function entrypoint
-		entrypointPath := filepath.Join(utils.FunctionsDir, slug)
-		require.NoError(t, fsys.MkdirAll(entrypointPath, 0755))
+		entrypointPath := filepath.Join(utils.FunctionsDir, slug, "index.ts")
+		require.NoError(t, afero.WriteFile(fsys, entrypointPath, []byte{}, 0644))
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token
@@ -286,15 +286,6 @@ func TestDeployCommand(t *testing.T) {
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on missing directory", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Run test
-		err := Run(context.Background(), nil, "", nil, "", fsys)
-		// Check error
-		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run("throws error on empty functions", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

closes https://github.com/supabase/cli/issues/456

## What is the new behavior?

- deploys all functions in `supabase/functions` sequentially
- avoids copying build scripts repeatedly for each function
- allow configuring max concurrency

TODO:
- [ ] fix api race condition when deploying concurrently

## Additional context

We could also consider deploying a single bundle with different entrypoint for each function.

```bash
$ supabase functions deploy
Version 1.30.3 is already installed
Bundling hello
Deploying hello (script size: 306.9kB)
Deployed Function hello on project cimpzzikygouamvsjwxa
You can inspect your deployment in the Dashboard: https://app.supabase.com/project/cimpzzikygouamvsjwxa/functions/hello/details
Bundling hello_world
Deploying hello_world (script size: 21.14kB)
Deployed Function hello_world on project cimpzzikygouamvsjwxa
You can inspect your deployment in the Dashboard: https://app.supabase.com/project/cimpzzikygouamvsjwxa/functions/hello_world/details
```
