### PR TITLE
fix: upgrade to edge runtime 1.3.4

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -98,6 +98,7 @@ serve(async (req: Request) => {
     .filter(([name, _]) =>
       !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_")
     );
+  const forceCreate = true;
   try {
     const worker = await EdgeRuntime.userWorkers.create({
       servicePath,
@@ -106,6 +107,7 @@ serve(async (req: Request) => {
       noModuleCache,
       importMapPath: functionsConfig[functionName].importMapPath,
       envVars,
+      forceCreate,
     });
     return await worker.fetch(req);
   } catch (e) {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	StudioImage      = "supabase/studio:20230512-ad596d8"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.2.19"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.3.4"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Upgrade Edge Runtime to 1.3.4.
- Modified the main serve function to pass `forceCreate: true` option so it will recreate workers per request. 
