### PR TITLE
Revert "chore: create _realtime schema on startup"

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -438,7 +438,7 @@ EOF
 					"DB_USER=supabase_admin",
 					"DB_PASSWORD=" + dbConfig.Password,
 					"DB_NAME=" + dbConfig.Database,
-					"DB_AFTER_CONNECT_QUERY=CREATE SCHEMA IF NOT EXISTS _realtime; SET search_path TO _realtime",
+					"DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime",
 					"DB_ENC_KEY=supabaserealtime",
 					"API_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
 					"FLY_ALLOC_ID=abc123",


### PR DESCRIPTION
This reverts commit 3ef9d042a4404b90fc82d563d7479c50d9969149.

## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1115

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
