### PR TITLE
fix: upgrade edge runtime to 1.3.5

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	StudioImage      = "supabase/studio:20230512-ad596d8"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.3.4"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.3.5"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade Edge Runtime to 1.3.5, which contains fixes for #1071 and #1114 