### PR TITLE
fix: discard role attributes that require superuser from dump

### DIFF
--- a/internal/db/dump/templates/dump_role.sh
+++ b/internal/db/dump/templates/dump_role.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 #
 #   - do not create or alter reserved roles as they are blocked by supautils
 #   - explicitly allow altering safe attributes, ie. statement_timeout, pgrst.*
+#   - discard role attributes that require superuser, ie. nosuperuser, noreplication
 #   - do not alter membership grants by supabase_admin role
 pg_dumpall \
     --roles-only \
@@ -18,6 +19,7 @@ pg_dumpall \
     --database "$DB_URL" \
 | sed -E "s/^CREATE ROLE \"($RESERVED_ROLES)\"/-- &/" \
 | sed -E "s/^ALTER ROLE \"($RESERVED_ROLES)\"/-- &/" \
+| sed -E "s/ (NOSUPERUSER|NOREPLICATION)//g" \
 | sed -E "s/^-- (.* SET \"($ALLOWED_CONFIGS)\" .*)/\1/" \
 | sed -E "s/GRANT \".*\" TO \"($RESERVED_ROLES)\"/-- &/" \
 | sed -E "${1:+/^--/d}" \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/933

## What is the current behavior?

Roles with `nosuperuser` and `noreplication` attribute cannot be restored as non-superuser.

## What is the new behavior?

Discard these role attributes from pg_dump as these the are [default values](https://www.postgresql.org/docs/current/sql-createrole.html) anyway.

## Additional context

Add any other context or screenshots.
