### PR TITLE
fix: git root resolution should not change workdir

### DIFF
--- a/internal/gen/keys/keys.go
+++ b/internal/gen/keys/keys.go
@@ -92,11 +92,10 @@ func GetGitBranch(fsys afero.Fs) string {
 		return head
 	}
 	branch := "main"
-	if gitRoot, _ := utils.GetGitRoot(fsys); gitRoot != nil {
-		if repo, err := git.PlainOpen(*gitRoot); err == nil {
-			if ref, err := repo.Head(); err == nil {
-				branch = ref.Name().Short()
-			}
+	opts := &git.PlainOpenOptions{DetectDotGit: true}
+	if repo, err := git.PlainOpenWithOptions(".", opts); err == nil {
+		if ref, err := repo.Head(); err == nil {
+			branch = ref.Name().Short()
 		}
 	}
 	return branch


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #1127 

## What is the current behavior?

`GetGitRoot` changes the working directory which causes some tests to fail

## What is the new behavior?

Look up git repository in parent directories using open options.

## Additional context

Add any other context or screenshots.
