### PR TITLE
fix: path resolution for deno on windows

### DIFF
--- a/internal/utils/denos/build.ts
+++ b/internal/utils/denos/build.ts
@@ -12,7 +12,7 @@ async function buildAndWrite(entrypointPath: string, importMapPath: string) {
     const url = new URL(specifier);
     if (url.protocol === "file:") {
       console.error(specifier);
-      const actualPath = url.pathname;
+      const actualPath = path.fromFileUrl(url);
 
       try {
         const content = await Deno.readTextFile(actualPath);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/orgs/supabase/discussions/14177#discussioncomment-5957134

## What is the current behavior?

```ps
file:///C:/Users/qiao/work/cli/supabase/functions/import_map.json
error: Uncaught (in promise) Error: Error: The filename, directory name, or volume label syntax is incorrect. (os error 123)
      const ret = new Error(getStringFromWasm0(arg0, arg1));
```

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
