### PR TITLE
fix: finding git root should not change workdir

### DIFF
--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/fs"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -24,18 +22,6 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-type StatErrorFs struct {
-	afero.MemMapFs
-	DenyPath string
-}
-
-func (m *StatErrorFs) Stat(name string) (fs.FileInfo, error) {
-	if strings.HasPrefix(name, m.DenyPath) {
-		return nil, fs.ErrPermission
-	}
-	return m.MemMapFs.Stat(name)
-}
-
 func TestInitBranch(t *testing.T) {
 	t.Run("throws error on permission denied", func(t *testing.T) {
 		// Setup in-memory fs
@@ -48,7 +34,7 @@ func TestInitBranch(t *testing.T) {
 
 	t.Run("throws error on stat failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &StatErrorFs{DenyPath: utils.CurrBranchPath}
+		fsys := &fstest.StatErrorFs{DenyPath: utils.CurrBranchPath}
 		// Run test
 		err := initCurrentBranch(fsys)
 		// Check error

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -45,7 +45,7 @@ func Run(fsys afero.Fs) error {
 	}
 
 	// 3. Append to `.gitignore`.
-	if gitRoot, _ := utils.GetGitRoot(fsys); gitRoot != nil {
+	if utils.IsGitRepo() {
 		if err := updateGitIgnore(utils.GitIgnorePath, fsys); err != nil {
 			return err
 		}

--- a/internal/testing/fstest/create.go
+++ b/internal/testing/fstest/create.go
@@ -1,0 +1,20 @@
+package fstest
+
+import (
+	"io/fs"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+type CreateErrorFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *CreateErrorFs) Create(name string) (afero.File, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.Create(name)
+}

--- a/internal/testing/fstest/stat.go
+++ b/internal/testing/fstest/stat.go
@@ -1,0 +1,20 @@
+package fstest
+
+import (
+	"io/fs"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+type StatErrorFs struct {
+	afero.MemMapFs
+	DenyPath string
+}
+
+func (m *StatErrorFs) Stat(name string) (fs.FileInfo, error) {
+	if strings.HasPrefix(name, m.DenyPath) {
+		return nil, fs.ErrPermission
+	}
+	return m.MemMapFs.Stat(name)
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 )
 
@@ -231,38 +232,10 @@ func AssertSupabaseDbIsRunning() error {
 	return nil
 }
 
-func GetGitRoot(fsys afero.Fs) (*string, error) {
-	origWd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
-	for {
-		_, err := afero.ReadDir(fsys, ".git")
-
-		if err == nil {
-			gitRoot, err := os.Getwd()
-			if err != nil {
-				return nil, err
-			}
-
-			if err := os.Chdir(origWd); err != nil {
-				return nil, err
-			}
-
-			return &gitRoot, nil
-		}
-
-		if cwd, err := os.Getwd(); err != nil {
-			return nil, err
-		} else if isRootDirectory(cwd) {
-			return nil, nil
-		}
-
-		if err := os.Chdir(".."); err != nil {
-			return nil, err
-		}
-	}
+func IsGitRepo() bool {
+	opts := &git.PlainOpenOptions{DetectDotGit: true}
+	_, err := git.PlainOpenWithOptions(".", opts)
+	return err == nil
 }
 
 // If the `os.Getwd()` is within a supabase project, this will return


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1143

## What is the current behavior?

GetGitRoot changes workdir, causing subsequent write to vscode setting to fail if the search recurses to `/`.

## What is the new behavior?

Use go-git library for finding git root.

## Additional context

Add any other context or screenshots.
