### PR TITLE
feat(typegen): relationships

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -30,7 +30,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v10.1.2"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage      = "supabase/postgres-meta:v0.60.7"
+	PgmetaImage      = "supabase/postgres-meta:v0.66.0"
 	StudioImage      = "supabase/studio:20230512-ad596d8"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"


### PR DESCRIPTION
Bump pg-meta to v0.66.0 which incorporates:
- https://github.com/supabase/postgres-meta/pull/577
- https://github.com/supabase/postgres-meta/pull/580

The version currently on prod is v0.64.6, guess we forgot to update the CLI. Diff: https://github.com/supabase/postgres-meta/compare/v0.64.6...v0.66.0