### PR TITLE
fix(typegen): use the right pg-meta script

### DIFF
--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -103,7 +103,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			},
 			[]string{
 				"node",
-				"dist/server/app.js",
+				"dist/server/server.js",
 				"gen",
 				"types",
 				"typescript",


### PR DESCRIPTION
This was changed [here](https://github.com/supabase/postgres-meta/commit/5e4c87f7b9738b49ff438278d5d99c824a6580bf)