### PR TITLE
fix: bump edge runtime to 1.4.2

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	StudioImage      = "supabase/studio:20230512-ad596d8"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.4.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.4.2"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://github.com/supabase/edge-runtime/releases/tag/v1.4.2