### PR TITLE
chore: collapse install sections of readme

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       new-release-published: ${{ steps.semantic-release.outputs.new_release_published }}
       new-release-version: ${{ steps.semantic-release.outputs.new_release_version }}
+      new-release-channel: ${{ steps.semantic-release.outputs.new_release_channel }}
     steps:
       - uses: actions/checkout@v3
       - id: semantic-release
@@ -66,6 +67,6 @@ jobs:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm --git-tag-version=false version ${{ needs.release.outputs.new-release-version }}
-      - run: npm publish --tag beta
+      - run: npm publish --tag ${{ needs.release.outputs.new-release-channel }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,19 @@
 
 ## Release process
 
-We release to stable channel once every two weeks.
+We release to stable channel every two weeks.
 
 We release to beta channel on merge to `main` branch.
 
-Hotfixes are released manually. The steps are:
+Hotfixes are released manually. Follow these steps:
 
-1. Create a new branch named `v*.*.*` from latest stable version. For eg.
-   1. If stable is on `v1.2.3` and beta is on `v1.3.1`, create `v1.2.4` and confirm it's a new tag.
-   2. If stable is on `v1.2.3` and beta is on `v1.2.6`, create `v1.2.7` or simply release all patch versions.
-2. Run the [Release (Beta)](https://github.com/supabase/cli/actions/workflows/release-beta.yml) workflow targetting your new branch.
-3. Update your local CLI to latest beta version to verify your fix.
-4. Once verified, edit [GitHub releases](https://github.com/supabase/cli/releases) to set your pre-release as latest.
+1. Create a new branch named `N.N.x` from latest stable version. For eg.
+   1. If stable is on `v1.2.3` and beta is on `v1.3.6`, create `1.2.x` branch.
+   2. If stable is on `v1.3.1` and beta is on `v1.3.6`, create `1.3.x` branch (or simply release all patch versions).
+2. Cherry-pick your hotfix on top of `N.N.x` branch.
+3. Run the [Release (Beta)](https://github.com/supabase/cli/actions/workflows/release-beta.yml) workflow targetting `N.N.x` branch.
+4. Verify your fix by running the hotfix version locally, eg. `npx supabase@N.N.x help`
+5. Edit [GitHub releases](https://github.com/supabase/cli/releases) to set your pre-release as latest stable.
 
 ## Unit testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Welcome to Supabase CLI contributing guide
+
+## Release process
+
+We release to stable channel once every two weeks.
+
+We release to beta channel on merge to `main` branch.
+
+Hotfixes are released manually. The steps are:
+
+1. Create a new branch named `v*.*.*` from latest stable version. For eg.
+   1. If stable is on `v1.2.3` and beta is on `v1.3.1`, create `v1.2.4` and confirm it's a new tag.
+   2. If stable is on `v1.2.3` and beta is on `v1.2.6`, create `v1.2.7` or simply release all patch versions.
+2. Run the [Release (Beta)](https://github.com/supabase/cli/actions/workflows/release-beta.yml) workflow targetting your new branch.
+3. Update your local CLI to latest beta version to verify your fix.
+4. Once verified, edit [GitHub releases](https://github.com/supabase/cli/releases) to set your pre-release as latest.
+
+## Unit testing
+
+All new code should aim to improve [test coverage](https://coveralls.io/github/supabase/cli).
+
+We use mock objects for unit testing code that interacts with external systems, such as
+
+- local filesystem (via [afero](https://github.com/spf13/afero))
+- Postgres database (via [pgmock](https://github.com/jackc/pgmock))
+- Supabase API (via [gock](https://github.com/h2non/gock))
+
+Wrappers and test helper methods can be found under [internal/testing](internal/testing).
+
+Integration tests are created under [test](test). To run all tests:
+
+```bash
+go test ./... -race -v -count=1 -failfast
+```
+
+## API client
+
+The Supabase API client is generated from OpenAPI spec. See [our guide](api/README.md) for updating the client and types.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,12 @@ Hotfixes are released manually. Follow these steps:
    2. If stable is on `v1.3.1` and beta is on `v1.3.6`, create `1.3.x` branch (or simply release all patch versions).
 2. Cherry-pick your hotfix on top of `N.N.x` branch.
 3. Run the [Release (Beta)](https://github.com/supabase/cli/actions/workflows/release-beta.yml) workflow targetting `N.N.x` branch.
-4. Verify your fix by running the hotfix version locally, eg. `npx supabase@N.N.x help`
-5. Edit [GitHub releases](https://github.com/supabase/cli/releases) to set your pre-release as latest stable.
+4. Verify your hotfix locally with `npx supabase@N.N.x help`
+5. Edit [GitHub releases](https://github.com/supabase/cli/releases) to set your hotfix pre-release as latest stable.
+
+After promoting the next beta version to stable, previous `N.N.x` branches may be deleted.
+
+To revert a stable release, set a previous release to latest. This will update brew and scoop to an old version. There's no need to revert npm as it supports version pinning.
 
 ## Unit testing
 

--- a/README.md
+++ b/README.md
@@ -19,107 +19,119 @@ This repository contains all the functionality for Supabase CLI.
 
 ### Install the CLI
 
-#### NodeJS
-
 Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
 
 ```bash
 npm i supabase --save-dev
 ```
 
-To run:
+To install the beta release channel:
 
 ```bash
-npx supabase -h
+npm i supabase@beta --save-dev
 ```
 
-#### macOS
+<details>
+  <summary><b>macOS</b></summary>
 
-Available via [Homebrew](https://brew.sh). To install:
+  Available via [Homebrew](https://brew.sh). To install:
 
-```sh
-brew install supabase/tap/supabase
-```
+  ```sh
+  brew install supabase/tap/supabase
+  ```
 
-To upgrade:
+  To upgrade:
 
-```sh
-brew upgrade supabase
-```
+  ```sh
+  brew upgrade supabase
+  ```
+</details>
 
-#### Windows
+<details>
+  <summary><b>Windows</b></summary>
 
-Available via [Scoop](https://scoop.sh). To install:
+  Available via [Scoop](https://scoop.sh). To install:
 
-```powershell
-scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
-scoop install supabase
-```
+  ```powershell
+  scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+  scoop install supabase
+  ```
 
-To upgrade:
+  To upgrade:
 
-```powershell
-scoop update supabase
-```
+  ```powershell
+  scoop update supabase
+  ```
+</details>
 
-#### Linux
+<details>
+  <summary><b>Linux</b></summary>
 
-Available via [Homebrew](https://brew.sh) and Linux packages.
+  Available via [Homebrew](https://brew.sh) and Linux packages.
 
-##### via Homebrew
+  #### via Homebrew
 
-To install:
+  To install:
 
-```sh
-brew install supabase/tap/supabase
-```
+  ```sh
+  brew install supabase/tap/supabase
+  ```
 
-To upgrade:
+  To upgrade:
 
-```sh
-brew upgrade supabase
-```
+  ```sh
+  brew upgrade supabase
+  ```
 
-##### via Linux packages
+  #### via Linux packages
 
-Linux packages are provided in [Releases](https://github.com/supabase/cli/releases). To install, download the `.apk`/`.deb`/`.rpm`/`.pkg.tar.zst` file depending on your package manager and run the respective commands.
+  Linux packages are provided in [Releases](https://github.com/supabase/cli/releases). To install, download the `.apk`/`.deb`/`.rpm`/`.pkg.tar.zst` file depending on your package manager and run the respective commands.
 
-```sh
-sudo apk add --allow-untrusted <...>.apk
-```
+  ```sh
+  sudo apk add --allow-untrusted <...>.apk
+  ```
 
-```sh
-sudo dpkg -i <...>.deb
-```
+  ```sh
+  sudo dpkg -i <...>.deb
+  ```
 
-```sh
-sudo rpm -i <...>.rpm
-```
+  ```sh
+  sudo rpm -i <...>.rpm
+  ```
 
-```sh
-sudo pacman -U <...>.pkg.tar.zst
-```
+  ```sh
+  sudo pacman -U <...>.pkg.tar.zst
+  ```
+</details>
 
-#### Other Platforms
+<details>
+  <summary><b>Other Platforms</b></summary>
 
-You can also install the CLI via [go modules](https://go.dev/ref/mod#go-install) without the help of package managers.
+  You can also install the CLI via [go modules](https://go.dev/ref/mod#go-install) without the help of package managers.
 
-```sh
-go install github.com/supabase/cli@latest
-```
+  ```sh
+  go install github.com/supabase/cli@latest
+  ```
 
-Add a symlink to the binary in `$PATH` for easier access:
+  Add a symlink to the binary in `$PATH` for easier access:
 
-```sh
-ln -s "$(go env GOPATH)/cli" /usr/bin/supabase
-```
+  ```sh
+  ln -s "$(go env GOPATH)/cli" /usr/bin/supabase
+  ```
 
-This works on other non-standard Linux distros.
+  This works on other non-standard Linux distros.
+</details>
 
 ### Run the CLI
 
-```sh
+```bash
 supabase help
+```
+
+Or using npx:
+
+```bash
+npx supabase help
 ```
 
 ## Docs

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "release": {
     "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
       {
         "name": "main",
         "channel": "beta"


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

- add steps to install beta release channel
- shorten readme by collapsing non-npm installation steps 
- adds contributing guide for hotfix release and reverting stable

## Additional context

Add any other context or screenshots.
