### PR TITLE
feat: add flag to bypass the prompt for creating a vscode workspace

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	createVscodeWorkspace string
+	createVscodeWorkspace = new(bool)
 
 	initCmd = &cobra.Command{
 		GroupID: groupLocalDev,
@@ -18,6 +18,9 @@ var (
 		Short:   "Initialize a local project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
+			if !cmd.Flags().Changed("create-vscode-workspace") {
+				createVscodeWorkspace = nil
+			}
 			if err := _init.Run(fsys, createVscodeWorkspace); err != nil {
 				return err
 			}
@@ -30,6 +33,6 @@ var (
 
 func init() {
 	flags := initCmd.Flags()
-	flags.StringVar(&createVscodeWorkspace, "create-vscode-workspace", "", "Generate VS Code workspace.")
+	flags.BoolVar(createVscodeWorkspace, "create-vscode-workspace", false, "Generate VS Code workspace.")
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,21 +9,27 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-var initCmd = &cobra.Command{
-	GroupID: groupLocalDev,
-	Use:     "init",
-	Short:   "Initialize a local project",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fsys := afero.NewOsFs()
-		if err := _init.Run(fsys); err != nil {
-			return err
-		}
+var (
+	createVscodeWorkspace string
 
-		fmt.Println("Finished " + utils.Aqua("supabase init") + ".")
-		return nil
-	},
-}
+	initCmd = &cobra.Command{
+		GroupID: groupLocalDev,
+		Use:     "init",
+		Short:   "Initialize a local project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := _init.Run(fsys, createVscodeWorkspace); err != nil {
+				return err
+			}
+
+			fmt.Println("Finished " + utils.Aqua("supabase init") + ".")
+			return nil
+		},
+	}
+)
 
 func init() {
+	flags := initCmd.Flags()
+	flags.StringVar(&createVscodeWorkspace, "create-vscode-workspace", "", "Generate VS Code workspace.")
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,7 +18,7 @@ var (
 		Short:   "Initialize a local project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
-			if !cmd.Flags().Changed("create-vscode-workspace") {
+			if !cmd.Flags().Changed("with-vscode-workspace") {
 				createVscodeWorkspace = nil
 			}
 			if err := _init.Run(fsys, createVscodeWorkspace); err != nil {
@@ -33,6 +33,6 @@ var (
 
 func init() {
 	flags := initCmd.Flags()
-	flags.BoolVar(createVscodeWorkspace, "create-vscode-workspace", false, "Generate VS Code workspace.")
+	flags.BoolVar(createVscodeWorkspace, "with-vscode-workspace", false, "Generate VS Code workspace.")
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -25,7 +24,7 @@ var (
 	errAlreadyInitialized = errors.New("Project already initialized. Remove " + utils.Bold(utils.ConfigPath) + " to reinitialize.")
 )
 
-func Run(fsys afero.Fs, createVscodeWorkspace string) error {
+func Run(fsys afero.Fs, createVscodeWorkspace *bool) error {
 	// Sanity checks.
 	{
 		if _, err := fsys.Stat(utils.ConfigPath); err == nil {
@@ -53,9 +52,8 @@ func Run(fsys afero.Fs, createVscodeWorkspace string) error {
 	}
 
 	// 4. Generate VS Code workspace settings.
-	skipVscodePrompt := len(createVscodeWorkspace) > 0
-	if skipVscodePrompt {
-		if strings.ToLower(createVscodeWorkspace) == "y" || strings.ToLower(createVscodeWorkspace) == "yes" {
+	if createVscodeWorkspace != nil {
+		if *createVscodeWorkspace {
 			return writeVscodeConfig(fsys)
 		}
 	} else {

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -24,7 +25,7 @@ var (
 	errAlreadyInitialized = errors.New("Project already initialized. Remove " + utils.Bold(utils.ConfigPath) + " to reinitialize.")
 )
 
-func Run(fsys afero.Fs) error {
+func Run(fsys afero.Fs, createVscodeWorkspace string) error {
 	// Sanity checks.
 	{
 		if _, err := fsys.Stat(utils.ConfigPath); err == nil {
@@ -52,9 +53,17 @@ func Run(fsys afero.Fs) error {
 	}
 
 	// 4. Generate VS Code workspace settings.
-	if isVscode := utils.PromptYesNo("Generate VS Code workspace settings?", false, os.Stdin); isVscode {
-		return writeVscodeConfig(fsys)
+	skipVscodePrompt := len(createVscodeWorkspace) > 0
+	if skipVscodePrompt {
+		if strings.ToLower(createVscodeWorkspace) == "y" || strings.ToLower(createVscodeWorkspace) == "yes" {
+			return writeVscodeConfig(fsys)
+		}
+	} else {
+		if isVscode := utils.PromptYesNo("Generate VS Code workspace settings?", false, os.Stdin); isVscode {
+			return writeVscodeConfig(fsys)
+		}
 	}
+
 	return nil
 }
 

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -20,7 +20,7 @@ func TestInitCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, fsys.Mkdir(".git", 0755))
 		// Run test
-		assert.NoError(t, Run(fsys, ""))
+		assert.NoError(t, Run(fsys, new(bool)))
 		// Validate generated config.toml
 		exists, err := afero.Exists(fsys, utils.ConfigPath)
 		assert.NoError(t, err)
@@ -45,14 +45,14 @@ func TestInitCommand(t *testing.T) {
 		_, err := fsys.Create(utils.ConfigPath)
 		require.NoError(t, err)
 		// Run test
-		assert.Error(t, Run(fsys, ""))
+		assert.Error(t, Run(fsys, new(bool)))
 	})
 
 	t.Run("throws error on permission denied", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.StatErrorFs{DenyPath: utils.ConfigPath}
 		// Run test
-		err := Run(fsys, "")
+		err := Run(fsys, new(bool))
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
@@ -61,14 +61,14 @@ func TestInitCommand(t *testing.T) {
 		// Setup read-only fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
-		assert.Error(t, Run(fsys, ""))
+		assert.Error(t, Run(fsys, new(bool)))
 	})
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.CreateErrorFs{DenyPath: utils.SeedDataPath}
 		// Run test
-		err := Run(fsys, "")
+		err := Run(fsys, new(bool))
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
@@ -79,7 +79,7 @@ func TestInitCommand(t *testing.T) {
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
 		// Run test
-		assert.NoError(t, Run(fsys, "yes"))
+		assert.NoError(t, Run(fsys, boolPointer(true)))
 		// Validate generated vscode workspace
 		exists, err := afero.Exists(fsys, filepath.Join(cwd, "init.code-workspace"))
 		assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestInitCommand(t *testing.T) {
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
 		// Run test
-		assert.NoError(t, Run(fsys, "no"))
+		assert.NoError(t, Run(fsys, boolPointer(false)))
 		// Validate vscode workspace isn't generated
 		exists, err := afero.Exists(fsys, filepath.Join(cwd, "init.code-workspace"))
 		assert.NoError(t, err)
@@ -134,4 +134,8 @@ func TestUpdateGitIgnore(t *testing.T) {
 		// Run test
 		assert.Error(t, updateGitIgnore(ignorePath, fsys))
 	})
+}
+
+func boolPointer(b bool) *bool {
+	return &b
 }

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -20,7 +20,7 @@ func TestInitCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, fsys.Mkdir(".git", 0755))
 		// Run test
-		assert.NoError(t, Run(fsys, new(bool)))
+		assert.NoError(t, Run(fsys, nil))
 		// Validate generated config.toml
 		exists, err := afero.Exists(fsys, utils.ConfigPath)
 		assert.NoError(t, err)
@@ -45,14 +45,14 @@ func TestInitCommand(t *testing.T) {
 		_, err := fsys.Create(utils.ConfigPath)
 		require.NoError(t, err)
 		// Run test
-		assert.Error(t, Run(fsys, new(bool)))
+		assert.Error(t, Run(fsys, nil))
 	})
 
 	t.Run("throws error on permission denied", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.StatErrorFs{DenyPath: utils.ConfigPath}
 		// Run test
-		err := Run(fsys, new(bool))
+		err := Run(fsys, nil)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
@@ -61,14 +61,14 @@ func TestInitCommand(t *testing.T) {
 		// Setup read-only fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
-		assert.Error(t, Run(fsys, new(bool)))
+		assert.Error(t, Run(fsys, nil))
 	})
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.CreateErrorFs{DenyPath: utils.SeedDataPath}
 		// Run test
-		err := Run(fsys, new(bool))
+		err := Run(fsys, nil)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -17,7 +17,7 @@ func TestInitCommand(t *testing.T) {
 		fsys := &afero.MemMapFs{}
 		require.NoError(t, fsys.Mkdir(".git", 0755))
 		// Run test
-		assert.NoError(t, Run(fsys))
+		assert.NoError(t, Run(fsys, ""))
 		// Validate generated config.toml
 		exists, err := afero.Exists(fsys, utils.ConfigPath)
 		assert.NoError(t, err)
@@ -38,14 +38,14 @@ func TestInitCommand(t *testing.T) {
 		_, err := fsys.Create(utils.ConfigPath)
 		require.NoError(t, err)
 		// Run test
-		assert.Error(t, Run(fsys))
+		assert.Error(t, Run(fsys, ""))
 	})
 
 	t.Run("throws error on permission denied", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.StatErrorFs{DenyPath: utils.ConfigPath}
 		// Run test
-		err := Run(fsys)
+		err := Run(fsys, "")
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
@@ -54,14 +54,14 @@ func TestInitCommand(t *testing.T) {
 		// Setup read-only fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
-		assert.Error(t, Run(fsys))
+		assert.Error(t, Run(fsys, ""))
 	})
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.CreateErrorFs{DenyPath: utils.SeedDataPath}
 		// Run test
-		err := Run(fsys)
+		err := Run(fsys, "")
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, closes #1106.

## What is the current behavior?

Users must interact with the prompt to run the init command.

## What is the new behavior?

Users can provide a flag to bypass the prompt for the init command.  If the flag isn't provided, there isn't any behavior change.

## Additional context

Without any argument
```bash
nrayburn@nrayburn-macbook cli % go run main.go init                                                                          
Generate VS Code workspace settings? [y/N] y
Open the cli.code-workspace file in VS Code.
Finished supabase init.
```

With yes/y argument
```bash
nrayburn@nrayburn-macbook cli % go run main.go init --create-vscode-workspace=yes                                            
Open the cli.code-workspace file in VS Code.
Finished supabase init.
```

With no/n argument
```bash
nrayburn@nrayburn-macbook cli % go run main.go init --create-vscode-workspace=no 
Finished supabase init.
```