### PR TITLE
feat: track migration statements in history table

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -66,7 +66,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return repair.Run(ctx, dbConfig, args[0], targetStatus.Value)
+			return repair.Run(ctx, dbConfig, args[0], targetStatus.Value, fsys)
 		},
 	}
 

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -91,7 +91,8 @@ func TestMigrationPush(t *testing.T) {
 			Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations")
+			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
+			Query(repair.ADD_STATEMENTS_COLUMN)
 		// Run test
 		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)
 		// Check error
@@ -112,7 +113,9 @@ func TestMigrationPush(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
 			Reply("CREATE TABLE").
-			Query(repair.INSERT_MIGRATION_VERSION, "0").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE").
+			Query(repair.INSERT_MIGRATION_VERSION, "0", "{}").
 			ReplyError(pgerrcode.NotNullViolation, `null value in column "version" of relation "schema_migrations"`)
 		// Run test
 		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/migration/apply"
+	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/status"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -112,7 +113,7 @@ func RecreateDatabase(ctx context.Context, options ...func(*pgx.ConnConfig)) err
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 	fmt.Fprintln(os.Stderr, "Seeding data "+utils.Bold(utils.SeedDataPath)+"...")
-	seed, err := apply.NewMigrationFromFile(utils.SeedDataPath, fsys)
+	seed, err := repair.NewMigrationFromFile(utils.SeedDataPath, fsys)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	} else if err != nil {
@@ -202,7 +203,7 @@ func resetRemote(ctx context.Context, config pgconn.Config, fsys afero.Fs, optio
 	}
 	userSchemas = append(userSchemas, "supabase_migrations")
 	// Drop user defined objects
-	migration := apply.MigrationFile{}
+	migration := repair.MigrationFile{}
 	for _, schema := range userSchemas {
 		sql := fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema)
 		migration.Lines = append(migration.Lines, sql)

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -131,11 +131,7 @@ func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pg
 	defer conn.Close(context.Background())
 	updatePostgresConfig(conn)
 	// If `schema_migrations` doesn't exist on the remote database, create it.
-	batch := pgconn.Batch{}
-	batch.ExecParams(repair.CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
-	batch.ExecParams(repair.CREATE_VERSION_TABLE, nil, nil, nil, nil)
-	_, err = conn.PgConn().ExecBatch(ctx, &batch).ReadAll()
-	return err
+	return repair.CreateMigrationTable(ctx, conn)
 }
 
 func updatePostgresConfig(conn *pgx.Conn) {

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -125,7 +125,9 @@ func TestLinkCommand(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE")
+			Reply("CREATE TABLE").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE")
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -300,7 +302,9 @@ func TestLinkDatabase(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE")
+			Reply("CREATE TABLE").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE")
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -320,7 +324,9 @@ func TestLinkDatabase(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE")
+			Reply("CREATE TABLE").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE")
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -340,7 +346,8 @@ func TestLinkDatabase(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations")
+			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
+			Query(repair.ADD_STATEMENTS_COLUMN)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -7,14 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
-	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/parser"
 )
 
 func MigrateDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
@@ -42,7 +39,7 @@ func MigrateUp(ctx context.Context, conn *pgx.Conn, pending []string, fsys afero
 func applyMigration(ctx context.Context, conn *pgx.Conn, filename string, fsys afero.Fs) error {
 	fmt.Fprintln(os.Stderr, "Applying migration "+utils.Bold(filename)+"...")
 	path := filepath.Join(utils.MigrationsDir, filename)
-	migration, err := NewMigrationFromFile(path, fsys)
+	migration, err := repair.NewMigrationFromFile(path, fsys)
 	if err != nil {
 		return err
 	}
@@ -50,81 +47,9 @@ func applyMigration(ctx context.Context, conn *pgx.Conn, filename string, fsys a
 }
 
 func BatchExecDDL(ctx context.Context, conn *pgx.Conn, sql io.Reader) error {
-	migration, err := NewMigrationFromReader(sql)
+	migration, err := repair.NewMigrationFromReader(sql)
 	if err != nil {
 		return err
 	}
 	return migration.ExecBatch(ctx, conn)
-}
-
-type MigrationFile struct {
-	Lines   []string
-	version string
-}
-
-func NewMigrationFromFile(path string, fsys afero.Fs) (*MigrationFile, error) {
-	sql, err := fsys.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer sql.Close()
-	// Unless explicitly specified, Use file length as max buffer size
-	if !viper.IsSet("SCANNER_BUFFER_SIZE") {
-		if fi, err := sql.Stat(); err == nil {
-			if size := int(fi.Size()); size > parser.MaxScannerCapacity {
-				parser.MaxScannerCapacity = size
-			}
-		}
-	}
-	file, err := NewMigrationFromReader(sql)
-	if err == nil {
-		// Parse version from file name
-		filename := filepath.Base(path)
-		matches := utils.MigrateFilePattern.FindStringSubmatch(filename)
-		if len(matches) > 1 {
-			file.version = matches[1]
-		}
-	}
-	return file, err
-}
-
-func NewMigrationFromReader(sql io.Reader) (*MigrationFile, error) {
-	lines, err := parser.SplitAndTrim(sql)
-	if err != nil {
-		return nil, err
-	}
-	return &MigrationFile{Lines: lines}, nil
-}
-
-func (m *MigrationFile) ExecBatch(ctx context.Context, conn *pgx.Conn) error {
-	// Batch migration commands, without using statement cache
-	batch := &pgconn.Batch{}
-	for _, line := range m.Lines {
-		batch.ExecParams(line, nil, nil, nil, nil)
-	}
-	// Insert into migration history
-	if len(m.version) > 0 {
-		repair.InsertVersionSQL(batch, m.version)
-	}
-	// ExecBatch is implicitly transactional
-	if result, err := conn.PgConn().ExecBatch(ctx, batch).ReadAll(); err != nil {
-		// Defaults to printing the last statement on error
-		stat := repair.INSERT_MIGRATION_VERSION
-		i := len(result)
-		if i < len(m.Lines) {
-			stat = m.Lines[i]
-		}
-		return fmt.Errorf("%w\nAt statement %d: %s", err, i, utils.Aqua(stat))
-	}
-	return nil
-}
-
-func (m *MigrationFile) ExecBatchWithCache(ctx context.Context, conn *pgx.Conn) error {
-	// Data statements don't mutate schemas, safe to use statement cache
-	batch := pgx.Batch{}
-	for _, line := range m.Lines {
-		batch.Queue(line)
-	}
-	// No need to track version here because there are no schema changes
-	return conn.SendBatch(ctx, &batch).Close()
 }

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -1,23 +1,20 @@
 package apply
 
 import (
-	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/parser"
 )
 
 func TestMigrateDatabase(t *testing.T) {
@@ -34,9 +31,11 @@ func TestMigrateDatabase(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
 			Reply("CREATE TABLE").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE").
 			Query(sql).
 			Reply("CREATE SCHEMA").
-			Query(repair.INSERT_MIGRATION_VERSION, "0").
+			Query(repair.INSERT_MIGRATION_VERSION, "0", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 1")
 		// Connect to mock
 		ctx := context.Background()
@@ -74,7 +73,8 @@ func TestMigrateUp(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations")
+			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
+			Query(repair.ADD_STATEMENTS_COLUMN)
 		// Connect to mock
 		ctx := context.Background()
 		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
@@ -95,7 +95,9 @@ func TestMigrateUp(t *testing.T) {
 		conn.Query(repair.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE")
+			Reply("CREATE TABLE").
+			Query(repair.ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE")
 		// Connect to mock
 		ctx := context.Background()
 		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
@@ -105,58 +107,5 @@ func TestMigrateUp(t *testing.T) {
 		err = MigrateUp(context.Background(), mock, []string{"20220727064247_missing.sql"}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrNotExist)
-	})
-}
-
-func TestMigrationFile(t *testing.T) {
-	t.Run("new from file sets max token", func(t *testing.T) {
-		viper.Reset()
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup initial migration
-		name := "20220727064247_create_table.sql"
-		path := filepath.Join(utils.MigrationsDir, name)
-		query := "BEGIN; " + strings.Repeat("a", parser.MaxScannerCapacity)
-		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
-		// Run test
-		migration, err := NewMigrationFromFile(path, fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Len(t, migration.Lines, 2)
-		assert.Equal(t, "20220727064247", migration.version)
-	})
-
-	t.Run("new from reader errors on max token", func(t *testing.T) {
-		viper.Reset()
-		sql := "\tBEGIN; " + strings.Repeat("a", parser.MaxScannerCapacity)
-		// Run test
-		migration, err := NewMigrationFromReader(strings.NewReader(sql))
-		// Check error
-		assert.ErrorIs(t, err, bufio.ErrTooLong)
-		assert.ErrorContains(t, err, "After statement 1: \tBEGIN;")
-		assert.Nil(t, migration)
-	})
-
-	t.Run("throws error on insert failure", func(t *testing.T) {
-		migration := MigrationFile{
-			Lines:   []string{"create schema public"},
-			version: "0",
-		}
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		conn.Query(migration.Lines[0]).
-			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`).
-			Query(repair.INSERT_MIGRATION_VERSION, "0")
-		// Connect to mock
-		ctx := context.Background()
-		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
-		require.NoError(t, err)
-		defer mock.Close(ctx)
-		// Run test
-		err = migration.ExecBatch(context.Background(), mock)
-		// Check error
-		assert.ErrorContains(t, err, "ERROR: schema \"public\" already exists (SQLSTATE 42P06)")
-		assert.ErrorContains(t, err, "At statement 0: create schema public")
 	})
 }

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -3,12 +3,17 @@ package repair
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/parser"
 )
 
 const (
@@ -19,24 +24,26 @@ const (
 const (
 	CREATE_VERSION_SCHEMA    = "CREATE SCHEMA IF NOT EXISTS supabase_migrations"
 	CREATE_VERSION_TABLE     = "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text NOT NULL PRIMARY KEY)"
-	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version) VALUES($1)"
+	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
+	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version, statements) VALUES($1, $2)"
 	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = $1"
 )
 
-func Run(ctx context.Context, config pgconn.Config, version, status string, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, config pgconn.Config, version, status string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(context.Background())
-	// Create history table if not exists
-	batch := pgconn.Batch{}
-	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
-	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
 	// Update migration history
+	batch := batchCreateTable()
 	switch status {
 	case Applied:
-		InsertVersionSQL(&batch, version)
+		f, err := NewMigrationFromVersion(version, fsys)
+		if err != nil {
+			return err
+		}
+		InsertVersionSQL(&batch, version, f.Lines)
 	case Reverted:
 		DeleteVersionSQL(&batch, version)
 	}
@@ -47,28 +54,126 @@ func Run(ctx context.Context, config pgconn.Config, version, status string, opti
 	return nil
 }
 
-func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
+func batchCreateTable() pgconn.Batch {
+	// Create history table if not exists
 	batch := pgconn.Batch{}
 	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
+	batch.ExecParams(ADD_STATEMENTS_COLUMN, nil, nil, nil, nil)
+	return batch
+}
+
+func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
+	batch := batchCreateTable()
 	_, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll()
 	return err
 }
 
-func InsertVersionSQL(batch *pgconn.Batch, version string) {
-	updateVersionSQL(batch, INSERT_MIGRATION_VERSION, version)
+func InsertVersionSQL(batch *pgconn.Batch, version string, stats []string) {
+	encoded := []byte{'{'}
+	for i, line := range stats {
+		if i > 0 {
+			encoded = append(encoded, ',')
+		}
+		encoded = append(encoded, pgtype.QuoteArrayElementIfNeeded(line)...)
+	}
+	encoded = append(encoded, '}')
+	batch.ExecParams(
+		INSERT_MIGRATION_VERSION,
+		[][]byte{[]byte(version), encoded},
+		[]uint32{pgtype.TextOID, pgtype.TextArrayOID},
+		[]int16{pgtype.TextFormatCode, pgtype.TextFormatCode},
+		nil,
+	)
 }
 
 func DeleteVersionSQL(batch *pgconn.Batch, version string) {
-	updateVersionSQL(batch, DELETE_MIGRATION_VERSION, version)
-}
-
-func updateVersionSQL(batch *pgconn.Batch, sql, version string) {
 	batch.ExecParams(
-		sql,
+		DELETE_MIGRATION_VERSION,
 		[][]byte{[]byte(version)},
 		[]uint32{pgtype.TextOID},
 		[]int16{pgtype.TextFormatCode},
 		nil,
 	)
+}
+
+type MigrationFile struct {
+	Lines   []string
+	version string
+}
+
+func NewMigrationFromVersion(version string, fsys afero.Fs) (*MigrationFile, error) {
+	path := filepath.Join(utils.MigrationsDir, version+"_*.sql")
+	matches, err := afero.Glob(fsys, path)
+	if err != nil || len(matches) == 0 {
+		return nil, err
+	}
+	return NewMigrationFromFile(matches[0], fsys)
+}
+
+func NewMigrationFromFile(path string, fsys afero.Fs) (*MigrationFile, error) {
+	sql, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer sql.Close()
+	// Unless explicitly specified, Use file length as max buffer size
+	if !viper.IsSet("SCANNER_BUFFER_SIZE") {
+		if fi, err := sql.Stat(); err == nil {
+			if size := int(fi.Size()); size > parser.MaxScannerCapacity {
+				parser.MaxScannerCapacity = size
+			}
+		}
+	}
+	file, err := NewMigrationFromReader(sql)
+	if err == nil {
+		// Parse version from file name
+		filename := filepath.Base(path)
+		matches := utils.MigrateFilePattern.FindStringSubmatch(filename)
+		if len(matches) > 1 {
+			file.version = matches[1]
+		}
+	}
+	return file, err
+}
+
+func NewMigrationFromReader(sql io.Reader) (*MigrationFile, error) {
+	lines, err := parser.SplitAndTrim(sql)
+	if err != nil {
+		return nil, err
+	}
+	return &MigrationFile{Lines: lines}, nil
+}
+
+func (m *MigrationFile) ExecBatch(ctx context.Context, conn *pgx.Conn) error {
+	// Batch migration commands, without using statement cache
+	batch := &pgconn.Batch{}
+	for _, line := range m.Lines {
+		batch.ExecParams(line, nil, nil, nil, nil)
+	}
+	// Insert into migration history
+	if len(m.version) > 0 {
+		InsertVersionSQL(batch, m.version, m.Lines)
+	}
+	// ExecBatch is implicitly transactional
+	if result, err := conn.PgConn().ExecBatch(ctx, batch).ReadAll(); err != nil {
+		// Defaults to printing the last statement on error
+		stat := INSERT_MIGRATION_VERSION
+		i := len(result)
+		if i < len(m.Lines) {
+			stat = m.Lines[i]
+		}
+		return fmt.Errorf("%w\nAt statement %d: %s", err, i, utils.Aqua(stat))
+	}
+	return nil
+}
+
+func (m *MigrationFile) ExecBatchWithCache(ctx context.Context, conn *pgx.Conn) error {
+	// Data statements don't mutate schemas, safe to use statement cache
+	batch := pgx.Batch{}
+	for _, line := range m.Lines {
+		batch.Queue(line)
+	}
+	// No need to track version here because there are no schema changes
+	return conn.SendBatch(ctx, &batch).Close()
 }

--- a/internal/migration/repair/repair_test.go
+++ b/internal/migration/repair/repair_test.go
@@ -1,13 +1,22 @@
 package repair
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/pgtest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/parser"
 )
 
 var dbConfig = pgconn.Config{
@@ -20,6 +29,10 @@ var dbConfig = pgconn.Config{
 
 func TestRepairCommand(t *testing.T) {
 	t.Run("applies new version", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
+		require.NoError(t, afero.WriteFile(fsys, path, []byte(""), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -27,15 +40,19 @@ func TestRepairCommand(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(CREATE_VERSION_TABLE).
 			Reply("CREATE TABLE").
-			Query(INSERT_MIGRATION_VERSION, "0").
+			Query(ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE").
+			Query(INSERT_MIGRATION_VERSION, "0", "{}").
 			Reply("INSERT 0 1")
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Applied, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Applied, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
 
 	t.Run("reverts old version", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -43,22 +60,30 @@ func TestRepairCommand(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(CREATE_VERSION_TABLE).
 			Reply("CREATE TABLE").
+			Query(ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE").
 			Query(DELETE_MIGRATION_VERSION, "0").
 			Reply("DELETE 1")
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Reverted, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Reverted, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
 
 	t.Run("throws error on connect failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), pgconn.Config{}, "0", Applied)
+		err := Run(context.Background(), pgconn.Config{}, "0", Applied, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
 	t.Run("throws error on insert failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
+		require.NoError(t, afero.WriteFile(fsys, path, []byte(""), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -66,11 +91,66 @@ func TestRepairCommand(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(CREATE_VERSION_TABLE).
 			Reply("CREATE TABLE").
-			Query(INSERT_MIGRATION_VERSION, "0").
+			Query(ADD_STATEMENTS_COLUMN).
+			Reply("ALTER TABLE").
+			Query(INSERT_MIGRATION_VERSION, "0", "{}").
 			ReplyError(pgerrcode.DuplicateObject, `relation "supabase_migrations.schema_migrations" does not exist`)
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Applied, conn.Intercept)
+		err := Run(context.Background(), dbConfig, "0", Applied, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42710)`)
+	})
+}
+
+func TestMigrationFile(t *testing.T) {
+	t.Run("new from file sets max token", func(t *testing.T) {
+		viper.Reset()
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup initial migration
+		name := "20220727064247_create_table.sql"
+		path := filepath.Join(utils.MigrationsDir, name)
+		query := "BEGIN; " + strings.Repeat("a", parser.MaxScannerCapacity)
+		require.NoError(t, afero.WriteFile(fsys, path, []byte(query), 0644))
+		// Run test
+		migration, err := NewMigrationFromFile(path, fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Len(t, migration.Lines, 2)
+		assert.Equal(t, "20220727064247", migration.version)
+	})
+
+	t.Run("new from reader errors on max token", func(t *testing.T) {
+		viper.Reset()
+		sql := "\tBEGIN; " + strings.Repeat("a", parser.MaxScannerCapacity)
+		// Run test
+		migration, err := NewMigrationFromReader(strings.NewReader(sql))
+		// Check error
+		assert.ErrorIs(t, err, bufio.ErrTooLong)
+		assert.ErrorContains(t, err, "After statement 1: \tBEGIN;")
+		assert.Nil(t, migration)
+	})
+
+	t.Run("throws error on insert failure", func(t *testing.T) {
+		migration := MigrationFile{
+			Lines:   []string{"create schema public"},
+			version: "0",
+		}
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(migration.Lines[0]).
+			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`).
+			Query(INSERT_MIGRATION_VERSION, "0", fmt.Sprintf("{%s}", migration.Lines[0]))
+		// Connect to mock
+		ctx := context.Background()
+		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
+		require.NoError(t, err)
+		defer mock.Close(ctx)
+		// Run test
+		err = migration.ExecBatch(context.Background(), mock)
+		// Check error
+		assert.ErrorContains(t, err, "ERROR: schema \"public\" already exists (SQLSTATE 42P06)")
+		assert.ErrorContains(t, err, "At statement 0: create schema public")
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature
closes https://github.com/supabase/cli/issues/1166

## What is the new behavior?

- adds a list of statements executed to migration history

TODO:
- [ ] backfill past migrations

## Additional context

![Screenshot 2023-06-06 at 2 30 12 PM](https://github.com/supabase/cli/assets/1639722/da383fb2-70bc-42c2-84ef-7323abe61bea)
