### PR TITLE
chore: revive beta tap and bucket

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -48,6 +48,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BREWTAP_TOKEN: ${{ secrets.GH_PAT }}
+          SCOOP_TOKEN: ${{ secrets.GH_PAT }}
 
       - run: gh release edit v${{ needs.release.outputs.new-release-version }} --draft=false --prerelease
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,37 @@ changelog:
       order: 1
     - title: Others
       order: 999
+brews:
+  - name: supabase@beta
+    tap:
+      owner: supabase
+      name: homebrew-tap
+      token: "{{ .Env.BREWTAP_TOKEN }}"
+    commit_author:
+      name: Bobbie Soedirgo
+      email: bobbie@soedirgo.dev
+    url_template: "https://github.com/supabase/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: https://supabase.com
+    description: Supabase CLI
+    license: MIT
+    install: |
+      bin.install "supabase"
+      (bash_completion/"supabase").write `#{bin}/supabase completion bash`
+      (fish_completion/"supabase.fish").write `#{bin}/supabase completion fish`
+      (zsh_completion/"_supabase").write `#{bin}/supabase completion zsh`
+scoops:
+  - name: supabase@beta
+    bucket:
+      owner: supabase
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_TOKEN }}"
+    commit_author:
+      name: Bobbie Soedirgo
+      email: bobbie@soedirgo.dev
+    url_template: "https://github.com/supabase/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: https://supabase.com
+    description: Supabase CLI
+    license: MIT
 nfpms:
   - vendor: Supabase
     description: Supabase CLI


### PR DESCRIPTION
## What kind of change does this PR introduce?

release

## What is the new behavior?

hopefully allows beta release
- `brew install supabase/tap/supabase@beta`
- `scoop install supabase@beta`

## Additional context

Add any other context or screenshots.
