### PR TITLE
fix: use relative paths for pg_prove to allow psql includes

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -46,8 +46,8 @@ func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
 	}
 
 	// Passing in script string means command line args must be set manually, ie. "$@"
-	testsPath := path.Join(dstPath, filepath.Dir(utils.DbTestsDir), filepath.Base(utils.DbTestsDir))
-	args := "set -- " + testsPath + ";"
+	testsPath := path.Join(filepath.Dir(utils.DbTestsDir), filepath.Base(utils.DbTestsDir))
+	args := "cd " + dstPath + ";set -- " + testsPath + ";"
 	// Requires unix path inside container
 	cmd := []string{"/bin/bash", "-c", args + testScript}
 	return utils.DockerExecOnceWithStream(ctx, utils.DbId, nil, cmd, os.Stdout, os.Stderr)


### PR DESCRIPTION
## What kind of change does this PR introduce?

`supabase db test` chdirs to /tmp before running tests. This allows `\i supabase/tests/my_helpers` psql macro to work properly.


## What is the current behavior?

I just wanted to create and use common helper functions in my pgtap tests without including them to the actual production db via migrations. \i macro could work, but, `supabase db tests` copies supabase/tests directory to the container in the /tmp directory, and then runs `pg_prove /tmp/supabase/tests` from the `/` directory. This forces me to use absolute paths in `\i`, like `\i /tmp/supabase/tests/helpers`. 


```
> supabase test db
/tmp/supabase/tests/database/001_row_level_security.sql .. ok
/tmp/supabase/tests/database/002_course_view.sql ......... ok
/tmp/supabase/tests/database/003_learning_paths.sql ...... ok
All tests successful.
Files=3, Tests=18,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.02 csys =  0.07 CPU)
Result: PASS
```

## What is the new behavior?

As an additional nice side effect, output of pgprove now shows relative paths too, which are valid on the developer host. This makes it easier to copy path to edit it later.

```
> supabase test db
supabase/tests/database/001_row_level_security.sql .. ok
supabase/tests/database/002_course_view.sql ......... ok
supabase/tests/database/003_learning_paths.sql ...... ok
All tests successful.
Files=3, Tests=18,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.02 csys =  0.07 CPU)
Result: PASS
```