### PR TITLE
fix: persist config volume between restarts

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -81,8 +81,11 @@ func StartDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 	hostConfig := WithSyslogConfig(container.HostConfig{
 		PortBindings:  nat.PortMap{"5432/tcp": []nat.PortBinding{{HostPort: hostPort}}},
 		RestartPolicy: container.RestartPolicy{Name: "always"},
-		Binds:         []string{utils.DbId + ":/var/lib/postgresql/data"},
-		ExtraHosts:    []string{"host.docker.internal:host-gateway"},
+		Binds: []string{
+			utils.DbId + ":/var/lib/postgresql/data",
+			utils.ConfigId + ":/etc/postgresql-custom",
+		},
+		ExtraHosts: []string{"host.docker.internal:host-gateway"},
 	})
 	if utils.Config.Db.MajorVersion <= 14 {
 		config.Entrypoint = nil

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -55,7 +55,7 @@ func stop(ctx context.Context, backup bool) error {
 		fmt.Fprintln(os.Stderr, "Storage directory saved to volume:", utils.StorageId)
 	} else {
 		// TODO: label named volumes to use VolumesPrune for branch support
-		volumes := []string{utils.DbId, utils.StorageId}
+		volumes := []string{utils.ConfigId, utils.DbId, utils.StorageId}
 		utils.WaitAll(volumes, func(name string) {
 			if err := utils.Docker.VolumeRemove(ctx, name, true); err != nil {
 				fmt.Fprintln(os.Stderr, "failed to remove volume:", name, err)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -21,6 +21,7 @@ var (
 	DbImage    string
 	NetId      string
 	DbId       string
+	ConfigId   string
 	KongId     string
 	GotrueId   string
 	InbucketId string
@@ -206,6 +207,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 		} else {
 			NetId = "supabase_network_" + Config.ProjectId
 			DbId = "supabase_db_" + Config.ProjectId
+			ConfigId = "supabase_config_" + Config.ProjectId
 			KongId = "supabase_kong_" + Config.ProjectId
 			GotrueId = "supabase_auth_" + Config.ProjectId
 			InbucketId = "supabase_inbucket_" + Config.ProjectId


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1204

## What is the new behavior?

Persists config volume where settings like extension custom scripts and vault key are stored.

## Additional context

Add any other context or screenshots.
