### PR TITLE
fix: validate version number for migration repair

### DIFF
--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -2,10 +2,12 @@ package repair
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
@@ -30,6 +32,9 @@ const (
 )
 
 func Run(ctx context.Context, config pgconn.Config, version, status string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	if _, err := strconv.Atoi(version); err != nil {
+		return errors.New("invalid version number")
+	}
 	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1209

## What is the new behavior?

- users must supply a version number as per [migration example](https://github.com/supabase/cli/blob/main/docs/supabase/migration/repair.md#supabase-migration-repair)

## Additional context

Add any other context or screenshots.
