### PR TITLE
chore: add spinner for stopping containers

### DIFF
--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -3,6 +3,7 @@ package stop
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -92,7 +93,7 @@ func TestStopServices(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.NetworksPruneReport{})
 		// Run test
-		err := stop(context.Background(), true)
+		err := stop(context.Background(), true, io.Discard)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -131,7 +132,7 @@ func TestStopServices(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.NetworksPruneReport{})
 		// Run test
-		err := stop(context.Background(), false)
+		err := stop(context.Background(), false, io.Discard)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -149,7 +150,7 @@ func TestStopServices(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/containers/prune").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := stop(context.Background(), true)
+		err := stop(context.Background(), true, io.Discard)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://www.notion.so/supabase/Show-a-spinner-when-running-supabase-stop-27519c4405644d3c8cdbd6b6cd43aeae?pvs=4

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
