### PR TITLE
fix: baseline should work without specifying version

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -85,6 +85,9 @@ var (
 			}
 			return squash.Run(ctx, version, dbConfig, fsys)
 		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Finished " + utils.Aqua("supabase migration squash") + ".")
+		},
 	}
 
 	migrationUpCmd = &cobra.Command{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/192#issuecomment-1599364500

## What is the new behavior?

Baselines the earliest version if none is specified.

## Additional context

Add any other context or screenshots.
