### PR TITLE
fix(storage): copied object should use new version

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	// updating any one of these.
 	GotrueImage   = "supabase/gotrue:v2.62.1"
 	RealtimeImage = "supabase/realtime:v2.10.1"
-	StorageImage  = "supabase/storage-api:v0.37.4"
+	StorageImage  = "supabase/storage-api:v0.40.4"
 	LogflareImage = "supabase/logflare:1.0.2"
 	// Should be kept in-sync with DenoRelayImage
 	DenoVersion = "1.30.3"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/633
relates to https://github.com/supabase/storage-api/pull/344

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
