### PR TITLE
chore(docs): update stop.md to match new default

### DIFF
--- a/docs/supabase/stop.md
+++ b/docs/supabase/stop.md
@@ -4,4 +4,4 @@ Stops the Supabase local development stack.
 
 Requires `supabase/config.toml` to be created in your current working directory by running `supabase init`.
 
-All Docker resources are cleaned up by default. Use `--backup` flag to persist your local development data between restarts.
+All Docker resources are maintained across restarts.  Use `--no-backup` flag to reset your local development data between restarts.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation update for stop command

## What is the current behavior?

Incorrectly shows the previous functionality where supabase stop would drop all data by default

## What is the new behavior?

Updated the docs to show the new behavior, but I'm not sure I worded it very well.  I tried to maintain the original docs style.
