### PR TITLE
fix: do not mount deno cache volume

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -272,7 +272,6 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	// 3. Parse custom import map
 	binds := []string{
 		filepath.Join(cwd, utils.FunctionsDir) + ":" + dockerFuncDirPath + ":rw,z",
-		utils.DenoRelayId + ":/root/.cache/deno:rw,z",
 	}
 	if importMapPath != "" {
 		modules, err := bindImportMap(importMapPath, dockerFlagImportMapPath, fsys)

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -59,10 +59,9 @@ func stop(ctx context.Context, backup bool, w io.Writer) error {
 		fmt.Fprintln(os.Stderr, "Postgres database saved to volume:", utils.DbId)
 		fmt.Fprintln(os.Stderr, "Postgres config saved to volume:", utils.ConfigId)
 		fmt.Fprintln(os.Stderr, "Storage directory saved to volume:", utils.StorageId)
-		fmt.Fprintln(os.Stderr, "Functions cache saved to volume:", utils.DenoRelayId)
 	} else {
 		// TODO: label named volumes to use VolumesPrune for branch support
-		volumes := []string{utils.ConfigId, utils.DbId, utils.StorageId, utils.DenoRelayId}
+		volumes := []string{utils.ConfigId, utils.DbId, utils.StorageId}
 		utils.WaitAll(volumes, func(name string) {
 			if err := utils.Docker.VolumeRemove(ctx, name, true); err != nil {
 				fmt.Fprintln(os.Stderr, "failed to remove volume:", name, err)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

No need to persist the deno cache volume between docker restarts.

## Additional context

Add any other context or screenshots.
