### PR TITLE
fix(functions): bump to Edge Runtime 1.5.2

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -60,6 +60,15 @@ async function verifyJWT(jwt: string): Promise<boolean> {
 serve(async (req: Request) => {
   const url = new URL(req.url);
   const { pathname } = url;
+
+  // handle health checks
+  if (pathname === "/_internal/health") {
+    return new Response(
+      JSON.stringify({ "message": "ok" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
   const pathParts = pathname.split("/");
   const functionName = pathParts[1];
 

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -100,7 +100,7 @@ serve(async (req: Request) => {
   console.error(`serving the request with ${servicePath}`);
 
   const memoryLimitMb = 150;
-  const workerTimeoutMs = 1 * 60 * 1000;
+  const workerTimeoutMs = 5 * 60 * 1000;
   const noModuleCache = false;
   const envVarsObj = Deno.env.toObject();
   const envVars = Object.entries(envVarsObj)

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -91,7 +91,7 @@ serve(async (req: Request) => {
   console.error(`serving the request with ${servicePath}`);
 
   const memoryLimitMb = 150;
-  const workerTimeoutMs = 1 * 60 * 5000;
+  const workerTimeoutMs = 1 * 60 * 1000;
   const noModuleCache = false;
   const envVarsObj = Deno.env.toObject();
   const envVars = Object.entries(envVarsObj)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	StudioImage      = "supabase/studio:20230622-d8395eb"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.5.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.5.2"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	StudioImage      = "supabase/studio:20230622-d8395eb"
 	DenoRelayImage   = "supabase/deno-relay:v1.6.0"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.4.2"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.5.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

* add navigator global ([77ebaf1](https://github.com/supabase/edge-runtime/commit/77ebaf1d24de02b8a11b6a7acf95e033a490cac3))
* handling concurrent requests to workers ([d47f05d](https://github.com/supabase/edge-runtime/commit/d47f05df6a04af2ffa307ae73be53a2c25627f0f))

Also, set the worker timeout to 1 min.

Updated to 1.5.2, which includes this fix - https://github.com/supabase/edge-runtime/pull/127