### PR TITLE
fix: apply migrations after creating shadow db

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -26,7 +26,7 @@ var (
 	postgresConfigUpdateCmd = &cobra.Command{
 		Use:   "update",
 		Short: "Update Postgres database config",
-		Long: `Overriding the default Postgres config could result in unstable database behaviour.
+		Long: `Overriding the default Postgres config could result in unstable database behavior.
 Custom configuration also overrides the optimizations generated based on the compute add-ons in use.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return update.Run(cmd.Context(), flags.ProjectRef, postgresConfigValues, postgresConfigUpdateReplaceMode, afero.NewOsFs())

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -21,6 +21,7 @@ import (
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/migration/apply"
+	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -127,7 +128,11 @@ func connectShadowDatabase(ctx context.Context, timeout time.Duration, options .
 }
 
 func MigrateShadowDatabase(ctx context.Context, container string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
-	return MigrateShadowDatabaseVersions(ctx, container, nil, fsys, options...)
+	migrations, err := list.LoadLocalMigrations(fsys)
+	if err != nil {
+		return err
+	}
+	return MigrateShadowDatabaseVersions(ctx, container, migrations, fsys, options...)
 }
 
 func MigrateShadowDatabaseVersions(ctx context.Context, container string, migrations []string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1253

## What is the current behavior?

broke db diff during last refactor, partly because we were missing a unit test

## What is the new behavior?

added unit test to check that local migrations are after creating shadow db

## Additional context

Add any other context or screenshots.
