### PR TITLE
feat: add kong config with nginx_worker_processes option

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -268,6 +268,22 @@ EOF
 	// Start Kong.
 	p.Send(utils.StatusMsg("Starting containers..."))
 	if !isContainerExcluded(utils.KongImage, excluded) {
+		env := []string{
+			"KONG_DATABASE=off",
+			"KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml",
+			"KONG_DNS_ORDER=LAST,A,CNAME", // https://github.com/supabase/cli/issues/14
+			"KONG_PLUGINS=request-transformer,cors",
+			// Need to increase the nginx buffers in kong to avoid it rejecting the rather
+			// sizeable response headers azure can generate
+			// Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126
+			"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
+			"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
+		}
+
+		if utils.Config.Kong.NginxWorkerProcesses != 0 {
+			env = append(env, fmt.Sprintf("KONG_NGINX_WORKER_PROCESSES=%d", utils.Config.Kong.NginxWorkerProcesses))
+		}
+
 		var kongConfigBuf bytes.Buffer
 
 		if err := kongConfigTemplate.Execute(&kongConfigBuf, kongConfig{
@@ -287,17 +303,7 @@ EOF
 			ctx,
 			container.Config{
 				Image: utils.KongImage,
-				Env: []string{
-					"KONG_DATABASE=off",
-					"KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml",
-					"KONG_DNS_ORDER=LAST,A,CNAME", // https://github.com/supabase/cli/issues/14
-					"KONG_PLUGINS=request-transformer,cors",
-					// Need to increase the nginx buffers in kong to avoid it rejecting the rather
-					// sizeable response headers azure can generate
-					// Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126
-					"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
-					"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
-				},
+				Env:   env,
 				Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /home/kong/kong.yml && ./docker-entrypoint.sh kong docker-start
 ` + kongConfigBuf.String() + `
 EOF

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -89,6 +89,7 @@ type (
 		Api       api                 `toml:"api"`
 		Db        db                  `toml:"db" mapstructure:"db"`
 		Studio    studio              `toml:"studio"`
+		Kong      kong                `toml:"kong"`
 		Inbucket  inbucket            `toml:"inbucket"`
 		Storage   storage             `toml:"storage"`
 		Auth      auth                `toml:"auth" mapstructure:"auth"`
@@ -114,6 +115,10 @@ type (
 
 	studio struct {
 		Port uint `toml:"port"`
+	}
+
+	kong struct {
+		NginxWorkerProcesses uint `toml:"nginx_worker_processes"`
 	}
 
 	inbucket struct {

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -25,6 +25,11 @@ major_version = 15
 # Port to use for Supabase Studio.
 port = 54323
 
+[kong]
+# Number of nginx workers for handling requests. Set this to 1 to minimize memory usage.
+# Omitting it or setting it to 0 will autodetect based on the number of CPU cores.
+nginx_worker_processes = 1
+
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
 [inbucket]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -25,6 +25,11 @@ major_version = 15
 # Port to use for Supabase Studio.
 port = 54323
 
+[kong]
+# Number of nginx workers for handling requests. Set this to 1 to minimize memory usage.
+# Omitting it or setting it to 0 will autodetect based on the number of CPU cores.
+nginx_worker_processes = 1
+
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
 [inbucket]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to configure [Kong's `nginx_worker_processes`](https://docs.konghq.com/gateway/latest/reference/configuration/#nginx_worker_processes) value via the below TOML config:
```toml
[kong]
# Number of Nginx workers. Set this to 1 to minimize memory usage.
nginx_worker_processes = 1
```

## What is the current behavior?

When running in memory-constrained environments, Kong/Nginx may spawn an excessive number of workers, drastically increasing memory usage.

## What is the new behavior?

This PR allows users to fine-tune the number of Kong/Nginx worker processes when desired. If no configuration is provided, the previous behavior (`auto`) is used.

## Additional context

For my use case, this allowed me to cut memory usage of the entire Supabase Docker compose by 79%! (1487 MiB -> 312 MiB) by setting it to just `1` (I'm not especially concerned about the reduced routing performance).