### PR TITLE
fix: wait for containers to be ready after db reset

### DIFF
--- a/internal/db/branch/switch_/switch_.go
+++ b/internal/db/branch/switch_/switch_.go
@@ -66,7 +66,11 @@ func switchDatabase(ctx context.Context, source, target string, options ...func(
 	if err := reset.DisconnectClients(ctx, conn); err != nil {
 		return err
 	}
-	defer reset.RestartDatabase(context.Background(), os.Stderr)
+	defer func() {
+		if err := reset.RestartDatabase(context.Background(), os.Stderr); err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to restart database:", err)
+		}
+	}()
 	backup := "ALTER DATABASE postgres RENAME TO " + source + ";"
 	if _, err := conn.Exec(ctx, backup); err != nil {
 		return err

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -101,7 +101,7 @@ func StartDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 		return err
 	}
 	if !reset.WaitForHealthyService(ctx, utils.DbId, 20*time.Second) {
-		fmt.Fprintln(os.Stderr, "Database is not healthy.")
+		return reset.ErrDatabase
 	}
 	// Initialise if we are on PG14 and there's no existing db volume
 	if noBackupVolume {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1277

## What is the new behavior?

Wait for storage migrations to finish running before applying user migrations.

## Additional context

Add any other context or screenshots.
