### PR TITLE
feat(db diff): add --local flag

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -88,7 +88,7 @@ var (
 				if err := parseDatabaseConfig(fsys); err != nil {
 					return err
 				}
-			}
+			} // else use --local, which is the default
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			if usePgAdmin {
 				return diff.Run(ctx, schema, file, dbConfig, fsys)
@@ -237,7 +237,10 @@ func init() {
 	diffFlags.BoolVar(&useMigra, "use-migra", true, "Use migra to generate schema diff.")
 	diffFlags.BoolVar(&usePgAdmin, "use-pgadmin", false, "Use pgAdmin to generate schema diff.")
 	dbDiffCmd.MarkFlagsMutuallyExclusive("use-migra", "use-pgadmin")
-	diffFlags.BoolVar(&linked, "linked", false, "Diffs local schema against the linked project.")
+	diffFlags.StringVar(&dbUrl, "db-url", "", "Diffs local migration files against the database specified by the connection string (must be percent-encoded).")
+	diffFlags.BoolVar(&linked, "linked", false, "Diffs local migration files against the linked project.")
+	diffFlags.BoolVar(&local, "local", false, "Diffs local migration files against the local database.")
+	dbDiffCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	diffFlags.StringVarP(&file, "file", "f", "", "Saves schema diff to a new migration file.")
 	diffFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "List of schema to include.")
 	diffFlags.Lookup("schema").DefValue = "all"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

`supabase db diff` defaults to diffing against the local database, but there's no `--local` flag, which makes it inconsistent with other `supabase db` subcommands.

## What is the new behavior?

Add `--local` flag (basically a noop vs. the existing behavior).