### PR TITLE
fix: pin configure-aws-credentials action to v1

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -65,7 +65,7 @@ jobs:
           TAG=${{ matrix.src }}
           echo "dst=${TAG##*/}" >> $GITHUB_OUTPUT
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -27,7 +27,7 @@ const (
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"
-	PostgrestImage   = "postgrest/postgrest:v10.1.2"
+	PostgrestImage   = "postgrest/postgrest:v11.1.0"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.66.3"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Something broke the upstream [configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials/tree/v2) action v2 since 6 July.

## Additional context

Add any other context or screenshots.
