### PR TITLE
fix: upgrade to Edge Runtime 1.6.6

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -108,6 +108,10 @@ serve(async (req: Request) => {
       !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_")
     );
   const forceCreate = true;
+  const customModuleRoot = ""; // empty string to allow any local path
+  const cpuTimeThresholdMs = 50;
+  const cpuBurstIntervalMs = 100;
+  const maxCpuBursts = 10;
   try {
     const worker = await EdgeRuntime.userWorkers.create({
       servicePath,
@@ -117,6 +121,10 @@ serve(async (req: Request) => {
       importMapPath: functionsConfig[functionName].importMapPath,
       envVars,
       forceCreate,
+      customModuleRoot,
+      cpuTimeThresholdMs,
+      cpuBurstIntervalMs,
+      maxCpuBursts,
     });
     return await worker.fetch(req);
   } catch (e) {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.66.3"
 	StudioImage      = "supabase/studio:v0.23.06"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.5.2"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.6.6"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR upgrades Edge Runtime to version 1.6.6

Notable changes:

* CPU time restriction is enforced locally, so users can simulate them locally and tweak their functions (currently set to 500ms for a function with wall clock time of 5mins)
* All function invocations will show the CPU time it used.


![Screen Shot 2023-07-11 at 10 38 21 am](https://github.com/supabase/cli/assets/5358/92e8b65b-5d1a-4e79-83d2-6e09ec55bafd)

