### PR TITLE
Add inspect commands heavily inspired by heroku pg:extra

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/index_usage"
 	"github.com/supabase/cli/internal/inspect/locks"
 	"github.com/supabase/cli/internal/inspect/blocking"
+	"github.com/supabase/cli/internal/inspect/outliers"
 )
 
 var (
@@ -89,6 +90,19 @@ var (
 			return blocking.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectOutliersCmd = &cobra.Command{
+		Use:   "outliers",
+		Short: "Shows queries from pg_stat_statements ordered by total execution time",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return blocking.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -100,5 +114,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectIndexUsageCmd)
 	inspectDBCmd.AddCommand(inspectLocksCmd)
 	inspectDBCmd.AddCommand(inspectBlockingCmd)
+	inspectDBCmd.AddCommand(inspectOutliersCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/locks"
 	"github.com/supabase/cli/internal/inspect/blocking"
 	"github.com/supabase/cli/internal/inspect/outliers"
+	"github.com/supabase/cli/internal/inspect/calls"
 )
 
 var (
@@ -103,6 +104,19 @@ var (
 			return blocking.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectCallsCmd = &cobra.Command{
+		Use:   "calls",
+		Short: "Shows queries from pg_stat_statements ordered by total times called",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return calls.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -115,5 +129,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectLocksCmd)
 	inspectDBCmd.AddCommand(inspectBlockingCmd)
 	inspectDBCmd.AddCommand(inspectOutliersCmd)
+	inspectDBCmd.AddCommand(inspectCallsCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/blocking"
 	"github.com/supabase/cli/internal/inspect/cache"
 	"github.com/supabase/cli/internal/inspect/calls"
+	"github.com/supabase/cli/internal/inspect/index_sizes"
 	"github.com/supabase/cli/internal/inspect/index_usage"
 	"github.com/supabase/cli/internal/inspect/locks"
 	"github.com/supabase/cli/internal/inspect/outliers"
@@ -131,6 +132,19 @@ var (
 			return total_index_size.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectIndexSizesCmd = &cobra.Command{
+		Use:   "index-sizes",
+		Short: "Shows total size of all indexes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return index_sizes.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -145,5 +159,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectOutliersCmd)
 	inspectDBCmd.AddCommand(inspectCallsCmd)
 	inspectDBCmd.AddCommand(inspectTotalIndexSizeCmd)
+	inspectDBCmd.AddCommand(inspectIndexSizesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/inspect/bloat"
 	"github.com/supabase/cli/internal/inspect/blocking"
 	"github.com/supabase/cli/internal/inspect/cache"
 	"github.com/supabase/cli/internal/inspect/calls"
@@ -243,6 +244,19 @@ var (
 			return table_record_counts.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectBloatCmd = &cobra.Command{
+		Use:   "bloat",
+		Short: "Estimates space allocated to a relation that is full of dead tuples",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return bloat.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -265,5 +279,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectSeqScansCmd)
 	inspectDBCmd.AddCommand(inspectLongRunningQueriesCmd)
 	inspectDBCmd.AddCommand(inspectTableRecordCountsCmd)
+	inspectDBCmd.AddCommand(inspectBloatCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/locks"
 	"github.com/supabase/cli/internal/inspect/outliers"
 	"github.com/supabase/cli/internal/inspect/replication_slots"
+	"github.com/supabase/cli/internal/inspect/table_index_sizes"
 	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
 )
@@ -159,6 +160,19 @@ var (
 			return table_sizes.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectTableIndexSizesCmd = &cobra.Command{
+		Use:   "table-index-sizes",
+		Short: "Shows index sizes of individual tables",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return table_index_sizes.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -175,5 +189,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectTotalIndexSizeCmd)
 	inspectDBCmd.AddCommand(inspectIndexSizesCmd)
 	inspectDBCmd.AddCommand(inspectTableSizesCmd)
+	inspectDBCmd.AddCommand(inspectTableIndexSizesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -18,6 +18,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
 	"github.com/supabase/cli/internal/inspect/total_table_sizes"
+	"github.com/supabase/cli/internal/inspect/unused_indexes"
 )
 
 var (
@@ -187,6 +188,19 @@ var (
 			return total_table_sizes.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectUnusedIndexesCmd = &cobra.Command{
+		Use:   "unused-indexes",
+		Short: "Show indexes with low usage",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return unused_indexes.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -205,5 +219,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectTableSizesCmd)
 	inspectDBCmd.AddCommand(inspectTableIndexSizesCmd)
 	inspectDBCmd.AddCommand(inspectTotalTableSizesCmd)
+	inspectDBCmd.AddCommand(inspectUnusedIndexesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/inspect/blocking"
 	"github.com/supabase/cli/internal/inspect/cache"
-	"github.com/supabase/cli/internal/inspect/replication_slots"
+	"github.com/supabase/cli/internal/inspect/calls"
 	"github.com/supabase/cli/internal/inspect/index_usage"
 	"github.com/supabase/cli/internal/inspect/locks"
-	"github.com/supabase/cli/internal/inspect/blocking"
 	"github.com/supabase/cli/internal/inspect/outliers"
-	"github.com/supabase/cli/internal/inspect/calls"
+	"github.com/supabase/cli/internal/inspect/replication_slots"
+	"github.com/supabase/cli/internal/inspect/total_index_size"
 )
 
 var (
@@ -23,8 +24,8 @@ var (
 	}
 
 	inspectDBCmd = &cobra.Command{
-		Use:     "db",
-		Short:   "Tools to inspect your Supabase ds",
+		Use:   "db",
+		Short: "Tools to inspect your Supabase ds",
 	}
 
 	inspectCacheHitCmd = &cobra.Command{
@@ -117,6 +118,19 @@ var (
 			return calls.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectTotalIndexSizeCmd = &cobra.Command{
+		Use:   "total-index-size",
+		Short: "Shows total size of all indexes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return total_index_size.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -130,5 +144,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectBlockingCmd)
 	inspectDBCmd.AddCommand(inspectOutliersCmd)
 	inspectDBCmd.AddCommand(inspectCallsCmd)
+	inspectDBCmd.AddCommand(inspectTotalIndexSizeCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/locks"
 	"github.com/supabase/cli/internal/inspect/outliers"
 	"github.com/supabase/cli/internal/inspect/replication_slots"
+	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
 )
 
@@ -135,7 +136,7 @@ var (
 
 	inspectIndexSizesCmd = &cobra.Command{
 		Use:   "index-sizes",
-		Short: "Shows total size of all indexes",
+		Short: "Shows index sizes of individual indexes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if err := parseDatabaseConfig(fsys); err != nil {
@@ -143,6 +144,19 @@ var (
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			return index_sizes.Run(ctx, dbConfig, fsys)
+		},
+	}
+
+	inspectTableSizesCmd = &cobra.Command{
+		Use:   "table-sizes",
+		Short: "Shows table sizes of individual tables",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return table_sizes.Run(ctx, dbConfig, fsys)
 		},
 	}
 )
@@ -160,5 +174,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectCallsCmd)
 	inspectDBCmd.AddCommand(inspectTotalIndexSizeCmd)
 	inspectDBCmd.AddCommand(inspectIndexSizesCmd)
+	inspectDBCmd.AddCommand(inspectTableSizesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -17,6 +17,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/replication_slots"
 	"github.com/supabase/cli/internal/inspect/seq_scans"
 	"github.com/supabase/cli/internal/inspect/table_index_sizes"
+	"github.com/supabase/cli/internal/inspect/table_record_counts"
 	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
 	"github.com/supabase/cli/internal/inspect/total_table_sizes"
@@ -229,6 +230,19 @@ var (
 			return long_running_queries.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectTableRecordCountsCmd = &cobra.Command{
+		Use:   "table-record-counts",
+		Short: "Show estimated number of rows per table",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return table_record_counts.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -250,5 +264,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectUnusedIndexesCmd)
 	inspectDBCmd.AddCommand(inspectSeqScansCmd)
 	inspectDBCmd.AddCommand(inspectLongRunningQueriesCmd)
+	inspectDBCmd.AddCommand(inspectTableRecordCountsCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -17,6 +17,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/table_index_sizes"
 	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
+	"github.com/supabase/cli/internal/inspect/total_table_sizes"
 )
 
 var (
@@ -150,7 +151,7 @@ var (
 
 	inspectTableSizesCmd = &cobra.Command{
 		Use:   "table-sizes",
-		Short: "Shows table sizes of individual tables",
+		Short: "Shows table sizes of individual tables without their index sizes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if err := parseDatabaseConfig(fsys); err != nil {
@@ -173,6 +174,19 @@ var (
 			return table_index_sizes.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectTotalTableSizesCmd = &cobra.Command{
+		Use:   "total-table-sizes",
+		Short: "Shows total table sizes, including table index sizes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return total_table_sizes.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -190,5 +204,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectIndexSizesCmd)
 	inspectDBCmd.AddCommand(inspectTableSizesCmd)
 	inspectDBCmd.AddCommand(inspectTableIndexSizesCmd)
+	inspectDBCmd.AddCommand(inspectTotalTableSizesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -23,6 +23,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/total_index_size"
 	"github.com/supabase/cli/internal/inspect/total_table_sizes"
 	"github.com/supabase/cli/internal/inspect/unused_indexes"
+	"github.com/supabase/cli/internal/inspect/vacuum_stats"
 )
 
 var (
@@ -257,6 +258,19 @@ var (
 			return bloat.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectVacuumStatsCmd = &cobra.Command{
+		Use:   "vacuum-stats",
+		Short: "Shows statistics related to vacuum operations per table",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return vacuum_stats.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -280,5 +294,6 @@ func init() {
 	inspectDBCmd.AddCommand(inspectLongRunningQueriesCmd)
 	inspectDBCmd.AddCommand(inspectTableRecordCountsCmd)
 	inspectDBCmd.AddCommand(inspectBloatCmd)
+	inspectDBCmd.AddCommand(inspectVacuumStatsCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -20,7 +20,7 @@ var (
 	}
 
 	inspectCacheHitCmd = &cobra.Command{
-		Use:   "db:cache-hit",
+		Use:   "db cache-hit",
 		Short: "Shows cache hit rates for tables and indices",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
@@ -33,7 +33,7 @@ var (
 	}
 
 	inspectReplicationSlotsCmd = &cobra.Command{
-		Use:   "db:replication-slots",
+		Use:   "db replication-slots",
 		Short: "Shows information about replication slots on the database",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
@@ -46,7 +46,7 @@ var (
 	}
 
 	inspectIndexUsageCmd = &cobra.Command{
-		Use:   "db:index-usage",
+		Use:   "db index-usage",
 		Short: "Shows information about the efficiency of indexes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/supabase/cli/internal/inspect/cache"
 	"github.com/supabase/cli/internal/inspect/replication_slots"
 	"github.com/supabase/cli/internal/inspect/index_usage"
+	"github.com/supabase/cli/internal/inspect/locks"
 )
 
 var (
@@ -56,6 +57,19 @@ var (
 			return index_usage.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectLocksCmd = &cobra.Command{
+		Use:   "db locks",
+		Short: "Shows queries which have taken out an exclusive lock on a relation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return locks.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -64,5 +78,6 @@ func init() {
 	inspectCmd.AddCommand(inspectCacheHitCmd)
 	inspectCmd.AddCommand(inspectReplicationSlotsCmd)
 	inspectCmd.AddCommand(inspectIndexUsageCmd)
+	inspectCmd.AddCommand(inspectLocksCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -12,8 +12,10 @@ import (
 	"github.com/supabase/cli/internal/inspect/index_sizes"
 	"github.com/supabase/cli/internal/inspect/index_usage"
 	"github.com/supabase/cli/internal/inspect/locks"
+	"github.com/supabase/cli/internal/inspect/long_running_queries"
 	"github.com/supabase/cli/internal/inspect/outliers"
 	"github.com/supabase/cli/internal/inspect/replication_slots"
+	"github.com/supabase/cli/internal/inspect/seq_scans"
 	"github.com/supabase/cli/internal/inspect/table_index_sizes"
 	"github.com/supabase/cli/internal/inspect/table_sizes"
 	"github.com/supabase/cli/internal/inspect/total_index_size"
@@ -201,6 +203,32 @@ var (
 			return unused_indexes.Run(ctx, dbConfig, fsys)
 		},
 	}
+
+	inspectSeqScansCmd = &cobra.Command{
+		Use:   "seq-scans",
+		Short: "Show number of sequential scans recorded against all tables",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return seq_scans.Run(ctx, dbConfig, fsys)
+		},
+	}
+
+	inspectLongRunningQueriesCmd = &cobra.Command{
+		Use:   "long-running-queries",
+		Short: "Show currently running queries running for longer than 5 minutes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := afero.NewOsFs()
+			if err := parseDatabaseConfig(fsys); err != nil {
+				return err
+			}
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			return long_running_queries.Run(ctx, dbConfig, fsys)
+		},
+	}
 )
 
 func init() {
@@ -220,5 +248,7 @@ func init() {
 	inspectDBCmd.AddCommand(inspectTableIndexSizesCmd)
 	inspectDBCmd.AddCommand(inspectTotalTableSizesCmd)
 	inspectDBCmd.AddCommand(inspectUnusedIndexesCmd)
+	inspectDBCmd.AddCommand(inspectSeqScansCmd)
+	inspectDBCmd.AddCommand(inspectLongRunningQueriesCmd)
 	rootCmd.AddCommand(inspectCmd)
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -101,7 +101,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return blocking.Run(ctx, dbConfig, fsys)
+			return outliers.Run(ctx, dbConfig, fsys)
 		},
 	}
 

--- a/internal/inspect/bloat/bloat.go
+++ b/internal/inspect/bloat/bloat.go
@@ -1,0 +1,104 @@
+package bloat
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+WITH constants AS (
+  SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
+), bloat_info AS (
+  SELECT
+    ma,bs,schemaname,tablename,
+    (datawidth+(hdr+ma-(case when hdr%ma=0 THEN ma ELSE hdr%ma END)))::numeric AS datahdr,
+    (maxfracsum*(nullhdr+ma-(case when nullhdr%ma=0 THEN ma ELSE nullhdr%ma END))) AS nullhdr2
+  FROM (
+    SELECT
+      schemaname, tablename, hdr, ma, bs,
+      SUM((1-null_frac)*avg_width) AS datawidth,
+      MAX(null_frac) AS maxfracsum,
+      hdr+(
+        SELECT 1+count(*)/8
+        FROM pg_stats s2
+        WHERE null_frac<>0 AND s2.schemaname = s.schemaname AND s2.tablename = s.tablename
+      ) AS nullhdr
+    FROM pg_stats s, constants
+    GROUP BY 1,2,3,4,5
+  ) AS foo
+), table_bloat AS (
+  SELECT
+    schemaname, tablename, cc.relpages, bs,
+    CEIL((cc.reltuples*((datahdr+ma-
+      (CASE WHEN datahdr%ma=0 THEN ma ELSE datahdr%ma END))+nullhdr2+4))/(bs-20::float)) AS otta
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+), index_bloat AS (
+  SELECT
+    schemaname, tablename, bs,
+    COALESCE(c2.relname,'?') AS iname, COALESCE(c2.reltuples,0) AS ituples, COALESCE(c2.relpages,0) AS ipages,
+    COALESCE(CEIL((c2.reltuples*(datahdr-12))/(bs-20::float)),0) AS iotta -- very rough approximation, assumes all cols
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+  JOIN pg_index i ON indrelid = cc.oid
+  JOIN pg_class c2 ON c2.oid = i.indexrelid
+)
+SELECT
+  type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste
+FROM
+(SELECT
+  'table' as type,
+  schemaname,
+  tablename as object_name,
+  ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1) AS bloat,
+  CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
+FROM
+  table_bloat
+    UNION
+SELECT
+  'index' as type,
+  schemaname,
+  tablename || '::' || iname as object_name,
+  ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1) AS bloat,
+  CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
+FROM
+  index_bloat) bloat_summary
+ORDER BY raw_waste DESC, bloat DESC`
+
+type Result struct {
+	Type        string
+	Schemaname  string
+	Object_name string
+	Bloat       string
+	Waste       string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Type|Schema name|Object name|Bloat|Waste\n|-|-|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|`%s`|\n", r.Type, r.Schemaname, r.Object_name, r.Bloat, r.Waste)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/blocking/blocking.go
+++ b/internal/inspect/blocking/blocking.go
@@ -33,12 +33,12 @@ WHERE NOT bl.granted
 `
 
 type BlockingResult struct {
-	Blocked_pid  string
+	Blocked_pid        string
 	Blocking_statement string
-	Blocking_duration string
-	Blocking_pid string
-	Blocked_statement string
-	Blocked_duration string
+	Blocking_duration  string
+	Blocking_pid       string
+	Blocked_statement  string
+	Blocked_duration   string
 }
 
 func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
@@ -59,13 +59,13 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	for _, r := range result {
 		// remove whitespace from query
 		re := regexp.MustCompile(`\s+|\r+|\n+|\t+|\v`)
-		blocking_statement := re.ReplaceAllString(r.Query, " ")
+		blocking_statement := re.ReplaceAllString(r.Blocking_statement, " ")
 		blocked_statement := re.ReplaceAllString(r.Blocked_statement, " ")
 
 		// escape pipes in query
 		re = regexp.MustCompile(`\|`)
-		blocking_statement := re.ReplaceAllString(r.Blocking_statement, `\|`)
-		blocked_statement := re.ReplaceAllString(r.Blocked_statement, `\|`)
+		blocking_statement = re.ReplaceAllString(r.Blocking_statement, `\|`)
+		blocked_statement = re.ReplaceAllString(r.Blocked_statement, `\|`)
 		table += fmt.Sprintf("|`%v`|`%v`|`%v`|`%v`|%s|`%v`|\n", r.Blocked_pid, blocking_statement, r.Blocking_duration, r.Blocking_pid, blocked_statement, r.Blocked_duration)
 	}
 	return list.RenderTable(table)

--- a/internal/inspect/blocking/blocking.go
+++ b/internal/inspect/blocking/blocking.go
@@ -1,0 +1,66 @@
+package blocking
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+// Ref: https://github.com/heroku/heroku-pg-extras/blob/main/commands/blocking.js#L7
+const BLOCKING_QUERY = `
+SELECT
+	bl.pid AS blocked_pid,
+	ka.query AS blocking_statement,
+	now() - ka.query_start AS blocking_duration,
+	kl.pid AS blocking_pid,
+	a.query AS blocked_statement,
+	now() - a.query_start AS blocked_duration
+FROM pg_catalog.pg_locks bl
+JOIN pg_catalog.pg_stat_activity a
+	ON bl.pid = a.pid
+JOIN pg_catalog.pg_locks kl
+JOIN pg_catalog.pg_stat_activity ka
+	ON kl.pid = ka.pid
+	ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
+WHERE NOT bl.granted
+`
+
+type BlockingResult struct {
+	Blocked_pid  string
+	Blocking_statement string
+	Blocking_duration string
+	Blocking_pid string
+	Blocked_statement string
+	Blocked_duration string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, BLOCKING_QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[BlockingResult](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|blocked pid|blocking statement|blocking duration|blocking pid|blocked statement|blocked duration|\n|-|-|-|-|-|-|\n"
+	for _, r := range result {
+		re := regexp.MustCompile(`\r?\n|\t`)
+		blocking_statement := re.ReplaceAllString(r.Blocking_statement, " ")
+		blocked_statement := re.ReplaceAllString(r.Blocked_statement, " ")
+		table += fmt.Sprintf("|`%v`|`%v`|`%v`|`%v`|%s|`%v`|\n", r.Blocked_pid, blocking_statement, r.Blocking_duration, r.Blocking_pid, blocked_statement, r.Blocked_duration)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/calls/calls.go
+++ b/internal/inspect/calls/calls.go
@@ -1,0 +1,54 @@
+package calls
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const CALLS_QUERY = `
+SELECT
+	query,
+	interval '1 millisecond' * total_exec_time AS total_exec_time,
+	to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+	to_char(calls, 'FM999G999G990') AS ncalls,
+	interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+FROM pg_stat_statements	
+ORDER BY calls DESC
+LIMIT 10
+`
+
+type CallsResult struct {
+	Total_exec_time  string
+	Prop_exec_time string
+	Ncalls string
+	Sync_io_time string
+	Query string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, CALLS_QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[CallsResult](rows)
+	if err != nil {
+		return err
+	}
+	// TODO: implement a markdown table marshaller
+	table := "|Query|Execution Time|Proportion of exec time|Number Calls|Sync IO time|\n|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|`%s`|\n", r.Query, r.Total_exec_time, r.Prop_exec_time, r.Ncalls, r.Sync_io_time)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/index_sizes/index_usage.go
+++ b/internal/inspect/index_sizes/index_usage.go
@@ -1,0 +1,50 @@
+package index_sizes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const INDEX_USAGE_QUERY = `
+SELECT c.relname AS name,
+  pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i'
+GROUP BY c.relname
+ORDER BY sum(c.relpages) DESC;`
+
+type IndexUsageResult struct {
+	Name string
+	Size string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, INDEX_USAGE_QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[IndexUsageResult](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Name|size|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Name, r.Size)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/index_usage/index_usage.go
+++ b/internal/inspect/index_usage/index_usage.go
@@ -14,9 +14,10 @@ import (
 
 const INDEX_USAGE_QUERY = `
 SELECT relname,
-   CASE idx_scan
-     WHEN 0 THEN 'Insufficient data'
-     ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
+CASE
+    WHEN idx_scan IS NULL THEN 'Insufficient data'
+    WHEN idx_scan = 0 THEN 'Insufficient data'
+    ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
    END percent_of_times_index_used,
    n_live_tup rows_in_table
  FROM

--- a/internal/inspect/locks/locks.go
+++ b/internal/inspect/locks/locks.go
@@ -1,0 +1,61 @@
+package locks
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const LOCKS_QUERY = `
+SELECT
+	pg_stat_activity.pid,
+	COALESCE(pg_class.relname, 'null') AS relname,
+	COALESCE(pg_locks.transactionid, 'null') AS transactionid,
+	pg_locks.granted,
+	pg_stat_activity.query,
+	age(now(),pg_stat_activity.query_start) AS age
+FROM pg_stat_activity, pg_locks LEFT OUTER JOIN pg_class ON (pg_locks.relation = pg_class.oid)
+WHERE pg_stat_activity.query <> '<insufficient privilege>'
+AND pg_locks.pid=pg_stat_activity.pid
+AND pg_locks.mode = 'ExclusiveLock'
+ORDER BY query_start;
+`
+
+type LocksResult struct {
+	Pid  string
+	Relname string
+	Transactionid string
+	Granted string
+	Query string
+	Age string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, LOCKS_QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[LocksResult](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|pid|relname|transaction id|granted|query|age|\n|-|-|-|-|-|-|\n"
+	for _, r := range result {
+		re := regexp.MustCompile(`\r?\n|\t`)
+		query := re.ReplaceAllString(r.Query, " ")
+		table += fmt.Sprintf("|`%v`|`%v`|`%v`|`%v`|%s|`%v`|\n", r.Pid, r.Relname, r.Transactionid, r.Granted, query, r.Age)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/locks/locks.go
+++ b/internal/inspect/locks/locks.go
@@ -53,8 +53,13 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 
 	table := "|pid|relname|transaction id|granted|query|age|\n|-|-|-|-|-|-|\n"
 	for _, r := range result {
-		re := regexp.MustCompile(`\r?\n|\t`)
+		// remove whitespace from query
+		re := regexp.MustCompile(`\s+|\r+|\n+|\t+|\v`)
 		query := re.ReplaceAllString(r.Query, " ")
+
+		// escape pipes in query
+		re = regexp.MustCompile(`\|`)
+		query = re.ReplaceAllString(query, `\|`)
 		table += fmt.Sprintf("|`%v`|`%v`|`%v`|`%v`|%s|`%v`|\n", r.Pid, r.Relname, r.Transactionid, r.Granted, query, r.Age)
 	}
 	return list.RenderTable(table)

--- a/internal/inspect/long_running_queries/long_running_queries.go
+++ b/internal/inspect/long_running_queries/long_running_queries.go
@@ -1,0 +1,54 @@
+package long_running_queries
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT
+  pid,
+  now() - pg_stat_activity.query_start AS duration,
+  query AS query
+FROM
+  pg_stat_activity
+WHERE
+  pg_stat_activity.query <> ''::text
+  AND state <> 'idle'
+  AND now() - pg_stat_activity.query_start > interval '5 minutes'
+ORDER BY
+  now() - pg_stat_activity.query_start DESC;`
+
+type Result struct {
+	Pid      string
+	Duration string
+	Query    string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|pid|Duration|Query|\n|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", r.Pid, r.Duration, r.Query)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/outliers/outliers.go
+++ b/internal/inspect/outliers/outliers.go
@@ -1,0 +1,54 @@
+package outliers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const OUTLIERS_QUERY = `
+SELECT
+	interval '1 millisecond' * total_exec_time AS total_exec_time,
+	to_char((total_exec_time}/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+	to_char(calls, 'FM999G999G999G990') AS ncalls,
+	interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+	query
+FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY total_exec_time DESC
+LIMIT 10
+`
+
+type OutliersResult struct {
+	Total_exec_time  string
+	Prop_exec_time string
+	Ncalls string
+	Sync_io_time string
+	Query string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, OUTLIERS_QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[OutliersResult](rows)
+	if err != nil {
+		return err
+	}
+	// TODO: implement a markdown table marshaller
+	table := "|Query|Execution Time|Proportion of exec time|Number Calls|Sync IO time|\n|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|`%s`|\n", r.Query, r.Total_exec_time, r.Prop_exec_time, r.Ncalls, r.Sync_io_time)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/seq_scans/seq_scans.go
+++ b/internal/inspect/seq_scans/seq_scans.go
@@ -1,0 +1,46 @@
+package seq_scans
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT relname AS name,
+       seq_scan as count
+FROM
+  pg_stat_user_tables
+ORDER BY seq_scan DESC;`
+
+type Result struct {
+	Name  string
+	Count string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Name|Count|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Name, r.Count)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/table_index_sizes/table_index_sizes.go
+++ b/internal/inspect/table_index_sizes/table_index_sizes.go
@@ -1,0 +1,49 @@
+package table_index_sizes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT c.relname AS table,
+  pg_size_pretty(pg_indexes_size(c.oid)) AS index_size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_indexes_size(c.oid) DESC;`
+
+type Result struct {
+	Table      string
+	Index_size string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Table|Index size|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Table, r.Index_size)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/table_record_counts/table_record_counts.go
+++ b/internal/inspect/table_record_counts/table_record_counts.go
@@ -1,0 +1,48 @@
+package table_record_counts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT
+  relname AS name,
+  n_live_tup AS estimated_count
+FROM
+  pg_stat_user_tables
+ORDER BY
+  n_live_tup DESC;`
+
+type Result struct {
+	Name            string
+	Estimated_count string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Name|Estimated count|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Name, r.Estimated_count)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/table_sizes/table_sizes.go
+++ b/internal/inspect/table_sizes/table_sizes.go
@@ -1,0 +1,49 @@
+package table_sizes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT c.relname AS name,
+  pg_size_pretty(pg_table_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_table_size(c.oid) DESC;`
+
+type Result struct {
+	Name string
+	Size string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Name|size|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Name, r.Size)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/total_index_size/total_index_size.go
+++ b/internal/inspect/total_index_size/total_index_size.go
@@ -1,0 +1,47 @@
+package total_index_size
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i';
+`
+
+type Result struct {
+	Size string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Size|\n|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|\n", r.Size)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/total_table_sizes/total_table_sizes.go
+++ b/internal/inspect/total_table_sizes/total_table_sizes.go
@@ -1,0 +1,50 @@
+package total_table_sizes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT c.relname AS name,
+  pg_size_pretty(pg_total_relation_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_total_relation_size(c.oid) DESC;
+`
+
+type Result struct {
+	Name string
+	Size string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Name|Size|\n|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|\n", r.Name, r.Size)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/unused_indexes/unused_indexes.go
+++ b/internal/inspect/unused_indexes/unused_indexes.go
@@ -1,0 +1,53 @@
+package unused_indexes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+SELECT
+  schemaname || '.' || relname AS table,
+  indexrelname AS index,
+  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+  idx_scan as index_scans
+FROM pg_stat_user_indexes ui
+JOIN pg_index i ON ui.indexrelid = i.indexrelid
+WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
+ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
+pg_relation_size(i.indexrelid) DESC;`
+
+type Result struct {
+	Table       string
+	Index       string
+	Index_size  string
+	Index_scans string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Table|Index|Index Size|Index Scans\n|-|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|\n", r.Table, r.Index, r.Index_size, r.Index_scans)
+	}
+	return list.RenderTable(table)
+}

--- a/internal/inspect/vacuum_stats/vacuum_stats.go
+++ b/internal/inspect/vacuum_stats/vacuum_stats.go
@@ -1,0 +1,86 @@
+package vacuum_stats
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/pgxv5"
+)
+
+const QUERY = `
+WITH table_opts AS (
+  SELECT
+    pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
+  FROM
+     pg_class INNER JOIN pg_namespace ns ON relnamespace = ns.oid
+), vacuum_settings AS (
+  SELECT
+    oid, relname, nspname,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
+        THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
+        ELSE current_setting('autovacuum_vacuum_threshold')::integer
+      END AS autovacuum_vacuum_threshold,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
+        THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
+        ELSE current_setting('autovacuum_vacuum_scale_factor')::real
+      END AS autovacuum_vacuum_scale_factor
+  FROM
+    table_opts
+)
+SELECT
+  vacuum_settings.nspname AS schema,
+  vacuum_settings.relname AS table,
+  coalesce(to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI'), '') AS last_vacuum,
+  coalesce(to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI'), '') AS last_autovacuum,
+  to_char(pg_class.reltuples, '9G999G999G999') AS rowcount,
+  to_char(psut.n_dead_tup, '9G999G999G999') AS dead_rowcount,
+  to_char(autovacuum_vacuum_threshold
+       + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autovacuum_threshold,
+  CASE
+    WHEN autovacuum_vacuum_threshold + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
+    THEN 'yes'
+    ELSE 'no'
+  END AS expect_autovacuum
+FROM
+  pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
+INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
+ORDER BY 1`
+
+type Result struct {
+	Schema               string
+	Table                string
+	Last_vacuum          string
+	Last_autovacuum      string
+	Rowcount             string
+	Dead_rowcount        string
+	Autovacuum_threshold string
+	Expect_autovacuum    string
+}
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectRemotePostgres(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	rows, err := conn.Query(ctx, QUERY)
+	if err != nil {
+		return err
+	}
+	result, err := pgxv5.CollectRows[Result](rows)
+	if err != nil {
+		return err
+	}
+
+	table := "|Schema|Table|Last Vacuum|Last Auto Vacuum|Row count|Dead row count|Expect autovacuum?\n|-|-|-|-|-|-|-|\n"
+	for _, r := range result {
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|\n", r.Schema, r.Table, r.Last_vacuum, r.Last_autovacuum, r.Rowcount, r.Dead_rowcount, r.Expect_autovacuum)
+	}
+	return list.RenderTable(table)
+}


### PR DESCRIPTION
Added the following inspection commands that run almost the same queries as you can find in pg:extra

Inspect commands implemented:

```
  bloat                Estimates space allocated to a relation that is full of dead tuples
  blocking             Shows queries that are holding locks and the queries that are waiting for them to be released
  cache-hit            Shows cache hit rates for tables and indices
  calls                Shows queries from pg_stat_statements ordered by total times called
  index-sizes          Shows index sizes of individual indexes
  index-usage          Shows information about the efficiency of indexes
  locks                Shows queries which have taken out an exclusive lock on a relation
  long-running-queries Show currently running queries running for longer than 5 minutes
  outliers             Shows queries from pg_stat_statements ordered by total execution time
  replication-slots    Shows information about replication slots on the database
  seq-scans            Show number of sequential scans recorded against all tables
  table-index-sizes    Shows index sizes of individual tables
  table-record-counts  Show estimated number of rows per table
  table-sizes          Shows table sizes of individual tables without their index sizes
  total-index-size     Shows total size of all indexes
  total-table-sizes    Shows total table sizes, including table index sizes
  unused-indexes       Show indexes with low usage
  vacuum-stats         Shows statistics related to vacuum operations per table
```