### PR TITLE
fix: build statically linked binaries on linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,12 @@ project_name: supabase
 builds:
   - id: supabase
     binary: supabase
+    flags:
+      - -trimpath
     ldflags:
-      - -X github.com/supabase/cli/internal/utils.Version={{.Version}}
+      - -s -w -X github.com/supabase/cli/internal/utils.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
     targets:
       - darwin_amd64
       - darwin_arm64


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1306

## What is the new behavior?

- trims paths so that panics don't reveal build paths like `/home/runner/cli/...`
- strips debug symbols from release build for 25% smaller binary size: `-s -w`
- disable cgo explicitly to force static linking when build on linux runner

## Additional context

Add any other context or screenshots.
