### PR TITLE
fix: set lc_collate to c.utf-8

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -51,6 +51,7 @@ func NewContainerConfig() container.Config {
 			"POSTGRES_PASSWORD=" + utils.Config.Db.Password,
 			"POSTGRES_HOST=/var/run/postgresql",
 			"POSTGRES_INITDB_ARGS=--lc-ctype=C.UTF-8",
+			"POSTGRES_INITDB_ARGS=--lc-collate=C.UTF-8",
 		},
 		Healthcheck: &container.HealthConfig{
 			Test:     []string{"CMD", "pg_isready", "-U", "postgres", "-h", "localhost", "-p", "5432"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

`LC_COLLATE` should match hosted platform which is `C.UTF-8`

## Additional context

Add any other context or screenshots.
