### PR TITLE
feat: implement preview branch management commands

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -1817,7 +1817,11 @@ components:
     BranchDetailResponse:
       type: object
       properties:
+        db_port:
+          type: integer
         ref:
+          type: string
+        postgres_version:
           type: string
         status:
           type: string
@@ -1835,8 +1839,6 @@ components:
             - PAUSING
         db_host:
           type: string
-        db_port:
-          type: number
         db_user:
           type: string
         db_pass:
@@ -1844,13 +1846,11 @@ components:
         jwt_secret:
           type: string
       required:
+        - db_port
         - ref
+        - postgres_version
         - status
         - db_host
-        - db_port
-        - db_user
-        - db_pass
-        - jwt_secret
     UpdateBranchBody:
       type: object
       properties:

--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -1,5 +1,76 @@
 openapi: 3.0.0
 paths:
+  /v1/branch/{branch_id}:
+    get:
+      operationId: getBranchDetails
+      summary: Get database branch config
+      description: Fetches configurations of the specified database branch
+      parameters:
+        - name: branch_id
+          required: true
+          in: path
+          description: Branch ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BranchDetailResponse'
+        '500':
+          description: Failed to update database branch
+      tags: &ref_0
+        - database branches (beta)
+      security: &ref_1
+        - bearer: []
+    patch:
+      operationId: updateBranch
+      summary: Update database branch config
+      description: Updates the configuration of the specified database branch
+      parameters:
+        - name: branch_id
+          required: true
+          in: path
+          description: Branch ID
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBranchBody'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BranchResponse'
+        '500':
+          description: Failed to update database branch
+      tags: *ref_0
+      security: *ref_1
+    delete:
+      operationId: deleteBranch
+      summary: Delete a database branch
+      description: Deletes the specified database branch
+      parameters:
+        - name: branch_id
+          required: true
+          in: path
+          description: Branch ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+        '500':
+          description: Failed to delete database branch
+      tags: *ref_0
+      security: *ref_1
   /v1/projects:
     get:
       operationId: getProjects
@@ -15,9 +86,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProjectResponse'
-      tags: &ref_0
+      tags: &ref_2
         - projects
-      security: &ref_1
+      security: &ref_3
         - bearer: []
     post:
       operationId: createProject
@@ -42,8 +113,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectResponse'
-      tags: *ref_0
-      security: *ref_1
+      tags: *ref_2
+      security: *ref_3
   /v1/organizations:
     get:
       operationId: getOrganizations
@@ -61,9 +132,9 @@ paths:
                   $ref: '#/components/schemas/OrganizationResponse'
         '500':
           description: Unexpected error listing organizations
-      tags: &ref_2
+      tags: &ref_4
         - organizations
-      security: &ref_3
+      security: &ref_5
         - bearer: []
     post:
       operationId: createOrganization
@@ -84,11 +155,12 @@ paths:
                 $ref: '#/components/schemas/OrganizationResponse'
         '500':
           description: Unexpected error creating an organization
-      tags: *ref_2
-      security: *ref_3
+      tags: *ref_4
+      security: *ref_5
   /v1/oauth/authorize:
     get:
       operationId: authorize
+      summary: Authorize user through oauth
       parameters:
         - name: client_id
           required: true
@@ -140,11 +212,12 @@ paths:
       responses:
         '200':
           description: ''
-      tags: &ref_4
+      tags: &ref_6
         - oauth (beta)
   /v1/oauth/token:
     post:
       operationId: token
+      summary: Exchange auth code for user's access and refresh token
       parameters:
         - name: grant_type
           required: true
@@ -187,7 +260,7 @@ paths:
       responses:
         '201':
           description: ''
-      tags: *ref_4
+      tags: *ref_6
   /v1/oauth/authorizations/{id}:
     get:
       operationId: getAuthorizationRequest
@@ -200,12 +273,13 @@ paths:
       responses:
         '200':
           description: ''
-      tags: &ref_5
+      tags: &ref_7
         - oauth (beta)
-      security: &ref_6
+      security: &ref_8
         - bearer: []
     post:
       operationId: approveAuthorizationRequest
+      summary: Approve oauth app authorization request
       parameters:
         - name: id
           required: true
@@ -221,10 +295,11 @@ paths:
       responses:
         '201':
           description: ''
-      tags: *ref_5
-      security: *ref_6
+      tags: *ref_7
+      security: *ref_8
     delete:
       operationId: declineAuthorizationRequest
+      summary: Decline oauth app authorization request
       parameters:
         - name: id
           required: true
@@ -234,8 +309,8 @@ paths:
       responses:
         '200':
           description: ''
-      tags: *ref_5
-      security: *ref_6
+      tags: *ref_7
+      security: *ref_8
   /v1/projects/{ref}/functions:
     post:
       operationId: createFunction
@@ -284,10 +359,10 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: &ref_7
+          application/json: &ref_9
             schema:
               $ref: '#/components/schemas/CreateFunctionBody'
-          application/vnd.denoland.eszip: *ref_7
+          application/vnd.denoland.eszip: *ref_9
       responses:
         '201':
           description: ''
@@ -299,9 +374,9 @@ paths:
           description: ''
         '500':
           description: Failed to create project's function
-      tags: &ref_8
+      tags: &ref_10
         - functions
-      security: &ref_9
+      security: &ref_11
         - apiKeyHeader: []
           apiKeyParam: []
         - bearer: []
@@ -331,8 +406,8 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's functions
-      tags: *ref_8
-      security: *ref_9
+      tags: *ref_10
+      security: *ref_11
   /v1/projects/{ref}/functions/{function_slug}:
     get:
       operationId: getFunction
@@ -365,9 +440,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve function with given slug
-      tags: &ref_11
+      tags: &ref_13
         - functions
-      security: &ref_12
+      security: &ref_14
         - apiKeyHeader: []
           apiKeyParam: []
         - bearer: []
@@ -425,10 +500,10 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: &ref_10
+          application/json: &ref_12
             schema:
               $ref: '#/components/schemas/UpdateFunctionBody'
-          application/vnd.denoland.eszip: *ref_10
+          application/vnd.denoland.eszip: *ref_12
       responses:
         '200':
           description: ''
@@ -440,8 +515,8 @@ paths:
           description: ''
         '500':
           description: Failed to update function with given slug
-      tags: *ref_11
-      security: *ref_12
+      tags: *ref_13
+      security: *ref_14
     delete:
       operationId: deleteFunction
       summary: Delete a function
@@ -469,8 +544,8 @@ paths:
           description: ''
         '500':
           description: Failed to delete function with given slug
-      tags: *ref_11
-      security: *ref_12
+      tags: *ref_13
+      security: *ref_14
   /v1/projects/{ref}/functions/{function_slug}/body:
     get:
       operationId: getFunctionBody
@@ -499,8 +574,8 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve function body with given slug
-      tags: *ref_11
-      security: *ref_12
+      tags: *ref_13
+      security: *ref_14
   /v1/projects/{ref}/api-keys:
     get:
       operationId: getProjectApiKeys
@@ -528,6 +603,85 @@ paths:
         - projects
       security:
         - bearer: []
+  /v1/projects/{ref}/branches:
+    get:
+      operationId: getBranches
+      summary: List all database branches
+      description: Returns all database branches of the specified project.
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BranchResponse'
+        '500':
+          description: Failed to retrieve database branches
+      tags: &ref_15
+        - database branches (beta)
+      security: &ref_16
+        - bearer: []
+    post:
+      operationId: createBranch
+      summary: Create a database branch
+      description: Creates a database branch from the specified project.
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBranchBody'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BranchResponse'
+        '500':
+          description: Failed to create database branch
+      tags: *ref_15
+      security: *ref_16
+    delete:
+      operationId: disableBranch
+      summary: Disables preview branching
+      description: Disables preview branching for the specified project
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      responses:
+        '200':
+          description: ''
+        '500':
+          description: Failed to disable preview branching
+      tags: *ref_15
+      security: *ref_16
   /v1/projects/{ref}/custom-hostname:
     get:
       operationId: getCustomHostnameConfig
@@ -552,9 +706,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's custom hostname config
-      tags: &ref_13
+      tags: &ref_17
         - custom hostname (beta)
-      security: &ref_14
+      security: &ref_18
         - bearer: []
     delete:
       operationId: removeCustomHostnameConfig
@@ -575,8 +729,8 @@ paths:
           description: ''
         '500':
           description: Failed to delete project custom hostname configuration
-      tags: *ref_13
-      security: *ref_14
+      tags: *ref_17
+      security: *ref_18
   /v1/projects/{ref}/custom-hostname/initialize:
     post:
       operationId: createCustomHostnameConfig
@@ -607,8 +761,8 @@ paths:
           description: ''
         '500':
           description: Failed to update project custom hostname configuration
-      tags: *ref_13
-      security: *ref_14
+      tags: *ref_17
+      security: *ref_18
   /v1/projects/{ref}/custom-hostname/reverify:
     post:
       operationId: reverify
@@ -635,8 +789,8 @@ paths:
           description: ''
         '500':
           description: Failed to verify project custom hostname configuration
-      tags: *ref_13
-      security: *ref_14
+      tags: *ref_17
+      security: *ref_18
   /v1/projects/{ref}/custom-hostname/activate:
     post:
       operationId: activate
@@ -661,8 +815,8 @@ paths:
           description: ''
         '500':
           description: Failed to activate project custom hostname configuration
-      tags: *ref_13
-      security: *ref_14
+      tags: *ref_17
+      security: *ref_18
   /v1/projects/{ref}/network-bans/retrieve:
     post:
       operationId: getNetworkBans
@@ -687,9 +841,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's network bans
-      tags: &ref_15
+      tags: &ref_19
         - network bans (beta)
-      security: &ref_16
+      security: &ref_20
         - bearer: []
   /v1/projects/{ref}/network-bans:
     delete:
@@ -717,8 +871,8 @@ paths:
           description: ''
         '500':
           description: Failed to remove network bans.
-      tags: *ref_15
-      security: *ref_16
+      tags: *ref_19
+      security: *ref_20
   /v1/projects/{ref}/network-restrictions:
     get:
       operationId: getNetworkRestrictions
@@ -743,9 +897,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's network restrictions
-      tags: &ref_17
+      tags: &ref_21
         - network restrictions (beta)
-      security: &ref_18
+      security: &ref_22
         - bearer: []
   /v1/projects/{ref}/network-restrictions/apply:
     post:
@@ -777,8 +931,8 @@ paths:
           description: ''
         '500':
           description: Failed to update project network restrictions
-      tags: *ref_17
-      security: *ref_18
+      tags: *ref_21
+      security: *ref_22
   /v1/projects/{ref}/pgsodium:
     get:
       operationId: getPgsodiumConfig
@@ -803,9 +957,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's pgsodium config
-      tags: &ref_19
+      tags: &ref_23
         - pgsodium (beta)
-      security: &ref_20
+      security: &ref_24
         - bearer: []
     put:
       operationId: updatePgsodiumConfig
@@ -838,8 +992,8 @@ paths:
           description: ''
         '500':
           description: Failed to update project's pgsodium config
-      tags: *ref_19
-      security: *ref_20
+      tags: *ref_23
+      security: *ref_24
   /v1/projects/{ref}/postgrest:
     get:
       operationId: getPostgRESTConfig
@@ -864,9 +1018,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's postgrest config
-      tags: &ref_21
+      tags: &ref_25
         - services
-      security: &ref_22
+      security: &ref_26
         - bearer: []
     patch:
       operationId: updatePostgRESTConfig
@@ -897,8 +1051,42 @@ paths:
           description: ''
         '500':
           description: Failed to update project's postgrest config
-      tags: *ref_21
-      security: *ref_22
+      tags: *ref_25
+      security: *ref_26
+  /v1/projects/{ref}/query:
+    post:
+      operationId: runQuery
+      summary: Run sql query
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunQueryBody'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+        '403':
+          description: ''
+        '500':
+          description: Failed to run sql query
+      tags:
+        - projects
+      security:
+        - bearer: []
   /v1/projects/{ref}/secrets:
     get:
       operationId: getSecrets
@@ -926,9 +1114,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's secrets
-      tags: &ref_23
+      tags: &ref_27
         - secrets
-      security: &ref_24
+      security: &ref_28
         - apiKeyHeader: []
           apiKeyParam: []
         - bearer: []
@@ -960,8 +1148,8 @@ paths:
           description: ''
         '500':
           description: Failed to create project's secrets
-      tags: *ref_23
-      security: *ref_24
+      tags: *ref_27
+      security: *ref_28
     delete:
       operationId: deleteSecrets
       summary: Bulk delete secrets
@@ -994,8 +1182,8 @@ paths:
           description: ''
         '500':
           description: Failed to delete secrets with given names
-      tags: *ref_23
-      security: *ref_24
+      tags: *ref_27
+      security: *ref_28
   /v1/projects/{ref}/ssl-enforcement:
     get:
       operationId: getSslEnforcementConfig
@@ -1020,9 +1208,9 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project's SSL enforcement config
-      tags: &ref_25
+      tags: &ref_29
         - ssl enforcement (beta)
-      security: &ref_26
+      security: &ref_30
         - bearer: []
     put:
       operationId: updateSslEnforcementConfig
@@ -1053,8 +1241,8 @@ paths:
           description: ''
         '500':
           description: Failed to update project's SSL enforcement configuration.
-      tags: *ref_25
-      security: *ref_26
+      tags: *ref_29
+      security: *ref_30
   /v1/projects/{ref}/types/typescript:
     get:
       operationId: getTypescriptTypes
@@ -1116,9 +1304,9 @@ paths:
           description: ''
         '500':
           description: Failed to get project vanity subdomain configuration
-      tags: &ref_27
+      tags: &ref_31
         - vanity subdomain (beta)
-      security: &ref_28
+      security: &ref_32
         - bearer: []
     delete:
       operationId: removeVanitySubdomainConfig
@@ -1139,8 +1327,8 @@ paths:
           description: ''
         '500':
           description: Failed to delete project vanity subdomain configuration
-      tags: *ref_27
-      security: *ref_28
+      tags: *ref_31
+      security: *ref_32
   /v1/projects/{ref}/vanity-subdomain/check-availability:
     post:
       operationId: checkVanitySubdomainAvailability
@@ -1171,8 +1359,8 @@ paths:
           description: ''
         '500':
           description: Failed to check project vanity subdomain configuration
-      tags: *ref_27
-      security: *ref_28
+      tags: *ref_31
+      security: *ref_32
   /v1/projects/{ref}/vanity-subdomain/activate:
     post:
       operationId: activateVanitySubdomainPlease
@@ -1203,8 +1391,8 @@ paths:
           description: ''
         '500':
           description: Failed to activate project vanity subdomain configuration
-      tags: *ref_27
-      security: *ref_28
+      tags: *ref_31
+      security: *ref_32
   /v1/projects/{ref}/upgrade:
     post:
       operationId: upgradeProject
@@ -1231,9 +1419,9 @@ paths:
           description: ''
         '500':
           description: Failed to initiate project upgrade
-      tags: &ref_29
+      tags: &ref_33
         - database version upgrade (beta)
-      security: &ref_30
+      security: &ref_34
         - bearer: []
   /v1/projects/{ref}/upgrade/eligibility:
     get:
@@ -1259,8 +1447,8 @@ paths:
           description: ''
         '500':
           description: Failed to determine project upgrade eligibility
-      tags: *ref_29
-      security: *ref_30
+      tags: *ref_33
+      security: *ref_34
   /v1/projects/{ref}/upgrade/status:
     get:
       operationId: getUpgradeStatus
@@ -1285,8 +1473,8 @@ paths:
           description: ''
         '500':
           description: Failed to retrieve project upgrade status
-      tags: *ref_29
-      security: *ref_30
+      tags: *ref_33
+      security: *ref_34
   /v1/projects/{ref}/readonly:
     get:
       operationId: getReadOnlyModeStatus
@@ -1309,9 +1497,9 @@ paths:
                 $ref: '#/components/schemas/ReadOnlyStatusResponse'
         '500':
           description: Failed to get project readonly mode status
-      tags: &ref_31
+      tags: &ref_35
         - database readonly mode
-      security: &ref_32
+      security: &ref_36
         - bearer: []
   /v1/projects/{ref}/readonly/temporary-disable:
     post:
@@ -1331,8 +1519,8 @@ paths:
           description: ''
         '500':
           description: Failed to disable project's readonly mode
-      tags: *ref_31
-      security: *ref_32
+      tags: *ref_35
+      security: *ref_36
   /v1/projects/{ref}/config/database/postgres:
     get:
       operationId: getConfig
@@ -1355,9 +1543,9 @@ paths:
                 $ref: '#/components/schemas/PostgresConfigResponse'
         '500':
           description: Failed to retrieve project's Postgres config
-      tags: &ref_33
+      tags: &ref_37
         - projects config
-      security: &ref_34
+      security: &ref_38
         - bearer: []
         - bearer: []
     put:
@@ -1387,8 +1575,8 @@ paths:
                 $ref: '#/components/schemas/PostgresConfigResponse'
         '500':
           description: Failed to update project's Postgres config
-      tags: *ref_33
-      security: *ref_34
+      tags: *ref_37
+      security: *ref_38
   /v1/projects/{ref}/config/database/pgbouncer:
     get:
       operationId: getPgbouncerConfig
@@ -1411,9 +1599,9 @@ paths:
                 $ref: '#/components/schemas/ProjectPgBouncerConfig'
         '500':
           description: Failed to retrieve project's pgbouncer config
-      tags: &ref_35
+      tags: &ref_39
         - projects config
-      security: &ref_36
+      security: &ref_40
         - bearer: []
     patch:
       operationId: updatePgbouncerConfig
@@ -1444,8 +1632,8 @@ paths:
           description: ''
         '500':
           description: Failed to update project's pgbouncer config
-      tags: *ref_35
-      security: *ref_36
+      tags: *ref_39
+      security: *ref_40
   /v1/projects/{ref}/config/auth/sso/providers:
     post:
       operationId: createProviderForProject
@@ -1476,9 +1664,9 @@ paths:
           description: ''
         '404':
           description: SAML 2.0 support is not enabled for this project
-      tags: &ref_37
+      tags: &ref_41
         - sso
-      security: &ref_38
+      security: &ref_42
         - bearer: []
     get:
       operationId: listAllProviders
@@ -1503,8 +1691,8 @@ paths:
           description: ''
         '404':
           description: SAML 2.0 support is not enabled for this project
-      tags: *ref_37
-      security: *ref_38
+      tags: *ref_41
+      security: *ref_42
   /v1/projects/{ref}/config/auth/sso/providers/{provider_id}:
     get:
       operationId: getProviderById
@@ -1536,8 +1724,8 @@ paths:
           description: >-
             Either SAML 2.0 was not enabled for this project, or the provider
             does not exist
-      tags: *ref_37
-      security: *ref_38
+      tags: *ref_41
+      security: *ref_42
     put:
       operationId: updateProviderById
       summary: Updates a SSO provider by its UUID
@@ -1574,8 +1762,8 @@ paths:
           description: >-
             Either SAML 2.0 was not enabled for this project, or the provider
             does not exist
-      tags: *ref_37
-      security: *ref_38
+      tags: *ref_41
+      security: *ref_42
     delete:
       operationId: removeProviderById
       summary: Removes a SSO provider by its UUID
@@ -1606,8 +1794,8 @@ paths:
           description: >-
             Either SAML 2.0 was not enabled for this project, or the provider
             does not exist
-      tags: *ref_37
-      security: *ref_38
+      tags: *ref_41
+      security: *ref_42
 info:
   title: Supabase API (v1)
   description: ''
@@ -1626,6 +1814,75 @@ components:
       bearerFormat: JWT
       type: http
   schemas:
+    BranchDetailResponse:
+      type: object
+      properties:
+        ref:
+          type: string
+        status:
+          type: string
+          enum:
+            - ACTIVE_HEALTHY
+            - ACTIVE_UNHEALTHY
+            - COMING_UP
+            - GOING_DOWN
+            - INACTIVE
+            - INIT_FAILED
+            - REMOVED
+            - RESTORING
+            - UNKNOWN
+            - UPGRADING
+            - PAUSING
+        db_host:
+          type: string
+        db_port:
+          type: number
+        db_user:
+          type: string
+        db_pass:
+          type: string
+        jwt_secret:
+          type: string
+      required:
+        - ref
+        - status
+        - db_host
+        - db_port
+        - db_user
+        - db_pass
+        - jwt_secret
+    UpdateBranchBody:
+      type: object
+      properties:
+        branch_name:
+          type: string
+        git_branch:
+          type: string
+    BranchResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        project_ref:
+          type: string
+        is_default:
+          type: boolean
+        git_branch:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - id
+        - name
+        - project_ref
+        - is_default
+        - git_branch
+        - created_at
+        - updated_at
     DatabaseResponse:
       type: object
       properties:
@@ -1762,7 +2019,7 @@ components:
         name:
           type: string
         status:
-          enum: &ref_39
+          enum: &ref_43
             - ACTIVE
             - REMOVED
             - THROTTLED
@@ -1799,7 +2056,7 @@ components:
         name:
           type: string
         status:
-          enum: *ref_39
+          enum: *ref_43
           type: string
         version:
           type: number
@@ -1842,6 +2099,17 @@ components:
       required:
         - name
         - api_key
+    CreateBranchBody:
+      type: object
+      properties:
+        branch_name:
+          type: string
+        git_branch:
+          type: string
+        region:
+          type: string
+      required:
+        - branch_name
     UpdateCustomHostnameResponse:
       type: object
       properties:
@@ -1969,6 +2237,13 @@ components:
         - max_rows
         - db_schema
         - db_extra_search_path
+    RunQueryBody:
+      type: object
+      properties:
+        query:
+          type: string
+      required:
+        - query
     SecretResponse:
       type: object
       properties:
@@ -2286,7 +2561,6 @@ components:
         - db_port
         - db_ssl
         - db_user
-        - default_pool_size
         - ignore_startup_parameters
         - inserted_at
         - pgbouncer_enabled
@@ -2298,7 +2572,7 @@ components:
         default_pool_size:
           type: integer
           minimum: 0
-          maximum: 65535
+          maximum: 1000
         max_client_conn:
           type: integer
           nullable: true
@@ -2309,13 +2583,12 @@ components:
         pgbouncer_enabled:
           type: boolean
         pool_mode:
-          enum: &ref_40
+          enum: &ref_44
             - transaction
             - session
             - statement
           type: string
       required:
-        - default_pool_size
         - ignore_startup_parameters
         - pgbouncer_enabled
         - pool_mode
@@ -2325,7 +2598,7 @@ components:
         default_pool_size:
           type: integer
           minimum: 0
-          maximum: 65535
+          maximum: 1000
         max_client_conn:
           type: integer
           nullable: true
@@ -2336,7 +2609,7 @@ components:
         pgbouncer_enabled:
           type: boolean
         pool_mode:
-          enum: *ref_40
+          enum: *ref_44
           type: string
         pgbouncer_status:
           enum:
@@ -2347,7 +2620,6 @@ components:
             - RELOADING
           type: string
       required:
-        - default_pool_size
         - ignore_startup_parameters
         - pgbouncer_enabled
         - pool_mode

--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/branches/create"
+	"github.com/supabase/cli/internal/branches/delete"
+	"github.com/supabase/cli/internal/branches/disable"
+	"github.com/supabase/cli/internal/branches/get"
+	"github.com/supabase/cli/internal/branches/list"
+	"github.com/supabase/cli/internal/branches/update"
+	"github.com/supabase/cli/pkg/api"
+)
+
+var (
+	branchesCmd = &cobra.Command{
+		GroupID: groupManagementAPI,
+		Use:     "branches",
+		Short:   "Manage Supabase preview branches",
+	}
+
+	branchCreateCmd = &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a preview branch",
+		Long:  "Create a preview branch for the linked project.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return create.Run(cmd.Context(), args[0], afero.NewOsFs())
+		},
+	}
+
+	branchListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all preview branches",
+		Long:  "List all preview branches of the linked project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list.Run(cmd.Context(), afero.NewOsFs())
+		},
+	}
+
+	branchGetCmd = &cobra.Command{
+		Use:   "get <branch-id>",
+		Short: "Retrieve details of a preview branch",
+		Long:  "Retrieve details of the specified preview branch.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return get.Run(cmd.Context(), args[0])
+		},
+	}
+
+	branchName string
+	gitBranch  string
+
+	branchUpdateCmd = &cobra.Command{
+		Use:   "update <branch-id>",
+		Short: "Update a preview branch",
+		Long:  "Update a preview branch by its ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var body api.UpdateBranchBody
+			if cmd.Flags().Changed("name") {
+				body.BranchName = &branchName
+			}
+			if cmd.Flags().Changed("git-branch") {
+				body.GitBranch = &gitBranch
+			}
+			return update.Run(cmd.Context(), args[0], body, afero.NewOsFs())
+		},
+	}
+
+	branchDeleteCmd = &cobra.Command{
+		Use:   "delete <branch-id>",
+		Short: "Delete a preview branch",
+		Long:  "Delete a preview branch by its ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return delete.Run(cmd.Context(), args[0])
+		},
+	}
+
+	branchDisableCmd = &cobra.Command{
+		Use:   "disable",
+		Short: "Disable preview branching",
+		Long:  "Disable preview branching for the linked project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return disable.Run(cmd.Context(), afero.NewOsFs())
+		},
+	}
+)
+
+func init() {
+	branchesCmd.AddCommand(branchCreateCmd)
+	branchesCmd.AddCommand(branchListCmd)
+	branchesCmd.AddCommand(branchGetCmd)
+	updateFlags := branchUpdateCmd.Flags()
+	updateFlags.StringVar(&branchName, "name", "", "Rename the preview branch.")
+	updateFlags.StringVar(&gitBranch, "git-branch", "", "Change the associated git branch.")
+	branchesCmd.AddCommand(branchUpdateCmd)
+	branchesCmd.AddCommand(branchDeleteCmd)
+	branchesCmd.AddCommand(branchDisableCmd)
+	rootCmd.AddCommand(branchesCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ var experimental = []*cobra.Command{
 	sslEnforcementCmd,
 	genKeysCmd,
 	postgresCmd,
+	branchesCmd,
 }
 
 func IsExperimental(cmd *cobra.Command) bool {

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -1,0 +1,34 @@
+package create
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/gen/keys"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+)
+
+func Run(ctx context.Context, name string, fsys afero.Fs) error {
+	ref, err := utils.LoadProjectRef(fsys)
+	if err != nil {
+		return err
+	}
+	gitBranch := keys.GetGitBranchOrDefault("", fsys)
+	resp, err := utils.GetSupabase().CreateBranchWithResponse(ctx, ref, api.CreateBranchJSONRequestBody{
+		BranchName: name,
+		GitBranch:  &gitBranch,
+	})
+	if err != nil {
+		return err
+	}
+
+	if resp.JSON201 == nil {
+		return errors.New("Unexpected error creating preview branch: " + string(resp.Body))
+	}
+
+	fmt.Println("Created preview branch:", resp.JSON201.Id)
+	return nil
+}

--- a/internal/branches/delete/delete.go
+++ b/internal/branches/delete/delete.go
@@ -1,0 +1,22 @@
+package delete
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, branchId string) error {
+	resp, err := utils.GetSupabase().DeleteBranchWithResponse(ctx, branchId)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return errors.New("Unexpected error deleting preview branch: " + string(resp.Body))
+	}
+	fmt.Println("Deleted preview branch:", branchId)
+	return nil
+}

--- a/internal/branches/disable/disable.go
+++ b/internal/branches/disable/disable.go
@@ -1,0 +1,27 @@
+package disable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, fsys afero.Fs) error {
+	ref, err := utils.LoadProjectRef(fsys)
+	if err != nil {
+		return err
+	}
+	resp, err := utils.GetSupabase().DisableBranchWithResponse(ctx, ref)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return errors.New("Unexpected error disabling preview branching: " + string(resp.Body))
+	}
+	fmt.Println("Disabled preview branching for project:", ref)
+	return nil
+}

--- a/internal/branches/get/get.go
+++ b/internal/branches/get/get.go
@@ -1,0 +1,45 @@
+package get
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, branchId string) error {
+	resp, err := utils.GetSupabase().GetBranchDetailsWithResponse(ctx, branchId)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return errors.New("Unexpected error retrieving preview branch: " + string(resp.Body))
+	}
+
+	masked := "******"
+	if resp.JSON200.DbUser == nil {
+		resp.JSON200.DbUser = &masked
+	}
+	if resp.JSON200.DbPass == nil {
+		resp.JSON200.DbPass = &masked
+	}
+	if resp.JSON200.JwtSecret == nil {
+		resp.JSON200.JwtSecret = &masked
+	}
+
+	table := `|HOST|PORT|USER|PASSWORD|JWT SECRET|POSTGRES VERSION|STATUS|
+|-|-|-|-|-|-|-|
+` + fmt.Sprintf(
+		"|`%s`|`%d`|`%s`|`%s`|`%s`|`%s`|`%s`|\n",
+		resp.JSON200.DbHost,
+		resp.JSON200.DbPort,
+		*resp.JSON200.DbUser,
+		*resp.JSON200.DbPass,
+		*resp.JSON200.JwtSecret,
+		resp.JSON200.PostgresVersion,
+		resp.JSON200.Status,
+	)
+	return list.RenderTable(table)
+}

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -1,0 +1,44 @@
+package list
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, fsys afero.Fs) error {
+	ref, err := utils.LoadProjectRef(fsys)
+	if err != nil {
+		return err
+	}
+	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return errors.New("Unexpected error listing preview branches: " + string(resp.Body))
+	}
+
+	table := `|ID|NAME|DEFAULT|GIT BRANCH|CREATED AT (UTC)|UPDATED AT (UTC)|
+|-|-|-|-|-|-|
+`
+	for _, branch := range *resp.JSON200 {
+		table += fmt.Sprintf(
+			"|`%s`|`%s`|`%t`|`%s`|`%s`|`%s`|\n",
+			branch.Id,
+			strings.ReplaceAll(branch.Name, "|", "\\|"),
+			branch.IsDefault,
+			strings.ReplaceAll(branch.GitBranch, "|", "\\|"),
+			utils.FormatTimestamp(branch.CreatedAt),
+			utils.FormatTimestamp(branch.UpdatedAt),
+		)
+	}
+
+	return list.RenderTable(table)
+}

--- a/internal/branches/update/update.go
+++ b/internal/branches/update/update.go
@@ -1,0 +1,23 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+)
+
+func Run(ctx context.Context, branchId string, body api.UpdateBranchBody, fsys afero.Fs) error {
+	resp, err := utils.GetSupabase().UpdateBranchWithResponse(ctx, branchId, body)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return errors.New("Unexpected error updating preview branch: " + string(resp.Body))
+	}
+	fmt.Println("Updated preview branch:", resp.JSON200.Id)
+	return nil
+}

--- a/internal/gen/keys/keys.go
+++ b/internal/gen/keys/keys.go
@@ -87,16 +87,19 @@ func GenerateSecrets(ctx context.Context, projectRef, branch string, fsys afero.
 }
 
 func GetGitBranch(fsys afero.Fs) string {
+	return GetGitBranchOrDefault("main", fsys)
+}
+
+func GetGitBranchOrDefault(def string, fsys afero.Fs) string {
 	head := os.Getenv("GITHUB_HEAD_REF")
 	if len(head) > 0 {
 		return head
 	}
-	branch := "main"
 	opts := &git.PlainOpenOptions{DetectDotGit: true}
 	if repo, err := git.PlainOpenWithOptions(".", opts); err == nil {
 		if ref, err := repo.Head(); err == nil {
-			branch = ref.Name().Short()
+			return ref.Name().Short()
 		}
 	}
-	return branch
+	return def
 }

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 			project.Id,
 			strings.ReplaceAll(project.Name, "|", "\\|"),
 			project.Region,
-			project.CreatedAt,
+			utils.FormatTimestamp(project.CreatedAt),
 		)
 	}
 

--- a/internal/sso/internal/render/render.go
+++ b/internal/sso/internal/render/render.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/go-xmlfmt/xmlfmt"
+	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
 
@@ -43,13 +43,7 @@ func formatTimestamp(timestamp *string) string {
 		return ""
 	}
 
-	t, err := time.Parse(time.RFC3339, *timestamp)
-
-	if err != nil {
-		return *timestamp
-	}
-
-	return t.UTC().Format("2006-01-02 15:04:05")
+	return utils.FormatTimestamp(*timestamp)
 }
 
 func formatDomains(provider api.Provider) string {

--- a/internal/utils/render.go
+++ b/internal/utils/render.go
@@ -1,0 +1,10 @@
+package utils
+
+import "time"
+
+func FormatTimestamp(timestamp string) string {
+	if t, err := time.Parse(time.RFC3339, timestamp); err == nil {
+		return t.UTC().Format("2006-01-02 15:04:05")
+	}
+	return timestamp
+}

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -89,6 +89,17 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// DeleteBranch request
+	DeleteBranch(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBranchDetails request
+	GetBranchDetails(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateBranch request with any body
+	UpdateBranchWithBody(ctx context.Context, branchId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateBranch(ctx context.Context, branchId string, body UpdateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DeclineAuthorizationRequest request
 	DeclineAuthorizationRequest(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -124,6 +135,17 @@ type ClientInterface interface {
 
 	// GetProjectApiKeys request
 	GetProjectApiKeys(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DisableBranch request
+	DisableBranch(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBranches request
+	GetBranches(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateBranch request with any body
+	CreateBranchWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateBranch(ctx context.Context, ref string, body CreateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListAllProviders request
 	ListAllProviders(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -231,6 +253,11 @@ type ClientInterface interface {
 
 	UpdatePostgRESTConfig(ctx context.Context, ref string, body UpdatePostgRESTConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RunQuery request with any body
+	RunQueryWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunQuery(ctx context.Context, ref string, body RunQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetReadOnlyModeStatus request
 	GetReadOnlyModeStatus(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -287,6 +314,54 @@ type ClientInterface interface {
 	CheckVanitySubdomainAvailabilityWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CheckVanitySubdomainAvailability(ctx context.Context, ref string, body CheckVanitySubdomainAvailabilityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) DeleteBranch(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteBranchRequest(c.Server, branchId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBranchDetails(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBranchDetailsRequest(c.Server, branchId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateBranchWithBody(ctx context.Context, branchId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateBranchRequestWithBody(c.Server, branchId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateBranch(ctx context.Context, branchId string, body UpdateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateBranchRequest(c.Server, branchId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) DeclineAuthorizationRequest(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -435,6 +510,54 @@ func (c *Client) CreateProject(ctx context.Context, body CreateProjectJSONReques
 
 func (c *Client) GetProjectApiKeys(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetProjectApiKeysRequest(c.Server, ref)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DisableBranch(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDisableBranchRequest(c.Server, ref)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBranches(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBranchesRequest(c.Server, ref)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateBranchWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateBranchRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateBranch(ctx context.Context, ref string, body CreateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateBranchRequest(c.Server, ref, body)
 	if err != nil {
 		return nil, err
 	}
@@ -913,6 +1036,30 @@ func (c *Client) UpdatePostgRESTConfig(ctx context.Context, ref string, body Upd
 	return c.Client.Do(req)
 }
 
+func (c *Client) RunQueryWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunQueryRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunQuery(ctx context.Context, ref string, body RunQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunQueryRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetReadOnlyModeStatus(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetReadOnlyModeStatusRequest(c.Server, ref)
 	if err != nil {
@@ -1163,6 +1310,121 @@ func (c *Client) CheckVanitySubdomainAvailability(ctx context.Context, ref strin
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewDeleteBranchRequest generates requests for DeleteBranch
+func NewDeleteBranchRequest(server string, branchId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "branch_id", runtime.ParamLocationPath, branchId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/branch/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBranchDetailsRequest generates requests for GetBranchDetails
+func NewGetBranchDetailsRequest(server string, branchId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "branch_id", runtime.ParamLocationPath, branchId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/branch/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateBranchRequest calls the generic UpdateBranch builder with application/json body
+func NewUpdateBranchRequest(server string, branchId string, body UpdateBranchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateBranchRequestWithBody(server, branchId, "application/json", bodyReader)
+}
+
+// NewUpdateBranchRequestWithBody generates requests for UpdateBranch with any type of body
+func NewUpdateBranchRequestWithBody(server string, branchId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "branch_id", runtime.ParamLocationPath, branchId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/branch/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
 }
 
 // NewDeclineAuthorizationRequestRequest generates requests for DeclineAuthorizationRequest
@@ -1722,6 +1984,121 @@ func NewGetProjectApiKeysRequest(server string, ref string) (*http.Request, erro
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewDisableBranchRequest generates requests for DisableBranch
+func NewDisableBranchRequest(server string, ref string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/branches", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBranchesRequest generates requests for GetBranches
+func NewGetBranchesRequest(server string, ref string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/branches", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateBranchRequest calls the generic CreateBranch builder with application/json body
+func NewCreateBranchRequest(server string, ref string, body CreateBranchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateBranchRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewCreateBranchRequestWithBody generates requests for CreateBranch with any type of body
+func NewCreateBranchRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/branches", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -3074,6 +3451,53 @@ func NewUpdatePostgRESTConfigRequestWithBody(server string, ref string, contentT
 	return req, nil
 }
 
+// NewRunQueryRequest calls the generic RunQuery builder with application/json body
+func NewRunQueryRequest(server string, ref string, body RunQueryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRunQueryRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewRunQueryRequestWithBody generates requests for RunQuery with any type of body
+func NewRunQueryRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/query", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetReadOnlyModeStatusRequest generates requests for GetReadOnlyModeStatus
 func NewGetReadOnlyModeStatusRequest(server string, ref string) (*http.Request, error) {
 	var err error
@@ -3727,6 +4151,17 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// DeleteBranch request
+	DeleteBranchWithResponse(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*DeleteBranchResponse, error)
+
+	// GetBranchDetails request
+	GetBranchDetailsWithResponse(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*GetBranchDetailsResponse, error)
+
+	// UpdateBranch request with any body
+	UpdateBranchWithBodyWithResponse(ctx context.Context, branchId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateBranchResponse, error)
+
+	UpdateBranchWithResponse(ctx context.Context, branchId string, body UpdateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateBranchResponse, error)
+
 	// DeclineAuthorizationRequest request
 	DeclineAuthorizationRequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeclineAuthorizationRequestResponse, error)
 
@@ -3762,6 +4197,17 @@ type ClientWithResponsesInterface interface {
 
 	// GetProjectApiKeys request
 	GetProjectApiKeysWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetProjectApiKeysResponse, error)
+
+	// DisableBranch request
+	DisableBranchWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*DisableBranchResponse, error)
+
+	// GetBranches request
+	GetBranchesWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBranchesResponse, error)
+
+	// CreateBranch request with any body
+	CreateBranchWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateBranchResponse, error)
+
+	CreateBranchWithResponse(ctx context.Context, ref string, body CreateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateBranchResponse, error)
 
 	// ListAllProviders request
 	ListAllProvidersWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*ListAllProvidersResponse, error)
@@ -3869,6 +4315,11 @@ type ClientWithResponsesInterface interface {
 
 	UpdatePostgRESTConfigWithResponse(ctx context.Context, ref string, body UpdatePostgRESTConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdatePostgRESTConfigResponse, error)
 
+	// RunQuery request with any body
+	RunQueryWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunQueryResponse, error)
+
+	RunQueryWithResponse(ctx context.Context, ref string, body RunQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*RunQueryResponse, error)
+
 	// GetReadOnlyModeStatus request
 	GetReadOnlyModeStatusWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetReadOnlyModeStatusResponse, error)
 
@@ -3925,6 +4376,71 @@ type ClientWithResponsesInterface interface {
 	CheckVanitySubdomainAvailabilityWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CheckVanitySubdomainAvailabilityResponse, error)
 
 	CheckVanitySubdomainAvailabilityWithResponse(ctx context.Context, ref string, body CheckVanitySubdomainAvailabilityJSONRequestBody, reqEditors ...RequestEditorFn) (*CheckVanitySubdomainAvailabilityResponse, error)
+}
+
+type DeleteBranchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetBranchDetailsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *BranchDetailResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBranchDetailsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBranchDetailsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateBranchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *BranchResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type DeclineAuthorizationRequestResponse struct {
@@ -4137,6 +4653,71 @@ func (r GetProjectApiKeysResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetProjectApiKeysResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DisableBranchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r DisableBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DisableBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetBranchesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]BranchResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBranchesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBranchesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateBranchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *BranchResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateBranchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -4755,6 +5336,28 @@ func (r UpdatePostgRESTConfigResponse) StatusCode() int {
 	return 0
 }
 
+type RunQueryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *map[string]interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r RunQueryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunQueryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetReadOnlyModeStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -5081,6 +5684,41 @@ func (r CheckVanitySubdomainAvailabilityResponse) StatusCode() int {
 	return 0
 }
 
+// DeleteBranchWithResponse request returning *DeleteBranchResponse
+func (c *ClientWithResponses) DeleteBranchWithResponse(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*DeleteBranchResponse, error) {
+	rsp, err := c.DeleteBranch(ctx, branchId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteBranchResponse(rsp)
+}
+
+// GetBranchDetailsWithResponse request returning *GetBranchDetailsResponse
+func (c *ClientWithResponses) GetBranchDetailsWithResponse(ctx context.Context, branchId string, reqEditors ...RequestEditorFn) (*GetBranchDetailsResponse, error) {
+	rsp, err := c.GetBranchDetails(ctx, branchId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBranchDetailsResponse(rsp)
+}
+
+// UpdateBranchWithBodyWithResponse request with arbitrary body returning *UpdateBranchResponse
+func (c *ClientWithResponses) UpdateBranchWithBodyWithResponse(ctx context.Context, branchId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateBranchResponse, error) {
+	rsp, err := c.UpdateBranchWithBody(ctx, branchId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateBranchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateBranchWithResponse(ctx context.Context, branchId string, body UpdateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateBranchResponse, error) {
+	rsp, err := c.UpdateBranch(ctx, branchId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateBranchResponse(rsp)
+}
+
 // DeclineAuthorizationRequestWithResponse request returning *DeclineAuthorizationRequestResponse
 func (c *ClientWithResponses) DeclineAuthorizationRequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeclineAuthorizationRequestResponse, error) {
 	rsp, err := c.DeclineAuthorizationRequest(ctx, id, reqEditors...)
@@ -5193,6 +5831,41 @@ func (c *ClientWithResponses) GetProjectApiKeysWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseGetProjectApiKeysResponse(rsp)
+}
+
+// DisableBranchWithResponse request returning *DisableBranchResponse
+func (c *ClientWithResponses) DisableBranchWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*DisableBranchResponse, error) {
+	rsp, err := c.DisableBranch(ctx, ref, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDisableBranchResponse(rsp)
+}
+
+// GetBranchesWithResponse request returning *GetBranchesResponse
+func (c *ClientWithResponses) GetBranchesWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBranchesResponse, error) {
+	rsp, err := c.GetBranches(ctx, ref, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBranchesResponse(rsp)
+}
+
+// CreateBranchWithBodyWithResponse request with arbitrary body returning *CreateBranchResponse
+func (c *ClientWithResponses) CreateBranchWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateBranchResponse, error) {
+	rsp, err := c.CreateBranchWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateBranchResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateBranchWithResponse(ctx context.Context, ref string, body CreateBranchJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateBranchResponse, error) {
+	rsp, err := c.CreateBranch(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateBranchResponse(rsp)
 }
 
 // ListAllProvidersWithResponse request returning *ListAllProvidersResponse
@@ -5535,6 +6208,23 @@ func (c *ClientWithResponses) UpdatePostgRESTConfigWithResponse(ctx context.Cont
 	return ParseUpdatePostgRESTConfigResponse(rsp)
 }
 
+// RunQueryWithBodyWithResponse request with arbitrary body returning *RunQueryResponse
+func (c *ClientWithResponses) RunQueryWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunQueryResponse, error) {
+	rsp, err := c.RunQueryWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunQueryResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunQueryWithResponse(ctx context.Context, ref string, body RunQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*RunQueryResponse, error) {
+	rsp, err := c.RunQuery(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunQueryResponse(rsp)
+}
+
 // GetReadOnlyModeStatusWithResponse request returning *GetReadOnlyModeStatusResponse
 func (c *ClientWithResponses) GetReadOnlyModeStatusWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetReadOnlyModeStatusResponse, error) {
 	rsp, err := c.GetReadOnlyModeStatus(ctx, ref, reqEditors...)
@@ -5716,6 +6406,74 @@ func (c *ClientWithResponses) CheckVanitySubdomainAvailabilityWithResponse(ctx c
 		return nil, err
 	}
 	return ParseCheckVanitySubdomainAvailabilityResponse(rsp)
+}
+
+// ParseDeleteBranchResponse parses an HTTP response from a DeleteBranchWithResponse call
+func ParseDeleteBranchResponse(rsp *http.Response) (*DeleteBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseGetBranchDetailsResponse parses an HTTP response from a GetBranchDetailsWithResponse call
+func ParseGetBranchDetailsResponse(rsp *http.Response) (*GetBranchDetailsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBranchDetailsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BranchDetailResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateBranchResponse parses an HTTP response from a UpdateBranchWithResponse call
+func ParseUpdateBranchResponse(rsp *http.Response) (*UpdateBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BranchResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseDeclineAuthorizationRequestResponse parses an HTTP response from a DeclineAuthorizationRequestWithResponse call
@@ -5929,6 +6687,74 @@ func ParseGetProjectApiKeysResponse(rsp *http.Response) (*GetProjectApiKeysRespo
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDisableBranchResponse parses an HTTP response from a DisableBranchWithResponse call
+func ParseDisableBranchResponse(rsp *http.Response) (*DisableBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DisableBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseGetBranchesResponse parses an HTTP response from a GetBranchesWithResponse call
+func ParseGetBranchesResponse(rsp *http.Response) (*GetBranchesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBranchesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []BranchResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateBranchResponse parses an HTTP response from a CreateBranchWithResponse call
+func ParseCreateBranchResponse(rsp *http.Response) (*CreateBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest BranchResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	}
 
@@ -6617,6 +7443,32 @@ func ParseUpdatePostgRESTConfigResponse(rsp *http.Response) (*UpdatePostgRESTCon
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunQueryResponse parses an HTTP response from a RunQueryWithResponse call
+func ParseRunQueryResponse(rsp *http.Response) (*RunQueryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunQueryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	}
 

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -15,6 +15,21 @@ const (
 	BearerScopes       = "bearer.Scopes"
 )
 
+// Defines values for BranchDetailResponseStatus.
+const (
+	BranchDetailResponseStatusACTIVEHEALTHY   BranchDetailResponseStatus = "ACTIVE_HEALTHY"
+	BranchDetailResponseStatusACTIVEUNHEALTHY BranchDetailResponseStatus = "ACTIVE_UNHEALTHY"
+	BranchDetailResponseStatusCOMINGUP        BranchDetailResponseStatus = "COMING_UP"
+	BranchDetailResponseStatusGOINGDOWN       BranchDetailResponseStatus = "GOING_DOWN"
+	BranchDetailResponseStatusINACTIVE        BranchDetailResponseStatus = "INACTIVE"
+	BranchDetailResponseStatusINITFAILED      BranchDetailResponseStatus = "INIT_FAILED"
+	BranchDetailResponseStatusPAUSING         BranchDetailResponseStatus = "PAUSING"
+	BranchDetailResponseStatusREMOVED         BranchDetailResponseStatus = "REMOVED"
+	BranchDetailResponseStatusRESTORING       BranchDetailResponseStatus = "RESTORING"
+	BranchDetailResponseStatusUNKNOWN         BranchDetailResponseStatus = "UNKNOWN"
+	BranchDetailResponseStatusUPGRADING       BranchDetailResponseStatus = "UPGRADING"
+)
+
 // Defines values for CreateProjectBodyPlan.
 const (
 	Free CreateProjectBodyPlan = "free"
@@ -85,9 +100,9 @@ const (
 
 // Defines values for FunctionSlugResponseStatus.
 const (
-	FunctionSlugResponseStatusACTIVE    FunctionSlugResponseStatus = "ACTIVE"
-	FunctionSlugResponseStatusREMOVED   FunctionSlugResponseStatus = "REMOVED"
-	FunctionSlugResponseStatusTHROTTLED FunctionSlugResponseStatus = "THROTTLED"
+	ACTIVE    FunctionSlugResponseStatus = "ACTIVE"
+	REMOVED   FunctionSlugResponseStatus = "REMOVED"
+	THROTTLED FunctionSlugResponseStatus = "THROTTLED"
 )
 
 // Defines values for NetworkRestrictionsResponseEntitlement.
@@ -233,6 +248,38 @@ type AttributeValue_Default struct {
 // AuthorizationsApproveBody defines model for AuthorizationsApproveBody.
 type AuthorizationsApproveBody struct {
 	OrganizationId string `json:"organization_id"`
+}
+
+// BranchDetailResponse defines model for BranchDetailResponse.
+type BranchDetailResponse struct {
+	DbHost    string                     `json:"db_host"`
+	DbPass    string                     `json:"db_pass"`
+	DbPort    float32                    `json:"db_port"`
+	DbUser    string                     `json:"db_user"`
+	JwtSecret string                     `json:"jwt_secret"`
+	Ref       string                     `json:"ref"`
+	Status    BranchDetailResponseStatus `json:"status"`
+}
+
+// BranchDetailResponseStatus defines model for BranchDetailResponse.Status.
+type BranchDetailResponseStatus string
+
+// BranchResponse defines model for BranchResponse.
+type BranchResponse struct {
+	CreatedAt  string `json:"created_at"`
+	GitBranch  string `json:"git_branch"`
+	Id         string `json:"id"`
+	IsDefault  bool   `json:"is_default"`
+	Name       string `json:"name"`
+	ProjectRef string `json:"project_ref"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+// CreateBranchBody defines model for CreateBranchBody.
+type CreateBranchBody struct {
+	BranchName string  `json:"branch_name"`
+	GitBranch  *string `json:"git_branch,omitempty"`
+	Region     *string `json:"region,omitempty"`
 }
 
 // CreateFunctionBody defines model for CreateFunctionBody.
@@ -477,7 +524,7 @@ type ProjectPgBouncerConfig struct {
 	DbPort                  float32                               `json:"db_port"`
 	DbSsl                   bool                                  `json:"db_ssl"`
 	DbUser                  string                                `json:"db_user"`
-	DefaultPoolSize         float32                               `json:"default_pool_size"`
+	DefaultPoolSize         *float32                              `json:"default_pool_size,omitempty"`
 	IgnoreStartupParameters string                                `json:"ignore_startup_parameters"`
 	InsertedAt              string                                `json:"inserted_at"`
 	MaxClientConn           *float32                              `json:"max_client_conn"`
@@ -548,6 +595,11 @@ type RemoveNetworkBanRequest struct {
 	Ipv4Addresses []string `json:"ipv4_addresses"`
 }
 
+// RunQueryBody defines model for RunQueryBody.
+type RunQueryBody struct {
+	Query string `json:"query"`
+}
+
 // SamlDescriptor defines model for SamlDescriptor.
 type SamlDescriptor struct {
 	AttributeMapping *AttributeMapping `json:"attribute_mapping,omitempty"`
@@ -589,6 +641,12 @@ type TypescriptResponse struct {
 	Types string `json:"types"`
 }
 
+// UpdateBranchBody defines model for UpdateBranchBody.
+type UpdateBranchBody struct {
+	BranchName *string `json:"branch_name,omitempty"`
+	GitBranch  *string `json:"git_branch,omitempty"`
+}
+
 // UpdateCustomHostnameBody defines model for UpdateCustomHostnameBody.
 type UpdateCustomHostnameBody struct {
 	CustomHostname string `json:"custom_hostname"`
@@ -613,7 +671,7 @@ type UpdateFunctionBody struct {
 
 // UpdatePgbouncerConfigBody defines model for UpdatePgbouncerConfigBody.
 type UpdatePgbouncerConfigBody struct {
-	DefaultPoolSize         int                               `json:"default_pool_size"`
+	DefaultPoolSize         *int                              `json:"default_pool_size,omitempty"`
 	IgnoreStartupParameters string                            `json:"ignore_startup_parameters"`
 	MaxClientConn           *int                              `json:"max_client_conn"`
 	PgbouncerEnabled        bool                              `json:"pgbouncer_enabled"`
@@ -630,7 +688,7 @@ type UpdatePgsodiumConfigBody struct {
 
 // UpdatePoolingConfigResponse defines model for UpdatePoolingConfigResponse.
 type UpdatePoolingConfigResponse struct {
-	DefaultPoolSize         int                                        `json:"default_pool_size"`
+	DefaultPoolSize         *int                                       `json:"default_pool_size,omitempty"`
 	IgnoreStartupParameters string                                     `json:"ignore_startup_parameters"`
 	MaxClientConn           *int                                       `json:"max_client_conn"`
 	PgbouncerEnabled        bool                                       `json:"pgbouncer_enabled"`
@@ -768,6 +826,9 @@ type GetTypescriptTypesParams struct {
 	IncludedSchemas *string `form:"included_schemas,omitempty" json:"included_schemas,omitempty"`
 }
 
+// UpdateBranchJSONRequestBody defines body for UpdateBranch for application/json ContentType.
+type UpdateBranchJSONRequestBody = UpdateBranchBody
+
 // ApproveAuthorizationRequestJSONRequestBody defines body for ApproveAuthorizationRequest for application/json ContentType.
 type ApproveAuthorizationRequestJSONRequestBody = AuthorizationsApproveBody
 
@@ -776,6 +837,9 @@ type CreateOrganizationJSONRequestBody = CreateOrganizationBody
 
 // CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
 type CreateProjectJSONRequestBody = CreateProjectBody
+
+// CreateBranchJSONRequestBody defines body for CreateBranch for application/json ContentType.
+type CreateBranchJSONRequestBody = CreateBranchBody
 
 // CreateProviderForProjectJSONRequestBody defines body for CreateProviderForProject for application/json ContentType.
 type CreateProviderForProjectJSONRequestBody = CreateProviderBody
@@ -809,6 +873,9 @@ type UpdatePgsodiumConfigJSONRequestBody = UpdatePgsodiumConfigBody
 
 // UpdatePostgRESTConfigJSONRequestBody defines body for UpdatePostgRESTConfig for application/json ContentType.
 type UpdatePostgRESTConfigJSONRequestBody = UpdatePostgrestConfigBody
+
+// RunQueryJSONRequestBody defines body for RunQuery for application/json ContentType.
+type RunQueryJSONRequestBody = RunQueryBody
 
 // DeleteSecretsJSONRequestBody defines body for DeleteSecrets for application/json ContentType.
 type DeleteSecretsJSONRequestBody = DeleteSecretsJSONBody

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -252,13 +252,14 @@ type AuthorizationsApproveBody struct {
 
 // BranchDetailResponse defines model for BranchDetailResponse.
 type BranchDetailResponse struct {
-	DbHost    string                     `json:"db_host"`
-	DbPass    string                     `json:"db_pass"`
-	DbPort    float32                    `json:"db_port"`
-	DbUser    string                     `json:"db_user"`
-	JwtSecret string                     `json:"jwt_secret"`
-	Ref       string                     `json:"ref"`
-	Status    BranchDetailResponseStatus `json:"status"`
+	DbHost          string                     `json:"db_host"`
+	DbPass          *string                    `json:"db_pass,omitempty"`
+	DbPort          int                        `json:"db_port"`
+	DbUser          *string                    `json:"db_user,omitempty"`
+	JwtSecret       *string                    `json:"jwt_secret,omitempty"`
+	PostgresVersion string                     `json:"postgres_version"`
+	Ref             string                     `json:"ref"`
+	Status          BranchDetailResponseStatus `json:"status"`
 }
 
 // BranchDetailResponseStatus defines model for BranchDetailResponse.Status.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Add `--experimental` commands for managing preview branches.
- `create Production` enables preview branching
- `get` retrieves branch db connection details
- `list` displays all branches in a table
- `update <uuid> --git-branch main`  updates git branch
- `delete <uuid>` deletes a branch by id
- `disable` disables branching for the project

## Additional context

These new commands would also allow GHA workflows to launch preview branches for each PR.
