### PR TITLE
feat: add flags to push custom roles and seed data

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -120,7 +120,9 @@ var (
 		},
 	}
 
-	dryRun bool
+	dryRun       bool
+	includeRoles bool
+	includeSeed  bool
 
 	dbPushCmd = &cobra.Command{
 		Use:   "push",
@@ -131,7 +133,7 @@ var (
 				return err
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return push.Run(ctx, dryRun, dbConfig, fsys)
+			return push.Run(ctx, dryRun, includeRoles, includeSeed, dbConfig, fsys)
 		},
 	}
 
@@ -261,6 +263,8 @@ func init() {
 	dbCmd.AddCommand(dbDumpCmd)
 	// Build push command
 	pushFlags := dbPushCmd.Flags()
+	pushFlags.BoolVar(&includeRoles, "include-roles", false, "Include custom roles from "+utils.CustomRolesPath+".")
+	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.SeedDataPath+".")
 	pushFlags.BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	pushFlags.StringVarP(&dbPassword, "password", "p", "", "Password to your remote Postgres database.")
 	cobra.CheckErr(viper.BindPFlag("DB_PASSWORD", pushFlags.Lookup("password")))

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -2,18 +2,21 @@ package push
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/migration/apply"
 	"github.com/supabase/cli/internal/migration/up"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, dryRun bool, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, dryRun, includeRoles, includeSeed bool, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	if dryRun {
 		fmt.Fprintln(os.Stderr, "DRY RUN: migrations will *not* be pushed to the database.")
 	}
@@ -22,6 +25,12 @@ func Run(ctx context.Context, dryRun bool, config pgconn.Config, fsys afero.Fs, 
 		return err
 	}
 	defer conn.Close(context.Background())
+	// Create roles
+	if includeRoles {
+		if err := CreateCustomRoles(ctx, conn, os.Stderr, fsys); err != nil {
+			return err
+		}
+	}
 	pending, err := up.GetPendingMigrations(ctx, conn, fsys)
 	if err != nil {
 		return err
@@ -40,6 +49,23 @@ func Run(ctx context.Context, dryRun bool, config pgconn.Config, fsys afero.Fs, 
 			return err
 		}
 	}
+	// Seed database
+	if includeSeed {
+		if err := reset.SeedDatabase(ctx, conn, fsys); err != nil {
+			return err
+		}
+	}
 	fmt.Println("Finished " + utils.Aqua("supabase db push") + ".")
 	return nil
+}
+
+func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, w io.Writer, fsys afero.Fs) error {
+	roles, err := fsys.Open(utils.CustomRolesPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, "Creating custom roles "+utils.Bold(utils.CustomRolesPath)+"...")
+	return apply.BatchExecDDL(ctx, conn, roles)
 }

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -36,7 +36,7 @@ func TestMigrationPush(t *testing.T) {
 		conn.Query(list.LIST_MIGRATION_VERSION).
 			Reply("SELECT 0")
 		// Run test
-		err := Run(context.Background(), true, dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), true, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -50,7 +50,7 @@ func TestMigrationPush(t *testing.T) {
 		conn.Query(list.LIST_MIGRATION_VERSION).
 			Reply("SELECT 0")
 		// Run test
-		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), false, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -59,7 +59,7 @@ func TestMigrationPush(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), false, pgconn.Config{}, fsys)
+		err := Run(context.Background(), false, false, false, pgconn.Config{}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
@@ -73,7 +73,7 @@ func TestMigrationPush(t *testing.T) {
 		conn.Query(list.LIST_MIGRATION_VERSION).
 			ReplyError(pgerrcode.InvalidCatalogName, `database "target" does not exist`)
 		// Run test
-		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), false, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: database "target" does not exist (SQLSTATE 3D000)`)
 	})
@@ -95,7 +95,7 @@ func TestMigrationPush(t *testing.T) {
 			Query(repair.ADD_STATEMENTS_COLUMN).
 			Query(repair.ADD_NAME_COLUMN)
 		// Run test
-		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), false, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: permission denied for relation supabase_migrations (SQLSTATE 42501)`)
 	})
@@ -121,7 +121,7 @@ func TestMigrationPush(t *testing.T) {
 			Query(repair.INSERT_MIGRATION_VERSION, "0", "test", "{}").
 			ReplyError(pgerrcode.NotNullViolation, `null value in column "version" of relation "schema_migrations"`)
 		// Run test
-		err := Run(context.Background(), false, dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), false, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: null value in column "version" of relation "schema_migrations" (SQLSTATE 23502)`)
 		assert.ErrorContains(t, err, "At statement 0: "+repair.INSERT_MIGRATION_VERSION)

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -125,13 +125,13 @@ func recreateDatabase(ctx context.Context, options ...func(*pgx.ConnConfig)) err
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	fmt.Fprintln(os.Stderr, "Seeding data "+utils.Bold(utils.SeedDataPath)+"...")
 	seed, err := repair.NewMigrationFromFile(utils.SeedDataPath, fsys)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	} else if err != nil {
 		return err
 	}
+	fmt.Fprintln(os.Stderr, "Seeding data "+utils.Bold(utils.SeedDataPath)+"...")
 	// Batch seed commands, safe to use statement cache
 	return seed.ExecBatchWithCache(ctx, conn)
 }

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/db/push"
 	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/migration/apply"
 	"github.com/supabase/cli/internal/utils"
@@ -167,12 +168,5 @@ func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer
 	if err := initSchema(ctx, conn, host, w); err != nil {
 		return err
 	}
-	roles, err := fsys.Open(utils.CustomRolesPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-	fmt.Fprintln(w, "Creating custom roles "+utils.Bold(utils.CustomRolesPath)+"...")
-	return apply.BatchExecDDL(ctx, conn, roles)
+	return push.CreateCustomRoles(ctx, conn, w, fsys)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Allows custom roles and seed data to be optionally pushed along with migrations.

```bash
supabase db push --include-roles --include-seed
```

Helps with setting up preview branch on remote project.

## Additional context

Add any other context or screenshots.
