### PR TITLE
fix(db): bump pg15 release to 15.1.0.103

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -23,7 +23,7 @@ var Version string
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.89"
-	Pg15Image = "supabase/postgres:15.1.0.90"
+	Pg15Image = "supabase/postgres:15.1.0.103"
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"


### PR DESCRIPTION
I don't know if it is that simple, but tests seem to pass and nothing showed up during casual usage ¯\_(ツ)_/¯ 

This release includes pg_graphql v1.2.3 which enables computed fields to return `setof`, that is a essential feature for one to many relations in general (we're using it for i18n)

https://supabase.github.io/pg_graphql/computed_fields/#to-many