### PR TITLE
fix(functions): bump edge runtime 181

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -111,7 +111,7 @@ serve(async (req: Request) => {
   const customModuleRoot = ""; // empty string to allow any local path
   const cpuTimeThresholdMs = 50;
   const cpuBurstIntervalMs = 100;
-  const maxCpuBursts = 10;
+  const maxCpuBursts = 100;
   try {
     const worker = await EdgeRuntime.userWorkers.create({
       servicePath,

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.66.3"
 	StudioImage      = "supabase/studio:v0.23.06"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.6.6"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.8.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	// Update initial schemas in internal/utils/templates/initial_schemas when
 	// updating any one of these.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps Edge Runtime image to 1.8.1 and also increases the CPU limit.
