### PR TITLE
chore: update channel name for hotfix branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
   },
   "release": {
     "branches": [
-      "+([0-9])?(.{+([0-9]),x}).x",
+      {
+        "name": "+([0-9])?(.{+([0-9]),x}).x",
+        "channel": "hotfix"
+      },
       {
         "name": "main",
         "channel": "beta"


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci update

## What is the new behavior?

Adds a new hotfix channel because `npm publish --tag <name>` cannot be a semver string.

## Additional context

Add any other context or screenshots.
