### PR TITLE
bump to logflare to version 1.4.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	GotrueImage   = "supabase/gotrue:v2.82.4"
 	RealtimeImage = "supabase/realtime:v2.10.1"
 	StorageImage  = "supabase/storage-api:v0.40.4"
-	LogflareImage = "supabase/logflare:1.3.28"
+	LogflareImage = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage
 	DenoVersion = "1.30.3"
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps Logflare version to 1.4.0 