### PR TITLE
feat: support resetting database to a specific version

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -175,7 +175,6 @@ var (
 	dbResetCmd = &cobra.Command{
 		Use:   "reset",
 		Short: "Resets the local database to current migrations",
-		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if linked || len(dbUrl) > 0 {

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -175,6 +175,7 @@ var (
 	dbResetCmd = &cobra.Command{
 		Use:   "reset",
 		Short: "Resets the local database to current migrations",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if linked || len(dbUrl) > 0 {
@@ -183,7 +184,7 @@ var (
 				}
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return reset.Run(ctx, dbConfig, fsys)
+			return reset.Run(ctx, version, dbConfig, fsys)
 		},
 	}
 
@@ -283,6 +284,7 @@ func init() {
 	// Build reset command
 	resetFlags := dbResetCmd.Flags()
 	resetFlags.BoolVar(&linked, "linked", false, "Resets the linked project to current migrations.")
+	resetFlags.StringVar(&version, "version", "", "Reset up to the specified version.")
 	dbCmd.AddCommand(dbResetCmd)
 	// Build lint command
 	lintFlags := dbLintCmd.Flags()

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
-	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/migration/apply"
 	"github.com/supabase/cli/internal/migration/up"
 	"github.com/supabase/cli/internal/utils"
@@ -51,7 +50,7 @@ func Run(ctx context.Context, dryRun, ignoreVersionMismatch bool, includeRoles, 
 	}
 	// Seed database
 	if !dryRun && includeSeed {
-		if err := reset.SeedDatabase(ctx, conn, fsys); err != nil {
+		if err := apply.SeedDatabase(ctx, conn, fsys); err != nil {
 			return err
 		}
 	}

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -44,6 +44,9 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		if _, err := strconv.Atoi(version); err != nil {
 			return repair.ErrInvalidVersion
 		}
+		if _, err := repair.GetMigrationFile(version, fsys); err != nil {
+			return err
+		}
 	}
 	if len(config.Password) > 0 {
 		return resetRemote(ctx, version, config, fsys, options...)

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
-	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
 	"gopkg.in/h2non/gock.v1"
@@ -113,63 +112,6 @@ func TestInitDatabase(t *testing.T) {
 		err := initDatabase(context.Background(), conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: schema "public" already exists (SQLSTATE 42P06)`)
-	})
-}
-
-func TestSeedDatabase(t *testing.T) {
-	t.Run("seeds from file", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup seed file
-		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		conn.Query(sql).
-			Reply("INSERT 0 1")
-		// Connect to mock
-		ctx := context.Background()
-		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
-		require.NoError(t, err)
-		defer mock.Close(ctx)
-		// Run test
-		assert.NoError(t, SeedDatabase(ctx, mock, fsys))
-	})
-
-	t.Run("ignores missing seed", func(t *testing.T) {
-		assert.NoError(t, SeedDatabase(context.Background(), nil, afero.NewMemMapFs()))
-	})
-
-	t.Run("throws error on read failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.SeedDataPath}
-		// Run test
-		err := SeedDatabase(context.Background(), nil, fsys)
-		// Check error
-		assert.ErrorIs(t, err, os.ErrPermission)
-	})
-
-	t.Run("throws error on insert failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup seed file
-		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		conn.Query(sql).
-			ReplyError(pgerrcode.NotNullViolation, `null value in column "age" of relation "employees"`)
-		// Connect to mock
-		ctx := context.Background()
-		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
-		require.NoError(t, err)
-		defer mock.Close(ctx)
-		// Run test
-		err = SeedDatabase(ctx, mock, fsys)
-		// Check error
-		assert.ErrorContains(t, err, `ERROR: null value in column "age" of relation "employees" (SQLSTATE 23502)`)
 	})
 }
 

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -29,13 +29,13 @@ func TestResetCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), pgconn.Config{Password: "postgres"}, fsys)
+		err := Run(context.Background(), "", pgconn.Config{Password: "postgres"}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
 	t.Run("throws error on missing config", func(t *testing.T) {
-		err := Run(context.Background(), pgconn.Config{}, afero.NewMemMapFs())
+		err := Run(context.Background(), "", pgconn.Config{}, afero.NewMemMapFs())
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
@@ -50,7 +50,7 @@ func TestResetCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), pgconn.Config{}, fsys)
+		err := Run(context.Background(), "", pgconn.Config{}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, utils.ErrNotRunning)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -73,7 +73,7 @@ func TestResetCommand(t *testing.T) {
 		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
 			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
 		// Run test
-		err := Run(context.Background(), pgconn.Config{}, fsys, conn.Intercept)
+		err := Run(context.Background(), "", pgconn.Config{}, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, "ERROR: cannot disallow connections for current database (SQLSTATE 22023)")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -371,7 +371,7 @@ func TestResetRemote(t *testing.T) {
 			Query(dropObjects).
 			Reply("INSERT 0")
 		// Run test
-		err := resetRemote(context.Background(), dbConfig, fsys, conn.Intercept)
+		err := resetRemote(context.Background(), "", dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -380,7 +380,7 @@ func TestResetRemote(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := resetRemote(context.Background(), pgconn.Config{}, fsys)
+		err := resetRemote(context.Background(), "", pgconn.Config{}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
@@ -394,7 +394,7 @@ func TestResetRemote(t *testing.T) {
 		conn.Query(strings.ReplaceAll(LIST_SCHEMAS, "$1", "'{public,auth,extensions,pgbouncer,realtime,\"\\\\_realtime\",storage,\"\\\\_analytics\",\"supabase\\\\_functions\",\"supabase\\\\_migrations\",\"information\\\\_schema\",\"pg\\\\_%\",cron,graphql,\"graphql\\\\_public\",net,pgsodium,\"pgsodium\\\\_masks\",pgtle,repack,tiger,\"tiger\\\\_data\",\"timescaledb\\\\_%\",\"\\\\_timescaledb\\\\_%\",topology,vault}'")).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation information_schema")
 		// Run test
-		err := resetRemote(context.Background(), dbConfig, fsys, conn.Intercept)
+		err := resetRemote(context.Background(), "", dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, "ERROR: permission denied for relation information_schema (SQLSTATE 42501)")
 	})
@@ -411,7 +411,7 @@ func TestResetRemote(t *testing.T) {
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(dropObjects)
 		// Run test
-		err := resetRemote(context.Background(), dbConfig, fsys, conn.Intercept)
+		err := resetRemote(context.Background(), "", dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, "ERROR: permission denied for relation supabase_migrations (SQLSTATE 42501)")
 	})

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -163,7 +163,7 @@ func setupDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 	if err := SetupDatabase(ctx, conn, utils.DbId, w, fsys); err != nil {
 		return err
 	}
-	return reset.InitialiseDatabase(ctx, conn, fsys)
+	return reset.InitialiseDatabase(ctx, "", conn, fsys)
 }
 
 func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer, fsys afero.Fs) error {

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -163,7 +163,7 @@ func setupDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 	if err := SetupDatabase(ctx, conn, utils.DbId, w, fsys); err != nil {
 		return err
 	}
-	return reset.InitialiseDatabase(ctx, "", conn, fsys)
+	return apply.MigrateAndSeed(ctx, "", conn, fsys)
 }
 
 func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer, fsys afero.Fs) error {

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,12 +15,27 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func MigrateDatabase(ctx context.Context, version string, conn *pgx.Conn, fsys afero.Fs) error {
+func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys afero.Fs) error {
 	migrations, err := list.LoadPartialMigrations(version, fsys)
 	if err != nil {
 		return err
 	}
-	return MigrateUp(ctx, conn, migrations, fsys)
+	if err := MigrateUp(ctx, conn, migrations, fsys); err != nil {
+		return err
+	}
+	return SeedDatabase(ctx, conn, fsys)
+}
+
+func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
+	seed, err := repair.NewMigrationFromFile(utils.SeedDataPath, fsys)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Seeding data "+utils.Bold(utils.SeedDataPath)+"...")
+	// Batch seed commands, safe to use statement cache
+	return seed.ExecBatchWithCache(ctx, conn)
 }
 
 func MigrateUp(ctx context.Context, conn *pgx.Conn, pending []string, fsys afero.Fs) error {

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -14,8 +14,8 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func MigrateDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	migrations, err := list.LoadLocalMigrations(fsys)
+func MigrateDatabase(ctx context.Context, version string, conn *pgx.Conn, fsys afero.Fs) error {
+	migrations, err := list.LoadPartialMigrations(version, fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/migration/repair"
+	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -45,22 +46,79 @@ func TestMigrateDatabase(t *testing.T) {
 		require.NoError(t, err)
 		defer mock.Close(ctx)
 		// Run test
-		err = MigrateDatabase(ctx, "", mock, fsys)
+		err = MigrateAndSeed(ctx, "", mock, fsys)
 		// Check error
 		assert.NoError(t, err)
 	})
 
 	t.Run("ignores empty local directory", func(t *testing.T) {
-		assert.NoError(t, MigrateDatabase(context.Background(), "", nil, afero.NewMemMapFs()))
+		assert.NoError(t, MigrateAndSeed(context.Background(), "", nil, afero.NewMemMapFs()))
 	})
 
 	t.Run("throws error on write failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := MigrateDatabase(context.Background(), "", nil, afero.NewReadOnlyFs(fsys))
+		err := MigrateAndSeed(context.Background(), "", nil, afero.NewReadOnlyFs(fsys))
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+}
+
+func TestSeedDatabase(t *testing.T) {
+	t.Run("seeds from file", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup seed file
+		sql := "INSERT INTO employees(name) VALUES ('Alice')"
+		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(sql).
+			Reply("INSERT 0 1")
+		// Connect to mock
+		ctx := context.Background()
+		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
+		require.NoError(t, err)
+		defer mock.Close(ctx)
+		// Run test
+		assert.NoError(t, SeedDatabase(ctx, mock, fsys))
+	})
+
+	t.Run("ignores missing seed", func(t *testing.T) {
+		assert.NoError(t, SeedDatabase(context.Background(), nil, afero.NewMemMapFs()))
+	})
+
+	t.Run("throws error on read failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := &fstest.OpenErrorFs{DenyPath: utils.SeedDataPath}
+		// Run test
+		err := SeedDatabase(context.Background(), nil, fsys)
+		// Check error
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+
+	t.Run("throws error on insert failure", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup seed file
+		sql := "INSERT INTO employees(name) VALUES ('Alice')"
+		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(sql).
+			ReplyError(pgerrcode.NotNullViolation, `null value in column "age" of relation "employees"`)
+		// Connect to mock
+		ctx := context.Background()
+		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
+		require.NoError(t, err)
+		defer mock.Close(ctx)
+		// Run test
+		err = SeedDatabase(ctx, mock, fsys)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: null value in column "age" of relation "employees" (SQLSTATE 23502)`)
 	})
 }
 

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -45,20 +45,20 @@ func TestMigrateDatabase(t *testing.T) {
 		require.NoError(t, err)
 		defer mock.Close(ctx)
 		// Run test
-		err = MigrateDatabase(ctx, mock, fsys)
+		err = MigrateDatabase(ctx, "", mock, fsys)
 		// Check error
 		assert.NoError(t, err)
 	})
 
 	t.Run("ignores empty local directory", func(t *testing.T) {
-		assert.NoError(t, MigrateDatabase(context.Background(), nil, afero.NewMemMapFs()))
+		assert.NoError(t, MigrateDatabase(context.Background(), "", nil, afero.NewMemMapFs()))
 	})
 
 	t.Run("throws error on write failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := MigrateDatabase(context.Background(), nil, afero.NewReadOnlyFs(fsys))
+		err := MigrateDatabase(context.Background(), "", nil, afero.NewReadOnlyFs(fsys))
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -25,6 +25,9 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		if _, err := strconv.Atoi(version); err != nil {
 			return repair.ErrInvalidVersion
 		}
+		if _, err := repair.GetMigrationFile(version, fsys); err != nil {
+			return err
+		}
 	}
 	if err := utils.LoadConfigFS(fsys); err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://news.ycombinator.com/reply?id=37075043&goto=item%3Fid%3D37072464%2337075043

## What is the current behavior?

> Using supabase migration up would mean moving the latest migration out of the migrations folder, running supabase db reset, moving the file back in and then calling supabase migration up.

## What is the new behavior?

Allows resetting database to a specific version. For eg.

- `supabase/migrations/20221014075902_first.sql`
- `supabase/migrations/20221014075903_second.sql`

```bash
$ supabase db reset --version 20221014075902
Resetting local database to version: 20221014075902
...

$ supabase migration up
Applying migration 20230810083342_test_pgsodium.sql...

$ supabase db reset --version 0
glob supabase/migrations/0_*.sql: file does not exist
...
```

## Additional context

Add any other context or screenshots.
