### PR TITLE
WIP: dump data when squashing migration

### DIFF
--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, path string, config pgconn.Config, schema []string
 	}
 	if dataOnly {
 		fmt.Fprintln(os.Stderr, "Dumping data from remote database...")
-		return dumpData(ctx, config, schema, useCopy, dryRun, outStream)
+		return DumpData(ctx, config, schema, useCopy, dryRun, outStream)
 	} else if roleOnly {
 		fmt.Fprintln(os.Stderr, "Dumping roles from remote database...")
 		return dumpRole(ctx, config, keepComments, dryRun, outStream)
@@ -62,7 +62,7 @@ func DumpSchema(ctx context.Context, config pgconn.Config, schema []string, keep
 	return dump(ctx, config, dumpSchemaScript, env, dryRun, stdout)
 }
 
-func dumpData(ctx context.Context, config pgconn.Config, schema []string, useCopy, dryRun bool, stdout io.Writer) error {
+func DumpData(ctx context.Context, config pgconn.Config, schema []string, useCopy, dryRun bool, stdout io.Writer) error {
 	// We want to dump user data in auth, storage, etc. for migrating to new project
 	excludedSchemas := append([]string{
 		// "auth",

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -92,7 +92,10 @@ func squashMigrations(ctx context.Context, migrations []string, fsys afero.Fs, o
 		User:     "postgres",
 		Password: utils.Config.Db.Password,
 	}
-	return dump.DumpSchema(ctx, config, nil, false, false, f)
+	if err := dump.DumpSchema(ctx, config, nil, false, false, f); err != nil {
+		return err
+	}
+	return dump.DumpData(ctx, config, nil, false, false, f)
 }
 
 const DELETE_MIGRATION_BEFORE = "DELETE FROM supabase_migrations.schema_migrations WHERE version <= $1"

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -54,6 +54,8 @@ func TestSquashCommand(t *testing.T) {
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-auth", ""))
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-db")
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-db", sql))
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-db")
+		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-db", sql))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1370

## What is the current behavior?

Migration files often contain data insert / delete statements. Squashing only dumps the schema.

## What is the new behavior?

Also dumps data.

TODO:
- [ ] probably also need to decrypt columns

## Additional context

Add any other context or screenshots.
