### PR TITLE
fix: pg-meta returning duplicate columns

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -30,7 +30,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v11.1.0"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
-	PgmetaImage      = "supabase/postgres-meta:v0.66.3"
+	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:v0.23.06"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.8.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a column has multiple check constraints, pg-meta returns duplicate entries on `GET /columns` and generated types.

## What is the new behavior?

Fix the bug

## Additional context

Fixes https://github.com/supabase/postgres-meta/issues/590
