### PR TITLE
fix: bump studio image version to 20230803

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,7 +31,7 @@ const (
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.66.3"
-	StudioImage      = "supabase/studio:v0.23.06"
+	StudioImage      = "supabase/studio:20230803-15c6762"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.8.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Updates studio image to match self-hosted.

## Additional context

Add any other context or screenshots.
