### PR TITLE
fix(db): confirm before resetting remote database

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -49,6 +49,9 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		}
 	}
 	if len(config.Password) > 0 {
+		if shouldReset := utils.PromptYesNo("Confirm resetting the remote database?", false, os.Stdin); !shouldReset {
+			return context.Canceled
+		}
 		return resetRemote(ctx, version, config, fsys, options...)
 	}
 

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -24,13 +24,13 @@ import (
 )
 
 func TestResetCommand(t *testing.T) {
-	t.Run("throws error on connect failure", func(t *testing.T) {
+	t.Run("throws error on context canceled", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
 		err := Run(context.Background(), "", pgconn.Config{Password: "postgres"}, fsys)
 		// Check error
-		assert.ErrorContains(t, err, "invalid port (outside range)")
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("throws error on missing config", func(t *testing.T) {

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -37,7 +37,7 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		return err
 	}
 	// 2. Update migration history
-	if len(config.Host) == 0 {
+	if len(config.Host) == 0 || !utils.PromptYesNo("Update remote migration history table?", true, os.Stdin) {
 		return nil
 	}
 	return baselineMigrations(ctx, config, version, fsys, options...)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1326

## What is the current behavior?

Some commands are missing confirmation when updating remote.

## What is the new behavior?

In general, we should prompt for confirmation before updating remote database. The exception is when the command name is explicit, for eg. db push.

## Additional context

Add any other context or screenshots.
