### PR TITLE
fix: update edge runtime to 1.11.1

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:20230803-15c6762"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.8.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.11.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1"
 	// Update initial schemas in internal/utils/templates/initial_schemas when


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates the edge runtime to 1.11.1 image.

Notable changes:
* Uses Deno 1.36
* Experimental support for Node built-ins 
* Enabled `Deno.stdout` or `Deno.isatty`
