### PR TITLE
Print stopped services only for pretty output

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -70,10 +70,10 @@ func Run(ctx context.Context, names CustomName, format string, fsys afero.Fs) er
 		utils.LogflareId,
 	}
 	stopped := checkServiceHealth(ctx, services, os.Stderr)
-	if len(stopped) > 0 {
-		fmt.Fprintln(os.Stderr, "Stopped services:", stopped)
-	}
 	if format == utils.OutputPretty {
+		if len(stopped) > 0 {
+			fmt.Fprintln(os.Stderr, "Stopped services:", stopped)
+		}
 		fmt.Fprintf(os.Stderr, "%s local development setup is running.\n\n", utils.Aqua("supabase"))
 		PrettyPrint(os.Stdout, stopped...)
 		return nil


### PR DESCRIPTION
Presumably, using the `-o env | json` option for the `status` command is to allow the connection parameters to be machine readable/parsable.  However, the line listing the stopped services breaks this functionality.  This PR changes the status command so that line is only printed on the pretty print (i.e. human readable) format.