### PR TITLE
fix: include only valid function slugs in deploy all

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -27,6 +27,12 @@ func Run(ctx context.Context, slugs []string, projectRef string, noVerifyJWT *bo
 			return err
 		}
 		slugs = allSlugs
+	} else {
+		for _, slug := range slugs {
+			if err := utils.ValidateFunctionSlug(slug); err != nil {
+				return err
+			}
+		}
 	}
 	if len(slugs) == 0 {
 		return errors.New("No Functions specified or found in " + utils.Bold(utils.FunctionsDir))
@@ -111,11 +117,7 @@ func deployFunction(ctx context.Context, projectRef, slug, entrypointUrl, import
 }
 
 func deployOne(ctx context.Context, slug, projectRef, importMapPath, buildScriptPath string, noVerifyJWT *bool, fsys afero.Fs) error {
-	// 1. Sanity checks.
-	if err := utils.ValidateFunctionSlug(slug); err != nil {
-		return err
-	}
-	// Ensure noVerifyJWT is not nil.
+	// 1. Ensure noVerifyJWT is not nil.
 	if noVerifyJWT == nil {
 		x := false
 		if functionConfig, ok := utils.Config.Functions[slug]; ok && !*functionConfig.VerifyJWT {

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -43,7 +43,9 @@ func getFunctionSlugs(fsys afero.Fs) ([]string, error) {
 	var slugs []string
 	for _, path := range paths {
 		slug := filepath.Base(filepath.Dir(path))
-		slugs = append(slugs, slug)
+		if utils.FuncSlugPattern.MatchString(slug) {
+			slugs = append(slugs, slug)
+		}
 	}
 	return slugs, nil
 }

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -106,18 +106,6 @@ func TestDeployOne(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
-	t.Run("throws error on malformed slug", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
-		// Run test
-		noVerifyJWT := true
-		err := deployOne(context.Background(), "@", project, "", "", &noVerifyJWT, fsys)
-		// Check error
-		assert.ErrorContains(t, err, "Invalid Function name.")
-	})
-
 	t.Run("throws error on missing import map", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -288,6 +276,15 @@ func TestDeployCommand(t *testing.T) {
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on malformed slug", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		err := Run(context.Background(), []string{"_invalid"}, "", nil, "", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Invalid Function name.")
 	})
 
 	t.Run("throws error on empty functions", func(t *testing.T) {

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -262,6 +262,8 @@ func TestDeployCommand(t *testing.T) {
 		// Setup function entrypoint
 		entrypointPath := filepath.Join(utils.FunctionsDir, slug, "index.ts")
 		require.NoError(t, afero.WriteFile(fsys, entrypointPath, []byte{}, 0644))
+		ignorePath := filepath.Join(utils.FunctionsDir, "_ignore", "index.ts")
+		require.NoError(t, afero.WriteFile(fsys, ignorePath, []byte{}, 0644))
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/456

## What is the new behavior?

`getFunctionSlugs` should only return valid function slugs. This is so that `deployAll` will skip shared modules.

## Additional context

Add any other context or screenshots.
