### PR TITLE
feat(realtime): support configuring realtime ip version

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -533,7 +533,7 @@ EOF
 	}
 
 	// Start Realtime.
-	if !isContainerExcluded(utils.RealtimeImage, excluded) {
+	if utils.Config.Realtime.Enabled && !isContainerExcluded(utils.RealtimeImage, excluded) {
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
@@ -555,6 +555,7 @@ EOF
 					"ENABLE_TAILSCALE=false",
 					"DNS_NODES=''",
 					"RLIMIT_NOFILE=",
+					"REALTIME_IP_VERSION=" + string(utils.Config.Realtime.IpVersion),
 				},
 				Cmd: []string{
 					"/bin/sh", "-c",

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -77,6 +77,13 @@ const (
 	SessionMode     PoolMode = "session"
 )
 
+type AddressFamily string
+
+const (
+	AddressIPv6 AddressFamily = "IPv6"
+	AddressIPv4 AddressFamily = "IPv4"
+)
+
 var Config = config{
 	Api: api{
 		// Defaults to true for backwards compatibility with existing config.toml
@@ -84,6 +91,10 @@ var Config = config{
 	},
 	Db: db{
 		Password: "postgres",
+	},
+	Realtime: realtime{
+		Enabled:   true,
+		IpVersion: AddressIPv6,
 	},
 	Storage: storage{
 		Enabled: true,
@@ -156,6 +167,7 @@ type (
 		ProjectId string              `toml:"project_id"`
 		Api       api                 `toml:"api"`
 		Db        db                  `toml:"db"`
+		Realtime  realtime            `toml:"realtime"`
 		Studio    studio              `toml:"studio"`
 		Inbucket  inbucket            `toml:"inbucket"`
 		Storage   storage             `toml:"storage"`
@@ -188,6 +200,11 @@ type (
 		PoolMode        PoolMode `toml:"pool_mode"`
 		DefaultPoolSize uint     `toml:"default_pool_size"`
 		MaxClientConn   uint     `toml:"max_client_conn"`
+	}
+
+	realtime struct {
+		Enabled   bool          `toml:"enabled"`
+		IpVersion AddressFamily `toml:"ip_version"`
 	}
 
 	studio struct {
@@ -387,6 +404,13 @@ func LoadConfigFS(fsys afero.Fs) error {
 			allowed := []PoolMode{TransactionMode, SessionMode}
 			if !SliceContains(allowed, Config.Db.Pooler.PoolMode) {
 				return fmt.Errorf("Invalid config for db.pooler.pool_mode. Must be one of: %v", allowed)
+			}
+		}
+		// Validate realtime config
+		if Config.Realtime.Enabled {
+			allowed := []AddressFamily{AddressIPv6, AddressIPv4}
+			if !SliceContains(allowed, Config.Realtime.IpVersion) {
+				return fmt.Errorf("Invalid config for realtime.ip_version. Must be one of: %v", allowed)
 			}
 		}
 		// Validate studio config

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -39,7 +39,7 @@ max_client_conn = 100
 [realtime]
 enabled = true
 # Bind realtime via either IPv4 or IPv6. (default: IPv6)
-ip_version = "IPv6"
+ip_version = "IPv4"
 
 [studio]
 enabled = true

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -31,6 +31,11 @@ pool_mode = "transaction"
 default_pool_size = 20
 max_client_conn = 100
 
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv6)
+ip_version = "IPv6"
+
 [studio]
 enabled = true
 # Port to use for Supabase Studio.

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -26,9 +26,14 @@ major_version = 15
 
 [db.pooler]
 enabled = true
+# Port to use for the local connection pooler.
 port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
 pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
 default_pool_size = 20
+# Maximum number of client connections allowed.
 max_client_conn = 100
 
 [realtime]
@@ -118,5 +123,5 @@ url = "https://login.microsoftonline.com/tenant"
 enabled = false
 port = 54327
 vector_port = 54328
-# Configure one of the supported backends: `postgres`, `bigquery`
+# Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -31,6 +31,11 @@ pool_mode = "transaction"
 default_pool_size = 20
 max_client_conn = 100
 
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv6)
+ip_version = "IPv6"
+
 [studio]
 enabled = true
 # Port to use for Supabase Studio.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -39,7 +39,7 @@ max_client_conn = 100
 [realtime]
 enabled = true
 # Bind realtime via either IPv4 or IPv6. (default: IPv6)
-ip_version = "IPv6"
+# ip_version = "IPv6"
 
 [studio]
 enabled = true

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -26,9 +26,14 @@ major_version = 15
 
 [db.pooler]
 enabled = false
+# Port to use for the local connection pooler.
 port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
 pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
 default_pool_size = 20
+# Maximum number of client connections allowed.
 max_client_conn = 100
 
 [realtime]
@@ -121,5 +126,5 @@ url = ""
 enabled = false
 port = 54327
 vector_port = 54328
-# Configure one of the supported backends: `postgres`, `bigquery`
+# Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1198

## What is the new behavior?

Adds the following config
- `realtime.enabled` allow disabling realtime service
- `realtime.ip_version` allow binding realtime to IPv4

## Additional context

Add any other context or screenshots.
