### PR TITLE
fix: skip volume mounts when running bitbucket pipeline

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -606,6 +606,7 @@ EOF
 
 	// Start Storage.
 	if utils.Config.Storage.Enabled && !isContainerExcluded(utils.StorageImage, excluded) {
+		dockerStoragePath := "/mnt"
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
@@ -618,7 +619,7 @@ EOF
 					fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:%d/%s", dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database),
 					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 					"STORAGE_BACKEND=file",
-					"FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
+					"FILE_STORAGE_BACKEND_PATH=" + dockerStoragePath,
 					"TENANT_ID=stub",
 					// TODO: https://github.com/supabase/storage-api/issues/55
 					"REGION=stub",
@@ -636,7 +637,7 @@ EOF
 			},
 			start.WithSyslogConfig(container.HostConfig{
 				RestartPolicy: container.RestartPolicy{Name: "always"},
-				Binds:         []string{utils.StorageId + ":/var/lib/storage"},
+				Binds:         []string{utils.StorageId + ":" + dockerStoragePath},
 			}),
 			utils.StorageId,
 		); err != nil {

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -265,6 +265,21 @@ func DockerStart(ctx context.Context, config container.Config, hostConfig contai
 			return "", err
 		}
 	}
+	// Skip named volume for BitBucket pipeline
+	bitbucket := os.Getenv("BITBUCKET_CLONE_DIR")
+	if len(bitbucket) > 0 {
+		var binds []string
+		for _, bind := range hostConfig.Binds {
+			spec, err := loader.ParseVolume(bind)
+			if err != nil {
+				return "", err
+			}
+			if spec.Type != string(mount.TypeVolume) {
+				binds = append(binds, bind)
+			}
+		}
+		hostConfig.Binds = binds
+	}
 	// Create container from image
 	resp, err := Docker.ContainerCreate(ctx, &config, &hostConfig, nil, nil, containerName)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1403

## What is the new behavior?

BitBucket pipeline only support bind mount.

Since we don't need to support backing up volumes in CI pipeline, skip named volumes altogether.

## Additional context

Add any other context or screenshots.
