### PR TITLE
chore: note that system tables are not included in table_sizes inspection command

### DIFF
--- a/docs/supabase/inspect/db-total-table-sizes.md
+++ b/docs/supabase/inspect/db-total-table-sizes.md
@@ -1,6 +1,6 @@
 # db-total-table-sizes
 
-This command displays the total size of each table in the database. It is the sum of the values that `pg_table_size()` and `pg_indexes_size()` gives for each table.
+This command displays the total size of each table in the database. It is the sum of the values that `pg_table_size()` and `pg_indexes_size()` gives for each table. System tables inside `pg_catalog` and `information_schema` are not included.
 
 ```
                 NAME               │    SIZE


### PR DESCRIPTION
We didn't document that system tables are excluded from the `supabase inspect db total_table_sizes` command. Some users use this query to check their db size usage and wonder why it doesn't match up.