### PR TITLE
fix: reset prompt defaults to true for CI environments

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -49,7 +49,7 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		}
 	}
 	if len(config.Password) > 0 {
-		if shouldReset := utils.PromptYesNo("Confirm resetting the remote database?", false, os.Stdin); !shouldReset {
+		if shouldReset := utils.PromptYesNo("Confirm resetting the remote database?", true, os.Stdin); !shouldReset {
 			return context.Canceled
 		}
 		return resetRemote(ctx, version, config, fsys, options...)

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -30,7 +30,7 @@ func TestResetCommand(t *testing.T) {
 		// Run test
 		err := Run(context.Background(), "", pgconn.Config{Password: "postgres"}, fsys)
 		// Check error
-		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
 
 	t.Run("throws error on missing config", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/cli/pull/1392

## What is the new behavior?

CI environments do not evaluate to terminal, hence the default value is used without prompting.

This PR allows running `db reset --db-url ...` in CI.

## Additional context

Add any other context or screenshots.
