### PR TITLE
fix: bump edge-runtime to 1.13.1

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:20230803-15c6762"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.11.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.13.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1"
 	// Update initial schemas in internal/utils/templates/initial_schemas when


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Deno.serve support
* fix for missing `globalThis.addEventListener`
