### PR TITLE
feat: add proxy support to npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bin-links": "^4.0.1",
     "node-fetch": "^3.2.10",
+    "proxy-agent": "^6.3.1",
     "tar": "6.1.15"
   },
   "release": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -8,6 +8,7 @@ import binLinks from "bin-links";
 import { createHash } from "crypto";
 import fs from "fs";
 import fetch from "node-fetch";
+import { ProxyAgent } from "proxy-agent";
 import path from "path";
 import tar from "tar";
 import zlib from "zlib";
@@ -71,7 +72,7 @@ const fetchAndParseCheckSumFile = async (packageJson) => {
 
   // Fetch the checksum file
   console.info("Downloading", checksumFileUrl);
-  const response = await fetch(checksumFileUrl);
+  const response = await fetch(checksumFileUrl, {agent: new ProxyAgent()});
   if (response.ok) {
     const checkSumContent = await response.text();
     const lines = checkSumContent.split("\n");

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -124,7 +124,7 @@ async function main() {
   const untar = tar.x({ cwd: binDir }, [binName]);
 
   console.info("Downloading", url);
-  const resp = await fetch(url);
+  const resp = await fetch(url, {agent: new ProxyAgent()});
 
   const hash = createHash("sha256");
   const pkgNameWithPlatform = `${pkg.name}_${platform}_${arch}.tar.gz`;

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -64,7 +64,7 @@ const parsePackageJson = (packageJson) => {
   return { binPath, url };
 };
 
-const fetchAndParseCheckSumFile = async (packageJson) => {
+const fetchAndParseCheckSumFile = async (packageJson, agent) => {
   const version = packageJson.version;
   const pkgName = packageJson.name;
   const repo = packageJson.repository;
@@ -72,7 +72,7 @@ const fetchAndParseCheckSumFile = async (packageJson) => {
 
   // Fetch the checksum file
   console.info("Downloading", checksumFileUrl);
-  const response = await fetch(checksumFileUrl, {agent: new ProxyAgent()});
+  const response = await fetch(checksumFileUrl, { agent });
   if (response.ok) {
     const checkSumContent = await response.text();
     const lines = checkSumContent.split("\n");
@@ -124,11 +124,12 @@ async function main() {
   const untar = tar.x({ cwd: binDir }, [binName]);
 
   console.info("Downloading", url);
-  const resp = await fetch(url, {agent: new ProxyAgent()});
+  const agent = new ProxyAgent();
+  const resp = await fetch(url, { agent });
 
   const hash = createHash("sha256");
   const pkgNameWithPlatform = `${pkg.name}_${platform}_${arch}.tar.gz`;
-  const checksumMap = await fetchAndParseCheckSumFile(pkg);
+  const checksumMap = await fetchAndParseCheckSumFile(pkg, agent);
 
   resp.body
     .on("data", (chunk) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enabled `node-fetch` proxy support by using `proxy-agent`.

## What is the current behavior?

`npm install supabase` fails to run in environments where a proxy is required.

## What is the new behavior?

It works fine under proxy environment.

## Additional context

None.
