### PR TITLE
fix(db): increase db start timeout to 30s

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -62,7 +62,7 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 		return err
 	}
 	defer utils.DockerRemove(shadow)
-	if !reset.WaitForHealthyService(ctx, shadow, healthTimeout) {
+	if !reset.WaitForHealthyService(ctx, shadow, reset.HealthTimeout) {
 		return reset.ErrDatabase
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys); err != nil {

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -25,11 +25,8 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-var (
-	healthTimeout = 20 * time.Second
-	//go:embed templates/migra.sh
-	diffSchemaScript string
-)
+//go:embed templates/migra.sh
+var diffSchemaScript string
 
 func RunMigra(ctx context.Context, schema []string, file string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) (err error) {
 	// Sanity checks.
@@ -181,7 +178,7 @@ func DiffDatabase(ctx context.Context, schema []string, config pgconn.Config, w 
 		return "", err
 	}
 	defer utils.DockerRemove(shadow)
-	if !reset.WaitForHealthyService(ctx, shadow, healthTimeout) {
+	if !reset.WaitForHealthyService(ctx, shadow, reset.HealthTimeout) {
 		return "", reset.ErrDatabase
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys, options...); err != nil {

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -246,7 +246,7 @@ func TestDiffDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on health check failure", func(t *testing.T) {
-		healthTimeout = time.Second
+		reset.HealthTimeout = time.Second
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock docker

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -274,7 +274,7 @@ func TestRestartDatabase(t *testing.T) {
 
 	t.Run("throws error on health check timeout", func(t *testing.T) {
 		utils.DbId = "test-reset"
-		healthTimeout = 0 * time.Second
+		HealthTimeout = 0 * time.Second
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -106,7 +106,7 @@ func StartDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 	if _, err := utils.DockerStart(ctx, config, hostConfig, utils.DbId); err != nil {
 		return err
 	}
-	if !reset.WaitForHealthyService(ctx, utils.DbId, 20*time.Second) {
+	if !reset.WaitForHealthyService(ctx, utils.DbId, reset.HealthTimeout) {
 		return reset.ErrDatabase
 	}
 	// Initialise if we are on PG14 and there's no existing db volume


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes https://github.com/supabase/cli/issues/1415
fixes https://github.com/supabase/cli/issues/1447

## What is the new behavior?

Use the same db health check timeout of 30 seconds everywhere.

## Additional context

Add any other context or screenshots.
