### PR TITLE
fix: remove extra period on migration creation

### DIFF
--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -30,7 +30,7 @@ func Run(migrationName string, stdin afero.File, fsys afero.Fs) error {
 		}
 	}
 
-	fmt.Println("Created new migration at " + utils.Bold(path) + ".")
+	fmt.Println("Created new migration at " + utils.Bold(path))
 	return nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove an extra period on new migrations that negatively affects usability in CLI. For example, double clicking will copy an invalid file path, since it has a trailing period.

## What is the current behavior?

Period is printed.

## What is the new behavior?

Period is removed.

## Additional context

N/A
