### PR TITLE
fix: reduce idle cpu usage with longer health check interval

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -34,7 +34,7 @@ const (
 var (
 	ErrUnhealthy  = errors.New("service not healthy")
 	ErrDatabase   = errors.New("database is not healthy")
-	HealthTimeout = 30 * time.Second
+	HealthTimeout = 40 * time.Second
 	//go:embed templates/drop.sql
 	dropObjects string
 )

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -60,9 +60,9 @@ func NewContainerConfig() container.Config {
 		},
 		Healthcheck: &container.HealthConfig{
 			Test:     []string{"CMD", "pg_isready", "-U", "postgres", "-h", "localhost", "-p", "5432"},
-			Interval: 2 * time.Second,
+			Interval: 10 * time.Second,
 			Timeout:  2 * time.Second,
-			Retries:  10,
+			Retries:  3,
 		},
 		Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /etc/postgresql.schema.sql && docker-entrypoint.sh postgres -D /etc/postgresql
 ` + initialSchema + `

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -170,9 +170,9 @@ EOF
 						"--tries=1",
 						"--spider",
 						"http://localhost:9001/health"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 				ExposedPorts: nat.PortSet{"9000/tcp": {}},
 			},
@@ -254,9 +254,9 @@ EOF
 `},
 				Healthcheck: &container.HealthConfig{
 					Test:        []string{"CMD", "curl", "-sSfL", "--head", "-o", "/dev/null", "http://localhost:4000/health"},
-					Interval:    2 * time.Second,
+					Interval:    10 * time.Second,
 					Timeout:     2 * time.Second,
-					Retries:     10,
+					Retries:     3,
 					StartPeriod: 10 * time.Second,
 				},
 				ExposedPorts: nat.PortSet{"4000/tcp": {}},
@@ -495,9 +495,9 @@ EOF
 				ExposedPorts: nat.PortSet{"9999/tcp": {}},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9999/health"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			start.WithSyslogConfig(container.HostConfig{
@@ -573,9 +573,9 @@ EOF
 				ExposedPorts: nat.PortSet{"4000/tcp": {}},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/4000"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			start.WithSyslogConfig(container.HostConfig{
@@ -640,9 +640,9 @@ EOF
 				Healthcheck: &container.HealthConfig{
 					// For some reason, localhost resolves to IPv6 address on GitPod which breaks healthcheck.
 					Test:     []string{"CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:5000/status"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			start.WithSyslogConfig(container.HostConfig{
@@ -669,9 +669,9 @@ EOF
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "imgproxy", "health"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			container.HostConfig{
@@ -710,9 +710,9 @@ EOF
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "node", "-e", "require('http').get('http://localhost:8080/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			container.HostConfig{
@@ -746,9 +746,9 @@ EOF
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "node", "-e", "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			container.HostConfig{
@@ -782,9 +782,9 @@ EOF
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/6432"},
-					Interval: 2 * time.Second,
+					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
-					Retries:  10,
+					Retries:  3,
 				},
 			},
 			container.HostConfig{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1415#issuecomment-1707025589
fixes https://github.com/supabase/cli/issues/1367

## What is the new behavior?

- increases database health timeout to accommodate more machine types
- reduces idle cpu usage by increasing health check interval from 2s => 10s 

## Additional context

Add any other context or screenshots.
