### PR TITLE
Bump offline studio version from prod deploy on 120923

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,7 +31,7 @@ const (
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
-	StudioImage      = "supabase/studio:20230905-f8c8a8e"
+	StudioImage      = "supabase/studio:20230912-748fd33"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.16.0"
 	VectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
Based on latest build from https://hub.docker.com/r/supabase/studio/tags