### PR TITLE
feat: add services command for listing service versions

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -171,7 +171,7 @@ var (
 		Use:   "reset",
 		Short: "Resets the local database to current migrations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return reset.Run(cmd.Context(), version, flags.DbConfig, afero.NewOsFs())
+			return reset.Run(cmd.Context(), migrationVersion, flags.DbConfig, afero.NewOsFs())
 		},
 	}
 
@@ -284,7 +284,7 @@ func init() {
 	resetFlags.Bool("linked", false, "Resets the linked project to current migrations.")
 	resetFlags.Bool("local", true, "Resets the local database to current migrations.")
 	dbResetCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
-	resetFlags.StringVar(&version, "version", "", "Reset up to the specified version.")
+	resetFlags.StringVar(&migrationVersion, "version", "", "Reset up to the specified version.")
 	dbCmd.AddCommand(dbResetCmd)
 	// Build lint command
 	lintFlags := dbLintCmd.Flags()

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -61,13 +61,13 @@ var (
 		},
 	}
 
-	version string
+	migrationVersion string
 
 	migrationSquashCmd = &cobra.Command{
 		Use:   "squash",
 		Short: "Squash migrations to a single file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return squash.Run(cmd.Context(), version, flags.DbConfig, afero.NewOsFs())
+			return squash.Run(cmd.Context(), migrationVersion, flags.DbConfig, afero.NewOsFs())
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Finished " + utils.Aqua("supabase migration squash") + ".")
@@ -111,7 +111,7 @@ func init() {
 	migrationCmd.AddCommand(migrationRepairCmd)
 	// Build squash command
 	squashFlags := migrationSquashCmd.Flags()
-	squashFlags.StringVar(&version, "version", "", "Squash up to the specified version.")
+	squashFlags.StringVar(&migrationVersion, "version", "", "Squash up to the specified version.")
 	squashFlags.String("db-url", "", "Squashes migrations of the database specified by the connection string (must be percent-encoded).")
 	squashFlags.Bool("linked", false, "Squashes the migration history of the linked project.")
 	squashFlags.Bool("local", true, "Squashes the migration history of the local database.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 const (
 	groupLocalDev      = "local-dev"
 	groupManagementAPI = "management-api"
+	suggestDebugFlag   = "Try rerunning the command with --debug to troubleshoot the error."
 )
 
 func IsManagementAPI(cmd *cobra.Command) bool {
@@ -89,7 +90,7 @@ var (
 				cmd.SetContext(utils.WithTraceContext(ctx))
 				fmt.Fprintln(os.Stderr, cmd.Root().Short)
 			} else {
-				utils.CmdSuggestion = "Try rerunning the command with --debug to troubleshoot the error."
+				utils.CmdSuggestion = suggestDebugFlag
 			}
 			return nil
 		},
@@ -104,6 +105,9 @@ func Execute() {
 			fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
 		}
 		os.Exit(1)
+	}
+	if utils.CmdSuggestion != suggestDebugFlag {
+		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
 	}
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -3,20 +3,20 @@ package cmd
 import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/supabase/cli/internal/version"
+	"github.com/supabase/cli/internal/services"
 )
 
 var (
-	versionCmd = &cobra.Command{
+	servicesCmd = &cobra.Command{
 		GroupID: groupManagementAPI,
-		Use:     "version",
+		Use:     "services",
 		Short:   "Show versions of all Supabase services",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return version.Run(cmd.Context(), afero.NewOsFs())
+			return services.Run(cmd.Context(), afero.NewOsFs())
 		},
 	}
 )
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(servicesCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/version"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		GroupID: groupManagementAPI,
+		Use:     "version",
+		Short:   "Show versions of all Supabase services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return version.Run(cmd.Context(), afero.NewOsFs())
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -30,8 +30,8 @@ type ConfigCopy struct {
 	Pooler interface{} `toml:"db.pooler"`
 }
 
-func (c ConfigCopy) IsChanged() bool {
-	return c.Api != nil || c.Db != nil || c.Pooler != nil
+func (c ConfigCopy) IsEmpty() bool {
+	return c.Api == nil && c.Db == nil && c.Pooler == nil
 }
 
 func PreRun(projectRef string, fsys afero.Fs) error {
@@ -75,7 +75,7 @@ func Run(ctx context.Context, projectRef, password string, fsys afero.Fs, option
 
 func PostRun(projectRef string, stdout io.Writer, fsys afero.Fs) error {
 	fmt.Fprintln(stdout, "Finished "+utils.Aqua("supabase link")+".")
-	if !updatedConfig.IsChanged() {
+	if updatedConfig.IsEmpty() {
 		return nil
 	}
 	fmt.Fprintln(os.Stderr, "Local config differs from linked project. Try updating", utils.Bold(utils.ConfigPath))

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -145,7 +145,7 @@ func TestLinkCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
-			JSON([]api.ApiKeyResponse{{ApiKey: "anon-key"}})
+			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		rest := tenant.SwaggerResponse{Info: tenant.SwaggerInfo{Version: "11.1.0"}}
 		gock.New(fmt.Sprintf("https://%s.supabase.co", project)).
 			Get("/rest/v1/").
@@ -197,7 +197,7 @@ func TestLinkCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
-			JSON([]api.ApiKeyResponse{{ApiKey: "anon-key"}})
+			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		// Link configs
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/postgrest").
@@ -232,7 +232,7 @@ func TestLinkCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
-			JSON([]api.ApiKeyResponse{{ApiKey: "anon-key"}})
+			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		// Link configs
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/postgrest").

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,4 +1,4 @@
-package version
+package services
 
 import (
 	"context"

--- a/internal/utils/tenant/client_test.go
+++ b/internal/utils/tenant/client_test.go
@@ -1,0 +1,48 @@
+package tenant
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestGetJSON(t *testing.T) {
+	t.Run("throws error on invalid url", func(t *testing.T) {
+		// Run test
+		data, err := GetJsonResponse[string](context.Background(), "http://h:p", "")
+		// Check error
+		assert.ErrorContains(t, err, "invalid port")
+		assert.Empty(t, data)
+	})
+
+	t.Run("throws error on server unavailable", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		data, err := GetJsonResponse[string](context.Background(), utils.DefaultApiHost, "")
+		// Check error
+		assert.ErrorContains(t, err, "Error status 503")
+		assert.Empty(t, data)
+	})
+
+	t.Run("throws error on malformed json", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/").
+			Reply(http.StatusOK).
+			JSON("malformed")
+		// Run test
+		data, err := GetJsonResponse[string](context.Background(), utils.DefaultApiHost, "")
+		// Check error
+		assert.ErrorContains(t, err, "invalid character")
+		assert.Empty(t, data)
+	})
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,10 @@ import (
 	"github.com/supabase/cli/internal/utils/tenant"
 )
 
-var errDatabaseVersion = errors.New("Database version not found.")
+var (
+	errDatabaseVersion = errors.New("Database version not found.")
+	suggestLinkCommand = fmt.Sprintf("Run %s to sync your local image versions with the linked project.", utils.Aqua("supabase link"))
+)
 
 func Run(ctx context.Context, fsys afero.Fs) error {
 	_ = utils.LoadConfigFS(fsys)
@@ -64,6 +67,8 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		version, ok := linked[image]
 		if !ok {
 			version = "-"
+		} else if parts[1] != version && image != utils.Config.Db.Image {
+			utils.CmdSuggestion = suggestLinkCommand
 		}
 		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", parts[0], parts[1], version)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,88 @@
+package version
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/tenant"
+)
+
+var errDatabaseVersion = errors.New("Database version not found.")
+
+func Run(ctx context.Context, fsys afero.Fs) error {
+	_ = utils.LoadConfigFS(fsys)
+	serviceImages := []string{
+		utils.Config.Db.Image,
+		utils.Config.Auth.Image,
+		utils.Config.Api.Image,
+		utils.RealtimeImage,
+		utils.StorageImage,
+		utils.EdgeRuntimeImage,
+		utils.StudioImage,
+		utils.PgmetaImage,
+		utils.LogflareImage,
+		utils.PgbouncerImage,
+		utils.ImageProxyImage,
+	}
+
+	linked := make(map[string]string)
+	if projectRef, err := utils.LoadProjectRef(fsys); err == nil {
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			if version, err := GetDatabaseVersion(ctx, projectRef); err == nil {
+				linked[utils.Config.Db.Image] = version
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if version, err := tenant.GetGotrueVersion(ctx, projectRef); err == nil {
+				linked[utils.Config.Auth.Image] = version
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if version, err := tenant.GetPostgrestVersion(ctx, projectRef); err == nil {
+				linked[utils.Config.Api.Image] = version
+			}
+		}()
+		wg.Wait()
+	}
+
+	table := `|SERVICE IMAGE|LOCAL|LINKED|
+|-|-|-|
+`
+	for _, image := range serviceImages {
+		parts := strings.Split(image, ":")
+		version, ok := linked[image]
+		if !ok {
+			version = "-"
+		}
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", parts[0], parts[1], version)
+	}
+
+	return list.RenderTable(table)
+}
+
+func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) {
+	resp, err := utils.GetSupabase().GetProjectsWithResponse(ctx)
+	if err != nil {
+		return "", err
+	}
+	if resp.JSON200 == nil {
+		return "", errors.New("Unexpected error retrieving projects: " + string(resp.Body))
+	}
+	for _, project := range *resp.JSON200 {
+		if project.Id == projectRef && len(project.Database.Version) > 0 {
+			return project.Database.Version, nil
+		}
+	}
+	return "", errDatabaseVersion
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1230

## What is the new behavior?

```bash
$ supabase services


        SERVICE IMAGE      │      LOCAL       │   LINKED
  ─────────────────────────┼──────────────────┼─────────────
    supabase/postgres      │ 15.1.0.103       │ 15.1.0.103
    supabase/gotrue        │ v2.92.1          │ v2.92.1
    postgrest/postgrest    │ v11.1.0          │ v11.1.0
    supabase/realtime      │ v2.10.1          │ -
    supabase/storage-api   │ v0.40.4          │ -
    supabase/edge-runtime  │ v1.16.0          │ -
    supabase/studio        │ 20230912-748fd33 │ -
    supabase/postgres-meta │ v0.68.0          │ -
    supabase/logflare      │ 1.4.0            │ -
    bitnami/pgbouncer      │ 1.20.1           │ -
    darthsim/imgproxy      │ v3.8.0           │ -
```

## Additional context

Add any other context or screenshots.
