### PR TITLE
fix(db): drop non-default extensions when resetting remote

### DIFF
--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -1,6 +1,15 @@
 do $$ declare
   rec record;
 begin
+  -- extensions
+  for rec in
+    select *
+    from pg_extension p
+    where p.extname not in ('pg_graphql', 'pg_net', 'pg_stat_statements', 'pgcrypto', 'pgjwt', 'pgsodium', 'plpgsql', 'supabase_vault', 'uuid-ossp')
+  loop
+    execute format('drop extension if exists %I cascade', rec.extname);
+  end loop;
+
   -- functions
   for rec in
     select *
@@ -11,17 +20,28 @@ begin
     execute format('drop routine if exists %I.%I(%s) cascade', rec.pronamespace::regnamespace::name, rec.proname, pg_catalog.pg_get_function_identity_arguments(rec.oid));
   end loop;
 
-  -- in order: tables (cascade to views), sequences
+  -- tables (cascade to views)
   for rec in
     select *
     from pg_class c
     where
       c.relnamespace::regnamespace::name = 'public'
-      and c.relkind not in ('c', 'v', 'm')
+      and c.relkind not in ('c', 'S', 'v', 'm')
     order by c.relkind desc
   loop
-    -- supports all kinds of relations, except views and complex types
+    -- supports all table like relations, except views, complex types, and sequences
     execute format('drop table if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
+  end loop;
+
+  -- sequences
+  for rec in
+    select *
+    from pg_class c
+    where
+      c.relnamespace::regnamespace::name = 'public'
+      and c.relkind = 's'
+  loop
+    execute format('drop sequence if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
   end loop;
 
   -- types


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1470

## What is the new behavior?

When resetting linked project
- drops non-default extensions first
- drops sequences after tables

## Additional context

Add any other context or screenshots.
