### PR TITLE
fix: update functions template to remove deprecated serve

### DIFF
--- a/internal/functions/new/templates/index.ts
+++ b/internal/functions/new/templates/index.ts
@@ -2,11 +2,9 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-
 console.log("Hello from Functions!")
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const { name } = await req.json()
   const data = {
     message: `Hello ${name}!`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

update template of new function as `serve` from `http/server.ts` is deprecated.

![image](https://github.com/supabase/cli/assets/5452613/ab3878f0-6ebd-4e6e-96b6-5b54981e7d29)

## What is the current behavior?
`import { serve } from "https://deno.land/std@0.201.0/http/server.ts";` is being used to serve 

## What is the new behavior?

`Deno.serve()` will be used for functions as it's what recommended from Deno

