### PR TITLE
fix: disable keyring on wsl

### DIFF
--- a/internal/utils/credentials/store.go
+++ b/internal/utils/credentials/store.go
@@ -1,6 +1,10 @@
 package credentials
 
 import (
+	"bytes"
+	"errors"
+	"os"
+
 	"github.com/zalando/go-keyring"
 )
 
@@ -8,15 +12,32 @@ const namespace = "Supabase CLI"
 
 // Retrieves the stored password of a project and username
 func Get(project string) (string, error) {
+	if err := assertKeyringSupported(); err != nil {
+		return "", err
+	}
 	return keyring.Get(namespace, project)
 }
 
 // Stores the password of a project and username
 func Set(project, password string) error {
+	if err := assertKeyringSupported(); err != nil {
+		return err
+	}
 	return keyring.Set(namespace, project, password)
 }
 
 // Erases the stored password of a project and username
 func Delete(project string) error {
+	if err := assertKeyringSupported(); err != nil {
+		return err
+	}
 	return keyring.Delete(namespace, project)
+}
+
+func assertKeyringSupported() error {
+	// Suggested check: https://github.com/microsoft/WSL/issues/423
+	if f, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil && bytes.Contains(f, []byte("WSL")) {
+		return errors.New("Keyring is not supported on WSL")
+	}
+	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes https://github.com/supabase/cli/issues/1506
fixes https://github.com/supabase/cli/issues/1483
fixes https://github.com/supabase/cli/issues/899

## What is the new behavior?

This means that db password won't be saved. Access token will be written to a file.

## Additional context

Add any other context or screenshots.
