### PR TITLE
fix(db): bump PG15 to 15.1.0.117

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -23,7 +23,7 @@ var Version string
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.89"
-	Pg15Image = "supabase/postgres:15.1.0.103"
+	Pg15Image = "supabase/postgres:15.1.0.118"
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -23,7 +23,7 @@ var Version string
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
 	Pg14Image = "supabase/postgres:14.1.0.89"
-	Pg15Image = "supabase/postgres:15.1.0.118"
+	Pg15Image = "supabase/postgres:15.1.0.117"
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"


### PR DESCRIPTION
Bump PG15 image to [latest](https://github.com/supabase/postgres/releases) v15.1.0.117.

Required to use pgvector v0.5.0 locally.