### PR TITLE
feat: sync database version with remote pg15 project

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -400,6 +400,10 @@ func LoadConfigFS(fsys afero.Fs) error {
 			Config.Db.Image = Pg14Image
 			InitialSchemaSql = InitialSchemaPg14Sql
 		case 15:
+			if version, err := afero.ReadFile(fsys, PostgresVersionPath); err == nil && len(version) > 0 {
+				index := strings.IndexByte(Pg15Image, ':')
+				Config.Db.Image = Pg15Image[:index+1] + string(version)
+			}
 		default:
 			return fmt.Errorf("Failed reading config: Invalid %s: %v.", Aqua("db.major_version"), Config.Db.MajorVersion)
 		}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -166,6 +166,7 @@ var (
 	ImportMapsDir         = filepath.Join(SupabaseDirPath, TempDir, "import_maps")
 	ProjectRefPath        = filepath.Join(SupabaseDirPath, TempDir, "project-ref")
 	RemoteDbPath          = filepath.Join(SupabaseDirPath, TempDir, "remote-db-url")
+	PostgresVersionPath   = filepath.Join(SupabaseDirPath, TempDir, "postgres-version")
 	GotrueVersionPath     = filepath.Join(SupabaseDirPath, TempDir, "gotrue-version")
 	RestVersionPath       = filepath.Join(SupabaseDirPath, TempDir, "rest-version")
 	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")

--- a/internal/utils/tenant/client.go
+++ b/internal/utils/tenant/client.go
@@ -16,7 +16,7 @@ var (
 	apiKey  ApiKey
 	keyOnce sync.Once
 
-	errAuthToken  = errors.New("Authorization failed for the access token and project ref pair")
+	ErrAuthToken  = errors.New("Authorization failed for the access token and project ref pair")
 	errMissingKey = errors.New("Anon key not found.")
 )
 
@@ -38,7 +38,7 @@ func GetApiKeys(ctx context.Context, projectRef string) (ApiKey, error) {
 			return
 		}
 		if resp.JSON200 == nil {
-			errKey = fmt.Errorf("%w: %s", errAuthToken, string(resp.Body))
+			errKey = fmt.Errorf("%w: %s", ErrAuthToken, string(resp.Body))
 			return
 		}
 		for _, key := range *resp.JSON200 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/491

## What is the new behavior?

Now that initial schema is removed, it is possible to use arbitrary pg15 image for local development. This PR links remote database image version to match local dev.

## Additional context

Add any other context or screenshots.
