### PR TITLE
fix: include more schemas in data only dump

### DIFF
--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -64,7 +64,25 @@ func DumpSchema(ctx context.Context, config pgconn.Config, schema []string, keep
 
 func dumpData(ctx context.Context, config pgconn.Config, schema []string, useCopy, dryRun bool, stdout io.Writer) error {
 	// We want to dump user data in auth, storage, etc. for migrating to new project
-	excludedSchemas := append([]string{
+	excludedSchemas := []string{
+		"information_schema",
+		"pg_*", // Wildcard pattern follows pg_dump
+		// Owned by extensions
+		// "cron",
+		"graphql",
+		"graphql_public",
+		// "net",
+		// "pgsodium",
+		// "pgsodium_masks",
+		"pgtle",
+		"repack",
+		"tiger",
+		"tiger_data",
+		"timescaledb_*",
+		"_timescaledb_*",
+		"topology",
+		// "vault",
+		// Managed by Supabase
 		// "auth",
 		"extensions",
 		"pgbouncer",
@@ -74,7 +92,7 @@ func dumpData(ctx context.Context, config pgconn.Config, schema []string, useCop
 		"_analytics",
 		// "supabase_functions",
 		"supabase_migrations",
-	}, utils.SystemSchemas...)
+	}
 	env := []string{"EXCLUDED_SCHEMAS=" + strings.Join(excludedSchemas, "|")}
 	if len(schema) > 0 {
 		env[0] = "INCLUDED_SCHEMAS=" + strings.Join(schema, "|")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

We should include user data from extension managed schemas. This is useful for migrating to new supabase project.
- `pgsodium` and `vault` for encrypted columns and values
- `net` for http request queue and history
- `cron` for cron jobs and run history
- `supabase_functions` for webhooks invocation history

Support for `postgins_tiger_geocoder` and `timescaledb` are still experimental. Users can try it by dumping them separately via `supabase db dump --schema tiger_data` flag.

## Additional context

Add any other context or screenshots.
