### PR TITLE
Return same error responses as production for Edge Functions

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:20230921-d657f29"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.20.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.20.2"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	GotrueImage      = "supabase/gotrue:v2.92.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates Edge Runtime dependency to 1.20.2. Also, updates the Edge Function error responses to return same status codes & messages as production.

## What is the current behavior?

Currently if a function experience a boot error or runs into a resource limit it returns a generic 500 error response. This differs from production, which returns specific error responses (eg: 546 status code for resource limit errors)

## What is the new behavior?

New behavior brings local dev in parity with production by returning the same error statuses and messages.

