### PR TITLE
fix: adds .env to initial .gitignore file

### DIFF
--- a/internal/init/templates/.gitignore
+++ b/internal/init/templates/.gitignore
@@ -1,3 +1,4 @@
 # Supabase
 .branches
 .temp
+.env


### PR DESCRIPTION
## What kind of change does this PR introduce?

We recommend to use `.env` file to manage Edge Functions secrets in our [guide](https://supabase.com/docs/guides/functions/secrets#production-secrets), so thought it would make sense to add it to the default .gitignore file. 