### PR TITLE
Disable forceCreate for functions serve

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -126,7 +126,7 @@ serve(async (req: Request) => {
     .filter(([name, _]) =>
       !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_")
     );
-  const forceCreate = true;
+  const forceCreate = false;
   const customModuleRoot = ""; // empty string to allow any local path
   const cpuTimeThresholdMs = 50;
   const cpuBurstIntervalMs = 100;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This reverts a change that causes a new worker to be created for every request. This causes the edge-runtime Docker container to be killed with a relatively low number of concurrent requests because worker processes aren't cleaned up after the request (only after a few minutes are they actually cleaned up).

Running a local load test on `supabase functions serve` with a tool like `autocannon` shows the following results:

```
autocannon -c 20 -d 60 localhost:54321/functions/v1/test
```

## What is the current behavior?


### `forceCreate: true` (crashed after only 20% of test)

```
Running 60s test @ http://localhost:54321/functions/v1/api/lol
20 connections


┌─────────┬──────┬──────┬─────────┬─────────┬───────────┬───────────┬─────────┐
│ Stat    │ 2.5% │ 50%  │ 97.5%   │ 99%     │ Avg       │ Stdev     │ Max     │
├─────────┼──────┼──────┼─────────┼─────────┼───────────┼───────────┼─────────┤
│ Latency │ 3 ms │ 6 ms │ 1345 ms │ 1426 ms │ 423.81 ms │ 469.83 ms │ 1517 ms │
└─────────┴──────┴──────┴─────────┴─────────┴───────────┴───────────┴─────────┘
┌───────────┬─────┬──────┬─────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%  │ 2.5% │ 50% │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────┼──────┼─────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 0   │ 0    │ 0   │ 36      │ 13.9    │ 58.74   │ 13      │
├───────────┼─────┼──────┼─────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 0 B │ 0 B  │ 0 B │ 9.35 kB │ 3.75 kB │ 16.3 kB │ 3.37 kB │
└───────────┴─────┴──────┴─────┴─────────┴─────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 60

376 2xx responses, 458 non 2xx responses
934 requests in 60.09s, 225 kB read
80 errors (80 timeouts)
```

Very low throughput, runtime crashes, and requests timeout

## What is the new behavior?


```
Running 60s test @ http://localhost:54321/functions/v1/api/lol
20 connections


┌─────────┬───────┬────────┬────────┬─────────┬───────────┬───────────┬─────────┐
│ Stat    │ 2.5%  │ 50%    │ 97.5%  │ 99%     │ Avg       │ Stdev     │ Max     │
├─────────┼───────┼────────┼────────┼─────────┼───────────┼───────────┼─────────┤
│ Latency │ 14 ms │ 284 ms │ 828 ms │ 1132 ms │ 298.22 ms │ 206.32 ms │ 1328 ms │
└─────────┴───────┴────────┴────────┴─────────┴───────────┴───────────┴─────────┘
┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼────────┤
│ Req/Sec   │ 456    │ 1018   │ 4107    │ 4791    │ 3843.55 │ 919.6  │ 456    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼────────┤
│ Bytes/Sec │ 122 kB │ 266 kB │ 1.07 MB │ 1.25 MB │ 998 kB  │ 238 kB │ 122 kB │
└───────────┴────────┴────────┴─────────┴─────────┴─────────┴────────┴────────┘

Req/Bytes counts sampled once per second.
# of samples: 60

230462 2xx responses, 117 non 2xx responses
233k requests in 60.03s, 59.9 MB read
```

Fast, very few timeouts

## Additional Context

@laktek as the original author, do you know of a reason for keeping this option set?
