### PR TITLE
feat: allow network to be defined

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -185,6 +185,7 @@ var Config = config{
 type (
 	config struct {
 		ProjectId string              `toml:"project_id"`
+		Network   string              `toml:"network"`
 		Api       api                 `toml:"api"`
 		Db        db                  `toml:"db" mapstructure:"db"`
 		Realtime  realtime            `toml:"realtime"`
@@ -395,6 +396,9 @@ func LoadConfigFS(fsys afero.Fs) error {
 			LogflareId = GetId(LogflareAliases[0])
 			VectorId = GetId(VectorAliases[0])
 			PoolerId = GetId(PoolerAliases[0])
+		}
+		if Config.Network != "" {
+			NetId = Config.Network
 		}
 		// Validate api config
 		if Config.Api.Port == 0 {

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -28,6 +28,9 @@ func TestConfigParsing(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		assert.NoError(t, WriteConfig(fsys, false))
 		assert.NoError(t, LoadConfigFS(fsys))
+
+		// Test default network
+		assert.Equal(t, "supabase_network_utils", NetId)
 	})
 
 	t.Run("config file with environment variables", func(t *testing.T) {
@@ -45,6 +48,9 @@ func TestConfigParsing(t *testing.T) {
 		// Check error
 		assert.Equal(t, "hello", Config.Auth.External["azure"].ClientId)
 		assert.Equal(t, "this is cool", Config.Auth.External["azure"].Secret)
+		// Check for overridden network
+		assert.Equal(t, "supabase-test-network", Config.Network)
+		assert.Equal(t, "supabase-test-network", NetId)
 	})
 
 	t.Run("config file with environment variables fails when unset", func(t *testing.T) {

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -1,6 +1,8 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "{{ .ProjectId }}"
+# Uncomment to use a custom docker network
+network = "supabase-test-network"
 
 [api]
 enabled = true

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -1,6 +1,8 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "{{ .ProjectId }}"
+# Uncomment to use a custom docker network
+# network = "supabase_network_{{ .ProjectId }}"
 
 [api]
 enabled = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Simple change to allow a custom docker network name to be used instead of the default.

## What is the current behavior?

Default and only available network is `supabase_network_project_id` (where `project_id` is that of the current project).

## What is the new behavior?

If the configuration toml defines this at the top-level:

```
network = my-custom-network
```

The network called `my-custom-network` will be used instead of the default.

## Additional context

This is useful for running supabase inside an existing local development network so that other docker images can access supabase resources without going through the host. Given the simple names of supabase services, like `db`, `auth`, `rest` etc. there is a chance of name collisions. #1510 helps reduce complications with longer aliases.
