### PR TITLE
fix: enable cancel context for management apis

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"os/signal"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -79,8 +78,7 @@ var (
 			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return new_.Run(ctx, args[0], afero.NewOsFs())
+			return new_.Run(cmd.Context(), args[0], afero.NewOsFs())
 		},
 	}
 
@@ -94,12 +92,11 @@ var (
 			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			// Fallback to config if user did not set the flag.
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return serve.Run(ctx, envFilePath, noVerifyJWT, importMapPath, afero.NewOsFs())
+			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, afero.NewOsFs())
 		},
 	}
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,11 +87,12 @@ var (
 			}
 			// Prepare context
 			if viper.GetBool("DEBUG") {
-				cmd.SetContext(utils.WithTraceContext(ctx))
+				ctx = utils.WithTraceContext(ctx)
 				fmt.Fprintln(os.Stderr, cmd.Root().Short)
 			} else {
 				utils.CmdSuggestion = suggestDebugFlag
 			}
+			cmd.SetContext(ctx)
 			return nil
 		},
 		SilenceErrors: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Sets cancellable context in root command. Currently context is only cancellable if run with `--debug` flag.

## Additional context

Add any other context or screenshots.
