### PR TITLE
feat: expose issuer in local JWTs

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -393,6 +393,7 @@ EOF
 			"GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated",
 			fmt.Sprintf("GOTRUE_JWT_EXP=%v", utils.Config.Auth.JwtExpiry),
 			"GOTRUE_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+			fmt.Sprintf("GOTRUE_JWT_ISSUER=http://127.0.0.1:%v/auth/v1", utils.Config.Api.Port),
 
 			fmt.Sprintf("GOTRUE_EXTERNAL_EMAIL_ENABLED=%v", utils.Config.Auth.Email.EnableSignup),
 			fmt.Sprintf("GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED=%v", utils.Config.Auth.Email.DoubleConfirmChanges),


### PR DESCRIPTION
Configures the `GOTRUE_JWT_ISSUER` environment variable to point to the local setup's Auth URL. This makes it easy to identify where the JWT came from and makes it easy to to use other tools like pg_graphql, graphbase and others that require the `iss` claim to be present. 