### PR TITLE
fix: prune local docker network by label

### DIFF
--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -245,7 +245,7 @@ func TestStartCommand(t *testing.T) {
 			ReplyError(errors.New("network error"))
 		// Cleanup resources
 		gock.New(utils.Docker.DaemonHost()).
-			Delete("/v" + utils.Docker.ClientVersion() + "/networks/").
+			Post("/v" + utils.Docker.ClientVersion() + "/networks/prune").
 			Reply(http.StatusOK)
 		// Run test
 		err := Run(context.Background(), fsys)

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
@@ -124,7 +125,9 @@ func DockerRemoveAll(ctx context.Context) {
 	_ = WaitAll(Volumes, func(name string) error {
 		return Docker.VolumeRemove(ctx, name, true)
 	})
-	_ = Docker.NetworkRemove(ctx, NetId)
+	_, _ = Docker.NetworksPrune(ctx, filters.NewArgs(
+		filters.Arg("label", "com.supabase.cli.project="+Config.ProjectId),
+	))
 }
 
 func DockerAddFile(ctx context.Context, container string, fileName string, content []byte) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to #1581 

## What is the new behavior?

Deletes custom network by label.

## Additional context

Add any other context or screenshots.
