### PR TITLE
fix: bump edge-runtime to 1.22.3

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:20231023-7e2cd92"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.20.2"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.22.3"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	GotrueImage      = "supabase/gotrue:v2.99.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps edge-runtime to 1.22.3. Main changes are:

* Upgrade to Deno 1.37.1