### PR TITLE
feat: Add automatic login flow support

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/functions/delete"
@@ -11,8 +9,6 @@ import (
 	"github.com/supabase/cli/internal/functions/list"
 	new_ "github.com/supabase/cli/internal/functions/new"
 	"github.com/supabase/cli/internal/functions/serve"
-	"github.com/supabase/cli/internal/login"
-	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 )
 
@@ -122,12 +118,4 @@ func init() {
 	functionsCmd.AddCommand(functionsServeCmd)
 	functionsCmd.AddCommand(functionsDownloadCmd)
 	rootCmd.AddCommand(functionsCmd)
-}
-
-func PromptLogin(fsys afero.Fs) error {
-	if _, err := utils.LoadAccessTokenFS(fsys); err == utils.ErrMissingToken {
-		return login.Run(os.Stdin, fsys)
-	} else {
-		return err
-	}
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,14 +1,40 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/user"
+	"strings"
+	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
+	"golang.org/x/term"
 )
+
+var (
+	ErrMissingToken = errors.New("Cannot use automatic login flow inside non-TTY environments. Please provide " + utils.Aqua("--token") + " flag or set the " + utils.Aqua("SUPABASE_ACCESS_TOKEN") + " environment variable.")
+)
+
+func generateTokenName() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("cannot retrieve username: %w", err)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("cannot retrieve hostname: %w", err)
+	}
+
+	return fmt.Sprintf("cli_%s@%s_%d", user.Username, hostname, time.Now().Unix()), nil
+}
 
 var (
 	loginCmd = &cobra.Command{
@@ -16,14 +42,63 @@ var (
 		Use:     "login",
 		Short:   "Authenticate using an access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return login.Run(os.Stdin, afero.NewOsFs())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Finished " + utils.Aqua("supabase login") + ".")
+			params := login.RunParams{
+				Fsys: afero.NewOsFs(),
+			}
+
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, os.Stdin); err == nil {
+					token := strings.TrimSpace(buf.String())
+					if len(token) > 0 {
+						params.Token = token
+					}
+				}
+			} else if cmd.Flags().Changed("token") {
+				token, err := cmd.Flags().GetString("token")
+				if err != nil {
+					return fmt.Errorf("cannot parse 'token' flag: %w", err)
+				}
+				params.Token = token
+			} else if token := os.Getenv("SUPABASE_ACCESS_TOKEN"); token != "" {
+				params.Token = token
+			}
+
+			if !term.IsTerminal(int(os.Stdin.Fd())) && params.Token == "" {
+				return ErrMissingToken
+			}
+
+			if cmd.Flags().Changed("name") {
+				name, err := cmd.Flags().GetString("name")
+				if err != nil {
+					return fmt.Errorf("cannot parse 'name' flag: %w", err)
+				}
+				params.Name = name
+			} else {
+				name, err := generateTokenName()
+				if err != nil {
+					params.Name = fmt.Sprintf("cli_%d", time.Now().Unix())
+				} else {
+					params.Name = name
+				}
+			}
+
+			if cmd.Flags().Changed("no-browser") {
+				params.OpenBrowser = false
+			} else {
+				// Skip the browser if we are inside non-TTY environment, which is the case for any CI.
+				params.OpenBrowser = isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+			}
+
+			return login.Run(cmd.Context(), os.Stdin, params)
 		},
 	}
 )
 
 func init() {
+	loginFlags := loginCmd.Flags()
+	loginFlags.String("token", "", "Use provided token instead of automatic login flow")
+	loginFlags.String("name", "", "Name that will be used to store token in your settings, defaults to built-in token name generator")
+	loginFlags.Bool("no-browser", false, "Do not open browser automatically")
 	rootCmd.AddCommand(loginCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ func IsManagementAPI(cmd *cobra.Command) bool {
 
 func PromptLogin(ctx context.Context, fsys afero.Fs) error {
 	if _, err := utils.LoadAccessTokenFS(fsys); err == utils.ErrMissingToken {
-		return login.Run(ctx, os.Stdin, login.RunParams{
+		return login.Run(ctx, os.Stdout, login.RunParams{
 			Fsys: fsys,
 		})
 	} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 )
@@ -33,6 +35,16 @@ func IsManagementAPI(cmd *cobra.Command) bool {
 		cmd = cmd.Parent()
 	}
 	return false
+}
+
+func PromptLogin(ctx context.Context, fsys afero.Fs) error {
+	if _, err := utils.LoadAccessTokenFS(fsys); err == utils.ErrMissingToken {
+		return login.Run(ctx, os.Stdin, login.RunParams{
+			Fsys: fsys,
+		})
+	} else {
+		return err
+	}
 }
 
 var experimental = []*cobra.Command{
@@ -73,7 +85,7 @@ var (
 			// Add common flags
 			ctx := cmd.Context()
 			if IsManagementAPI(cmd) {
-				if err := PromptLogin(fsys); err != nil {
+				if err := PromptLogin(ctx, fsys); err != nil {
 					return err
 				}
 				if cmd.Flags().Lookup("project-ref") != nil {

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -1,18 +1,193 @@
 package login
 
 import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
 )
 
-func Run(stdin *os.File, fsys afero.Fs) error {
-	accessToken := PromptAccessToken(stdin)
-	return utils.SaveAccessToken(accessToken, fsys)
+type RunParams struct {
+	Token       string
+	Name        string
+	OpenBrowser bool
+	Fsys        afero.Fs
+}
+
+type AccessTokenResponse struct {
+	SessionId   string `json:"id"`
+	CreatedAt   string `json:"created_at"`
+	AccessToken string `json:"access_token"`
+	PublicKey   string `json:"public_key"`
+	Nonce       string `json:"nonce"`
+}
+
+const defaultRetryAfterSeconds = 2
+const decryptionErrorMsg = "cannot decrypt access token"
+
+var loggedInMsg = "You are now logged in. " + utils.Aqua("Happy coding!")
+
+func decryptAccessToken(accessTokenResponse AccessTokenResponse, curve ecdh.Curve, privateKey *ecdh.PrivateKey) (string, error) {
+	decodedAccessToken, err := hex.DecodeString(accessTokenResponse.AccessToken)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	nonce, err := hex.DecodeString(accessTokenResponse.Nonce)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	publicKey, err := hex.DecodeString(accessTokenResponse.PublicKey)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	remotePublicKey, err := curve.NewPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	secret, err := privateKey.ECDH(remotePublicKey)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	block, err := aes.NewCipher(secret)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	decryptedAccessToken, err := aesgcm.Open(nil, nonce, decodedAccessToken, nil)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", decryptionErrorMsg, err)
+	}
+
+	return string(decryptedAccessToken), nil
+}
+
+func pollForAccessToken(url string) (AccessTokenResponse, error) {
+	var accessTokenResponse AccessTokenResponse
+
+	// We fully control the url here, so it's safe to perform the request and ignore the G107 gosec rule.
+	// TODO: Move to OpenAPI-generated http client once we reach v1 on API schema.
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return accessTokenResponse, fmt.Errorf("cannot fetch access token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		retryAfterSeconds, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+		if err != nil {
+			retryAfterSeconds = defaultRetryAfterSeconds
+		}
+		time.Sleep(time.Duration(retryAfterSeconds) * time.Second)
+		return pollForAccessToken(url)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+
+		if err != nil {
+			return accessTokenResponse, fmt.Errorf("cannot read access token response body: %w", err)
+		}
+
+		if err := json.Unmarshal(body, &accessTokenResponse); err != nil {
+			return accessTokenResponse, fmt.Errorf("cannot unmarshal access token response: %w", err)
+		}
+
+		return accessTokenResponse, nil
+	}
+
+	return accessTokenResponse, fmt.Errorf("HTTP %s: cannot retrieve access token", resp.Status)
+}
+
+func Run(ctx context.Context, stdin *os.File, params RunParams) error {
+	if params.Token != "" {
+		err := utils.SaveAccessToken(params.Token, params.Fsys)
+		if err != nil {
+			return fmt.Errorf("cannot save provided token: %w", err)
+		}
+		fmt.Println(loggedInMsg)
+		return nil
+	}
+
+	if params.OpenBrowser {
+		fmt.Print("Hello from ", utils.Aqua("Supabase"), "! Press ", utils.Aqua("Enter"), " to open browser and login automatically.\n")
+		fmt.Scanln()
+	}
+
+	sessionId := uuid.New().String()
+	tokenName := params.Name
+	curve := ecdh.P256()
+	privateKey, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("cannot generate encryption key: %w", err)
+	}
+	publicKey := privateKey.PublicKey()
+	encodedPublicKey := hex.EncodeToString(publicKey.Bytes())
+
+	createLoginSessionPath := "/cli/login"
+	createLoginSessionQuery := "?session_id=" + sessionId + "&token_name=" + tokenName + "&public_key=" + encodedPublicKey
+	createLoginSessionUrl := utils.GetSupabaseDashboardURL() + createLoginSessionPath + createLoginSessionQuery
+
+	if params.OpenBrowser {
+		fmt.Printf("Here is your login link in case browser did not open %s\n\n", utils.Bold(createLoginSessionUrl))
+
+		openCmd := exec.CommandContext(ctx, "open", createLoginSessionUrl)
+		if err := openCmd.Run(); err != nil {
+			return fmt.Errorf("cannot open default browser: %w", err)
+		}
+	} else {
+		fmt.Printf("Here is your login link, open it in the browser %s\n\n", utils.Bold(createLoginSessionUrl))
+	}
+
+	err = utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
+		p.Send(utils.StatusMsg("Your token is now being generated and securely encrypted. Waiting for it to arrive..."))
+
+		sessionPollingUrl := utils.GetSupabaseAPIHost() + "/platform/cli/login/" + sessionId
+		accessTokenResponse, err := pollForAccessToken(sessionPollingUrl)
+		if err != nil {
+			return err
+		}
+
+		decryptedAccessToken, err := decryptAccessToken(accessTokenResponse, curve, privateKey)
+		if err != nil {
+			return err
+		}
+
+		return utils.SaveAccessToken(decryptedAccessToken, params.Fsys)
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Token %s created successfully.\n\n", utils.Bold(tokenName))
+	fmt.Println(loggedInMsg)
+
+	return nil
 }
 
 func PromptAccessToken(stdin *os.File) string {

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -16,7 +17,7 @@ import (
 func TestLoginCommand(t *testing.T) {
 	keyring.MockInit()
 
-	t.Run("prompts and validates api token", func(t *testing.T) {
+	t.Run("accepts --token flag and validates provided value", func(t *testing.T) {
 		token := apitest.RandomAccessToken(t)
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -27,7 +28,7 @@ func TestLoginCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, w.Close())
 		// Run test
-		assert.NoError(t, Run(r, fsys))
+		assert.NoError(t, Run(context.Background(), r, RunParams{Token: string(token), Fsys: fsys}))
 		// Validate saved token
 		saved, err := credentials.Get(utils.AccessTokenKey)
 		assert.NoError(t, err)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1,7 +1,10 @@
 package login
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -12,26 +15,76 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/zalando/go-keyring"
+	"gopkg.in/h2non/gock.v1"
 )
+
+type MockEncryption struct {
+	token     string
+	publicKey string
+}
+
+func (enc *MockEncryption) encodedPublicKey() string {
+	return enc.publicKey
+}
+
+func (enc *MockEncryption) decryptAccessToken(accessToken string, publicKey string, nonce string) (string, error) {
+	return enc.token, nil
+}
 
 func TestLoginCommand(t *testing.T) {
 	keyring.MockInit()
 
 	t.Run("accepts --token flag and validates provided value", func(t *testing.T) {
-		token := apitest.RandomAccessToken(t)
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup stdin with random token
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		_, err = w.Write(token)
-		require.NoError(t, err)
-		require.NoError(t, w.Close())
-		// Run test
-		assert.NoError(t, Run(context.Background(), r, RunParams{Token: string(token), Fsys: fsys}))
-		// Validate saved token
+		token := string(apitest.RandomAccessToken(t))
+		assert.NoError(t, Run(context.Background(), os.Stdout, RunParams{
+			Token: token,
+			Fsys:  afero.NewMemMapFs(),
+		}))
 		saved, err := credentials.Get(utils.AccessTokenKey)
 		assert.NoError(t, err)
-		assert.Equal(t, string(token), saved)
+		assert.Equal(t, token, saved)
+	})
+
+	t.Run("goes through automated flow successfully", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+
+		sessionId := "random_session_id"
+		token := string(apitest.RandomAccessToken(t))
+		tokenName := "random_token_name"
+		publicKey := "random_public_key"
+
+		defer gock.OffAll()
+
+		gock.New(utils.GetSupabaseAPIHost()).
+			Get("/platform/cli/login/" + sessionId).
+			Reply(200).
+			JSON(map[string]any{
+				"id":           "0b0d48f6-878b-4190-88d7-2ca33ed800bc",
+				"created_at":   "2023-03-28T13:50:14.464Z",
+				"access_token": "picklerick",
+				"public_key":   "iddqd",
+				"nonce":        "idkfa",
+			})
+
+		enc := &MockEncryption{publicKey: publicKey, token: token}
+		runParams := RunParams{
+			TokenName:  tokenName,
+			SessionId:  sessionId,
+			Fsys:       afero.NewMemMapFs(),
+			Encryption: enc,
+		}
+		assert.NoError(t, Run(context.Background(), w, runParams))
+		w.Close()
+
+		var out bytes.Buffer
+		_, _ = io.Copy(&out, r)
+
+		expectedBrowserUrl := fmt.Sprintf("%s/cli/login?session_id=%s&token_name=%s&public_key=%s", utils.GetSupabaseDashboardURL(), sessionId, tokenName, publicKey)
+		assert.Contains(t, out.String(), expectedBrowserUrl)
+
+		saved, err := credentials.Get(utils.AccessTokenKey)
+		assert.NoError(t, err)
+		assert.Equal(t, token, saved)
 	})
 }

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -50,6 +50,8 @@ func (suite *LoginTestSuite) TestLink() {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tmpfile
 
+	err = login.Flags().Set("token", key)
+	require.NoError(suite.T(), err)
 	require.NoError(suite.T(), login.RunE(login, []string{}))
 
 	// check token is saved


### PR DESCRIPTION
Adds automated login flow, which uses the browser session to authenticate and generate a new token, which is used in the cli `login` command.

```
Usage:
  supabase login [flags]

Flags:
  -h, --help           help for login
      --name string    Name that will be used to store token in your settings, defaults to built-in token name generator
      --no-browser     Do not open browser automatically
      --token string   Use provided token instead of automatic login flow
```

RFC: https://www.notion.so/supabase/RFC-Automatic-browser-based-CLI-login-flow-fc4f91fc7e7f4f168d2da6192841dcec?d=d8c9bcbe826c4665a89f9240d0854a36

API changes: https://github.com/supabase/infrastructure/pull/15529
Studio changes: https://github.com/supabase/supabase/pull/18641