### PR TITLE
chore: add pkgx to install options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ npm i supabase@beta --save-dev
 > **Note**
 For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
 
+Available via [pkgx](https://pkgx.sh/). To install in your working directory:
+
+```bash
+pkgx install supabase
+```
+
 <details>
   <summary><b>macOS</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/
 <details>
   <summary><b>Community Maintained Packages</b></summary>
 
-  Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/0a870774137cde2e1e9a6fb0bd63064077127bf3/projects/supabase.com/cli/package.yml)
+  Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/0a870774137cde2e1e9a6fb0bd63064077127bf3/projects/supabase.com/cli/package.yml).
   To install in your working directory:
 
   ```bash
   pkgx install supabase
   ```
 
-  Available via Nixpkgs. Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix)
+  Available via Nixpkgs. Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix).
 </details>
 
 ### Run the CLI

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains all the functionality for Supabase CLI.
 
 ### Install the CLI
 
-## Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
+#### Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
 
 ```bash
 npm i supabase --save-dev
@@ -34,7 +34,7 @@ npm i supabase@beta --save-dev
 > **Note**
 For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
 
-## Available via [pkgx](https://pkgx.sh/). To install in your working directory:
+#### Available via [pkgx](https://pkgx.sh/). To install in your working directory:
 
 ```bash
 pkgx install supabase

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains all the functionality for Supabase CLI.
 
 ### Install the CLI
 
-#### Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
+Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
 
 ```bash
 npm i supabase --save-dev
@@ -33,12 +33,6 @@ npm i supabase@beta --save-dev
 
 > **Note**
 For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
-
-#### Available via [pkgx](https://pkgx.sh/). To install in your working directory:
-
-```bash
-pkgx install supabase
-```
 
 <details>
   <summary><b>macOS</b></summary>
@@ -136,6 +130,19 @@ pkgx install supabase
   ```
 
   This works on other non-standard Linux distros.
+</details>
+
+<details>
+  <summary><b>Community Maintained Packages</b></summary>
+
+  Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/0a870774137cde2e1e9a6fb0bd63064077127bf3/projects/supabase.com/cli/package.yml)
+  To install in your working directory:
+
+  ```bash
+  pkgx install supabase
+  ```
+
+  Available via Nixpkgs. Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix)
 </details>
 
 ### Run the CLI

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains all the functionality for Supabase CLI.
 
 ### Install the CLI
 
-Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
+## Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
 
 ```bash
 npm i supabase --save-dev
@@ -34,7 +34,7 @@ npm i supabase@beta --save-dev
 > **Note**
 For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
 
-Available via [pkgx](https://pkgx.sh/). To install in your working directory:
+## Available via [pkgx](https://pkgx.sh/). To install in your working directory:
 
 ```bash
 pkgx install supabase

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ For Bun users, you must add `supabase` as a [trusted dependency](https://bun.sh/
 <details>
   <summary><b>Community Maintained Packages</b></summary>
 
-  Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/0a870774137cde2e1e9a6fb0bd63064077127bf3/projects/supabase.com/cli/package.yml).
+  Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/main/projects/supabase.com/cli/package.yml).
   To install in your working directory:
 
   ```bash
   pkgx install supabase
   ```
 
-  Available via Nixpkgs. Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix).
+  Available via [Nixpkgs](https://nixos.org/). Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix).
 </details>
 
 ### Run the CLI


### PR DESCRIPTION
This is a readme update to include pkgx package manger install instructions

I created the build script from source [here](https://github.com/pkgxdev/pantry/blob/0a870774137cde2e1e9a6fb0bd63064077127bf3/projects/supabase.com/cli/package.yml)
