### PR TITLE
fix: Bump up Realtime to version 2.25.27

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	GotrueImage      = "supabase/gotrue:v2.99.0"
-	RealtimeImage    = "supabase/realtime:v2.10.1"
+	RealtimeImage    = "supabase/realtime:v2.25.27"
 	StorageImage     = "supabase/storage-api:v0.40.4"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up Realtime to version 2.25.27
