### PR TITLE
fix: adding gotrue expected format to GOTRUE_SMS_TEST_OTP env

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -369,7 +369,7 @@ EOF
 	if utils.Config.Auth.Enabled && !isContainerExcluded(utils.Config.Auth.Image, excluded) {
 		var testOTP bytes.Buffer
 		if len(utils.Config.Auth.Sms.TestOTP) > 0 {
-			formatMapForEnvconfig(utils.Config.Auth.Sms.TestOTP, &testOTP)
+			formatMapForEnvConfig(utils.Config.Auth.Sms.TestOTP, &testOTP)
 		}
 
 		env := []string{
@@ -415,7 +415,7 @@ EOF
 			"GOTRUE_SMS_OTP_EXP=6000",
 			"GOTRUE_SMS_OTP_LENGTH=6",
 			"GOTRUE_SMS_TEMPLATE=Your code is {{ .Code }}",
-			fmt.Sprintf("GOTRUE_SMS_TEST_OTP=%s", testOTP.String()),
+			"GOTRUE_SMS_TEST_OTP=" + testOTP.String(),
 
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=%v", utils.Config.Auth.EnableRefreshTokenRotation),
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=%v", utils.Config.Auth.RefreshTokenReuseInterval),
@@ -904,7 +904,7 @@ func ExcludableContainers() []string {
 	return names
 }
 
-func formatMapForEnvconfig(input map[string]string, output *bytes.Buffer) {
+func formatMapForEnvConfig(input map[string]string, output *bytes.Buffer) {
 	numOfKeyPairs := len(input)
 	i := 0
 	for k, v := range input {

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -249,14 +249,14 @@ func TestFormatMapForEnvConfig(t *testing.T) {
 			`^\w{6}:\w{6},\w{6}:\w{6},\w{6}:\w{6}$`,
 			`^\w{6}:\w{6},\w{6}:\w{6},\w{6}:\w{6},\w{6}:\w{6}$`,
 		}
-		formatMapForEnvconfig(input, &output)
+		formatMapForEnvConfig(input, &output)
 		if len(output.Bytes()) > 0 {
 			t.Error("No values should be expected when empty map is provided")
 		}
 		for i := 0; i < 4; i++ {
 			output.Reset()
 			input[keys[i]] = values[i]
-			formatMapForEnvconfig(input, &output)
+			formatMapForEnvConfig(input, &output)
 			result := output.String()
 			assert.Regexp(t, regexp.MustCompile(expected[i]), result)
 		}


### PR DESCRIPTION
```
# original commit
fix: adding gotrue expected format to testotp env

* Removing previous json encoding
* Adding a new method that outputs map as key1:value1,key2:value2,...
* Adding new test for the method above
```
## What kind of change does this PR introduce?

This PR aims to address what has been pointed in https://github.com/supabase/gotrue/issues/1293.
In short:
* the cli was encoding a `map[string]string` as a json string
* this string was the value for a env that gotrue was trying to use to generate the same map
* the library gotrue is using expected `key1:value1,key2:value2,...` instead of json

## What is the current behavior?

The current behavior generates a json string as the value for the `GOTRUE_SMS_TEST_OTP` environment variable that gotrue is supposed to use.

To attest this:
```bash
# init the configs
go run . init

# then add some key-values for the test otp in config.toml file
# [auth.sms.test_otp]
# 12345678 = "654987"
# 123456 = "6554987"
# 136789 = "665454987"
# 236789 = "65495487"

# now start as usual
go run . start

# store gotrue container id
export CONTAINER=$(docker container ls | grep gotrue | awk '{print $1}')

# check what is in the env
docker container exec $CONTAINER printenv | grep GOTRUE_SMS_TEST_OTP=

``` 
example output:
![Screenshot from 2023-11-12 21-03-26](https://github.com/supabase/cli/assets/48366106/39aad41a-3d38-4351-aa72-6f62b85e6ca3)


## What is the new behavior?
In the new behavior the string is formated as `key1:value1,key2:value2,...`

if we follow the same steps we should expect the following:
![Screenshot from 2023-11-12 21-08-43](https://github.com/supabase/cli/assets/48366106/f80cbd44-39fd-4182-8234-2820587e7ef7)


