### PR TITLE
feat: use sms template from config.toml

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -414,7 +414,7 @@ EOF
 			"GOTRUE_SMS_MAX_FREQUENCY=5s",
 			"GOTRUE_SMS_OTP_EXP=6000",
 			"GOTRUE_SMS_OTP_LENGTH=6",
-			"GOTRUE_SMS_TEMPLATE=Your code is {{ .Code }}",
+			fmt.Sprintf("GOTRUE_SMS_TEMPLATE=%v", utils.Config.Auth.Sms.Template),
 			"GOTRUE_SMS_TEST_OTP=" + testOTP.String(),
 
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=%v", utils.Config.Auth.EnableRefreshTokenRotation),

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -285,6 +285,7 @@ type (
 	sms struct {
 		EnableSignup        bool              `toml:"enable_signup"`
 		EnableConfirmations bool              `toml:"enable_confirmations"`
+		Template            string            `toml:"template"`
 		Twilio              twilioConfig      `toml:"twilio" mapstructure:"twilio"`
 		TwilioVerify        twilioConfig      `toml:"twilio_verify" mapstructure:"twilio_verify"`
 		Messagebird         messagebirdConfig `toml:"messagebird" mapstructure:"messagebird"`

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -130,6 +130,9 @@ var Config = config{
 				"email_change": {},
 			},
 		},
+		Sms: sms{
+			Template: "Your code is {{ .Code }} .",
+		},
 		External: map[string]provider{
 			"apple":     {},
 			"azure":     {},

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -99,6 +99,8 @@ content_path = "./supabase/templates/invite.html"
 enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }} ."
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -100,7 +100,7 @@ enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ `{{.Code }}` }} ."  
+template = "Your code is {{ `{{ .Code }}` }} ."  
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -100,7 +100,7 @@ enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ .Code }} ."
+template = "Your code is {{ `{{.Code }}` }} ."  
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -99,6 +99,8 @@ enable_confirmations = false
 enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }} ."
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -100,7 +100,7 @@ enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ `{{.Code }}` }} ."  
+template = "Your code is {{ `{{ .Code }}` }} ."  
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -100,7 +100,7 @@ enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ .Code }} ."
+template = "Your code is {{ `{{.Code }}` }} ."  
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use SMS template from `config.toml` instead of hardcoded string

## What is the current behavior?

Uses the hardcoded template for sending SMS otp

## What is the new behavior?

Uses template from env for sending SMS OTP message

## Additional context

gotrue repo already has the env, let me know if any other changes are required
https://github.com/supabase/gotrue/blob/93e5f82ced83c08799ce99020be9dea82fc56d24/example.env#L183
