### PR TITLE
chore: update templates to quote test_otp

### DIFF
--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -104,7 +104,7 @@ template = "Your code is {{ `{{ .Code }}` }} ."
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]
-4152127777 = "123456"
+"4152127777" = "123456"
 
 # Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
 [auth.sms.twilio]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -104,7 +104,7 @@ template = "Your code is {{ `{{ .Code }}` }} ."
 
 # Use pre-defined map of phone number to OTP for testing.
 [auth.sms.test_otp]
-# 4152127777 = "123456"
+# "4152127777" = "123456"
 
 # Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
 [auth.sms.twilio]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test otp phone number needs to be in quotes 

Relevant issue: https://github.com/supabase/gotrue/issues/1293

