### PR TITLE
fix: mirror latest postgrest image

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -27,7 +27,7 @@ const (
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"
-	PostgrestImage   = "postgrest/postgrest:v11.2.0"
+	PostgrestImage   = "postgrest/postgrest:v11.2.2"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Latest projects are using PostgREST 11.2.2 and we don't have the image mirrored

## What is the new behavior?

Bump the version and mirror the image