### PR TITLE
fix: Bump up Realtime to 2.25.35

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	GotrueImage      = "supabase/gotrue:v2.99.0"
-	RealtimeImage    = "supabase/realtime:v2.25.27"
+	RealtimeImage    = "supabase/realtime:v2.25.35"
 	StorageImage     = "supabase/storage-api:v0.40.4"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up Realtime to 2.25.35

Fixes seeding issues:
https://github.com/supabase/realtime/pull/742
https://github.com/supabase/realtime/pull/739
https://github.com/supabase/realtime/pull/736

<img width="2543" alt="Screenshot 2023-11-17 at 17 39 50" src="https://github.com/supabase/cli/assets/1697301/d2183077-eac6-4df7-a104-5469b4f76d33">
