### PR TITLE
chore: added the 'REFERENCE' word in the projects list so that it becomes easy to know the ID

### DIFF
--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -28,7 +28,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		fmt.Fprintln(os.Stderr, err)
 	}
 
-	table := `LINKED|ORG ID|ID|NAME|REGION|CREATED AT (UTC)
+	table := `LINKED|ORG ID|REFERENCE ID|NAME|REGION|CREATED AT (UTC)
 |-|-|-|-|-|-|
 `
 	for _, project := range *resp.JSON200 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

In this PR, I added the 'REFERENCE' word in the projects list so that it becomes easy to know what is ID actually because when I was trying to delete the project, I was not sure what to enter in the ID. 

The ID could be anything but it's good to mention that the reference ID is required.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
