### PR TITLE
fix: Use skratchdot/open-golang to open login url in the browser

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -193,8 +192,7 @@ func Run(ctx context.Context, stdout *os.File, params RunParams) error {
 	if params.OpenBrowser {
 		fmt.Fprintf(stdout, "Here is your login link in case browser did not open %s\n\n", utils.Bold(createLoginSessionUrl))
 
-		openCmd := exec.CommandContext(ctx, "open", createLoginSessionUrl)
-		if err := openCmd.Run(); err != nil {
+		if err := RunOpenCmd(ctx, createLoginSessionUrl); err != nil {
 			return fmt.Errorf("cannot open default browser: %w", err)
 		}
 	} else {

--- a/internal/login/login_darwin.go
+++ b/internal/login/login_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package login
+
+import (
+	"context"
+	"os/exec"
+)
+
+func RunOpenCmd(ctx context.Context, input string) error {
+	cmd := exec.CommandContext(ctx, "open", input)
+	return cmd.Run()
+}

--- a/internal/login/login_windows.go
+++ b/internal/login/login_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package login
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func RunOpenCmd(ctx context.Context, input string) error {
+	cmd := exec.CommandContext(ctx, filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe"), "url.dll,FileProtocolHandler", input)
+	return cmd.Run()
+}

--- a/internal/login/login_xdg.go
+++ b/internal/login/login_xdg.go
@@ -1,0 +1,13 @@
+//go:build !windows && !darwin
+
+package login
+
+import (
+	"context"
+	"os/exec"
+)
+
+func RunOpenCmd(ctx context.Context, input string) error {
+	cmd := exec.CommandContext(ctx, "xdg-open", input)
+	return cmd.Run()
+}


### PR DESCRIPTION
Right now it only worked in environments that had `open` command.