### PR TITLE
feat: Upgrade to edge-runtime 1.23

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -119,7 +119,7 @@ serve(async (req: Request) => {
   console.error(`serving the request with ${servicePath}`);
 
   const memoryLimitMb = 150;
-  const workerTimeoutMs = 5 * 60 * 1000;
+  const workerTimeoutMs = 400 * 1000;
   const noModuleCache = false;
   const envVarsObj = Deno.env.toObject();
   const envVars = Object.entries(envVarsObj)
@@ -128,9 +128,8 @@ serve(async (req: Request) => {
     );
   const forceCreate = true;
   const customModuleRoot = ""; // empty string to allow any local path
-  const cpuTimeThresholdMs = 50;
-  const cpuBurstIntervalMs = 100;
-  const maxCpuBursts = 100;
+  const cpuTimeSoftLimitMs = 10000;
+  const cpuTimeHardLimitMs = 20000;
   try {
     const worker = await EdgeRuntime.userWorkers.create({
       servicePath,
@@ -141,9 +140,8 @@ serve(async (req: Request) => {
       envVars,
       forceCreate,
       customModuleRoot,
-      cpuTimeThresholdMs,
-      cpuBurstIntervalMs,
-      maxCpuBursts,
+      cpuTimeSoftLimitMs,
+      cpuTimeHardLimitMs,
     });
     const controller = new AbortController();
 

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -33,7 +33,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.68.0"
 	StudioImage      = "supabase/studio:20231123-64a766a"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.22.4"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.23.0"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	GotrueImage      = "supabase/gotrue:v2.99.0"


### PR DESCRIPTION
This upgrade introduces soft and hard limits for CPU time.

* An isolate can handle multiple requests for a function. It will run till the wall clock limit (set to 400s).

* When an isolate reaches soft limit it will be retired, which means it won’t handle anymore new requests. But it will run to complete any pending requests until it reaches the CPU time hard limit or wall clock limit (whichever comes first).

* Any new requests will be handled by a newly created isolate.
