### PR TITLE
fix: default preview branch name to local git branch

### DIFF
--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -27,10 +27,10 @@ var (
 	}
 
 	branchCreateCmd = &cobra.Command{
-		Use:   "create <name>",
+		Use:   "create [name]",
 		Short: "Create a preview branch",
 		Long:  "Create a preview branch for the linked project.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return create.Run(cmd.Context(), args[0], branchRegion.Value, afero.NewOsFs())
 		},

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -17,6 +17,10 @@ func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
 		return err
 	}
 	gitBranch := keys.GetGitBranchOrDefault("", fsys)
+	if len(name) == 0 {
+		name = gitBranch
+	}
+
 	resp, err := utils.GetSupabase().CreateBranchWithResponse(ctx, ref, api.CreateBranchJSONRequestBody{
 		BranchName: name,
 		GitBranch:  &gitBranch,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the new behavior?

Aligns with frontend naming convention, ie. branch name == git branch
Makes `<name>` arg optional for backwards compatibility.

## Additional context

Add any other context or screenshots.
