### PR TITLE
feat: support stopping supabase without config file

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -18,7 +18,7 @@ var (
 		Short:   "Stop all local Supabase containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return stop.Run(ctx, !noBackup, afero.NewOsFs())
+			return stop.Run(ctx, !noBackup, projectId, afero.NewOsFs())
 		},
 	}
 )
@@ -26,6 +26,7 @@ var (
 func init() {
 	flags := stopCmd.Flags()
 	flags.Bool("backup", true, "Backs up the current database before stopping.")
+	flags.StringVar(&projectId, "project-id", "", "Local project ID to stop.")
 	cobra.CheckErr(flags.MarkHidden("backup"))
 	flags.BoolVar(&noBackup, "no-backup", false, "Deletes all data volumes after stopping.")
 	rootCmd.AddCommand(stopCmd)

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -38,9 +37,7 @@ func Run(ctx context.Context, backup bool, projectId string, fsys afero.Fs) erro
 }
 
 func stop(ctx context.Context, backup bool, w io.Writer) error {
-	args := filters.NewArgs(
-		filters.Arg("label", "com.supabase.cli.project="+utils.Config.ProjectId),
-	)
+	args := utils.CliProjectFilter()
 	containers, err := utils.Docker.ContainerList(ctx, types.ContainerListOptions{
 		All:     true,
 		Filters: args,

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -16,9 +16,12 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, backup bool, fsys afero.Fs) error {
+func Run(ctx context.Context, backup bool, projectId string, fsys afero.Fs) error {
 	// Sanity checks.
-	if err := utils.LoadConfigFS(fsys); err != nil {
+	if len(projectId) > 0 {
+		utils.Config.ProjectId = projectId
+		utils.UpdateDockerIds()
+	} else if err := utils.LoadConfigFS(fsys); err != nil {
 		return err
 	}
 

--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -38,7 +38,7 @@ func TestStopCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.NetworksPruneReport{})
 		// Run test
-		err := Run(context.Background(), true, fsys)
+		err := Run(context.Background(), true, "", fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -48,7 +48,7 @@ func TestStopCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), false, fsys)
+		err := Run(context.Background(), false, "", fsys)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
@@ -64,7 +64,7 @@ func TestStopCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), false, afero.NewReadOnlyFs(fsys))
+		err := Run(context.Background(), false, "test", afero.NewReadOnlyFs(fsys))
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -69,6 +69,26 @@ func GetId(name string) string {
 	return "supabase_" + name + "_" + Config.ProjectId
 }
 
+func UpdateDockerIds() {
+	NetId = GetId("network")
+	DbId = GetId(DbAliases[0])
+	ConfigId = GetId("config")
+	KongId = GetId(KongAliases[0])
+	GotrueId = GetId(GotrueAliases[0])
+	InbucketId = GetId(InbucketAliases[0])
+	RealtimeId = "realtime-dev." + GetId(RealtimeAliases[0])
+	RestId = GetId(RestAliases[0])
+	StorageId = GetId(StorageAliases[0])
+	ImgProxyId = "storage_" + ImgProxyAliases[0] + "_" + Config.ProjectId
+	DifferId = GetId("differ")
+	PgmetaId = GetId(PgmetaAliases[0])
+	StudioId = GetId(StudioAliases[0])
+	EdgeRuntimeId = GetId(EdgeRuntimeAliases[0])
+	LogflareId = GetId(LogflareAliases[0])
+	VectorId = GetId(VectorAliases[0])
+	PoolerId = GetId(PoolerAliases[0])
+}
+
 // Type for turning human-friendly bytes string ("5MB", "32kB") into an int64 during toml decoding.
 type sizeInBytes int64
 
@@ -393,25 +413,8 @@ func LoadConfigFS(fsys afero.Fs) error {
 	{
 		if Config.ProjectId == "" {
 			return errors.New("Missing required field in config: project_id")
-		} else {
-			NetId = GetId("network")
-			DbId = GetId(DbAliases[0])
-			ConfigId = GetId("config")
-			KongId = GetId(KongAliases[0])
-			GotrueId = GetId(GotrueAliases[0])
-			InbucketId = GetId(InbucketAliases[0])
-			RealtimeId = "realtime-dev." + GetId(RealtimeAliases[0])
-			RestId = GetId(RestAliases[0])
-			StorageId = GetId(StorageAliases[0])
-			ImgProxyId = "storage_" + ImgProxyAliases[0] + "_" + Config.ProjectId
-			DifferId = GetId("differ")
-			PgmetaId = GetId(PgmetaAliases[0])
-			StudioId = GetId(StudioAliases[0])
-			EdgeRuntimeId = GetId(EdgeRuntimeAliases[0])
-			LogflareId = GetId(LogflareAliases[0])
-			VectorId = GetId(VectorAliases[0])
-			PoolerId = GetId(PoolerAliases[0])
 		}
+		UpdateDockerIds()
 		// Validate api config
 		if Config.Api.Port == 0 {
 			return errors.New("Missing required field in config: api.port")


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature
closes https://github.com/supabase/cli/issues/1221

## What is the new behavior?

- Stop supabase stack from any directory by specifying the local project id
```bash
supabase stop --project-id cli-demo
```

- Suggest using a different port when bind fails
```bash
$ supabase db start
Starting database...
Error response from daemon: driver failed programming external connectivity on endpoint supabase_db_cli (7a755ba6e40a10271d24e270728bcb4982cea5d2c7206b6ab17f795630b638f4): Bind for 0.0.0.0:54322 failed: port is already allocated

Try stopping the running project with supabase stop --project-id cli-demo
Or configure a different db port in supabase/config.toml
exit status 1
```

## Additional context

Add any other context or screenshots.
