### PR TITLE
fix: entrypoint path for functions deploy on windows

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/andybalholm/brotli"
@@ -218,11 +219,8 @@ func deployOne(ctx context.Context, slug, projectRef, importMapPath string, noVe
 	}
 
 	// 2. Bundle Function.
-	dockerEntrypointPath, err := filepath.Abs(filepath.Join(utils.DockerFuncDirPath, slug, "index.ts"))
-	if err != nil {
-		return err
-	}
 	fmt.Println("Bundling " + utils.Bold(slug))
+	dockerEntrypointPath := path.Join(utils.DockerFuncDirPath, slug, "index.ts")
 	functionBody, err := bundleFunction(ctx, slug, dockerEntrypointPath, importMapPath, fsys)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Path inside container should always be unix style.

## Additional context

Add any other context or screenshots.
