### PR TITLE
fix: preserve file extension when bundling import map paths

### DIFF
--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -303,6 +303,9 @@ func getModulePath(hostPath string) string {
 	if strings.HasSuffix(hostPath, "/") {
 		mod += "/"
 	}
+	if ext := filepath.Ext(hostPath); len(ext) > 0 {
+		mod += ext
+	}
 	return mod
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1739

## What is the new behavior?

Preserves imported file extension so that deno is happy.

## Additional context

Add any other context or screenshots.
