### PR TITLE
feat: `--create-ticket` flag to send error reports to sentry

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -50,6 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BREWTAP_TOKEN: ${{ secrets.GH_PAT }}
           SCOOP_TOKEN: ${{ secrets.GH_PAT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - run: gh release edit v${{ needs.release.outputs.new-release-version }} --draft=false --prerelease
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/supabase/cli/internal/utils.Version={{.Version}}
+      - -s -w -X github.com/supabase/cli/internal/utils.Version={{.Version}} -X github.com/supabase/cli/internal/utils.SentryDsn={{ .Env.SENTRY_DSN }}
     env:
       - CGO_ENABLED=0
     targets:
@@ -14,6 +14,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
+      - windows_arm64
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,6 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
-      - windows_arm64
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 release:

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-errors/errors"
 	"github.com/google/uuid"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/afero"
@@ -20,18 +20,18 @@ import (
 )
 
 var (
-	ErrMissingToken = errors.New("Cannot use automatic login flow inside non-TTY environments. Please provide " + utils.Aqua("--token") + " flag or set the " + utils.Aqua("SUPABASE_ACCESS_TOKEN") + " environment variable.")
+	ErrMissingToken = errors.Errorf("Cannot use automatic login flow inside non-TTY environments. Please provide %s flag or set the %s environment variable.", utils.Aqua("--token"), utils.Aqua("SUPABASE_ACCESS_TOKEN"))
 )
 
 func generateTokenName() (string, error) {
 	user, err := user.Current()
 	if err != nil {
-		return "", fmt.Errorf("cannot retrieve username: %w", err)
+		return "", errors.Errorf("cannot retrieve username: %w", err)
 	}
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		return "", fmt.Errorf("cannot retrieve hostname: %w", err)
+		return "", errors.Errorf("cannot retrieve hostname: %w", err)
 	}
 
 	return fmt.Sprintf("cli_%s@%s_%d", user.Username, hostname, time.Now().Unix()), nil
@@ -58,7 +58,7 @@ var (
 			} else if cmd.Flags().Changed("token") {
 				token, err := cmd.Flags().GetString("token")
 				if err != nil {
-					return fmt.Errorf("cannot parse 'token' flag: %w", err)
+					return errors.Errorf("cannot parse 'token' flag: %w", err)
 				}
 				params.Token = token
 			} else if token := os.Getenv("SUPABASE_ACCESS_TOKEN"); token != "" {
@@ -83,7 +83,7 @@ var (
 			if cmd.Flags().Changed("name") {
 				name, err := cmd.Flags().GetString("name")
 				if err != nil {
-					return fmt.Errorf("cannot parse 'name' flag: %w", err)
+					return errors.Errorf("cannot parse 'name' flag: %w", err)
 				}
 				params.TokenName = name
 			} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,7 +212,7 @@ func addSentryScope(scope *sentry.Scope) {
 	}
 	scope.SetContext("Services", imageToVersion)
 	scope.SetContext("Config", map[string]interface{}{
-		"INTERNAL_IMAGE_REGISTRY": viper.Get("INTERNAL_IMAGE_REGISTRY"),
-		"PROJECT_ID":              flags.ProjectRef,
+		"Image Registry": utils.GetRegistry(),
+		"Project ID":     flags.ProjectRef,
 	})
 }

--- a/cmd/sslEnforcement.go
+++ b/cmd/sslEnforcement.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/ssl_enforcement/get"
@@ -25,7 +24,7 @@ var (
 		Short: "Update SSL enforcement configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !dbEnforceSsl && !dbDisableSsl {
-				return fmt.Errorf("enable/disable not specified")
+				return errors.New("enable/disable not specified")
 			}
 			return update.Run(cmd.Context(), flags.ProjectRef, dbEnforceSsl, afero.NewOsFs())
 		},

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/supabase/cli/internal/sso/create"
@@ -66,7 +65,7 @@ var (
 		Example: `  supabase sso remove b5ae62f9-ef1d-4f11-a02b-731c8bbb11e8 --project-ref mwjylndxudmiehsxhmmz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !utils.UUIDPattern.MatchString(args[0]) {
-				return fmt.Errorf("identity provider ID %q is not a UUID", args[0])
+				return errors.Errorf("identity provider ID %q is not a UUID", args[0])
 			}
 
 			return remove.Run(cmd.Context(), flags.ProjectRef, args[0], ssoOutput.Value)
@@ -81,7 +80,7 @@ var (
 		Example: `  supabase sso update b5ae62f9-ef1d-4f11-a02b-731c8bbb11e8 --project-ref mwjylndxudmiehsxhmmz --add-domains example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !utils.UUIDPattern.MatchString(args[0]) {
-				return fmt.Errorf("identity provider ID %q is not a UUID", args[0])
+				return errors.Errorf("identity provider ID %q is not a UUID", args[0])
 			}
 
 			return update.Run(cmd.Context(), update.RunParams{
@@ -108,7 +107,7 @@ var (
 		Example: `  supabase sso show b5ae62f9-ef1d-4f11-a02b-731c8bbb11e8 --project-ref mwjylndxudmiehsxhmmz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !utils.UUIDPattern.MatchString(args[0]) {
-				return fmt.Errorf("identity provider ID %q is not a UUID", args[0])
+				return errors.Errorf("identity provider ID %q is not a UUID", args[0])
 			}
 
 			format := ssoOutput.Value

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/start"
-	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 )
 
@@ -23,11 +22,9 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()
 			if preview {
-				projectRef, err := utils.LoadProjectRef(fsys)
-				if err != nil {
+				if _, err := flags.LoadProjectRef(fsys); err != nil {
 					return err
 				}
-				flags.ProjectRef = projectRef
 			}
 			return start.Run(cmd.Context(), fsys, excludedContainers, ignoreHealthCheck, flags.ProjectRef)
 		},

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/docker/cli v24.0.7+incompatible
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/getsentry/sentry-go v0.25.0
+	github.com/go-errors/errors v1.5.1
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/golang-jwt/jwt/v5 v5.2.0
@@ -57,9 +59,7 @@ require (
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/getkin/kin-openapi v0.118.0 // indirect
-	github.com/getsentry/sentry-go v0.25.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,9 @@ require (
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/getkin/kin-openapi v0.118.0 // indirect
+	github.com/getsentry/sentry-go v0.25.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,7 +91,6 @@ github.com/containers/common v0.57.1 h1:KWAs4PMPgBFmBV4QNbXhUB8TqvlgR95BJN2sbbXk
 github.com/containers/common v0.57.1/go.mod h1:t/Z+/sFrapvFMEJe3YnecN49/Tae2wYEQShbEN6SRaU=
 github.com/containers/storage v1.51.0 h1:AowbcpiWXzAjHosKz7MKvPEqpyX+ryZA/ZurytRrFNA=
 github.com/containers/storage v1.51.0/go.mod h1:ybl8a3j1PPtpyaEi/5A6TOFs+5TrEyObeKJzVtkUlfc=
-github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -255,10 +254,6 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
-github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -354,7 +349,6 @@ github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgSh
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -408,7 +402,6 @@ github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -463,6 +456,7 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -640,7 +634,6 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -789,7 +782,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,7 @@ github.com/containers/common v0.57.1 h1:KWAs4PMPgBFmBV4QNbXhUB8TqvlgR95BJN2sbbXk
 github.com/containers/common v0.57.1/go.mod h1:t/Z+/sFrapvFMEJe3YnecN49/Tae2wYEQShbEN6SRaU=
 github.com/containers/storage v1.51.0 h1:AowbcpiWXzAjHosKz7MKvPEqpyX+ryZA/ZurytRrFNA=
 github.com/containers/storage v1.51.0/go.mod h1:ybl8a3j1PPtpyaEi/5A6TOFs+5TrEyObeKJzVtkUlfc=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -149,11 +150,15 @@ github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/getkin/kin-openapi v0.118.0 h1:z43njxPmJ7TaPpMSCQb7PN0dEYno4tyBPQcrFdHoLuM=
 github.com/getkin/kin-openapi v0.118.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
+github.com/getsentry/sentry-go v0.25.0 h1:q6Eo+hS+yoJlTO3uu/azhQadsD8V+jQn2D8VvX1eOyI=
+github.com/getsentry/sentry-go v0.25.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
+github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
+github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
@@ -250,6 +255,10 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -345,6 +354,7 @@ github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgSh
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -398,6 +408,7 @@ github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -629,6 +640,7 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -777,6 +789,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=

--- a/internal/bans/get/get.go
+++ b/internal/bans/get/get.go
@@ -2,9 +2,9 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		resp, err := utils.GetSupabase().GetNetworkBansWithResponse(ctx, projectRef)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve network bans: %w", err)
+			return errors.Errorf("failed to retrieve network bans: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to retrieve network bans; received: " + string(resp.Body))

--- a/internal/bans/get/get.go
+++ b/internal/bans/get/get.go
@@ -18,11 +18,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 			return errors.Errorf("failed to retrieve network bans: %w", err)
 		}
 		if resp.JSON201 == nil {
-			return errors.New("failed to retrieve network bans; received: " + string(resp.Body))
-		}
-
-		if err != nil {
-			return err
+			return errors.New("Unexpected error retrieving network bans: " + string(resp.Body))
 		}
 		fmt.Printf("DB banned IPs: %+v\n", resp.JSON201.BannedIpv4Addresses)
 		return nil

--- a/internal/bans/update/update.go
+++ b/internal/bans/update/update.go
@@ -2,10 +2,10 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -15,7 +15,7 @@ func validateIps(ips []string) error {
 	for _, ip := range ips {
 		ip := net.ParseIP(ip)
 		if ip.To4() == nil {
-			return fmt.Errorf("only IPv4 supported at the moment: %s", ip)
+			return errors.Errorf("only IPv4 supported at the moment: %s", ip)
 		}
 	}
 	return nil

--- a/internal/bans/update/update.go
+++ b/internal/bans/update/update.go
@@ -36,10 +36,10 @@ func Run(ctx context.Context, projectRef string, dbIpsToUnban []string, fsys afe
 			Ipv4Addresses: dbIpsToUnban,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to remove network bans: %w", err)
 		}
 		if resp.StatusCode() != 200 {
-			return errors.New("failed to remove network bans: " + string(resp.Body))
+			return errors.New("Unexpected error removing network bans: " + string(resp.Body))
 		}
 		fmt.Printf("Successfully removed bans for %+v.\n", dbIpsToUnban)
 		return nil

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -2,9 +2,9 @@ package create
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/utils"
@@ -27,7 +27,7 @@ func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
 		Region:     &region,
 	})
 	if err != nil {
-		return err
+		return errors.Errorf("failed to create preview branch: %w", err)
 	}
 
 	if resp.JSON201 == nil {

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -8,11 +8,12 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
 )
 
 func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
-	ref, err := utils.LoadProjectRef(fsys)
+	ref, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/branches/create/create_test.go
+++ b/internal/branches/create/create_test.go
@@ -1,0 +1,84 @@
+package create
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/testing/fstest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestCreateCommand(t *testing.T) {
+	t.Run("creates preview branch", func(t *testing.T) {
+		// Setup valid project ref
+		ref := apitest.RandomProjectRef()
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/branches").
+			Reply(http.StatusCreated).
+			JSON(api.BranchResponse{
+				Id: "test-uuid",
+			})
+		// Run test
+		err := Run(context.Background(), "", "sin", fsys)
+		// Check error
+		assert.NoError(t, err)
+	})
+
+	t.Run("throws error on permission denied", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := &fstest.OpenErrorFs{DenyPath: utils.ProjectRefPath}
+		// Run test
+		err := Run(context.Background(), "branch", "region", fsys)
+		// Check error
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+
+	t.Run("throws error on network disconnected", func(t *testing.T) {
+		ref := apitest.RandomProjectRef()
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/branches").
+			ReplyError(net.ErrClosed)
+		// Run test
+		err := Run(context.Background(), "", "sin", fsys)
+		// Check error
+		assert.ErrorIs(t, err, net.ErrClosed)
+	})
+
+	t.Run("throws error on service unavailable", func(t *testing.T) {
+		ref := apitest.RandomProjectRef()
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/branches").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := Run(context.Background(), "", "sin", fsys)
+		// Check error
+		assert.ErrorContains(t, err, "Unexpected error creating preview branch:")
+	})
+}

--- a/internal/branches/delete/delete.go
+++ b/internal/branches/delete/delete.go
@@ -2,17 +2,17 @@ package delete
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
 func Run(ctx context.Context, branchId string) error {
 	resp, err := utils.GetSupabase().DeleteBranchWithResponse(ctx, branchId)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to delete preview branch: %w", err)
 	}
 	if resp.StatusCode() != http.StatusOK {
 		return errors.New("Unexpected error deleting preview branch: " + string(resp.Body))

--- a/internal/branches/disable/disable.go
+++ b/internal/branches/disable/disable.go
@@ -2,10 +2,10 @@ package disable
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -17,7 +17,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 	resp, err := utils.GetSupabase().DisableBranchWithResponse(ctx, ref)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to disable preview branching: %w", err)
 	}
 	if resp.StatusCode() != http.StatusOK {
 		return errors.New("Unexpected error disabling preview branching: " + string(resp.Body))

--- a/internal/branches/disable/disable.go
+++ b/internal/branches/disable/disable.go
@@ -8,10 +8,11 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := utils.LoadProjectRef(fsys)
+	ref, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/branches/get/get.go
+++ b/internal/branches/get/get.go
@@ -2,9 +2,9 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -12,7 +12,7 @@ import (
 func Run(ctx context.Context, branchId string) error {
 	resp, err := utils.GetSupabase().GetBranchDetailsWithResponse(ctx, branchId)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to retrieve preview branch: %w", err)
 	}
 	if resp.JSON200 == nil {
 		return errors.New("Unexpected error retrieving preview branch: " + string(resp.Body))

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -18,7 +18,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, ref)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list preview branches: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -9,10 +9,11 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := utils.LoadProjectRef(fsys)
+	ref, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/branches/update/update.go
+++ b/internal/branches/update/update.go
@@ -2,9 +2,9 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -13,7 +13,7 @@ import (
 func Run(ctx context.Context, branchId string, body api.UpdateBranchBody, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().UpdateBranchWithResponse(ctx, branchId, body)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to update preview branch: %w", err)
 	}
 	if resp.JSON200 == nil {
 		return errors.New("Unexpected error updating preview branch: " + string(resp.Body))

--- a/internal/db/branch/create/create.go
+++ b/internal/db/branch/create/create.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )

--- a/internal/db/branch/delete/delete.go
+++ b/internal/db/branch/delete/delete.go
@@ -3,13 +3,13 @@ package delete
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -51,7 +51,7 @@ func deleteBranchDir(branch string, fsys afero.Fs) error {
 	}
 
 	if err := fsys.RemoveAll(branchPath); err != nil {
-		return fmt.Errorf("Failed deleting branch %s: %w", utils.Aqua(branch), err)
+		return errors.Errorf("Failed deleting branch %s: %w", utils.Aqua(branch), err)
 	}
 
 	return nil

--- a/internal/db/branch/list/list.go
+++ b/internal/db/branch/list/list.go
@@ -1,12 +1,12 @@
 package list
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )

--- a/internal/db/branch/switch_/switch_.go
+++ b/internal/db/branch/switch_/switch_.go
@@ -2,11 +2,11 @@ package switch_
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"

--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -175,7 +175,7 @@ func TestSwitchCommand(t *testing.T) {
 		// Run test
 		err := Run(context.Background(), branch, fsys, conn.Intercept)
 		// Check error
-		assert.ErrorContains(t, err, "Error switching to branch target: conn closed")
+		assert.ErrorContains(t, err, "Error switching to branch target")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/start"
@@ -22,7 +23,7 @@ func SaveDiff(out, file string, fsys afero.Fs) error {
 	} else if len(file) > 0 {
 		path := new.GetMigrationPath(utils.GetCurrentTimestamp(), file)
 		if err := afero.WriteFile(fsys, path, []byte(out), 0644); err != nil {
-			return err
+			return errors.Errorf("failed to save diff: %w", err)
 		}
 		fmt.Fprintln(os.Stderr, warnDiff)
 	} else {
@@ -63,7 +64,7 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 	}
 	defer utils.DockerRemove(shadow)
 	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
-		return start.ErrDatabase
+		return errors.New(start.ErrDatabase)
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys); err != nil {
 		return err

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -164,7 +164,7 @@ func DiffDatabase(ctx context.Context, schema []string, config pgconn.Config, w 
 	}
 	defer utils.DockerRemove(shadow)
 	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
-		return "", start.ErrDatabase
+		return "", errors.New(start.ErrDatabase)
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys, options...); err != nil {
 		return "", err

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -151,7 +151,7 @@ func DiffSchemaMigra(ctx context.Context, source, target string, schema []string
 		&out,
 		&stderr,
 	); err != nil {
-		return "", fmt.Errorf("error diffing schema: %w:\n%s", err, stderr.String())
+		return "", errors.Errorf("error diffing schema: %w:\n%s", err, stderr.String())
 	}
 	return out.String(), nil
 }

--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -30,7 +31,7 @@ func Run(ctx context.Context, path string, config pgconn.Config, schema []string
 	if len(path) > 0 {
 		f, err := fsys.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to open dump file: %w", err)
 		}
 		defer f.Close()
 		outStream = f

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -2,11 +2,11 @@ package push
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -63,7 +63,7 @@ func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, w io.Writer, fsys af
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	} else if err != nil {
-		return err
+		return errors.Errorf("failed to load custom roles: %w", err)
 	}
 	fmt.Fprintln(w, "Creating custom roles "+utils.Bold(utils.CustomRolesPath)+"...")
 	return apply.BatchExecDDL(ctx, conn, roles)

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/errdefs"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/spf13/afero"
@@ -276,7 +275,7 @@ func TestRestartDatabase(t *testing.T) {
 		// Run test
 		err := RestartDatabase(context.Background(), io.Discard)
 		// Check error
-		assert.True(t, errdefs.IsUnavailable(err))
+		assert.ErrorContains(t, err, "failed to restart container")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -38,10 +39,10 @@ func pgProve(ctx context.Context, dstPath string, fsys afero.Fs) error {
 	// Copy tests into database container
 	var buf bytes.Buffer
 	if err := compress(utils.DbTestsDir, &buf, fsys); err != nil {
-		return err
+		return errors.Errorf("failed to compress directory: %w", err)
 	}
 	if err := utils.Docker.CopyToContainer(ctx, utils.DbId, dstPath, &buf, types.CopyToContainerOptions{}); err != nil {
-		return err
+		return errors.Errorf("failed to copy into container: %w", err)
 	}
 	// Passing in script string means command line args must be set manually, ie. "$@"
 	args := "set -- " + filepath.ToSlash(utils.DbTestsDir) + ";"

--- a/internal/encryption/get/get.go
+++ b/internal/encryption/get/get.go
@@ -2,16 +2,16 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
 func Run(ctx context.Context, projectRef string) error {
 	resp, err := utils.GetSupabase().GetPgsodiumConfigWithResponse(ctx, projectRef)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to retrieve pgsodium config: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/encryption/update/update.go
+++ b/internal/encryption/update/update.go
@@ -2,11 +2,11 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/supabase/cli/pkg/api"
@@ -19,7 +19,7 @@ func Run(ctx context.Context, projectRef string, stdin *os.File) error {
 		RootKey: strings.TrimSpace(input),
 	})
 	if err != nil {
-		return err
+		return errors.Errorf("failed to update pgsodium config: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/functions/delete/delete.go
+++ b/internal/functions/delete/delete.go
@@ -2,10 +2,10 @@ package delete
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -21,7 +21,7 @@ func Run(ctx context.Context, slug string, projectRef string, fsys afero.Fs) err
 	// 2. Delete Function.
 	resp, err := utils.GetSupabase().DeleteFunctionWithResponse(ctx, projectRef, slug)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to delete function: %w", err)
 	}
 	switch resp.StatusCode() {
 	case http.StatusNotFound:

--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -3,7 +3,6 @@ package download
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/utils"
@@ -58,11 +58,11 @@ func getFunctionMetadata(ctx context.Context, projectRef, slug string) (*api.Fun
 
 	switch resp.StatusCode() {
 	case http.StatusNotFound:
-		return nil, errors.New("Function " + utils.Aqua(slug) + " does not exist on the Supabase project.")
+		return nil, errors.Errorf("Function %s does not exist on the Supabase project.", utils.Aqua(slug))
 	case http.StatusOK:
 		break
 	default:
-		return nil, errors.New("Failed to download Function " + utils.Aqua(slug) + " on the Supabase project: " + string(resp.Body))
+		return nil, errors.Errorf("Failed to download Function %s on the Supabase project: %s", utils.Aqua(slug), string(resp.Body))
 	}
 
 	if resp.JSON200.EntrypointPath == nil {
@@ -103,7 +103,7 @@ func downloadFunction(ctx context.Context, projectRef, slug, extractScriptPath s
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Error downloading function: %w\n%v", err, errBuf.String())
+		return errors.Errorf("Error downloading function: %w\n%v", err, errBuf.String())
 	}
 	return nil
 }

--- a/internal/functions/list/list.go
+++ b/internal/functions/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -14,7 +14,7 @@ import (
 func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().GetFunctionsWithResponse(ctx, projectRef)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list functions: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/functions/new/new_test.go
+++ b/internal/functions/new/new_test.go
@@ -33,8 +33,8 @@ func TestNewCommand(t *testing.T) {
 	t.Run("throws error on duplicate slug", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		funcDir := filepath.Join(utils.FunctionsDir, "test-func")
-		require.NoError(t, fsys.Mkdir(funcDir, 0755))
+		funcPath := filepath.Join(utils.FunctionsDir, "test-func", "index.ts")
+		require.NoError(t, afero.WriteFile(fsys, funcPath, []byte{}, 0644))
 		// Run test
 		assert.Error(t, Run(context.Background(), "test-func", fsys))
 	})

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -70,7 +70,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return errors.Errorf("failed to get working directory: %w", err)
 	}
 	if importMapPath != "" {
 		if !filepath.IsAbs(importMapPath) {
@@ -184,12 +184,12 @@ func parseEnvFile(envFilePath string, fsys afero.Fs) ([]string, error) {
 	}
 	f, err := fsys.Open(envFilePath)
 	if err != nil {
-		return env, err
+		return env, errors.Errorf("failed to open env file: %w", err)
 	}
 	defer f.Close()
 	envMap, err := godotenv.Parse(f)
 	if err != nil {
-		return env, err
+		return env, errors.Errorf("failed to parse env file: %w", err)
 	}
 	for name, value := range envMap {
 		if strings.HasPrefix(name, "SUPABASE_") {
@@ -210,12 +210,12 @@ func populatePerFunctionConfigs(binds []string, importMapPath string, noVerifyJW
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Errorf("failed to get working directory: %w", err)
 	}
 
 	functions, err := afero.ReadDir(fsys, utils.FunctionsDir)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Errorf("failed to read directory: %w", err)
 	}
 	for _, function := range functions {
 		if !function.IsDir() {
@@ -257,7 +257,7 @@ func populatePerFunctionConfigs(binds []string, importMapPath string, noVerifyJW
 
 	functionsConfigBytes, err := json.Marshal(functionsConfig)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Errorf("failed to marshal config json: %w", err)
 	}
 
 	return binds, string(functionsConfigBytes), nil

--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -35,7 +35,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			IncludedSchemas: &included,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to get typescript types: %w", err)
 		}
 
 		if resp.JSON200 == nil {
@@ -124,7 +124,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			IncludedSchemas: &included,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to get typescript types: %w", err)
 		}
 
 		if resp.JSON200 == nil {

--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
 )
 
@@ -114,7 +115,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 	}
 
 	if useLinked {
-		projectId, err := utils.LoadProjectRef(fsys)
+		projectId, err := flags.LoadProjectRef(fsys)
 		if err != nil {
 			return err
 		}

--- a/internal/hostnames/activate/activate.go
+++ b/internal/hostnames/activate/activate.go
@@ -2,9 +2,9 @@ package activate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/hostnames"
 	"github.com/supabase/cli/internal/utils"
@@ -27,7 +27,7 @@ func Run(ctx context.Context, projectRef string, includeRawOutput bool, fsys afe
 	{
 		resp, err := utils.GetSupabase().ActivateWithResponse(ctx, projectRef)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to active custom hostname: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to activate custom hostname config: " + string(resp.Body))

--- a/internal/hostnames/common.go
+++ b/internal/hostnames/common.go
@@ -14,7 +14,7 @@ import (
 func GetCustomHostnameConfig(ctx context.Context, projectRef string) (*api.GetCustomHostnameConfigResponse, error) {
 	resp, err := utils.GetSupabase().GetCustomHostnameConfigWithResponse(ctx, projectRef)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to get custom hostname: %w", err)
 	}
 	if resp.JSON200 == nil {
 		return nil, errors.New("failed to get custom hostname config; received: " + string(resp.Body))
@@ -59,7 +59,7 @@ type RawResponse struct {
 func serializeRawOutput(response *api.UpdateCustomHostnameResponse) (string, error) {
 	output, err := json.MarshalIndent(response, "", "    ")
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to serialize json: %w", err)
 	}
 	return string(output), nil
 }

--- a/internal/hostnames/common.go
+++ b/internal/hostnames/common.go
@@ -3,10 +3,10 @@ package hostnames
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
@@ -26,10 +26,10 @@ func VerifyCNAME(ctx context.Context, projectRef string, customHostname string) 
 	expectedEndpoint := fmt.Sprintf("%s.", utils.GetSupabaseHost(projectRef))
 	cname, err := utils.ResolveCNAME(ctx, customHostname)
 	if err != nil {
-		return fmt.Errorf("expected custom hostname '%s' to have a CNAME record pointing to your project at '%s', but it failed to resolve: %w", customHostname, expectedEndpoint, err)
+		return errors.Errorf("expected custom hostname '%s' to have a CNAME record pointing to your project at '%s', but it failed to resolve: %w", customHostname, expectedEndpoint, err)
 	}
 	if cname != expectedEndpoint {
-		return fmt.Errorf("expected custom hostname '%s' to have a CNAME record pointing to your project at '%s', but it is currently set to '%s'", customHostname, expectedEndpoint, cname)
+		return errors.Errorf("expected custom hostname '%s' to have a CNAME record pointing to your project at '%s', but it is currently set to '%s'", customHostname, expectedEndpoint, cname)
 	}
 	return nil
 }
@@ -83,11 +83,11 @@ func TranslateStatus(response *api.UpdateCustomHostnameResponse, includeRawOutpu
 		var res RawResponse
 		rawBody, err := json.Marshal(response.Data)
 		if err != nil {
-			return "", fmt.Errorf("failed to serialize body: %w", err)
+			return "", errors.Errorf("failed to serialize body: %w", err)
 		}
 		err = json.Unmarshal(rawBody, &res)
 		if err != nil {
-			return "", fmt.Errorf("failed to deserialize body: %w", err)
+			return "", errors.Errorf("failed to deserialize body: %w", err)
 		}
 		return appendRawOutputIfNeeded(fmt.Sprintf(`Custom hostname configuration complete, and ready for activation.
 
@@ -98,11 +98,11 @@ Please ensure that your custom domain is set up as a CNAME record to your Supaba
 		var res RawResponse
 		rawBody, err := json.Marshal(response.Data)
 		if err != nil {
-			return "", fmt.Errorf("failed to serialize body: %w", err)
+			return "", errors.Errorf("failed to serialize body: %w", err)
 		}
 		err = json.Unmarshal(rawBody, &res)
 		if err != nil {
-			return "", fmt.Errorf("failed to deserialize body: %w", err)
+			return "", errors.Errorf("failed to deserialize body: %w", err)
 		}
 		owner := res.Result.OwnershipVerification
 		ssl := res.Result.Ssl.ValidationRecords
@@ -121,7 +121,7 @@ Please ensure that your custom domain is set up as a CNAME record to your Supaba
 			return appendRawOutputIfNeeded(fmt.Sprintf("SSL validation errors: \n\t- %s\n", valErrors), response, includeRawOutput), nil
 		}
 		if len(ssl) != 1 {
-			return "", fmt.Errorf("expected a single SSL verification record, received: %+v", ssl)
+			return "", errors.Errorf("expected a single SSL verification record, received: %+v", ssl)
 		}
 		records := ""
 		if owner.Name != "" {

--- a/internal/hostnames/create/create.go
+++ b/internal/hostnames/create/create.go
@@ -2,10 +2,10 @@ package create
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/hostnames"
 	"github.com/supabase/cli/internal/utils"
@@ -32,7 +32,7 @@ func Run(ctx context.Context, projectRef string, customHostname string, includeR
 			CustomHostname: hostname,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to create custom hostname: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to create custom hostname config: " + string(resp.Body))

--- a/internal/hostnames/delete/delete.go
+++ b/internal/hostnames/delete/delete.go
@@ -2,9 +2,9 @@ package delete
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		resp, err := utils.GetSupabase().RemoveCustomHostnameConfigWithResponse(ctx, projectRef)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to delete custom hostname: %w", err)
 		}
 		if resp.StatusCode() != 200 {
 			return errors.New("failed to delete custom hostname config; received: " + resp.Status())

--- a/internal/hostnames/reverify/reverify.go
+++ b/internal/hostnames/reverify/reverify.go
@@ -2,9 +2,9 @@ package reverify
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/hostnames"
 	"github.com/supabase/cli/internal/utils"
@@ -16,7 +16,7 @@ func Run(ctx context.Context, projectRef string, includeRawOutput bool, fsys afe
 	{
 		resp, err := utils.GetSupabase().ReverifyWithResponse(ctx, projectRef)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to re-verify custom hostname: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to re-verify custom hostname config: " + string(resp.Body))

--- a/internal/inspect/bloat/bloat.go
+++ b/internal/inspect/bloat/bloat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -89,7 +90,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/blocking/blocking.go
+++ b/internal/inspect/blocking/blocking.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -48,7 +49,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/cache/cache.go
+++ b/internal/inspect/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -37,7 +38,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/calls/calls.go
+++ b/internal/inspect/calls/calls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -40,7 +41,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/index_sizes/index_sizes.go
+++ b/internal/inspect/index_sizes/index_sizes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -35,7 +36,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/index_usage/index_usage.go
+++ b/internal/inspect/index_usage/index_usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -44,7 +45,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/locks/locks.go
+++ b/internal/inspect/locks/locks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -44,7 +45,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/long_running_queries/long_running_queries.go
+++ b/internal/inspect/long_running_queries/long_running_queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -39,7 +40,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/outliers/outliers.go
+++ b/internal/inspect/outliers/outliers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -40,7 +41,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/replication_slots/replication_slots.go
+++ b/internal/inspect/replication_slots/replication_slots.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -41,7 +42,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/role_connections/role_connections.go
+++ b/internal/inspect/role_connections/role_connections.go
@@ -66,13 +66,10 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 		fmt.Printf("\nActive connections %d/%d\n\n", sum, result[0].Connection_limit)
 	}
 
-	ref, err := utils.LoadProjectRef(fsys)
-	if err != nil {
-		return err
+	if matches := utils.ProjectHostPattern.FindStringSubmatch(config.Host); len(matches) == 4 {
+		fmt.Println("Go to the dashboard for more here:")
+		fmt.Printf("https://app.supabase.com/project/%s/database/roles\n", matches[2])
 	}
-
-	fmt.Println("Go to the dashboard for more here:")
-	fmt.Printf("https://app.supabase.com/project/%s/database/roles\n", ref)
 
 	return nil
 }

--- a/internal/inspect/role_connections/role_connections.go
+++ b/internal/inspect/role_connections/role_connections.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -43,7 +44,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {
@@ -57,9 +58,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 		sum += r.Active_connections
 	}
 
-	err = list.RenderTable(table)
-	if err != nil {
-		fmt.Println(err)
+	if err := list.RenderTable(table); err != nil {
 		return err
 	}
 

--- a/internal/inspect/seq_scans/seq_scans.go
+++ b/internal/inspect/seq_scans/seq_scans.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -31,7 +32,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/table_index_sizes/table_index_sizes.go
+++ b/internal/inspect/table_index_sizes/table_index_sizes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -34,7 +35,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/table_record_counts/table_record_counts.go
+++ b/internal/inspect/table_record_counts/table_record_counts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -33,7 +34,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/table_sizes/table_sizes.go
+++ b/internal/inspect/table_sizes/table_sizes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -34,7 +35,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/total_index_size/total_index_size.go
+++ b/internal/inspect/total_index_size/total_index_size.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -32,7 +33,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/total_table_sizes/total_table_sizes.go
+++ b/internal/inspect/total_table_sizes/total_table_sizes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -35,7 +36,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/unused_indexes/unused_indexes.go
+++ b/internal/inspect/unused_indexes/unused_indexes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -38,7 +39,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/inspect/vacuum_stats/vacuum_stats.go
+++ b/internal/inspect/vacuum_stats/vacuum_stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -77,7 +78,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	}
 	rows, err := conn.Query(ctx, QUERY)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to query rows: %w", err)
 	}
 	result, err := pgxv5.CollectRows[Result](rows)
 	if err != nil {

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/toml"
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -134,7 +135,7 @@ func linkPostgrest(ctx context.Context, projectRef string) error {
 		return err
 	}
 	if resp.JSON200 == nil {
-		return fmt.Errorf("%w: %s", tenant.ErrAuthToken, string(resp.Body))
+		return errors.Errorf("%w: %s", tenant.ErrAuthToken, string(resp.Body))
 	}
 	updateApiConfig(*resp.JSON200)
 	return nil
@@ -242,7 +243,7 @@ func linkPooler(ctx context.Context, projectRef string) error {
 		return err
 	}
 	if resp.JSON200 == nil {
-		return fmt.Errorf("%w: %s", tenant.ErrAuthToken, string(resp.Body))
+		return errors.Errorf("%w: %s", tenant.ErrAuthToken, string(resp.Body))
 	}
 	updatePoolerConfig(*resp.JSON200)
 	return nil

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/migration/repair"
-	"github.com/supabase/cli/internal/services"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/supabase/cli/internal/utils/tenant"
@@ -201,7 +200,7 @@ func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pg
 }
 
 func linkDatabaseVersion(ctx context.Context, projectRef string, fsys afero.Fs) error {
-	version, err := services.GetDatabaseVersion(ctx, projectRef)
+	version, err := tenant.GetDatabaseVersion(ctx, projectRef)
 	if err != nil {
 		return err
 	}

--- a/internal/migration/list/list_test.go
+++ b/internal/migration/list/list_test.go
@@ -93,7 +93,7 @@ func TestRemoteMigrations(t *testing.T) {
 		// Run test
 		versions, err := loadRemoteVersions(context.Background(), dbConfig, conn.Intercept)
 		// Check error
-		assert.NoError(t, err)
+		assert.ErrorContains(t, err, "failed to parse rows")
 		assert.Empty(t, versions)
 	})
 

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -17,16 +18,16 @@ func Run(migrationName string, stdin afero.File, fsys afero.Fs) error {
 	}
 	f, err := fsys.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to open migration file: %w", err)
 	}
 	defer f.Close()
 
 	if fi, err := stdin.Stat(); err != nil {
-		return err
+		return errors.Errorf("failed to initialise stdin: %w", err)
 	} else if (fi.Mode() & os.ModeCharDevice) == 0 {
 		// Ref: https://stackoverflow.com/a/26567513
 		if _, err := io.Copy(f, stdin); err != nil {
-			return err
+			return errors.Errorf("failed to copy from stdin: %w", err)
 		}
 	}
 

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -2,13 +2,13 @@ package repair
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
@@ -36,7 +36,7 @@ var ErrInvalidVersion = errors.New("invalid version number")
 
 func Run(ctx context.Context, config pgconn.Config, version, status string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	if _, err := strconv.Atoi(version); err != nil {
-		return ErrInvalidVersion
+		return errors.New(ErrInvalidVersion)
 	}
 	conn, err := utils.ConnectByConfig(ctx, config, options...)
 	if err != nil {
@@ -118,7 +118,7 @@ func GetMigrationFile(version string, fsys afero.Fs) (string, error) {
 		return "", err
 	}
 	if len(matches) == 0 {
-		return "", fmt.Errorf("glob %s: %w", path, os.ErrNotExist)
+		return "", errors.Errorf("glob %s: %w", path, os.ErrNotExist)
 	}
 	return matches[0], nil
 }
@@ -190,7 +190,7 @@ func (m *MigrationFile) ExecBatch(ctx context.Context, conn *pgx.Conn) error {
 		if i < len(m.Lines) {
 			stat = m.Lines[i]
 		}
-		return fmt.Errorf("%w\nAt statement %d: %s", err, i, stat)
+		return errors.Errorf("%w\nAt statement %d: %s", err, i, stat)
 	}
 	return nil
 }

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -63,8 +63,10 @@ func UpdateMigrationTable(ctx context.Context, conn *pgx.Conn, version, status s
 	case Reverted:
 		DeleteVersionSQL(&batch, version)
 	}
-	_, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll()
-	return err
+	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
+		return errors.Errorf("failed to update migration table: %w", err)
+	}
+	return nil
 }
 
 func batchCreateTable() pgconn.Batch {
@@ -79,8 +81,10 @@ func batchCreateTable() pgconn.Batch {
 
 func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
 	batch := batchCreateTable()
-	_, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll()
-	return err
+	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
+		return errors.Errorf("failed to create migration table: %w", err)
+	}
+	return nil
 }
 
 func InsertVersionSQL(batch *pgconn.Batch, version, name string, stats []string) {
@@ -115,7 +119,7 @@ func GetMigrationFile(version string, fsys afero.Fs) (string, error) {
 	path := filepath.Join(utils.MigrationsDir, version+"_*.sql")
 	matches, err := afero.Glob(fsys, path)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to glob migration files: %w", err)
 	}
 	if len(matches) == 0 {
 		return "", errors.Errorf("glob %s: %w", path, os.ErrNotExist)
@@ -140,7 +144,7 @@ func NewMigrationFromVersion(version string, fsys afero.Fs) (*MigrationFile, err
 func NewMigrationFromFile(path string, fsys afero.Fs) (*MigrationFile, error) {
 	sql, err := fsys.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to open migration file: %w", err)
 	}
 	defer sql.Close()
 	// Unless explicitly specified, Use file length as max buffer size
@@ -202,5 +206,8 @@ func (m *MigrationFile) ExecBatchWithCache(ctx context.Context, conn *pgx.Conn) 
 		batch.Queue(line)
 	}
 	// No need to track version here because there are no schema changes
-	return conn.SendBatch(ctx, &batch).Close()
+	if err := conn.SendBatch(ctx, &batch).Close(); err != nil {
+		return errors.Errorf("failed to send batch: %w", err)
+	}
+	return nil
 }

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -190,7 +190,7 @@ func (m *MigrationFile) ExecBatch(ctx context.Context, conn *pgx.Conn) error {
 		if i < len(m.Lines) {
 			stat = m.Lines[i]
 		}
-		return fmt.Errorf("%w\nAt statement %d: %s", err, i, utils.Aqua(stat))
+		return fmt.Errorf("%w\nAt statement %d: %s", err, i, stat)
 	}
 	return nil
 }

--- a/internal/migration/repair/repair_test.go
+++ b/internal/migration/repair/repair_test.go
@@ -133,7 +133,7 @@ func TestMigrationFile(t *testing.T) {
 		migration, err := NewMigrationFromReader(strings.NewReader(sql))
 		// Check error
 		assert.ErrorIs(t, err, bufio.ErrTooLong)
-		assert.ErrorContains(t, err, "After statement 1:     BEGIN;")
+		assert.ErrorContains(t, err, "After statement 1: \tBEGIN;")
 		assert.Nil(t, migration)
 	})
 

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -2,12 +2,12 @@ package squash
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -23,7 +23,7 @@ var ErrMissingVersion = errors.New("version not found")
 func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	if len(version) > 0 {
 		if _, err := strconv.Atoi(version); err != nil {
-			return repair.ErrInvalidVersion
+			return errors.New(repair.ErrInvalidVersion)
 		}
 		if _, err := repair.GetMigrationFile(version, fsys); err != nil {
 			return err
@@ -49,7 +49,7 @@ func squashToVersion(ctx context.Context, version string, fsys afero.Fs, options
 		return err
 	}
 	if len(migrations) == 0 {
-		return ErrMissingVersion
+		return errors.New(ErrMissingVersion)
 	}
 	// Migrate to target version and dump
 	path := filepath.Join(utils.MigrationsDir, migrations[len(migrations)-1])

--- a/internal/orgs/create/create.go
+++ b/internal/orgs/create/create.go
@@ -2,9 +2,9 @@ package create
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
@@ -12,7 +12,7 @@ import (
 func Run(ctx context.Context, name string) error {
 	resp, err := utils.GetSupabase().CreateOrganizationWithResponse(ctx, api.CreateOrganizationJSONRequestBody{Name: name})
 	if err != nil {
-		return err
+		return errors.Errorf("failed to create organization: %w", err)
 	}
 
 	if resp.JSON201 == nil {

--- a/internal/orgs/list/list.go
+++ b/internal/orgs/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -13,7 +13,7 @@ import (
 func Run(ctx context.Context) error {
 	resp, err := utils.GetSupabase().GetOrganizationsWithResponse(ctx)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list organizations: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/postgresConfig/get/get.go
+++ b/internal/postgresConfig/get/get.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/charmbracelet/glamour"
 	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -41,20 +41,9 @@ func PrintOutPostgresConfigOverrides(config map[string]interface{}) error {
 		))
 	}
 
-	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(-1),
-	)
-	if err != nil {
+	if err := list.RenderTable(strings.Join(markdownTable, "")); err != nil {
 		return err
 	}
-
-	out, err := r.Render(strings.Join(markdownTable, ""))
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(out)
 	fmt.Println("- End of Custom Postgres Config -")
 	return nil
 }

--- a/internal/postgresConfig/get/get.go
+++ b/internal/postgresConfig/get/get.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -61,20 +62,20 @@ func PrintOutPostgresConfigOverrides(config map[string]interface{}) error {
 func GetCurrentPostgresConfig(ctx context.Context, projectRef string) (map[string]interface{}, error) {
 	resp, err := utils.GetSupabase().GetConfig(ctx, projectRef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Postgres config overrides: %w", err)
+		return nil, errors.Errorf("failed to retrieve Postgres config overrides: %w", err)
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("error in retrieving Postgres config overrides: %s", resp.Status)
+		return nil, errors.Errorf("error in retrieving Postgres config overrides: %s", resp.Status)
 	}
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, errors.Errorf("failed to read response body: %w", err)
 	}
 
 	var config map[string]interface{}
 	err = json.Unmarshal(contents, &config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body: %w. Contents were %s", err, contents)
+		return nil, errors.Errorf("failed to unmarshal response body: %w. Contents were %s", err, contents)
 	}
 	return config, nil
 }

--- a/internal/postgresConfig/update/update.go
+++ b/internal/postgresConfig/update/update.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/postgresConfig/get"
 	"github.com/supabase/cli/internal/utils"
@@ -19,7 +19,7 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 	for _, config := range values {
 		splits := strings.Split(config, "=")
 		if len(splits) != 2 {
-			return fmt.Errorf("expected config value in key:value format, received: '%s'", config)
+			return errors.Errorf("expected config value in key:value format, received: '%s'", config)
 		}
 		newConfigOverrides[splits[0]] = splits[1]
 	}
@@ -51,7 +51,7 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 	{
 		bts, err := json.Marshal(finalOverrides)
 		if err != nil {
-			return fmt.Errorf("failed to serialize config overrides: %w", err)
+			return errors.Errorf("failed to serialize config overrides: %w", err)
 		}
 		resp, err := utils.GetSupabase().UpdateConfigWithBodyWithResponse(ctx, projectRef, "application/json", bytes.NewReader(bts))
 		if err != nil {
@@ -59,9 +59,9 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 		}
 		if resp.JSON200 == nil {
 			if resp.StatusCode() == 400 {
-				return fmt.Errorf("failed to update config overrides: %s (%s). This usually indicates that an unsupported or invalid config override was attempted. Please refer to https://supabase.com/docs/guides/platform/custom-postgres-config", resp.Status(), string(resp.Body))
+				return errors.Errorf("failed to update config overrides: %s (%s). This usually indicates that an unsupported or invalid config override was attempted. Please refer to https://supabase.com/docs/guides/platform/custom-postgres-config", resp.Status(), string(resp.Body))
 			}
-			return fmt.Errorf("failed to update config overrides: %s (%s)", resp.Status(), string(resp.Body))
+			return errors.Errorf("failed to update config overrides: %s (%s)", resp.Status(), string(resp.Body))
 		}
 	}
 	return get.Run(ctx, projectRef, fsys)

--- a/internal/postgresConfig/update/update.go
+++ b/internal/postgresConfig/update/update.go
@@ -55,7 +55,7 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 		}
 		resp, err := utils.GetSupabase().UpdateConfigWithBodyWithResponse(ctx, projectRef, "application/json", bytes.NewReader(bts))
 		if err != nil {
-			return err
+			return errors.Errorf("failed to update config overrides: %w", err)
 		}
 		if resp.JSON200 == nil {
 			if resp.StatusCode() == 400 {

--- a/internal/projects/apiKeys/api_keys.go
+++ b/internal/projects/apiKeys/api_keys.go
@@ -2,10 +2,10 @@ package apiKeys
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -14,7 +14,7 @@ import (
 func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().GetProjectApiKeysWithResponse(ctx, projectRef)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to get api keys: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/projects/create/create.go
+++ b/internal/projects/create/create.go
@@ -2,9 +2,9 @@ package create
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -17,7 +17,7 @@ func Run(ctx context.Context, params api.CreateProjectBody, fsys afero.Fs) error
 
 	resp, err := utils.GetSupabase().CreateProjectWithResponse(ctx, params)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to create project: %w", err)
 	}
 
 	if resp.JSON201 == nil {

--- a/internal/projects/delete/delete.go
+++ b/internal/projects/delete/delete.go
@@ -2,11 +2,11 @@ package delete
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
@@ -26,7 +26,7 @@ func PreRun(ref string) error {
 func Run(ctx context.Context, ref string, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().DeleteProjectWithResponse(ctx, ref)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to delete project: %w", err)
 	}
 
 	switch resp.StatusCode() {
@@ -35,7 +35,7 @@ func Run(ctx context.Context, ref string, fsys afero.Fs) error {
 	case http.StatusOK:
 		break
 	default:
-		return errors.New("Failed to delete project " + utils.Aqua(ref) + ": " + string(resp.Body))
+		return errors.Errorf("Failed to delete project %s: %s", utils.Aqua(ref), string(resp.Body))
 	}
 
 	// Unlink project

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
@@ -23,7 +24,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		return errors.New("Unexpected error retrieving projects: " + string(resp.Body))
 	}
 
-	projectRef, err := utils.LoadProjectRef(fsys)
+	projectRef, err := flags.LoadProjectRef(fsys)
 	if err != nil && err != utils.ErrNotLinked {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -2,12 +2,12 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -16,7 +16,7 @@ import (
 func Run(ctx context.Context, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().GetProjectsWithResponse(ctx)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list projects: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/restrictions/get/get.go
+++ b/internal/restrictions/get/get.go
@@ -21,9 +21,6 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 			return errors.New("failed to retrieve network restrictions; received: " + string(resp.Body))
 		}
 
-		if err != nil {
-			return err
-		}
 		fmt.Printf("DB Allowed CIDRs: %+v\n", resp.JSON200.Config.DbAllowedCidrs)
 		fmt.Printf("Restrictions applied successfully: %+v\n", resp.JSON200.Status == "applied")
 		return nil

--- a/internal/restrictions/get/get.go
+++ b/internal/restrictions/get/get.go
@@ -2,9 +2,9 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		resp, err := utils.GetSupabase().GetNetworkRestrictionsWithResponse(ctx, projectRef)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve network restrictions: %w", err)
+			return errors.Errorf("failed to retrieve network restrictions: %w", err)
 		}
 		if resp.JSON200 == nil {
 			return errors.New("failed to retrieve network restrictions; received: " + string(resp.Body))

--- a/internal/restrictions/update/update.go
+++ b/internal/restrictions/update/update.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, projectRef string, dbCidrsToAllow []string, bypass
 			DbAllowedCidrs: dbCidrsToAllow,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to apply network restrictions: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to update network restrictions: " + string(resp.Body))

--- a/internal/restrictions/update/update.go
+++ b/internal/restrictions/update/update.go
@@ -2,10 +2,10 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -15,13 +15,13 @@ func validateCidrs(cidrs []string, bypassChecks bool) error {
 	for _, cidr := range cidrs {
 		ip, _, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return fmt.Errorf("failed to parse IP: %s", cidr)
+			return errors.Errorf("failed to parse IP: %s", cidr)
 		}
 		if ip.IsPrivate() && !bypassChecks {
-			return fmt.Errorf("private IP provided: %s", cidr)
+			return errors.Errorf("private IP provided: %s", cidr)
 		}
 		if ip.To4() == nil {
-			return fmt.Errorf("only IPv4 supported at the moment: %s", cidr)
+			return errors.Errorf("only IPv4 supported at the moment: %s", cidr)
 		}
 	}
 	return nil

--- a/internal/secrets/list/list.go
+++ b/internal/secrets/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -14,7 +14,7 @@ import (
 func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().GetSecretsWithResponse(ctx, projectRef)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list secrets: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/secrets/set/set.go
+++ b/internal/secrets/set/set.go
@@ -2,11 +2,11 @@ package set
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/joho/godotenv"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
@@ -21,7 +21,7 @@ func Run(ctx context.Context, projectRef, envFilePath string, args []string, fsy
 		if envFilePath != "" {
 			envMap, err := godotenv.Read(envFilePath)
 			if err != nil {
-				return err
+				return errors.Errorf("failed to read env file: %w", err)
 			}
 			for name, value := range envMap {
 				secret := api.CreateSecretBody{
@@ -49,7 +49,7 @@ func Run(ctx context.Context, projectRef, envFilePath string, args []string, fsy
 
 		resp, err := utils.GetSupabase().CreateSecretsWithResponse(ctx, projectRef, secrets)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to set secrets: %w", err)
 		}
 
 		// TODO: remove the StatusOK case after 2022-08-20

--- a/internal/secrets/unset/unset.go
+++ b/internal/secrets/unset/unset.go
@@ -2,10 +2,10 @@ package unset
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -16,7 +16,7 @@ func Run(ctx context.Context, projectRef string, args []string, fsys afero.Fs) e
 	{
 		resp, err := utils.GetSupabase().DeleteSecretsWithResponse(ctx, projectRef, args)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to delete secrets: %w", err)
 		}
 
 		if resp.StatusCode() != http.StatusOK {

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -20,19 +20,7 @@ var (
 
 func Run(ctx context.Context, fsys afero.Fs) error {
 	_ = utils.LoadConfigFS(fsys)
-	serviceImages := []string{
-		utils.Config.Db.Image,
-		utils.Config.Auth.Image,
-		utils.Config.Api.Image,
-		utils.RealtimeImage,
-		utils.Config.Storage.Image,
-		utils.EdgeRuntimeImage,
-		utils.StudioImage,
-		utils.PgmetaImage,
-		utils.LogflareImage,
-		utils.PgbouncerImage,
-		utils.ImageProxyImage,
-	}
+	serviceImages := GetServiceImages()
 
 	linked := make(map[string]string)
 	if projectRef, err := utils.LoadProjectRef(fsys); err == nil {
@@ -80,6 +68,22 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 
 	return list.RenderTable(table)
+}
+
+func GetServiceImages() []string {
+	return []string{
+		utils.Config.Db.Image,
+		utils.Config.Auth.Image,
+		utils.Config.Api.Image,
+		utils.RealtimeImage,
+		utils.Config.Storage.Image,
+		utils.EdgeRuntimeImage,
+		utils.StudioImage,
+		utils.PgmetaImage,
+		utils.LogflareImage,
+		utils.PgbouncerImage,
+		utils.ImageProxyImage,
+	}
 }
 
 func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) {

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -2,11 +2,11 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -85,7 +85,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) {
 	resp, err := utils.GetSupabase().GetProjectsWithResponse(ctx)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to retrieve projects: %w", err)
 	}
 	if resp.JSON200 == nil {
 		return "", errors.New("Unexpected error retrieving projects: " + string(resp.Body))
@@ -95,5 +95,5 @@ func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) 
 			return project.Database.Version, nil
 		}
 	}
-	return "", errDatabaseVersion
+	return "", errors.New(errDatabaseVersion)
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -6,29 +6,26 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/internal/utils/tenant"
 )
 
-var (
-	errDatabaseVersion = errors.New("Database version not found.")
-	suggestLinkCommand = fmt.Sprintf("Run %s to sync your local image versions with the linked project.", utils.Aqua("supabase link"))
-)
+var suggestLinkCommand = fmt.Sprintf("Run %s to sync your local image versions with the linked project.", utils.Aqua("supabase link"))
 
 func Run(ctx context.Context, fsys afero.Fs) error {
 	_ = utils.LoadConfigFS(fsys)
 	serviceImages := GetServiceImages()
 
 	linked := make(map[string]string)
-	if projectRef, err := utils.LoadProjectRef(fsys); err == nil {
+	if projectRef, err := flags.LoadProjectRef(fsys); err == nil {
 		var wg sync.WaitGroup
 		wg.Add(4)
 		go func() {
 			defer wg.Done()
-			if version, err := GetDatabaseVersion(ctx, projectRef); err == nil {
+			if version, err := tenant.GetDatabaseVersion(ctx, projectRef); err == nil {
 				linked[utils.Config.Db.Image] = version
 			}
 		}()
@@ -84,20 +81,4 @@ func GetServiceImages() []string {
 		utils.PgbouncerImage,
 		utils.ImageProxyImage,
 	}
-}
-
-func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) {
-	resp, err := utils.GetSupabase().GetProjectsWithResponse(ctx)
-	if err != nil {
-		return "", errors.Errorf("failed to retrieve projects: %w", err)
-	}
-	if resp.JSON200 == nil {
-		return "", errors.New("Unexpected error retrieving projects: " + string(resp.Body))
-	}
-	for _, project := range *resp.JSON200 {
-		if project.Id == projectRef && len(project.Database.Version) > 0 {
-			return project.Database.Version, nil
-		}
-	}
-	return "", errors.New(errDatabaseVersion)
 }

--- a/internal/snippets/download/download.go
+++ b/internal/snippets/download/download.go
@@ -2,9 +2,9 @@ package download
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -12,7 +12,7 @@ import (
 func Run(ctx context.Context, snippetId string, fsys afero.Fs) error {
 	resp, err := utils.GetSupabase().GetSnippetWithResponse(ctx, snippetId)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to download snippet: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/snippets/list/list.go
+++ b/internal/snippets/list/list.go
@@ -9,11 +9,12 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := utils.LoadProjectRef(fsys)
+	ref, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/snippets/list/list.go
+++ b/internal/snippets/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
@@ -19,7 +19,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 	resp, err := utils.GetSupabase().ListSnippetsWithResponse(ctx, &api.ListSnippetsParams{ProjectRef: &ref})
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list snippets: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/ssl_enforcement/get/get.go
+++ b/internal/ssl_enforcement/get/get.go
@@ -21,9 +21,6 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 			return errors.New("failed to retrieve SSL enforcement config; received: " + string(resp.Body))
 		}
 
-		if err != nil {
-			return err
-		}
 		if resp.JSON200.CurrentConfig.Database && resp.JSON200.AppliedSuccessfully {
 			fmt.Println("SSL is being enforced.")
 		} else {

--- a/internal/ssl_enforcement/get/get.go
+++ b/internal/ssl_enforcement/get/get.go
@@ -2,9 +2,9 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		resp, err := utils.GetSupabase().GetSslEnforcementConfigWithResponse(ctx, projectRef)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve SSL enforcement config: %w", err)
+			return errors.Errorf("failed to retrieve SSL enforcement config: %w", err)
 		}
 		if resp.JSON200 == nil {
 			return errors.New("failed to retrieve SSL enforcement config; received: " + string(resp.Body))

--- a/internal/ssl_enforcement/update/update.go
+++ b/internal/ssl_enforcement/update/update.go
@@ -2,9 +2,9 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -20,7 +20,7 @@ func Run(ctx context.Context, projectRef string, enforceDbSsl bool, fsys afero.F
 			},
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to update ssl enforcement: %w", err)
 		}
 		if resp.JSON200 == nil {
 			return errors.New("failed to update SSL enforcement confnig: " + string(resp.Body))

--- a/internal/sso/create/create.go
+++ b/internal/sso/create/create.go
@@ -2,13 +2,11 @@ package create
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
-
 	"github.com/supabase/cli/internal/sso/internal/render"
 	"github.com/supabase/cli/internal/sso/internal/saml"
 	"github.com/supabase/cli/internal/utils"
@@ -43,7 +41,7 @@ func Run(ctx context.Context, params RunParams) error {
 	} else if params.MetadataURL != "" {
 		if !params.SkipURLValidation {
 			if err := saml.ValidateMetadataURL(ctx, params.MetadataURL); err != nil {
-				return fmt.Errorf("%w Use --skip-url-validation to suppress this error", err)
+				return errors.Errorf("%w Use --skip-url-validation to suppress this error", err)
 			}
 		}
 

--- a/internal/sso/create/create.go
+++ b/internal/sso/create/create.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, params RunParams) error {
 
 	resp, err := utils.GetSupabase().CreateProviderForProjectWithResponse(ctx, params.ProjectRef, body)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to create sso provider: %w", err)
 	}
 
 	if resp.JSON201 == nil {

--- a/internal/sso/get/get.go
+++ b/internal/sso/get/get.go
@@ -2,11 +2,11 @@ package get
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/sso/internal/render"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -20,7 +20,7 @@ func Run(ctx context.Context, ref, providerId, format string) error {
 
 	if resp.JSON200 == nil {
 		if resp.StatusCode() == http.StatusNotFound {
-			return fmt.Errorf("An identity provider with ID %q could not be found.", providerId)
+			return errors.Errorf("An identity provider with ID %q could not be found.", providerId)
 		}
 
 		return errors.New("Unexpected error fetching identity provider: " + string(resp.Body))

--- a/internal/sso/internal/render/render.go
+++ b/internal/sso/internal/render/render.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/go-errors/errors"
 	"github.com/go-xmlfmt/xmlfmt"
+	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
@@ -32,7 +33,7 @@ func formatMetadataSource(provider api.Provider) string {
 func formatAttributeMapping(attributeMapping *api.AttributeMapping) (string, error) {
 	data, err := json.MarshalIndent(attributeMapping, "", "  ")
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to marshal attribute mapping: %w", err)
 	}
 
 	return string(data), nil
@@ -91,21 +92,7 @@ func ListMarkdown(providers []api.Provider) error {
 		))
 	}
 
-	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(-1),
-	)
-	if err != nil {
-		return err
-	}
-
-	out, err := r.Render(strings.Join(markdownTable, ""))
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(out)
-	return nil
+	return list.RenderTable(strings.Join(markdownTable, ""))
 }
 
 func SingleMarkdown(provider api.Provider) error {
@@ -165,21 +152,7 @@ func SingleMarkdown(provider api.Provider) error {
 		markdownTable = append(markdownTable, "", "## SAML 2.0 Metadata XML", "```xml", prettyXML, "```")
 	}
 
-	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(-1),
-	)
-	if err != nil {
-		return err
-	}
-
-	out, err := r.Render(strings.Join(markdownTable, "\n"))
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(out)
-	return nil
+	return list.RenderTable(strings.Join(markdownTable, "\n"))
 }
 
 func InfoMarkdown(ref string) error {
@@ -203,19 +176,5 @@ func InfoMarkdown(ref string) error {
 		fmt.Sprintf("https://%s.supabase.co", ref),
 	))
 
-	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(-1),
-	)
-	if err != nil {
-		return err
-	}
-
-	out, err := r.Render(strings.Join(markdownTable, "\n"))
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(out)
-	return nil
+	return list.RenderTable(strings.Join(markdownTable, "\n"))
 }

--- a/internal/sso/internal/saml/files.go
+++ b/internal/sso/internal/saml/files.go
@@ -3,14 +3,13 @@ package saml
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/pkg/api"
 )
@@ -57,7 +56,7 @@ func ReadAttributeMappingFile(fsys afero.Fs, path string) (*api.AttributeMapping
 
 func ValidateMetadata(data []byte, source string) error {
 	if !utf8.Valid(data) {
-		return fmt.Errorf("SAML Metadata XML at %q is not UTF-8 encoded", source)
+		return errors.Errorf("SAML Metadata XML at %q is not UTF-8 encoded", source)
 	}
 
 	return nil
@@ -87,7 +86,7 @@ func ValidateMetadataURL(ctx context.Context, metadataURL string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received HTTP %v when fetching metatada at %q", resp.Status, metadataURL)
+		return errors.Errorf("received HTTP %v when fetching metatada at %q", resp.Status, metadataURL)
 	}
 
 	data, err := io.ReadAll(resp.Body)

--- a/internal/sso/internal/saml/files_test.go
+++ b/internal/sso/internal/saml/files_test.go
@@ -7,65 +7,47 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadAttributeMappingFile(t *testing.T) {
 	t.Run("open file that does not exist", func(t *testing.T) {
 		_, err := ReadAttributeMappingFile(afero.NewMemMapFs(), "/does-not-exist")
-		if !os.IsNotExist(err) {
-			t.Fatalf("unexpected error %v", err)
-		}
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run("open file that is not valid JSON", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		assert.NoError(t, afero.WriteFile(fs, "/not-valid-json", []byte("not-valid-JSON"), 0755))
+		require.NoError(t, afero.WriteFile(fs, "/not-valid-json", []byte("not-valid-JSON"), 0755))
 
 		_, err := ReadAttributeMappingFile(fs, "/not-valid-json")
-		if err == nil {
-			t.Fatalf("expected error")
-		}
+		assert.ErrorContains(t, err, "failed to parse attribute mapping")
 	})
 
 	t.Run("open valid file", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		assert.NoError(t, afero.WriteFile(fs, "/valid-json", []byte(`{"keys":{"abc":{"names":["x","y","z"],"default":2,"name":"k"}}}`), 0755))
+		require.NoError(t, afero.WriteFile(fs, "/valid-json", []byte(`{"keys":{"abc":{"names":["x","y","z"],"default":2,"name":"k"}}}`), 0755))
 
 		_, err := ReadAttributeMappingFile(fs, "/valid-json")
-		if err != nil {
-			t.Fatalf("unexpected error %v", err)
-		}
+		assert.NoError(t, err)
 	})
 }
 
 func TestValidateMetadata(t *testing.T) {
 	t.Run("with invalid UTF-8", func(t *testing.T) {
 		err := ValidateMetadata([]byte{0xFF, 0xFF, 0xFF}, "/invalid-utf-8")
-		if err == nil || err.Error() != "SAML Metadata XML at \"/invalid-utf-8\" is not UTF-8 encoded" {
-			t.Fatalf("unexpected error %v", err)
-		}
+		assert.ErrorContains(t, err, `SAML Metadata XML at "/invalid-utf-8" is not UTF-8 encoded`)
 	})
 }
 
 func TestValidateMetadataURL(t *testing.T) {
 	t.Run("with relative URL", func(t *testing.T) {
 		err := ValidateMetadataURL(context.TODO(), "./relative-url")
-		if err == nil || err.Error() != "parse \"./relative-url\": invalid URI for request" {
-			t.Fatalf("unexpected error %v", err)
-		}
+		assert.ErrorContains(t, err, "invalid URI for request")
 	})
 
 	t.Run("with HTTP URL", func(t *testing.T) {
 		err := ValidateMetadataURL(context.TODO(), "http://example.com")
-		if err == nil || err.Error() != "only HTTPS Metadata URLs are supported" {
-			t.Fatalf("unexpected error %v", err)
-		}
-	})
-
-	t.Run("with HTTP URL", func(t *testing.T) {
-		err := ValidateMetadataURL(context.TODO(), "http://example.com")
-		if err == nil || err.Error() != "only HTTPS Metadata URLs are supported" {
-			t.Fatalf("unexpected error %v", err)
-		}
+		assert.ErrorContains(t, err, "only HTTPS Metadata URLs are supported")
 	})
 }

--- a/internal/sso/list/list.go
+++ b/internal/sso/list/list.go
@@ -2,10 +2,10 @@ package list
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/sso/internal/render"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -13,7 +13,7 @@ import (
 func Run(ctx context.Context, ref, format string) error {
 	resp, err := utils.GetSupabase().ListAllProvidersWithResponse(ctx, ref)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to list sso providers: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/sso/remove/remove.go
+++ b/internal/sso/remove/remove.go
@@ -2,11 +2,10 @@ package remove
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/sso/internal/render"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -20,7 +19,7 @@ func Run(ctx context.Context, ref, providerId, format string) error {
 
 	if resp.JSON200 == nil {
 		if resp.StatusCode() == http.StatusNotFound {
-			return fmt.Errorf("An identity provider with ID %q could not be found.", providerId)
+			return errors.Errorf("An identity provider with ID %q could not be found.", providerId)
 		}
 
 		return errors.New("Unexpected error removing identity provider: " + string(resp.Body))

--- a/internal/sso/remove/remove.go
+++ b/internal/sso/remove/remove.go
@@ -14,7 +14,7 @@ import (
 func Run(ctx context.Context, ref, providerId, format string) error {
 	resp, err := utils.GetSupabase().RemoveProviderByIdWithResponse(ctx, ref, providerId)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to remove sso provider: %w", err)
 	}
 
 	if resp.JSON200 == nil {

--- a/internal/sso/update/update.go
+++ b/internal/sso/update/update.go
@@ -2,13 +2,11 @@ package update
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
-
 	"github.com/supabase/cli/internal/sso/internal/render"
 	"github.com/supabase/cli/internal/sso/internal/saml"
 	"github.com/supabase/cli/internal/utils"
@@ -40,7 +38,7 @@ func Run(ctx context.Context, params RunParams) error {
 
 	if getResp.JSON200 == nil {
 		if getResp.StatusCode() == http.StatusNotFound {
-			return fmt.Errorf("An identity provider with ID %q could not be found.", params.ProviderID)
+			return errors.Errorf("An identity provider with ID %q could not be found.", params.ProviderID)
 		}
 
 		return errors.New("unexpected error fetching identity provider: " + string(getResp.Body))
@@ -58,7 +56,7 @@ func Run(ctx context.Context, params RunParams) error {
 	} else if params.MetadataURL != "" {
 		if !params.SkipURLValidation {
 			if err := saml.ValidateMetadataURL(ctx, params.MetadataURL); err != nil {
-				return fmt.Errorf("%w Use --skip-url-validation to suppress this error.", err)
+				return errors.Errorf("%w Use --skip-url-validation to suppress this error.", err)
 			}
 		}
 

--- a/internal/sso/update/update.go
+++ b/internal/sso/update/update.go
@@ -33,7 +33,7 @@ type RunParams struct {
 func Run(ctx context.Context, params RunParams) error {
 	getResp, err := utils.GetSupabase().GetProviderByIdWithResponse(ctx, params.ProjectRef, params.ProviderID)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to get sso provider: %w", err)
 	}
 
 	if getResp.JSON200 == nil {
@@ -103,7 +103,7 @@ func Run(ctx context.Context, params RunParams) error {
 
 	putResp, err := utils.GetSupabase().UpdateProviderByIdWithResponse(ctx, params.ProjectRef, params.ProviderID, body)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to update sso provider: %w", err)
 	}
 
 	if putResp.JSON200 == nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -17,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -142,7 +142,7 @@ func run(p utils.Program, ctx context.Context, fsys afero.Fs, excludedContainers
 			EdgeRuntimeId: utils.EdgeRuntimeId,
 			DbId:          utils.DbId,
 		}); err != nil {
-			return err
+			return errors.Errorf("failed to exec template: %w", err)
 		}
 		p.Send(utils.StatusMsg("Starting syslog driver..."))
 		if _, err := utils.DockerStart(
@@ -222,7 +222,7 @@ EOF
 		case utils.LogflareBigQuery:
 			workdir, err := os.Getwd()
 			if err != nil {
-				return err
+				return errors.Errorf("failed to get working directory: %w", err)
 			}
 			hostJwtPath := filepath.Join(workdir, utils.Config.Analytics.GcpJwtPath)
 			bind = append(bind, hostJwtPath+":/opt/app/rel/logflare/bin/gcloud.json")
@@ -296,7 +296,7 @@ EOF
 			LogflareId:    utils.LogflareId,
 			ApiPort:       utils.Config.Api.Port,
 		}); err != nil {
-			return err
+			return errors.Errorf("failed to exec template: %w", err)
 		}
 
 		binds := []string{}
@@ -309,7 +309,7 @@ EOF
 				var err error
 				hostPath, err = filepath.Abs(hostPath)
 				if err != nil {
-					return err
+					return errors.Errorf("failed to resolve absolute path: %w", err)
 				}
 			}
 			dockerPath := path.Join(nginxEmailTemplateDir, id+filepath.Ext(hostPath))

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/docker/docker/client"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -99,9 +100,9 @@ func AssertContainerHealthy(ctx context.Context, container string) error {
 	if resp, err := utils.Docker.ContainerInspect(ctx, container); err != nil {
 		return err
 	} else if !resp.State.Running {
-		return fmt.Errorf("%s container is not running: %s", container, resp.State.Status)
+		return errors.Errorf("%s container is not running: %s", container, resp.State.Status)
 	} else if resp.State.Health != nil && resp.State.Health.Status != "healthy" {
-		return fmt.Errorf("%s container is not ready: %s", container, resp.State.Health.Status)
+		return errors.Errorf("%s container is not ready: %s", container, resp.State.Health.Status)
 	}
 	return nil
 }

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -3,7 +3,6 @@ package stop
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -80,7 +80,7 @@ func stop(ctx context.Context, backup bool, w io.Writer) error {
 		}
 		result = utils.WaitAll(volumes, func(name string) error {
 			if err := utils.Docker.VolumeRemove(ctx, name, true); err != nil && !errdefs.IsNotFound(err) {
-				return fmt.Errorf("Failed to remove volume %s: %w", name, err)
+				return errors.Errorf("Failed to remove volume %s: %w", name, err)
 			}
 			return nil
 		})

--- a/internal/storage/client/objects.go
+++ b/internal/storage/client/objects.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/tenant"
@@ -105,7 +106,7 @@ func UploadStorageObject(ctx context.Context, projectRef, remotePath, localPath 
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Error status %d: %s", resp.StatusCode, body)
+		return errors.Errorf("Error status %d: %s", resp.StatusCode, body)
 	}
 	return nil
 }
@@ -133,7 +134,7 @@ func DownloadStorageObject(ctx context.Context, projectRef, remotePath, localPat
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Error status %d: %s", resp.StatusCode, body)
+		return errors.Errorf("Error status %d: %s", resp.StatusCode, body)
 	}
 	// Streams to file
 	f, err := fsys.OpenFile(localPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)

--- a/internal/storage/cp/cp.go
+++ b/internal/storage/cp/cp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/supabase/cli/internal/storage/client"
 	"github.com/supabase/cli/internal/storage/ls"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 var errUnsupportedOperation = errors.New("Unsupported operation")
@@ -29,7 +30,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, fsys afero.Fs) er
 	if err != nil {
 		return errors.Errorf("failed to parse dst url: %w", err)
 	}
-	projectRef, err := utils.LoadProjectRef(fsys)
+	projectRef, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/cp/cp.go
+++ b/internal/storage/cp/cp.go
@@ -2,7 +2,6 @@ package cp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/storage"
 	"github.com/supabase/cli/internal/storage/client"
@@ -23,11 +23,11 @@ var errUnsupportedOperation = errors.New("Unsupported operation")
 func Run(ctx context.Context, src, dst string, recursive bool, fsys afero.Fs) error {
 	srcParsed, err := url.Parse(src)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to parse src url: %w", err)
 	}
 	dstParsed, err := url.Parse(dst)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to parse dst url: %w", err)
 	}
 	projectRef, err := utils.LoadProjectRef(fsys)
 	if err != nil {
@@ -47,7 +47,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, fsys afero.Fs) er
 		return errors.New("Copying between buckets is not supported")
 	}
 	utils.CmdSuggestion = fmt.Sprintf("Run %s to copy between local directories.", utils.Aqua("cp -r <src> <dst>"))
-	return errUnsupportedOperation
+	return errors.New(errUnsupportedOperation)
 }
 
 func DownloadStorageObjectAll(ctx context.Context, projectRef, remotePath, localPath string, fsys afero.Fs) error {
@@ -96,14 +96,14 @@ func UploadStorageObjectAll(ctx context.Context, projectRef, remotePath, localPa
 	baseName := filepath.Base(localPath)
 	return afero.Walk(fsys, localPath, func(filePath string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return errors.New(err)
 		}
 		if !info.Mode().IsRegular() {
 			return nil
 		}
 		relPath, err := filepath.Rel(localPath, filePath)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to resolve relative path: %w", err)
 		}
 		dstPath := remotePath
 		// Copying single file

--- a/internal/storage/ls/ls.go
+++ b/internal/storage/ls/ls.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/storage"
 	"github.com/supabase/cli/internal/storage/client"
-	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 func Run(ctx context.Context, objectPath string, recursive bool, fsys afero.Fs) error {
@@ -18,7 +18,7 @@ func Run(ctx context.Context, objectPath string, recursive bool, fsys afero.Fs) 
 	if err != nil {
 		return err
 	}
-	projectRef, err := utils.LoadProjectRef(fsys)
+	projectRef, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/mv/mv.go
+++ b/internal/storage/mv/mv.go
@@ -2,12 +2,12 @@ package mv
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/storage"
 	"github.com/supabase/cli/internal/storage/client"
@@ -36,10 +36,10 @@ func Run(ctx context.Context, src, dst string, recursive bool, fsys afero.Fs) er
 	srcBucket, srcPrefix := storage.SplitBucketPrefix(srcParsed)
 	dstBucket, dstPrefix := storage.SplitBucketPrefix(dstParsed)
 	if len(srcPrefix) == 0 && len(dstPrefix) == 0 {
-		return errMissingPath
+		return errors.New(errMissingPath)
 	}
 	if srcBucket != dstBucket {
-		return errUnsupportedMove
+		return errors.New(errUnsupportedMove)
 	}
 	fmt.Fprintln(os.Stderr, "Moving object:", srcParsed, "=>", dstParsed)
 	data, err := client.MoveStorageObject(ctx, projectRef, srcBucket, srcPrefix, dstPrefix)

--- a/internal/storage/mv/mv.go
+++ b/internal/storage/mv/mv.go
@@ -12,7 +12,7 @@ import (
 	"github.com/supabase/cli/internal/storage"
 	"github.com/supabase/cli/internal/storage/client"
 	"github.com/supabase/cli/internal/storage/ls"
-	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 var (
@@ -29,7 +29,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, fsys afero.Fs) er
 	if err != nil {
 		return err
 	}
-	projectRef, err := utils.LoadProjectRef(fsys)
+	projectRef, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/rm/rm.go
+++ b/internal/storage/rm/rm.go
@@ -2,11 +2,11 @@ package rm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/storage"
 	"github.com/supabase/cli/internal/storage/client"
@@ -37,10 +37,10 @@ func Run(ctx context.Context, paths []string, recursive bool, fsys afero.Fs) err
 		bucket, prefix := storage.SplitBucketPrefix(remotePath)
 		// Ignore attempts to delete all buckets
 		if len(bucket) == 0 {
-			return errMissingBucket
+			return errors.New(errMissingBucket)
 		}
 		if cp.IsDir(prefix) && !recursive {
-			return errMissingFlag
+			return errors.New(errMissingFlag)
 		}
 		groups[bucket] = append(groups[bucket], prefix)
 	}
@@ -95,7 +95,7 @@ func RemoveStoragePathAll(ctx context.Context, projectRef, bucket, prefix string
 			return err
 		}
 		if len(paths) == 0 && len(prefix) > 0 {
-			return fmt.Errorf("%w: %s/%s", errMissingObject, bucket, prefix)
+			return errors.Errorf("%w: %s/%s", errMissingObject, bucket, prefix)
 		}
 		var files []string
 		for _, objectName := range paths {

--- a/internal/storage/rm/rm.go
+++ b/internal/storage/rm/rm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supabase/cli/internal/storage/cp"
 	"github.com/supabase/cli/internal/storage/ls"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 var (
@@ -44,7 +45,7 @@ func Run(ctx context.Context, paths []string, recursive bool, fsys afero.Fs) err
 		}
 		groups[bucket] = append(groups[bucket], prefix)
 	}
-	projectRef, err := utils.LoadProjectRef(fsys)
+	projectRef, err := flags.LoadProjectRef(fsys)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/scheme.go
+++ b/internal/storage/scheme.go
@@ -1,9 +1,10 @@
 package storage
 
 import (
-	"errors"
 	"net/url"
 	"strings"
+
+	"github.com/go-errors/errors"
 )
 
 const STORAGE_SCHEME = "ss"
@@ -13,10 +14,10 @@ var ErrInvalidURL = errors.New("URL must match pattern ss:///bucket/[prefix]")
 func ParseStorageURL(objectURL string) (string, error) {
 	parsed, err := url.Parse(objectURL)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to parse storage url: %w", err)
 	}
 	if strings.ToLower(parsed.Scheme) != STORAGE_SCHEME || len(parsed.Path) == 0 || len(parsed.Host) > 0 {
-		return "", ErrInvalidURL
+		return "", errors.New(ErrInvalidURL)
 	}
 	return parsed.Path, nil
 }

--- a/internal/test/new/new.go
+++ b/internal/test/new/new.go
@@ -22,17 +22,14 @@ var (
 
 func Run(ctx context.Context, name, template string, fsys afero.Fs) error {
 	path := filepath.Join(utils.DbTestsDir, fmt.Sprintf("%s_test.sql", name))
-	if err := utils.MkdirIfNotExistFS(fsys, filepath.Dir(path)); err != nil {
-		return err
-	}
 	if _, err := fsys.Stat(path); err == nil {
 		return errors.New(path + " already exists.")
 	}
-	err := afero.WriteFile(fsys, path, getTemplate(template), 0644)
-	if err == nil {
-		fmt.Printf("Created new %s test at %s.\n", template, utils.Bold(path))
+	if err := utils.WriteFile(path, getTemplate(template), fsys); err != nil {
+		return err
 	}
-	return err
+	fmt.Printf("Created new %s test at %s.\n", template, utils.Bold(path))
+	return nil
 }
 
 func getTemplate(name string) []byte {

--- a/internal/testing/pgtest/step.go
+++ b/internal/testing/pgtest/step.go
@@ -1,9 +1,9 @@
 package pgtest
 
 import (
-	"fmt"
 	"reflect"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgmock"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
@@ -26,7 +26,7 @@ func (e *extendedQueryStep) Step(backend *pgproto3.Backend) error {
 	if m, ok := msg.(*pgproto3.Parse); ok {
 		want := &pgproto3.Parse{Name: m.Name, Query: e.sql, ParameterOIDs: m.ParameterOIDs}
 		if !reflect.DeepEqual(m, want) {
-			return fmt.Errorf("msg => %#v, e.want => %#v", m, want)
+			return errors.Errorf("msg => %#v, e.want => %#v", m, want)
 		}
 		// Anonymous ps falls through
 		if m.Name != "" {
@@ -62,7 +62,7 @@ func (e *extendedQueryStep) Step(backend *pgproto3.Backend) error {
 			PreparedStatement:    m.PreparedStatement,
 		}
 		if !reflect.DeepEqual(m, want) {
-			return fmt.Errorf("msg => %#v, e.want => %#v", msg, want)
+			return errors.Errorf("msg => %#v, e.want => %#v", msg, want)
 		}
 		e.reply.Steps = append([]pgmock.Step{
 			pgmock.ExpectMessage(&pgproto3.Describe{ObjectType: 'P'}),
@@ -80,7 +80,7 @@ func (e *extendedQueryStep) Step(backend *pgproto3.Backend) error {
 		return e.reply.Run(backend)
 	}
 
-	return fmt.Errorf("msg => %#v, e.want => %#v", msg, want)
+	return errors.Errorf("msg => %#v, e.want => %#v", msg, want)
 }
 
 // Expects a SQL query in any form: simple, prepared, or anonymous.
@@ -101,7 +101,7 @@ func (e *terminateStep) Step(backend *pgproto3.Backend) error {
 		return nil
 	}
 
-	return fmt.Errorf("msg => %#v, e.want => %#v", msg, &pgproto3.Terminate{})
+	return errors.Errorf("msg => %#v, e.want => %#v", msg, &pgproto3.Terminate{})
 }
 
 func ExpectTerminate() pgmock.Step {

--- a/internal/utils/access_token.go
+++ b/internal/utils/access_token.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/zalando/go-keyring"
@@ -14,7 +14,7 @@ import (
 var (
 	AccessTokenPattern = regexp.MustCompile(`^sbp_[a-f0-9]{40}$`)
 	ErrInvalidToken    = errors.New("Invalid access token format. Must be like `sbp_0102...1920`.")
-	ErrMissingToken    = errors.New("Access token not provided. Supply an access token by running " + Aqua("supabase login") + " or setting the SUPABASE_ACCESS_TOKEN environment variable.")
+	ErrMissingToken    = errors.Errorf("Access token not provided. Supply an access token by running %s or setting the SUPABASE_ACCESS_TOKEN environment variable.", Aqua("supabase login"))
 	ErrNotLoggedIn     = errors.New("You were not logged in, nothing to do.")
 )
 
@@ -30,9 +30,9 @@ func LoadAccessTokenFS(fsys afero.Fs) (string, error) {
 		return "", err
 	}
 	if !AccessTokenPattern.MatchString(accessToken) {
-		return "", ErrInvalidToken
+		return "", errors.New(ErrInvalidToken)
 	}
-	return accessToken, err
+	return accessToken, nil
 }
 
 func loadAccessToken(fsys afero.Fs) (string, error) {
@@ -55,9 +55,9 @@ func fallbackLoadToken(fsys afero.Fs) (string, error) {
 	}
 	accessToken, err := afero.ReadFile(fsys, path)
 	if errors.Is(err, os.ErrNotExist) {
-		return "", ErrMissingToken
+		return "", errors.New(ErrMissingToken)
 	} else if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to read access token file: %w", err)
 	}
 	return string(accessToken), nil
 }
@@ -65,7 +65,7 @@ func fallbackLoadToken(fsys afero.Fs) (string, error) {
 func SaveAccessToken(accessToken string, fsys afero.Fs) error {
 	// Validate access token
 	if !AccessTokenPattern.MatchString(accessToken) {
-		return ErrInvalidToken
+		return errors.New(ErrInvalidToken)
 	}
 	// Save to native credentials store
 	if err := credentials.Set(AccessTokenKey, accessToken); err == nil {
@@ -83,7 +83,10 @@ func fallbackSaveToken(accessToken string, fsys afero.Fs) error {
 	if err := MkdirIfNotExistFS(fsys, filepath.Dir(path)); err != nil {
 		return err
 	}
-	return afero.WriteFile(fsys, path, []byte(accessToken), 0600)
+	if err := afero.WriteFile(fsys, path, []byte(accessToken), 0600); err != nil {
+		return errors.Errorf("failed to save access token file: %w", err)
+	}
+	return nil
 }
 
 func DeleteAccessToken(fsys afero.Fs) error {
@@ -99,9 +102,11 @@ func DeleteAccessToken(fsys afero.Fs) error {
 	// Fallback not found, delete from native credentials store
 	err := credentials.Delete(AccessTokenKey)
 	if errors.Is(err, credentials.ErrNotSupported) || errors.Is(err, keyring.ErrNotFound) {
-		return ErrNotLoggedIn
+		return errors.New(ErrNotLoggedIn)
+	} else if err != nil {
+		return errors.Errorf("failed to delete access token from keyring: %w", err)
 	}
-	return err
+	return nil
 }
 
 func fallbackDeleteToken(fsys afero.Fs) error {
@@ -109,13 +114,16 @@ func fallbackDeleteToken(fsys afero.Fs) error {
 	if err != nil {
 		return err
 	}
-	return fsys.Remove(path)
+	if err := fsys.Remove(path); err != nil {
+		return errors.Errorf("failed to remove access token file: %w", err)
+	}
+	return nil
 }
 
 func getAccessTokenPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to get $HOME directory: %w", err)
 	}
 	// TODO: fallback to workdir
 	return filepath.Join(home, ".supabase", AccessTokenKey), nil

--- a/internal/utils/credentials/store.go
+++ b/internal/utils/credentials/store.go
@@ -2,9 +2,9 @@ package credentials
 
 import (
 	"bytes"
-	"errors"
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/zalando/go-keyring"
 )
 
@@ -17,7 +17,11 @@ func Get(project string) (string, error) {
 	if err := assertKeyringSupported(); err != nil {
 		return "", err
 	}
-	return keyring.Get(namespace, project)
+	val, err := keyring.Get(namespace, project)
+	if err != nil {
+		return "", errors.Errorf("failed to load credentials: %w", err)
+	}
+	return val, nil
 }
 
 // Stores the password of a project and username
@@ -25,7 +29,10 @@ func Set(project, password string) error {
 	if err := assertKeyringSupported(); err != nil {
 		return err
 	}
-	return keyring.Set(namespace, project, password)
+	if err := keyring.Set(namespace, project, password); err != nil {
+		return errors.Errorf("failed to set credentials: %w", err)
+	}
+	return nil
 }
 
 // Erases the stored password of a project and username
@@ -33,13 +40,16 @@ func Delete(project string) error {
 	if err := assertKeyringSupported(); err != nil {
 		return err
 	}
-	return keyring.Delete(namespace, project)
+	if err := keyring.Delete(namespace, project); err != nil {
+		return errors.Errorf("failed to delete credentials: %w", err)
+	}
+	return nil
 }
 
 func assertKeyringSupported() error {
 	// Suggested check: https://github.com/microsoft/WSL/issues/423
 	if f, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil && bytes.Contains(f, []byte("WSL")) {
-		return ErrNotSupported
+		return errors.New(ErrNotSupported)
 	}
 	return nil
 }

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -8,7 +8,6 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -20,6 +19,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 )
 
@@ -218,7 +218,7 @@ type ImportMap struct {
 func NewImportMap(path string, fsys afero.Fs) (*ImportMap, error) {
 	contents, err := fsys.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to load import map: %w", err)
 	}
 	defer contents.Close()
 	return NewFromReader(contents)
@@ -228,7 +228,7 @@ func NewFromReader(r io.Reader) (*ImportMap, error) {
 	decoder := json.NewDecoder(r)
 	importMap := &ImportMap{}
 	if err := decoder.Decode(importMap); err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to parse import map: %w", err)
 	}
 	return importMap, nil
 }
@@ -332,7 +332,7 @@ func AbsImportMapPath(importMapPath, slug string, fsys afero.Fs) (string, error)
 		return "", err
 	}
 	if f, err := fsys.Stat(resolved); err != nil {
-		return "", fmt.Errorf("Failed to read import map: %w", err)
+		return "", errors.Errorf("Failed to read import map: %w", err)
 	} else if f.IsDir() {
 		return "", errors.New("Importing directory is unsupported: " + resolved)
 	}
@@ -354,11 +354,11 @@ func BindImportMap(hostImportMapPath, dockerImportMapPath string, fsys afero.Fs)
 	if len(binds) > 0 {
 		cwd, err := os.Getwd()
 		if err != nil {
-			return nil, err
+			return nil, errors.Errorf("failed to get working directory: %w", err)
 		}
 		contents, err := json.MarshalIndent(resolved, "", "    ")
 		if err != nil {
-			return nil, err
+			return nil, errors.Errorf("failed to encode json: %w", err)
 		}
 		// Rewrite import map to temporary host path
 		hostImportMapPath = AbsTempImportMapPath(cwd, hostImportMapPath)

--- a/internal/utils/deno_darwin.go
+++ b/internal/utils/deno_darwin.go
@@ -3,8 +3,9 @@
 package utils
 
 import (
-	"fmt"
 	"syscall"
+
+	"github.com/go-errors/errors"
 )
 
 func getDenoAssetFileName() (string, error) {
@@ -19,7 +20,7 @@ func getDenoAssetFileName() (string, error) {
 			// Running on Intel Mac.
 			return "deno-x86_64-apple-darwin.zip", nil
 		} else {
-			return "", fmt.Errorf("failed to determine OS triple: %w", err)
+			return "", errors.Errorf("failed to determine OS triple: %w", err)
 		}
 	} else {
 		// Running on Apple Silicon.

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -53,7 +53,7 @@ func AssertDockerIsRunning(ctx context.Context) error {
 		if client.IsErrConnectionFailed(err) {
 			CmdSuggestion = suggestDockerInstall
 		}
-		return NewError(err.Error())
+		return errors.New(err)
 	}
 
 	return nil

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -170,7 +170,7 @@ func GetRegistryAuth() string {
 	registryOnce.Do(func() {
 		config := dockerConfig.LoadDefaultConfigFile(os.Stderr)
 		// Ref: https://docs.docker.com/engine/api/sdk/examples/#pull-an-image-with-authentication
-		auth, err := config.GetAuthConfig(getRegistry())
+		auth, err := config.GetAuthConfig(GetRegistry())
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Failed to load registry credentials:", err)
 			return
@@ -188,7 +188,7 @@ func GetRegistryAuth() string {
 // Defaults to Supabase public ECR for faster image pull
 const defaultRegistry = "public.ecr.aws"
 
-func getRegistry() string {
+func GetRegistry() string {
 	registry := viper.GetString("INTERNAL_IMAGE_REGISTRY")
 	if len(registry) == 0 {
 		return defaultRegistry
@@ -197,7 +197,7 @@ func getRegistry() string {
 }
 
 func GetRegistryImageUrl(imageName string) string {
-	registry := getRegistry()
+	registry := GetRegistry()
 	if registry == "docker.io" {
 		return imageName
 	}

--- a/internal/utils/enum.go
+++ b/internal/utils/enum.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"fmt"
 	"strings"
+
+	"github.com/go-errors/errors"
 )
 
 // Ref: https://github.com/spf13/pflag/issues/236#issuecomment-931600452
@@ -25,7 +27,7 @@ func (a *EnumFlag) Set(p string) error {
 		return false
 	}
 	if !isIncluded(a.Allowed, p) {
-		return fmt.Errorf("must be one of [ %s ]", strings.Join(a.Allowed, " | "))
+		return errors.Errorf("must be one of [ %s ]", strings.Join(a.Allowed, " | "))
 	}
 	a.Value = p
 	return nil

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"os"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
@@ -47,7 +48,7 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 		if flag := flagSet.Lookup("db-url"); flag != nil {
 			config, err := pgconn.ParseConfig(flag.Value.String())
 			if err != nil {
-				return err
+				return errors.Errorf("failed to parse connection string: %w", err)
 			}
 			DbConfig = *config
 		}

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -62,7 +62,7 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 		DbConfig.Password = utils.Config.Db.Password
 		DbConfig.Database = "postgres"
 	case linked:
-		projectRef, err := utils.LoadProjectRef(fsys)
+		projectRef, err := LoadProjectRef(fsys)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 		if err != nil {
 			return err
 		}
-		projectRef, err := utils.LoadProjectRef(fsys)
+		projectRef, err := LoadProjectRef(fsys)
 		if err != nil {
 			return err
 		}

--- a/internal/utils/flags/project_ref.go
+++ b/internal/utils/flags/project_ref.go
@@ -3,12 +3,12 @@ package flags
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils"
@@ -30,13 +30,13 @@ func ParseProjectRef(fsys afero.Fs) error {
 		ProjectRef = string(bytes.TrimSpace(projectRefBytes))
 		return utils.AssertProjectRefIsValid(ProjectRef)
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return errors.Errorf("failed to load project ref: %w", err)
 	}
 	// Prompt as the last resort
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		return promptProjectRef(os.Stdin)
 	}
-	return utils.ErrNotLinked
+	return errors.New(utils.ErrNotLinked)
 }
 
 func promptProjectRef(stdin io.Reader) error {
@@ -46,7 +46,7 @@ Enter your project ref: `, utils.GetSupabaseDashboardURL())
 	scanner := bufio.NewScanner(stdin)
 	scanner.Scan()
 	if err := scanner.Err(); err != nil {
-		return err
+		return errors.Errorf("failed to read project ref: %w", err)
 	}
 	ProjectRef = strings.TrimSpace(scanner.Text())
 	return utils.AssertProjectRefIsValid(ProjectRef)

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
 
+	"github.com/go-errors/errors"
 	openapi "github.com/supabase/cli/pkg/api"
 )
 
@@ -19,7 +19,7 @@ func JsonResponse[T any](ctx context.Context, method, url string, reqBody any, r
 	if reqBody != nil {
 		enc := json.NewEncoder(&body)
 		if err := enc.Encode(reqBody); err != nil {
-			return nil, err
+			return nil, errors.Errorf("failed to encode request body: %w", err)
 		}
 		reqEditors = append(reqEditors, func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Content-Type", "application/json")
@@ -29,7 +29,7 @@ func JsonResponse[T any](ctx context.Context, method, url string, reqBody any, r
 	// Creates request
 	req, err := http.NewRequestWithContext(ctx, method, url, &body)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to initialise http request: %w", err)
 	}
 	for _, edit := range reqEditors {
 		if err := edit(ctx, req); err != nil {
@@ -40,21 +40,21 @@ func JsonResponse[T any](ctx context.Context, method, url string, reqBody any, r
 	// Sends request
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to execute http request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, err
+			return nil, errors.Errorf("failed to read response body: %w", err)
 		}
-		return nil, fmt.Errorf("Error status %d: %s", resp.StatusCode, data)
+		return nil, errors.Errorf("Error status %d: %s", resp.StatusCode, data)
 	}
 	// Parses response
 	var data T
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&data); err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to parse response body: %w", err)
 	}
 	return &data, nil
 }
@@ -62,7 +62,7 @@ func JsonResponse[T any](ctx context.Context, method, url string, reqBody any, r
 func TextResponse(ctx context.Context, method, url string, body io.Reader, reqEditors ...openapi.RequestEditorFn) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to initialise http request: %w", err)
 	}
 	for _, edit := range reqEditors {
 		if err := edit(ctx, req); err != nil {
@@ -73,15 +73,15 @@ func TextResponse(ctx context.Context, method, url string, body io.Reader, reqEd
 	// Sends request
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to execute http request: %w", err)
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("failed to read response body: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Error status %d: %s", resp.StatusCode, body)
+		return "", errors.Errorf("Error status %d: %s", resp.StatusCode, body)
 	}
 	return string(data), nil
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -4,12 +4,9 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/client"
@@ -201,36 +198,6 @@ func GetCurrentBranchFS(fsys afero.Fs) (string, error) {
 	}
 
 	return string(branch), nil
-}
-
-// TODO: Make all errors use this.
-func NewError(s string) error {
-	// Ask runtime.Callers for up to 5 PCs, excluding runtime.Callers and NewError.
-	pc := make([]uintptr, 5)
-	n := runtime.Callers(2, pc)
-
-	pc = pc[:n] // pass only valid pcs to runtime.CallersFrames
-	frames := runtime.CallersFrames(pc)
-
-	// Loop to get frames.
-	// A fixed number of PCs can expand to an indefinite number of Frames.
-	for {
-		frame, more := frames.Next()
-
-		// Process this frame.
-		//
-		// We're only interested in the stack trace in this repo.
-		if strings.HasPrefix(frame.Function, "github.com/supabase/cli/internal") {
-			s += fmt.Sprintf("\n  in %s:%d", frame.Function, frame.Line)
-		}
-
-		// Check whether there are more frames to process after this one.
-		if !more {
-			break
-		}
-	}
-
-	return errors.New(s)
 }
 
 func AssertSupabaseDbIsRunning() error {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"os"
@@ -95,7 +94,7 @@ var (
 
 	ProjectRefPattern  = regexp.MustCompile(`^[a-z]{20}$`)
 	UUIDPattern        = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-	ProjectHostPattern = regexp.MustCompile(`^(db\.)[a-z]{20}\.supabase\.(co|red)$`)
+	ProjectHostPattern = regexp.MustCompile(`^(db\.)([a-z]{20})\.supabase\.(co|red)$`)
 	MigrateFilePattern = regexp.MustCompile(`^([0-9]+)_(.*)\.sql$`)
 	BranchNamePattern  = regexp.MustCompile(`[[:word:]-]+`)
 	FuncSlugPattern    = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
@@ -287,20 +286,6 @@ func AssertProjectRefIsValid(projectRef string) error {
 		return errors.New(ErrInvalidRef)
 	}
 	return nil
-}
-
-func LoadProjectRef(fsys afero.Fs) (string, error) {
-	projectRefBytes, err := afero.ReadFile(fsys, ProjectRefPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return "", errors.New(ErrNotLinked)
-	} else if err != nil {
-		return "", errors.Errorf("failed to load project ref: %w", err)
-	}
-	projectRef := string(bytes.TrimSpace(projectRefBytes))
-	if !ProjectRefPattern.MatchString(projectRef) {
-		return "", errors.New(ErrInvalidRef)
-	}
-	return projectRef, nil
 }
 
 func ValidateFunctionSlug(slug string) error {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,12 +13,16 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/go-errors/errors"
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 )
 
-// Version is assigned using `-ldflags` https://stackoverflow.com/q/11354518.
-var Version string
+// Assigned using `-ldflags` https://stackoverflow.com/q/11354518
+var (
+	Version   string
+	SentryDsn string
+)
 
 const (
 	Pg13Image = "supabase/postgres:13.3.0"
@@ -183,7 +186,7 @@ var (
 
 	ErrNotLinked  = errors.New("Cannot find project ref. Have you run " + Aqua("supabase link") + "?")
 	ErrInvalidRef = errors.New("Invalid project ref format. Must be like `abcdefghijklmnopqrst`.")
-	ErrNotRunning = errors.New(Aqua("supabase start") + " is not running.")
+	ErrNotRunning = errors.Errorf("%s is not running.", Aqua("supabase start"))
 )
 
 func GetCurrentTimestamp() string {
@@ -233,7 +236,7 @@ func NewError(s string) error {
 func AssertSupabaseDbIsRunning() error {
 	_, err := Docker.ContainerInspect(context.Background(), DbId)
 	if client.IsErrNotFound(err) {
-		return ErrNotRunning
+		return errors.New(ErrNotRunning)
 	}
 	if client.IsErrConnectionFailed(err) {
 		CmdSuggestion = suggestDockerInstall

--- a/internal/utils/parser/token.go
+++ b/internal/utils/parser/token.go
@@ -2,14 +2,12 @@ package parser
 
 import (
 	"bufio"
-	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/viper"
-	"github.com/supabase/cli/internal/utils"
 )
 
 // Equal to `startBufSize` from `bufio/scan.go`
@@ -105,10 +103,10 @@ func Split(sql io.Reader, transform ...func(string) string) (stats []string, err
 	}
 	err = scanner.Err()
 	if err != nil {
-		err = fmt.Errorf("%w\nAfter statement %d: %s", err, len(stats), utils.Aqua(token))
+		err = errors.Errorf("%w\nAfter statement %d: %s", err, len(stats), token)
 	}
 	if errors.Is(err, bufio.ErrTooLong) {
-		err = fmt.Errorf("%w\nTry setting SUPABASE_SCANNER_BUFFER_SIZE=5MB (current size is %dKB)", err, maxbuf>>10)
+		err = errors.Errorf("%w\nTry setting SUPABASE_SCANNER_BUFFER_SIZE=5MB (current size is %dKB)", err, maxbuf>>10)
 	}
 	return stats, err
 }

--- a/internal/utils/parser/token_test.go
+++ b/internal/utils/parser/token_test.go
@@ -47,6 +47,6 @@ func TestSplitAndTrim(t *testing.T) {
 	stats, err := SplitAndTrim(strings.NewReader(sql))
 	// Check error
 	assert.ErrorIs(t, err, bufio.ErrTooLong)
-	assert.ErrorContains(t, err, "After statement 1:     BEGIN;")
+	assert.ErrorContains(t, err, "After statement 1: \tBEGIN;")
 	assert.ElementsMatch(t, []string{"BEGIN"}, stats)
 }

--- a/internal/utils/pgxv5/rows.go
+++ b/internal/utils/pgxv5/rows.go
@@ -10,6 +10,21 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
+func CollectStrings(rows pgx.Rows) ([]string, error) {
+	result := []string{}
+	for rows.Next() {
+		var version string
+		if err := rows.Scan(&version); err != nil {
+			return nil, errors.Errorf("failed to scan rows: %w", err)
+		}
+		result = append(result, version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Errorf("failed to parse rows: %w", err)
+	}
+	return result, nil
+}
+
 // CollectRows iterates through rows, calling fn for each row, and collecting the results into a slice of T.
 func CollectRows[T any](rows pgx.Rows) ([]T, error) {
 	defer rows.Close()

--- a/internal/utils/prompt.go
+++ b/internal/utils/prompt.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/go-errors/errors"
 	"golang.org/x/term"
 )
 
@@ -132,7 +132,7 @@ func PromptChoice(ctx context.Context, title string, items []PromptItem) (Prompt
 	prog := tea.NewProgram(initial)
 	state, err := prog.Run()
 	if err != nil {
-		return initial.choice, err
+		return initial.choice, errors.Errorf("failed to prompt choice: %w", err)
 	}
 	if ctx.Err() != nil {
 		return initial.choice, ctx.Err()

--- a/internal/utils/tenant/client.go
+++ b/internal/utils/tenant/client.go
@@ -2,11 +2,10 @@ package tenant
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"sync"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -32,11 +31,11 @@ func GetApiKeys(ctx context.Context, projectRef string) (ApiKey, error) {
 	keyOnce.Do(func() {
 		resp, err := utils.GetSupabase().GetProjectApiKeysWithResponse(ctx, projectRef)
 		if err != nil {
-			errKey = err
+			errKey = errors.Errorf("failed to get api keys: %w", err)
 			return
 		}
 		if resp.JSON200 == nil {
-			errKey = fmt.Errorf("%w: %s", ErrAuthToken, string(resp.Body))
+			errKey = errors.Errorf("%w: %s", ErrAuthToken, string(resp.Body))
 			return
 		}
 		for _, key := range *resp.JSON200 {
@@ -48,7 +47,7 @@ func GetApiKeys(ctx context.Context, projectRef string) (ApiKey, error) {
 			}
 		}
 		if apiKey.IsEmpty() {
-			errKey = errMissingKey
+			errKey = errors.New(errMissingKey)
 		}
 	})
 	return apiKey, errKey

--- a/internal/utils/tenant/database.go
+++ b/internal/utils/tenant/database.go
@@ -1,0 +1,26 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/go-errors/errors"
+	"github.com/supabase/cli/internal/utils"
+)
+
+var errDatabaseVersion = errors.New("Database version not found.")
+
+func GetDatabaseVersion(ctx context.Context, projectRef string) (string, error) {
+	resp, err := utils.GetSupabase().GetProjectsWithResponse(ctx)
+	if err != nil {
+		return "", errors.Errorf("failed to retrieve projects: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return "", errors.New("Unexpected error retrieving projects: " + string(resp.Body))
+	}
+	for _, project := range *resp.JSON200 {
+		if project.Id == projectRef && len(project.Database.Version) > 0 {
+			return project.Database.Version, nil
+		}
+	}
+	return "", errors.New(errDatabaseVersion)
+}

--- a/internal/utils/tenant/gotrue.go
+++ b/internal/utils/tenant/gotrue.go
@@ -2,9 +2,9 @@ package tenant
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -27,7 +27,7 @@ func GetGotrueVersion(ctx context.Context, projectRef string) (string, error) {
 		return "", err
 	}
 	if len(data.Version) == 0 {
-		return "", errGotrueVersion
+		return "", errors.New(errGotrueVersion)
 	}
 	return data.Version, nil
 }

--- a/internal/utils/tenant/postgrest.go
+++ b/internal/utils/tenant/postgrest.go
@@ -2,10 +2,10 @@ package tenant
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -33,7 +33,7 @@ func GetPostgrestVersion(ctx context.Context, projectRef string) (string, error)
 		return "", err
 	}
 	if len(data.Info.Version) == 0 {
-		return "", errPostgrestVersion
+		return "", errors.New(errPostgrestVersion)
 	}
 	parts := strings.Split(data.Info.Version, " ")
 	return "v" + parts[0], nil

--- a/internal/utils/tenant/storage.go
+++ b/internal/utils/tenant/storage.go
@@ -2,9 +2,9 @@ package tenant
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/utils"
 )
 
@@ -21,7 +21,7 @@ func GetStorageVersion(ctx context.Context, projectRef string) (string, error) {
 		return "", err
 	}
 	if len(data) == 0 || data == "0.0.0" {
-		return "", errStorageVersion
+		return "", errors.New(errStorageVersion)
 	}
 	return "v" + data, nil
 }

--- a/internal/vanity_subdomains/activate/activate.go
+++ b/internal/vanity_subdomains/activate/activate.go
@@ -2,10 +2,10 @@ package activate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -26,7 +26,7 @@ func Run(ctx context.Context, projectRef string, desiredSubdomain string, fsys a
 			VanitySubdomain: subdomain,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed activate vanity subdomain: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to create vanity subdomain config: " + string(resp.Body))

--- a/internal/vanity_subdomains/check/check.go
+++ b/internal/vanity_subdomains/check/check.go
@@ -2,10 +2,10 @@ package check
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
@@ -26,7 +26,7 @@ func Run(ctx context.Context, projectRef string, desiredSubdomain string, fsys a
 			VanitySubdomain: subdomain,
 		})
 		if err != nil {
-			return err
+			return errors.Errorf("failed to check vanity subdomain: %w", err)
 		}
 		if resp.JSON201 == nil {
 			return errors.New("failed to check subdomain availability: " + string(resp.Body))

--- a/internal/vanity_subdomains/delete/delete.go
+++ b/internal/vanity_subdomains/delete/delete.go
@@ -2,9 +2,9 @@ package delete
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		resp, err := utils.GetSupabase().RemoveVanitySubdomainConfigWithResponse(ctx, projectRef)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to delete vanity subdomain: %w", err)
 		}
 		if resp.StatusCode() != 200 {
 			return errors.New("failed to delete vanity subdomain config; received: " + string(resp.Body))

--- a/internal/vanity_subdomains/get/get.go
+++ b/internal/vanity_subdomains/get/get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -17,7 +18,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 			return err
 		}
 		if response.JSON200 == nil {
-			return fmt.Errorf("failed to obtain vanity subdomain config: %+v", string(response.Body))
+			return errors.Errorf("failed to obtain vanity subdomain config: %+v", string(response.Body))
 		}
 		fmt.Printf("Status: %s\n", response.JSON200.Status)
 		if response.JSON200.CustomDomain != nil {

--- a/internal/vanity_subdomains/get/get.go
+++ b/internal/vanity_subdomains/get/get.go
@@ -15,7 +15,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 	{
 		response, err := utils.GetSupabase().GetVanitySubdomainConfigWithResponse(ctx, projectRef)
 		if err != nil {
-			return err
+			return errors.Errorf("failed to get vanity subdomain: %w", err)
 		}
 		if response.JSON200 == nil {
 			return errors.Errorf("failed to obtain vanity subdomain config: %+v", string(response.Body))

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/go-errors/errors"
 	"github.com/google/go-github/v53/github"
 	"github.com/supabase/cli/tools/shared"
 )
@@ -99,9 +100,9 @@ func checkStatus(resp *http.Response, status int) error {
 	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("status %d: %w", resp.StatusCode, err)
+		return errors.Errorf("status %d: %w", resp.StatusCode, err)
 	}
-	return fmt.Errorf("status %d: %s", resp.StatusCode, string(data))
+	return errors.Errorf("status %d: %s", resp.StatusCode, string(data))
 }
 
 func updatePackage(ctx context.Context, client *github.Client, repo, path string, tmpl *template.Template, config PackageConfig) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Reports error to sentry when any commands are with `--create-ticket` flag. Helps to collect diagnostics information.
- [x] server side rate limiting
- [x] add stacktrace to all errors

Going forward, any errors from external packages should be wrapped in `errors.New(err)` using [go-errors](https://github.com/go-errors/errors).

## Additional context

Eg: https://supabase.sentry.io/issues/4734608486/events/e250b9cc83c245d1aa520f1e3ece5017
