### PR TITLE
fix(db): generate data only dump with disabled triggers

### DIFF
--- a/internal/db/dump/templates/dump_data.sh
+++ b/internal/db/dump/templates/dump_data.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Disable triggers so that data dump can be restored exactly as it is
+echo "SET session_replication_role = replica;\n"
+
 # Explanation of pg_dump flags:
 #
 #   --exclude-schema omit data from internal schemas as they are maintained by platform

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -221,7 +221,7 @@ var timeUnit = time.Second
 func DockerImagePullWithRetry(ctx context.Context, image string, retries int) error {
 	err := DockerImagePull(ctx, image, os.Stderr)
 	for i := 0; i < retries; i++ {
-		if err == nil {
+		if err == nil || errors.Is(ctx.Err(), context.Canceled) {
 			break
 		}
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1420

## What is the new behavior?

Since data only dump is an exact copy of the database state, we should always disable triggers when restoring.

This setting may not apply to handwritten seed.sql so we don't apply it in code.

## Additional context

Add any other context or screenshots.
