### PR TITLE
fix: use C collation when launching orioledb

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -56,18 +56,20 @@ func NewContainerConfig() container.Config {
 		"POSTGRES_PASSWORD=" + utils.Config.Db.Password,
 		"POSTGRES_HOST=/var/run/postgresql",
 		"POSTGRES_INITDB_ARGS=--lc-ctype=C.UTF-8",
-		"POSTGRES_INITDB_ARGS=--lc-collate=C.UTF-8",
 		"JWT_SECRET=" + utils.Config.Auth.JwtSecret,
 		fmt.Sprintf("JWT_EXP=%d", utils.Config.Auth.JwtExpiry),
 	}
 	if len(utils.Config.Experimental.OrioleDBVersion) > 0 {
 		env = append(env,
+			"POSTGRES_INITDB_ARGS=--lc-collate=C",
 			fmt.Sprintf("S3_ENABLED=%t", true),
 			"S3_HOST="+utils.Config.Experimental.S3Host,
 			"S3_REGION="+utils.Config.Experimental.S3Region,
 			"S3_ACCESS_KEY="+utils.Config.Experimental.S3AccessKey,
 			"S3_SECRET_KEY="+utils.Config.Experimental.S3SecretKey,
 		)
+	} else {
+		env = append(env, "POSTGRES_INITDB_ARGS=--lc-collate=C.UTF-8")
 	}
 	config := container.Config{
 		Image: utils.Config.Db.Image,

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -135,8 +135,8 @@ backend = "postgres"
 # Experimental features may be deprecated any time
 [experimental]
 # Configures Postgres storage engine to use OrioleDB (S3)
-orioledb_version = "15.1.0.148"
-# Configures S3 bucket URL, eg. <bucket>.s3-accelerate.amazonaws.com
+orioledb_version = "15.1.0.150"
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
 s3_host = "orioledb.s3-accelerate.amazonaws.com"
 # Configures S3 bucket region, eg. us-east-1
 s3_region = "ap-southeast-1"

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -138,8 +138,8 @@ backend = "postgres"
 # Experimental features may be deprecated any time
 [experimental]
 # Configures Postgres storage engine to use OrioleDB (S3)
-orioledb_version = "{{if .UseOrioleDB}}15.1.0.148{{end}}"
-# Configures S3 bucket URL, eg. <bucket>.s3-accelerate.amazonaws.com
+orioledb_version = "{{if .UseOrioleDB}}15.1.0.150{{end}}"
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
 s3_host = "env(S3_HOST)"
 # Configures S3 bucket region, eg. us-east-1
 s3_region = "env(S3_REGION)"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Text fields should work.
```sql
create extension orioledb;

create table foo (
    id int,
    name text
) using orioledb;
```

## Additional context

Add any other context or screenshots.
