### PR TITLE
fix: support arm64 build for windows surface

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
+      - windows_arm64
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 release:


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1315

## What is the new behavior?

Configure goreleaser to build for windows surface 9.

## Additional context

Add any other context or screenshots.
