### PR TITLE
fix: generate anon and service keys from custom jwt secret

### DIFF
--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -134,3 +134,24 @@ func TestSanitizeProjectI(t *testing.T) {
 	// Replaces consecutive invalid characters with a single _
 	assert.Equal(t, "a_bc-", sanitizeProjectId("a@@bc-"))
 }
+
+const (
+	defaultAnonKey        = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+	defaultServiceRoleKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+)
+
+func TestSigningJWT(t *testing.T) {
+	t.Run("signs default anon key", func(t *testing.T) {
+		anonToken := CustomClaims{Role: "anon"}.NewToken()
+		signed, err := anonToken.SignedString([]byte(defaultJwtSecret))
+		assert.NoError(t, err)
+		assert.Equal(t, defaultAnonKey, signed)
+	})
+
+	t.Run("signs default service_role key", func(t *testing.T) {
+		anonToken := CustomClaims{Role: "service_role"}.NewToken()
+		signed, err := anonToken.SignedString([]byte(defaultJwtSecret))
+		assert.NoError(t, err)
+		assert.Equal(t, defaultServiceRoleKey, signed)
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Tedious to rotate `anon` and `service_role` keys as they need to be statically generated.

## What is the new behavior?

Allows defining a single `SUPABASE_AUTH_JWT_SECRET` env var to rotate JWT tokens.

## Additional context

Add any other context or screenshots.
