### PR TITLE
feat: use pooler connection string when available

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -1264,6 +1264,62 @@ paths:
         - database readonly mode
       security:
         - bearer: []
+  /v1/projects/{ref}/read-replicas/setup:
+    post:
+      operationId: setUpReadReplica
+      summary: Set up a read replica
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetUpReadReplicaBody'
+      responses:
+        '201':
+          description: ''
+        '500':
+          description: Failed to set up read replica
+      tags:
+        - read replicas (beta)
+      security:
+        - bearer: []
+  /v1/projects/{ref}/read-replicas/remove:
+    post:
+      operationId: removeReadReplica
+      summary: Remove a read replica
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveReadReplicaBody'
+      responses:
+        '201':
+          description: ''
+        '500':
+          description: Failed to remove read replica
+      tags:
+        - read replicas (beta)
+      security:
+        - bearer: []
   /v1/projects/{ref}/health:
     get:
       operationId: checkServiceHealth
@@ -1294,6 +1350,7 @@ paths:
               enum:
                 - auth
                 - db
+                - pooler
                 - realtime
                 - rest
                 - storage
@@ -2755,6 +2812,37 @@ components:
         - enabled
         - override_enabled
         - override_active_until
+    SetUpReadReplicaBody:
+      type: object
+      properties:
+        read_replica_region:
+          type: string
+          enum:
+            - us-east-1
+            - us-west-1
+            - us-west-2
+            - ap-southeast-1
+            - ap-northeast-1
+            - ap-northeast-2
+            - ap-southeast-2
+            - eu-west-1
+            - eu-west-2
+            - eu-west-3
+            - eu-central-1
+            - ca-central-1
+            - ap-south-1
+            - sa-east-1
+          description: Region you want your read replica to reside in
+          example: us-east-1
+      required:
+        - read_replica_region
+    RemoveReadReplicaBody:
+      type: object
+      properties:
+        database_identifier:
+          type: string
+      required:
+        - database_identifier
     AuthHealthResponse:
       type: object
       properties:
@@ -2792,17 +2880,25 @@ components:
           enum:
             - auth
             - db
+            - pooler
             - realtime
             - rest
             - storage
           type: string
         healthy:
           type: boolean
+        status:
+          enum:
+            - COMING_UP
+            - ACTIVE_HEALTHY
+            - UNHEALTHY
+          type: string
         error:
           type: string
       required:
         - name
         - healthy
+        - status
     PostgresConfigResponse:
       type: object
       properties:
@@ -2896,6 +2992,8 @@ components:
           type: string
         max_client_conn:
           type: number
+        connection_string:
+          type: string
     AuthConfigResponse:
       type: object
       properties:

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, projectRef, password string, fsys afero.Fs, option
 	if len(password) > 0 {
 		if err := linkDatabase(ctx, pgconn.Config{
 			Host:     utils.GetSupabaseDbHost(projectRef),
-			Port:     6543,
+			Port:     5432,
 			User:     "postgres",
 			Password: password,
 			Database: "postgres",

--- a/internal/projects/create/create_test.go
+++ b/internal/projects/create/create_test.go
@@ -18,7 +18,7 @@ func TestProjectCreateCommand(t *testing.T) {
 		Name:           "Test Project",
 		OrganizationId: "combined-fuchsia-lion",
 		DbPass:         "redacted",
-		Region:         api.UsWest1,
+		Region:         api.CreateProjectBodyRegionUsWest1,
 		Plan:           api.Free,
 	}
 

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -266,11 +266,12 @@ type (
 	}
 
 	pooler struct {
-		Enabled         bool     `toml:"enabled"`
-		Port            uint16   `toml:"port"`
-		PoolMode        PoolMode `toml:"pool_mode"`
-		DefaultPoolSize uint     `toml:"default_pool_size"`
-		MaxClientConn   uint     `toml:"max_client_conn"`
+		Enabled          bool     `toml:"enabled"`
+		Port             uint16   `toml:"port"`
+		PoolMode         PoolMode `toml:"pool_mode"`
+		DefaultPoolSize  uint     `toml:"default_pool_size"`
+		MaxClientConn    uint     `toml:"max_client_conn"`
+		ConnectionString string   `toml:"-"`
 	}
 
 	realtime struct {
@@ -517,6 +518,9 @@ func LoadConfigFS(fsys afero.Fs) error {
 			if !SliceContains(allowed, Config.Db.Pooler.PoolMode) {
 				return errors.Errorf("Invalid config for db.pooler.pool_mode. Must be one of: %v", allowed)
 			}
+		}
+		if connString, err := afero.ReadFile(fsys, PoolerUrlPath); err == nil && len(connString) > 0 {
+			Config.Db.Pooler.ConnectionString = string(connString)
 		}
 		// Validate realtime config
 		if Config.Realtime.Enabled {

--- a/internal/utils/connect.go
+++ b/internal/utils/connect.go
@@ -81,7 +81,7 @@ func getPoolerConfig(dbConfig pgconn.Config) *pgconn.Config {
 	}
 	poolerConfig := dbConfig.Copy()
 	poolerConfig.Host = host
-	if poolerPort, err := strconv.ParseUint(port, 10, 0); err == nil {
+	if poolerPort, err := strconv.ParseUint(port, 10, 16); err == nil {
 		poolerConfig.Port = uint16(poolerPort)
 	}
 	poolerConfig.User = fmt.Sprintf("%s.%s", poolerConfig.User, ref)

--- a/internal/utils/connect_test.go
+++ b/internal/utils/connect_test.go
@@ -26,6 +26,7 @@ var dbConfig = pgconn.Config{
 
 func TestConnectRemotePostgres(t *testing.T) {
 	t.Run("connects to remote postgres with DoH", func(t *testing.T) {
+		Config.Db.Pooler.ConnectionString = ""
 		DNSResolver.Value = DNS_OVER_HTTPS
 		// Setup http mock
 		defer gock.OffAll()
@@ -63,6 +64,7 @@ func TestConnectRemotePostgres(t *testing.T) {
 		defer conn.Close(t)
 		// Run test
 		config := *dbConfig.Copy()
+		config.Host = "localhost"
 		config.Password = "pass word"
 		c, err := ConnectRemotePostgres(context.Background(), config, conn.Intercept)
 		require.NoError(t, err)
@@ -70,27 +72,22 @@ func TestConnectRemotePostgres(t *testing.T) {
 		assert.Equal(t, config.Password, c.Config().Password)
 	})
 
-	t.Run("abort on dial error when connecting directly", func(t *testing.T) {
-		DNSResolver.Value = DNS_OVER_HTTPS
-		netErr := errors.New("network error")
-		// Setup http mock
-		defer gock.OffAll()
-		gock.New("https://1.1.1.1").
-			Get("/dns-query").
-			MatchParam("name", "fly.dev").
-			MatchHeader("accept", "application/dns-json").
-			ReplyError(&net.OpError{Op: "dial", Err: netErr})
+	t.Run("no retry on connecting successfully with pooler", func(t *testing.T) {
+		Config.Db.Pooler.ConnectionString = "postgres://postgres.nlhaskwsizylhnffaqkd:[YOUR-PASSWORD]@fly-0-sin.pooler.supabase.green:6543/postgres"
+		DNSResolver.Value = DNS_GO_NATIVE
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
 		// Run test
-		_, err := ConnectRemotePostgres(context.Background(), pgconn.Config{
-			Host: "fly.dev",
-			Port: 6543,
-		})
+		c, err := ConnectRemotePostgres(context.Background(), dbConfig, conn.Intercept)
 		// Check error
-		require.ErrorIs(t, err, netErr)
+		require.NoError(t, err)
+		defer c.Close(context.Background())
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
 	t.Run("fallback to postgres port on dial error", func(t *testing.T) {
+		Config.Db.Pooler.ConnectionString = "postgres://postgres.nlhaskwsizylhnffaqkd:[YOUR-PASSWORD]@fly-0-sin.pooler.supabase.green:6543/postgres"
 		DNSResolver.Value = DNS_OVER_HTTPS
 		netErr := errors.New("network error")
 		// Setup http mock
@@ -102,12 +99,11 @@ func TestConnectRemotePostgres(t *testing.T) {
 			ReplyError(&net.OpError{Op: "dial", Err: netErr})
 		gock.New("https://1.1.1.1").
 			Get("/dns-query").
-			MatchParam("name", dbConfig.Host).
+			MatchParam("name", "fly-0-sin.pooler.supabase.green").
 			MatchHeader("accept", "application/dns-json").
 			ReplyError(&net.OpError{Op: "dial", Err: netErr})
 		// Run test
-		ctx := context.Background()
-		_, err := ConnectRemotePostgres(ctx, dbConfig)
+		_, err := ConnectRemotePostgres(context.Background(), dbConfig)
 		// Check error
 		require.ErrorIs(t, err, netErr)
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -62,12 +62,15 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 		DbConfig.Password = utils.Config.Db.Password
 		DbConfig.Database = "postgres"
 	case linked:
+		if err := utils.LoadConfigFS(fsys); err != nil {
+			return err
+		}
 		projectRef, err := LoadProjectRef(fsys)
 		if err != nil {
 			return err
 		}
 		DbConfig.Host = utils.GetSupabaseDbHost(projectRef)
-		DbConfig.Port = 6543
+		DbConfig.Port = 5432
 		DbConfig.User = "postgres"
 		DbConfig.Password = getPassword(projectRef)
 		DbConfig.Database = "postgres"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -166,7 +166,7 @@ var (
 	TempDir               = filepath.Join(SupabaseDirPath, ".temp")
 	ImportMapsDir         = filepath.Join(TempDir, "import_maps")
 	ProjectRefPath        = filepath.Join(TempDir, "project-ref")
-	RemoteDbPath          = filepath.Join(TempDir, "remote-db-url")
+	PoolerUrlPath         = filepath.Join(TempDir, "pooler-url")
 	PostgresVersionPath   = filepath.Join(TempDir, "postgres-version")
 	GotrueVersionPath     = filepath.Join(TempDir, "gotrue-version")
 	RestVersionPath       = filepath.Join(TempDir, "rest-version")

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -269,6 +269,16 @@ type ClientInterface interface {
 
 	UpdatePostgRESTConfig(ctx context.Context, ref string, body UpdatePostgRESTConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RemoveReadReplicaWithBody request with any body
+	RemoveReadReplicaWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RemoveReadReplica(ctx context.Context, ref string, body RemoveReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetUpReadReplicaWithBody request with any body
+	SetUpReadReplicaWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetUpReadReplica(ctx context.Context, ref string, body SetUpReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetReadOnlyModeStatus request
 	GetReadOnlyModeStatus(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1115,6 +1125,54 @@ func (c *Client) UpdatePostgRESTConfigWithBody(ctx context.Context, ref string, 
 
 func (c *Client) UpdatePostgRESTConfig(ctx context.Context, ref string, body UpdatePostgRESTConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdatePostgRESTConfigRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RemoveReadReplicaWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRemoveReadReplicaRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RemoveReadReplica(ctx context.Context, ref string, body RemoveReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRemoveReadReplicaRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUpReadReplicaWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUpReadReplicaRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUpReadReplica(ctx context.Context, ref string, body SetUpReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUpReadReplicaRequest(c.Server, ref, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3634,6 +3692,100 @@ func NewUpdatePostgRESTConfigRequestWithBody(server string, ref string, contentT
 	return req, nil
 }
 
+// NewRemoveReadReplicaRequest calls the generic RemoveReadReplica builder with application/json body
+func NewRemoveReadReplicaRequest(server string, ref string, body RemoveReadReplicaJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRemoveReadReplicaRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewRemoveReadReplicaRequestWithBody generates requests for RemoveReadReplica with any type of body
+func NewRemoveReadReplicaRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/read-replicas/remove", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSetUpReadReplicaRequest calls the generic SetUpReadReplica builder with application/json body
+func NewSetUpReadReplicaRequest(server string, ref string, body SetUpReadReplicaJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetUpReadReplicaRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewSetUpReadReplicaRequestWithBody generates requests for SetUpReadReplica with any type of body
+func NewSetUpReadReplicaRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/read-replicas/setup", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetReadOnlyModeStatusRequest generates requests for GetReadOnlyModeStatus
 func NewGetReadOnlyModeStatusRequest(server string, ref string) (*http.Request, error) {
 	var err error
@@ -4549,6 +4701,16 @@ type ClientWithResponsesInterface interface {
 	UpdatePostgRESTConfigWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdatePostgRESTConfigResponse, error)
 
 	UpdatePostgRESTConfigWithResponse(ctx context.Context, ref string, body UpdatePostgRESTConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdatePostgRESTConfigResponse, error)
+
+	// RemoveReadReplicaWithBodyWithResponse request with any body
+	RemoveReadReplicaWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RemoveReadReplicaResponse, error)
+
+	RemoveReadReplicaWithResponse(ctx context.Context, ref string, body RemoveReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*RemoveReadReplicaResponse, error)
+
+	// SetUpReadReplicaWithBodyWithResponse request with any body
+	SetUpReadReplicaWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUpReadReplicaResponse, error)
+
+	SetUpReadReplicaWithResponse(ctx context.Context, ref string, body SetUpReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUpReadReplicaResponse, error)
 
 	// GetReadOnlyModeStatusWithResponse request
 	GetReadOnlyModeStatusWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetReadOnlyModeStatusResponse, error)
@@ -5662,6 +5824,48 @@ func (r UpdatePostgRESTConfigResponse) StatusCode() int {
 	return 0
 }
 
+type RemoveReadReplicaResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r RemoveReadReplicaResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RemoveReadReplicaResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SetUpReadReplicaResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r SetUpReadReplicaResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetUpReadReplicaResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetReadOnlyModeStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6607,6 +6811,40 @@ func (c *ClientWithResponses) UpdatePostgRESTConfigWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseUpdatePostgRESTConfigResponse(rsp)
+}
+
+// RemoveReadReplicaWithBodyWithResponse request with arbitrary body returning *RemoveReadReplicaResponse
+func (c *ClientWithResponses) RemoveReadReplicaWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RemoveReadReplicaResponse, error) {
+	rsp, err := c.RemoveReadReplicaWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRemoveReadReplicaResponse(rsp)
+}
+
+func (c *ClientWithResponses) RemoveReadReplicaWithResponse(ctx context.Context, ref string, body RemoveReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*RemoveReadReplicaResponse, error) {
+	rsp, err := c.RemoveReadReplica(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRemoveReadReplicaResponse(rsp)
+}
+
+// SetUpReadReplicaWithBodyWithResponse request with arbitrary body returning *SetUpReadReplicaResponse
+func (c *ClientWithResponses) SetUpReadReplicaWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUpReadReplicaResponse, error) {
+	rsp, err := c.SetUpReadReplicaWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUpReadReplicaResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetUpReadReplicaWithResponse(ctx context.Context, ref string, body SetUpReadReplicaJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUpReadReplicaResponse, error) {
+	rsp, err := c.SetUpReadReplica(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUpReadReplicaResponse(rsp)
 }
 
 // GetReadOnlyModeStatusWithResponse request returning *GetReadOnlyModeStatusResponse
@@ -7970,6 +8208,38 @@ func ParseUpdatePostgRESTConfigResponse(rsp *http.Response) (*UpdatePostgRESTCon
 		}
 		response.JSON200 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseRemoveReadReplicaResponse parses an HTTP response from a RemoveReadReplicaWithResponse call
+func ParseRemoveReadReplicaResponse(rsp *http.Response) (*RemoveReadReplicaResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RemoveReadReplicaResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseSetUpReadReplicaResponse parses an HTTP response from a SetUpReadReplicaWithResponse call
+func ParseSetUpReadReplicaResponse(rsp *http.Response) (*SetUpReadReplicaResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetUpReadReplicaResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -36,20 +36,20 @@ const (
 
 // Defines values for CreateProjectBodyRegion.
 const (
-	ApNortheast1 CreateProjectBodyRegion = "ap-northeast-1"
-	ApNortheast2 CreateProjectBodyRegion = "ap-northeast-2"
-	ApSouth1     CreateProjectBodyRegion = "ap-south-1"
-	ApSoutheast1 CreateProjectBodyRegion = "ap-southeast-1"
-	ApSoutheast2 CreateProjectBodyRegion = "ap-southeast-2"
-	CaCentral1   CreateProjectBodyRegion = "ca-central-1"
-	EuCentral1   CreateProjectBodyRegion = "eu-central-1"
-	EuWest1      CreateProjectBodyRegion = "eu-west-1"
-	EuWest2      CreateProjectBodyRegion = "eu-west-2"
-	EuWest3      CreateProjectBodyRegion = "eu-west-3"
-	SaEast1      CreateProjectBodyRegion = "sa-east-1"
-	UsEast1      CreateProjectBodyRegion = "us-east-1"
-	UsWest1      CreateProjectBodyRegion = "us-west-1"
-	UsWest2      CreateProjectBodyRegion = "us-west-2"
+	CreateProjectBodyRegionApNortheast1 CreateProjectBodyRegion = "ap-northeast-1"
+	CreateProjectBodyRegionApNortheast2 CreateProjectBodyRegion = "ap-northeast-2"
+	CreateProjectBodyRegionApSouth1     CreateProjectBodyRegion = "ap-south-1"
+	CreateProjectBodyRegionApSoutheast1 CreateProjectBodyRegion = "ap-southeast-1"
+	CreateProjectBodyRegionApSoutheast2 CreateProjectBodyRegion = "ap-southeast-2"
+	CreateProjectBodyRegionCaCentral1   CreateProjectBodyRegion = "ca-central-1"
+	CreateProjectBodyRegionEuCentral1   CreateProjectBodyRegion = "eu-central-1"
+	CreateProjectBodyRegionEuWest1      CreateProjectBodyRegion = "eu-west-1"
+	CreateProjectBodyRegionEuWest2      CreateProjectBodyRegion = "eu-west-2"
+	CreateProjectBodyRegionEuWest3      CreateProjectBodyRegion = "eu-west-3"
+	CreateProjectBodyRegionSaEast1      CreateProjectBodyRegion = "sa-east-1"
+	CreateProjectBodyRegionUsEast1      CreateProjectBodyRegion = "us-east-1"
+	CreateProjectBodyRegionUsWest1      CreateProjectBodyRegion = "us-west-1"
+	CreateProjectBodyRegionUsWest2      CreateProjectBodyRegion = "us-west-2"
 )
 
 // Defines values for CreateProviderBodyType.
@@ -137,9 +137,35 @@ const (
 const (
 	ServiceHealthResponseNameAuth     ServiceHealthResponseName = "auth"
 	ServiceHealthResponseNameDb       ServiceHealthResponseName = "db"
+	ServiceHealthResponseNamePooler   ServiceHealthResponseName = "pooler"
 	ServiceHealthResponseNameRealtime ServiceHealthResponseName = "realtime"
 	ServiceHealthResponseNameRest     ServiceHealthResponseName = "rest"
 	ServiceHealthResponseNameStorage  ServiceHealthResponseName = "storage"
+)
+
+// Defines values for ServiceHealthResponseStatus.
+const (
+	ACTIVEHEALTHY ServiceHealthResponseStatus = "ACTIVE_HEALTHY"
+	COMINGUP      ServiceHealthResponseStatus = "COMING_UP"
+	UNHEALTHY     ServiceHealthResponseStatus = "UNHEALTHY"
+)
+
+// Defines values for SetUpReadReplicaBodyReadReplicaRegion.
+const (
+	SetUpReadReplicaBodyReadReplicaRegionApNortheast1 SetUpReadReplicaBodyReadReplicaRegion = "ap-northeast-1"
+	SetUpReadReplicaBodyReadReplicaRegionApNortheast2 SetUpReadReplicaBodyReadReplicaRegion = "ap-northeast-2"
+	SetUpReadReplicaBodyReadReplicaRegionApSouth1     SetUpReadReplicaBodyReadReplicaRegion = "ap-south-1"
+	SetUpReadReplicaBodyReadReplicaRegionApSoutheast1 SetUpReadReplicaBodyReadReplicaRegion = "ap-southeast-1"
+	SetUpReadReplicaBodyReadReplicaRegionApSoutheast2 SetUpReadReplicaBodyReadReplicaRegion = "ap-southeast-2"
+	SetUpReadReplicaBodyReadReplicaRegionCaCentral1   SetUpReadReplicaBodyReadReplicaRegion = "ca-central-1"
+	SetUpReadReplicaBodyReadReplicaRegionEuCentral1   SetUpReadReplicaBodyReadReplicaRegion = "eu-central-1"
+	SetUpReadReplicaBodyReadReplicaRegionEuWest1      SetUpReadReplicaBodyReadReplicaRegion = "eu-west-1"
+	SetUpReadReplicaBodyReadReplicaRegionEuWest2      SetUpReadReplicaBodyReadReplicaRegion = "eu-west-2"
+	SetUpReadReplicaBodyReadReplicaRegionEuWest3      SetUpReadReplicaBodyReadReplicaRegion = "eu-west-3"
+	SetUpReadReplicaBodyReadReplicaRegionSaEast1      SetUpReadReplicaBodyReadReplicaRegion = "sa-east-1"
+	SetUpReadReplicaBodyReadReplicaRegionUsEast1      SetUpReadReplicaBodyReadReplicaRegion = "us-east-1"
+	SetUpReadReplicaBodyReadReplicaRegionUsWest1      SetUpReadReplicaBodyReadReplicaRegion = "us-west-1"
+	SetUpReadReplicaBodyReadReplicaRegionUsWest2      SetUpReadReplicaBodyReadReplicaRegion = "us-west-2"
 )
 
 // Defines values for SnippetMetaType.
@@ -216,6 +242,7 @@ const (
 const (
 	CheckServiceHealthParamsServicesAuth     CheckServiceHealthParamsServices = "auth"
 	CheckServiceHealthParamsServicesDb       CheckServiceHealthParamsServices = "db"
+	CheckServiceHealthParamsServicesPooler   CheckServiceHealthParamsServices = "pooler"
 	CheckServiceHealthParamsServicesRealtime CheckServiceHealthParamsServices = "realtime"
 	CheckServiceHealthParamsServicesRest     CheckServiceHealthParamsServices = "rest"
 	CheckServiceHealthParamsServicesStorage  CheckServiceHealthParamsServices = "storage"
@@ -656,6 +683,11 @@ type RemoveNetworkBanRequest struct {
 	Ipv4Addresses []string `json:"ipv4_addresses"`
 }
 
+// RemoveReadReplicaBody defines model for RemoveReadReplicaBody.
+type RemoveReadReplicaBody struct {
+	DatabaseIdentifier string `json:"database_identifier"`
+}
+
 // RunQueryBody defines model for RunQueryBody.
 type RunQueryBody struct {
 	Query string `json:"query"`
@@ -682,6 +714,7 @@ type ServiceHealthResponse struct {
 	Healthy bool                        `json:"healthy"`
 	Info    *ServiceHealthResponse_Info `json:"info,omitempty"`
 	Name    ServiceHealthResponseName   `json:"name"`
+	Status  ServiceHealthResponseStatus `json:"status"`
 }
 
 // ServiceHealthResponse_Info defines model for ServiceHealthResponse.Info.
@@ -691,6 +724,18 @@ type ServiceHealthResponse_Info struct {
 
 // ServiceHealthResponseName defines model for ServiceHealthResponse.Name.
 type ServiceHealthResponseName string
+
+// ServiceHealthResponseStatus defines model for ServiceHealthResponse.Status.
+type ServiceHealthResponseStatus string
+
+// SetUpReadReplicaBody defines model for SetUpReadReplicaBody.
+type SetUpReadReplicaBody struct {
+	// ReadReplicaRegion Region you want your read replica to reside in
+	ReadReplicaRegion SetUpReadReplicaBodyReadReplicaRegion `json:"read_replica_region"`
+}
+
+// SetUpReadReplicaBodyReadReplicaRegion Region you want your read replica to reside in
+type SetUpReadReplicaBodyReadReplicaRegion string
 
 // SnippetContent defines model for SnippetContent.
 type SnippetContent struct {
@@ -887,6 +932,7 @@ type V1OrganizationMemberResponse struct {
 
 // V1PgbouncerConfigResponse defines model for V1PgbouncerConfigResponse.
 type V1PgbouncerConfigResponse struct {
+	ConnectionString        *string                            `json:"connection_string,omitempty"`
 	DefaultPoolSize         *float32                           `json:"default_pool_size,omitempty"`
 	IgnoreStartupParameters *string                            `json:"ignore_startup_parameters,omitempty"`
 	MaxClientConn           *float32                           `json:"max_client_conn,omitempty"`
@@ -1031,6 +1077,12 @@ type UpdatePgsodiumConfigJSONRequestBody = UpdatePgsodiumConfigBody
 
 // UpdatePostgRESTConfigJSONRequestBody defines body for UpdatePostgRESTConfig for application/json ContentType.
 type UpdatePostgRESTConfigJSONRequestBody = UpdatePostgrestConfigBody
+
+// RemoveReadReplicaJSONRequestBody defines body for RemoveReadReplica for application/json ContentType.
+type RemoveReadReplicaJSONRequestBody = RemoveReadReplicaBody
+
+// SetUpReadReplicaJSONRequestBody defines body for SetUpReadReplica for application/json ContentType.
+type SetUpReadReplicaJSONRequestBody = SetUpReadReplicaBody
 
 // DeleteSecretsJSONRequestBody defines body for DeleteSecrets for application/json ContentType.
 type DeleteSecretsJSONRequestBody = DeleteSecretsJSONBody


### PR DESCRIPTION
## What kind of change does this PR introduce?

supersedes https://github.com/supabase/cli/pull/1730

## What is the new behavior?

Since pgbouncer is being deprecated, use supavisor connection string when available.

## Additional context

Add any other context or screenshots.
