### PR TITLE
fix(api): bump postgrest image to 12.0.1

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -27,7 +27,7 @@ const (
 	// Append to ServiceImages when adding new dependencies below
 	KongImage        = "library/kong:2.8.1"
 	InbucketImage    = "inbucket/inbucket:3.0.3"
-	PostgrestImage   = "postgrest/postgrest:v11.2.2"
+	PostgrestImage   = "postgrest/postgrest:v12.0.1"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "djrobstep/migra:3.0.1621480950"
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: https://github.com/supabase/cli/issues/1767

## What is the new behavior?

Update default PostgREST version and mirror to ECR.

## Additional context

Add any other context or screenshots.
