### PR TITLE
fix(functions): update bundle output directory permission

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -79,7 +79,8 @@ func bundleFunction(ctx context.Context, slug, dockerEntrypointPath, importMapPa
 
 	// create temp directory to store generated eszip
 	hostOutputDir := filepath.Join(utils.TempDir, fmt.Sprintf(".output_%s", slug))
-	if err := fsys.MkdirAll(hostOutputDir, 0755); err != nil {
+	// BitBucket pipelines require docker bind mounts to be world writable
+	if err := fsys.MkdirAll(hostOutputDir, 0777); err != nil {
 		return nil, errors.Errorf("failed to mkdir: %w", err)
 	}
 	defer func() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1774

## What is the new behavior?

Bind mounts need to be world writable for containerized processes to save output file.

## Additional context

Add any other context or screenshots.
