### PR TITLE
fix(diff): warn about generated drop statements

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/supabase/cli/internal/migration/apply"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/parser"
 )
 
 //go:embed templates/migra.sh
@@ -48,7 +50,32 @@ func RunMigra(ctx context.Context, schema []string, file string, config pgconn.C
 	}
 	branch := keys.GetGitBranch(fsys)
 	fmt.Fprintln(os.Stderr, "Finished "+utils.Aqua("supabase db diff")+" on branch "+utils.Aqua(branch)+".\n")
-	return SaveDiff(out, file, fsys)
+	if err := SaveDiff(out, file, fsys); err != nil {
+		return err
+	}
+	drops := findDropStatements(out)
+	if len(drops) > 0 {
+		fmt.Fprintln(os.Stderr, "Found drop statements in schema diff. Please double check if these are expected:")
+		fmt.Fprintln(os.Stderr, utils.Yellow(strings.Join(drops, "\n")))
+	}
+	return nil
+}
+
+// https://github.com/djrobstep/migra/blob/master/migra/statements.py#L6
+var dropStatementPattern = regexp.MustCompile(`(?i)drop\s+`)
+
+func findDropStatements(out string) []string {
+	lines, err := parser.SplitAndTrim(strings.NewReader(out))
+	if err != nil {
+		return nil
+	}
+	var drops []string
+	for _, line := range lines {
+		if dropStatementPattern.MatchString(line) {
+			drops = append(drops, line)
+		}
+	}
+	return drops
 }
 
 func loadSchema(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) ([]string, error) {

--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -358,3 +358,8 @@ func TestUserSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"test"}, schemas)
 }
+
+func TestDropStatements(t *testing.T) {
+	drops := findDropStatements("create table t(); drop table t; alter table t drop column c")
+	assert.Equal(t, []string{"drop table t", "alter table t drop column c"}, drops)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1721

## What is the new behavior?

Print warnings when drop statements are generated.

## Additional context

Add any other context or screenshots.
