### PR TITLE
chore: add ci workflows for publishing pg_prove image

### DIFF
--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -1,0 +1,46 @@
+name: Mirror Image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "org/image:tag"
+        required: true
+        type: string
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - id: strip
+        run: |
+          TAG=${{ inputs.image }}
+          echo "image=${TAG##*/}" >> $GITHUB_OUTPUT
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: us-east-1
+      - uses: docker/login-action@v3
+        with:
+          registry: public.ecr.aws
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: docker.io/${{ inputs.image }}
+          dst: |
+            public.ecr.aws/supabase/${{ steps.strip.outputs.image }}
+            ghcr.io/supabase/${{ steps.strip.outputs.image }}

--- a/.github/workflows/pg-prove.yml
+++ b/.github/workflows/pg-prove.yml
@@ -1,0 +1,84 @@
+name: Publish pg_prove
+
+on:
+  workflow_dispatch:
+
+jobs:
+  settings:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: supabase/pg_prove:${{ steps.version.outputs.pg_prove }}
+    steps:
+      - run: docker context create builders
+      - uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
+      - uses: docker/build-push-action@v5
+        with:
+          load: true
+          context: https://github.com/horrendo/pg_prove.git
+          target: builder
+          tags: builder
+      - id: version
+        # Replace space with equal to get the raw version string, ie. pg_prove=3.36
+        run: docker run --rm -it builder pg_prove --version | tr ' ' '=' >> $GITHUB_OUTPUT
+
+  build_image:
+    needs:
+      - settings
+    strategy:
+      matrix:
+        include:
+          - runner: [self-hosted, X64]
+            arch: amd64
+          - runner: arm-runner
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - run: docker context create builders
+      - uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - id: build
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: https://github.com/horrendo/pg_prove.git
+          tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-pg_prove-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-pg_prove-${{ matrix.arch }}
+
+  merge_manifest:
+    needs:
+      - settings
+      - build_image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Merge multi-arch manifests
+        run: |
+          docker buildx imagetools create -t ${{ needs.settings.outputs.image_tag }} \
+          ${{ needs.settings.outputs.image_tag }}_amd64 \
+          ${{ needs.settings.outputs.image_tag }}_arm64
+
+  publish:
+    needs:
+      - settings
+      - merge_manifest
+    # Call workflow explicitly because events from actions cannot trigger more actions
+    uses: ./.github/workflows/mirror-image.yml
+    with:
+      image: ${{ needs.settings.outputs.image_tag }}
+    secrets: inherit


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Add ci workflows for publishing [pg_prove image](https://hub.docker.com/r/horrendo/pg_prove) with support for arm64 build.

## Additional context

Add any other context or screenshots.
