### PR TITLE
feat: update auth version to v2.130.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.29.1"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
-	GotrueImage      = "supabase/gotrue:v2.125.1"
+	GotrueImage      = "supabase/gotrue:v2.130.0"
 	RealtimeImage    = "supabase/realtime:v2.25.50"
 	StorageImage     = "supabase/storage-api:v0.43.11"
 	LogflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the latest deploy, GoTrue is now on v2.130.0 

Looks like no sql statements are involved. Diff: https://github.com/supabase/gotrue/compare/v2.125.1...v2.130.0
