### PR TITLE
fix(diff): pin migra image to version 3.0.1663481299

### DIFF
--- a/internal/db/diff/templates/migra.sh
+++ b/internal/db/diff/templates/migra.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -eu
 
-# pin to latest version: https://pypi.org/project/migra/
-pip install -qU migra==3.0.1663481299
-
 # migra doesn't shutdown gracefully, so kill it ourselves
 trap 'kill -9 %1' TERM
 

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -29,7 +29,7 @@ const (
 	InbucketImage    = "inbucket/inbucket:3.0.3"
 	PostgrestImage   = "postgrest/postgrest:v12.0.1"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
-	MigraImage       = "djrobstep/migra:3.0.1621480950"
+	MigraImage       = "supabase/migra:3.0.1663481299"
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
 	StudioImage      = "supabase/studio:20231123-64a766a"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Pin migra image version instead of using pip install every time.

## Additional context

Add any other context or screenshots.
