### PR TITLE
fix(db): failed start should not remove backup volume

### DIFF
--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -50,13 +50,7 @@ func TestInitBranch(t *testing.T) {
 }
 
 func TestStartDatabase(t *testing.T) {
-	teardown := func() {
-		utils.Containers = []string{}
-		utils.Volumes = []string{}
-	}
-
 	t.Run("initialize main branch", func(t *testing.T) {
-		defer teardown()
 		utils.Config.Db.MajorVersion = 15
 		utils.Config.Db.Image = utils.Pg15Image
 		utils.DbId = "supabase_db_test"
@@ -108,7 +102,6 @@ func TestStartDatabase(t *testing.T) {
 	})
 
 	t.Run("recover from backup volume", func(t *testing.T) {
-		defer teardown()
 		utils.Config.Db.MajorVersion = 14
 		utils.Config.Db.Image = utils.Pg15Image
 		utils.DbId = "supabase_db_test"
@@ -145,7 +138,6 @@ func TestStartDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on start failure", func(t *testing.T) {
-		defer teardown()
 		utils.Config.Db.MajorVersion = 15
 		utils.Config.Db.Image = utils.Pg15Image
 		utils.DbId = "supabase_db_test"
@@ -241,9 +233,7 @@ func TestStartCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/images/" + utils.GetRegistryImageUrl(utils.Pg15Image) + "/json").
 			ReplyError(errors.New("network error"))
 		// Cleanup resources
-		gock.New(utils.Docker.DaemonHost()).
-			Post("/v" + utils.Docker.ClientVersion() + "/networks/prune").
-			Reply(http.StatusOK)
+		apitest.MockDockerStop(utils.Docker)
 		// Run test
 		err := Run(context.Background(), fsys)
 		// Check error

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -71,7 +72,9 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignore
 		if ignoreHealthCheck && errors.Is(err, reset.ErrUnhealthy) {
 			fmt.Fprintln(os.Stderr, err)
 		} else {
-			utils.DockerRemoveAll(context.Background())
+			if err := utils.DockerRemoveAll(context.Background(), io.Discard); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
 			return err
 		}
 	}

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -150,38 +149,6 @@ func CliProjectFilter() filters.Args {
 	return filters.NewArgs(
 		filters.Arg("label", CliProjectLabel+"="+Config.ProjectId),
 	)
-}
-
-func DockerAddFile(ctx context.Context, container string, fileName string, content []byte) error {
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-	err := tw.WriteHeader(&tar.Header{
-		Name: fileName,
-		Mode: 0777,
-		Size: int64(len(content)),
-	})
-
-	if err != nil {
-		return errors.Errorf("failed to copy file: %w", err)
-	}
-
-	_, err = tw.Write(content)
-
-	if err != nil {
-		return errors.Errorf("failed to copy file: %w", err)
-	}
-
-	err = tw.Close()
-
-	if err != nil {
-		return errors.Errorf("failed to copy file: %w", err)
-	}
-
-	err = Docker.CopyToContainer(ctx, container, "/tmp", &buf, types.CopyToContainerOptions{})
-	if err != nil {
-		return errors.Errorf("failed to copy file: %w", err)
-	}
-	return nil
 }
 
 var (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If there's a local backup volume and db start encounters an error, the backup volume is deleted.

## What is the new behavior?

If backup volume exists, failed start should not remove them. Otherwise if it's a fresh start, delete any backup volume.

Also in this PR:
- adds project label to named volumes by creating them explicitly via docker api
- reuses remove all method in stop command
- cleans up dead code for docker add file

## Additional context

Add any other context or screenshots.
