### PR TITLE
fix: match CPU limits to the hosted version

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -128,8 +128,8 @@ serve(async (req: Request) => {
     );
   const forceCreate = true;
   const customModuleRoot = ""; // empty string to allow any local path
-  const cpuTimeSoftLimitMs = 10000;
-  const cpuTimeHardLimitMs = 20000;
+  const cpuTimeSoftLimitMs = 1000;
+  const cpuTimeHardLimitMs = 2000;
   try {
     const worker = await EdgeRuntime.userWorkers.create({
       servicePath,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates Edge Functions CPU limits to match to the limits currently set in the hosted version.
