### PR TITLE
feat: upgrade GoTrue CLI version to 2.132.3

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"
-	GotrueImage      = "supabase/gotrue:v2.130.0"
+	GotrueImage      = "supabase/gotrue:v2.132.3"
 	RealtimeImage    = "supabase/realtime:v2.25.50"
 	StorageImage     = "supabase/storage-api:v0.43.11"
 	LogflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

We're upgrading GoTrue to v2.132.3 and we should update CLI to reflect that. We should probably also update self-hosted. The deploy for the last region is in progress so we should probably only merge this after GMT+8 midnight
