### PR TITLE
fix(test): support bitbucket pipeline for pgtap tests

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -74,6 +74,13 @@ func pgProve(ctx context.Context, testFiles []string, config pgconn.Config, opti
 			}
 		}()
 	}
+	// Use custom network when connecting to local database
+	networkID := "host"
+	if utils.IsLoopback(config.Host) && config.Port == uint16(utils.Config.Db.Port) {
+		config.Host = utils.DbAliases[0]
+		config.Port = 5432
+		networkID = utils.NetId
+	}
 	// Run pg_prove on volume mount
 	return utils.DockerRunOnceWithConfig(
 		ctx,
@@ -90,7 +97,7 @@ func pgProve(ctx context.Context, testFiles []string, config pgconn.Config, opti
 			WorkingDir: dstPath,
 		},
 		container.HostConfig{
-			NetworkMode: container.NetworkMode("host"),
+			NetworkMode: container.NetworkMode(networkID),
 			Binds:       binds,
 		},
 		network.NetworkingConfig{},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1830

## What is the current behavior?

BitBucket pipeline enables user namespace for docker daemon, which doesn't allow host network mode. https://community.atlassian.com/t5/Bitbucket-articles/Changes-to-make-your-containers-more-secure-on-Bitbucket/ba-p/998464

## What is the new behavior?

When connecting to local database, join the existing custom network instead.

## Additional context

Add any other context or screenshots.
