### PR TITLE
fix(db): create history table before inserting migration

### DIFF
--- a/internal/db/diff/migra_test.go
+++ b/internal/db/diff/migra_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/db/start"
-	"github.com/supabase/cli/internal/migration/repair"
+	"github.com/supabase/cli/internal/migration/history"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
@@ -148,17 +148,10 @@ func TestMigrateShadow(t *testing.T) {
 			Reply("CREATE SCHEMA").
 			Query(utils.InitialSchemaSql).
 			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE").
 			Query(sql).
-			Reply("CREATE SCHEMA").
-			Query(repair.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+			Reply("CREATE SCHEMA")
+		pgtest.MockMigrationHistory(conn)
+		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Run test
 		err := MigrateShadowDatabase(context.Background(), "test-shadow-db", fsys, conn.Intercept)
@@ -320,17 +313,10 @@ At statement 0: create schema public`)
 			Reply("CREATE SCHEMA").
 			Query(utils.InitialSchemaSql).
 			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE").
 			Query(sql).
-			Reply("CREATE SCHEMA").
-			Query(repair.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+			Reply("CREATE SCHEMA")
+		pgtest.MockMigrationHistory(conn)
+		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Run test
 		diff, err := DiffDatabase(context.Background(), []string{"public"}, dbConfig, io.Discard, fsys, conn.Intercept)

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/migration/repair"
+	"github.com/supabase/cli/internal/migration/history"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
@@ -123,14 +123,7 @@ func TestLinkCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE")
+		pgtest.MockMigrationHistory(conn)
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -390,14 +383,7 @@ func TestLinkDatabase(t *testing.T) {
 			"standard_conforming_strings": "on",
 		})
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE")
+		pgtest.MockMigrationHistory(conn)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -414,14 +400,7 @@ func TestLinkDatabase(t *testing.T) {
 			"server_version":              "15.0",
 		})
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE")
+		pgtest.MockMigrationHistory(conn)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -438,12 +417,12 @@ func TestLinkDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
+		conn.Query(history.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
+			Query(history.CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Query(repair.ADD_NAME_COLUMN)
+			Query(history.ADD_STATEMENTS_COLUMN).
+			Query(history.ADD_NAME_COLUMN)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/migration/repair"
+	"github.com/supabase/cli/internal/migration/history"
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/pgtest"
 	"github.com/supabase/cli/internal/utils"
@@ -28,18 +28,11 @@ func TestMigrateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE").
-			Query(sql).
-			Reply("CREATE SCHEMA").
-			Query(repair.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
-			Reply("INSERT 1")
+		conn.Query(sql).
+			Reply("CREATE SCHEMA")
+		pgtest.MockMigrationHistory(conn)
+		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+			Reply("INSERT 0 1")
 		// Connect to mock
 		ctx := context.Background()
 		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
@@ -123,43 +116,12 @@ func TestSeedDatabase(t *testing.T) {
 }
 
 func TestMigrateUp(t *testing.T) {
-	t.Run("throws error on exec failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Query(repair.ADD_NAME_COLUMN)
-		// Connect to mock
-		ctx := context.Background()
-		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)
-		require.NoError(t, err)
-		defer mock.Close(ctx)
-		// Run test
-		err = MigrateUp(context.Background(), mock, []string{"20220727064247_employees.sql"}, fsys)
-		// Check error
-		assert.ErrorContains(t, err, "ERROR: permission denied for relation supabase_migrations (SQLSTATE 42501)")
-	})
-
 	t.Run("throws error on missing file", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(repair.CREATE_VERSION_SCHEMA).
-			Reply("CREATE SCHEMA").
-			Query(repair.CREATE_VERSION_TABLE).
-			Reply("CREATE TABLE").
-			Query(repair.ADD_STATEMENTS_COLUMN).
-			Reply("ALTER TABLE").
-			Query(repair.ADD_NAME_COLUMN).
-			Reply("ALTER TABLE")
 		// Connect to mock
 		ctx := context.Background()
 		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)

--- a/internal/migration/history/history.go
+++ b/internal/migration/history/history.go
@@ -1,0 +1,21 @@
+package history
+
+import "github.com/jackc/pgconn"
+
+const (
+	CREATE_VERSION_SCHEMA    = "CREATE SCHEMA IF NOT EXISTS supabase_migrations"
+	CREATE_VERSION_TABLE     = "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text NOT NULL PRIMARY KEY)"
+	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
+	ADD_NAME_COLUMN          = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS name text"
+	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES($1, $2, $3)"
+	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = $1"
+	DELETE_MIGRATION_BEFORE  = "DELETE FROM supabase_migrations.schema_migrations WHERE version <= $1"
+)
+
+func AddCreateTableStatements(batch *pgconn.Batch) {
+	// Create history table if not exists
+	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
+	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
+	batch.ExecParams(ADD_STATEMENTS_COLUMN, nil, nil, nil, nil)
+	batch.ExecParams(ADD_NAME_COLUMN, nil, nil, nil, nil)
+}

--- a/internal/testing/pgtest/helper.go
+++ b/internal/testing/pgtest/helper.go
@@ -1,0 +1,16 @@
+package pgtest
+
+import (
+	"github.com/supabase/cli/internal/migration/history"
+)
+
+func MockMigrationHistory(conn *MockConn) {
+	conn.Query(history.CREATE_VERSION_SCHEMA).
+		Reply("CREATE SCHEMA").
+		Query(history.CREATE_VERSION_TABLE).
+		Reply("CREATE TABLE").
+		Query(history.ADD_STATEMENTS_COLUMN).
+		Reply("ALTER TABLE").
+		Query(history.ADD_NAME_COLUMN).
+		Reply("ALTER TABLE")
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1428

## What is the new behavior?

Since migration history table is now dumped by db pull, we have to insert into the history table after applying user's migration to accommodate for future schema changes to the history table.

## Additional context

Add any other context or screenshots.
