### PR TITLE
feat: check local service versions on supabase start

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,7 +223,7 @@ func changeWorkDir(fsys afero.Fs) error {
 func addSentryScope(scope *sentry.Scope) {
 	serviceImages := services.GetServiceImages()
 	imageToVersion := make(map[string]interface{}, len(serviceImages))
-	for _, image := range services.GetServiceImages() {
+	for _, image := range serviceImages {
 		parts := strings.Split(image, ":")
 		// Bypasses sentry's IP sanitization rule, ie. 15.1.0.147
 		if net.ParseIP(parts[1]) != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/start"
-	"github.com/supabase/cli/internal/utils/flags"
 )
 
 var (
@@ -20,13 +19,7 @@ var (
 		Use:     "start",
 		Short:   "Start containers for Supabase local development",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fsys := afero.NewOsFs()
-			if preview {
-				if _, err := flags.LoadProjectRef(fsys); err != nil {
-					return err
-				}
-			}
-			return start.Run(cmd.Context(), fsys, excludedContainers, ignoreHealthCheck, flags.ProjectRef)
+			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers, ignoreHealthCheck)
 		},
 	}
 )

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -24,12 +24,11 @@ import (
 	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/functions/serve"
-	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/status"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignoreHealthCheck bool, projectRef string) error {
+func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignoreHealthCheck bool) error {
 	// Sanity checks.
 	{
 		if err := utils.LoadConfigFS(fsys); err != nil {
@@ -45,27 +44,12 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignore
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
-		var dbConfig pgconn.Config
-		if len(projectRef) > 0 {
-			branch := keys.GetGitBranch(fsys)
-			if err := keys.GenerateSecrets(ctx, projectRef, branch, fsys); err != nil {
-				return err
-			}
-			dbConfig = pgconn.Config{
-				Host:     fmt.Sprintf("%s-%s.fly.dev", projectRef, branch),
-				Port:     5432,
-				User:     "postgres",
-				Password: utils.Config.Db.Password,
-				Database: "postgres",
-			}
-		} else {
-			dbConfig = pgconn.Config{
-				Host:     utils.DbId,
-				Port:     5432,
-				User:     "postgres",
-				Password: utils.Config.Db.Password,
-				Database: "postgres",
-			}
+		dbConfig := pgconn.Config{
+			Host:     utils.DbId,
+			Port:     5432,
+			User:     "postgres",
+			Password: utils.Config.Db.Password,
+			Database: "postgres",
 		}
 		return run(p, ctx, fsys, excludedContainers, dbConfig)
 	}); err != nil {

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestStartCommand(t *testing.T) {
 	t.Run("throws error on missing config", func(t *testing.T) {
-		err := Run(context.Background(), afero.NewMemMapFs(), []string{}, false, "")
+		err := Run(context.Background(), afero.NewMemMapFs(), []string{}, false)
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
@@ -32,7 +32,7 @@ func TestStartCommand(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false, "")
+		err := Run(context.Background(), fsys, []string{}, false)
 		// Check error
 		assert.ErrorContains(t, err, "toml: line 0: unexpected EOF; expected key separator '='")
 	})
@@ -48,7 +48,7 @@ func TestStartCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false, "")
+		err := Run(context.Background(), fsys, []string{}, false)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -76,7 +76,7 @@ func TestStartCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false, "")
+		err := Run(context.Background(), fsys, []string{}, false)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -110,6 +110,7 @@ func TestDatabaseStart(t *testing.T) {
 		}
 		// Start postgres
 		utils.DbId = "test-postgres"
+		utils.ConfigId = "test-config"
 		utils.Config.Db.Port = 54322
 		utils.Config.Db.MajorVersion = 15
 		gock.New(utils.Docker.DaemonHost()).
@@ -205,6 +206,7 @@ func TestDatabaseStart(t *testing.T) {
 			JSON(types.ImageInspect{})
 		// Start postgres
 		utils.DbId = "test-postgres"
+		utils.ConfigId = "test-config"
 		utils.Config.Db.Port = 54322
 		utils.Config.Db.MajorVersion = 15
 		gock.New(utils.Docker.DaemonHost()).


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/issues/1617

## What is the current behavior?

It's not intuitive how to update local service versions.

## What is the new behavior?

Show suggestion when service images are found to be out of date.

```bash
$ supabase start
You are running outdated service versions:
supabase/postgres:15.1.0.147 => 15.1.0.155
postgrest/postgrest:v12.0.1 => v12.0.2
Run supabase link to update them.
Started supabase local development setup.
```

## Additional context

Add any other context or screenshots.
