### PR TITLE
fix: add enable manual linking option to auth config

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -380,7 +380,7 @@ EOF
 			"GOTRUE_SITE_URL=" + utils.Config.Auth.SiteUrl,
 			"GOTRUE_URI_ALLOW_LIST=" + strings.Join(utils.Config.Auth.AdditionalRedirectUrls, ","),
 			fmt.Sprintf("GOTRUE_DISABLE_SIGNUP=%v", !utils.Config.Auth.EnableSignup),
-			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking)
+			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
 
 			"GOTRUE_JWT_ADMIN_ROLES=service_role",
 			"GOTRUE_JWT_AUD=authenticated",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -380,6 +380,7 @@ EOF
 			"GOTRUE_SITE_URL=" + utils.Config.Auth.SiteUrl,
 			"GOTRUE_URI_ALLOW_LIST=" + strings.Join(utils.Config.Auth.AdditionalRedirectUrls, ","),
 			fmt.Sprintf("GOTRUE_DISABLE_SIGNUP=%v", !utils.Config.Auth.EnableSignup),
+			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking)
 
 			"GOTRUE_JWT_ADMIN_ROLES=service_role",
 			"GOTRUE_JWT_AUD=authenticated",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -380,7 +380,6 @@ EOF
 			"GOTRUE_SITE_URL=" + utils.Config.Auth.SiteUrl,
 			"GOTRUE_URI_ALLOW_LIST=" + strings.Join(utils.Config.Auth.AdditionalRedirectUrls, ","),
 			fmt.Sprintf("GOTRUE_DISABLE_SIGNUP=%v", !utils.Config.Auth.EnableSignup),
-			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
 
 			"GOTRUE_JWT_ADMIN_ROLES=service_role",
 			"GOTRUE_JWT_AUD=authenticated",
@@ -416,6 +415,7 @@ EOF
 
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=%v", utils.Config.Auth.EnableRefreshTokenRotation),
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=%v", utils.Config.Auth.RefreshTokenReuseInterval),
+			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
 		}
 
 		for id, tmpl := range utils.Config.Auth.Email.Template {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -735,7 +735,7 @@ func InitConfig(params InitParams, fsys afero.Fs) error {
 	if err := MkdirIfNotExistFS(fsys, filepath.Dir(ConfigPath)); err != nil {
 		return err
 	}
-	f, err := fsys.OpenFile(ConfigPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	f, err := fsys.OpenFile(ConfigPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return errors.Errorf("failed to create config file: %w", err)
 	}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -310,10 +310,11 @@ type (
 		EnableRefreshTokenRotation bool `toml:"enable_refresh_token_rotation"`
 		RefreshTokenReuseInterval  uint `toml:"refresh_token_reuse_interval"`
 
-		EnableSignup bool  `toml:"enable_signup"`
-		Email        email `toml:"email"`
-		Sms          sms   `toml:"sms"`
-		External     map[string]provider
+		EnableSignup 				bool  `toml:"enable_signup"`
+		EnableManualLinking bool  `toml:"enable_manual_linking"`
+		Email        				email `toml:"email"`
+		Sms         			  sms   `toml:"sms"`
+		External     				map[string]provider
 
 		// Custom secrets can be injected from .env file
 		JwtSecret      string `toml:"-" mapstructure:"jwt_secret"`

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -309,12 +309,12 @@ type (
 		JwtExpiry                  uint `toml:"jwt_expiry"`
 		EnableRefreshTokenRotation bool `toml:"enable_refresh_token_rotation"`
 		RefreshTokenReuseInterval  uint `toml:"refresh_token_reuse_interval"`
+		EnableManualLinking        bool `toml:"enable_manual_linking"`
 
-		EnableSignup        bool  `toml:"enable_signup"`
-		EnableManualLinking bool  `toml:"enable_manual_linking"`
-		Email               email `toml:"email"`
-		Sms                 sms   `toml:"sms"`
-		External            map[string]provider
+		EnableSignup bool  `toml:"enable_signup"`
+		Email        email `toml:"email"`
+		Sms          sms   `toml:"sms"`
+		External     map[string]provider
 
 		// Custom secrets can be injected from .env file
 		JwtSecret      string `toml:"-" mapstructure:"jwt_secret"`
@@ -735,7 +735,7 @@ func InitConfig(params InitParams, fsys afero.Fs) error {
 	if err := MkdirIfNotExistFS(fsys, filepath.Dir(ConfigPath)); err != nil {
 		return err
 	}
-	f, err := fsys.OpenFile(ConfigPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	f, err := fsys.OpenFile(ConfigPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return errors.Errorf("failed to create config file: %w", err)
 	}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -310,11 +310,11 @@ type (
 		EnableRefreshTokenRotation bool `toml:"enable_refresh_token_rotation"`
 		RefreshTokenReuseInterval  uint `toml:"refresh_token_reuse_interval"`
 
-		EnableSignup 				bool  `toml:"enable_signup"`
+		EnableSignup        bool  `toml:"enable_signup"`
 		EnableManualLinking bool  `toml:"enable_manual_linking"`
-		Email        				email `toml:"email"`
-		Sms         			  sms   `toml:"sms"`
-		External     				map[string]provider
+		Email               email `toml:"email"`
+		Sms                 sms   `toml:"sms"`
+		External            map[string]provider
 
 		// Custom secrets can be injected from .env file
 		JwtSecret      string `toml:"-" mapstructure:"jwt_secret"`

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -81,6 +81,8 @@ enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = true
 
 [auth.email]
 # Allow/disallow new user signups via email to your project.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -81,6 +81,8 @@ enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
 
 [auth.email]
 # Allow/disallow new user signups via email to your project.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow us to test manual linking in localhost

## What is the current behavior?

[Please link any relevant issues here.](https://github.com/supabase/gotrue/pull/1317#issuecomment-1892937708)

## What is the new behavior?

It allows you to specify config.toml value that lets us test manual linking locally

## Additional context

Add any other context or screenshots.
