### PR TITLE
fix: upgrade edge-runtime to 1.31.1

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
 	StudioImage      = "supabase/studio:20240101-8e4a094"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.29.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.31.0"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Edge Runtime 1.31.1 contains various stability fixes on CPU & Wall clock time enforcement. Check the EdgeRuntime releases for more details - https://github.com/supabase/edge-runtime/releases/tag/v1.31.0