### PR TITLE
fix(db): do not dump migration history entries by default

### DIFF
--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -93,7 +93,7 @@ func dumpData(ctx context.Context, config pgconn.Config, schema []string, useCop
 		// "storage",
 		"_analytics",
 		// "supabase_functions",
-		// "supabase_migrations",
+		"supabase_migrations",
 	}
 	var env []string
 	if len(schema) > 0 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1844

## What is the current behavior?

When dumping data to seed.sql, migration history is included by default. This breaks when seeding local database.

## What is the new behavior?

Let CLI manage writing to `schema_migrations` table instead.

## Additional context

Add any other context or screenshots.
