### PR TITLE
feat: support IPv6 CIDR for network restrictions

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -292,6 +292,7 @@ paths:
   /v1/projects/{ref}/api-keys:
     get:
       operationId: getProjectApiKeys
+      summary: Get project api keys
       parameters:
         - name: ref
           required: true
@@ -1842,6 +1843,36 @@ paths:
         - functions
       security:
         - bearer: []
+  /v1/projects/{ref}/storage/buckets:
+    get:
+      operationId: getBuckets
+      summary: Lists all buckets
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/V1StorageBucketResponse'
+        '403':
+          description: ''
+        '500':
+          description: Failed to get list of buckets
+      tags:
+        - storage
+      security:
+        - bearer: []
   /v1/projects/{ref}/config/auth/sso/providers:
     post:
       operationId: createProviderForProject
@@ -2012,6 +2043,32 @@ paths:
         - sso
       security:
         - bearer: []
+  /v1/projects/{ref}/database/backups:
+    get:
+      operationId: getBackups
+      summary: Lists all backups
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1BackupsResponse'
+        '500':
+          description: Failed to get backups
+      tags:
+        - backups
+      security:
+        - bearer: []
   /v1/projects/{ref}/database/backups/restore-pitr:
     post:
       operationId: v1RestorePitr
@@ -2035,7 +2092,7 @@ paths:
         '201':
           description: ''
       tags:
-        - backups (beta)
+        - backups
       security:
         - bearer: []
   /v1/organizations/{slug}/members:
@@ -2057,6 +2114,27 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/V1OrganizationMemberResponse'
+      tags:
+        - organizations
+      security:
+        - bearer: []
+  /v1/organizations/{slug}:
+    get:
+      operationId: getOrganization
+      summary: Gets information about the organization
+      parameters:
+        - name: slug
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1OrganizationSlugResponse'
       tags:
         - organizations
       security:
@@ -2225,6 +2303,7 @@ components:
             - us-east-1
             - us-west-1
             - us-west-2
+            - ap-east-1
             - ap-southeast-1
             - ap-northeast-1
             - ap-northeast-2
@@ -2507,8 +2586,10 @@ components:
           type: array
           items:
             type: string
-      required:
-        - dbAllowedCidrs
+        dbAllowedCidrsV6:
+          type: array
+          items:
+            type: string
     NetworkRestrictionsResponse:
       type: object
       properties:
@@ -2723,9 +2804,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProjectVersion'
-        requires_manual_intervention:
-          type: string
-          nullable: true
         potential_breaking_changes:
           type: array
           items:
@@ -2745,7 +2823,6 @@ components:
         - current_app_version
         - latest_app_version
         - target_upgrade_versions
-        - requires_manual_intervention
         - potential_breaking_changes
         - duration_estimate_hours
         - legacy_auth_custom_roles
@@ -2771,6 +2848,7 @@ components:
         progress:
           type: string
           enum:
+            - 0_requested
             - 1_started
             - 2_launched_upgraded_instance
             - 3_detached_volume_from_upgraded_instance
@@ -2821,6 +2899,7 @@ components:
             - us-east-1
             - us-west-1
             - us-west-2
+            - ap-east-1
             - ap-southeast-1
             - ap-northeast-1
             - ap-northeast-2
@@ -2912,6 +2991,10 @@ components:
           type: integer
           minimum: 1
           maximum: 262143
+        max_locks_per_transaction:
+          type: integer
+          minimum: 10
+          maximum: 2147483640
         max_parallel_maintenance_workers:
           type: integer
           minimum: 0
@@ -2951,6 +3034,10 @@ components:
           type: integer
           minimum: 1
           maximum: 262143
+        max_locks_per_transaction:
+          type: integer
+          minimum: 10
+          maximum: 2147483640
         max_parallel_maintenance_workers:
           type: integer
           minimum: 0
@@ -3142,6 +3229,28 @@ components:
           type: string
         verify_jwt:
           type: boolean
+    V1StorageBucketResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        public:
+          type: boolean
+      required:
+        - id
+        - name
+        - owner
+        - created_at
+        - updated_at
+        - public
     AttributeValue:
       type: object
       properties:
@@ -3322,6 +3431,53 @@ components:
           type: string
       required:
         - id
+    V1Backup:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - COMPLETED
+            - FAILED
+            - PENDING
+            - REMOVED
+            - ARCHIVED
+        is_physical_backup:
+          type: boolean
+        inserted_at:
+          type: string
+      required:
+        - status
+        - is_physical_backup
+        - inserted_at
+    PhysicalBackup:
+      type: object
+      properties:
+        earliest_physical_backup_date_unix:
+          type: number
+        latest_physical_backup_date_unix:
+          type: number
+    V1BackupsResponse:
+      type: object
+      properties:
+        region:
+          type: string
+        walg_enabled:
+          type: boolean
+        pitr_enabled:
+          type: boolean
+        backups:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1Backup'
+        physical_backup_data:
+          $ref: '#/components/schemas/PhysicalBackup'
+      required:
+        - region
+        - walg_enabled
+        - pitr_enabled
+        - backups
+        - physical_backup_data
     V1RestorePitrBody:
       type: object
       properties:
@@ -3347,3 +3503,30 @@ components:
         - user_name
         - role_name
         - mfa_enabled
+    BillingPlanId:
+      type: string
+      enum:
+        - free
+        - pro
+        - team
+        - enterprise
+    V1OrganizationSlugResponse:
+      type: object
+      properties:
+        plan:
+          $ref: '#/components/schemas/BillingPlanId'
+        opt_in_tags:
+          type: array
+          items:
+            type: string
+            enum:
+              - AI_SQL_GENERATOR_OPT_IN
+              - PREVIEW_BRANCHES_OPT_IN
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - opt_in_tags
+        - id
+        - name

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -35,8 +35,8 @@ var (
 		Allowed: make([]string, len(utils.RegionMap)),
 	}
 	plan = utils.EnumFlag{
-		Allowed: []string{string(api.Free), string(api.Pro)},
-		Value:   string(api.Free),
+		Allowed: []string{string(api.CreateProjectBodyPlanFree), string(api.CreateProjectBodyPlanPro)},
+		Value:   string(api.CreateProjectBodyPlanFree),
 	}
 
 	projectsCreateCmd = &cobra.Command{
@@ -165,8 +165,8 @@ func PromptCreateFlags(cmd *cobra.Command) error {
 	if !cmd.Flags().Changed("plan") {
 		title := "Do you want a free or pro plan?"
 		choice, err := utils.PromptChoice(ctx, title, []utils.PromptItem{
-			{Summary: string(api.Free)},
-			{Summary: string(api.Pro)},
+			{Summary: string(api.CreateProjectBodyPlanFree)},
+			{Summary: string(api.CreateProjectBodyPlanPro)},
 		})
 		if err != nil {
 			return err

--- a/cmd/restrictions.go
+++ b/cmd/restrictions.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/restrictions/get"
 	"github.com/supabase/cli/internal/restrictions/update"
@@ -22,7 +21,7 @@ var (
 		Use:   "update",
 		Short: "Update network restrictions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return update.Run(cmd.Context(), flags.ProjectRef, dbCidrsToAllow, bypassCidrChecks, afero.NewOsFs())
+			return update.Run(cmd.Context(), flags.ProjectRef, dbCidrsToAllow, bypassCidrChecks)
 		},
 	}
 
@@ -30,7 +29,7 @@ var (
 		Use:   "get",
 		Short: "Get the current network restrictions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return get.Run(cmd.Context(), flags.ProjectRef, afero.NewOsFs())
+			return get.Run(cmd.Context(), flags.ProjectRef)
 		},
 	}
 )
@@ -41,6 +40,5 @@ func init() {
 	restrictionsUpdateCmd.Flags().BoolVar(&bypassCidrChecks, "bypass-cidr-checks", false, "Bypass some of the CIDR validation checks.")
 	restrictionsCmd.AddCommand(restrictionsGetCmd)
 	restrictionsCmd.AddCommand(restrictionsUpdateCmd)
-
 	rootCmd.AddCommand(restrictionsCmd)
 }

--- a/internal/projects/create/create_test.go
+++ b/internal/projects/create/create_test.go
@@ -19,7 +19,7 @@ func TestProjectCreateCommand(t *testing.T) {
 		OrganizationId: "combined-fuchsia-lion",
 		DbPass:         "redacted",
 		Region:         api.CreateProjectBodyRegionUsWest1,
-		Plan:           api.Free,
+		Plan:           api.CreateProjectBodyPlanFree,
 	}
 
 	t.Run("creates a new project", func(t *testing.T) {

--- a/internal/restrictions/get/get.go
+++ b/internal/restrictions/get/get.go
@@ -5,24 +5,20 @@ import (
 	"fmt"
 
 	"github.com/go-errors/errors"
-	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
-	// 1. Sanity checks.
-	// 2. get network restrictions
-	{
-		resp, err := utils.GetSupabase().GetNetworkRestrictionsWithResponse(ctx, projectRef)
-		if err != nil {
-			return errors.Errorf("failed to retrieve network restrictions: %w", err)
-		}
-		if resp.JSON200 == nil {
-			return errors.New("failed to retrieve network restrictions; received: " + string(resp.Body))
-		}
-
-		fmt.Printf("DB Allowed CIDRs: %+v\n", resp.JSON200.Config.DbAllowedCidrs)
-		fmt.Printf("Restrictions applied successfully: %+v\n", resp.JSON200.Status == "applied")
-		return nil
+func Run(ctx context.Context, projectRef string) error {
+	resp, err := utils.GetSupabase().GetNetworkRestrictionsWithResponse(ctx, projectRef)
+	if err != nil {
+		return errors.Errorf("failed to retrieve network restrictions: %w", err)
 	}
+	if resp.JSON200 == nil {
+		return errors.New("failed to retrieve network restrictions; received: " + string(resp.Body))
+	}
+
+	fmt.Printf("DB Allowed IPv4 CIDRs: %+v\n", resp.JSON200.Config.DbAllowedCidrs)
+	fmt.Printf("DB Allowed IPv6 CIDRs: %+v\n", resp.JSON200.Config.DbAllowedCidrsV6)
+	fmt.Printf("Restrictions applied successfully: %+v\n", resp.JSON200.Status == "applied")
+	return nil
 }

--- a/internal/restrictions/update/update_test.go
+++ b/internal/restrictions/update/update_test.go
@@ -1,28 +1,121 @@
 package update
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
+	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+	"gopkg.in/h2non/gock.v1"
 )
 
-func TestPrivateSubnet(t *testing.T) {
-	err := validateCidrs([]string{"12.3.4.5/32", "10.0.0.0/8", "1.2.3.1/24"}, false)
-	assert.ErrorContains(t, err, "private IP provided: 10.0.0.0/8")
-	err = validateCidrs([]string{"10.0.0.0/8"}, true)
-	assert.Nil(t, err, "should bypass private subnet checks")
+func TestUpdateRestrictionsCommand(t *testing.T) {
+	projectRef := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
+	t.Run("updates v4 and v6 CIDR", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + projectRef + "/network-restrictions/apply").
+			MatchType("json").
+			JSON(api.NetworkRestrictionsRequest{
+				DbAllowedCidrs:   &[]string{"12.3.4.5/32", "1.2.3.1/24"},
+				DbAllowedCidrsV6: &[]string{"2001:db8:abcd:0012::0/64"},
+			}).
+			Reply(http.StatusCreated).
+			JSON(api.NetworkRestrictionsResponse{
+				Status: api.NetworkRestrictionsResponseStatus("applied"),
+			})
+		// Run test
+		err := Run(context.Background(), projectRef, []string{"12.3.4.5/32", "2001:db8:abcd:0012::0/64", "1.2.3.1/24"}, false)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on network failure", func(t *testing.T) {
+		errNetwork := errors.New("network error")
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + projectRef + "/network-restrictions/apply").
+			MatchType("json").
+			JSON(api.NetworkRestrictionsRequest{
+				DbAllowedCidrs:   &[]string{},
+				DbAllowedCidrsV6: &[]string{},
+			}).
+			ReplyError(errNetwork)
+		// Run test
+		err := Run(context.Background(), projectRef, []string{}, true)
+		// Check error
+		assert.ErrorIs(t, err, errNetwork)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on server unavailable", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + projectRef + "/network-restrictions/apply").
+			MatchType("json").
+			JSON(api.NetworkRestrictionsRequest{
+				DbAllowedCidrs:   &[]string{},
+				DbAllowedCidrsV6: &[]string{},
+			}).
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := Run(context.Background(), projectRef, []string{}, true)
+		// Check error
+		assert.ErrorContains(t, err, "failed to apply network restrictions:")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
 }
 
-func TestIpv4(t *testing.T) {
-	err := validateCidrs([]string{"12.3.4.5/32", "2001:db8:abcd:0012::0/64", "1.2.3.1/24"}, false)
-	assert.ErrorContains(t, err, "only IPv4 supported at the moment: 2001:db8:abcd:0012::0/64")
-	err = validateCidrs([]string{"12.3.4.5/32", "2001:db8:abcd:0012::0/64", "1.2.3.1/24"}, true)
-	assert.ErrorContains(t, err, "only IPv4 supported at the moment: 2001:db8:abcd:0012::0/64")
-}
+func TestValidateCIDR(t *testing.T) {
+	projectRef := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 
-func TestInvalidSubnets(t *testing.T) {
-	err := validateCidrs([]string{"12.3.4.5", "10.0.0.0/8", "1.2.3.1/24"}, false)
-	assert.ErrorContains(t, err, "failed to parse IP: 12.3.4.5")
-	err = validateCidrs([]string{"100/36"}, true)
-	assert.ErrorContains(t, err, "failed to parse IP: 100/36")
+	t.Run("bypasses private subnet checks", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + projectRef + "/network-restrictions/apply").
+			MatchType("json").
+			JSON(api.NetworkRestrictionsRequest{
+				DbAllowedCidrs:   &[]string{"10.0.0.0/8"},
+				DbAllowedCidrsV6: &[]string{},
+			}).
+			Reply(http.StatusCreated).
+			JSON(api.NetworkRestrictionsResponse{
+				Status: api.NetworkRestrictionsResponseStatus("applied"),
+			})
+		// Run test
+		err := Run(context.Background(), projectRef, []string{"10.0.0.0/8"}, true)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on private subnet", func(t *testing.T) {
+		// Run test
+		err := Run(context.Background(), projectRef, []string{"12.3.4.5/32", "10.0.0.0/8", "1.2.3.1/24"}, false)
+		// Check error
+		assert.ErrorContains(t, err, "private IP provided: 10.0.0.0/8")
+	})
+
+	t.Run("throws error on invalid subnet", func(t *testing.T) {
+		// Run test
+		err := Run(context.Background(), projectRef, []string{"12.3.4.5", "10.0.0.0/8", "1.2.3.1/24"}, false)
+		// Check error
+		assert.ErrorContains(t, err, "failed to parse IP: 12.3.4.5")
+	})
 }

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -116,6 +116,9 @@ type ClientInterface interface {
 
 	CreateOrganization(ctx context.Context, body CreateOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetOrganization request
+	GetOrganization(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// V1ListOrganizationMembers request
 	V1ListOrganizationMembers(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -198,6 +201,9 @@ type ClientInterface interface {
 
 	// Reverify request
 	Reverify(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBackups request
+	GetBackups(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// V1RestorePitrWithBody request with any body
 	V1RestorePitrWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -305,6 +311,9 @@ type ClientInterface interface {
 	UpdateSslEnforcementConfigWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateSslEnforcementConfig(ctx context.Context, ref string, body UpdateSslEnforcementConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBuckets request
+	GetBuckets(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTypescriptTypes request
 	GetTypescriptTypes(ctx context.Context, ref string, params *GetTypescriptTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -453,6 +462,18 @@ func (c *Client) CreateOrganizationWithBody(ctx context.Context, contentType str
 
 func (c *Client) CreateOrganization(ctx context.Context, body CreateOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateOrganizationRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetOrganization(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetOrganizationRequest(c.Server, slug)
 	if err != nil {
 		return nil, err
 	}
@@ -813,6 +834,18 @@ func (c *Client) CreateCustomHostnameConfig(ctx context.Context, ref string, bod
 
 func (c *Client) Reverify(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewReverifyRequest(c.Server, ref)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBackups(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBackupsRequest(c.Server, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -1293,6 +1326,18 @@ func (c *Client) UpdateSslEnforcementConfigWithBody(ctx context.Context, ref str
 
 func (c *Client) UpdateSslEnforcementConfig(ctx context.Context, ref string, body UpdateSslEnforcementConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateSslEnforcementConfigRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBuckets(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBucketsRequest(c.Server, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -1826,6 +1871,40 @@ func NewCreateOrganizationRequestWithBody(server string, contentType string, bod
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetOrganizationRequest generates requests for GetOrganization
+func NewGetOrganizationRequest(server string, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -2703,6 +2782,40 @@ func NewReverifyRequest(server string, ref string) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBackupsRequest generates requests for GetBackups
+func NewGetBackupsRequest(server string, ref string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/database/backups", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4063,6 +4176,40 @@ func NewUpdateSslEnforcementConfigRequestWithBody(server string, ref string, con
 	return req, nil
 }
 
+// NewGetBucketsRequest generates requests for GetBuckets
+func NewGetBucketsRequest(server string, ref string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/storage/buckets", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetTypescriptTypesRequest generates requests for GetTypescriptTypes
 func NewGetTypescriptTypesRequest(server string, ref string, params *GetTypescriptTypesParams) (*http.Request, error) {
 	var err error
@@ -4549,6 +4696,9 @@ type ClientWithResponsesInterface interface {
 
 	CreateOrganizationWithResponse(ctx context.Context, body CreateOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateOrganizationResponse, error)
 
+	// GetOrganizationWithResponse request
+	GetOrganizationWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*GetOrganizationResponse, error)
+
 	// V1ListOrganizationMembersWithResponse request
 	V1ListOrganizationMembersWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*V1ListOrganizationMembersResponse, error)
 
@@ -4631,6 +4781,9 @@ type ClientWithResponsesInterface interface {
 
 	// ReverifyWithResponse request
 	ReverifyWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*ReverifyResponse, error)
+
+	// GetBackupsWithResponse request
+	GetBackupsWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBackupsResponse, error)
 
 	// V1RestorePitrWithBodyWithResponse request with any body
 	V1RestorePitrWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1RestorePitrResponse, error)
@@ -4738,6 +4891,9 @@ type ClientWithResponsesInterface interface {
 	UpdateSslEnforcementConfigWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSslEnforcementConfigResponse, error)
 
 	UpdateSslEnforcementConfigWithResponse(ctx context.Context, ref string, body UpdateSslEnforcementConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSslEnforcementConfigResponse, error)
+
+	// GetBucketsWithResponse request
+	GetBucketsWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBucketsResponse, error)
 
 	// GetTypescriptTypesWithResponse request
 	GetTypescriptTypesWithResponse(ctx context.Context, ref string, params *GetTypescriptTypesParams, reqEditors ...RequestEditorFn) (*GetTypescriptTypesResponse, error)
@@ -4922,6 +5078,28 @@ func (r CreateOrganizationResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateOrganizationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetOrganizationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *V1OrganizationSlugResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetOrganizationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetOrganizationResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5427,6 +5605,28 @@ func (r ReverifyResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ReverifyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetBackupsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *V1BackupsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBackupsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBackupsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6018,6 +6218,28 @@ func (r UpdateSslEnforcementConfigResponse) StatusCode() int {
 	return 0
 }
 
+type GetBucketsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]V1StorageBucketResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBucketsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBucketsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetTypescriptTypesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6324,6 +6546,15 @@ func (c *ClientWithResponses) CreateOrganizationWithResponse(ctx context.Context
 	return ParseCreateOrganizationResponse(rsp)
 }
 
+// GetOrganizationWithResponse request returning *GetOrganizationResponse
+func (c *ClientWithResponses) GetOrganizationWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*GetOrganizationResponse, error) {
+	rsp, err := c.GetOrganization(ctx, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetOrganizationResponse(rsp)
+}
+
 // V1ListOrganizationMembersWithResponse request returning *V1ListOrganizationMembersResponse
 func (c *ClientWithResponses) V1ListOrganizationMembersWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*V1ListOrganizationMembersResponse, error) {
 	rsp, err := c.V1ListOrganizationMembers(ctx, slug, reqEditors...)
@@ -6585,6 +6816,15 @@ func (c *ClientWithResponses) ReverifyWithResponse(ctx context.Context, ref stri
 		return nil, err
 	}
 	return ParseReverifyResponse(rsp)
+}
+
+// GetBackupsWithResponse request returning *GetBackupsResponse
+func (c *ClientWithResponses) GetBackupsWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBackupsResponse, error) {
+	rsp, err := c.GetBackups(ctx, ref, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBackupsResponse(rsp)
 }
 
 // V1RestorePitrWithBodyWithResponse request with arbitrary body returning *V1RestorePitrResponse
@@ -6934,6 +7174,15 @@ func (c *ClientWithResponses) UpdateSslEnforcementConfigWithResponse(ctx context
 	return ParseUpdateSslEnforcementConfigResponse(rsp)
 }
 
+// GetBucketsWithResponse request returning *GetBucketsResponse
+func (c *ClientWithResponses) GetBucketsWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*GetBucketsResponse, error) {
+	rsp, err := c.GetBuckets(ctx, ref, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBucketsResponse(rsp)
+}
+
 // GetTypescriptTypesWithResponse request returning *GetTypescriptTypesResponse
 func (c *ClientWithResponses) GetTypescriptTypesWithResponse(ctx context.Context, ref string, params *GetTypescriptTypesParams, reqEditors ...RequestEditorFn) (*GetTypescriptTypesResponse, error) {
 	rsp, err := c.GetTypescriptTypes(ctx, ref, params, reqEditors...)
@@ -7204,6 +7453,32 @@ func ParseCreateOrganizationResponse(rsp *http.Response) (*CreateOrganizationRes
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetOrganizationResponse parses an HTTP response from a GetOrganizationWithResponse call
+func ParseGetOrganizationResponse(rsp *http.Response) (*GetOrganizationResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetOrganizationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest V1OrganizationSlugResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 
@@ -7789,6 +8064,32 @@ func ParseReverifyResponse(rsp *http.Response) (*ReverifyResponse, error) {
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBackupsResponse parses an HTTP response from a GetBackupsWithResponse call
+func ParseGetBackupsResponse(rsp *http.Response) (*GetBackupsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBackupsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest V1BackupsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 
@@ -8397,6 +8698,32 @@ func ParseUpdateSslEnforcementConfigResponse(rsp *http.Response) (*UpdateSslEnfo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SslEnforcementResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBucketsResponse parses an HTTP response from a GetBucketsWithResponse call
+func ParseGetBucketsResponse(rsp *http.Response) (*GetBucketsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBucketsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []V1StorageBucketResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -13,6 +13,14 @@ const (
 	BearerScopes = "bearer.Scopes"
 )
 
+// Defines values for BillingPlanId.
+const (
+	BillingPlanIdEnterprise BillingPlanId = "enterprise"
+	BillingPlanIdFree       BillingPlanId = "free"
+	BillingPlanIdPro        BillingPlanId = "pro"
+	BillingPlanIdTeam       BillingPlanId = "team"
+)
+
 // Defines values for BranchDetailResponseStatus.
 const (
 	BranchDetailResponseStatusACTIVEHEALTHY   BranchDetailResponseStatus = "ACTIVE_HEALTHY"
@@ -30,12 +38,13 @@ const (
 
 // Defines values for CreateProjectBodyPlan.
 const (
-	Free CreateProjectBodyPlan = "free"
-	Pro  CreateProjectBodyPlan = "pro"
+	CreateProjectBodyPlanFree CreateProjectBodyPlan = "free"
+	CreateProjectBodyPlanPro  CreateProjectBodyPlan = "pro"
 )
 
 // Defines values for CreateProjectBodyRegion.
 const (
+	CreateProjectBodyRegionApEast1      CreateProjectBodyRegion = "ap-east-1"
 	CreateProjectBodyRegionApNortheast1 CreateProjectBodyRegion = "ap-northeast-1"
 	CreateProjectBodyRegionApNortheast2 CreateProjectBodyRegion = "ap-northeast-2"
 	CreateProjectBodyRegionApSouth1     CreateProjectBodyRegion = "ap-south-1"
@@ -71,6 +80,7 @@ const (
 
 // Defines values for DatabaseUpgradeStatusProgress.
 const (
+	N0Requested                          DatabaseUpgradeStatusProgress = "0_requested"
 	N1Started                            DatabaseUpgradeStatusProgress = "1_started"
 	N2LaunchedUpgradedInstance           DatabaseUpgradeStatusProgress = "2_launched_upgraded_instance"
 	N3DetachedVolumeFromUpgradedInstance DatabaseUpgradeStatusProgress = "3_detached_volume_from_upgraded_instance"
@@ -98,9 +108,9 @@ const (
 
 // Defines values for FunctionSlugResponseStatus.
 const (
-	ACTIVE    FunctionSlugResponseStatus = "ACTIVE"
-	REMOVED   FunctionSlugResponseStatus = "REMOVED"
-	THROTTLED FunctionSlugResponseStatus = "THROTTLED"
+	FunctionSlugResponseStatusACTIVE    FunctionSlugResponseStatus = "ACTIVE"
+	FunctionSlugResponseStatusREMOVED   FunctionSlugResponseStatus = "REMOVED"
+	FunctionSlugResponseStatusTHROTTLED FunctionSlugResponseStatus = "THROTTLED"
 )
 
 // Defines values for NetworkRestrictionsResponseEntitlement.
@@ -152,6 +162,7 @@ const (
 
 // Defines values for SetUpReadReplicaBodyReadReplicaRegion.
 const (
+	SetUpReadReplicaBodyReadReplicaRegionApEast1      SetUpReadReplicaBodyReadReplicaRegion = "ap-east-1"
 	SetUpReadReplicaBodyReadReplicaRegionApNortheast1 SetUpReadReplicaBodyReadReplicaRegion = "ap-northeast-1"
 	SetUpReadReplicaBodyReadReplicaRegionApNortheast2 SetUpReadReplicaBodyReadReplicaRegion = "ap-northeast-2"
 	SetUpReadReplicaBodyReadReplicaRegionApSouth1     SetUpReadReplicaBodyReadReplicaRegion = "ap-south-1"
@@ -208,6 +219,21 @@ const (
 	UpdatePostgresConfigBodySessionReplicationRoleLocal   UpdatePostgresConfigBodySessionReplicationRole = "local"
 	UpdatePostgresConfigBodySessionReplicationRoleOrigin  UpdatePostgresConfigBodySessionReplicationRole = "origin"
 	UpdatePostgresConfigBodySessionReplicationRoleReplica UpdatePostgresConfigBodySessionReplicationRole = "replica"
+)
+
+// Defines values for V1BackupStatus.
+const (
+	V1BackupStatusARCHIVED  V1BackupStatus = "ARCHIVED"
+	V1BackupStatusCOMPLETED V1BackupStatus = "COMPLETED"
+	V1BackupStatusFAILED    V1BackupStatus = "FAILED"
+	V1BackupStatusPENDING   V1BackupStatus = "PENDING"
+	V1BackupStatusREMOVED   V1BackupStatus = "REMOVED"
+)
+
+// Defines values for V1OrganizationSlugResponseOptInTags.
+const (
+	AISQLGENERATOROPTIN  V1OrganizationSlugResponseOptInTags = "AI_SQL_GENERATOR_OPT_IN"
+	PREVIEWBRANCHESOPTIN V1OrganizationSlugResponseOptInTags = "PREVIEW_BRANCHES_OPT_IN"
 )
 
 // Defines values for V1PgbouncerConfigResponsePoolMode.
@@ -306,6 +332,9 @@ type AuthHealthResponse struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`
 }
+
+// BillingPlanId defines model for BillingPlanId.
+type BillingPlanId string
 
 // BranchDetailResponse defines model for BranchDetailResponse.
 type BranchDetailResponse struct {
@@ -519,7 +548,8 @@ type NetworkBanResponse struct {
 
 // NetworkRestrictionsRequest defines model for NetworkRestrictionsRequest.
 type NetworkRestrictionsRequest struct {
-	DbAllowedCidrs []string `json:"dbAllowedCidrs"`
+	DbAllowedCidrs   *[]string `json:"dbAllowedCidrs,omitempty"`
+	DbAllowedCidrsV6 *[]string `json:"dbAllowedCidrsV6,omitempty"`
 }
 
 // NetworkRestrictionsResponse defines model for NetworkRestrictionsResponse.
@@ -572,11 +602,18 @@ type PgsodiumConfigResponse struct {
 	RootKey string `json:"root_key"`
 }
 
+// PhysicalBackup defines model for PhysicalBackup.
+type PhysicalBackup struct {
+	EarliestPhysicalBackupDateUnix *float32 `json:"earliest_physical_backup_date_unix,omitempty"`
+	LatestPhysicalBackupDateUnix   *float32 `json:"latest_physical_backup_date_unix,omitempty"`
+}
+
 // PostgresConfigResponse defines model for PostgresConfigResponse.
 type PostgresConfigResponse struct {
 	EffectiveCacheSize            *string                                       `json:"effective_cache_size,omitempty"`
 	MaintenanceWorkMem            *string                                       `json:"maintenance_work_mem,omitempty"`
 	MaxConnections                *int                                          `json:"max_connections,omitempty"`
+	MaxLocksPerTransaction        *int                                          `json:"max_locks_per_transaction,omitempty"`
 	MaxParallelMaintenanceWorkers *int                                          `json:"max_parallel_maintenance_workers,omitempty"`
 	MaxParallelWorkers            *int                                          `json:"max_parallel_workers,omitempty"`
 	MaxParallelWorkersPerGather   *int                                          `json:"max_parallel_workers_per_gather,omitempty"`
@@ -633,15 +670,14 @@ type ProjectResponse struct {
 
 // ProjectUpgradeEligibilityResponse defines model for ProjectUpgradeEligibilityResponse.
 type ProjectUpgradeEligibilityResponse struct {
-	CurrentAppVersion          string           `json:"current_app_version"`
-	DurationEstimateHours      float32          `json:"duration_estimate_hours"`
-	Eligible                   bool             `json:"eligible"`
-	ExtensionDependentObjects  []string         `json:"extension_dependent_objects"`
-	LatestAppVersion           string           `json:"latest_app_version"`
-	LegacyAuthCustomRoles      []string         `json:"legacy_auth_custom_roles"`
-	PotentialBreakingChanges   []string         `json:"potential_breaking_changes"`
-	RequiresManualIntervention *string          `json:"requires_manual_intervention"`
-	TargetUpgradeVersions      []ProjectVersion `json:"target_upgrade_versions"`
+	CurrentAppVersion         string           `json:"current_app_version"`
+	DurationEstimateHours     float32          `json:"duration_estimate_hours"`
+	Eligible                  bool             `json:"eligible"`
+	ExtensionDependentObjects []string         `json:"extension_dependent_objects"`
+	LatestAppVersion          string           `json:"latest_app_version"`
+	LegacyAuthCustomRoles     []string         `json:"legacy_auth_custom_roles"`
+	PotentialBreakingChanges  []string         `json:"potential_breaking_changes"`
+	TargetUpgradeVersions     []ProjectVersion `json:"target_upgrade_versions"`
 }
 
 // ProjectUpgradeInitiateResponse defines model for ProjectUpgradeInitiateResponse.
@@ -879,6 +915,7 @@ type UpdatePostgresConfigBody struct {
 	EffectiveCacheSize            *string                                         `json:"effective_cache_size,omitempty"`
 	MaintenanceWorkMem            *string                                         `json:"maintenance_work_mem,omitempty"`
 	MaxConnections                *int                                            `json:"max_connections,omitempty"`
+	MaxLocksPerTransaction        *int                                            `json:"max_locks_per_transaction,omitempty"`
 	MaxParallelMaintenanceWorkers *int                                            `json:"max_parallel_maintenance_workers,omitempty"`
 	MaxParallelWorkers            *int                                            `json:"max_parallel_workers,omitempty"`
 	MaxParallelWorkersPerGather   *int                                            `json:"max_parallel_workers_per_gather,omitempty"`
@@ -921,6 +958,25 @@ type UpgradeDatabaseBody struct {
 	TargetVersion float32 `json:"target_version"`
 }
 
+// V1Backup defines model for V1Backup.
+type V1Backup struct {
+	InsertedAt       string         `json:"inserted_at"`
+	IsPhysicalBackup bool           `json:"is_physical_backup"`
+	Status           V1BackupStatus `json:"status"`
+}
+
+// V1BackupStatus defines model for V1Backup.Status.
+type V1BackupStatus string
+
+// V1BackupsResponse defines model for V1BackupsResponse.
+type V1BackupsResponse struct {
+	Backups            []V1Backup     `json:"backups"`
+	PhysicalBackupData PhysicalBackup `json:"physical_backup_data"`
+	PitrEnabled        bool           `json:"pitr_enabled"`
+	Region             string         `json:"region"`
+	WalgEnabled        bool           `json:"walg_enabled"`
+}
+
 // V1OrganizationMemberResponse defines model for V1OrganizationMemberResponse.
 type V1OrganizationMemberResponse struct {
 	Email      *string `json:"email,omitempty"`
@@ -929,6 +985,17 @@ type V1OrganizationMemberResponse struct {
 	UserId     string  `json:"user_id"`
 	UserName   string  `json:"user_name"`
 }
+
+// V1OrganizationSlugResponse defines model for V1OrganizationSlugResponse.
+type V1OrganizationSlugResponse struct {
+	Id        string                                `json:"id"`
+	Name      string                                `json:"name"`
+	OptInTags []V1OrganizationSlugResponseOptInTags `json:"opt_in_tags"`
+	Plan      *BillingPlanId                        `json:"plan,omitempty"`
+}
+
+// V1OrganizationSlugResponseOptInTags defines model for V1OrganizationSlugResponse.OptInTags.
+type V1OrganizationSlugResponseOptInTags string
 
 // V1PgbouncerConfigResponse defines model for V1PgbouncerConfigResponse.
 type V1PgbouncerConfigResponse struct {
@@ -945,6 +1012,16 @@ type V1PgbouncerConfigResponsePoolMode string
 // V1RestorePitrBody defines model for V1RestorePitrBody.
 type V1RestorePitrBody struct {
 	RecoveryTimeTargetUnix float32 `json:"recovery_time_target_unix"`
+}
+
+// V1StorageBucketResponse defines model for V1StorageBucketResponse.
+type V1StorageBucketResponse struct {
+	CreatedAt string `json:"created_at"`
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	Owner     string `json:"owner"`
+	Public    bool   `json:"public"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // VanitySubdomainBody defines model for VanitySubdomainBody.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature https://www.notion.so/supabase/support-ipv6-network-restrictions-3b6a98b2c2da40e4a76ca3899145b2f7?pvs=4

## What is the current behavior?

Support IPv6 addresses as arguments for `--db-allow-cidr` flag.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
