### PR TITLE
fix(storage): default db_install_roles to false for backwards compat

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -208,6 +208,7 @@ func initSchema14(ctx context.Context, conn *pgx.Conn) error {
 func initSchema15(ctx context.Context, host string) error {
 	// Apply service migrations
 	if err := utils.DockerRunOnceWithStream(ctx, utils.Config.Storage.Image, []string{
+		"DB_INSTALL_ROLES=false",
 		"ANON_KEY=" + utils.Config.Auth.AnonKey,
 		"SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey,
 		"PGRST_JWT_SECRET=" + utils.Config.Auth.JwtSecret,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1877

## What is the new behavior?

`DB_INSTALL_ROLES` is introduced in storage version 0.46.3. Set to false for backwards compatibility.

## Additional context

Verified locally with `supabase start`
