### PR TITLE
fix(storage): bump storage version to v0.46.4

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -709,7 +709,6 @@ EOF
 					fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:%d/%s", dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database),
 					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 					"STORAGE_BACKEND=file",
-					"DB_INSTALL_ROLES=false",
 					"FILE_STORAGE_BACKEND_PATH=" + dockerStoragePath,
 					"TENANT_ID=stub",
 					// TODO: https://github.com/supabase/storage-api/issues/55

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -709,6 +709,7 @@ EOF
 					fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:%d/%s", dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database),
 					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 					"STORAGE_BACKEND=file",
+					"DB_INSTALL_ROLES=false",
 					"FILE_STORAGE_BACKEND_PATH=" + dockerStoragePath,
 					"TENANT_ID=stub",
 					// TODO: https://github.com/supabase/storage-api/issues/55

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.132.3"
 	RealtimeImage    = "supabase/realtime:v2.25.50"
-	StorageImage     = "supabase/storage-api:v0.46.3"
+	StorageImage     = "supabase/storage-api:v0.46.4"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage
 	DenoVersion = "1.30.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/go-errors/errors"
-	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 )
 
@@ -40,7 +39,7 @@ const (
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.132.3"
 	RealtimeImage    = "supabase/realtime:v2.25.50"
-	StorageImage     = "supabase/storage-api:v0.43.11"
+	StorageImage     = "supabase/storage-api:v0.46.3"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage
 	DenoVersion = "1.30.3"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/go-errors/errors"
+	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 )
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Version Update Storage 0.46.3
