### PR TITLE
feat(migration): exlude custom schema.table from data-only dump

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -104,12 +104,13 @@ var (
 	useCopy      bool
 	roleOnly     bool
 	keepComments bool
+	excludeTable []string
 
 	dbDumpCmd = &cobra.Command{
 		Use:   "dump",
 		Short: "Dumps data or schemas from the remote database",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return dump.Run(cmd.Context(), file, flags.DbConfig, schema, dataOnly, roleOnly, keepComments, useCopy, dryRun, afero.NewOsFs())
+			return dump.Run(cmd.Context(), file, flags.DbConfig, schema, excludeTable, dataOnly, roleOnly, keepComments, useCopy, dryRun, afero.NewOsFs())
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			if len(file) > 0 {
@@ -234,6 +235,7 @@ func init() {
 	dumpFlags.BoolVar(&dryRun, "dry-run", false, "Prints the pg_dump script that would be executed.")
 	dumpFlags.BoolVar(&dataOnly, "data-only", false, "Dumps only data records.")
 	dumpFlags.BoolVar(&useCopy, "use-copy", false, "Uses copy statements in place of inserts.")
+	dumpFlags.StringSliceVarP(&excludeTable, "exclude", "x", []string{}, "Excludes schema.tables from data-only dump.")
 	dumpFlags.BoolVar(&roleOnly, "role-only", false, "Dumps only cluster roles.")
 	dumpFlags.BoolVar(&keepComments, "keep-comments", false, "Keeps commented lines from pg_dump output.")
 	dbDumpCmd.MarkFlagsMutuallyExclusive("data-only", "role-only")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,7 +26,9 @@ var (
 			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.MarkFlagsRequiredTogether("use-orioledb", "experimental")
+			if useOrioleDB {
+				cobra.CheckErr(cmd.MarkFlagRequired("experimental"))
+			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fsys := afero.NewOsFs()

--- a/internal/db/dump/dump_test.go
+++ b/internal/db/dump/dump_test.go
@@ -35,7 +35,7 @@ func TestPullCommand(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world"))
 		// Run test
-		err := Run(context.Background(), "schema.sql", dbConfig, nil, false, false, false, false, false, fsys)
+		err := Run(context.Background(), "schema.sql", dbConfig, nil, nil, false, false, false, false, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -54,7 +54,7 @@ func TestPullCommand(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world"))
 		// Run test
-		err := Run(context.Background(), "", dbConfig, []string{"public"}, false, false, false, false, false, fsys)
+		err := Run(context.Background(), "", dbConfig, []string{"public"}, nil, false, false, false, false, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -70,7 +70,7 @@ func TestPullCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := Run(context.Background(), "", dbConfig, nil, false, false, false, false, false, fsys)
+		err := Run(context.Background(), "", dbConfig, nil, nil, false, false, false, false, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "request returned Service Unavailable for API route and version")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -85,7 +85,7 @@ func TestPullCommand(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world"))
 		// Run test
-		err := Run(context.Background(), "schema.sql", dbConfig, nil, false, false, false, false, false, fsys)
+		err := Run(context.Background(), "schema.sql", dbConfig, nil, nil, false, false, false, false, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "operation not permitted")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -74,7 +74,7 @@ func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestam
 		return err
 	} else if len(migrations) == 0 {
 		p.Send(utils.StatusMsg("Committing initial migration on remote database..."))
-		return dump.Run(ctx, path, config, nil, false, false, false, false, false, fsys)
+		return dump.Run(ctx, path, config, nil, nil, false, false, false, false, false, fsys)
 	}
 
 	w := utils.StatusWriter{Program: p}


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1772

## What is the new behavior?

```
supabase db dump --data-only --exclude auth.audit_log_entries,auth.mfa_amr_claims
```

## Additional context

Add any other context or screenshots.
