### PR TITLE
fix: do not dump migration history schema by default

### DIFF
--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -54,9 +54,14 @@ func Run(ctx context.Context, path string, config pgconn.Config, schema, exclude
 }
 
 func DumpSchema(ctx context.Context, config pgconn.Config, schema []string, keepComments, dryRun bool, stdout io.Writer) error {
-	env := []string{"EXCLUDED_SCHEMAS=" + strings.Join(utils.InternalSchemas, "|")}
+	var env []string
 	if len(schema) > 0 {
-		env[0] = "EXTRA_FLAGS=--schema " + strings.Join(schema, "|")
+		env = append(env, "EXTRA_FLAGS=--schema "+strings.Join(schema, "|"))
+	} else {
+		env = append(env,
+			"EXCLUDED_SCHEMAS="+strings.Join(utils.InternalSchemas, "|"),
+			"EXTRA_FLAGS=--extension '*'",
+		)
 	}
 	if !keepComments {
 		env = append(env, "EXTRA_SED=/^--/d")

--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -23,7 +23,6 @@ pg_dump \
     --schema-only \
     --quote-all-identifier \
     --exclude-schema "${EXCLUDED_SCHEMAS:-}" \
-    --extension '*' \
     --no-comments \
     ${EXTRA_FLAGS:-} \
 | sed -E 's/^CREATE SCHEMA "/CREATE SCHEMA IF NOT EXISTS "/' \

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -269,7 +269,12 @@ func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys
 	}
 	defer conn.Close(context.Background())
 	// List user defined schemas
-	excludes := append([]string{"public"}, utils.InternalSchemas...)
+	excludes := []string{"public"}
+	for _, schema := range utils.InternalSchemas {
+		if schema != "supabase_migrations" {
+			excludes = append(excludes, schema)
+		}
+	}
 	userSchemas, err := ListSchemas(ctx, conn, excludes...)
 	if err != nil {
 		return err

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -132,6 +132,7 @@ var (
 		"storage",
 		"_analytics",
 		"supabase_functions",
+		"supabase_migrations",
 	}, SystemSchemas...)
 	ReservedRoles = []string{
 		"anon",


### PR DESCRIPTION
## What kind of change does this PR introduce?

reverts https://github.com/supabase/cli/pull/1783

## What is the current behavior?

Too many errors pulling the migration history table https://github.com/supabase/cli/issues/1428#issuecomment-1911563752

## What is the new behavior?

Revert back to the old default of not including history schema. We will recommend dumping `supabase_schema.schema_migrations` separately in docs.

```bash
$ supabase db dump -s supabase_schema
Dumping schemas from remote database...

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
SET client_encoding = 'UTF8';
SET standard_conforming_strings = on;
SELECT pg_catalog.set_config('search_path', '', false);
SET check_function_bodies = false;
SET xmloption = content;
SET client_min_messages = warning;
SET row_security = off;

CREATE SCHEMA IF NOT EXISTS "supabase_migrations";

ALTER SCHEMA "supabase_migrations" OWNER TO "postgres";

SET default_tablespace = '';

SET default_table_access_method = "heap";

CREATE TABLE IF NOT EXISTS "supabase_migrations"."schema_migrations" (
    "version" "text" NOT NULL,
    "statements" "text"[],
    "name" "text"
);

ALTER TABLE "supabase_migrations"."schema_migrations" OWNER TO "postgres";

ALTER TABLE ONLY "supabase_migrations"."schema_migrations"
    ADD CONSTRAINT "schema_migrations_pkey" PRIMARY KEY ("version");

RESET ALL;
```

## Additional context

Add any other context or screenshots.
