### PR TITLE
fix: prevent wild card pattern from double escaped

### DIFF
--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -12,7 +12,6 @@ export PGDATABASE="$PGDATABASE"
 #   --schema-only     omit data like migration history, pgsodium key, etc.
 #   --exclude-schema  omit internal schemas as they are maintained by platform
 #   --no-comments     only object owner can set comment, omit to allow restore by non-superuser
-#   --extension '*'   prevents event triggers from being dumped, bash escaped with single quote
 #
 # Explanation of sed substitutions:
 #
@@ -23,8 +22,8 @@ pg_dump \
     --schema-only \
     --quote-all-identifier \
     --exclude-schema "${EXCLUDED_SCHEMAS:-}" \
+    --schema "${INCLUDED_SCHEMAS:-}" \
     --no-comments \
-    ${EXTRA_FLAGS:-} \
 | sed -E 's/^CREATE SCHEMA "/CREATE SCHEMA IF NOT EXISTS "/' \
 | sed -E 's/^CREATE TABLE "/CREATE TABLE IF NOT EXISTS "/' \
 | sed -E 's/^CREATE SEQUENCE "/CREATE SEQUENCE IF NOT EXISTS "/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1428#issuecomment-1913329636

## What is the current behavior?

`'*'` was double escaped to `'\''*'\''` by bash.

## What is the new behavior?

Always set `--schema` flag so we don't need to optionally pass in `--extension` flag to pg_dump.

## Additional context

Add any other context or screenshots.
