### PR TITLE
fix: bump edge runtime to 1.32.4

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
 	StudioImage      = "supabase/studio:20240101-8e4a094"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.32.0"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.32.4"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps Edge Runtime to 1.32.4 (check Edge Runtime [release notes](https://github.com/supabase/edge-runtime/releases) for details)
