### PR TITLE
feat(migration): support batch repair of migration history

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -55,11 +55,11 @@ var (
 	}
 
 	migrationRepairCmd = &cobra.Command{
-		Use:   "repair <version>",
+		Use:   "repair [version] ...",
 		Short: "Repair the migration history table",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return repair.Run(cmd.Context(), flags.DbConfig, args[0], targetStatus.Value, afero.NewOsFs())
+			return repair.Run(cmd.Context(), flags.DbConfig, args, targetStatus.Value, afero.NewOsFs())
 		},
 	}
 

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -57,7 +57,6 @@ var (
 	migrationRepairCmd = &cobra.Command{
 		Use:   "repair [version] ...",
 		Short: "Repair the migration history table",
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return repair.Run(cmd.Context(), flags.DbConfig, args, targetStatus.Value, afero.NewOsFs())
 		},

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -60,6 +60,9 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return repair.Run(cmd.Context(), flags.DbConfig, args, targetStatus.Value, afero.NewOsFs())
 		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Finished " + utils.Aqua("supabase migration repair") + ".")
+		},
 	}
 
 	migrationVersion string

--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, schema []string, config pgconn.Config, name string
 	// 4. Insert a row to `schema_migrations`
 	fmt.Fprintln(os.Stderr, "Schema written to "+utils.Bold(path))
 	if shouldUpdate := utils.PromptYesNo("Update remote migration history table?", true, os.Stdin); shouldUpdate {
-		return repair.UpdateMigrationTable(ctx, conn, timestamp, repair.Applied, fsys)
+		return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, fsys)
 	}
 	return nil
 }

--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, schema []string, config pgconn.Config, name string
 	// 4. Insert a row to `schema_migrations`
 	fmt.Fprintln(os.Stderr, "Schema written to "+utils.Bold(path))
 	if shouldUpdate := utils.PromptYesNo("Update remote migration history table?", true, os.Stdin); shouldUpdate {
-		return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, fsys)
+		return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, false, fsys)
 	}
 	return nil
 }

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -64,7 +64,7 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 	}
 
 	// 3. Insert a row to `schema_migrations`
-	return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, fsys)
+	return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, false, fsys)
 }
 
 func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestamp string, config pgconn.Config, fsys afero.Fs) error {

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -64,7 +64,7 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 	}
 
 	// 3. Insert a row to `schema_migrations`
-	return repair.UpdateMigrationTable(ctx, conn, timestamp, repair.Applied, fsys)
+	return repair.UpdateMigrationTable(ctx, conn, []string{timestamp}, repair.Applied, fsys)
 }
 
 func fetchRemote(p utils.Program, ctx context.Context, schema []string, timestamp string, config pgconn.Config, fsys afero.Fs) error {

--- a/internal/migration/history/history.go
+++ b/internal/migration/history/history.go
@@ -8,8 +8,9 @@ const (
 	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
 	ADD_NAME_COLUMN          = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS name text"
 	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES($1, $2, $3)"
-	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = $1"
+	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = ANY($1)"
 	DELETE_MIGRATION_BEFORE  = "DELETE FROM supabase_migrations.schema_migrations WHERE version <= $1"
+	TRUNCATE_VERSION_TABLE   = "TRUNCATE supabase_migrations.schema_migrations"
 )
 
 func AddCreateTableStatements(batch *pgconn.Batch) {

--- a/internal/migration/repair/repair_test.go
+++ b/internal/migration/repair/repair_test.go
@@ -41,7 +41,7 @@ func TestRepairCommand(t *testing.T) {
 		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", "{}").
 			Reply("INSERT 0 1")
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Applied, fsys, conn.Intercept)
+		err := Run(context.Background(), dbConfig, []string{"0"}, Applied, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -55,7 +55,7 @@ func TestRepairCommand(t *testing.T) {
 		conn.Query(history.DELETE_MIGRATION_VERSION, "0").
 			Reply("DELETE 1")
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Reverted, fsys, conn.Intercept)
+		err := Run(context.Background(), dbConfig, []string{"0"}, Reverted, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 	})
@@ -64,7 +64,7 @@ func TestRepairCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), pgconn.Config{}, "0", Applied, fsys)
+		err := Run(context.Background(), pgconn.Config{}, []string{"0"}, Applied, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
@@ -81,7 +81,7 @@ func TestRepairCommand(t *testing.T) {
 		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", "{}").
 			ReplyError(pgerrcode.DuplicateObject, `relation "supabase_migrations.schema_migrations" does not exist`)
 		// Run test
-		err := Run(context.Background(), dbConfig, "0", Applied, fsys, conn.Intercept)
+		err := Run(context.Background(), dbConfig, []string{"0"}, Applied, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: relation "supabase_migrations.schema_migrations" does not exist (SQLSTATE 42710)`)
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- allows multiple versions to be applied / reverted together
```bash
$ supabase migration repair --status reverted 0 ... 2
Connecting to remote database...
Repaired migration history: [0 1 2] => reverted
Finished supabase migration repair.
Run supabase migration list to show the updated migration history.
```

- prompts to repair the whole history if no version is specified
```bash
$ supabase migration repair --status applied
Do you want to repair the entire migration history table to match local migration files? [y/N] y
Connecting to remote database...
Finished supabase migration repair.
Run supabase migration list to show the updated migration history.
```

## Additional context

Add any other context or screenshots.
