### PR TITLE
fix: use pooler url for all docker commands

### DIFF
--- a/internal/utils/connect.go
+++ b/internal/utils/connect.go
@@ -51,17 +51,10 @@ func ConnectRemotePostgres(ctx context.Context, config pgconn.Config, options ..
 			cc.LookupFunc = FallbackLookupIP
 		}
 	})
-	// Try connection pooler when available
-	if poolerConfig := getPoolerConfig(config); poolerConfig != nil {
-		if conn, err := ConnectByUrl(ctx, ToPostgresURL(*poolerConfig), opts...); err == nil {
-			return conn, nil
-		}
-		fmt.Fprintln(os.Stderr, "Retrying...", config.Host, config.Port)
-	}
 	return ConnectByUrl(ctx, ToPostgresURL(config), opts...)
 }
 
-func getPoolerConfig(dbConfig pgconn.Config) *pgconn.Config {
+func GetPoolerConfig(dbConfig pgconn.Config) *pgconn.Config {
 	logger := getDebugLogger()
 	if len(Config.Db.Pooler.ConnectionString) == 0 {
 		fmt.Fprintln(logger, "Pooler URL is not configured")

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -74,6 +74,9 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 		DbConfig.User = "postgres"
 		DbConfig.Password = getPassword(projectRef)
 		DbConfig.Database = "postgres"
+		if poolerConfig := utils.GetPoolerConfig(DbConfig); poolerConfig != nil {
+			DbConfig = *poolerConfig
+		}
 	case proxy:
 		token, err := utils.LoadAccessTokenFS(fsys)
 		if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1625

## What is the new behavior?

Prefer using pooler url when available because some hosts cannot resolve IPv6.

## Additional context

Add any other context or screenshots.
