### PR TITLE
fix: show edge-runtime & deno version on start

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -182,7 +182,7 @@ serve(async (req: Request) => {
 }, {
   onListen: () => {
     console.log(
-      `Serving functions on http://127.0.0.1:${HOST_PORT}/functions/v1/<function-name>`,
+      `Serving functions on http://127.0.0.1:${HOST_PORT}/functions/v1/<function-name>\nUsing ${Deno.version.deno}`,
     );
   },
 });

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
 	StudioImage      = "supabase/studio:20240101-8e4a094"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.33.0"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.33.5"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Show Edge Runtime & Deno version at start of `supabase functions serve`

## What is the current behavior?

It's hard to find the exact Edge Runtime & Deno version when running Edge Functions locally.

## What is the new behavior?

Check screenshot below

![Screen Shot 2024-02-05 at 3 45 29 pm](https://github.com/supabase/cli/assets/5358/b9d6bbdb-7add-43f9-89a5-348c496417b7)


## Additional context

Add any other context or screenshots.
