### PR TITLE
feat: bump studio version to 20240205

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -32,7 +32,7 @@ const (
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
 	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
-	StudioImage      = "supabase/studio:20240101-8e4a094"
+	StudioImage      = "supabase/studio:20240205-b145c86"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.33.5"
 	VectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
Updates service studio new version to [20240205-b145c86](https://hub.docker.com/layers/supabase/studio/20240205-b145c86/images/sha256-5434f89c18caf7bdc070f411abbc07dcb652113f53f86dcfbe816d02d6013ab9?context=explore).