### PR TITLE
fix(typegen): support db-url that require ssl mode

### DIFF
--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 			return errors.Errorf("URL is not a valid Supabase connection string: %w", err)
 		}
 		escaped := fmt.Sprintf(
-			"postgresql://%s@%s:%d/%s",
+			"postgresql://%s@%s:%d/%s?sslmode=prefer",
 			url.UserPassword(config.User, config.Password),
 			config.Host,
 			config.Port,
@@ -67,7 +67,6 @@ func Run(ctx context.Context, useLocal bool, useLinked bool, projectId string, d
 				Image: utils.PgmetaImage,
 				Env: []string{
 					"PG_META_DB_URL=" + escaped,
-					"PG_META_DB_SSL_MODE=prefer",
 					"PG_META_GENERATE_TYPES=typescript",
 					"PG_META_GENERATE_TYPES_INCLUDED_SCHEMAS=" + included,
 					fmt.Sprintf("PG_META_GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS=%v", !postgrestV9Compat),

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -805,7 +805,7 @@ EOF
 					"PG_META_DB_PASSWORD=" + dbConfig.Password,
 				},
 				Healthcheck: &container.HealthConfig{
-					Test:     []string{"CMD", "node", "-e", "require('http').get('http://127.0.0.1:8080/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"},
+					Test:     []string{"CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then((r) => {if (r.status !== 200) throw new Error(r.status)})"},
 					Interval: 10 * time.Second,
 					Timeout:  2 * time.Second,
 					Retries:  3,

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,7 +31,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v12.0.1"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
-	PgmetaImage      = "supabase/postgres-meta:v0.75.0"
+	PgmetaImage      = "supabase/postgres-meta:v0.77.2"
 	StudioImage      = "supabase/studio:20240205-b145c86"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.36.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/postgres-meta/issues/719

## What is the new behavior?

Updates `postgres-meta` to 0.77.2 for ssl support.

## Additional context

Add any other context or screenshots.
