### PR TITLE
feat: prompt for project id when running typegen

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	noBackup bool
+	noBackup  bool
+	projectId string
 
 	stopCmd = &cobra.Command{
 		GroupID: groupLocalDev,

--- a/internal/gen/types/typescript/typescript_test.go
+++ b/internal/gen/types/typescript/typescript_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,79 +18,83 @@ import (
 )
 
 func TestGenLocalCommand(t *testing.T) {
+	utils.DbId = "test-db"
+	utils.Config.Hostname = "localhost"
+	utils.Config.Db.Port = 5432
+
+	dbConfig := pgconn.Config{
+		Host:     utils.Config.Hostname,
+		Port:     uint16(utils.Config.Db.Port),
+		User:     "admin",
+		Password: "password",
+	}
+
 	t.Run("generates typescript types", func(t *testing.T) {
-		containerId := "test-pgmeta"
+		const containerId = "test-pgmeta"
 		imageUrl := utils.GetRegistryImageUrl(utils.PgmetaImage)
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(200).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
+			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world"))
 		// Run test
-		assert.NoError(t, Run(context.Background(), true, false, "", "", []string{}, true, fsys))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on missing config", func(t *testing.T) {
-		assert.Error(t, Run(context.Background(), true, false, "", "", []string{}, true, afero.NewMemMapFs()))
 	})
 
 	t.Run("throws error when db is not started", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), true, false, "", "", []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
 	t.Run("throws error on image fetch failure", func(t *testing.T) {
+		utils.Config.Api.Image = "v9"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers").
-			Reply(200).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
+			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), true, false, "", "", []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }
 
 func TestGenLinkedCommand(t *testing.T) {
+	// Setup valid projectId id
+	projectId := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
 	t.Run("generates typescript types", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(projectId), 0644))
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -97,113 +102,51 @@ func TestGenLinkedCommand(t *testing.T) {
 			Reply(200).
 			JSON(api.TypescriptResponse{Types: ""})
 		// Run test
-		assert.NoError(t, Run(context.Background(), false, true, "", "", []string{}, true, fsys))
+		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on missing config file", func(t *testing.T) {
-		assert.Error(t, Run(context.Background(), false, true, "", "", []string{}, true, afero.NewMemMapFs()))
-	})
-
-	t.Run("throws error on missing project id", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		// Run test
-		assert.Error(t, Run(context.Background(), false, true, "", "", []string{}, true, fsys))
-	})
-
-	t.Run("throws error on missing access token", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(projectId), 0644))
-		// Run test
-		assert.Error(t, Run(context.Background(), false, true, "", "", []string{}, true, fsys))
 	})
 
 	t.Run("throws error on network failure", func(t *testing.T) {
+		errNetwork := errors.New("network error")
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(projectId), 0644))
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + projectId + "/types/typescript").
-			ReplyError(errors.New("network failure"))
+			ReplyError(errNetwork)
 		// Run test
-		err := Run(context.Background(), false, true, "", "", []string{}, true, fsys)
+		err := Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys)
 		// Validate api
-		assert.ErrorContains(t, err, "network failure")
+		assert.ErrorIs(t, err, errNetwork)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
-}
 
-func TestGenProjectIdCommand(t *testing.T) {
-	t.Run("generates typescript types", func(t *testing.T) {
+	t.Run("throws error on service unavailable", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + projectId + "/types/typescript").
-			Reply(200).
-			JSON(api.TypescriptResponse{Types: ""})
+			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.NoError(t, Run(context.Background(), false, false, projectId, "", []string{}, true, fsys))
-		// Validate api
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on missing access token", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		// Run test
-		assert.Error(t, Run(context.Background(), false, false, projectId, "", []string{}, true, fsys))
-	})
-
-	t.Run("throws error on network failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Setup valid projectId id
-		projectId := apitest.RandomProjectRef()
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
-		// Flush pending mocks after test execution
-		defer gock.OffAll()
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects/" + projectId + "/types/typescript").
-			ReplyError(errors.New("network failure"))
-		// Run test
-		err := Run(context.Background(), false, false, projectId, "", []string{}, true, fsys)
-		// Validate api
-		assert.ErrorContains(t, err, "network failure")
-		assert.Empty(t, apitest.ListUnmatchedRequests())
+		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys))
 	})
 }
 
 func TestGenRemoteCommand(t *testing.T) {
-	const dbUrl = "postgres://postgres:@127.0.0.1:5432/postgres"
-	const containerId = "test-container"
+	dbConfig := pgconn.Config{
+		Host:     "db.supabase.co",
+		Port:     5432,
+		User:     "admin",
+		Password: "password",
+		Database: "postgres",
+	}
 
 	t.Run("generates type from remote db", func(t *testing.T) {
+		const containerId = "test-pgmeta"
 		imageUrl := utils.GetRegistryImageUrl(utils.PgmetaImage)
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
@@ -211,25 +154,7 @@ func TestGenRemoteCommand(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world"))
 		// Run test
-		assert.NoError(t, Run(context.Background(), false, false, "", dbUrl, []string{}, true, afero.NewMemMapFs()))
-		// Validate api
-		assert.Empty(t, apitest.ListUnmatchedRequests())
-	})
-
-	t.Run("throws error on malformed db url", func(t *testing.T) {
-		// Run test
-		assert.Error(t, Run(context.Background(), false, false, "", "foo", []string{}, true, afero.NewMemMapFs()))
-	})
-
-	t.Run("throws error when docker is not started", func(t *testing.T) {
-		// Setup mock docker
-		require.NoError(t, apitest.MockDocker(utils.Docker))
-		defer gock.OffAll()
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/images").
-			Reply(http.StatusServiceUnavailable)
-		// Run test
-		assert.Error(t, Run(context.Background(), false, false, "", dbUrl, []string{}, true, afero.NewMemMapFs()))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, []string{"public"}, true, afero.NewMemMapFs()))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -16,7 +16,8 @@ import (
 type connection int
 
 const (
-	direct connection = iota
+	unknown connection = iota
+	direct
 	local
 	linked
 	proxy

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,7 +31,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v12.0.1"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
-	PgmetaImage      = "supabase/postgres-meta:v0.77.2"
+	PgmetaImage      = "supabase/postgres-meta:v0.78.1"
 	StudioImage      = "supabase/studio:20240205-b145c86"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.36.1"

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,7 +31,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v12.0.1"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
-	PgmetaImage      = "supabase/postgres-meta:v0.78.1"
+	PgmetaImage      = "supabase/postgres-meta:v0.78.2"
 	StudioImage      = "supabase/studio:20240205-b145c86"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.36.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

```bash
$ supabase gen types typescript

    Select a project:

  >  1. <redacted> [name: <redacted>, org: supabase, region: us-west-1]
```

## Additional context

Add any other context or screenshots.
