### PR TITLE
fix: confirm pushing migrations to remote database

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -51,7 +51,9 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		}
 	}
 	if !utils.IsLocalDatabase(config) {
-		if shouldReset := utils.PromptYesNo("Confirm resetting the remote database?", true, os.Stdin); !shouldReset {
+		msg := "Do you want to reset the remote database?"
+		if shouldReset := utils.PromptYesNo(msg, true, os.Stdin); !shouldReset {
+			utils.CmdSuggestion = ""
 			return errors.New(context.Canceled)
 		}
 		return resetRemote(ctx, version, config, fsys, options...)

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -37,8 +37,8 @@ func Run(ctx context.Context, config pgconn.Config, version []string, status str
 	if repairAll {
 		msg := "Do you want to repair the entire migration history table to match local migration files?"
 		if shouldRepair := utils.PromptYesNo(msg, false, os.Stdin); !shouldRepair {
-			fmt.Fprintln(os.Stderr, "Nothing to repair.")
-			return nil
+			utils.CmdSuggestion = ""
+			return errors.New(context.Canceled)
 		}
 		local, err := list.LoadLocalVersions(fsys)
 		if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

related https://github.com/supabase/cli/issues/1976

## What is the new behavior?

```bash
$ supabase db push
Connecting to remote database...
Do you want to push these migrations to the remote database?
 • 0_schema.sql
 • 1_test.sql

 [Y/n] n
context canceled
exit status 1
```

## Additional context

Add any other context or screenshots.
