### PR TITLE
fix: dont loose comments when dumping schema

### DIFF
--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -11,7 +11,6 @@ export PGDATABASE="$PGDATABASE"
 #
 #   --schema-only     omit data like migration history, pgsodium key, etc.
 #   --exclude-schema  omit internal schemas as they are maintained by platform
-#   --no-comments     only object owner can set comment, omit to allow restore by non-superuser
 #
 # Explanation of sed substitutions:
 #
@@ -23,7 +22,6 @@ pg_dump \
     --quote-all-identifier \
     --exclude-schema "${EXCLUDED_SCHEMAS:-}" \
     --schema "${INCLUDED_SCHEMAS:-}" \
-    --no-comments \
     ${EXTRA_FLAGS:-} \
 | sed -E 's/^CREATE SCHEMA "/CREATE SCHEMA IF NOT EXISTS "/' \
 | sed -E 's/^CREATE TABLE "/CREATE TABLE IF NOT EXISTS "/' \
@@ -34,6 +32,7 @@ pg_dump \
 | sed -E 's/^ALTER DEFAULT PRIVILEGES FOR ROLE "supabase_admin"/-- &/' \
 | sed -E "s/^GRANT (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
+| sed -E 's/^COMMENT ON EXTENSION (.+)/-- &/' \
 | sed -E 's/^CREATE POLICY "cron_job_/-- &/' \
 | sed -E 's/^ALTER TABLE "cron"/-- &/' \
 | sed -E "${EXTRA_SED:-}" \


### PR DESCRIPTION
Remove comments in extensions

## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1328

## What is the current behavior?

Every dump does not include the comments for tables, columns, functions, etc.

## What is the new behavior?

The db dump includes the comments for tables, columns, functions, etc. but not for the extensions. The extension is enabled by dashboard user and does not need to change the comment about the extension itself.

## Additional context

If you use the supabase cli as a backup solution for schema, data and roles data like it is described in [Supabase Doc - Automated backups using GitHub Actions](https://supabase.com/docs/guides/cli/github-action/backups) and you have setup a lot of comments for tables, functions etc. You will loose these comments, they are never included in the schema.

I removed the `--no-comments` flag in template `dump_schema.sh` because of this.
