### PR TITLE
feat: enable Supabase AI during local development

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -843,6 +843,7 @@ EOF
 					"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
 					"SUPABASE_SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey,
 					"LOGFLARE_API_KEY=" + utils.Config.Analytics.ApiKey,
+					"OPENAI_KEY=" + utils.Config.Studio.OpenaiApiKey,
 					fmt.Sprintf("LOGFLARE_URL=http://%v:4000", utils.LogflareId),
 					fmt.Sprintf("NEXT_PUBLIC_ENABLE_LOGS=%v", utils.Config.Analytics.Enabled),
 					fmt.Sprintf("NEXT_ANALYTICS_BACKEND_PROVIDER=%v", utils.Config.Analytics.Backend),

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -213,7 +213,7 @@ var Config = config{
 }
 
 // We follow these rules when adding new config:
-//  1. Update init_config.toml with the new key, default value, and comments to explain usage.
+//  1. Update init_config.toml (and init_config.test.toml) with the new key, default value, and comments to explain usage.
 //  2. Update config struct with new field and toml tag (spelled in snake_case).
 //  3. Add custom field validations to LoadConfigFS function for eg. integer range checks.
 //

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -286,9 +286,10 @@ type (
 	}
 
 	studio struct {
-		Enabled bool   `toml:"enabled"`
-		Port    uint   `toml:"port"`
-		ApiUrl  string `toml:"api_url"`
+		Enabled 	 bool   `toml:"enabled"`
+		Port    	 uint   `toml:"port"`
+		ApiUrl  	 string `toml:"api_url"`
+		OpenaiApiKey string `toml:"openai_api_key"`
 	}
 
 	inbucket struct {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -561,6 +561,7 @@ func LoadConfigFS(fsys afero.Fs) error {
 			if Config.Studio.Port == 0 {
 				return errors.New("Missing required field in config: studio.port")
 			}
+			Config.Studio.OpenaiApiKey, _ = maybeLoadEnv(Config.Studio.OpenaiApiKey)
 		}
 		// Validate email config
 		if Config.Inbucket.Enabled {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -286,9 +286,9 @@ type (
 	}
 
 	studio struct {
-		Enabled 	 bool   `toml:"enabled"`
-		Port    	 uint   `toml:"port"`
-		ApiUrl  	 string `toml:"api_url"`
+		Enabled      bool   `toml:"enabled"`
+		Port         uint   `toml:"port"`
+		ApiUrl       string `toml:"api_url"`
 		OpenaiApiKey string `toml:"openai_api_key"`
 	}
 

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -49,6 +49,8 @@ enabled = true
 port = 54323
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -49,6 +49,8 @@ enabled = true
 port = 54323
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows users to bring their own OpenAI API key into the Supabase Studio so Supabase AI works when developing locally too.

## What is the current behavior?

When using the Supabase AI fields locally, one gets an error message which is just the HTML of the standard error page. Also, the container throws an error that the OpenAI key cannot be found.

<img width="1385" alt="Screenshot 2024-02-22 at 08 29 06" src="https://github.com/supabase/cli/assets/27334472/2a6c401d-8a65-4bca-b889-3704ac53f73e">

## What is the new behavior?

When specifying the `OPENAI_API_KEY` while starting Supabase locally, it should now pass it through the config into the container as an env variable.

## Additional context

Further ideas for improvement:
- If accepted, should add this to the docs somewhere so people know where and how to add their OpenAI keys
- It would really be great if `supabase start` would also read the `.env` file (also for social auth secrets)
- Show a better error message when using the AI without the key (maybe pointing to above docs)