### PR TITLE
fix: Add Realtime REST routes to CLI

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -75,16 +75,29 @@ services:
           add:
             headers:
               - "Content-Profile: graphql_public"
-  - name: realtime-v1
+  - name: realtime-v1-ws
     _comment: "Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*"
     url: http://{{ .RealtimeId }}:4000/socket
+    protocol: ws
     routes:
-      - name: realtime-v1-all
+      - name: realtime-v1-ws
         strip_path: true
         paths:
           - /realtime/v1/
     plugins:
       - name: cors
+  - name: realtime-v1-rest
+    _comment: "Realtime: /realtime/v1/* -> http://realtime:4000/api/*"
+    url: http://{{ .RealtimeId }}:4000/api
+    protocol: http
+    routes:
+      - name: realtime-v1-rest
+        strip_path: true
+        paths:
+          - /realtime/v1/api
+    plugins:
+      - name: cors
+
   - name: storage-v1
     _comment: "Storage: /storage/v1/* -> http://storage-api:5000/*"
     url: http://{{ .StorageId }}:5000/

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -39,7 +39,7 @@ const (
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.143.0"
-	RealtimeImage    = "supabase/realtime:v2.25.50"
+	RealtimeImage    = "supabase/realtime:v2.25.66"
 	StorageImage     = "supabase/storage-api:v0.46.4"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION

## What kind of change does this PR introduce?

Adds REST routes to CLI so users can call Broadcast endpoint and in the future handle their Channels.

## What is the current behavior?

We were only supporting Websockets at the moment which means users could not use the HTTP Broadcast approach

## What is the new behavior?

Opened up routes for Realtime API to be accessible via HTTP requests

## Additional context
Test after the change:

<img width="635" alt="Screenshot 2024-02-26 at 14 19 49" src="https://github.com/supabase/cli/assets/1697301/8e47bab6-4c3d-40de-913d-3d312fddae7f">

