### PR TITLE
fix: Bump studio to 2024-03-01

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -838,7 +838,6 @@ EOF
 					"STUDIO_PG_META_URL=http://" + utils.PgmetaId + ":8080",
 					"POSTGRES_PASSWORD=" + dbConfig.Password,
 					"SUPABASE_URL=http://" + utils.KongId + ":8000",
-					fmt.Sprintf("SUPABASE_REST_URL=%s:%v/rest/v1/", utils.Config.Studio.ApiUrl, utils.Config.Api.Port),
 					fmt.Sprintf("SUPABASE_PUBLIC_URL=%s:%v/", utils.Config.Studio.ApiUrl, utils.Config.Api.Port),
 					"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
 					"SUPABASE_SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey,

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -32,7 +32,7 @@ const (
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
 	PgmetaImage      = "supabase/postgres-meta:v0.79.0"
-	StudioImage      = "supabase/studio:20240205-b145c86"
+	StudioImage      = "supabase/studio:20240301-0942bfe"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.38.0"
 	VectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
This PR bumps the Studio image to the latest one. It also removes `SUPABASE_REST_URL` since it's not used anywhere in the studio.