### PR TITLE
fix: update migrations history separately from applying

### DIFF
--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -148,11 +148,11 @@ func TestMigrateShadow(t *testing.T) {
 		conn.Query(utils.GlobalsSql).
 			Reply("CREATE SCHEMA").
 			Query(utils.InitialSchemaSql).
-			Reply("CREATE SCHEMA").
-			Query(sql).
 			Reply("CREATE SCHEMA")
 		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+		conn.Query(sql).
+			Reply("CREATE SCHEMA").
+			Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Run test
 		err := MigrateShadowDatabase(context.Background(), "test-shadow-db", fsys, conn.Intercept)
@@ -313,11 +313,11 @@ At statement 0: create schema public`)
 		conn.Query(utils.GlobalsSql).
 			Reply("CREATE SCHEMA").
 			Query(utils.InitialSchemaSql).
-			Reply("CREATE SCHEMA").
-			Query(sql).
 			Reply("CREATE SCHEMA")
 		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+		conn.Query(sql).
+			Reply("CREATE SCHEMA").
+			Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Run test
 		diff, err := DiffDatabase(context.Background(), []string{"public"}, dbConfig, io.Discard, fsys, DiffSchemaMigra, conn.Intercept)

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -101,6 +101,6 @@ func TestMigrationPush(t *testing.T) {
 		err := Run(context.Background(), false, false, false, false, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: null value in column "version" of relation "schema_migrations" (SQLSTATE 23502)`)
-		assert.ErrorContains(t, err, "At statement 4: "+history.INSERT_MIGRATION_VERSION)
+		assert.ErrorContains(t, err, "At statement 0: "+history.INSERT_MIGRATION_VERSION)
 	})
 }

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -39,6 +39,11 @@ func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 }
 
 func MigrateUp(ctx context.Context, conn *pgx.Conn, pending []string, fsys afero.Fs) error {
+	if len(pending) > 0 {
+		if err := repair.CreateMigrationTable(ctx, conn); err != nil {
+			return err
+		}
+	}
 	for _, filename := range pending {
 		if err := applyMigration(ctx, conn, filename, fsys); err != nil {
 			return err

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -28,10 +28,10 @@ func TestMigrateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(sql).
-			Reply("CREATE SCHEMA")
 		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
+		conn.Query(sql).
+			Reply("CREATE SCHEMA").
+			Query(history.INSERT_MIGRATION_VERSION, "0", "test", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Connect to mock
 		ctx := context.Background()
@@ -122,6 +122,7 @@ func TestMigrateUp(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		// Connect to mock
 		ctx := context.Background()
 		mock, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{Port: 5432}, conn.Intercept)

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -100,8 +100,6 @@ func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
 }
 
 func InsertVersionSQL(batch *pgconn.Batch, version, name string, stats []string) {
-	// Create history table if not exists
-	history.AddCreateTableStatements(batch)
 	encoded := []byte{'{'}
 	for i, line := range stats {
 		if i > 0 {

--- a/internal/migration/repair/repair_test.go
+++ b/internal/migration/repair/repair_test.go
@@ -126,9 +126,8 @@ func TestMigrationFile(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		conn.Query(migration.Lines[0]).
-			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`)
-		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "", fmt.Sprintf("{%s}", migration.Lines[0])).
+			ReplyError(pgerrcode.DuplicateSchema, `schema "public" already exists`).
+			Query(history.INSERT_MIGRATION_VERSION, "0", "", fmt.Sprintf("{%s}", migration.Lines[0])).
 			Reply("INSERT 0 1")
 		// Connect to mock
 		ctx := context.Background()

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -115,6 +115,9 @@ func baselineMigrations(ctx context.Context, config pgconn.Config, version strin
 		return err
 	}
 	defer conn.Close(context.Background())
+	if err := repair.CreateMigrationTable(ctx, conn); err != nil {
+		return err
+	}
 	m, err := repair.NewMigrationFromVersion(version, fsys)
 	if err != nil {
 		return err

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -59,13 +59,12 @@ func TestSquashCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		conn.Query(sql).
-			Reply("CREATE SCHEMA")
-		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "init", fmt.Sprintf("{%s}", sql)).
-			Reply("INSERT 0 1")
-		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "1", "target", "{}").
+			Reply("CREATE SCHEMA").
+			Query(history.INSERT_MIGRATION_VERSION, "0", "init", fmt.Sprintf("{%s}", sql)).
+			Reply("INSERT 0 1").
+			Query(history.INSERT_MIGRATION_VERSION, "1", "target", "{}").
 			Reply("INSERT 0 1")
 		// Run test
 		err := Run(context.Background(), "", pgconn.Config{
@@ -93,6 +92,7 @@ func TestSquashCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		conn.Query(fmt.Sprintf("DELETE FROM supabase_migrations.schema_migrations WHERE version <= ('0');INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES(('0'), ('init'), ('{%s}'))", sql)).
 			Reply("INSERT 0 1")
 		// Run test
@@ -227,10 +227,10 @@ func TestSquashMigrations(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(sql).
-			Reply("CREATE SCHEMA")
 		pgtest.MockMigrationHistory(conn)
-		conn.Query(history.INSERT_MIGRATION_VERSION, "0", "init", fmt.Sprintf("{%s}", sql)).
+		conn.Query(sql).
+			Reply("CREATE SCHEMA").
+			Query(history.INSERT_MIGRATION_VERSION, "0", "init", fmt.Sprintf("{%s}", sql)).
 			Reply("INSERT 0 1")
 		// Run test
 		err := squashMigrations(context.Background(), []string{filepath.Base(path)}, afero.NewReadOnlyFs(fsys), conn.Intercept)
@@ -254,6 +254,7 @@ func TestBaselineMigration(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		conn.Query(fmt.Sprintf("DELETE FROM supabase_migrations.schema_migrations WHERE version <= ('0');INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES(('0'), ('init'), ('{%s}'))", sql)).
 			Reply("INSERT 0 1")
 		// Run test
@@ -279,6 +280,7 @@ func TestBaselineMigration(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		conn.Query(fmt.Sprintf("DELETE FROM supabase_migrations.schema_migrations WHERE version <= ('%[1]s');INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES(('%[1]s'), ('init'), (null))", "0")).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations")
 		// Run test
@@ -293,6 +295,7 @@ func TestBaselineMigration(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		pgtest.MockMigrationHistory(conn)
 		// Run test
 		err := baselineMigrations(context.Background(), dbConfig, "0", fsys, conn.Intercept)
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Running alter table after actual migration may lead to deadlock.

## What is the new behavior?

Update migration history schema before running mgirations.

## Additional context

Add any other context or screenshots.
