### PR TITLE
fix: set lock timeout when migrating history schema

### DIFF
--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -50,6 +50,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 	}
 
 	fmt.Fprintln(os.Stderr, "Connecting to", dbConfig.Host, dbConfig.Port)
+	// pg-meta does not set username as the default database, ie. postgres
 	if len(dbConfig.Database) == 0 {
 		dbConfig.Database = "postgres"
 	}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
-	"github.com/supabase/cli/internal/migration/repair"
+	"github.com/supabase/cli/internal/migration/history"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/credentials"
 	"github.com/supabase/cli/internal/utils/flags"
@@ -184,7 +184,7 @@ func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pg
 	defer conn.Close(context.Background())
 	updatePostgresConfig(conn)
 	// If `schema_migrations` doesn't exist on the remote database, create it.
-	return repair.CreateMigrationTable(ctx, conn)
+	return history.CreateMigrationTable(ctx, conn)
 }
 
 func linkDatabaseVersion(ctx context.Context, projectRef string, fsys afero.Fs) error {

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -386,7 +386,8 @@ func TestLinkDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(history.CREATE_VERSION_SCHEMA).
+		conn.Query(history.SET_LOCK_TIMEOUT).
+			Query(history.CREATE_VERSION_SCHEMA).
 			Reply("CREATE SCHEMA").
 			Query(history.CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/history"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/utils"
@@ -40,7 +41,7 @@ func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 
 func MigrateUp(ctx context.Context, conn *pgx.Conn, pending []string, fsys afero.Fs) error {
 	if len(pending) > 0 {
-		if err := repair.CreateMigrationTable(ctx, conn); err != nil {
+		if err := history.CreateMigrationTable(ctx, conn); err != nil {
 			return err
 		}
 	}

--- a/internal/migration/history/history.go
+++ b/internal/migration/history/history.go
@@ -3,6 +3,7 @@ package history
 import "github.com/jackc/pgconn"
 
 const (
+	SET_LOCK_TIMEOUT         = "SET LOCAL lock_timeout = '4s'"
 	CREATE_VERSION_SCHEMA    = "CREATE SCHEMA IF NOT EXISTS supabase_migrations"
 	CREATE_VERSION_TABLE     = "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text NOT NULL PRIMARY KEY)"
 	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
@@ -15,6 +16,7 @@ const (
 
 func AddCreateTableStatements(batch *pgconn.Batch) {
 	// Create history table if not exists
+	batch.ExecParams(SET_LOCK_TIMEOUT, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
 	batch.ExecParams(ADD_STATEMENTS_COLUMN, nil, nil, nil, nil)

--- a/internal/migration/history/history.go
+++ b/internal/migration/history/history.go
@@ -1,6 +1,12 @@
 package history
 
-import "github.com/jackc/pgconn"
+import (
+	"context"
+
+	"github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+)
 
 const (
 	SET_LOCK_TIMEOUT         = "SET LOCAL lock_timeout = '4s'"
@@ -14,11 +20,17 @@ const (
 	TRUNCATE_VERSION_TABLE   = "TRUNCATE supabase_migrations.schema_migrations"
 )
 
-func AddCreateTableStatements(batch *pgconn.Batch) {
-	// Create history table if not exists
+func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
+	// This must be run without prepared statements because each statement in the batch depends on
+	// the previous schema change. The lock timeout will be reset when implicit transaction ends.
+	batch := pgconn.Batch{}
 	batch.ExecParams(SET_LOCK_TIMEOUT, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
 	batch.ExecParams(ADD_STATEMENTS_COLUMN, nil, nil, nil, nil)
 	batch.ExecParams(ADD_NAME_COLUMN, nil, nil, nil, nil)
+	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
+		return errors.Errorf("failed to create migration table: %w", err)
+	}
+	return nil
 }

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -115,7 +115,7 @@ func baselineMigrations(ctx context.Context, config pgconn.Config, version strin
 		return err
 	}
 	defer conn.Close(context.Background())
-	if err := repair.CreateMigrationTable(ctx, conn); err != nil {
+	if err := history.CreateMigrationTable(ctx, conn); err != nil {
 		return err
 	}
 	m, err := repair.NewMigrationFromVersion(version, fsys)

--- a/internal/testing/pgtest/helper.go
+++ b/internal/testing/pgtest/helper.go
@@ -5,7 +5,8 @@ import (
 )
 
 func MockMigrationHistory(conn *MockConn) {
-	conn.Query(history.CREATE_VERSION_SCHEMA).
+	conn.Query(history.SET_LOCK_TIMEOUT).
+		Query(history.CREATE_VERSION_SCHEMA).
 		Reply("CREATE SCHEMA").
 		Query(history.CREATE_VERSION_TABLE).
 		Reply("CREATE TABLE").


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Adds lock timeout when altering `schema_migrations` table.

## Additional context

Add any other context or screenshots.
