### PR TITLE
Update start.go for https://github.com/supabase/postgres/pull/901

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -81,7 +81,7 @@ func NewContainerConfig() container.Config {
 			Timeout:  2 * time.Second,
 			Retries:  3,
 		},
-		Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /etc/postgresql.schema.sql && cat <<'EOF' > /etc/postgresql-custom/pgsodium_root.key && docker-entrypoint.sh postgres -D /etc/postgresql
+		Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /etc/postgresql.schema.sql && cat <<'EOF' > /etc/postgresql-custom/pgsodium/pgsodium_root.key && docker-entrypoint.sh postgres -D /etc/postgresql
 ` + initialSchema + `
 EOF
 ` + utils.Config.Db.RootKey + `


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix cohesive with https://github.com/supabase/postgres/pull/901

**WARN** needs https://github.com/supabase/postgres/pull/901 **first**

## What is the current behavior?

pgsodium key does not survive docker compose down, see https://github.com/supabase/postgres/pull/901

## What is the new behavior?

Handled by https://github.com/supabase/postgres/pull/901, this PR just keeps changes current across co-dependent repos.

## Additional context

NEEDS: https://github.com/supabase/postgres/pull/901