### PR TITLE
fix: disable keyring when exec binary is not found

### DIFF
--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -93,6 +93,9 @@ func run(p utils.Program, ctx context.Context, schema []string, path string, con
 func dumpRemoteSchema(p utils.Program, ctx context.Context, path string, config pgconn.Config, fsys afero.Fs) error {
 	// Special case if this is the first migration
 	p.Send(utils.StatusMsg("Dumping schema from remote database..."))
+	if err := utils.MkdirIfNotExistFS(fsys, utils.MigrationsDir); err != nil {
+		return err
+	}
 	f, err := fsys.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return errors.Errorf("failed to open dump file: %w", err)

--- a/internal/utils/credentials/store.go
+++ b/internal/utils/credentials/store.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"bytes"
 	"os"
+	"os/exec"
 
 	"github.com/go-errors/errors"
 	"github.com/zalando/go-keyring"
@@ -18,7 +19,9 @@ func Get(project string) (string, error) {
 		return "", err
 	}
 	val, err := keyring.Get(namespace, project)
-	if err != nil {
+	if errors.Is(err, exec.ErrNotFound) {
+		return "", errors.New(ErrNotSupported)
+	} else if err != nil {
 		return "", errors.Errorf("failed to load credentials: %w", err)
 	}
 	return val, nil
@@ -29,7 +32,9 @@ func Set(project, password string) error {
 	if err := assertKeyringSupported(); err != nil {
 		return err
 	}
-	if err := keyring.Set(namespace, project, password); err != nil {
+	if err := keyring.Set(namespace, project, password); errors.Is(err, exec.ErrNotFound) {
+		return errors.New(ErrNotSupported)
+	} else if err != nil {
 		return errors.Errorf("failed to set credentials: %w", err)
 	}
 	return nil
@@ -40,7 +45,9 @@ func Delete(project string) error {
 	if err := assertKeyringSupported(); err != nil {
 		return err
 	}
-	if err := keyring.Delete(namespace, project); err != nil {
+	if err := keyring.Delete(namespace, project); errors.Is(err, exec.ErrNotFound) {
+		return errors.New(ErrNotSupported)
+	} else if err != nil {
 		return errors.Errorf("failed to delete credentials: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2005

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
