### PR TITLE
fix: always use session mode when connecting to pooler

### DIFF
--- a/internal/utils/connect.go
+++ b/internal/utils/connect.go
@@ -79,11 +79,7 @@ func GetPoolerConfig(projectRef string) *pgconn.Config {
 	}
 	fmt.Fprintln(logger, "Using connection pooler:", poolerUrl)
 	// Supavisor transaction mode does not support prepared statement
-	if poolerConfig.Port == 6543 {
-		if _, ok := poolerConfig.RuntimeParams["statement_cache_mode"]; !ok {
-			poolerConfig.RuntimeParams["statement_cache_mode"] = "describe"
-		}
-	}
+	poolerConfig.Port = 5432
 	return poolerConfig
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2077

## What is the new behavior?

Since CLI commands are short lived, one off commands, there's no reason to use transaction mode.

## Additional context

Add any other context or screenshots.
