### PR TITLE
fix: check project health on bootstrap

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -100,7 +100,15 @@ func Run(ctx context.Context, templateUrl string, fsys afero.Fs, options ...func
 	if err := utils.WriteFile(utils.ProjectRefPath, []byte(flags.ProjectRef), fsys); err != nil {
 		return err
 	}
-	// 5. Push migrations
+	// 5. Wait for project healthy
+	policy.Reset()
+	if err := backoff.RetryNotify(func() error {
+		fmt.Fprintln(os.Stderr, "Checking project health...")
+		return checkProjectHealth(ctx)
+	}, policy, newErrorCallback()); err != nil {
+		return err
+	}
+	// 6. Push migrations
 	config := flags.NewDbConfigWithPassword(flags.ProjectRef)
 	if err := writeDotEnv(keys, config, fsys); err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to create .env file:", err)
@@ -135,6 +143,27 @@ func suggestAppStart(cwd string) string {
 		suggestion += fmt.Sprintf("\n  %s", utils.Aqua(c))
 	}
 	return suggestion
+}
+
+func checkProjectHealth(ctx context.Context) error {
+	params := api.CheckServiceHealthParams{
+		Services: []api.CheckServiceHealthParamsServices{
+			api.CheckServiceHealthParamsServicesDb,
+		},
+	}
+	resp, err := utils.GetSupabase().CheckServiceHealthWithResponse(ctx, flags.ProjectRef, &params)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return errors.Errorf("Error status %d: %s", resp.StatusCode(), resp.Body)
+	}
+	for _, service := range *resp.JSON200 {
+		if !service.Healthy {
+			return errors.Errorf("Service not healthy: %s (%s)", service.Name, service.Status)
+		}
+	}
+	return nil
 }
 
 const maxRetries = 8


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Bootstrap project may timeout waiting to become active healthy.

## What is the new behavior?

Sepearate database and pooler status checks so that bootstrap is more robust against timeouts.

```
Linking project...
Retry (1/8): Linking project...
Checking project health...
Retry (1/8): Checking project health...
Retry (2/8): Checking project health...
Retry (3/8): Checking project health...
Retry (4/8): Checking project health...
Retry (5/8): Checking project health...
Connecting to remote database...
Retry (1/8): Connecting to remote database...
Retry (2/8): Connecting to remote database...
Retry (3/8): Connecting to remote database...
Retry (4/8): Connecting to remote database...
Retry (5/8): Connecting to remote database...
Retry (6/8): Connecting to remote database...
Remote database is up to date.
To start your app:
  cd empty
  npm ci
  npm run dev
```

## Additional context

Add any other context or screenshots.
