### PR TITLE
feat: support fetching migration history table to files

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/migration/fetch"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/migration/repair"
@@ -88,6 +89,14 @@ var (
 			fmt.Println("Local database is up to date.")
 		},
 	}
+
+	migrationFetchCmd = &cobra.Command{
+		Use:   "fetch",
+		Short: "Fetch migration files from history table",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fetch.Run(cmd.Context(), flags.DbConfig, afero.NewOsFs())
+		},
+	}
 )
 
 func init() {
@@ -132,6 +141,13 @@ func init() {
 	upFlags.Bool("local", true, "Applies pending migrations to the local database.")
 	migrationUpCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	migrationCmd.AddCommand(migrationUpCmd)
+	// Build up command
+	fetchFlags := migrationFetchCmd.Flags()
+	fetchFlags.String("db-url", "", "Fetches migrations from the database specified by the connection string (must be percent-encoded).")
+	fetchFlags.Bool("linked", true, "Fetches migration history from the linked project.")
+	fetchFlags.Bool("local", false, "Fetches migration history from the local database.")
+	migrationFetchCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
+	migrationCmd.AddCommand(migrationFetchCmd)
 	// Build new command
 	migrationCmd.AddCommand(migrationNewCmd)
 	rootCmd.AddCommand(migrationCmd)

--- a/internal/migration/fetch/fetch.go
+++ b/internal/migration/fetch/fetch.go
@@ -1,0 +1,52 @@
+package fetch
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/migration/history"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	if err := utils.MkdirIfNotExistFS(fsys, utils.MigrationsDir); err != nil {
+		return err
+	}
+	if empty, err := afero.IsEmpty(fsys, utils.MigrationsDir); err != nil {
+		return errors.Errorf("failed to read migrations: %w", err)
+	} else if !empty {
+		console := utils.NewConsole()
+		title := fmt.Sprintf("Do you want to overwrite existing files in %s directory?", utils.Bold(utils.MigrationsDir))
+		if !console.PromptYesNo(title, true) {
+			return context.Canceled
+		}
+	}
+	result, err := fetchMigrationHistory(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	for _, r := range result {
+		name := fmt.Sprintf("%s_%s.sql", r.Version, r.Name)
+		path := filepath.Join(utils.MigrationsDir, name)
+		contents := strings.Join(r.Statements, ";\n") + ";\n"
+		if err := afero.WriteFile(fsys, path, []byte(contents), 0644); err != nil {
+			return errors.Errorf("failed to write migration: %w", err)
+		}
+	}
+	return nil
+}
+
+func fetchMigrationHistory(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) ([]history.SchemaMigration, error) {
+	conn, err := utils.ConnectByConfig(ctx, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(context.Background())
+	return history.ReadMigrationTable(ctx, conn)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

`supabase migration fetch` to download statements in migration history table as local migration files.

## Additional context

Add any other context or screenshots.
