### PR TITLE
feat: bump auth version 2.145.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"
-	GotrueImage      = "supabase/gotrue:v2.143.0"
+	GotrueImage      = "supabase/gotrue:v2.145.0"
 	RealtimeImage    = "supabase/realtime:v2.27.5"
 	StorageImage     = "supabase/storage-api:v0.46.4"
 	LogflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade auth version to 2.145.0 as we are nearing the end of the deploy. A follow up PR will be made to add relevant env vars.