### PR TITLE
feat: add `template_url` param to `bootstrap`

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -2322,6 +2322,11 @@ components:
         kps_enabled:
           type: boolean
           deprecated: true
+        template_url:
+          template_url:
+          type: string
+          description: Template URL used to create the project from the CLI.
+          example: https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone
       required:
         - db_pass
         - name

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -75,7 +75,10 @@ func Run(ctx context.Context, templateUrl string, fsys afero.Fs, options ...func
 		return err
 	}
 	// 2. Create project
-	params := api.CreateProjectBody{Name: filepath.Base(workdir)}
+	params := api.CreateProjectBody{
+		Name:        filepath.Base(workdir),
+		TemplateUrl: &templateUrl,
+	}
 	if err := create.Run(ctx, params, fsys); err != nil {
 		return err
 	}

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -555,6 +555,9 @@ type CreateProjectBody struct {
 
 	// Region Region you want your server to reside in
 	Region CreateProjectBodyRegion `json:"region"`
+
+	// TemplateUrl Template URL used to create the project from the CLI.
+	TemplateUrl *string `json:"template_url,omitempty"`
 }
 
 // CreateProjectBodyPlan Subscription plan is now set on organization level and is ignored in this request


### PR DESCRIPTION
Adds the `template_url` value when the `bootstrap` command is executed, for tracking which template was used to create a project.

I've manually edited the OpenAPI file, as it appears the latest platform generated OpenAPI renames `CreateProjectBody` to `V1CreateProjectBody`.

Do not merge until the API is deployed.