### PR TITLE
fix(functions): unbundle to slug directory by default

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -78,7 +78,7 @@ func bundleFunction(ctx context.Context, slug, dockerEntrypointPath, importMapPa
 		return nil, errors.Errorf("failed to get working directory: %w", err)
 	}
 
-	// create temp directory to store generated eszip
+	// Create temp directory to store generated eszip
 	hostOutputDir := filepath.Join(utils.TempDir, fmt.Sprintf(".output_%s", slug))
 	// BitBucket pipelines require docker bind mounts to be world writable
 	if err := fsys.MkdirAll(hostOutputDir, 0777); err != nil {

--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -129,14 +129,14 @@ func Run(ctx context.Context, slug string, projectRef string, useLegacyBundle bo
 		}
 	}()
 	// Extract eszip to functions directory
-	err = extractOne(ctx, eszipPath)
+	err = extractOne(ctx, slug, eszipPath)
 	if err != nil {
 		utils.CmdSuggestion += suggestLegacyBundle(slug)
 	}
 	return err
 }
 
-func downloadOne(ctx context.Context, slug string, projectRef string, fsys afero.Fs) (string, error) {
+func downloadOne(ctx context.Context, slug, projectRef string, fsys afero.Fs) (string, error) {
 	fmt.Println("Downloading " + utils.Bold(slug))
 	resp, err := utils.GetSupabase().GetFunctionBody(ctx, projectRef, slug)
 	if err != nil {
@@ -161,23 +161,24 @@ func downloadOne(ctx context.Context, slug string, projectRef string, fsys afero
 	return eszipPath, nil
 }
 
-func extractOne(ctx context.Context, eszipPath string) error {
-	hostFuncDirPath, err := filepath.Abs(utils.FunctionsDir)
+func extractOne(ctx context.Context, slug, eszipPath string) error {
+	hostFuncDirPath, err := filepath.Abs(filepath.Join(utils.FunctionsDir, slug))
 	if err != nil {
 		return errors.Errorf("failed to resolve absolute path: %w", err)
 	}
+
 	hostEszipPath, err := filepath.Abs(eszipPath)
 	if err != nil {
 		return errors.Errorf("failed to resolve eszip path: %w", err)
 	}
-
 	dockerEszipPath := path.Join(dockerEszipDir, filepath.Base(hostEszipPath))
+
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts
 		// https://denolib.gitbook.io/guide/advanced/deno_dir-code-fetch-and-cache
 		utils.EdgeRuntimeId + ":/root/.cache/deno:rw,z",
 		hostEszipPath + ":" + dockerEszipPath + ":ro,z",
-		hostFuncDirPath + ":" + utils.DockerFuncDirPath + ":rw,z",
+		hostFuncDirPath + ":" + utils.DockerDenoDir + ":rw,z",
 	}
 
 	return utils.DockerRunOnceWithConfig(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1912

## What is the current behavior?

If only `--entrypoint` flag is used, the eszip will be unbundled as a single `index.ts` file
```
edge-runtime bundle --entrypoint functions/hello/index.ts --output /tmp/output.eszip
edge-runtime unbundle --eszip /tmp/output.eszip --output .
```

But if an `--import-map` flag is also used, for eg.

```
edge-runtime bundle --entrypoint functions/hello/index.ts --import-map import_map.json --output /tmp/output.eszip
edge-runtime unbundle --eszip /tmp/output.eszip --output .
```

The entrypoint file will be extracted relative to the import map:
```
import_map.json
functions/hello/index.ts
```

## What is the new behavior?

It's too complicated to maintain the original bundled file structure when extracting. So we will simply extract the eszip folder as it is.

## Additional context

Add any other context or screenshots.
