### PR TITLE
feat: add HTTP hook Secret Configuration

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -497,6 +497,7 @@ EOF
 				env,
 				"GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED=true",
 				"GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_URI="+utils.Config.Auth.Hook.MFAVerificationAttempt.URI,
+				"GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS="+utils.Config.Auth.Hook.MFAVerificationAttempt.Secrets,
 			)
 		}
 
@@ -505,6 +506,7 @@ EOF
 				env,
 				"GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED=true",
 				"GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI="+utils.Config.Auth.Hook.PasswordVerificationAttempt.URI,
+				"GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS="+utils.Config.Auth.Hook.PasswordVerificationAttempt.Secrets,
 			)
 		}
 
@@ -513,6 +515,25 @@ EOF
 				env,
 				"GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED=true",
 				"GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI="+utils.Config.Auth.Hook.CustomAccessToken.URI,
+				"GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_SECRETS="+utils.Config.Auth.Hook.CustomAccessToken.Secrets,
+			)
+		}
+
+		if utils.Config.Auth.Hook.SendSMS.Enabled {
+			env = append(
+				env,
+				"GOTRUE_HOOK_SEND_SMS_ENABLED=true",
+				"GOTRUE_HOOK_SEND_SMS_URI="+utils.Config.Auth.Hook.SendSMS.URI,
+				"GOTRUE_HOOK_SEND_SMS_SECRETS="+utils.Config.Auth.Hook.SendSMS.Secrets,
+			)
+		}
+
+		if utils.Config.Auth.Hook.SendEmail.Enabled {
+			env = append(
+				env,
+				"GOTRUE_HOOK_SEND_EMAIL_ENABLED=true",
+				"GOTRUE_HOOK_SEND_EMAIL_URI="+utils.Config.Auth.Hook.SendEmail.URI,
+				"GOTRUE_HOOK_SEND_EMAIL_SECRETS="+utils.Config.Auth.Hook.SendEmail.Secrets,
 			)
 		}
 

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -387,11 +388,14 @@ type (
 		MFAVerificationAttempt      hookConfig `toml:"mfa_verification_attempt"`
 		PasswordVerificationAttempt hookConfig `toml:"password_verification_attempt"`
 		CustomAccessToken           hookConfig `toml:"custom_access_token"`
+		SendSMS                     hookConfig `toml:"send_sms"`
+		SendEmail                   hookConfig `toml:"send_email"`
 	}
 
 	hookConfig struct {
 		Enabled bool   `toml:"enabled"`
 		URI     string `toml:"uri"`
+		Secrets string `toml:"secrets"`
 	}
 
 	twilioConfig struct {
@@ -459,6 +463,24 @@ type (
 	// 	AfterMigrations  string `toml:"after_migrations"`
 	// }
 )
+
+func (h *hookConfig) HandleHook(hookType string) error {
+	// If not enabled do nothing
+	if !h.Enabled {
+		return nil
+	}
+	if h.URI == "" {
+		return fmt.Errorf("missing required field in config: auth.hook.%s.uri", hookType)
+	}
+	if err := validateHookURI(h.URI, hookType); err != nil {
+		return err
+	}
+	var err error
+	if h.Secrets, err = maybeLoadEnv(h.Secrets); err != nil {
+		return fmt.Errorf("missing required field in config: auth.hook.%s.secrets", hookType)
+	}
+	return nil
+}
 
 func LoadConfigFS(fsys afero.Fs) error {
 	// Load default values
@@ -687,25 +709,21 @@ func LoadConfigFS(fsys afero.Fs) error {
 					return err
 				}
 			}
-
-			if Config.Auth.Hook.MFAVerificationAttempt.Enabled {
-				if Config.Auth.Hook.MFAVerificationAttempt.URI == "" {
-					return errors.New("Missing required field in config: auth.hook.mfa_verification_atempt.uri")
-				}
+			if err := Config.Auth.Hook.MFAVerificationAttempt.HandleHook("mfa_verification_attempt"); err != nil {
+				return err
 			}
-
-			if Config.Auth.Hook.PasswordVerificationAttempt.Enabled {
-				if Config.Auth.Hook.PasswordVerificationAttempt.URI == "" {
-					return errors.New("Missing required field in config: auth.hook.password_verification_attempt.uri")
-				}
+			if err := Config.Auth.Hook.PasswordVerificationAttempt.HandleHook("password_verification_attempt"); err != nil {
+				return err
 			}
-
-			if Config.Auth.Hook.CustomAccessToken.Enabled {
-				if Config.Auth.Hook.CustomAccessToken.URI == "" {
-					return errors.New("Missing required field in config: auth.hook.custom_access_token.uri")
-				}
+			if err := Config.Auth.Hook.CustomAccessToken.HandleHook("custom_access_token"); err != nil {
+				return err
 			}
-
+			if err := Config.Auth.Hook.SendSMS.HandleHook("send_sms"); err != nil {
+				return err
+			}
+			if err := Config.Auth.Hook.SendEmail.HandleHook("send_email"); err != nil {
+				return err
+			}
 			// Validate oauth config
 			for ext, provider := range Config.Auth.External {
 				if !provider.Enabled {
@@ -859,6 +877,17 @@ func loadDefaultEnv() error {
 func loadEnvIfExists(path string) error {
 	if err := godotenv.Load(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Errorf("failed to load %s: %w", Bold(".env"), err)
+	}
+	return nil
+}
+
+func validateHookURI(uri, hookName string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return errors.Errorf("failed to parse template url: %w", err)
+	}
+	if !(parsed.Scheme == "http" || parsed.Scheme == "https" || parsed.Scheme == "pg-functions") {
+		return errors.Errorf("Invalid HTTP hook config: auth.hook.%v should be a Postgres function URI, or a HTTP or HTTPS URL", hookName)
 	}
 	return nil
 }

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -470,14 +470,14 @@ func (h *hookConfig) HandleHook(hookType string) error {
 		return nil
 	}
 	if h.URI == "" {
-		return fmt.Errorf("missing required field in config: auth.hook.%s.uri", hookType)
+		return errors.Errorf("missing required field in config: auth.hook.%s.uri", hookType)
 	}
 	if err := validateHookURI(h.URI, hookType); err != nil {
 		return err
 	}
 	var err error
 	if h.Secrets, err = maybeLoadEnv(h.Secrets); err != nil {
-		return fmt.Errorf("missing required field in config: auth.hook.%s.secrets", hookType)
+		return errors.Errorf("missing required field in config: auth.hook.%s.secrets", hookType)
 	}
 	return nil
 }

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -41,6 +41,7 @@ func TestConfigParsing(t *testing.T) {
 		t.Setenv("TWILIO_AUTH_TOKEN", "token")
 		t.Setenv("AZURE_CLIENT_ID", "hello")
 		t.Setenv("AZURE_SECRET", "this is cool")
+		t.Setenv("AUTH_SEND_SMS_SECRETS", "v1,whsec_aWxpa2VzdXBhYmFzZXZlcnltdWNoYW5kaWhvcGV5b3Vkb3Rvbw==")
 		assert.NoError(t, LoadConfigFS(fsys))
 		// Check error
 		assert.Equal(t, "hello", Config.Auth.External["azure"].ClientId)

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -123,6 +123,11 @@ max_frequency = "5s"
 enabled = true
 uri = "pg-functions://postgres/auth/custom-access-token-hook"
 
+[auth.hook.send_sms]
+enabled = true
+uri = "http://host.docker.internal/functions/v1/send_sms"
+secrets = "env(AUTH_SEND_SMS_SECRETS)"
+
 
 # Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
 [auth.sms.twilio]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the corresponding configuration for the `SendSMS` and `SendEmail` HTTP Hooks. Also introduces Secrets for previous hooks - `custom_access_token`, `mfa_verification_attempt` , `password_verification_attempt`


Backend PR (Merged): https://github.com/supabase/infrastructure/pull/17848
Frontend PR (WIP): https://github.com/supabase/supabase/pull/22495