### PR TITLE
feat: fetch start command for bootstrap from samples.json

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -151,7 +151,7 @@ func suggestAppStart(cwd string) string {
 	}
 	fileBytes, err := ioutil.ReadFile("samples.json")
 	if err != nil {
-		log.Fatalf("failed to read file: %v", err)
+		errors.Errorf("failed to read file: %v", err)
 	}
 
 	var samples SamplesFile

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -34,6 +34,17 @@ import (
 	"golang.org/x/term"
 )
 
+type Sample struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Start       string `json:"start"`
+}
+
+type SamplesFile struct {
+	Samples []Sample `json:"samples"`
+}
+
 func Run(ctx context.Context, templateUrl string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	workdir := viper.GetString("WORKDIR")
 	if !filepath.IsAbs(workdir) {
@@ -137,6 +148,21 @@ func suggestAppStart(cwd string) string {
 	if len(workdir) > 0 && workdir != "." {
 		cmd = append(cmd, "cd "+workdir)
 	}
+	fileBytes, err := ioutil.ReadFile("samples.json")
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+	}
+
+	var samples SamplesFile
+	err = json.Unmarshal(fileBytes, &samples)
+	if err != nil {
+		log.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	for _, sample := range samples.Samples {
+		fmt.Printf("To start your app run:", sample.Start)
+	}
+	// TODO: refactor this part properly
 	cmd = append(cmd, "npm ci", "npm run dev")
 	suggestion := "To start your app:"
 	for _, c := range cmd {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -151,17 +151,17 @@ func suggestAppStart(cwd string) string {
 	}
 	fileBytes, err := ioutil.ReadFile("samples.json")
 	if err != nil {
-		errors.Errorf("failed to read file: %v", err)
+		return errors.Errorf("failed to read file: %v", err)
 	}
 
 	var samples SamplesFile
 	err = json.Unmarshal(fileBytes, &samples)
 	if err != nil {
-		errors.Errorf("failed to unmarshal JSON: %v", err)
+		return errors.Errorf("failed to unmarshal JSON: %v", err)
 	}
 
 	for _, sample := range samples.Samples {
-		fmt.Printf("To start your app run:", sample.Start)
+		fmt.Printf("To start your app run: %q", sample.Start)
 	}
 	// TODO: refactor this part properly
 	cmd = append(cmd, "npm ci", "npm run dev")

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -156,7 +157,7 @@ func suggestAppStart(cwd string) string {
 	var samples SamplesFile
 	err = json.Unmarshal(fileBytes, &samples)
 	if err != nil {
-		log.Fatalf("failed to unmarshal JSON: %v", err)
+		errors.Errorf("failed to unmarshal JSON: %v", err)
 	}
 
 	for _, sample := range samples.Samples {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, we  use a hardcoded start command (e.g. `npm run dev`) which might not generalize to non-javascript projects. This PR aims to fix this by fetching from `samples.json`
