### PR TITLE
feat: add seed command to generate test users

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+	"os/signal"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/seed"
+)
+
+var (
+	seedCmd = &cobra.Command{
+		GroupID: groupLocalDev,
+		Use:     "seed",
+		Short:   "Generate seed data",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			cmd.SetContext(ctx)
+			return cmd.Root().PersistentPreRunE(cmd, args)
+		},
+	}
+
+	seedAuthCmd = &cobra.Command{
+		Use:   "auth",
+		Short: "Generate seed data for the Auth schema",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return seed.Run(cmd.Context(), afero.NewOsFs())
+		},
+	}
+)
+
+func init() {
+	seedCmd.AddCommand(seedAuthCmd)
+	rootCmd.AddCommand(seedCmd)
+}

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -115,7 +115,7 @@ func CreateShadowDatabase(ctx context.Context) (string, error) {
 		config.Entrypoint = nil
 		hostConfig.Tmpfs = map[string]string{"/docker-entrypoint-initdb.d": ""}
 	}
-	return utils.DockerStart(ctx, config, hostConfig, networkingConfig, "")
+	return utils.DockerStart(ctx, config, hostConfig, networkingConfig, "supabase_db_shadow")
 }
 
 func ConnectShadowDatabase(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {

--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -48,7 +48,7 @@ func Run(ctx context.Context, path string, config pgconn.Config, schema, exclude
 	}
 	if dataOnly {
 		fmt.Fprintf(os.Stderr, "Dumping data from %s database...\n", db)
-		return dumpData(ctx, config, schema, excludeTable, useCopy, dryRun, outStream)
+		return DumpData(ctx, config, schema, excludeTable, useCopy, dryRun, outStream)
 	} else if roleOnly {
 		fmt.Fprintf(os.Stderr, "Dumping roles from %s database...\n", db)
 		return dumpRole(ctx, config, keepComments, dryRun, outStream)
@@ -71,7 +71,7 @@ func DumpSchema(ctx context.Context, config pgconn.Config, schema []string, keep
 	return dump(ctx, config, dumpSchemaScript, env, dryRun, stdout)
 }
 
-func dumpData(ctx context.Context, config pgconn.Config, schema, excludeTable []string, useCopy, dryRun bool, stdout io.Writer) error {
+func DumpData(ctx context.Context, config pgconn.Config, schema, excludeTable []string, useCopy, dryRun bool, stdout io.Writer) error {
 	// We want to dump user data in auth, storage, etc. for migrating to new project
 	excludedSchemas := []string{
 		"information_schema",

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -1,0 +1,194 @@
+package seed
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
+	"github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/db/diff"
+	"github.com/supabase/cli/internal/db/dump"
+	"github.com/supabase/cli/internal/db/reset"
+	"github.com/supabase/cli/internal/db/start"
+	"github.com/supabase/cli/internal/utils"
+)
+
+type UserResponse struct {
+	Id    string `json:"id"`
+	Email string `json:"email"`
+}
+
+var (
+	numberOfTestUsersCreated int = 5
+)
+
+func Run(ctx context.Context, fsys afero.Fs) error {
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
+	}
+
+	fmt.Println("Generating seed data for test users...")
+	shadow, err := diff.CreateShadowDatabase(ctx)
+	if err != nil {
+		return err
+	}
+	defer utils.DockerRemove(shadow)
+	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
+		return errors.New(start.ErrDatabase)
+	}
+	config := pgconn.Config{
+		Host:     "supabase_db_shadow",
+		Port:     5432,
+		User:     "supabase_auth_admin",
+		Password: utils.Config.Db.Password,
+		Database: "postgres",
+	}
+	source := utils.ToPostgresURL(config)
+
+	// minimal set of config to get a shadow gotrue container running
+	env := []string{
+		fmt.Sprintf("API_EXTERNAL_URL=http://%s:%d", utils.Config.Hostname, utils.Config.Api.Port),
+
+		"GOTRUE_API_HOST=0.0.0.0",
+		"GOTRUE_API_PORT=9999",
+		"GOTRUE_TRACING_ENABLED=false",
+		"GOTRUE_METRICS_ENABLED=false",
+
+		"GOTRUE_DB_DRIVER=postgres",
+		"GOTRUE_DB_NAMESPACE=postgres",
+		fmt.Sprintf("GOTRUE_DB_DATABASE_URL=%s", source),
+
+		"GOTRUE_SITE_URL=" + utils.Config.Auth.SiteUrl,
+
+		"GOTRUE_JWT_ADMIN_ROLES=service_role",
+		"GOTRUE_JWT_AUD=authenticated",
+		"GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated",
+		fmt.Sprintf("GOTRUE_JWT_EXP=%v", utils.Config.Auth.JwtExpiry),
+		"GOTRUE_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+		fmt.Sprintf("GOTRUE_JWT_ISSUER=http://%s:%d/auth/v1", utils.Config.Hostname, utils.Config.Api.Port),
+	}
+
+	gotrueContainerId, err := utils.DockerStart(
+		ctx,
+		container.Config{
+			Image:        utils.Config.Auth.Image,
+			Env:          env,
+			ExposedPorts: nat.PortSet{"9999/tcp": {}},
+			Healthcheck: &container.HealthConfig{
+				Test:     []string{"CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:9999/health"},
+				Interval: 10 * time.Second,
+				Timeout:  2 * time.Second,
+				Retries:  3,
+			},
+		},
+		container.HostConfig{
+			PortBindings:  nat.PortMap{"9999/tcp": []nat.PortBinding{{HostPort: "54325"}}},
+			RestartPolicy: container.RestartPolicy{Name: "always"},
+		},
+		network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				utils.NetId: {
+					Aliases: utils.GotrueAliases,
+				},
+			},
+		},
+		fmt.Sprintf("%s_%s", utils.GotrueId, "shadow"),
+	)
+	if err != nil {
+		return err
+	}
+	defer utils.DockerRemove(gotrueContainerId)
+	if err := reset.WaitForServiceReady(ctx, []string{gotrueContainerId}); err != nil {
+		return err
+	}
+
+	// call admin endpoint to create some test users
+	if err := createTestUsers(ctx, numberOfTestUsersCreated); err != nil {
+		return err
+	}
+
+	// write dump out to supabase/seed.example.sql file
+	outStream, err := fsys.OpenFile(utils.SeedExampleDataPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return errors.Errorf("failed to open seed example file: %w", err)
+	}
+	defer outStream.Close()
+
+	// dump data from shadow db
+	if err := dump.DumpData(ctx, pgconn.Config{
+		Host:     utils.Config.Hostname,
+		Port:     uint16(utils.Config.Db.ShadowPort),
+		User:     "postgres",
+		Password: utils.Config.Db.Password,
+		Database: "postgres",
+	}, []string{"auth"}, []string{
+		// auth schema needs to be specified to exclude the audit_log_entries table
+		"auth.audit_log_entries",
+		"instances",
+		"sessions",
+		"schema_migrations",
+		"refresh_tokens",
+		"mfa_amr_claims",
+		"mfa_challenges",
+		"mfa_factors",
+		"saml_providers",
+		"sso_providers",
+		"sso_domains",
+		"saml_relay_state",
+		"flow_state",
+	}, false, false, outStream); err != nil {
+		return err
+	}
+
+	// use awk to remove unnecessary sections from the dump
+	awkCmd := exec.Command("awk", `
+		/-- Data for Name: users; Type: TABLE DATA; Schema: auth;/ {flag=1; next}
+		/-- Data for Name: identities; Type: TABLE DATA; Schema: auth;/ {flag=1; next}
+		/-- Data for Name:/ {flag=0} flag {print}
+	`)
+	dump, err := afero.ReadFile(fsys, utils.SeedExampleDataPath)
+	if err != nil {
+		return err
+	}
+	awkCmd.Stdin = bytes.NewReader(dump)
+	var out bytes.Buffer
+	awkCmd.Stdout = &out
+	if err := awkCmd.Run(); err != nil {
+		return err
+	}
+	if err := afero.WriteFile(fsys, utils.SeedExampleDataPath, out.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	fmt.Println("Seed data written to supabase/seed.example.sql")
+	return nil
+}
+
+func createTestUsers(ctx context.Context, n int) error {
+	reqEditors := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", utils.Config.Auth.ServiceRoleKey))
+		return nil
+	}
+	endpoint := "http://localhost:54325/admin/users"
+
+	for i := 0; i < n; i++ {
+		reqBody := map[string]interface{}{
+			"email":    fmt.Sprintf("test%v@supabase.io", i),
+			"password": "password123",
+		}
+		_, err := utils.JsonResponse[UserResponse](ctx, "POST", endpoint, reqBody, reqEditors)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		return err
 	}
 
-	fmt.Println("Generating seed data for test users...")
+	fmt.Println("Generating seed data examples for test users...")
 	shadow, err := diff.CreateShadowDatabase(ctx)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		return err
 	}
 
-	fmt.Println("Seed data written to supabase/seed.example.sql")
+	fmt.Printf("Seed data written to %s\n", utils.SeedExampleDataPath)
 	return nil
 }
 

--- a/internal/seed/seed_test.go
+++ b/internal/seed/seed_test.go
@@ -1,0 +1,78 @@
+package seed
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestSeedCommand(t *testing.T) {
+	t.Run("throws error on missing config", func(t *testing.T) {
+		err := Run(context.Background(), afero.NewOsFs())
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("generate seed data for auth schema", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+
+		// Set up mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+
+		// mocks for creating the shadow db
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-shadow-db")
+		gock.New(utils.Docker.DaemonHost()).
+			Delete("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
+			}})
+
+		// mocks for creating the shadow auth container
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.GotrueImage), "test-shadow-auth")
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-auth/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{
+					Running: true,
+					Health:  &types.Health{Status: "healthy"},
+				},
+			}})
+
+		// mock admin requests to auth
+		req := gock.New("http://localhost:54325").Post("/admin/users").Reply(http.StatusOK).JSON(UserResponse{
+			Id:    "ab8e2e95-cf43-429e-9dab-a241778e3d64",
+			Email: "test@example.com",
+		})
+		req.Mock.Request().Counter = numberOfTestUsersCreated
+
+		// mocks for dumping the shadow db
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Pg15Image), "test-shadow-db")
+		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-shadow-db", ""))
+
+		err := Run(context.Background(), fsys)
+		assert.NoError(t, err)
+
+		// check seed example file generated
+		hasFile, err := afero.Exists(fsys, utils.SeedExampleDataPath)
+		assert.NoError(t, err)
+		assert.True(t, hasFile)
+	})
+}

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -184,6 +184,7 @@ var (
 	FallbackEnvFilePath   = filepath.Join(FunctionsDir, ".env")
 	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
 	SeedDataPath          = filepath.Join(SupabaseDirPath, "seed.sql")
+	SeedExampleDataPath   = filepath.Join(SupabaseDirPath, "seed.example.sql")
 	CustomRolesPath       = filepath.Join(SupabaseDirPath, "roles.sql")
 
 	ErrNotLinked   = errors.Errorf("Cannot find project ref. Have you run %s?", Aqua("supabase link"))


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a `supabase seed auth` command that generates sql examples to add test
users and saves them in a `seed.example.sql` file

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
