### PR TITLE
fix: bump edge-runtime to 1.41.5

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240326-5e5586d"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.41.3"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.41.5"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates to edge-runtime 1.41.5, which fixes an oddity when 

## What is the current behavior?

Previously if a relative path import like `../shared/index.ts` was included in the function bundle, it would get unbundled in to something like `./home/deno/functions/shared/index.ts`

## What is the new behavior?

Now unbundle command would create a `function-name/src` directory for the source. Any relative imports will be placed in top-level `function-name/` directory.

