### PR TITLE
fix: migration repair example more understandable

### DIFF
--- a/docs/supabase/migration/repair.md
+++ b/docs/supabase/migration/repair.md
@@ -12,13 +12,14 @@ For example, your migration history table may look like this after running `db p
 $ supabase migration list
         LOCAL      │     REMOTE     │     TIME (UTC)
   ─────────────────┼────────────────┼──────────────────────
-    20230103054303 │ 20230103054303 │ 2023-01-03 05:43:03
+                   │ 20230103054303 │ 2023-01-03 05:43:03
+   20230103054315  │                │ 2023-01-03 05:43:15
 ```
 
 To reset your migration history to a clean state, first delete your local migration file.
 
 ```bash
-$ rm supabase/migrations/20230103054303_remote_commit.sql
+$ rm supabase/migrations/20230103054315_remote_commit.sql
 $ supabase migration list
         LOCAL      │     REMOTE     │     TIME (UTC)
   ─────────────────┼────────────────┼──────────────────────

--- a/docs/supabase/migration/repair.md
+++ b/docs/supabase/migration/repair.md
@@ -6,7 +6,7 @@ Requires your local project to be linked to a remote database by running `supaba
 
 If your local and remote migration history goes out of sync, you can repair the remote history by marking specific migrations as `--status applied` or `--status reverted`. Marking as `reverted` will delete an existing record from the migration history table while marking as `applied` will insert a new record.
 
-For example, your migration history table may look like this after running `db pull` for the first time.
+For example, your migration history may look like the table below, with missing entries in either local or remote.
 
 ```bash
 $ supabase migration list
@@ -20,6 +20,7 @@ To reset your migration history to a clean state, first delete your local migrat
 
 ```bash
 $ rm supabase/migrations/20230103054315_remote_commit.sql
+
 $ supabase migration list
         LOCAL      │     REMOTE     │     TIME (UTC)
   ─────────────────┼────────────────┼──────────────────────
@@ -30,10 +31,27 @@ Then mark the remote migration `20230103054303` as reverted.
 
 ```bash
 $ supabase migration repair 20230103054303 --status reverted
-Repaired migration history: 20230103054303 => reverted
+Connecting to remote database...
+Repaired migration history: [20220810154537] => reverted
+Finished supabase migration repair.
+
 $ supabase migration list
         LOCAL      │     REMOTE     │     TIME (UTC)
   ─────────────────┼────────────────┼──────────────────────
 ```
 
 Now you can run `db pull` again to dump the remote schema as a local migration file.
+
+```bash
+$ supabase db pull
+Connecting to remote database...
+Schema written to supabase/migrations/20240414044403_remote_schema.sql
+Update remote migration history table? [Y/n]
+Repaired migration history: [20240414044403] => applied
+Finished supabase db pull.
+
+$ supabase migration list
+        LOCAL      │     REMOTE     │     TIME (UTC)
+  ─────────────────┼────────────────┼──────────────────────
+    20240414044403 │ 20240414044403 │ 2024-04-14 04:44:03
+```


### PR DESCRIPTION
## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

The example provided with the command `migragrion repair` was showing an output with no issue and thus the example was hard to understand

## What is the new behavior?

NA


