### PR TITLE
chore: remove storage from db_schemas

### DIFF
--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -288,7 +288,7 @@ func TestLinkPostgrest(t *testing.T) {
 			Get("/v1/projects/" + project + "/postgrest").
 			Reply(200).
 			JSON(api.PostgrestConfigResponse{
-				DbSchema:          "public, storage, graphql_public",
+				DbSchema:          "public, graphql_public",
 				DbExtraSearchPath: "public, extensions",
 				MaxRows:           1000,
 			})
@@ -297,7 +297,7 @@ func TestLinkPostgrest(t *testing.T) {
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
-		utils.Config.Api.Schemas = []string{"public", "storage", "graphql_public"}
+		utils.Config.Api.Schemas = []string{"public", "graphql_public"}
 		utils.Config.Api.ExtraSearchPath = []string{"public", "extensions"}
 		utils.Config.Api.MaxRows = 1000
 		assert.Equal(t, ConfigCopy{

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -8,7 +8,7 @@ enabled = true
 port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. public and storage are always included.
-schemas = ["public", "storage", "graphql_public"]
+schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -8,7 +8,7 @@ enabled = true
 port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. public and storage are always included.
-schemas = ["public", "storage", "graphql_public"]
+schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size


### PR DESCRIPTION
Storage no longer uses PostgREST, so we don't need it in db_schemas

Prevent noise when linking a fresh project w/ no modifications:
```
Local config differs from linked project. Try updating supabase/config.toml
[api]
enabled = true
port = 54321
schemas = ["public", "graphql_public"]
extra_search_path = ["public", "extensions"]
max_rows = 1000
```
