### PR TITLE
fix(functions): always resolve absolute path in container

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -120,11 +120,13 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 			return err
 		}
 	}
-	modules, err := utils.BindImportMap(fallbackImportMapPath, dockerFallbackImportMapPath, fsys)
-	if err != nil {
-		return err
+	if fallbackImportMapPath != importMapPath {
+		modules, err := utils.BindImportMap(fallbackImportMapPath, dockerFallbackImportMapPath, fsys)
+		if err != nil {
+			return err
+		}
+		binds = append(binds, modules...)
 	}
-	binds = append(binds, modules...)
 
 	if err := utils.MkdirIfNotExistFS(fsys, utils.FunctionsDir); err != nil {
 		return err

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -278,16 +278,8 @@ func resolveHostPath(hostPath string, fsys afero.Fs) string {
 	if filepath.IsAbs(hostPath) {
 		return getModulePath(hostPath)
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return hostPath
-	}
 	rel := filepath.Join(FunctionsDir, hostPath)
-	if strings.HasPrefix(rel, FunctionsDir) {
-		return hostPath
-	}
-	rebased := filepath.Join(cwd, rel)
-	exists, err := afero.Exists(fsys, rebased)
+	exists, err := afero.Exists(fsys, rel)
 	if err != nil {
 		logger := GetDebugLogger()
 		fmt.Fprintln(logger, err)
@@ -295,20 +287,23 @@ func resolveHostPath(hostPath string, fsys afero.Fs) string {
 	if !exists {
 		return hostPath
 	}
+	if strings.HasPrefix(rel, FunctionsDir) {
+		suffix := strings.TrimPrefix(rel, FunctionsDir)
+		return path.Join(DockerFuncDirPath, filepath.ToSlash(suffix))
+	}
 	// Directory imports need to be suffixed with /
 	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
-	if strings.HasSuffix(hostPath, "/") {
-		rel += "/"
+	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
+		rel += string(filepath.Separator)
 	}
 	return getModulePath(rel)
 }
 
 func getModulePath(hostPath string) string {
 	mod := path.Join(DockerModsDir, GetPathHash(hostPath))
-	if strings.HasSuffix(hostPath, "/") {
+	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
 		mod += "/"
-	}
-	if ext := filepath.Ext(hostPath); len(ext) > 0 {
+	} else if ext := filepath.Ext(hostPath); len(ext) > 0 {
 		mod += ext
 	}
 	return mod

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -23,18 +23,16 @@ func TestResolveImports(t *testing.T) {
 		}
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, "common"), 0755))
-		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, DbTestsDir), 0755))
-		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, FunctionsDir, "child"), 0755))
+		require.NoError(t, fsys.Mkdir("common", 0755))
+		require.NoError(t, fsys.Mkdir(DbTestsDir, 0755))
+		require.NoError(t, fsys.Mkdir(filepath.Join(FunctionsDir, "child"), 0755))
 		// Run test
 		resolved := importMap.Resolve(fsys)
 		// Check error
 		assert.Equal(t, "/home/deno/modules/ac351c7174c8f47a9a9056bd96bcd71cfb980c906daee74ab9bce8308c68b811/", resolved.Imports["abs/"])
 		assert.Equal(t, "/home/deno/modules/92a5dc04bd6f9fb8f29f8066fed8a5c1e81bc59ad48a11283b63736867e4f2a8", resolved.Imports["root"])
 		assert.Equal(t, "/home/deno/modules/faaed96206118cf98625ea8065b6b3864f8cf9484814c423b58ebaa9b2d1e47b", resolved.Imports["parent"])
-		assert.Equal(t, "child", resolved.Imports["child"])
+		assert.Equal(t, "/home/deno/functions/child", resolved.Imports["child"])
 		assert.Equal(t, "../missing", resolved.Imports["missing"])
 	})
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1338

## What is the new behavior?

- Always use absolute path in generated import map when serving inside edge runtime, because import map must be mounted at `/home/deno` instead of `/home/deno/functions`
- Rewrite windows path separator to unix for mounting in container.
- Avoid duplicate mount point when both `--import-map` flag and `functions/import_map.json` are used.

## Additional context

Add any other context or screenshots.
