### PR TITLE
feat(branch): add persistent flag for project ref

### DIFF
--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -12,6 +12,7 @@ import (
 	"github.com/supabase/cli/internal/branches/list"
 	"github.com/supabase/cli/internal/branches/update"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
 )
 
@@ -105,7 +106,8 @@ var (
 )
 
 func init() {
-	branchesCmd.AddCommand(branchCreateCmd)
+	branchFlags := branchesCmd.PersistentFlags()
+	branchFlags.StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	// Setup enum flags
 	i := 0
 	for k := range utils.FlyRegions {
@@ -115,6 +117,7 @@ func init() {
 	sort.Strings(branchRegion.Allowed)
 	createFlags := branchCreateCmd.Flags()
 	createFlags.Var(&branchRegion, "region", "Select a region to deploy the branch database.")
+	branchesCmd.AddCommand(branchCreateCmd)
 	branchesCmd.AddCommand(branchListCmd)
 	branchesCmd.AddCommand(branchGetCmd)
 	updateFlags := branchUpdateCmd.Flags()

--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"sort"
 
+	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/branches/create"
@@ -11,6 +15,7 @@ import (
 	"github.com/supabase/cli/internal/branches/get"
 	"github.com/supabase/cli/internal/branches/list"
 	"github.com/supabase/cli/internal/branches/update"
+	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
@@ -51,13 +56,23 @@ var (
 		},
 	}
 
+	branchId string
+
 	branchGetCmd = &cobra.Command{
-		Use:   "get <branch-id>",
+		Use:   "get [branch-id]",
 		Short: "Retrieve details of a preview branch",
 		Long:  "Retrieve details of the specified preview branch.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return get.Run(cmd.Context(), args[0])
+			ctx := cmd.Context()
+			if len(args) == 0 {
+				if err := promptBranchId(ctx, flags.ProjectRef); err != nil {
+					return err
+				}
+			} else {
+				branchId = args[0]
+			}
+			return get.Run(ctx, branchId)
 		},
 	}
 
@@ -66,7 +81,7 @@ var (
 	resetOnPush bool
 
 	branchUpdateCmd = &cobra.Command{
-		Use:   "update <branch-id>",
+		Use:   "update [branch-id]",
 		Short: "Update a preview branch",
 		Long:  "Update a preview branch by its ID.",
 		Args:  cobra.ExactArgs(1),
@@ -81,17 +96,33 @@ var (
 			if cmd.Flags().Changed("reset-on-push") {
 				body.ResetOnPush = &resetOnPush
 			}
-			return update.Run(cmd.Context(), args[0], body, afero.NewOsFs())
+			ctx := cmd.Context()
+			if len(args) == 0 {
+				if err := promptBranchId(ctx, flags.ProjectRef); err != nil {
+					return err
+				}
+			} else {
+				branchId = args[0]
+			}
+			return update.Run(cmd.Context(), branchId, body, afero.NewOsFs())
 		},
 	}
 
 	branchDeleteCmd = &cobra.Command{
-		Use:   "delete <branch-id>",
+		Use:   "delete [branch-id]",
 		Short: "Delete a preview branch",
 		Long:  "Delete a preview branch by its ID.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return delete.Run(cmd.Context(), args[0])
+			ctx := cmd.Context()
+			if len(args) == 0 {
+				if err := promptBranchId(ctx, flags.ProjectRef); err != nil {
+					return err
+				}
+			} else {
+				branchId = args[0]
+			}
+			return delete.Run(ctx, branchId)
 		},
 	}
 
@@ -128,4 +159,49 @@ func init() {
 	branchesCmd.AddCommand(branchDeleteCmd)
 	branchesCmd.AddCommand(branchDisableCmd)
 	rootCmd.AddCommand(branchesCmd)
+}
+
+func promptBranchId(ctx context.Context, ref string) error {
+	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, ref)
+	if err != nil {
+		return errors.Errorf("failed to list preview branches: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return errors.New("Unexpected error listing preview branches: " + string(resp.Body))
+	}
+	console := utils.NewConsole()
+	if !console.IsTTY {
+		// Fallback to current git branch on GHA
+		gitBranch := keys.GetGitBranch(afero.NewOsFs())
+		title := "Enter the name of your branch: "
+		if len(gitBranch) > 0 {
+			title = fmt.Sprintf("%-2s (or leave blank to use %s): ", title, utils.Aqua(gitBranch))
+		}
+		if name, err := console.PromptText(title); err != nil {
+			return err
+		} else if len(name) > 0 {
+			gitBranch = name
+		}
+		for _, branch := range *resp.JSON200 {
+			if branch.Name == gitBranch {
+				branchId = branch.Id
+				return nil
+			}
+		}
+		return errors.Errorf("Branch not found: %s", gitBranch)
+	}
+	items := make([]utils.PromptItem, len(*resp.JSON200))
+	for i, branch := range *resp.JSON200 {
+		items[i] = utils.PromptItem{
+			Summary: branch.Name,
+			Details: branch.Id,
+		}
+	}
+	title := "Select a branch:"
+	choice, err := utils.PromptChoice(ctx, title, items)
+	if err == nil {
+		branchId = choice.Details
+		fmt.Fprintln(os.Stderr, "Selected branch ID:", branchId)
+	}
+	return err
 }

--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -44,6 +44,7 @@ var (
 		Use:   "list",
 		Short: "List all preview branches",
 		Long:  "List all preview branches of the linked project.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return list.Run(cmd.Context(), afero.NewOsFs())
 		},

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
-	ref, err := flags.LoadProjectRef(fsys)
-	if err != nil {
+	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
 		return err
 	}
 	gitBranch := keys.GetGitBranchOrDefault("", fsys)
@@ -22,7 +21,7 @@ func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
 		name = gitBranch
 	}
 
-	resp, err := utils.GetSupabase().CreateBranchWithResponse(ctx, ref, api.CreateBranchJSONRequestBody{
+	resp, err := utils.GetSupabase().CreateBranchWithResponse(ctx, flags.ProjectRef, api.CreateBranchJSONRequestBody{
 		BranchName: name,
 		GitBranch:  &gitBranch,
 		Region:     &region,

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -13,9 +13,6 @@ import (
 )
 
 func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
-	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
-		return err
-	}
 	gitBranch := keys.GetGitBranchOrDefault("", fsys)
 	if len(name) == 0 {
 		name = gitBranch

--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -14,7 +14,11 @@ import (
 
 func Run(ctx context.Context, name, region string, fsys afero.Fs) error {
 	gitBranch := keys.GetGitBranchOrDefault("", fsys)
-	if len(name) == 0 {
+	if len(name) == 0 && len(gitBranch) > 0 {
+		title := fmt.Sprintf("Do you want to create a branch named %s?", utils.Aqua(gitBranch))
+		if shouldCreate := utils.NewConsole().PromptYesNo(title, true); !shouldCreate {
+			return context.Canceled
+		}
 		name = gitBranch
 	}
 

--- a/internal/branches/create/create_test.go
+++ b/internal/branches/create/create_test.go
@@ -4,33 +4,32 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
-	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
 	"gopkg.in/h2non/gock.v1"
 )
 
 func TestCreateCommand(t *testing.T) {
+	// Setup valid project ref
+	flags.ProjectRef = apitest.RandomProjectRef()
+
 	t.Run("creates preview branch", func(t *testing.T) {
-		// Setup valid project ref
-		ref := apitest.RandomProjectRef()
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)
 		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
-			Post("/v1/projects/" + ref + "/branches").
+			Post("/v1/projects/" + flags.ProjectRef + "/branches").
 			Reply(http.StatusCreated).
 			JSON(api.BranchResponse{
 				Id: "test-uuid",
@@ -41,24 +40,14 @@ func TestCreateCommand(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("throws error on permission denied", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.ProjectRefPath}
-		// Run test
-		err := Run(context.Background(), "branch", "region", fsys)
-		// Check error
-		assert.ErrorIs(t, err, os.ErrPermission)
-	})
-
 	t.Run("throws error on network disconnected", func(t *testing.T) {
-		ref := apitest.RandomProjectRef()
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(flags.ProjectRef), 0644))
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
-			Post("/v1/projects/" + ref + "/branches").
+			Post("/v1/projects/" + flags.ProjectRef + "/branches").
 			ReplyError(net.ErrClosed)
 		// Run test
 		err := Run(context.Background(), "", "sin", fsys)
@@ -67,14 +56,13 @@ func TestCreateCommand(t *testing.T) {
 	})
 
 	t.Run("throws error on service unavailable", func(t *testing.T) {
-		ref := apitest.RandomProjectRef()
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(flags.ProjectRef), 0644))
 		// Setup mock api
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
-			Post("/v1/projects/" + ref + "/branches").
+			Post("/v1/projects/" + flags.ProjectRef + "/branches").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
 		err := Run(context.Background(), "", "sin", fsys)

--- a/internal/branches/disable/disable.go
+++ b/internal/branches/disable/disable.go
@@ -12,17 +12,16 @@ import (
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := flags.LoadProjectRef(fsys)
-	if err != nil {
+	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
 		return err
 	}
-	resp, err := utils.GetSupabase().DisableBranchWithResponse(ctx, ref)
+	resp, err := utils.GetSupabase().DisableBranchWithResponse(ctx, flags.ProjectRef)
 	if err != nil {
 		return errors.Errorf("failed to disable preview branching: %w", err)
 	}
 	if resp.StatusCode() != http.StatusOK {
 		return errors.New("Unexpected error disabling preview branching: " + string(resp.Body))
 	}
-	fmt.Println("Disabled preview branching for project:", ref)
+	fmt.Println("Disabled preview branching for project:", flags.ProjectRef)
 	return nil
 }

--- a/internal/branches/disable/disable.go
+++ b/internal/branches/disable/disable.go
@@ -12,9 +12,6 @@ import (
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
-		return err
-	}
 	resp, err := utils.GetSupabase().DisableBranchWithResponse(ctx, flags.ProjectRef)
 	if err != nil {
 		return errors.Errorf("failed to disable preview branching: %w", err)

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -13,11 +13,10 @@ import (
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := flags.LoadProjectRef(fsys)
-	if err != nil {
+	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
 		return err
 	}
-	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, ref)
+	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, flags.ProjectRef)
 	if err != nil {
 		return errors.Errorf("failed to list preview branches: %w", err)
 	}
@@ -27,7 +26,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 
 	table := `|ID|NAME|DEFAULT|GIT BRANCH|RESET ON PUSH|STATUS|CREATED AT (UTC)|UPDATED AT (UTC)|
-|-|-|-|-|-|-|-|
+|-|-|-|-|-|-|-|-|
 `
 	for _, branch := range *resp.JSON200 {
 		gitBranch := " "

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -13,9 +13,6 @@ import (
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	if err := flags.ParseProjectRef(ctx, fsys); err != nil {
-		return err
-	}
 	resp, err := utils.GetSupabase().GetBranchesWithResponse(ctx, flags.ProjectRef)
 	if err != nil {
 		return errors.Errorf("failed to list preview branches: %w", err)

--- a/internal/utils/console.go
+++ b/internal/utils/console.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Console struct {
-	isTTY  bool
+	IsTTY  bool
 	stdin  *bufio.Scanner
 	stdout io.Writer
 	stderr io.Writer
@@ -20,7 +20,7 @@ type Console struct {
 
 func NewConsole() Console {
 	return Console{
-		isTTY:  term.IsTerminal(int(os.Stdin.Fd())),
+		IsTTY:  term.IsTerminal(int(os.Stdin.Fd())),
 		stdin:  bufio.NewScanner(os.Stdin),
 		stdout: os.Stdout,
 		stderr: GetDebugLogger(),
@@ -69,7 +69,7 @@ func (c Console) PromptText(label string) (string, error) {
 	}
 	token := strings.TrimSpace(c.stdin.Text())
 	// Echo input from non-interactive terminal
-	if !c.isTTY {
+	if !c.IsTTY {
 		fmt.Fprintln(c.stdout, token)
 	}
 	return token, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

```
$ supabase --experimental branches get
Selected project: zekxecbchaedtrzpqysa

    Select a branch:

    1. fix-import [5f9b7ee4-5204-4cb5-94b5-3ab2bb8ed2f4]
  >  2. fly-branch [8ec676b6-3a8d-4375-b326-1322965ba211]


    ↑/k up • ↓/j down • / filter • q quit • ? more
```

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
