### PR TITLE
chore: Bump up the version for Realtime on self hosted

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -41,7 +41,7 @@ const (
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.145.0"
-	RealtimeImage    = "supabase/realtime:v2.28.23"
+	RealtimeImage    = "supabase/realtime:v2.28.32"
 	StorageImage     = "supabase/storage-api:v1.0.6"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up the version for Realtime on self hosted
