### PR TITLE
fix: add dbdev to schema ignore list

### DIFF
--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -44,6 +44,7 @@ var escapedSchemas = []string{
 	`supabase\_functions`,
 	`supabase\_migrations`,
 	"cron",
+	"dbdev",
 	"graphql",
 	`graphql\_public`,
 	"net",

--- a/internal/db/pull/pull_test.go
+++ b/internal/db/pull/pull_test.go
@@ -40,6 +40,7 @@ var escapedSchemas = []string{
 	`supabase\_functions`,
 	`supabase\_migrations`,
 	"cron",
+	"dbdev",
 	"graphql",
 	`graphql\_public`,
 	"net",

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -314,6 +314,7 @@ var escapedSchemas = []string{
 	`\_analytics`,
 	`supabase\_functions`,
 	"cron",
+	"dbdev",
 	"graphql",
 	`graphql\_public`,
 	"net",

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -114,6 +114,7 @@ var (
 	SystemSchemas = append([]string{
 		// Owned by extensions
 		"cron",
+		"dbdev",
 		"graphql",
 		"graphql_public",
 		"net",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Ignore `dbdev` schema since it's managed by extension.

## Additional context

Add any other context or screenshots.
