### PR TITLE
fix: add fixed order when selecting types to drop (fixes issue #2207)

### DIFF
--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -59,7 +59,8 @@ begin
   for rec in
     select *
     from pg_type t
-    where t.typnamespace::regnamespace::name = 'public'
+    where
+      t.typnamespace::regnamespace::name = 'public'
       and typtype != 'b'
   loop
     execute format('drop type if exists %I.%I cascade', rec.typnamespace::regnamespace::name, rec.typname);

--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -60,13 +60,7 @@ begin
     select *
     from pg_type t
     where t.typnamespace::regnamespace::name = 'public'
-    order by (
-      select count(d.objid)
-      from pg_depend d
-        left join pg_class c on d.refclassid = c.oid
-      where t.oid = d.objid
-        and c.relname = 'pg_type'
-    )
+      and typtype != 'b'
   loop
     execute format('drop type if exists %I.%I cascade', rec.typnamespace::regnamespace::name, rec.typname);
   end loop;

--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -60,6 +60,13 @@ begin
     select *
     from pg_type t
     where t.typnamespace::regnamespace::name = 'public'
+    order by (
+      select count(d.objid)
+      from pg_depend d
+        left join pg_class c on d.refclassid = c.oid
+      where t.oid = d.objid
+        and c.relname = 'pg_type'
+    )
   loop
     execute format('drop type if exists %I.%I cascade', rec.typnamespace::regnamespace::name, rec.typname);
   end loop;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a fixed order when selecting the types to drop for the `supabase db reset`command.

## What is the current behavior?

Currently, the order is not defined and this can lead to errors when dropping types. (More details: https://github.com/supabase/cli/issues/2207)

## What is the new behavior?

The types are dropped in a fixed order. The order is the number of type dependencies ascending.

The idea is that "base" types are always dropped before e.g. "array" types which have at least 1 type dependency to its "base" type.