### PR TITLE
fix(auth): Update GoTrue Image to avoid signup link generation bug

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -40,7 +40,7 @@ const (
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"
-	GotrueImage      = "supabase/gotrue:v2.145.0"
+	GotrueImage      = "supabase/gotrue:v2.149.0"
 	RealtimeImage    = "supabase/realtime:v2.28.23"
 	StorageImage     = "supabase/storage-api:v1.0.6"
 	LogflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?
GoTrue version 2.145.0 has a bug where generating a signup link will fail with "user_not_found", which was fixed in 2.146.0 (https://github.com/supabase/auth/pull/1514). Since 2.145.0 is locked in the CLI, we can't get the bug fix out, and the only fix is to downgrade to an older version.

This PR updates the image to 2.149.0 which is the most recent version as of 2024-04-22 so the signup link generation works again.

## What is the current behavior?
The CLI is fixed on GoTrue version 2.145.0 which has a bug related to signup link generation.

## What is the new behavior?
The CLI now uses GoTrue version 2.149.0 which does not have a bug related to signup link generation.

## Additional context