### PR TITLE
fix: add unit test for cache hit

### DIFF
--- a/internal/debug/postgres.go
+++ b/internal/debug/postgres.go
@@ -3,6 +3,7 @@ package debug
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -59,7 +60,7 @@ func (p *Proxy) DialFunc(ctx context.Context, network, addr string) (net.Conn, e
 
 		for {
 			// Since pgx closes connection first, every EOF is seen as unexpected
-			if err := <-p.errChan; err != nil && err != io.ErrUnexpectedEOF {
+			if err := <-p.errChan; err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 				panic(err)
 			}
 		}

--- a/internal/inspect/cache/cache.go
+++ b/internal/inspect/cache/cache.go
@@ -24,6 +24,7 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 	if err != nil {
 		return err
 	}
+	defer conn.Close(context.Background())
 	rows, err := conn.Query(ctx, inspect.CACHE_QUERY)
 	if err != nil {
 		return errors.Errorf("failed to query rows: %w", err)

--- a/internal/inspect/cache/cache_test.go
+++ b/internal/inspect/cache/cache_test.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/inspect"
+	"github.com/supabase/cli/internal/testing/pgtest"
+)
+
+var dbConfig = pgconn.Config{
+	Host:     "127.0.0.1",
+	Port:     5432,
+	User:     "admin",
+	Password: "password",
+	Database: "postgres",
+}
+
+func TestCacheCommand(t *testing.T) {
+	t.Run("inspects cache hit rate", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(inspect.CACHE_QUERY).
+			Reply("SELECT 1", Result{
+				Name:  "index hit rate",
+				Ratio: 0.9,
+			})
+		// Run test
+		err := Run(context.Background(), dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.NoError(t, err)
+	})
+
+	t.Run("throws error on empty result", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(inspect.CACHE_QUERY).
+			Reply("SELECT 1", []interface{}{})
+		// Run test
+		err := Run(context.Background(), dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "cannot find field Name in returned row")
+	})
+}

--- a/internal/migration/list/list_test.go
+++ b/internal/migration/list/list_test.go
@@ -103,7 +103,7 @@ func TestRemoteMigrations(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		conn.Query(LIST_MIGRATION_VERSION).
-			Reply("SELECT 1", nil)
+			Reply("SELECT 1", []interface{}{})
 		// Run test
 		_, err := loadRemoteVersions(context.Background(), dbConfig, conn.Intercept)
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- Support mocking struct as postgres reply type.
- Fixes an issue where pgconn is not closed by run.

## Additional context

Add any other context or screenshots.
