### PR TITLE
fix: bump edge-runtime to 1.53.0

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240506-2976cd6"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.49.0"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.0"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.53.0
