### PR TITLE
feat: suggest upgrade when cli version is outdated

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -34,7 +34,7 @@ var (
 				viper.Set("WORKDIR", workdir)
 			}
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			client := bootstrap.GetGtihubClient(ctx)
+			client := utils.GetGtihubClient(ctx)
 			templates, err := bootstrap.ListSamples(ctx, client)
 			if err != nil {
 				return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,7 @@ func shouldFetchRelease(fsys afero.Fs) bool {
 func suggestUpgrade(version string) string {
 	const guide = "https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli"
 	return fmt.Sprintf(`A new version of Supabase CLI is available: v%s => %s
-Follow our guide to upgrade: %s`, utils.Version, utils.Aqua(version), utils.Bold(guide))
+Follow our guide to upgrade: %s`, utils.Version, utils.Yellow(version), utils.Bold(guide))
 }
 
 func recoverAndExit() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,8 +180,8 @@ func shouldFetchRelease(fsys afero.Fs) bool {
 
 func suggestUpgrade(version string) string {
 	const guide = "https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli"
-	return fmt.Sprintf(`A new version of Supabase CLI is available: v%s => %s
-Follow our guide to upgrade: %s`, utils.Version, utils.Yellow(version), utils.Bold(guide))
+	return fmt.Sprintf(`A new version of Supabase CLI is available: %s (currently installed v%s)
+We recommend updating regularly for new features and bug fixes: %s`, utils.Yellow(version), utils.Version, utils.Bold(guide))
 }
 
 func recoverAndExit() {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golangci/golangci-lint v1.58.1
-	github.com/google/go-github/v53 v53.2.0
+	github.com/google/go-github/v62 v62.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgconn v1.14.3

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
-github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
+github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwMmHdhl4=
+github.com/google/go-github/v62 v62.0.0/go.mod h1:EMxeUqGJq2xRu9DYBMwel/mr7kZrzUOfQmmpYrZn2a4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -9,12 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-errors/errors"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v62/github"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/joho/godotenv"
@@ -31,7 +30,6 @@ import (
 	"github.com/supabase/cli/internal/utils/tenant"
 	"github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/pkg/fetcher"
-	"golang.org/x/oauth2"
 	"golang.org/x/term"
 )
 
@@ -56,7 +54,7 @@ func Run(ctx context.Context, starter StarterTemplate, fsys afero.Fs, options ..
 	}
 	// 0. Download starter template
 	if len(starter.Url) > 0 {
-		client := GetGtihubClient(ctx)
+		client := utils.GetGtihubClient(ctx)
 		if err := downloadSample(ctx, client, starter.Url, fsys); err != nil {
 			return err
 		}
@@ -285,26 +283,6 @@ func parseExampleEnv(fsys afero.Fs) (map[string]string, error) {
 		return nil, errors.Errorf("failed to parse %s: %w", path, err)
 	}
 	return envs, nil
-}
-
-var (
-	githubClient *github.Client
-	clientOnce   sync.Once
-)
-
-func GetGtihubClient(ctx context.Context) *github.Client {
-	clientOnce.Do(func() {
-		var client *http.Client
-		token := os.Getenv("GITHUB_TOKEN")
-		if len(token) > 0 {
-			ts := oauth2.StaticTokenSource(
-				&oauth2.Token{AccessToken: token},
-			)
-			client = oauth2.NewClient(ctx, ts)
-		}
-		githubClient = github.NewClient(client)
-	})
-	return githubClient
 }
 
 type samplesRepo struct {

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -47,7 +47,6 @@ func Run(ctx context.Context, dryRun, ignoreVersionMismatch bool, includeRoles, 
 	} else {
 		msg := fmt.Sprintf("Do you want to push these migrations to the remote database?\n • %s\n\n", strings.Join(pending, "\n • "))
 		if shouldPush := utils.NewConsole().PromptYesNo(msg, true); !shouldPush {
-			utils.CmdSuggestion = ""
 			return errors.New(context.Canceled)
 		}
 		if includeRoles {

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -49,7 +49,6 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 	if !utils.IsLocalDatabase(config) {
 		msg := "Do you want to reset the remote database?"
 		if shouldReset := utils.NewConsole().PromptYesNo(msg, false); !shouldReset {
-			utils.CmdSuggestion = ""
 			return errors.New(context.Canceled)
 		}
 		return resetRemote(ctx, version, config, fsys, options...)

--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -48,7 +48,7 @@ func Run(ctx context.Context, slug string, fsys afero.Fs) error {
 		// Templatize index.ts by config.toml if available
 		utils.Config.Api.Port = 54321
 		if err := utils.LoadConfigFS(fsys); err != nil {
-			utils.CmdSuggestion = utils.SuggestDebugFlag
+			utils.CmdSuggestion = ""
 		}
 		config := indexConfig{
 			Port:  utils.Config.Api.Port,

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -64,7 +64,7 @@ func PostRun(projectRef string, stdout io.Writer, fsys afero.Fs) error {
 	if updatedConfig.IsEmpty() {
 		return nil
 	}
-	fmt.Fprintln(os.Stderr, "Local config differs from linked project. Try updating", utils.Bold(utils.ConfigPath))
+	fmt.Fprintln(os.Stderr, utils.Yellow("Warning:"), "Local config differs from linked project. Try updating", utils.Bold(utils.ConfigPath))
 	enc := toml.NewEncoder(stdout)
 	enc.Indent = ""
 	if err := enc.Encode(updatedConfig); err != nil {

--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -37,7 +37,6 @@ func Run(ctx context.Context, config pgconn.Config, version []string, status str
 	if repairAll {
 		msg := "Do you want to repair the entire migration history table to match local migration files?"
 		if shouldRepair := utils.NewConsole().PromptYesNo(msg, false); !shouldRepair {
-			utils.CmdSuggestion = ""
 			return errors.New(context.Canceled)
 		}
 		local, err := list.LoadLocalVersions(fsys)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -187,6 +187,7 @@ var (
 	GotrueVersionPath     = filepath.Join(TempDir, "gotrue-version")
 	RestVersionPath       = filepath.Join(TempDir, "rest-version")
 	StorageVersionPath    = filepath.Join(TempDir, "storage-version")
+	CliVersionPath        = filepath.Join(TempDir, "cli-latest")
 	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
 	SchemasDir            = filepath.Join(SupabaseDirPath, "schemas")
 	MigrationsDir         = filepath.Join(SupabaseDirPath, "migrations")

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/google/go-github/v62/github"
+	"golang.org/x/oauth2"
+)
+
+var (
+	githubClient *github.Client
+	githubOnce   sync.Once
+)
+
+func GetGtihubClient(ctx context.Context) *github.Client {
+	githubOnce.Do(func() {
+		var client *http.Client
+		token := os.Getenv("GITHUB_TOKEN")
+		if len(token) > 0 {
+			ts := oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: token},
+			)
+			client = oauth2.NewClient(ctx, ts)
+		}
+		githubClient = github.NewClient(client)
+	})
+	return githubClient
+}

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/go-errors/errors"
 	"github.com/google/go-github/v62/github"
 	"golang.org/x/oauth2"
 )
@@ -28,4 +29,21 @@ func GetGtihubClient(ctx context.Context) *github.Client {
 		githubClient = github.NewClient(client)
 	})
 	return githubClient
+}
+
+const (
+	CLI_OWNER = "supabase"
+	CLI_REPO  = "cli"
+)
+
+func GetLatestRelease(ctx context.Context) (string, error) {
+	client := GetGtihubClient(ctx)
+	release, _, err := client.Repositories.GetLatestRelease(ctx, CLI_OWNER, CLI_REPO)
+	if err != nil {
+		return "", errors.Errorf("Failed to fetch latest release: %w", err)
+	}
+	if release.TagName == nil {
+		return "", nil
+	}
+	return *release.TagName, nil
 }

--- a/internal/utils/release_test.go
+++ b/internal/utils/release_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-errors/errors"
+	"github.com/google/go-github/v62/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestLatestRelease(t *testing.T) {
+	t.Run("fetches latest release", func(t *testing.T) {
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New("https://api.github.com").
+			Get("/repos/supabase/cli/releases/latest").
+			Reply(http.StatusOK).
+			JSON(github.RepositoryRelease{TagName: Ptr("v2")})
+		// Run test
+		version, err := GetLatestRelease(context.Background())
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, version, "v2")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("ignores missing version", func(t *testing.T) {
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New("https://api.github.com").
+			Get("/repos/supabase/cli/releases/latest").
+			Reply(http.StatusOK).
+			JSON(github.RepositoryRelease{})
+		// Run test
+		version, err := GetLatestRelease(context.Background())
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, version)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on network error", func(t *testing.T) {
+		errNetwork := errors.New("network error")
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New("https://api.github.com").
+			Get("/repos/supabase/cli/releases/latest").
+			ReplyError(errNetwork)
+		// Run test
+		version, err := GetLatestRelease(context.Background())
+		// Check error
+		assert.ErrorIs(t, err, errNetwork)
+		assert.Empty(t, version)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}

--- a/tools/bumpdoc/main.go
+++ b/tools/bumpdoc/main.go
@@ -11,7 +11,8 @@ import (
 	"os/signal"
 	"regexp"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v62/github"
+	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/tools/shared"
 )
 
@@ -45,7 +46,7 @@ func updateRefDoc(ctx context.Context, path string, stdin io.Reader) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "Updating reference doc: %s\n", path)
-	client := shared.NewGtihubClient(ctx)
+	client := utils.GetGtihubClient(ctx)
 	branch := "cli/ref-doc"
 	master := "master"
 	if err := shared.CreateGitBranch(ctx, client, SUPABASE_OWNER, SUPABASE_REPO, branch, master); err != nil {

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -17,11 +17,6 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-const (
-	SUPABASE_OWNER = "supabase"
-	SUPABASE_REPO  = "cli"
-)
-
 func main() {
 	slackChannel := ""
 	if len(os.Args) > 1 {
@@ -36,7 +31,7 @@ func main() {
 
 func showChangeLog(ctx context.Context, slackChannel string) error {
 	client := utils.GetGtihubClient(ctx)
-	releases, _, err := client.Repositories.ListReleases(ctx, SUPABASE_OWNER, SUPABASE_REPO, &github.ListOptions{})
+	releases, _, err := client.Repositories.ListReleases(ctx, utils.CLI_OWNER, utils.CLI_REPO, &github.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -53,7 +48,7 @@ func showChangeLog(ctx context.Context, slackChannel string) error {
 		opts.TagName = "v1.0.0"
 	}
 	fmt.Fprintln(os.Stderr, "Generating changelog for", opts.TagName)
-	notes, _, err := client.Repositories.GenerateReleaseNotes(ctx, SUPABASE_OWNER, SUPABASE_REPO, &opts)
+	notes, _, err := client.Repositories.GenerateReleaseNotes(ctx, utils.CLI_OWNER, utils.CLI_REPO, &opts)
 	if err != nil {
 		return err
 	}

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v62/github"
 	"github.com/slack-go/slack"
-	"github.com/supabase/cli/tools/shared"
+	"github.com/supabase/cli/internal/utils"
 )
 
 const (
@@ -35,7 +35,7 @@ func main() {
 }
 
 func showChangeLog(ctx context.Context, slackChannel string) error {
-	client := shared.NewGtihubClient(ctx)
+	client := utils.GetGtihubClient(ctx)
 	releases, _, err := client.Repositories.ListReleases(ctx, SUPABASE_OWNER, SUPABASE_REPO, &github.ListOptions{})
 	if err != nil {
 		return err

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -17,7 +17,8 @@ import (
 	"text/template"
 
 	"github.com/go-errors/errors"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v62/github"
+	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/tools/shared"
 )
 
@@ -66,7 +67,7 @@ func publishPackages(ctx context.Context, version string, beta bool) error {
 		config.Description += " (Beta)"
 		filename += "-beta"
 	}
-	client := shared.NewGtihubClient(ctx)
+	client := utils.GetGtihubClient(ctx)
 	if err := updatePackage(ctx, client, HOMEBREW_REPO, filename+".rb", brewFormulaTemplate, config); err != nil {
 		return err
 	}

--- a/tools/selfhost/main.go
+++ b/tools/selfhost/main.go
@@ -10,7 +10,7 @@ import (
 	"os/signal"
 	"strings"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v62/github"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/tools/shared"
 	"gopkg.in/yaml.v3"
@@ -42,7 +42,7 @@ type ComposeFile struct {
 }
 
 func updateSelfHosted(ctx context.Context, branch string) error {
-	client := shared.NewGtihubClient(ctx)
+	client := utils.GetGtihubClient(ctx)
 	master := "master"
 	if err := shared.CreateGitBranch(ctx, client, SUPABASE_OWNER, SUPABASE_REPO, branch, master); err != nil {
 		return err

--- a/tools/shared/github.go
+++ b/tools/shared/github.go
@@ -2,20 +2,10 @@ package shared
 
 import (
 	"context"
-	"os"
 	"strings"
 
-	"github.com/google/go-github/v53/github"
-	"golang.org/x/oauth2"
+	"github.com/google/go-github/v62/github"
 )
-
-func NewGtihubClient(ctx context.Context) *github.Client {
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-	return github.NewClient(tc)
-}
 
 func CreateGitBranch(ctx context.Context, client *github.Client, owner, repo, branch, base string) error {
 	master, _, err := client.Git.GetRef(ctx, owner, repo, "refs/heads/"+base)


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/2051

## What is the new behavior?

```
$ supabase --version
1.0.0
A new version of Supabase CLI is available: v1.167.4 (currently installed v1.0.0)
We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli
```

## Additional context

Add any other context or screenshots.
