### PR TITLE
feat: enable edge runtime inspector feature

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -155,7 +155,6 @@ func init() {
 	functionsServeCmd.Flags().Var(&policy, "policy", "Policy to the handling of incoming requests.")
 	functionsServeCmd.Flags().Bool("inspect-main", false, "Allow creating inspector for main worker.")
 	functionsServeCmd.MarkFlagsMutuallyExclusive("inspect", "inspect-mode")
-	functionsServeCmd.Flags().Uint64("wallclock-limit-sec", uint64(400), "Worker's wall clock limit in seconds. If 0 is specified, unlimited.")
 	cobra.CheckErr(functionsServeCmd.Flags().MarkHidden("all"))
 	functionsDownloadCmd.Flags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDownloadCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -126,7 +126,12 @@ var (
 			}
 
 			if value, err := cmd.Flags().GetUint64("wallclock-limit-sec"); err == nil {
-				runtimeOption.WallClockLimitSec = &value
+				if runtimeOption.InspectMode != nil && !cmd.Flags().Changed("wallclock-limit-sec") {
+					zero := uint64(0)
+					runtimeOption.WallClockLimitSec = &zero
+				} else {
+					runtimeOption.WallClockLimitSec = &value
+				}
 			}
 
 			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, runtimeOption, afero.NewOsFs())

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -56,8 +56,7 @@ var (
 		Value:   string(serve.PolicyDefault),
 	}
 	inspectMode = utils.EnumFlag{
-		Allowed: []string{"off", string(serve.InspectModeRun), string(serve.InspectModeBrk), string(serve.InspectModeWait)},
-		Value:   "off",
+		Allowed: []string{string(serve.InspectModeRun), string(serve.InspectModeBrk), string(serve.InspectModeWait)},
 	}
 
 	noVerifyJWT     = new(bool)
@@ -108,7 +107,7 @@ var (
 
 			runtimeOption.Policy = serve.Policy(policy.Value)
 
-			if inspectMode.Value == "off" {
+			if inspectMode.Value == "" {
 				if value, err := cmd.Flags().GetBool("inspect"); err == nil && value {
 					runtimeOption.InspectMode = &serve.InspectModeDefault
 				}

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/functions/delete"
@@ -49,6 +51,7 @@ var (
 	}
 
 	noVerifyJWT     = new(bool)
+	inspectorFlag   = new(serve.InspectorFlag)
 	useLegacyBundle bool
 	importMapPath   string
 
@@ -92,7 +95,26 @@ var (
 			if !cmd.Flags().Changed("no-verify-jwt") {
 				noVerifyJWT = nil
 			}
-			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, afero.NewOsFs())
+
+			if value, err := cmd.Flags().GetBool("inspect"); err == nil && value {
+				inspectorFlag.Str = "inspect"
+			} else if value, err := cmd.Flags().GetBool("inspect-brk"); err == nil && value {
+				inspectorFlag.Str = "inspect-brk"
+			} else if value, err := cmd.Flags().GetBool("inspect-wait"); err == nil && value {
+				inspectorFlag.Str = "inspect-brk"
+			} else {
+				inspectorFlag = nil
+			}
+
+			if value, err := cmd.Flags().GetBool("inspect-main"); err == nil && value {
+				if inspectorFlag == nil {
+					return fmt.Errorf("the following required one of the flags was not provided: [inspect inspect-brk inspect-wait]")
+				} else {
+					inspectorFlag.WithMain = true
+				}
+			}
+
+			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, inspectorFlag, afero.NewOsFs())
 		},
 	}
 )
@@ -109,6 +131,11 @@ func init() {
 	functionsServeCmd.Flags().StringVar(&envFilePath, "env-file", "", "Path to an env file to be populated to the Function environment.")
 	functionsServeCmd.Flags().StringVar(&importMapPath, "import-map", "", "Path to import map file.")
 	functionsServeCmd.Flags().Bool("all", true, "Serve all Functions")
+	functionsServeCmd.Flags().Bool("inspect", false, "Activate inspector")
+	functionsServeCmd.Flags().Bool("inspect-brk", false, "Activate inspector and wait for debugger to connect and break at the start of function")
+	functionsServeCmd.Flags().Bool("inspect-wait", false, "Activate inspector and wait for debugger to connect before running user code")
+	functionsServeCmd.Flags().Bool("inspect-main", false, "Allow creating inspector for main worker")
+	functionsServeCmd.MarkFlagsMutuallyExclusive("inspect", "inspect-brk", "inspect-wait")
 	cobra.CheckErr(functionsServeCmd.Flags().MarkHidden("all"))
 	functionsDownloadCmd.Flags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDownloadCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -118,11 +118,6 @@ var (
 				return fmt.Errorf("--inspect-main must be used with one of the following flags: [inspect inspect-mode]")
 			}
 
-			// TODO: remove wall clock option from flags since it's an env var
-			if runtimeOption.InspectMode != nil {
-				runtimeOption.WallClockLimitSec = utils.Ptr(uint64(0))
-			}
-
 			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, runtimeOption, afero.NewOsFs())
 		},
 	}

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -124,13 +124,9 @@ var (
 				}
 			}
 
-			if value, err := cmd.Flags().GetUint64("wallclock-limit-sec"); err == nil {
-				if runtimeOption.InspectMode != nil && !cmd.Flags().Changed("wallclock-limit-sec") {
-					zero := uint64(0)
-					runtimeOption.WallClockLimitSec = &zero
-				} else {
-					runtimeOption.WallClockLimitSec = &value
-				}
+			if runtimeOption.InspectMode != nil {
+				zero := uint64(0)
+				runtimeOption.WallClockLimitSec = &zero
 			}
 
 			return serve.Run(cmd.Context(), envFilePath, noVerifyJWT, importMapPath, runtimeOption, afero.NewOsFs())

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -101,7 +101,7 @@ var (
 			} else if value, err := cmd.Flags().GetBool("inspect-brk"); err == nil && value {
 				inspectorFlag.Str = "inspect-brk"
 			} else if value, err := cmd.Flags().GetBool("inspect-wait"); err == nil && value {
-				inspectorFlag.Str = "inspect-brk"
+				inspectorFlag.Str = "inspect-wait"
 			} else {
 				inspectorFlag = nil
 			}

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -56,8 +56,8 @@ var (
 		Value:   string(serve.PolicyDefault),
 	}
 	inspectMode = utils.EnumFlag{
-		Allowed: []string{string(serve.InspectModeRun), string(serve.InspectModeBrk), string(serve.InspectModeWait)},
-		Value:   string(serve.InspectModeDefault),
+		Allowed: []string{"off", string(serve.InspectModeRun), string(serve.InspectModeBrk), string(serve.InspectModeWait)},
+		Value:   "off",
 	}
 
 	noVerifyJWT     = new(bool)
@@ -108,8 +108,8 @@ var (
 
 			runtimeOption.Policy = serve.Policy(policy.Value)
 
-			if inspectMode.Value == string(serve.InspectModeDefault) {
-				if value, err := cmd.Flags().GetBool("inspect"); cmd.Flags().Changed("inspect-mode") || (err == nil && value) {
+			if inspectMode.Value == "off" {
+				if value, err := cmd.Flags().GetBool("inspect"); err == nil && value {
 					runtimeOption.InspectMode = &serve.InspectModeDefault
 				}
 			} else {

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -21,7 +21,7 @@ Serve all Functions locally.
    * By default, creating an inspector session for the main worker is not allowed, but this flag allows it.
    * Other behaviors follow the `inspect-mode` flag mentioned above.
 
-4. `--policy [ per_worker | oneshot ] (default per_worker)`
+### Policy
    * A value that indicates how the edge-runtime should forward incoming HTTP requests to the worker.
    * `per_worker` allows multiple HTTP requests to be forwarded to a worker that has already been created.
    * `oneshot` will force the worker to process a single HTTP request and then exit. (Debugging purpose, This is especially useful if you want to reflect changes you've made immediately.)

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -24,4 +24,4 @@ Serve all Functions locally.
 4. `--policy [ per_worker | oneshot ] (default per_worker)`
    * A value that indicates how the edge-runtime should forward incoming HTTP requests to the worker.
    * `per_worker` allows multiple HTTP requests to be forwarded to a worker that has already been created.
-   * `oneshot` will force the worker to process a single HTTP request and then exit. (Debugging purpose, This is especially useful if you want to reflect changes you've made immediately).
+   * `oneshot` will force the worker to process a single HTTP request and then exit. (Debugging purpose, This is especially useful if you want to reflect changes you've made immediately.)

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -9,7 +9,7 @@ Serve all Functions locally.
 1. `--inspect`
    * Alias of `--inspect-mode run`.
 
-2. `--inspect-mode [ off | run | brk | wait ] (default off)`
+2. `--inspect-mode [ run | brk | wait ]`
    * Activates the inspector capability.
    * The port used to listen to the Inspector session can be overridden in `supabase/config.toml` via the `inspector_port` property in the `edge_runtime` section.
    * `run` mode simply allows a connection without additional behavior. It is not ideal for short scripts, but it can be useful for long-running scripts where you might occasionally want to set breakpoints.

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -4,25 +4,24 @@ Serve all Functions locally.
 
 ### Debugging Your Code
 
-`supabase functions serve` command includes additional flags to assist developers in debugging using tools like `DevTools`. These flags are simple switches that can be used without extra input.
-
-However, these three flags are mutually exclusive, and only one can be selected.
-
-Note that the `--inspect-main` flag must be used in conjunction with one of these three flags.
+`supabase functions serve` command includes additional flags to assist developers in debugging using tools like `DevTools`.
 
 1. `--inspect`
+   * Alias of `--inspect-mode run`.
+
+2. `--inspect-mode [ run | brk | wait ]`
    * Activates the inspector capability.
-   * Simply allows a connection without additional actions.
-   * Not ideal for short scripts, but can be useful for long-running scripts where you might occasionally want to set breakpoints.
+   * The port used to listen to the Inspector session can be overridden in `supabase/config.toml` via the `inspector_port` property in the `edge_runtime` section.
+   * `run` mode simply allows a connection without additional behavior. It is not ideal for short scripts, but it can be useful for long-running scripts where you might occasionally want to set breakpoints.
+   * `brk` mode same as `run` mode, but additionally sets a breakpoint at the first line to pause script execution before any code runs.
+   * `wait` mode similar to `brk` mode, but instead of setting a breakpoint at the first line, it pauses script execution until an inspector session is connected.
 
-2. `--inspect-brk`
-   * Functions the same as `--inspect`, but additionally sets a breakpoint at the first line to pause script execution before any code runs.
+3. `--inspect-main`
+   * Can only be used when one of the above two flags is enabled.
+   * By default, creating an inspector session for the main worker is not allowed, but this flag allows it.
+   * Other behaviors follow the `inspect-mode` flag mentioned above.
 
-3. `--inspect-wait`
-   * Similar to `--inspect-brk`, but instead of setting a breakpoint at the first line, it pauses script execution until an inspector session is connected.
-
-#### Additional Flag
-* `--inspect-main`
-  * Can only be used when one of the above three flags is enabled.
-  * By default, creating an inspector session for the main worker is not allowed, but this flag allows it.
-  * Other behaviors follow the chosen flag among the three mentioned above.
+4. `--policy [ per_worker | oneshot ] (default per_worker)`
+   * A value that indicates how the edge-runtime should forward incoming HTTP requests to the worker.
+   * `per_worker` allows multiple HTTP requests to be forwarded to a worker that has already been created.
+   * `oneshot` will force the worker to process a single HTTP request and then exit. (Debugging purpose, This is especially useful if you want to reflect changes you've made immediately).

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -1,0 +1,28 @@
+## supabase-functions-serve
+
+Serve all Functions locally.
+
+### Debugging Your Code
+
+`supabase functions serve` command includes additional flags to assist developers in debugging using tools like `DevTools`. These flags are simple switches that can be used without extra input.
+
+However, these three flags are mutually exclusive, and only one can be selected.
+
+Note that the `--inspect-main` flag must be used in conjunction with one of these three flags.
+
+1. `--inspect`
+   * Activates the inspector capability.
+   * Simply allows a connection without additional actions.
+   * Not ideal for short scripts, but can be useful for long-running scripts where you might occasionally want to set breakpoints.
+
+2. `--inspect-brk`
+   * Functions the same as `--inspect`, but additionally sets a breakpoint at the first line to pause script execution before any code runs.
+
+3. `--inspect-wait`
+   * Similar to `--inspect-brk`, but instead of setting a breakpoint at the first line, it pauses script execution until an inspector session is connected.
+
+#### Additional Flag
+* `--inspect-main`
+  * Can only be used when one of the above three flags is enabled.
+  * By default, creating an inspector session for the main worker is not allowed, but this flag allows it.
+  * Other behaviors follow the chosen flag among the three mentioned above.

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -2,8 +2,6 @@
 
 Serve all Functions locally.
 
-### Debugging Your Code
-
 `supabase functions serve` command includes additional flags to assist developers in debugging using tools like `DevTools`.
 
 1. `--inspect`
@@ -11,7 +9,6 @@ Serve all Functions locally.
 
 2. `--inspect-mode [ run | brk | wait ]`
    * Activates the inspector capability.
-   * The port used to listen to the Inspector session can be overridden in `supabase/config.toml` via the `inspector_port` property in the `edge_runtime` section.
    * `run` mode simply allows a connection without additional behavior. It is not ideal for short scripts, but it can be useful for long-running scripts where you might occasionally want to set breakpoints.
    * `brk` mode same as `run` mode, but additionally sets a breakpoint at the first line to pause script execution before any code runs.
    * `wait` mode similar to `brk` mode, but instead of setting a breakpoint at the first line, it pauses script execution until an inspector session is connected.
@@ -21,7 +18,11 @@ Serve all Functions locally.
    * By default, creating an inspector session for the main worker is not allowed, but this flag allows it.
    * Other behaviors follow the `inspect-mode` flag mentioned above.
 
-### Policy
+Additionally, the following properties can be customised via `supabase/config.toml` under `edge_runtime` section.
+
+1. `inspector_port`
+   * The port used to listen to the Inspector session, defaults to 8083.
+2. `policy`
    * A value that indicates how the edge-runtime should forward incoming HTTP requests to the worker.
    * `per_worker` allows multiple HTTP requests to be forwarded to a worker that has already been created.
    * `oneshot` will force the worker to process a single HTTP request and then exit. (Debugging purpose, This is especially useful if you want to reflect changes you've made immediately.)

--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -9,7 +9,7 @@ Serve all Functions locally.
 1. `--inspect`
    * Alias of `--inspect-mode run`.
 
-2. `--inspect-mode [ run | brk | wait ]`
+2. `--inspect-mode [ off | run | brk | wait ] (default off)`
    * Activates the inspector capability.
    * The port used to listen to the Inspector session can be overridden in `supabase/config.toml` via the `inspector_port` property in the `edge_runtime` section.
    * `run` mode simply allows a connection without additional behavior. It is not ideal for short scripts, but it can be useful for long-running scripts where you might occasionally want to set breakpoints.

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -181,7 +181,7 @@ EOF
 	portBindings := nat.PortMap{}
 	if inspectorFlag != nil {
 		portStr := fmt.Sprintf("%d/tcp", dockerInternalInspectorPort)
-		hostPort := strconv.FormatUint(uint64(utils.Config.Experimental.FunctionsInspectorPort), 10)
+		hostPort := strconv.FormatUint(uint64(utils.Config.EdgeRuntime.InspectorPort), 10)
 		exposedPorts[nat.Port(portStr)] = struct{}{}
 		portBindings[nat.Port(portStr)] = []nat.PortBinding{{HostPort: hostPort}}
 	}

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -149,7 +149,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	if viper.GetBool("DEBUG") {
 		env = append(env, "SUPABASE_INTERNAL_DEBUG=true")
 	}
-	if runtimeOption.WallClockLimitSec != nil {
+	if runtimeOption != nil && runtimeOption.WallClockLimitSec != nil {
 		env = append(env, fmt.Sprintf("SUPABASE_INTERNAL_WALLCLOCK_LIMIT_SEC=%d", *runtimeOption.WallClockLimitSec))
 	}
 	// 3. Parse custom import map
@@ -215,7 +215,7 @@ EOF
 
 	exposedPorts := nat.PortSet{"8081/tcp": {}}
 	portBindings := nat.PortMap{}
-	if runtimeOption.InspectMode != nil {
+	if runtimeOption != nil && runtimeOption.InspectMode != nil {
 		portStr := fmt.Sprintf("%d/tcp", dockerInternalInspectorPort)
 		hostPort := strconv.FormatUint(uint64(utils.Config.EdgeRuntime.InspectorPort), 10)
 		exposedPorts[nat.Port(portStr)] = struct{}{}

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -42,24 +42,16 @@ func (mode InspectMode) toFlag() string {
 	}
 }
 
-type Policy string
-
-const (
-	PolicyPerWorker Policy = "per_worker"
-	PolicyOneshot   Policy = "oneshot"
-)
-
 type RuntimeOption struct {
-	Policy            Policy
-	InspectMode       *InspectMode
-	WithInspectorMain bool
+	InspectMode *InspectMode
+	InspectMain bool
 }
 
 func (i *RuntimeOption) toArgs() []string {
-	flags := []string{fmt.Sprintf("--policy=%s", i.Policy)}
+	flags := []string{}
 	if i.InspectMode != nil {
 		flags = append(flags, fmt.Sprintf("--%s=0.0.0.0:%d", i.InspectMode.toFlag(), dockerRuntimeInspectorPort))
-		if i.WithInspectorMain {
+		if i.InspectMain {
 			flags = append(flags, "--inspect-main")
 		}
 	}
@@ -193,6 +185,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		"start",
 		"--main-service=.",
 		fmt.Sprintf("--port=%d", dockerRuntimeServerPort),
+		fmt.Sprintf("--policy=%s", utils.Config.EdgeRuntime.Policy),
 	}, runtimeOption.toArgs()...)
 	if viper.GetBool("DEBUG") {
 		cmd = append(cmd, "--verbose")
@@ -288,7 +281,6 @@ func populatePerFunctionConfigs(binds []string, importMapPath string, noVerifyJW
 		}
 
 		// CLI flags take priority over config.toml.
-
 		dockerImportMapPath := dockerFallbackImportMapPath
 		if importMapPath != "" {
 			dockerImportMapPath = dockerFlagImportMapPath

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -144,6 +144,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		"SUPABASE_DB_URL=" + dbUrl,
 		"SUPABASE_INTERNAL_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
 		fmt.Sprintf("SUPABASE_INTERNAL_HOST_PORT=%d", utils.Config.Api.Port),
+		"SUPABASE_INTERNAL_FUNCTIONS_PATH=" + utils.DockerFuncDirPath,
 	}
 	if viper.GetBool("DEBUG") {
 		env = append(env, "SUPABASE_INTERNAL_DEBUG=true")

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -36,7 +36,7 @@ func TestServeCommand(t *testing.T) {
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "success"))
 		// Run test
 		noVerifyJWT := true
-		err := Run(context.Background(), ".env", &noVerifyJWT, "", fsys)
+		err := Run(context.Background(), ".env", &noVerifyJWT, "", nil, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -46,7 +46,7 @@ func TestServeCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), "", nil, "", fsys)
+		err := Run(context.Background(), "", nil, "", nil, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "open supabase/config.toml: file does not exist")
 	})
@@ -62,7 +62,7 @@ func TestServeCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
 			Reply(http.StatusNotFound)
 		// Run test
-		err := Run(context.Background(), "", nil, "", fsys)
+		err := Run(context.Background(), "", nil, "", nil, fsys)
 		// Check error
 		assert.ErrorIs(t, err, utils.ErrNotRunning)
 	})
@@ -79,7 +79,7 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), ".env", nil, "", fsys)
+		err := Run(context.Background(), ".env", nil, "", nil, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "open .env: file does not exist")
 	})
@@ -97,7 +97,7 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), ".env", nil, "import_map.json", fsys)
+		err := Run(context.Background(), ".env", nil, "import_map.json", nil, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to read import map")
 		assert.ErrorContains(t, err, "file does not exist")

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -36,7 +36,7 @@ func TestServeCommand(t *testing.T) {
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "success"))
 		// Run test
 		noVerifyJWT := true
-		err := Run(context.Background(), ".env", &noVerifyJWT, "", nil, fsys)
+		err := Run(context.Background(), ".env", &noVerifyJWT, "", RuntimeOption{}, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -46,7 +46,7 @@ func TestServeCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), "", nil, "", nil, fsys)
+		err := Run(context.Background(), "", nil, "", RuntimeOption{}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "open supabase/config.toml: file does not exist")
 	})
@@ -62,7 +62,7 @@ func TestServeCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
 			Reply(http.StatusNotFound)
 		// Run test
-		err := Run(context.Background(), "", nil, "", nil, fsys)
+		err := Run(context.Background(), "", nil, "", RuntimeOption{}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, utils.ErrNotRunning)
 	})
@@ -79,7 +79,7 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), ".env", nil, "", nil, fsys)
+		err := Run(context.Background(), ".env", nil, "", RuntimeOption{}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "open .env: file does not exist")
 	})
@@ -97,7 +97,7 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), ".env", nil, "import_map.json", nil, fsys)
+		err := Run(context.Background(), ".env", nil, "import_map.json", RuntimeOption{}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Failed to read import map")
 		assert.ErrorContains(t, err, "file does not exist")

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -142,7 +142,7 @@ Deno.serve({
     console.error(`serving the request with ${servicePath}`);
 
     const memoryLimitMb = 150;
-    const workerTimeoutMs = !isNaN(WALLCLOCK_LIMIT_SEC) && isFinite(WALLCLOCK_LIMIT_SEC) ? WALLCLOCK_LIMIT_SEC * 1000 : 400 * 1000;
+    const workerTimeoutMs = isFinite(WALLCLOCK_LIMIT_SEC) ? WALLCLOCK_LIMIT_SEC * 1000 : 400 * 1000;
     const noModuleCache = false;
     const envVarsObj = Deno.env.toObject();
     const envVars = Object.entries(envVarsObj)

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -117,6 +117,12 @@ Deno.serve({
       return getResponse({ message: "ok" }, STATUS_CODE.OK);
     }
 
+    // handle metrics
+    if (pathname === '/_internal/metric') {
+      const metric = await EdgeRuntime.getRuntimeMetrics();
+      return Response.json(metric);
+    }
+
     const pathParts = pathname.split("/");
     const functionName = pathParts[1];
 

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -34,6 +34,8 @@ const FUNCTIONS_CONFIG_STRING = Deno.env.get(
   "SUPABASE_INTERNAL_FUNCTIONS_CONFIG",
 )!;
 
+const WALLCLOCK_LIMIT_SEC = parseInt(Deno.env.get("SUPABASE_INTERNAL_WALLCLOCK_LIMIT_SEC"));
+
 const DENO_SB_ERROR_MAP = new Map([
   [Deno.errors.InvalidWorkerCreation, SB_SPECIFIC_ERROR_CODE.BootError],
   [Deno.errors.InvalidWorkerResponse, SB_SPECIFIC_ERROR_CODE.WorkerLimit],
@@ -140,7 +142,7 @@ Deno.serve({
     console.error(`serving the request with ${servicePath}`);
 
     const memoryLimitMb = 150;
-    const workerTimeoutMs = 400 * 1000;
+    const workerTimeoutMs = !isNaN(WALLCLOCK_LIMIT_SEC) && isFinite(WALLCLOCK_LIMIT_SEC) ? WALLCLOCK_LIMIT_SEC * 1000 : 400 * 1000;
     const noModuleCache = false;
     const envVarsObj = Deno.env.toObject();
     const envVars = Object.entries(envVarsObj)

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -150,7 +150,7 @@ Deno.serve({
         !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_")
       );
 
-    const forceCreate = true;
+    const forceCreate = false;
     const customModuleRoot = ""; // empty string to allow any local path
     const cpuTimeSoftLimitMs = 1000;
     const cpuTimeHardLimitMs = 2000;

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -816,7 +816,7 @@ EOF
 	// Start all functions.
 	if utils.Config.EdgeRuntime.Enabled && !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
 		dbUrl := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database)
-		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, nil, w, fsys); err != nil {
+		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, serve.RuntimeOption{}, w, fsys); err != nil {
 			return err
 		}
 		started = append(started, utils.EdgeRuntimeId)

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -816,7 +816,7 @@ EOF
 	// Start all functions.
 	if utils.Config.EdgeRuntime.Enabled && !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
 		dbUrl := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database)
-		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, w, fsys); err != nil {
+		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, nil, w, fsys); err != nil {
 			return err
 		}
 		started = append(started, utils.EdgeRuntimeId)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -159,6 +159,13 @@ func (c CustomClaims) NewToken() *jwt.Token {
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, c)
 }
 
+type RequestPolicy string
+
+const (
+	PolicyPerWorker RequestPolicy = "per_worker"
+	PolicyOneshot   RequestPolicy = "oneshot"
+)
+
 var Config = config{
 	Api: api{
 		Image: PostgrestImage,
@@ -441,8 +448,9 @@ type (
 	}
 
 	edgeRuntime struct {
-		Enabled       bool   `toml:"enabled"`
-		InspectorPort uint16 `toml:"inspector_port"`
+		Enabled       bool          `toml:"enabled"`
+		Policy        RequestPolicy `toml:"policy"`
+		InspectorPort uint16        `toml:"inspector_port"`
 	}
 
 	function struct {
@@ -770,10 +778,15 @@ func LoadConfigFS(fsys afero.Fs) error {
 		}
 	}
 	// Validate functions config
+	if Config.EdgeRuntime.Enabled {
+		allowed := []RequestPolicy{PolicyPerWorker, PolicyOneshot}
+		if !SliceContains(allowed, Config.EdgeRuntime.Policy) {
+			return errors.Errorf("Invalid config for edge_runtime.policy. Must be one of: %v", allowed)
+		}
+	}
 	for name, functionConfig := range Config.Functions {
 		if functionConfig.VerifyJWT == nil {
-			verifyJWT := true
-			functionConfig.VerifyJWT = &verifyJWT
+			functionConfig.VerifyJWT = Ptr(true)
 			Config.Functions[name] = functionConfig
 		}
 	}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -441,7 +441,8 @@ type (
 	}
 
 	edgeRuntime struct {
-		Enabled bool `toml:"enabled"`
+		Enabled       bool   `toml:"enabled"`
+		InspectorPort uint16 `toml:"inspector_port"`
 	}
 
 	function struct {
@@ -461,12 +462,11 @@ type (
 	}
 
 	experimental struct {
-		OrioleDBVersion        string `toml:"orioledb_version"`
-		S3Host                 string `toml:"s3_host"`
-		S3Region               string `toml:"s3_region"`
-		S3AccessKey            string `toml:"s3_access_key"`
-		S3SecretKey            string `toml:"s3_secret_key"`
-		FunctionsInspectorPort uint16 `toml:"functions_inspector_port"`
+		OrioleDBVersion string `toml:"orioledb_version"`
+		S3Host          string `toml:"s3_host"`
+		S3Region        string `toml:"s3_region"`
+		S3AccessKey     string `toml:"s3_access_key"`
+		S3SecretKey     string `toml:"s3_secret_key"`
 	}
 
 	// TODO

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -461,11 +461,12 @@ type (
 	}
 
 	experimental struct {
-		OrioleDBVersion string `toml:"orioledb_version"`
-		S3Host          string `toml:"s3_host"`
-		S3Region        string `toml:"s3_region"`
-		S3AccessKey     string `toml:"s3_access_key"`
-		S3SecretKey     string `toml:"s3_secret_key"`
+		OrioleDBVersion        string `toml:"orioledb_version"`
+		S3Host                 string `toml:"s3_host"`
+		S3Region               string `toml:"s3_region"`
+		S3AccessKey            string `toml:"s3_access_key"`
+		S3SecretKey            string `toml:"s3_secret_key"`
+		FunctionsInspectorPort uint16 `toml:"functions_inspector_port"`
 	}
 
 	// TODO

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -152,6 +152,10 @@ skip_nonce_check = true
 
 [edge_runtime]
 enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "per_worker"
+inspector_port = 8083
 
 [analytics]
 enabled = false

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -152,6 +152,9 @@ skip_nonce_check = false
 
 [edge_runtime]
 enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
 inspector_port = 8083
 
 [analytics]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -172,3 +172,4 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+functions_inspector_port = 8083

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -152,6 +152,7 @@ skip_nonce_check = false
 
 [edge_runtime]
 enabled = true
+inspector_port = 8083
 
 [analytics]
 enabled = false
@@ -172,4 +173,3 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
-functions_inspector_port = 8083


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature
closes https://github.com/supabase/cli/issues/2311
closes https://github.com/supabase/edge-runtime/issues/212

## Description
This PR introduces several flags to the `supabase functions serve` command to enable the inspector capability of edge-runtime.

See the [doc](https://github.com/supabase/cli/blob/a20368fc36857eb25dae07c93f6c8d23fc2d359c/docs/supabase/functions/serve.md) added to this PR for about these flags.