### PR TITLE
fix(config): support disabling edge runtime from toml

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -814,7 +814,7 @@ EOF
 	}
 
 	// Start all functions.
-	if !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
+	if utils.Config.EdgeRuntime.Enabled && !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
 		dbUrl := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database)
 		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, w, fsys); err != nil {
 			return err
@@ -957,10 +957,8 @@ EOF
 
 func isContainerExcluded(imageName string, excluded map[string]bool) bool {
 	short := utils.ShortContainerImageName(imageName)
-	if val, ok := excluded[short]; ok && val {
-		return true
-	}
-	return false
+	val, ok := excluded[short]
+	return ok && val
 }
 
 func ExcludableContainers() []string {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -258,6 +258,7 @@ type (
 		Inbucket     inbucket            `toml:"inbucket"`
 		Storage      storage             `toml:"storage"`
 		Auth         auth                `toml:"auth" mapstructure:"auth"`
+		EdgeRuntime  edgeRuntime         `toml:"edge_runtime"`
 		Functions    map[string]function `toml:"functions"`
 		Analytics    analytics           `toml:"analytics"`
 		Experimental experimental        `toml:"experimental" mapstructure:"-"`
@@ -431,6 +432,10 @@ type (
 		Url            string `toml:"url"`
 		RedirectUri    string `toml:"redirect_uri"`
 		SkipNonceCheck bool   `toml:"skip_nonce_check"`
+	}
+
+	edgeRuntime struct {
+		Enabled bool `toml:"enabled"`
 	}
 
 	function struct {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -56,14 +56,17 @@ var ServiceImages = []string{
 	KongImage,
 	InbucketImage,
 	PostgrestImage,
-	DifferImage,
-	MigraImage,
 	PgmetaImage,
 	StudioImage,
 	EdgeRuntimeImage,
 	LogflareImage,
 	VectorImage,
 	PgbouncerImage,
+}
+
+var JobImages = []string{
+	DifferImage,
+	MigraImage,
 	PgProveImage,
 }
 

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -150,6 +150,9 @@ url = "https://login.microsoftonline.com/tenant"
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = true
 
+[edge_runtime]
+enabled = true
+
 [analytics]
 enabled = false
 port = 54327

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -150,6 +150,9 @@ url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
 
+[edge_runtime]
+enabled = true
+
 [analytics]
 enabled = false
 port = 54327


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1414

## What is the current behavior?

Not possible to disable edge runtime from config.toml

## What is the new behavior?

Adds `[edge_runtime]` block to config.


## Additional context

Add any other context or screenshots.
