### PR TITLE
fix: bump edge-runtime to 1.53.2

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240514-6f5cabd"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.1"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.2"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.53.2

### Changes

#### Bug Fixes

* change the status code emitted when an idle timeout occurs for a worker ([#349](https://github.com/supabase/edge-runtime/issues/349)) ([8ff5c47](https://github.com/supabase/edge-runtime/commit/8ff5c479d2deecd043e234277a74d407904bdebb))
* relaxing the condition which can be activated inspector feature ([#348](https://github.com/supabase/edge-runtime/issues/348)) ([0edba27](https://github.com/supabase/edge-runtime/commit/0edba27680e83333f7ea03ba16c17b1943a2a4b1))
