### PR TITLE
chore: suggest init force when config exists

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -34,6 +34,9 @@ var (
 func Run(ctx context.Context, fsys afero.Fs, createVscodeSettings, createIntellijSettings *bool, params utils.InitParams) error {
 	// 1. Write `config.toml`.
 	if err := utils.InitConfig(params, fsys); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			utils.CmdSuggestion = fmt.Sprintf("Run %s to overwrite existing config file.", utils.Aqua("supabase init --force"))
+		}
 		return err
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

```
$ supabase init
failed to create config file: open supabase/config.toml: file exists
Run supabase init --force to overwrite existing config file.
exit status 1
```

## Additional context

Add any other context or screenshots.
