### PR TITLE
fix: bump edge-runtime to 1.53.3

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240514-6f5cabd"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.2"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.3"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	PgbouncerImage   = "bitnami/pgbouncer:1.20.1-debian-11-r39"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.53.3

### Changes

#### Bug Fixes

* don't emit `RequestCancelledBySupervisor` when event loop error has been raised ([#350](https://github.com/supabase/edge-runtime/issues/350)) ([e27ffca](https://github.com/supabase/edge-runtime/commit/e27ffcac24577b3b4d6ba7347d042650b8c92f5a))