### PR TITLE
fix: add _analytics and _realtime to managed schemas

### DIFF
--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -35,6 +35,8 @@ var dbConfig = pgconn.Config{
 }
 
 var escapedSchemas = []string{
+	`\_analytics`,
+	`\_realtime`,
 	"pgbouncer",
 	"pgsodium",
 	"pgtle",

--- a/internal/db/pull/pull_test.go
+++ b/internal/db/pull/pull_test.go
@@ -30,6 +30,8 @@ var dbConfig = pgconn.Config{
 }
 
 var escapedSchemas = []string{
+	`\_analytics`,
+	`\_realtime`,
 	"pgbouncer",
 	"pgsodium",
 	"pgtle",

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -306,6 +306,8 @@ func TestRestartDatabase(t *testing.T) {
 var escapedSchemas = []string{
 	"extensions",
 	"public",
+	`\_analytics`,
+	`\_realtime`,
 	"pgbouncer",
 	"pgsodium",
 	"pgtle",

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -116,6 +116,8 @@ var (
 	}
 	// Initialised by postgres image and owned by postgres role
 	ManagedSchemas = append([]string{
+		"_analytics",
+		"_realtime",
 		"pgbouncer",
 		"pgsodium",
 		"pgtle",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/supabase/issues/26245

## What is the new behavior?

`_analytics` and `_realtime` schemas are local only.

## Additional context

Add any other context or screenshots.
