### PR TITLE
feat: support local override of studio and pgmeta image

### DIFF
--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 	return utils.DockerRunOnceWithConfig(
 		ctx,
 		container.Config{
-			Image: utils.PgmetaImage,
+			Image: utils.Config.Studio.PgmetaImage,
 			Env: []string{
 				"PG_META_DB_URL=" + escaped,
 				"PG_META_GENERATE_TYPES=typescript",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -823,11 +823,11 @@ EOF
 	}
 
 	// Start pg-meta.
-	if utils.Config.Studio.Enabled && !isContainerExcluded(utils.PgmetaImage, excluded) {
+	if utils.Config.Studio.Enabled && !isContainerExcluded(utils.Config.Studio.PgmetaImage, excluded) {
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.PgmetaImage,
+				Image: utils.Config.Studio.PgmetaImage,
 				Env: []string{
 					"PG_META_PORT=8080",
 					"PG_META_DB_HOST=" + dbConfig.Host,
@@ -861,11 +861,11 @@ EOF
 	}
 
 	// Start Studio.
-	if utils.Config.Studio.Enabled && !isContainerExcluded(utils.StudioImage, excluded) {
+	if utils.Config.Studio.Enabled && !isContainerExcluded(utils.Config.Studio.Image, excluded) {
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.StudioImage,
+				Image: utils.Config.Studio.Image,
 				Env: []string{
 					"STUDIO_PG_META_URL=http://" + utils.PgmetaId + ":8080",
 					"POSTGRES_PASSWORD=" + dbConfig.Password,

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -38,7 +38,7 @@ func (c *CustomName) toValues(exclude ...string) map[string]string {
 		values[c.ApiURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Api.Port)
 		values[c.GraphqlURL] = fmt.Sprintf("http://%s:%d/graphql/v1", utils.Config.Hostname, utils.Config.Api.Port)
 	}
-	if utils.Config.Studio.Enabled && !utils.SliceContains(exclude, utils.StudioId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.StudioImage)) {
+	if utils.Config.Studio.Enabled && !utils.SliceContains(exclude, utils.StudioId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.Config.Studio.Image)) {
 		values[c.StudioURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Studio.Port)
 	}
 	if utils.Config.Auth.Enabled && !utils.SliceContains(exclude, utils.GotrueId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.Config.Auth.Image)) {

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -192,6 +192,8 @@ var (
 	GotrueVersionPath     = filepath.Join(TempDir, "gotrue-version")
 	RestVersionPath       = filepath.Join(TempDir, "rest-version")
 	StorageVersionPath    = filepath.Join(TempDir, "storage-version")
+	StudioVersionPath     = filepath.Join(TempDir, "studio-version")
+	PgmetaVersionPath     = filepath.Join(TempDir, "pgmeta-version")
 	CliVersionPath        = filepath.Join(TempDir, "cli-latest")
 	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
 	SchemasDir            = filepath.Join(SupabaseDirPath, "schemas")


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature https://github.com/supabase/cli/issues/1702

## What is the current behavior?

No way to rollback studio / pgmeta releases.

## What is the new behavior?

Allow users to override the version of studio and pgmeta used by cli.
- pins pgmeta for stable typegen
- pins studio for ui fixes

## Additional context

Add any other context or screenshots.
