### PR TITLE
fix(db): exclude auth schema migrations table from linked reset

### DIFF
--- a/internal/db/reset/templates/drop.sql
+++ b/internal/db/reset/templates/drop.sql
@@ -38,7 +38,8 @@ begin
     select *
     from pg_class c
     where
-      c.relnamespace::regnamespace::name in ('auth', 'supabase_migrations')
+      (c.relnamespace::regnamespace::name = 'auth' and c.relname != 'schema_migrations'
+      or c.relnamespace::regnamespace::name = 'supabase_migrations')
       and c.relkind = 'r'
   loop
     execute format('truncate %I.%I restart identity cascade', rec.relnamespace::regnamespace::name, rec.relname);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/orgs/supabase/discussions/20722

## What is the new behavior?

Should not truncate `auth.schema_migrations` table when resetting.

## Additional context

Add any other context or screenshots.
