### PR TITLE
fix: declare password flag for viper bind

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -65,7 +65,7 @@ var (
 
 func init() {
 	bootstrapFlags := bootstrapCmd.Flags()
-	bootstrapFlags.StringP("password", "p", "", "Password to your remote Postgres database.")
+	bootstrapFlags.StringVarP(&dbPassword, "password", "p", "", "Password to your remote Postgres database.")
 	cobra.CheckErr(viper.BindPFlag("DB_PASSWORD", bootstrapFlags.Lookup("password")))
 	rootCmd.AddCommand(bootstrapCmd)
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -45,7 +45,8 @@ var (
 func init() {
 	linkFlags := linkCmd.Flags()
 	linkFlags.StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
-	linkFlags.StringP("password", "p", "", "Password to your remote Postgres database.")
+	linkFlags.StringVarP(&dbPassword, "password", "p", "", "Password to your remote Postgres database.")
+	// For some reason, BindPFlag only works for StringVarP instead of StringP
 	cobra.CheckErr(viper.BindPFlag("DB_PASSWORD", linkFlags.Lookup("password")))
 	rootCmd.AddCommand(linkCmd)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2347

## What is the new behavior?

Reuse dbPassword variable to bind pflag.

## Additional context

Add any other context or screenshots.
