### PR TITLE
feat: support custom docker network id

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -241,6 +241,7 @@ func init() {
 	flags.Bool("debug", false, "output debug logs to stderr")
 	flags.String("workdir", "", "path to a Supabase project directory")
 	flags.Bool("experimental", false, "enable experimental features")
+	flags.String("network-id", "", "use the specified docker network instead of a generated one")
 	flags.Var(&utils.DNSResolver, "dns-resolver", "lookup domain names using the specified resolver")
 	flags.BoolVar(&createTicket, "create-ticket", false, "create a support ticket for any CLI error")
 	cobra.CheckErr(viper.BindPFlags(flags))

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -30,7 +30,7 @@ func DiffSchemaMigra(ctx context.Context, source, target string, schema []string
 			Cmd:   cmd,
 		},
 		container.HostConfig{
-			NetworkMode: container.NetworkMode("host"),
+			NetworkMode: network.NetworkHost,
 		},
 		network.NetworkingConfig{},
 		"",

--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -174,7 +174,7 @@ func dump(ctx context.Context, config pgconn.Config, script string, env []string
 			Cmd:   []string{"bash", "-c", script, "--"},
 		},
 		container.HostConfig{
-			NetworkMode: container.NetworkMode("host"),
+			NetworkMode: network.NetworkHost,
 		},
 		network.NetworkingConfig{},
 		"",

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -66,11 +66,12 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		}()
 	}
 	// Use custom network when connecting to local database
-	networkID := "host"
+	hostConfig := container.HostConfig{Binds: binds}
 	if utils.IsLocalDatabase(config) {
 		config.Host = utils.DbAliases[0]
 		config.Port = 5432
-		networkID = utils.NetId
+	} else {
+		hostConfig.NetworkMode = network.NetworkHost
 	}
 	// Run pg_prove on volume mount
 	return utils.DockerRunOnceWithConfig(
@@ -87,10 +88,7 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 			Cmd:        cmd,
 			WorkingDir: dstPath,
 		},
-		container.HostConfig{
-			NetworkMode: container.NetworkMode(networkID),
-			Binds:       binds,
-		},
+		hostConfig,
 		network.NetworkingConfig{},
 		"",
 		os.Stdout,

--- a/internal/gen/types/typescript/typescript.go
+++ b/internal/gen/types/typescript/typescript.go
@@ -40,7 +40,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 		return nil
 	}
 
-	networkID := "host"
+	hostConfig := container.HostConfig{}
 	if utils.IsLocalDatabase(dbConfig) {
 		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
 			return err
@@ -53,7 +53,8 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 		// Use custom network when connecting to local database
 		dbConfig.Host = utils.DbAliases[0]
 		dbConfig.Port = 5432
-		networkID = utils.NetId
+	} else {
+		hostConfig.NetworkMode = network.NetworkHost
 	}
 	// pg-meta does not set username as the default database, ie. postgres
 	if len(dbConfig.Database) == 0 {
@@ -81,9 +82,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 			},
 			Cmd: []string{"node", "dist/server/server.js"},
 		},
-		container.HostConfig{
-			NetworkMode: container.NetworkMode(networkID),
-		},
+		hostConfig,
 		network.NetworkingConfig{},
 		"",
 		os.Stdout,

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -15,7 +15,6 @@ func Run(ctx context.Context, backup bool, projectId string, fsys afero.Fs) erro
 	// Sanity checks.
 	if len(projectId) > 0 {
 		utils.Config.ProjectId = projectId
-		utils.UpdateDockerIds()
 	} else if err := utils.LoadConfigFS(fsys); err != nil {
 		return err
 	}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -74,7 +74,9 @@ func GetId(name string) string {
 }
 
 func UpdateDockerIds() {
-	NetId = GetId("network")
+	if NetId = viper.GetString("network-id"); len(NetId) == 0 {
+		NetId = GetId("network")
+	}
 	DbId = GetId(DbAliases[0])
 	ConfigId = GetId("config")
 	KongId = GetId(KongAliases[0])

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -257,11 +257,13 @@ func DockerStart(ctx context.Context, config container.Config, hostConfig contai
 	}
 	config.Labels[CliProjectLabel] = Config.ProjectId
 	config.Labels[composeProjectLabel] = Config.ProjectId
-	if len(hostConfig.NetworkMode) == 0 {
+	if networkId := viper.GetString("network-id"); len(networkId) > 0 {
+		hostConfig.NetworkMode = container.NetworkMode(networkId)
+	} else if len(hostConfig.NetworkMode) == 0 {
 		hostConfig.NetworkMode = container.NetworkMode(NetId)
 	}
 	// Create network with name
-	if hostConfig.NetworkMode.IsUserDefined() && hostConfig.NetworkMode.UserDefined() != "host" {
+	if hostConfig.NetworkMode.IsUserDefined() && hostConfig.NetworkMode.UserDefined() != network.NetworkHost {
 		if err := DockerNetworkCreateIfNotExists(ctx, hostConfig.NetworkMode.NetworkName()); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/2358
supersedes: https://github.com/supabase/cli/pull/1581

## What is the new behavior?

```
supabase start --network-id test-network
```

or 

```
SUPABASE_NETWORK_ID=test-network supabase test db --db-url <conn-string>
```

## Additional context

Add any other context or screenshots.
