### PR TITLE
chore: Bump up Realtime to 2.29.3

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -41,7 +41,7 @@ const (
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.151.0"
-	RealtimeImage    = "supabase/realtime:v2.28.32"
+	RealtimeImage    = "supabase/realtime:v2.29.3"
 	StorageImage     = "supabase/storage-api:v1.0.6"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up Realtime to 2.29.3