### PR TITLE
fix: remove z option from docker volume config

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		return errors.Errorf("failed to resolve absolute path: %w", err)
 	}
 	dstPath := "/tmp"
-	binds := []string{fmt.Sprintf("%s:%s:ro,z", srcPath, dstPath)}
+	binds := []string{fmt.Sprintf("%s:%s:ro", srcPath, dstPath)}
 	// Enable pgTAP if not already exists
 	alreadyExists := false
 	options = append(options, func(cc *pgx.ConnConfig) {

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -102,9 +102,9 @@ func bundleFunction(ctx context.Context, slug, dockerEntrypointPath, importMapPa
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts
 		// https://denolib.gitbook.io/guide/advanced/deno_dir-code-fetch-and-cache
-		utils.EdgeRuntimeId + ":/root/.cache/deno:rw,z",
-		filepath.Join(cwd, utils.FunctionsDir) + ":" + utils.DockerFuncDirPath + ":ro,z",
-		filepath.Join(cwd, hostOutputDir) + ":" + dockerOutputDir + ":rw,z",
+		utils.EdgeRuntimeId + ":/root/.cache/deno:rw",
+		filepath.Join(cwd, utils.FunctionsDir) + ":" + utils.DockerFuncDirPath + ":ro",
+		filepath.Join(cwd, hostOutputDir) + ":" + dockerOutputDir + ":rw",
 	}
 
 	cmd := []string{"bundle", "--entrypoint", dockerEntrypointPath, "--output", outputPath}

--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -176,9 +176,9 @@ func extractOne(ctx context.Context, slug, eszipPath string) error {
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts
 		// https://denolib.gitbook.io/guide/advanced/deno_dir-code-fetch-and-cache
-		utils.EdgeRuntimeId + ":/root/.cache/deno:rw,z",
-		hostEszipPath + ":" + dockerEszipPath + ":ro,z",
-		hostFuncDirPath + ":" + utils.DockerDenoDir + ":rw,z",
+		utils.EdgeRuntimeId + ":/root/.cache/deno:rw",
+		hostEszipPath + ":" + dockerEszipPath + ":ro",
+		hostFuncDirPath + ":" + utils.DockerDenoDir + ":rw",
 	}
 
 	return utils.DockerRunOnceWithConfig(

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -143,8 +143,8 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts
 		// https://denolib.gitbook.io/guide/advanced/deno_dir-code-fetch-and-cache
-		utils.EdgeRuntimeId + ":/root/.cache/deno:rw,z",
-		filepath.Join(cwd, utils.FunctionsDir) + ":" + utils.DockerFuncDirPath + ":rw,z",
+		utils.EdgeRuntimeId + ":/root/.cache/deno:rw",
+		filepath.Join(cwd, utils.FunctionsDir) + ":" + utils.DockerFuncDirPath + ":rw",
 	}
 	if importMapPath != "" {
 		modules, err := utils.BindImportMap(importMapPath, dockerFlagImportMapPath, fsys)

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -344,7 +344,7 @@ EOF
 				}
 			}
 			dockerPath := path.Join(nginxEmailTemplateDir, id+filepath.Ext(hostPath))
-			binds = append(binds, fmt.Sprintf("%s:%s:rw,z", hostPath, dockerPath))
+			binds = append(binds, fmt.Sprintf("%s:%s:rw", hostPath, dockerPath))
 		}
 
 		if _, err := utils.DockerStart(

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -259,14 +259,14 @@ func (m *ImportMap) BindModules(resolved ImportMap) []string {
 	for k, dockerPath := range resolved.Imports {
 		if strings.HasPrefix(dockerPath, DockerModsDir) {
 			hostPath := filepath.Join(cwd, FunctionsDir, m.Imports[k])
-			binds = append(binds, hostPath+":"+dockerPath+":ro,z")
+			binds = append(binds, hostPath+":"+dockerPath+":ro")
 		}
 	}
 	for module, mapping := range resolved.Scopes {
 		for k, dockerPath := range mapping {
 			if strings.HasPrefix(dockerPath, DockerModsDir) {
 				hostPath := filepath.Join(cwd, FunctionsDir, m.Scopes[module][k])
-				binds = append(binds, hostPath+":"+dockerPath+":ro,z")
+				binds = append(binds, hostPath+":"+dockerPath+":ro")
 			}
 		}
 	}
@@ -370,6 +370,6 @@ func BindImportMap(hostImportMapPath, dockerImportMapPath string, fsys afero.Fs)
 			return nil, err
 		}
 	}
-	binds = append(binds, hostImportMapPath+":"+dockerImportMapPath+":ro,z")
+	binds = append(binds, hostImportMapPath+":"+dockerImportMapPath+":ro")
 	return binds, nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/issues/265#issuecomment-1832282812

## What is the current behavior?

`z` volume option is not supported by podman on macOS because it's an extended filesystem attribute.

```
lsetxattr /Users/.../supabase/functions: operation not supported
```

## What is the new behavior?

Since we don't need to share volume between containers, it is safe to remove `z` volume option.

## Additional context

Add any other context or screenshots.
