### PR TITLE
fix: bump edge-runtime to 1.53.4

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.3"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.4"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.53.4

### Changes

#### Bug Fixes

* attaching inline source map into module code when inspect is enabled ([#356](https://github.com/supabase/edge-runtime/issues/356)) ([9b95ff3](https://github.com/supabase/edge-runtime/commit/9b95ff3f161aa78d089d74b6f296e380a4271a0d))
* include detailed memory metric in event record ([#354](https://github.com/supabase/edge-runtime/issues/354)) ([15407a7](https://github.com/supabase/edge-runtime/commit/15407a7da64589025dbcf7e5d4e3050c703c0354))