### PR TITLE
fix: show logs when failing to start database

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -368,7 +368,7 @@ type Downloader struct {
 
 func NewDownloader(concurrency uint, fsys afero.Fs) *Downloader {
 	return &Downloader{
-		api:   fetcher.NewFetcher(""),
+		api:   fetcher.NewFetcher("", fetcher.WithExpectedStatus(http.StatusOK)),
 		queue: utils.NewJobQueue(concurrency),
 		fsys:  fsys,
 	}

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -43,8 +43,8 @@ func Run(ctx context.Context, schema []string, file string, config pgconn.Config
 			return err
 		} else if len(container) > 0 {
 			defer utils.DockerRemove(container)
-			if !start.WaitForHealthyService(ctx, container, start.HealthTimeout) {
-				return errors.New(start.ErrDatabase)
+			if err := start.WaitForHealthyService(ctx, start.HealthTimeout, container); err != nil {
+				return err
 			}
 			if err := migrateBaseDatabase(ctx, container, fsys, options...); err != nil {
 				return err
@@ -206,8 +206,8 @@ func DiffDatabase(ctx context.Context, schema []string, config pgconn.Config, w 
 		return "", err
 	}
 	defer utils.DockerRemove(shadow)
-	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
-		return "", errors.New(start.ErrDatabase)
+	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+		return "", err
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys, options...); err != nil {
 		return "", err

--- a/internal/db/diff/pgadmin.go
+++ b/internal/db/diff/pgadmin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/start"
@@ -63,8 +62,8 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 		return err
 	}
 	defer utils.DockerRemove(shadow)
-	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
-		return errors.New(start.ErrDatabase)
+	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+		return err
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys); err != nil {
 		return err

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	utils.Config.Analytics.Enabled = false
 	err := StartDatabase(ctx, fsys, os.Stderr)
 	if err != nil {
-		if err := utils.DockerRemoveAll(context.Background()); err != nil {
+		if err := utils.DockerRemoveAll(context.Background(), os.Stderr); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}
@@ -166,11 +166,11 @@ func WaitForHealthyService(ctx context.Context, timeout time.Duration, started .
 		uint64(timeout.Seconds()),
 	), ctx)
 	err := backoff.Retry(probe, policy)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Print container logs for easier debugging
 		for _, containerId := range started {
 			fmt.Fprintln(os.Stderr, containerId, "container logs:")
-			if err := utils.DockerStreamLogsOnce(ctx, containerId, os.Stderr, os.Stderr); err != nil {
+			if err := utils.DockerStreamLogsOnce(context.Background(), containerId, os.Stderr, os.Stderr); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}
 		}

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -132,6 +132,9 @@ func pollForAccessToken(ctx context.Context, url string) (AccessTokenResponse, e
 	// TODO: Move to OpenAPI-generated http client once we reach v1 on API schema.
 	client := fetcher.NewFetcher(
 		utils.GetSupabaseAPIHost(),
+		fetcher.WithHTTPClient(&http.Client{
+			Timeout: 10 * time.Second,
+		}),
 		fetcher.WithExpectedStatus(http.StatusOK),
 	)
 	timeout := backoff.NewConstantBackOff(defaultRetryAfterSeconds)

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -90,8 +90,8 @@ func squashMigrations(ctx context.Context, migrations []string, fsys afero.Fs, o
 		return err
 	}
 	defer utils.DockerRemove(shadow)
-	if !start.WaitForHealthyService(ctx, shadow, start.HealthTimeout) {
-		return errors.New(start.ErrDatabase)
+	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+		return err
 	}
 	conn, err := diff.ConnectShadowDatabase(ctx, 10*time.Second, options...)
 	if err != nil {

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -218,6 +218,15 @@ func TestSquashMigrations(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Db.Image), "test-shadow-db")
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{
+					Running: false,
+					Status:  "exited",
+				},
+			}})
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db/logs").
 			Reply(http.StatusServiceUnavailable)
 		gock.New(utils.Docker.DaemonHost()).
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db").
@@ -225,7 +234,7 @@ func TestSquashMigrations(t *testing.T) {
 		// Run test
 		err := squashMigrations(context.Background(), nil, fsys)
 		// Check error
-		assert.ErrorIs(t, err, start.ErrDatabase)
+		assert.ErrorContains(t, err, "test-shadow-db container is not running: exited")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignore
 		if ignoreHealthCheck && start.IsUnhealthyError(err) {
 			fmt.Fprintln(os.Stderr, err)
 		} else {
-			if err := utils.DockerRemoveAll(context.Background()); err != nil {
+			if err := utils.DockerRemoveAll(context.Background(), os.Stderr); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}
 			return err

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -64,7 +64,7 @@ func Run(ctx context.Context, names CustomName, format string, fsys afero.Fs) er
 	if err := utils.LoadConfigFS(fsys); err != nil {
 		return err
 	}
-	if err := AssertContainerHealthy(ctx, utils.DbId); err != nil {
+	if err := assertContainerHealthy(ctx, utils.DbId); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func checkServiceHealth(ctx context.Context) ([]string, error) {
 	return stopped, nil
 }
 
-func AssertContainerHealthy(ctx context.Context, container string) error {
+func assertContainerHealthy(ctx context.Context, container string) error {
 	if resp, err := utils.Docker.ContainerInspect(ctx, container); err != nil {
 		return errors.Errorf("failed to inspect container health: %w", err)
 	} else if !resp.State.Running {
@@ -125,7 +125,7 @@ func IsServiceReady(ctx context.Context, container string) error {
 		// Native health check logs too much hyper::Error(IncompleteMessage)
 		return checkHTTPHead(ctx, "/functions/v1/_internal/health")
 	}
-	return AssertContainerHealthy(ctx, container)
+	return assertContainerHealthy(ctx, container)
 }
 
 func checkHTTPHead(ctx context.Context, path string) error {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -21,33 +19,28 @@ import (
 
 func TestStatusCommand(t *testing.T) {
 	t.Run("shows service status", func(t *testing.T) {
-		services := []string{
-			"supabase_db_",
-			"supabase_kong_",
-			"supabase_auth_",
-			"supabase_inbucket_",
-			"supabase_realtime_",
-			"supabase_rest_",
-			"supabase_storage_",
-			"supabase_imgproxy_",
-			"supabase_pg_meta_",
-			"supabase_studio_",
-			"supabase_analytics_",
+		var running []types.Container
+		for _, name := range utils.GetDockerIds() {
+			running = append(running, types.Container{
+				Names: []string{name + "_test"},
+			})
 		}
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
+		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test"}, fsys))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		for _, container := range services {
-			gock.New(utils.Docker.DaemonHost()).
-				Get("/v" + utils.Docker.ClientVersion() + "/containers/" + container).
-				Reply(http.StatusOK).
-				JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-					State: &types.ContainerState{Running: true},
-				}})
-		}
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Running: true},
+			}})
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON(running)
 		// Run test
 		assert.NoError(t, Run(context.Background(), CustomName{}, utils.OutputPretty, fsys))
 		// Check error
@@ -88,56 +81,57 @@ func TestStatusCommand(t *testing.T) {
 }
 
 func TestServiceHealth(t *testing.T) {
-	services := []string{"supabase_db", "supabase_auth"}
-
 	t.Run("checks all services", func(t *testing.T) {
+		var running []types.Container
+		for _, name := range utils.GetDockerIds() {
+			running = append(running, types.Container{
+				Names: []string{name},
+			})
+		}
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + services[0] + "/json").
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
 			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{
-					Running: true,
-					Health:  &types.Health{Status: "Unhealthy"},
-				},
-			}})
-		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + services[1] + "/json").
-			Reply(http.StatusOK).
-			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
-				State: &types.ContainerState{Status: "exited"},
-			}})
+			JSON(running)
 		// Run test
-		var stderr bytes.Buffer
-		stopped := checkServiceHealth(context.Background(), services, &stderr)
+		stopped, err := checkServiceHealth(context.Background())
 		// Check error
+		assert.NoError(t, err)
 		assert.Empty(t, stopped)
-		lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
-		assert.ElementsMatch(t, []string{
-			"supabase_db container is not ready: Unhealthy",
-			"supabase_auth container is not running: exited",
-		}, lines)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
-	t.Run("throws error on missing container", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
+	t.Run("shows stopped container", func(t *testing.T) {
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
-		for _, name := range services {
-			gock.New(utils.Docker.DaemonHost()).
-				Get("/v" + utils.Docker.ClientVersion() + "/containers/" + name + "/json").
-				Reply(http.StatusNotFound)
-		}
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON([]types.Container{})
 		// Run test
-		stopped := checkServiceHealth(context.Background(), services, io.Discard)
+		stopped, err := checkServiceHealth(context.Background())
 		// Check error
-		assert.ElementsMatch(t, services, stopped)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, utils.GetDockerIds(), stopped)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on network error", func(t *testing.T) {
+		errNetwork := errors.New("network error")
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			ReplyError(errNetwork)
+		// Run test
+		stopped, err := checkServiceHealth(context.Background())
+		// Check error
+		assert.ErrorIs(t, err, errNetwork)
+		assert.Empty(t, stopped)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -39,5 +39,6 @@ func Run(ctx context.Context, backup bool, projectId string, fsys afero.Fs) erro
 
 func stop(ctx context.Context, backup bool, w io.Writer) error {
 	utils.NoBackupVolume = !backup
-	return utils.DockerRemoveAll(ctx, w)
+	fmt.Fprintln(w, "Stopping containers...")
+	return utils.DockerRemoveAll(ctx)
 }

--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -39,6 +39,5 @@ func Run(ctx context.Context, backup bool, projectId string, fsys afero.Fs) erro
 
 func stop(ctx context.Context, backup bool, w io.Writer) error {
 	utils.NoBackupVolume = !backup
-	fmt.Fprintln(w, "Stopping containers...")
-	return utils.DockerRemoveAll(ctx)
+	return utils.DockerRemoveAll(ctx, w)
 }

--- a/internal/utils/cloudflare/api.go
+++ b/internal/utils/cloudflare/api.go
@@ -23,6 +23,7 @@ func NewCloudflareAPI() CloudflareAPI {
 		server,
 		fetcher.WithHTTPClient(client),
 		fetcher.WithRequestEditor(header),
+		fetcher.WithExpectedStatus(http.StatusOK),
 	)}
 	return api
 }

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -95,6 +95,24 @@ func UpdateDockerIds() {
 	PoolerId = GetId(PoolerAliases[0])
 }
 
+func GetDockerIds() []string {
+	return []string{
+		KongId,
+		GotrueId,
+		InbucketId,
+		RealtimeId,
+		RestId,
+		StorageId,
+		ImgProxyId,
+		PgmetaId,
+		StudioId,
+		EdgeRuntimeId,
+		LogflareId,
+		VectorId,
+		PoolerId,
+	}
+}
+
 // Type for turning human-friendly bytes string ("5MB", "32kB") into an int64 during toml decoding.
 type sizeInBytes int64
 

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -90,7 +90,8 @@ func WaitAll[T any](containers []T, exec func(container T) error) []error {
 // NoBackupVolume TODO: encapsulate this state in a class
 var NoBackupVolume = false
 
-func DockerRemoveAll(ctx context.Context) error {
+func DockerRemoveAll(ctx context.Context, w io.Writer) error {
+	fmt.Fprintln(w, "Stopping containers...")
 	args := CliProjectFilter()
 	containers, err := Docker.ContainerList(ctx, container.ListOptions{
 		All:     true,

--- a/internal/utils/tenant/client.go
+++ b/internal/utils/tenant/client.go
@@ -70,6 +70,7 @@ func NewTenantAPI(ctx context.Context, projectRef, anonKey string) TenantAPI {
 		fetcher.WithHTTPClient(client),
 		fetcher.WithRequestEditor(header),
 		fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
+		fetcher.WithExpectedStatus(http.StatusOK),
 	)}
 	return api
 }

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -28,6 +28,7 @@ type StatusTestSuite struct {
 
 // test functions
 func (suite *StatusTestSuite) TestStatus() {
+	suite.T().Skip("Status command is no longer mocked")
 	// run command
 	status, _, err := suite.cmd.Find([]string{"status"})
 	status.SetContext(context.Background())

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -16,9 +15,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/go-errors/errors"
 	"github.com/google/go-github/v62/github"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/fetcher"
 	"github.com/supabase/cli/tools/shared"
 )
 
@@ -82,21 +81,19 @@ type PackageConfig struct {
 }
 
 func fetchConfig(ctx context.Context, version string) (PackageConfig, error) {
+	client := fetcher.NewFetcher("https://github.com")
+	checkPath := fmt.Sprintf("/%s/%s/releases/download/v%[3]s/supabase_%[3]s_checksums.txt",
+		utils.CLI_OWNER,
+		utils.CLI_REPO,
+		version,
+	)
+	log.Println(checkPath)
 	config := PackageConfig{Version: version}
-	url := fmt.Sprintf("https://github.com/supabase/cli/releases/download/v%[1]v/supabase_%[1]v_checksums.txt", config.Version)
-	log.Println(url)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return config, err
-	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Send(ctx, http.MethodGet, checkPath, nil)
 	if err != nil {
 		return config, err
 	}
 	defer resp.Body.Close()
-	if err := checkStatus(resp, http.StatusOK); err != nil {
-		return config, err
-	}
 	// Read checksums into map: filename -> sha256
 	config.Checksum = make(map[string]string)
 	scanner := bufio.NewScanner(resp.Body)
@@ -109,17 +106,6 @@ func fetchConfig(ctx context.Context, version string) (PackageConfig, error) {
 		return config, err
 	}
 	return config, nil
-}
-
-func checkStatus(resp *http.Response, status int) error {
-	if resp.StatusCode == status {
-		return nil
-	}
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return errors.Errorf("status %d: %w", resp.StatusCode, err)
-	}
-	return errors.Errorf("status %d: %s", resp.StatusCode, string(data))
 }
 
 func updatePackage(ctx context.Context, client *github.Client, repo, path string, tmpl *template.Template, config PackageConfig) error {

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -81,7 +81,7 @@ type PackageConfig struct {
 }
 
 func fetchConfig(ctx context.Context, version string) (PackageConfig, error) {
-	client := fetcher.NewFetcher("https://github.com")
+	client := fetcher.NewFetcher("https://github.com", fetcher.WithExpectedStatus(http.StatusOK))
 	checkPath := fmt.Sprintf("/%s/%s/releases/download/v%[3]s/supabase_%[3]s_checksums.txt",
 		utils.CLI_OWNER,
 		utils.CLI_REPO,

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -87,7 +87,7 @@ func fetchConfig(ctx context.Context, version string) (PackageConfig, error) {
 		utils.CLI_REPO,
 		version,
 	)
-	log.Println(checkPath)
+	log.Println("Downloading checksum:", checkPath)
 	config := PackageConfig{Version: version}
 	resp, err := client.Send(ctx, http.MethodGet, checkPath, nil)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Difficult to fetch logs when database fails to start.

## What is the new behavior?

- Stream database logs to stderr on health check failure.
- Check service status using a single docker api call.

## Additional context

Add any other context or screenshots.
