### PR TITLE
fix: set default max retry for auto login

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -18,11 +18,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-errors/errors"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/fetcher"
 )
 
 type RunParams struct {
@@ -43,6 +45,7 @@ type AccessTokenResponse struct {
 }
 
 const defaultRetryAfterSeconds = 2
+const defaultMaxRetries = 90
 const decryptionErrorMsg = "cannot decrypt access token"
 
 var loggedInMsg = "You are now logged in. " + utils.Aqua("Happy coding!")
@@ -128,47 +131,27 @@ func (enc LoginEncryption) decryptAccessToken(accessToken string, publicKey stri
 
 func pollForAccessToken(ctx context.Context, url string) (AccessTokenResponse, error) {
 	var accessTokenResponse AccessTokenResponse
-
 	// TODO: Move to OpenAPI-generated http client once we reach v1 on API schema.
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return accessTokenResponse, errors.Errorf("cannot fetch access token: %w", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return accessTokenResponse, errors.Errorf("cannot fetch access token: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		retryAfterSeconds, err := strconv.Atoi(resp.Header.Get("Retry-After"))
-		if err != nil {
-			retryAfterSeconds = defaultRetryAfterSeconds
+	client := fetcher.NewFetcher(utils.GetSupabaseAPIHost())
+	timeout := backoff.NewConstantBackOff(defaultRetryAfterSeconds)
+	probe := func() error {
+		resp, err := client.Send(ctx, http.MethodGet, url, nil)
+		if err == nil {
+			defer resp.Body.Close()
+			dec := json.NewDecoder(resp.Body)
+			if err := dec.Decode(&accessTokenResponse); err != nil {
+				return errors.Errorf("failed to decode access token response: %w", err)
+			}
+		} else if resp != nil && resp.StatusCode == http.StatusNotFound {
+			if retryAfterSeconds, err := strconv.Atoi(resp.Header.Get("Retry-After")); err == nil {
+				timeout.Interval = time.Duration(retryAfterSeconds) * time.Second
+			}
 		}
-		t := time.NewTimer(time.Duration(retryAfterSeconds) * time.Second)
-		select {
-		case <-ctx.Done():
-			t.Stop()
-		case <-t.C:
-		}
-		return pollForAccessToken(ctx, url)
+		return err
 	}
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-
-		if err != nil {
-			return accessTokenResponse, errors.Errorf("cannot read access token response body: %w", err)
-		}
-
-		if err := json.Unmarshal(body, &accessTokenResponse); err != nil {
-			return accessTokenResponse, errors.Errorf("cannot unmarshal access token response: %w", err)
-		}
-
-		return accessTokenResponse, nil
-	}
-
-	return accessTokenResponse, errors.Errorf("HTTP %s: cannot retrieve access token", resp.Status)
+	policy := backoff.WithContext(backoff.WithMaxRetries(timeout, defaultMaxRetries), ctx)
+	err := backoff.Retry(probe, policy)
+	return accessTokenResponse, err
 }
 
 func Run(ctx context.Context, stdout io.Writer, params RunParams) error {
@@ -215,7 +198,7 @@ func Run(ctx context.Context, stdout io.Writer, params RunParams) error {
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
 		p.Send(utils.StatusMsg("Your token is now being generated and securely encrypted. Waiting for it to arrive..."))
 
-		sessionPollingUrl := utils.GetSupabaseAPIHost() + "/platform/cli/login/" + params.SessionId
+		sessionPollingUrl := "/platform/cli/login/" + params.SessionId
 		accessTokenResponse, err := pollForAccessToken(ctx, sessionPollingUrl)
 		if err != nil {
 			return err

--- a/internal/utils/cloudflare/dns.go
+++ b/internal/utils/cloudflare/dns.go
@@ -141,14 +141,14 @@ type DNSParams struct {
 
 // Performs DNS lookup via HTTPS, in case firewall blocks native netgo resolver.
 // Ref: https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json
-func (c *CloudflareAPI) DNSQuery(ctx context.Context, params DNSParams) (*DNSResponse, error) {
+func (c *CloudflareAPI) DNSQuery(ctx context.Context, params DNSParams) (DNSResponse, error) {
 	values, err := query.Values(params)
 	if err != nil {
-		return nil, errors.Errorf("failed to encode query params: %w", err)
+		return DNSResponse{}, errors.Errorf("failed to encode query params: %w", err)
 	}
 	resp, err := c.Send(ctx, http.MethodGet, "/dns-query?"+values.Encode(), nil)
 	if err != nil {
-		return nil, err
+		return DNSResponse{}, err
 	}
 	defer resp.Body.Close()
 	return fetcher.ParseJSON[DNSResponse](resp.Body)

--- a/pkg/fetcher/http.go
+++ b/pkg/fetcher/http.go
@@ -90,9 +90,9 @@ func (s *Fetcher) Send(ctx context.Context, method, path string, reqBody any, re
 		defer resp.Body.Close()
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, errors.Errorf("Error status %d: %w", resp.StatusCode, err)
+			return resp, errors.Errorf("Error status %d: %w", resp.StatusCode, err)
 		}
-		return nil, errors.Errorf("Error status %d: %s", resp.StatusCode, data)
+		return resp, errors.Errorf("Error status %d: %s", resp.StatusCode, data)
 	}
 	return resp, nil
 }

--- a/pkg/fetcher/http.go
+++ b/pkg/fetcher/http.go
@@ -110,11 +110,11 @@ func (s *Fetcher) Send(ctx context.Context, method, path string, reqBody any, re
 	return resp, nil
 }
 
-func ParseJSON[T any](r io.Reader) (*T, error) {
+func ParseJSON[T any](r io.Reader) (T, error) {
 	var data T
 	dec := json.NewDecoder(r)
 	if err := dec.Decode(&data); err != nil {
-		return nil, errors.Errorf("failed to parse response body: %w", err)
+		return data, errors.Errorf("failed to parse response body: %w", err)
 	}
-	return &data, nil
+	return data, nil
 }

--- a/pkg/storage/buckets.go
+++ b/pkg/storage/buckets.go
@@ -24,11 +24,7 @@ func (s *StorageAPI) ListBuckets(ctx context.Context) ([]BucketResponse, error) 
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := fetcher.ParseJSON[[]BucketResponse](resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return *data, nil
+	return fetcher.ParseJSON[[]BucketResponse](resp.Body)
 }
 
 type CreateBucketRequest struct {
@@ -43,11 +39,11 @@ type CreateBucketResponse struct {
 	Name string `json:"name"`
 }
 
-func (s *StorageAPI) CreateBucket(ctx context.Context, bucketName string) (*CreateBucketResponse, error) {
+func (s *StorageAPI) CreateBucket(ctx context.Context, bucketName string) (CreateBucketResponse, error) {
 	body := CreateBucketRequest{Name: bucketName}
 	resp, err := s.Send(ctx, http.MethodPost, "/storage/v1/bucket", body)
 	if err != nil {
-		return nil, err
+		return CreateBucketResponse{}, err
 	}
 	defer resp.Body.Close()
 	return fetcher.ParseJSON[CreateBucketResponse](resp.Body)
@@ -57,10 +53,10 @@ type DeleteBucketResponse struct {
 	Message string `json:"message"`
 }
 
-func (s *StorageAPI) DeleteBucket(ctx context.Context, bucketId string) (*DeleteBucketResponse, error) {
+func (s *StorageAPI) DeleteBucket(ctx context.Context, bucketId string) (DeleteBucketResponse, error) {
 	resp, err := s.Send(ctx, http.MethodDelete, "/storage/v1/bucket/"+bucketId, nil)
 	if err != nil {
-		return nil, err
+		return DeleteBucketResponse{}, err
 	}
 	defer resp.Body.Close()
 	return fetcher.ParseJSON[DeleteBucketResponse](resp.Body)

--- a/pkg/storage/objects.go
+++ b/pkg/storage/objects.go
@@ -51,11 +51,7 @@ func (s *StorageAPI) ListObjects(ctx context.Context, bucket, prefix string, pag
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := fetcher.ParseJSON[[]ObjectResponse](resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return *data, nil
+	return fetcher.ParseJSON[[]ObjectResponse](resp.Body)
 }
 
 type FileOptions struct {
@@ -134,7 +130,7 @@ type MoveObjectRequest struct {
 
 type MoveObjectResponse = DeleteBucketResponse
 
-func (s *StorageAPI) MoveObject(ctx context.Context, bucketId, srcPath, dstPath string) (*MoveObjectResponse, error) {
+func (s *StorageAPI) MoveObject(ctx context.Context, bucketId, srcPath, dstPath string) (MoveObjectResponse, error) {
 	body := MoveObjectRequest{
 		BucketId:       bucketId,
 		SourceKey:      srcPath,
@@ -142,7 +138,7 @@ func (s *StorageAPI) MoveObject(ctx context.Context, bucketId, srcPath, dstPath 
 	}
 	resp, err := s.Send(ctx, http.MethodPost, "/storage/v1/object/move", body)
 	if err != nil {
-		return nil, err
+		return MoveObjectResponse{}, err
 	}
 	defer resp.Body.Close()
 	return fetcher.ParseJSON[MoveObjectResponse](resp.Body)
@@ -154,7 +150,7 @@ type CopyObjectResponse struct {
 	Key string `json:"key"`
 }
 
-func (s *StorageAPI) CopyObject(ctx context.Context, bucketId, srcPath, dstPath string) (*CopyObjectResponse, error) {
+func (s *StorageAPI) CopyObject(ctx context.Context, bucketId, srcPath, dstPath string) (CopyObjectResponse, error) {
 	body := CopyObjectRequest{
 		BucketId:       bucketId,
 		SourceKey:      srcPath,
@@ -162,7 +158,7 @@ func (s *StorageAPI) CopyObject(ctx context.Context, bucketId, srcPath, dstPath 
 	}
 	resp, err := s.Send(ctx, http.MethodPost, "/storage/v1/object/copy", body)
 	if err != nil {
-		return nil, err
+		return CopyObjectResponse{}, err
 	}
 	defer resp.Body.Close()
 	return fetcher.ParseJSON[CopyObjectResponse](resp.Body)
@@ -192,9 +188,5 @@ func (s *StorageAPI) DeleteObjects(ctx context.Context, bucket string, prefixes 
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := fetcher.ParseJSON[[]DeleteObjectsResponse](resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return *data, nil
+	return fetcher.ParseJSON[[]DeleteObjectsResponse](resp.Body)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Set max retries (90) when waiting for login token, instead of waiting indefinitely for non-404 server error.
Also addresses a memory leak where closing http response reader is deferred on retry until program exit.

## Additional context

Add any other context or screenshots.
