### PR TITLE
feat: support custom pooler and realtime image

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -223,7 +223,7 @@ func initSchema14(ctx context.Context, conn *pgx.Conn) error {
 func initSchema15(ctx context.Context, host string) error {
 	// Apply service migrations
 	logger := utils.GetDebugLogger()
-	if err := utils.DockerRunOnceWithStream(ctx, utils.RealtimeImage, []string{
+	if err := utils.DockerRunOnceWithStream(ctx, utils.Config.Realtime.Image, []string{
 		"PORT=4000",
 		"DB_HOST=" + host,
 		"DB_PORT=5432",

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -46,13 +46,13 @@ func GetServiceImages() []string {
 		utils.Config.Db.Image,
 		utils.Config.Auth.Image,
 		utils.Config.Api.Image,
-		utils.RealtimeImage,
+		utils.Config.Realtime.Image,
 		utils.Config.Storage.Image,
 		utils.EdgeRuntimeImage,
-		utils.StudioImage,
-		utils.PgmetaImage,
+		utils.Config.Studio.Image,
+		utils.Config.Studio.PgmetaImage,
 		utils.LogflareImage,
-		utils.SupavisorImage,
+		utils.Config.Db.Pooler.Image,
 		utils.ImageProxyImage,
 	}
 }

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -650,11 +650,11 @@ EOF
 	}
 
 	// Start Realtime.
-	if utils.Config.Realtime.Enabled && !isContainerExcluded(utils.RealtimeImage, excluded) {
+	if utils.Config.Realtime.Enabled && !isContainerExcluded(utils.Config.Realtime.Image, excluded) {
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.RealtimeImage,
+				Image: utils.Config.Realtime.Image,
 				Env: []string{
 					"PORT=4000",
 					"DB_HOST=" + dbConfig.Host,
@@ -930,7 +930,7 @@ EOF
 	}
 
 	// Start pooler.
-	if utils.Config.Db.Pooler.Enabled && !isContainerExcluded(utils.SupavisorImage, excluded) {
+	if utils.Config.Db.Pooler.Enabled && !isContainerExcluded(utils.Config.Db.Pooler.Image, excluded) {
 		portSession := uint16(5432)
 		portTransaction := uint16(6543)
 		dockerPort := portTransaction
@@ -954,7 +954,7 @@ EOF
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.SupavisorImage,
+				Image: utils.Config.Db.Pooler.Image,
 				Env: []string{
 					"PORT=4000",
 					fmt.Sprintf("PROXY_PORT_SESSION=%d", portSession),

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -196,6 +196,8 @@ var (
 	StorageVersionPath    = filepath.Join(TempDir, "storage-version")
 	StudioVersionPath     = filepath.Join(TempDir, "studio-version")
 	PgmetaVersionPath     = filepath.Join(TempDir, "pgmeta-version")
+	PoolerVersionPath     = filepath.Join(TempDir, "pooler-version")
+	RealtimeVersionPath   = filepath.Join(TempDir, "realtime-version")
 	CliVersionPath        = filepath.Join(TempDir, "cli-latest")
 	CurrBranchPath        = filepath.Join(SupabaseDirPath, ".branches", "_current_branch")
 	SchemasDir            = filepath.Join(SupabaseDirPath, "schemas")


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1702

## What is the new behavior?

Allows pooler and realtime image versions to be overridden locally.

```bash
echo "v2.28.32" > supabase/.temp/realtime-version
echo "1.1.56" > supabase/.temp/pooler-version
```

## Additional context

Add any other context or screenshots.
