### PR TITLE
fix: use env file paths relative to current directory

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -202,44 +202,15 @@ func deployFunction(ctx context.Context, projectRef, slug, entrypointUrl, import
 }
 
 func deployOne(ctx context.Context, slug, projectRef, importMapPath string, noVerifyJWT *bool, fsys afero.Fs) error {
-	// 1. Ensure noVerifyJWT is not nil.
-	if noVerifyJWT == nil {
-		x := false
-		if functionConfig, ok := utils.Config.Functions[slug]; ok && !*functionConfig.VerifyJWT {
-			x = true
-		}
-		noVerifyJWT = &x
-	}
-	resolved, err := utils.AbsImportMapPath(importMapPath, slug, fsys)
-	if err != nil {
-		return err
-	}
-	// Upstream server expects import map to be always defined
-	if importMapPath == "" {
-		resolved, err = filepath.Abs(utils.FallbackImportMapPath)
-		if err != nil {
-			return errors.Errorf("failed to resolve absolute path: %w", err)
-		}
-	}
-	exists, err := afero.Exists(fsys, resolved)
-	if err != nil {
-		logger := utils.GetDebugLogger()
-		fmt.Fprintln(logger, err)
-	}
-	if exists {
-		importMapPath = resolved
-	} else {
-		importMapPath = ""
-	}
-
-	// 2. Bundle Function.
+	// 1. Bundle Function.
 	fmt.Println("Bundling " + utils.Bold(slug))
+	fc := utils.GetFunctionConfig(slug, importMapPath, noVerifyJWT, fsys)
 	dockerEntrypointPath := path.Join(utils.DockerFuncDirPath, slug, "index.ts")
-	functionBody, err := bundleFunction(ctx, slug, dockerEntrypointPath, importMapPath, fsys)
+	functionBody, err := bundleFunction(ctx, slug, dockerEntrypointPath, fc.ImportMap, fsys)
 	if err != nil {
 		return err
 	}
-	// 3. Deploy new Function.
+	// 2. Deploy new Function.
 	functionSize := units.HumanSize(float64(functionBody.Len()))
 	fmt.Println("Deploying " + utils.Bold(slug) + " (script size: " + utils.Bold(functionSize) + ")")
 	policy := backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3), ctx)
@@ -250,7 +221,7 @@ func deployOne(ctx context.Context, slug, projectRef, importMapPath string, noVe
 			slug,
 			"file://"+dockerEntrypointPath,
 			"file://"+dockerImportMapPath,
-			!*noVerifyJWT,
+			*fc.VerifyJWT,
 			functionBody,
 		)
 	}, policy)

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, slugs []string, projectRef string, noVerifyJWT *bo
 		return err
 	}
 	if len(slugs) == 0 {
-		allSlugs, err := getFunctionSlugs(fsys)
+		allSlugs, err := GetFunctionSlugs(fsys)
 		if err != nil {
 			return err
 		}
@@ -57,14 +57,14 @@ func Run(ctx context.Context, slugs []string, projectRef string, noVerifyJWT *bo
 }
 
 func RunDefault(ctx context.Context, projectRef string, fsys afero.Fs) error {
-	slugs, err := getFunctionSlugs(fsys)
+	slugs, err := GetFunctionSlugs(fsys)
 	if len(slugs) == 0 {
 		return err
 	}
 	return deployAll(ctx, slugs, projectRef, "", nil, fsys)
 }
 
-func getFunctionSlugs(fsys afero.Fs) ([]string, error) {
+func GetFunctionSlugs(fsys afero.Fs) ([]string, error) {
 	pattern := filepath.Join(utils.FunctionsDir, "*", "index.ts")
 	paths, err := afero.Glob(fsys, pattern)
 	if err != nil {

--- a/internal/secrets/set/set.go
+++ b/internal/secrets/set/set.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -19,6 +20,9 @@ func Run(ctx context.Context, projectRef, envFilePath string, args []string, fsy
 	// 1. Sanity checks.
 	envMap := make(map[string]string, len(args))
 	if len(envFilePath) > 0 {
+		if !filepath.IsAbs(envFilePath) {
+			envFilePath = filepath.Join(utils.CurrentDirAbs, envFilePath)
+		}
 		parsed, err := ParseEnvFile(envFilePath, fsys)
 		if err != nil {
 			return err

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -486,8 +486,8 @@ type (
 	}
 
 	function struct {
-		VerifyJWT *bool  `toml:"verify_jwt"`
-		ImportMap string `toml:"import_map"`
+		VerifyJWT *bool  `toml:"verify_jwt" json:"verifyJWT"`
+		ImportMap string `toml:"import_map" json:"importMapPath,omitempty"`
 	}
 
 	analytics struct {

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -58,14 +57,10 @@ func TestImportMapPath(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, FallbackImportMapPath, []byte("{}"), 0644))
-		absPath, err := filepath.Abs(FallbackImportMapPath)
-		require.NoError(t, err)
-		require.NoError(t, afero.WriteFile(fsys, absPath, []byte("{}"), 0644))
 		// Run test
-		resolved, err := AbsImportMapPath("", "", fsys)
+		fc := GetFunctionConfig("", "", nil, fsys)
 		// Check error
-		assert.NoError(t, err)
-		assert.Equal(t, absPath, resolved)
+		assert.Equal(t, FallbackImportMapPath, fc.ImportMap)
 	})
 
 	t.Run("per function config takes precedence", func(t *testing.T) {
@@ -73,49 +68,46 @@ func TestImportMapPath(t *testing.T) {
 		Config.Functions = map[string]function{
 			slug: {ImportMap: "import_map.json"},
 		}
-		absPath, err := filepath.Abs("supabase/import_map.json")
-		require.NoError(t, err)
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, FallbackImportMapPath, []byte("{}"), 0644))
-		require.NoError(t, afero.WriteFile(fsys, absPath, []byte("{}"), 0644))
 		// Run test
-		resolved, err := AbsImportMapPath("", slug, fsys)
+		fc := GetFunctionConfig(slug, "", nil, fsys)
 		// Check error
-		assert.NoError(t, err)
-		assert.Equal(t, absPath, resolved)
+		assert.Equal(t, "supabase/import_map.json", fc.ImportMap)
+	})
+
+	t.Run("overrides with cli flag", func(t *testing.T) {
+		slug := "hello"
+		Config.Functions = map[string]function{
+			slug: {ImportMap: "import_map.json"},
+		}
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, FallbackImportMapPath, []byte("{}"), 0644))
+		// Run test
+		fc := GetFunctionConfig(slug, FallbackImportMapPath, Ptr(false), fsys)
+		// Check error
+		assert.Equal(t, FallbackImportMapPath, fc.ImportMap)
 	})
 
 	t.Run("returns empty string if no fallback", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		resolved, err := AbsImportMapPath("", "", fsys)
+		fc := GetFunctionConfig("", "", nil, fsys)
 		// Check error
-		assert.NoError(t, err)
-		assert.Empty(t, resolved)
+		assert.Empty(t, fc.ImportMap)
 	})
 
-	t.Run("throws error on missing file", func(t *testing.T) {
-		path := "/tmp/import_map"
+	t.Run("preserves absolute path", func(t *testing.T) {
+		path := "/tmp/import_map.json"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, FallbackImportMapPath, []byte("{}"), 0644))
 		// Run test
-		resolved, err := AbsImportMapPath(path, "", fsys)
+		fc := GetFunctionConfig("", path, nil, fsys)
 		// Check error
-		assert.ErrorIs(t, err, os.ErrNotExist)
-		assert.Empty(t, resolved)
-	})
-
-	t.Run("throws error on importing directory", func(t *testing.T) {
-		path := "/tmp/import_map"
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, fsys.MkdirAll(path, 0755))
-		// Run test
-		resolved, err := AbsImportMapPath(path, "", fsys)
-		// Check error
-		assert.ErrorContains(t, err, "Importing directory is unsupported: "+path)
-		assert.Empty(t, resolved)
+		assert.Equal(t, path, fc.ImportMap)
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2002

## What is the current behavior?

`--env-file` and `--import-map` flags are resolved relative to workdir.

## What is the new behavior?

Resolve file path flags relative to current working directory.
Refactor common code paths between deploy and serve.

## Additional context

Add any other context or screenshots.
