### PR TITLE
fix: only write version file if supabase directory exists

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,7 @@ func Execute() {
 func checkUpgrade(ctx context.Context, fsys afero.Fs) (string, error) {
 	if shouldFetchRelease(fsys) {
 		version, err := utils.GetLatestRelease(ctx)
-		if len(version) > 0 {
+		if exists, _ := afero.DirExists(fsys, utils.SupabaseDirPath); exists && len(version) > 0 {
 			err = utils.WriteFile(utils.CliVersionPath, []byte(version), fsys)
 		}
 		return version, err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Bash completion is sometimes added to ~/.zshrc files resulting in `supabase/.temp/cli-latest` created in every directory where a new shell is launched.

## What is the new behavior?

Only writes the version file if there's an existing `supabase` directory.

## Additional context

Add any other context or screenshots.
