### PR TITLE
fix: bump edge-runtime to 1.54.2

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.53.4"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.2"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.2

### Changes

### [1.54.0](https://github.com/supabase/edge-runtime/compare/v1.53.4...v1.54.0) (2024-06-12)

#### Features

* Deno 1.43 upgrade ([aa72f73](https://github.com/supabase/edge-runtime/commit/aa72f7370ebf55bbe647b2b6500995d23ec90272))

### [1.54.1](https://github.com/supabase/edge-runtime/compare/v1.54.0...v1.54.1) (2024-06-12)

#### Bug Fixes

* bump rust builder image to `1.78-bookworm` ([#361](https://github.com/supabase/edge-runtime/issues/361)) ([c6313b3](https://github.com/supabase/edge-runtime/commit/c6313b3c59f8553b7a3253873a3cab2021f9ec3e))

### [1.54.2](https://github.com/supabase/edge-runtime/compare/v1.54.1...v1.54.2) (2024-06-12)

#### Bug Fixes

* downgrade rust builder image to `rust:1.77.2-bookworm` ([#362](https://github.com/supabase/edge-runtime/issues/362)) ([cb19187](https://github.com/supabase/edge-runtime/commit/cb19187532c948836d6fa0c5c2bd72d14857f104))