### PR TITLE
fix: import map resolution for all relative paths

### DIFF
--- a/internal/functions/download/download.go
+++ b/internal/functions/download/download.go
@@ -108,8 +108,6 @@ func downloadFunction(ctx context.Context, projectRef, slug, extractScriptPath s
 	return nil
 }
 
-const dockerEszipDir = "/root/eszips"
-
 func Run(ctx context.Context, slug string, projectRef string, useLegacyBundle bool, fsys afero.Fs) error {
 	if useLegacyBundle {
 		return RunLegacy(ctx, slug, projectRef, fsys)
@@ -171,7 +169,7 @@ func extractOne(ctx context.Context, slug, eszipPath string) error {
 	if err != nil {
 		return errors.Errorf("failed to resolve eszip path: %w", err)
 	}
-	dockerEszipPath := path.Join(dockerEszipDir, filepath.Base(hostEszipPath))
+	dockerEszipPath := path.Join(utils.DockerEszipDir, filepath.Base(hostEszipPath))
 
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -31,9 +31,11 @@ var (
 )
 
 const (
-	DockerDenoDir     = "/home/deno"
-	DockerModsDir     = DockerDenoDir + "/modules"
-	DockerFuncDirPath = DockerDenoDir + "/functions"
+	DockerDenoDir               = "/home/deno"
+	DockerModsDir               = DockerDenoDir + "/modules"
+	DockerFuncDirPath           = DockerDenoDir + "/functions"
+	DockerImportMapDir          = DockerDenoDir + "/import_maps"
+	DockerFallbackImportMapPath = DockerFuncDirPath + "/import_map.json"
 )
 
 func GetDenoPath() (string, error) {
@@ -215,91 +217,102 @@ type ImportMap struct {
 	Scopes  map[string]map[string]string `json:"scopes"`
 }
 
-func NewImportMap(path string, fsys afero.Fs) (*ImportMap, error) {
-	contents, err := fsys.Open(path)
+func NewImportMap(absJsonPath string, fsys afero.Fs) (*ImportMap, error) {
+	contents, err := fsys.Open(absJsonPath)
 	if err != nil {
 		return nil, errors.Errorf("failed to load import map: %w", err)
 	}
 	defer contents.Close()
-	return NewFromReader(contents)
-}
-
-func NewFromReader(r io.Reader) (*ImportMap, error) {
-	decoder := json.NewDecoder(r)
-	importMap := &ImportMap{}
-	if err := decoder.Decode(importMap); err != nil {
+	result := ImportMap{}
+	decoder := json.NewDecoder(contents)
+	if err := decoder.Decode(&result); err != nil {
 		return nil, errors.Errorf("failed to parse import map: %w", err)
 	}
-	return importMap, nil
-}
-
-func (m *ImportMap) Resolve(fsys afero.Fs) ImportMap {
-	result := ImportMap{
-		Imports: make(map[string]string, len(m.Imports)),
-		Scopes:  make(map[string]map[string]string, len(m.Scopes)),
+	// Resolve all paths relative to current file
+	for k, v := range result.Imports {
+		result.Imports[k] = resolveHostPath(absJsonPath, v, fsys)
 	}
-	for k, v := range m.Imports {
-		result.Imports[k] = resolveHostPath(v, fsys)
-	}
-	for module, mapping := range m.Scopes {
-		result.Scopes[module] = map[string]string{}
+	for module, mapping := range result.Scopes {
 		for k, v := range mapping {
-			result.Scopes[module][k] = resolveHostPath(v, fsys)
+			result.Scopes[module][k] = resolveHostPath(absJsonPath, v, fsys)
 		}
 	}
-	return result
+	return &result, nil
 }
 
-func (m *ImportMap) BindModules(resolved ImportMap) []string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
-	binds := []string{}
-	for k, dockerPath := range resolved.Imports {
-		if strings.HasPrefix(dockerPath, DockerModsDir) {
-			hostPath := filepath.Join(cwd, FunctionsDir, m.Imports[k])
-			binds = append(binds, hostPath+":"+dockerPath+":ro")
-		}
-	}
-	for module, mapping := range resolved.Scopes {
-		for k, dockerPath := range mapping {
-			if strings.HasPrefix(dockerPath, DockerModsDir) {
-				hostPath := filepath.Join(cwd, FunctionsDir, m.Scopes[module][k])
-				binds = append(binds, hostPath+":"+dockerPath+":ro")
-			}
-		}
-	}
-	return binds
-}
-
-func resolveHostPath(hostPath string, fsys afero.Fs) string {
-	// All local fs imports will be mounted to /home/deno/modules
+func resolveHostPath(jsonPath, hostPath string, fsys afero.Fs) string {
+	// Leave absolute paths unchanged
 	if filepath.IsAbs(hostPath) {
-		return getModulePath(hostPath)
+		return hostPath
 	}
-	rel := filepath.Join(FunctionsDir, hostPath)
-	exists, err := afero.Exists(fsys, rel)
-	if err != nil {
-		logger := GetDebugLogger()
-		fmt.Fprintln(logger, err)
-	}
-	if !exists {
+	resolved := filepath.Join(filepath.Dir(jsonPath), hostPath)
+	if exists, err := afero.Exists(fsys, resolved); !exists {
+		// Leave URLs unchanged
+		if err != nil {
+			logger := GetDebugLogger()
+			fmt.Fprintln(logger, err)
+		}
 		return hostPath
 	}
 	// Directory imports need to be suffixed with /
 	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
 	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
-		rel += string(filepath.Separator)
+		resolved += string(filepath.Separator)
 	}
-	if strings.HasPrefix(rel, FunctionsDir) {
-		suffix := strings.TrimPrefix(rel, FunctionsDir)
-		return DockerFuncDirPath + filepath.ToSlash(suffix)
-	}
-	return getModulePath(rel)
+	return resolved
 }
 
-func getModulePath(hostPath string) string {
+// Converts host import map to docker import map and returns any bind mounts.
+func (m *ImportMap) BindModules() ([]string, ImportMap) {
+	binds := []string{}
+	resolved := ImportMap{
+		Imports: make(map[string]string, len(m.Imports)),
+		Scopes:  make(map[string]map[string]string, len(m.Scopes)),
+	}
+	for k, hostPath := range m.Imports {
+		dockerPath := toDockerPath(hostPath)
+		resolved.Imports[k] = dockerPath
+		if strings.HasPrefix(dockerPath, DockerModsDir) {
+			binds = append(binds, hostPath+":"+dockerPath+":ro")
+		}
+	}
+	for module, mapping := range m.Scopes {
+		resolved.Scopes[module] = map[string]string{}
+		for k, hostPath := range mapping {
+			dockerPath := toDockerPath(hostPath)
+			resolved.Scopes[module][k] = dockerPath
+			if strings.HasPrefix(dockerPath, DockerModsDir) {
+				binds = append(binds, hostPath+":"+dockerPath+":ro")
+			}
+		}
+	}
+	return binds, resolved
+}
+
+func toDockerPath(hostPath string) string {
+	// Leave URL unchanged
+	if !filepath.IsAbs(hostPath) {
+		return hostPath
+	}
+	hostFuncDir, err := filepath.Abs(FunctionsDir)
+	if err != nil {
+		logger := GetDebugLogger()
+		fmt.Fprintln(logger, err)
+	}
+	return absDockerPath(hostPath, hostFuncDir)
+}
+
+func absDockerPath(hostPath, hostFuncDir string) string {
+	// Maps supabase/functions directory to /home/deno/functions
+	if strings.HasPrefix(hostPath, hostFuncDir) {
+		suffix := strings.TrimPrefix(hostPath, hostFuncDir)
+		return DockerFuncDirPath + filepath.ToSlash(suffix)
+	}
+	// Other local fs imports will be mounted to /home/deno/modules
+	return absModulePath(hostPath)
+}
+
+func absModulePath(hostPath string) string {
 	mod := path.Join(DockerModsDir, GetPathHash(hostPath))
 	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
 		mod += "/"
@@ -327,6 +340,7 @@ func GetFunctionConfig(slug, importMapPath string, noVerifyJWT *bool, fsys afero
 	return fc
 }
 
+// Path returned is either absolute or relative to CWD.
 func getImportMapPath(flagImportMap, slugImportMap string, fsys afero.Fs) string {
 	// Precedence order: CLI flags > config.toml > fallback value
 	if filepath.IsAbs(flagImportMap) {
@@ -342,42 +356,39 @@ func getImportMapPath(flagImportMap, slugImportMap string, fsys afero.Fs) string
 		return filepath.Join(SupabaseDirPath, slugImportMap)
 	}
 	if exists, err := afero.Exists(fsys, FallbackImportMapPath); err != nil {
-		fmt.Fprintln(GetDebugLogger(), "failed to fallback import map:", err)
+		logger := GetDebugLogger()
+		fmt.Fprintln(logger, err)
 	} else if exists {
 		return FallbackImportMapPath
 	}
 	return ""
 }
 
-func AbsTempImportMapPath(cwd, hostPath string) string {
-	name := GetPathHash(hostPath) + ".json"
-	return filepath.Join(cwd, ImportMapsDir, name)
-}
-
-func BindImportMap(hostImportMapPath, dockerImportMapPath string, fsys afero.Fs) ([]string, error) {
+func BindImportMap(importMapPath string, fsys afero.Fs) ([]string, string, error) {
+	hostImportMapPath, err := filepath.Abs(importMapPath)
+	if err != nil {
+		return nil, "", errors.Errorf("failed to resolve json path: %w", err)
+	}
+	fallback, err := filepath.Abs(FallbackImportMapPath)
+	if err != nil {
+		return nil, "", errors.Errorf("failed to resolve fallback path: %w", err)
+	}
 	importMap, err := NewImportMap(hostImportMapPath, fsys)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, errors.Errorf("failed to get working directory: %w", err)
-	}
-	resolved := importMap.Resolve(fsys)
-	binds := importMap.BindModules(resolved)
-	if len(binds) > 0 {
+	if mods, resolved := importMap.BindModules(); len(mods) > 0 || hostImportMapPath != fallback {
 		contents, err := json.MarshalIndent(resolved, "", "    ")
 		if err != nil {
-			return nil, errors.Errorf("failed to encode json: %w", err)
+			return nil, "", errors.Errorf("failed to encode json: %w", err)
 		}
 		// Rewrite import map to temporary host path
-		hostImportMapPath = AbsTempImportMapPath(cwd, hostImportMapPath)
-		if err := WriteFile(hostImportMapPath, contents, fsys); err != nil {
-			return nil, err
+		name := GetPathHash(hostImportMapPath) + ".json"
+		tmpImportMapPath := filepath.Join(ImportMapsDir, name)
+		if err := WriteFile(tmpImportMapPath, contents, fsys); err != nil {
+			return nil, "", err
 		}
-	} else if !filepath.IsAbs(hostImportMapPath) {
-		hostImportMapPath = filepath.Join(cwd, hostImportMapPath)
+		return mods, path.Join(DockerImportMapDir, name), nil
 	}
-	binds = append(binds, hostImportMapPath+":"+dockerImportMapPath+":ro")
-	return binds, nil
+	return nil, DockerFallbackImportMapPath, nil
 }

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -11,43 +13,88 @@ import (
 
 func TestResolveImports(t *testing.T) {
 	t.Run("resolves relative directory", func(t *testing.T) {
-		importMap := &ImportMap{
-			Imports: map[string]string{
-				"abs/":    "/tmp/",
-				"root":    "../../common",
-				"parent":  "../tests",
-				"child":   "child/",
-				"missing": "../missing",
-			},
-		}
+		importMap := []byte(`{
+	"imports": {
+		"abs/":    "/tmp/",
+		"root":    "../../common",
+		"parent":  "../tests",
+		"child":   "child/",
+		"missing": "../missing"
+	}
+}`)
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, fsys.Mkdir("common", 0755))
-		require.NoError(t, fsys.Mkdir(DbTestsDir, 0755))
-		require.NoError(t, fsys.Mkdir(filepath.Join(FunctionsDir, "child"), 0755))
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		jsonPath := filepath.Join(cwd, FallbackImportMapPath)
+		require.NoError(t, afero.WriteFile(fsys, jsonPath, importMap, 0644))
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, "common"), 0755))
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, DbTestsDir), 0755))
+		require.NoError(t, fsys.Mkdir(filepath.Join(cwd, FunctionsDir, "child"), 0755))
 		// Run test
-		resolved := importMap.Resolve(fsys)
+		resolved, err := NewImportMap(jsonPath, fsys)
 		// Check error
-		assert.Equal(t, "/home/deno/modules/ac351c7174c8f47a9a9056bd96bcd71cfb980c906daee74ab9bce8308c68b811/", resolved.Imports["abs/"])
-		assert.Equal(t, "/home/deno/modules/92a5dc04bd6f9fb8f29f8066fed8a5c1e81bc59ad48a11283b63736867e4f2a8", resolved.Imports["root"])
-		assert.Equal(t, "/home/deno/modules/faaed96206118cf98625ea8065b6b3864f8cf9484814c423b58ebaa9b2d1e47b", resolved.Imports["parent"])
-		assert.Equal(t, "/home/deno/functions/child/", resolved.Imports["child"])
+		assert.NoError(t, err)
+		assert.Equal(t, "/tmp/", resolved.Imports["abs/"])
+		assert.Equal(t, cwd+"/common", resolved.Imports["root"])
+		assert.Equal(t, cwd+"/supabase/tests", resolved.Imports["parent"])
+		assert.Equal(t, cwd+"/supabase/functions/child/", resolved.Imports["child"])
 		assert.Equal(t, "../missing", resolved.Imports["missing"])
 	})
 
 	t.Run("resolves parent scopes", func(t *testing.T) {
-		importMap := &ImportMap{
+		importMap := []byte(`{
+	"scopes": {
+		"my-scope": {
+			"my-mod": "https://deno.land"
+		}
+	}
+}`)
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, FallbackImportMapPath, importMap, 0644))
+		// Run test
+		resolved, err := NewImportMap(FallbackImportMapPath, fsys)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, "https://deno.land", resolved.Scopes["my-scope"]["my-mod"])
+	})
+}
+
+func TestBindModules(t *testing.T) {
+	t.Run("binds docker imports", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		importMap := ImportMap{
+			Imports: map[string]string{
+				"abs/":   "/tmp/",
+				"root":   cwd + "/common",
+				"parent": cwd + "/supabase/tests",
+				"child":  cwd + "/supabase/functions/child/",
+			},
+		}
+		// Run test
+		mods, resolved := importMap.BindModules()
+		// Check error
+		assert.Len(t, mods, 3)
+		assert.True(t, strings.HasPrefix(resolved.Imports["abs/"], "/home/deno/modules/"))
+		assert.True(t, strings.HasPrefix(resolved.Imports["root"], "/home/deno/modules/"))
+		assert.True(t, strings.HasPrefix(resolved.Imports["parent"], "/home/deno/modules/"))
+		assert.Equal(t, "/home/deno/functions/child/", resolved.Imports["child"])
+	})
+
+	t.Run("binds docker scopes", func(t *testing.T) {
+		importMap := ImportMap{
 			Scopes: map[string]map[string]string{
 				"my-scope": {
 					"my-mod": "https://deno.land",
 				},
 			},
 		}
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
 		// Run test
-		resolved := importMap.Resolve(fsys)
+		mods, resolved := importMap.BindModules()
 		// Check error
+		assert.Empty(t, mods)
 		assert.Equal(t, "https://deno.land", resolved.Scopes["my-scope"]["my-mod"])
 	})
 }

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -74,13 +73,13 @@ func TestBindModules(t *testing.T) {
 			},
 		}
 		// Run test
-		mods, resolved := importMap.BindModules()
+		mods := importMap.BindHostModules()
 		// Check error
-		assert.Len(t, mods, 3)
-		assert.True(t, strings.HasPrefix(resolved.Imports["abs/"], "/home/deno/modules/"))
-		assert.True(t, strings.HasPrefix(resolved.Imports["root"], "/home/deno/modules/"))
-		assert.True(t, strings.HasPrefix(resolved.Imports["parent"], "/home/deno/modules/"))
-		assert.Equal(t, "/home/deno/functions/child/", resolved.Imports["child"])
+		assert.ElementsMatch(t, mods, []string{
+			"/tmp/:/tmp/:ro",
+			cwd + "/common:" + cwd + "/common:ro",
+			cwd + "/supabase/tests:" + cwd + "/supabase/tests:ro",
+		})
 	})
 
 	t.Run("binds docker scopes", func(t *testing.T) {
@@ -92,10 +91,9 @@ func TestBindModules(t *testing.T) {
 			},
 		}
 		// Run test
-		mods, resolved := importMap.BindModules()
+		mods := importMap.BindHostModules()
 		// Check error
 		assert.Empty(t, mods)
-		assert.Equal(t, "https://deno.land", resolved.Scopes["my-scope"]["my-mod"])
 	})
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/1303

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Users can provide import map in the following order of precedence
1. `--import-map <path>` flag
2. `[functions.name] import_map = "path"` in config.toml
3. create `supabase/functions/import_map.json`

For compatibility with deno LSP, entries in those import maps should be specified relative to the json file. Hence, we resolve the host paths on creating the `ImportMap` struct.

~When mounting into edge runtime container, relative paths above workdir are resolved to `/home/deno/modules/<hash>` so it doesn't mount in arbitrary levels. Import maps are then rewritten to `/home/deno/import_maps/<hash>.json`. If the host import map path is 3, and it doesn't import from 2 levels up, we use 3 as it is.~

## Additional context

Add any other context or screenshots.
