### PR TITLE
fix: prefix docker container id with slash

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -99,9 +99,9 @@ func checkServiceHealth(ctx context.Context) ([]string, error) {
 		}
 	}
 	var stopped []string
-	for _, n := range utils.GetDockerIds() {
-		if _, ok := running[n]; !ok {
-			stopped = append(stopped, n)
+	for _, containerId := range utils.GetDockerIds() {
+		if _, ok := running["/"+containerId]; !ok {
+			stopped = append(stopped, containerId)
 		}
 	}
 	return stopped, nil

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -85,7 +85,7 @@ func TestServiceHealth(t *testing.T) {
 		var running []types.Container
 		for _, name := range utils.GetDockerIds() {
 			running = append(running, types.Container{
-				Names: []string{name},
+				Names: []string{"/" + name},
 			})
 		}
 		// Setup mock docker


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2419

## What is the new behavior?

Docker container name is prefixed with `/`

## Additional context

Add any other context or screenshots.
