### PR TITLE
feat(auth): add custom smtp support

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -423,26 +423,26 @@ EOF
 			fmt.Sprintf("GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=%v", utils.Config.Auth.EnableAnonymousSignIns),
 
 			"GOTRUE_SMTP_HOST=" + func() string {
-				if utils.Config.Auth.Email.SmtpHost != "" {
-					return utils.Config.Auth.Email.SmtpHost
+				if utils.Config.Auth.Email.Smtp.Host != "" {
+					return utils.Config.Auth.Email.Smtp.Host
 				}
 				return utils.InbucketId
 			}(),
 			"GOTRUE_SMTP_PORT=" + func() string {
-				if utils.Config.Auth.Email.SmtpPort != "2500" {
-					return utils.Config.Auth.Email.SmtpPort
+				if utils.Config.Auth.Email.Smtp.Port != "2500" {
+					return utils.Config.Auth.Email.Smtp.Port
 				}
 				return strconv.Itoa(2500)
 			}(),
 			"GOTRUE_SMTP_ADMIN_EMAIL=" + func() string {
-				if utils.Config.Auth.Email.SmtpAdminEmail != "admin@email.com" {
-					return utils.Config.Auth.Email.SmtpAdminEmail
+				if utils.Config.Auth.Email.Smtp.AdminEmail != "admin@email.com" {
+					return utils.Config.Auth.Email.Smtp.AdminEmail
 				}
 				return "admin@email.com"
 			}(),
-			"GOTRUE_SMTP_USER=" + utils.Config.Auth.Email.SmtpUser,
-			"GOTRUE_SMTP_PASS=" + utils.Config.Auth.Email.SmtpPass,
-			"GOTRUE_SMTP_SENDER_NAME=" + utils.Config.Auth.Email.SmtpSenderName,
+			"GOTRUE_SMTP_USER=" + utils.Config.Auth.Email.Smtp.User,
+			"GOTRUE_SMTP_PASS=" + utils.Config.Auth.Email.Smtp.Pass,
+			"GOTRUE_SMTP_SENDER_NAME=" + utils.Config.Auth.Email.Smtp.SenderName,
 			fmt.Sprintf("GOTRUE_SMTP_MAX_FREQUENCY=%v", utils.Config.Auth.Email.MaxFrequency),
 			// TODO: To be reverted to `/auth/v1/verify` once
 			// https://github.com/supabase/supabase/issues/16100

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -422,28 +422,14 @@ EOF
 
 			fmt.Sprintf("GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=%v", utils.Config.Auth.EnableAnonymousSignIns),
 
-			"GOTRUE_SMTP_HOST=" + func() string {
-				if utils.Config.Auth.Email.Smtp.Host != "" {
-					return utils.Config.Auth.Email.Smtp.Host
-				}
-				return utils.InbucketId
-			}(),
-			"GOTRUE_SMTP_PORT=" + func() string {
-				if utils.Config.Auth.Email.Smtp.Port != "2500" {
-					return utils.Config.Auth.Email.Smtp.Port
-				}
-				return strconv.Itoa(2500)
-			}(),
-			"GOTRUE_SMTP_ADMIN_EMAIL=" + func() string {
-				if utils.Config.Auth.Email.Smtp.AdminEmail != "admin@email.com" {
-					return utils.Config.Auth.Email.Smtp.AdminEmail
-				}
-				return "admin@email.com"
-			}(),
-			"GOTRUE_SMTP_USER=" + utils.Config.Auth.Email.Smtp.User,
-			"GOTRUE_SMTP_PASS=" + utils.Config.Auth.Email.Smtp.Pass,
-			"GOTRUE_SMTP_SENDER_NAME=" + utils.Config.Auth.Email.Smtp.SenderName,
+			fmt.Sprintf("GOTRUE_SMTP_HOST=%s", utils.Config.Auth.Email.Smtp.Host),
+			fmt.Sprintf("GOTRUE_SMTP_PORT=%d", utils.Config.Auth.Email.Smtp.Port),
+			fmt.Sprintf("GOTRUE_SMTP_USER=%s", utils.Config.Auth.Email.Smtp.User),
+			fmt.Sprintf("GOTRUE_SMTP_PASS=%s", utils.Config.Auth.Email.Smtp.Pass),
+			fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", utils.Config.Auth.Email.Smtp.AdminEmail),
+			fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", utils.Config.Auth.Email.Smtp.SenderName),
 			fmt.Sprintf("GOTRUE_SMTP_MAX_FREQUENCY=%v", utils.Config.Auth.Email.MaxFrequency),
+
 			// TODO: To be reverted to `/auth/v1/verify` once
 			// https://github.com/supabase/supabase/issues/16100
 			// is fixed on upstream GoTrue.

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -422,9 +422,27 @@ EOF
 
 			fmt.Sprintf("GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=%v", utils.Config.Auth.EnableAnonymousSignIns),
 
-			"GOTRUE_SMTP_HOST=" + utils.InbucketId,
-			"GOTRUE_SMTP_PORT=2500",
-			"GOTRUE_SMTP_ADMIN_EMAIL=admin@email.com",
+			"GOTRUE_SMTP_HOST=" + func() string {
+				if utils.Config.Auth.Email.SmtpHost != "" {
+					return utils.Config.Auth.Email.SmtpHost
+				}
+				return utils.InbucketId
+			}(),
+			"GOTRUE_SMTP_PORT=" + func() string {
+				if utils.Config.Auth.Email.SmtpPort != "2500" {
+					return utils.Config.Auth.Email.SmtpPort
+				}
+				return strconv.Itoa(2500)
+			}(),
+			"GOTRUE_SMTP_ADMIN_EMAIL=" + func() string {
+				if utils.Config.Auth.Email.SmtpAdminEmail != "admin@email.com" {
+					return utils.Config.Auth.Email.SmtpAdminEmail
+				}
+				return "admin@email.com"
+			}(),
+			"GOTRUE_SMTP_USER=" + utils.Config.Auth.Email.SmtpUser,
+			"GOTRUE_SMTP_PASS=" + utils.Config.Auth.Email.SmtpPass,
+			"GOTRUE_SMTP_SENDER_NAME=" + utils.Config.Auth.Email.SmtpSenderName,
 			fmt.Sprintf("GOTRUE_SMTP_MAX_FREQUENCY=%v", utils.Config.Auth.Email.MaxFrequency),
 			// TODO: To be reverted to `/auth/v1/verify` once
 			// https://github.com/supabase/supabase/issues/16100

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -411,13 +411,17 @@ type (
 		DoubleConfirmChanges bool                     `toml:"double_confirm_changes"`
 		EnableConfirmations  bool                     `toml:"enable_confirmations"`
 		Template             map[string]emailTemplate `toml:"template"`
-		SmtpAdminEmail       string                   `toml:"smtp_admin_email"`
-		SmtpHost             string                   `toml:"smtp_host"`
-		SmtpPort             string                   `toml:"smtp_port"`
-		SmtpUser             string                   `toml:"smtp_user"`
-		SmtpPass             string                   `toml:"smtp_pass"`
-		SmtpSenderName       string                   `toml:"smtp_sender_name"`
+		Smtp                 smtp                     `toml:"smtp"`
 		MaxFrequency         time.Duration            `toml:"max_frequency"`
+	}
+
+	smtp struct {
+		Host       string `toml:"host"`
+		Port       string `toml:"port"`
+		User       string `toml:"user"`
+		Pass       string `toml:"pass"`
+		AdminEmail string `toml:"admin_email"`
+		SenderName string `toml:"sender_name"`
 	}
 
 	emailTemplate struct {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -230,6 +230,11 @@ var Config = config{
 				"magic_link":   {},
 				"email_change": {},
 			},
+			Smtp: smtp{
+				Host:       InbucketAliases[0],
+				Port:       2500,
+				AdminEmail: "admin@email.com",
+			},
 		},
 		External: map[string]provider{
 			"apple":         {},
@@ -417,7 +422,7 @@ type (
 
 	smtp struct {
 		Host       string `toml:"host"`
-		Port       string `toml:"port"`
+		Port       uint16 `toml:"port"`
 		User       string `toml:"user"`
 		Pass       string `toml:"pass"`
 		AdminEmail string `toml:"admin_email"`
@@ -724,6 +729,9 @@ func LoadConfigFS(fsys afero.Fs) error {
 						return errors.Errorf("failed to read file info: %w", err)
 					}
 				}
+			}
+			if Config.Auth.Email.Smtp.Pass, err = maybeLoadEnv(Config.Auth.Email.Smtp.Pass); err != nil {
+				return err
 			}
 			// Validate sms config
 			if Config.Auth.Sms.Twilio.Enabled {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -417,7 +417,7 @@ type (
 
 	smtp struct {
 		Host       string `toml:"host"`
-		Port       string `toml:"port"`
+		Port       uint16 `toml:"port"`
 		User       string `toml:"user"`
 		Pass       string `toml:"pass"`
 		AdminEmail string `toml:"admin_email"`

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -417,7 +417,7 @@ type (
 
 	smtp struct {
 		Host       string `toml:"host"`
-		Port       uint16 `toml:"port"`
+		Port       string `toml:"port"`
 		User       string `toml:"user"`
 		Pass       string `toml:"pass"`
 		AdminEmail string `toml:"admin_email"`

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -409,6 +409,12 @@ type (
 		DoubleConfirmChanges bool                     `toml:"double_confirm_changes"`
 		EnableConfirmations  bool                     `toml:"enable_confirmations"`
 		Template             map[string]emailTemplate `toml:"template"`
+		SmtpAdminEmail       string                   `toml:"smtp_admin_email"`
+		SmtpHost             string                   `toml:"smtp_host"`
+		SmtpPort             string                   `toml:"smtp_port"`
+		SmtpUser             string                   `toml:"smtp_user"`
+		SmtpPass             string                   `toml:"smtp_pass"`
+		SmtpSenderName       string                   `toml:"smtp_sender_name"`
 		MaxFrequency         time.Duration            `toml:"max_frequency"`
 	}
 

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -42,6 +42,7 @@ func TestConfigParsing(t *testing.T) {
 		t.Setenv("AZURE_CLIENT_ID", "hello")
 		t.Setenv("AZURE_SECRET", "this is cool")
 		t.Setenv("AUTH_SEND_SMS_SECRETS", "v1,whsec_aWxpa2VzdXBhYmFzZXZlcnltdWNoYW5kaWhvcGV5b3Vkb3Rvbw==")
+		t.Setenv("SENDGRID_API_KEY", "sendgrid")
 		assert.NoError(t, LoadConfigFS(fsys))
 		// Check error
 		assert.Equal(t, "hello", Config.Auth.External["azure"].ClientId)

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -97,6 +97,13 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# Use a production-ready SMTP server
+# smtp_admin_email = "3ilbi6ee8c@gmail.com"
+# smtp_host = "smtp.sendgrid.net"
+# smtp_port = "587"
+# smtp_user = "apikey"
+# smtp_pass = "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"
+# smtp_sender_name = "John Doe"
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -97,15 +97,17 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
-# Use a production-ready SMTP server
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+
+# Uncomment to use a production-ready SMTP server
+# [auth.email.smtp]
 # smtp_admin_email = "3ilbi6ee8c@gmail.com"
 # smtp_host = "smtp.sendgrid.net"
 # smtp_port = "587"
 # smtp_user = "apikey"
 # smtp_pass = "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"
 # smtp_sender_name = "John Doe"
-# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
-max_frequency = "1s"
 
 # Uncomment to customize email template
 [auth.email.template.invite]

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -100,14 +100,14 @@ enable_confirmations = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 
-# Uncomment to use a production-ready SMTP server
-# [auth.email.smtp]
-# smtp_admin_email = "3ilbi6ee8c@gmail.com"
-# smtp_host = "smtp.sendgrid.net"
-# smtp_port = "587"
-# smtp_user = "apikey"
-# smtp_pass = "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"
-# smtp_sender_name = "John Doe"
+# Use a production-ready SMTP server
+[auth.email.smtp]
+host = "smtp.sendgrid.net"
+port = 587
+user = "apikey"
+pass = "env(SENDGRID_API_KEY)"
+admin_email = "admin@email.com"
+sender_name = "Admin"
 
 # Uncomment to customize email template
 [auth.email.template.invite]

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -101,13 +101,13 @@ enable_confirmations = false
 max_frequency = "1s"
 
 # Uncomment to use a production-ready SMTP server
-[auth.email.smtp]
-host = "smtp.sendgrid.net"
-port = 587
-user = "apikey"
-pass = "env(SENDGRID_API_KEY)"
-admin_email = "3ilbi6ee8c@gmail.com"
-sender_name = "John Doe"
+# [auth.email.smtp]
+# smtp_admin_email = "3ilbi6ee8c@gmail.com"
+# smtp_host = "smtp.sendgrid.net"
+# smtp_port = "587"
+# smtp_user = "apikey"
+# smtp_pass = "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"
+# smtp_sender_name = "John Doe"
 
 # Uncomment to customize email template
 [auth.email.template.invite]

--- a/internal/utils/templates/init_config.test.toml
+++ b/internal/utils/templates/init_config.test.toml
@@ -101,13 +101,13 @@ enable_confirmations = false
 max_frequency = "1s"
 
 # Uncomment to use a production-ready SMTP server
-# [auth.email.smtp]
-# smtp_admin_email = "3ilbi6ee8c@gmail.com"
-# smtp_host = "smtp.sendgrid.net"
-# smtp_port = "587"
-# smtp_user = "apikey"
-# smtp_pass = "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"
-# smtp_sender_name = "John Doe"
+[auth.email.smtp]
+host = "smtp.sendgrid.net"
+port = 587
+user = "apikey"
+pass = "env(SENDGRID_API_KEY)"
+admin_email = "3ilbi6ee8c@gmail.com"
+sender_name = "John Doe"
 
 # Uncomment to customize email template
 [auth.email.template.invite]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -108,7 +108,7 @@ max_frequency = "1s"
 # smtp_host = "smtp.sendgrid.net"
 # smtp_port = "587"
 # smtp_user = "apikey"
-# smtp_pass = "env(SENDGRID_API_KEY)"
+# smtp_pass = "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"
 # smtp_sender_name = "John Doe"
 
 # Uncomment to customize email template

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -99,15 +99,17 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
-# Use a production-ready SMTP server
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+
+# Uncomment to use a production-ready SMTP server
+# [auth.email.smtp]
 # smtp_admin_email = "3ilbi6ee8c@gmail.com"
 # smtp_host = "smtp.sendgrid.net"
 # smtp_port = "587"
 # smtp_user = "apikey"
 # smtp_pass = "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"
 # smtp_sender_name = "John Doe"
-# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
-max_frequency = "1s"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -108,7 +108,7 @@ max_frequency = "1s"
 # smtp_host = "smtp.sendgrid.net"
 # smtp_port = "587"
 # smtp_user = "apikey"
-# smtp_pass = "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"
+# smtp_pass = "env(SENDGRID_API_KEY)"
 # smtp_sender_name = "John Doe"
 
 # Uncomment to customize email template

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -102,14 +102,14 @@ enable_confirmations = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 
-# Uncomment to use a production-ready SMTP server
+# Use a production-ready SMTP server
 # [auth.email.smtp]
-# smtp_admin_email = "3ilbi6ee8c@gmail.com"
-# smtp_host = "smtp.sendgrid.net"
-# smtp_port = "587"
-# smtp_user = "apikey"
-# smtp_pass = "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"
-# smtp_sender_name = "John Doe"
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]

--- a/internal/utils/templates/init_config.toml
+++ b/internal/utils/templates/init_config.toml
@@ -99,6 +99,13 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# Use a production-ready SMTP server
+# smtp_admin_email = "3ilbi6ee8c@gmail.com"
+# smtp_host = "smtp.sendgrid.net"
+# smtp_port = "587"
+# smtp_user = "apikey"
+# smtp_pass = "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"
+# smtp_sender_name = "John Doe"
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Some change generated using ChatGPT.

## What is the current behavior?

Supabase CLI only works with Inbucket.

## What is the new behavior?

Add support for Custom SMTP using Supabase CLI.

## Additional context

Maybe need to iterate so it still supports Inbucket.

```
$ go build -o supabase.exe
$ cp supabase.exe ~/project/node_modules/supabase/bin/supabase.exe
$ cd ~/project
```

Add the following to your `config.toml`:

```
smtp_admin_email = "3ilbi6ee8c@gmail.com"
smtp_host = "smtp.sendgrid.net"
smtp_port = "587"
smtp_user = "apikey"
smtp_pass = "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"
smtp_sender_name = "John Doe"
```

Restart:

```
$ ./node_modules/supabase/bin/supabase.exe stop
$ ./node_modules/supabase/bin/supabase.exe start
```

Try sending a transactional email by inviting an user in Supabase Studio:

```
2024-06-13 11:40:40 {"auth_event":{"action":"user_invited","actor_id":"00000000-0000-0000-0000-000000000000","actor_username":"service_role","actor_via_sso":false,"log_type":"team","traits":{"user_email":"unauthorized.nebula@hele.win","user_id":"8dd42c90-4766-44b8-96cf-d9a81e3f75fb"}},"component":"api","duration":6534360435,"level":"info","method":"POST","msg":"request completed","path":"/invite","referer":"http://localhost:3000","remote_addr":"172.23.0.14","status":200,"time":"2024-06-13T10:40:40Z","timestamp":"2024-06-13T10:40:33Z"}
```

![image](https://github.com/supabase/cli/assets/56048320/f60299ef-eff1-4ae8-b040-3d0d4648d664)
