### PR TITLE
fix: remove volume name from docker mount path

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -101,7 +101,7 @@ func bundleFunction(ctx context.Context, slug, hostImportMapPath string, fsys af
 	}()
 
 	hostFuncDir := filepath.Join(cwd, utils.FunctionsDir)
-	dockerFuncDir := filepath.ToSlash(hostFuncDir)
+	dockerFuncDir := utils.ToDockerPath(hostFuncDir)
 
 	outputPath := utils.DockerEszipDir + "/output.eszip"
 	binds := []string{

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -113,7 +113,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	if err != nil {
 		return errors.Errorf("failed to resolve functions dir: %w", err)
 	}
-	dockerFuncDir := filepath.ToSlash(hostFuncDir)
+	dockerFuncDir := utils.ToDockerPath(hostFuncDir)
 	env = append(env,
 		fmt.Sprintf("SUPABASE_URL=http://%s:8000", utils.KongAliases[0]),
 		"SUPABASE_ANON_KEY="+utils.Config.Auth.AnonKey,

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -268,7 +268,7 @@ func (m *ImportMap) BindHostModules() []string {
 		if !filepath.IsAbs(hostPath) || strings.HasPrefix(hostPath, hostFuncDir) {
 			continue
 		}
-		dockerPath := filepath.ToSlash(hostPath)
+		dockerPath := ToDockerPath(hostPath)
 		binds = append(binds, hostPath+":"+dockerPath+":ro")
 	}
 	for _, mapping := range m.Scopes {
@@ -276,7 +276,7 @@ func (m *ImportMap) BindHostModules() []string {
 			if !filepath.IsAbs(hostPath) || strings.HasPrefix(hostPath, hostFuncDir) {
 				continue
 			}
-			dockerPath := filepath.ToSlash(hostPath)
+			dockerPath := ToDockerPath(hostPath)
 			binds = append(binds, hostPath+":"+dockerPath+":ro")
 		}
 	}
@@ -329,7 +329,7 @@ func BindImportMap(importMapPath string, fsys afero.Fs) ([]string, string, error
 	if err != nil {
 		return nil, "", errors.Errorf("failed to resolve host import map: %w", err)
 	}
-	dockerImportMapPath := filepath.ToSlash(hostImportMapPath)
+	dockerImportMapPath := ToDockerPath(hostImportMapPath)
 	importMap, err := NewImportMap(hostImportMapPath, fsys)
 	if err != nil {
 		return nil, "", err
@@ -339,4 +339,10 @@ func BindImportMap(importMapPath string, fsys afero.Fs) ([]string, string, error
 		binds = append(binds, hostImportMapPath+":"+dockerImportMapPath+":ro")
 	}
 	return binds, dockerImportMapPath, nil
+}
+
+func ToDockerPath(absHostPath string) string {
+	prefix := filepath.VolumeName(absHostPath)
+	dockerPath := filepath.ToSlash(absHostPath)
+	return strings.TrimPrefix(dockerPath, prefix)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2428

## What is the new behavior?

Removes `C:` from docker path on windows.

## Additional context

Add any other context or screenshots.
