### PR TITLE
fix: bump edge-runtime to 1.54.3

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.2"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.3"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.3

### Changes

### [1.54.3](https://github.com/supabase/edge-runtime/compare/v1.54.2...v1.54.3) (2024-06-14)

#### Bug Fixes

* include more detailed memory metric in mem check record ([#364](https://github.com/supabase/edge-runtime/issues/364)) ([ac6a0a4](https://github.com/supabase/edge-runtime/commit/ac6a0a42269ef5b60eb37d9962a8582b5676f39c))
