### PR TITLE
fix: bump edge-runtime to 1.54.4

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.3"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.4"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.4

### Changes

### [1.54.4](https://github.com/supabase/edge-runtime/compare/v1.54.3...v1.54.4) (2024-06-17)

#### Bug Fixes

* simplify the shutdown reason due to the memory limit of the event record ([#367](https://github.com/supabase/edge-runtime/issues/367)) ([29d2176](https://github.com/supabase/edge-runtime/commit/29d2176ced4030b4c63c4662973c70b7777f89b0))
