### PR TITLE
fix: bump edge-runtime to 1.54.5

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.4"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.5"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.5

### Changes

### [1.54.5](https://github.com/supabase/edge-runtime/compare/v1.54.4...v1.54.5) (2024-06-19)

#### Bug Fixes

* don’t update mem stat if exceeded the memory limit ([#370](https://github.com/supabase/edge-runtime/issues/370)) ([b135a19](https://github.com/supabase/edge-runtime/commit/b135a1932d0ded6703470e1a6b6e0c0aec4429fd))
