### PR TITLE
fix: bump edge-runtime to 1.54.6

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.5"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.6"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.6

### Changes

### [1.54.6](https://github.com/supabase/edge-runtime/compare/v1.54.5...v1.54.6) (2024-06-19)

#### Bug Fixes

* **node:** refer the internal rid correctly ([#373](https://github.com/supabase/edge-runtime/issues/373)) ([88f8b77](https://github.com/supabase/edge-runtime/commit/88f8b77b780b4bc62be221684029c64accbe195e))
