### PR TITLE
fix(pooler): check if tenant exists before creating

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -850,7 +850,7 @@ EOF
 	// Start all functions.
 	if utils.Config.EdgeRuntime.Enabled && !isContainerExcluded(utils.EdgeRuntimeImage, excluded) {
 		dbUrl := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database)
-		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, serve.RuntimeOption{}, w, fsys); err != nil {
+		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, serve.RuntimeOption{}, fsys); err != nil {
 			return err
 		}
 		started = append(started, utils.EdgeRuntimeId)

--- a/internal/start/templates/pooler.exs
+++ b/internal/start/templates/pooler.exs
@@ -25,4 +25,6 @@ params = %{
   }]
 }
 
-{:ok, _} = Supavisor.Tenants.create_tenant(params)
+if !Supavisor.Tenants.get_tenant_by_external_id(params["external_id"]) do
+  {:ok, _} = Supavisor.Tenants.create_tenant(params)
+end

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -230,14 +230,18 @@ func GetCurrentBranchFS(fsys afero.Fs) (string, error) {
 }
 
 func AssertSupabaseDbIsRunning() error {
-	if _, err := Docker.ContainerInspect(context.Background(), DbId); err != nil {
+	return AssertServiceIsRunning(context.Background(), DbId)
+}
+
+func AssertServiceIsRunning(ctx context.Context, containerId string) error {
+	if _, err := Docker.ContainerInspect(ctx, containerId); err != nil {
 		if client.IsErrNotFound(err) {
 			return errors.New(ErrNotRunning)
 		}
 		if client.IsErrConnectionFailed(err) {
 			CmdSuggestion = suggestDockerInstall
 		}
-		return errors.Errorf("failed to inspect database container: %w", err)
+		return errors.Errorf("failed to inspect service: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2440

## What is the current behavior?

Pooler always recreates tenant on restart.

## What is the new behavior?

Check if tenant exists before creating.

## Additional context

Add any other context or screenshots.
