### PR TITLE
fix: truncate project id in config when longer than 40 chars

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -100,7 +100,7 @@ var (
 			differ := diff.DiffSchemaMigra
 			if usePgSchema {
 				differ = diff.DiffPgSchema
-				fmt.Fprintln(os.Stderr, "WARNING: --use-pg-schema flag is experimental and may not include all entities, such as RLS policies, enums, and grants.")
+				fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "--use-pg-schema flag is experimental and may not include all entities, such as RLS policies, enums, and grants.")
 			}
 			return diff.Run(cmd.Context(), schema, file, flags.DbConfig, differ, afero.NewOsFs())
 		},

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -64,7 +64,7 @@ func PostRun(projectRef string, stdout io.Writer, fsys afero.Fs) error {
 	if updatedConfig.IsEmpty() {
 		return nil
 	}
-	fmt.Fprintln(os.Stderr, utils.Yellow("Warning:"), "Local config differs from linked project. Try updating", utils.Bold(utils.ConfigPath))
+	fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "Local config differs from linked project. Try updating", utils.Bold(utils.ConfigPath))
 	enc := toml.NewEncoder(stdout)
 	enc.Indent = ""
 	if err := enc.Encode(updatedConfig); err != nil {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -897,7 +897,7 @@ func maybeLoadEnv(s string) (string, error) {
 	return "", errors.Errorf(`Error evaluating "%s": environment variable %s is unset.`, s, envName)
 }
 
-function checkAndWarnProjectIdLength(projectId string) {
+func checkAndWarnProjectIdLength(projectId string) {
 	if len(projectId) > maxProjectIdLength {
 		fmt.Fprintln(os.Stderr, "WARNING: Derived Project ID (from folder name) is too long, truncating to 40 characters.")
 	}

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	_ "embed"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -135,6 +136,9 @@ func TestSanitizeProjectI(t *testing.T) {
 	assert.Equal(t, "abc", sanitizeProjectId("_@abc"))
 	// Replaces consecutive invalid characters with a single _
 	assert.Equal(t, "a_bc-", sanitizeProjectId("a@@bc-"))
+	// Truncates to less than 40 characters
+	sanitized := strings.Repeat("a", maxProjectIdLength)
+	assert.Equal(t, sanitized, sanitizeProjectId(sanitized+"bb"))
 }
 
 const (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the `projectId` is derived, one must ensure that the total length of the created container is smaller than `63` chars or else we will have failures within the container network due to unmatchable hostnames

## What is the new behavior?

For new repos: Truncation.
For existing ones: Warnings.

## How to reproduce
Create a folder like this and try to initialize and run Supabase locally: 
`project_id = "Crafting-Production-Ready-Web-Apps-Using-Supabase-Test"`

