### PR TITLE
fix: bump edge-runtime to 1.54.7

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.6"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.7"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.7

### Changes

### [1.54.7](https://github.com/supabase/edge-runtime/compare/v1.54.6...v1.54.7) (2024-06-24)

#### Bug Fixes

* **sb_workers:** don't propagate promise rejection on request body streaming failure ([#374](https://github.com/supabase/edge-runtime/issues/374)) ([5657032](https://github.com/supabase/edge-runtime/commit/5657032885bf9982097d23cf6225e342ce8a6cba))
