### PR TITLE
fix: bump edge-runtime to 1.54.8

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.6"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.8"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.8

### Changes

### [1.54.8](https://github.com/supabase/edge-runtime/compare/v1.54.7...v1.54.8) (2024-06-25)

#### Bug Fixes

* mitigate denoland/deno_core#762 ([#377](https://github.com/supabase/edge-runtime/issues/377)) ([107f27d](https://github.com/supabase/edge-runtime/commit/107f27d031a47cc16a580c8f480763e8b05160bf))
