### PR TITLE
fix: bump edge-runtime to 1.54.9

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -36,7 +36,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.8"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.9"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.9

### Changes

### [1.54.9](https://github.com/supabase/edge-runtime/compare/v1.54.8...v1.54.9) (2024-06-27)

#### Bug Fixes

* narrow the lifetime of the connection token ([#379](https://github.com/supabase/edge-runtime/issues/379)) ([ef3c0a1](https://github.com/supabase/edge-runtime/commit/ef3c0a1814c60e6ae6139af701be0f6fb068c399))
