### PR TITLE
fix: move docker socket warning to start cmd

### DIFF
--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/docker/docker/client"
 	"github.com/docker/go-units"
 	"github.com/go-errors/errors"
 	"github.com/golang-jwt/jwt/v5"
@@ -864,9 +863,6 @@ func LoadConfigFS(fsys afero.Fs) error {
 	}
 	// Validate logflare config
 	if Config.Analytics.Enabled {
-		if Docker.DaemonHost() != client.DefaultDockerHost {
-			fmt.Fprintln(os.Stderr, Yellow("WARNING:"), "running analytics in docker rootless mode is unsupported.")
-		}
 		switch Config.Analytics.Backend {
 		case LogflareBigQuery:
 			if len(Config.Analytics.GcpProjectId) == 0 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #2061 

## What is the new behavior?

Show warning only on supabase start.

## Additional context

Add any other context or screenshots.
