### PR TITLE
feat(typegen): support generating types for golang

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -52,8 +52,11 @@ var (
 	}
 
 	lang = utils.EnumFlag{
-		Allowed: types.SupportedLanguages,
-		Value:   types.SupportedLanguages[0],
+		Allowed: []string{
+			types.LangTypescript,
+			types.LangGo,
+		},
+		Value: types.LangTypescript,
 	}
 	postgrestV9Compat bool
 
@@ -89,7 +92,7 @@ var (
 		Use:        "typescript",
 		Short:      "Generate types for TypeScript",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			lang.Value = types.SupportedLanguages[0]
+			lang.Value = types.LangTypescript
 			return cmd.Parent().PreRunE(cmd, args)
 		},
 		RunE: genTypesCmd.RunE,

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -106,7 +106,7 @@ func init() {
 	genFlags.String("db-url", "", "Generate types from a database url.")
 	genFlags.StringVar(&flags.ProjectRef, "project-id", "", "Generate types from a project ID.")
 	genTypesCmd.MarkFlagsMutuallyExclusive("local", "linked", "project-id", "db-url")
-	genFlags.Var(&lang, "lang", "Language to generate types for.")
+	genFlags.Var(&lang, "lang", "Output language of the generated types.")
 	genFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	genFlags.BoolVar(&postgrestV9Compat, "postgrest-v9-compat", false, "Generate types compatible with PostgREST v9 and below. Only use together with --db-url.")
 	genTypesCmd.AddCommand(genTypesTypescriptCmd)

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/gen/keys"
-	"github.com/supabase/cli/internal/gen/types/typescript"
+	"github.com/supabase/cli/internal/gen/types"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 )
@@ -51,16 +51,15 @@ var (
 		},
 	}
 
+	lang = utils.EnumFlag{
+		Allowed: types.SupportedLanguages,
+		Value:   types.SupportedLanguages[0],
+	}
+	postgrestV9Compat bool
+
 	genTypesCmd = &cobra.Command{
 		Use:   "types",
 		Short: "Generate types from Postgres schema",
-	}
-
-	postgrestV9Compat bool
-
-	genTypesTypescriptCmd = &cobra.Command{
-		Use:   "typescript",
-		Short: "Generate types for TypeScript",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if postgrestV9Compat && !cmd.Flags().Changed("db-url") {
 				return errors.New("--postgrest-v9-compat can only be used together with --db-url.")
@@ -77,22 +76,34 @@ var (
 					return err
 				}
 			}
-			return typescript.Run(ctx, flags.ProjectRef, flags.DbConfig, schema, postgrestV9Compat, afero.NewOsFs())
+			return types.Run(ctx, flags.ProjectRef, flags.DbConfig, lang.Value, schema, postgrestV9Compat, afero.NewOsFs())
 		},
-		Example: `  supabase gen types typescript --local
-  supabase gen types typescript --linked
-  supabase gen types typescript --project-id abc-def-123 --schema public --schema private
-  supabase gen types typescript --db-url 'postgresql://...' --schema public --schema auth`,
+		Example: `  supabase gen types --local
+  supabase gen types --linked --lang=go
+  supabase gen types --project-id abc-def-123 --schema public --schema private
+  supabase gen types --db-url 'postgresql://...' --schema public --schema auth`,
+	}
+
+	genTypesTypescriptCmd = &cobra.Command{
+		Deprecated: "use \"gen types --lang=typescript\" instead.\n",
+		Use:        "typescript",
+		Short:      "Generate types for TypeScript",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			lang.Value = types.SupportedLanguages[0]
+			return cmd.Parent().PreRunE(cmd, args)
+		},
+		RunE: genTypesCmd.RunE,
 	}
 )
 
 func init() {
-	genFlags := genTypesTypescriptCmd.Flags()
+	genFlags := genTypesCmd.PersistentFlags()
 	genFlags.Bool("local", false, "Generate types from the local dev database.")
 	genFlags.Bool("linked", false, "Generate types from the linked project.")
 	genFlags.String("db-url", "", "Generate types from a database url.")
 	genFlags.StringVar(&flags.ProjectRef, "project-id", "", "Generate types from a project ID.")
-	genTypesTypescriptCmd.MarkFlagsMutuallyExclusive("local", "linked", "project-id", "db-url")
+	genTypesCmd.MarkFlagsMutuallyExclusive("local", "linked", "project-id", "db-url")
+	genFlags.Var(&lang, "lang", "Language to generate types for.")
 	genFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	genFlags.BoolVar(&postgrestV9Compat, "postgrest-v9-compat", false, "Generate types compatible with PostgREST v9 and below. Only use together with --db-url.")
 	genTypesCmd.AddCommand(genTypesTypescriptCmd)

--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -16,10 +16,10 @@ import (
 	"github.com/supabase/cli/pkg/api"
 )
 
-var SupportedLanguages = []string{
-	"typescript",
-	"go",
-}
+const (
+	LangTypescript = "typescript"
+	LangGo         = "go"
+)
 
 func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	originalURL := utils.ToPostgresURL(dbConfig)
@@ -30,6 +30,9 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang str
 	included := strings.Join(schemas, ",")
 
 	if projectId != "" {
+		if lang != LangTypescript {
+			return errors.Errorf("Unable to generate %s types for selected project. Try using --db-url flag instead.", lang)
+		}
 		resp, err := utils.GetSupabase().V1GenerateTypescriptTypesWithResponse(ctx, projectId, &api.V1GenerateTypescriptTypesParams{
 			IncludedSchemas: &included,
 		})

--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -1,4 +1,4 @@
-package typescript
+package types
 
 import (
 	"context"
@@ -16,7 +16,12 @@ import (
 	"github.com/supabase/cli/pkg/api"
 )
 
-func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas []string, postgrestV9Compat bool, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+var SupportedLanguages = []string{
+	"typescript",
+	"go",
+}
+
+func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	originalURL := utils.ToPostgresURL(dbConfig)
 	// Add default schemas if --schema flag is not specified
 	if len(schemas) == 0 {
@@ -76,7 +81,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, schemas 
 			Image: utils.Config.Studio.PgmetaImage,
 			Env: []string{
 				"PG_META_DB_URL=" + escaped,
-				"PG_META_GENERATE_TYPES=typescript",
+				"PG_META_GENERATE_TYPES=" + lang,
 				"PG_META_GENERATE_TYPES_INCLUDED_SCHEMAS=" + included,
 				fmt.Sprintf("PG_META_GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS=%v", !postgrestV9Compat),
 			},

--- a/internal/gen/types/types_test.go
+++ b/internal/gen/types/types_test.go
@@ -1,4 +1,4 @@
-package typescript
+package types
 
 import (
 	"context"
@@ -48,7 +48,7 @@ func TestGenLocalCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys, conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys, conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -63,7 +63,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -83,7 +83,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -106,7 +106,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Reply(200).
 			JSON(api.TypescriptResponse{Types: ""})
 		// Run test
-		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys))
+		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -121,7 +121,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			ReplyError(errNetwork)
 		// Run test
-		err := Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys)
+		err := Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys)
 		// Validate api
 		assert.ErrorIs(t, err, errNetwork)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -136,7 +136,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys))
 	})
 }
 
@@ -161,7 +161,7 @@ func TestGenRemoteCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, []string{"public"}, true, afero.NewMemMapFs(), conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, "", []string{"public"}, true, afero.NewMemMapFs(), conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})

--- a/internal/gen/types/types_test.go
+++ b/internal/gen/types/types_test.go
@@ -48,7 +48,7 @@ func TestGenLocalCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys, conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, fsys, conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -63,7 +63,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -83,7 +83,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, "", []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -106,7 +106,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Reply(200).
 			JSON(api.TypescriptResponse{Types: ""})
 		// Run test
-		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys))
+		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, fsys))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -121,7 +121,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			ReplyError(errNetwork)
 		// Run test
-		err := Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys)
+		err := Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, fsys)
 		// Validate api
 		assert.ErrorIs(t, err, errNetwork)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -136,7 +136,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, "", []string{}, true, fsys))
+		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, fsys))
 	})
 }
 
@@ -161,7 +161,7 @@ func TestGenRemoteCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, "", []string{"public"}, true, afero.NewMemMapFs(), conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{"public"}, true, afero.NewMemMapFs(), conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -34,7 +34,7 @@ const (
 	PostgrestImage   = "postgrest/postgrest:v12.2.0"
 	DifferImage      = "supabase/pgadmin-schema-diff:cli-0.0.5"
 	MigraImage       = "supabase/migra:3.0.1663481299"
-	PgmetaImage      = "supabase/postgres-meta:v0.80.0"
+	PgmetaImage      = "supabase/postgres-meta:v0.83.0"
 	StudioImage      = "supabase/studio:20240422-5cf8f30"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.9"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature
relates to https://github.com/supabase/cli/pull/2476

## What is the new behavior?

```bash
supabase gen types --lang=go --local
```

## Additional context

Add any other context or screenshots.
