### PR TITLE
fix: disable interactive console when seeding on start

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -26,7 +26,7 @@ var (
 		Short: "Seed buckets declared in [storage.buckets]",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return buckets.Run(cmd.Context())
+			return buckets.Run(cmd.Context(), utils.NewConsole())
 		},
 	}
 )

--- a/internal/seed/buckets/buckets.go
+++ b/internal/seed/buckets/buckets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/supabase/cli/pkg/storage"
 )
 
-func Run(ctx context.Context) error {
+func Run(ctx context.Context, console *utils.Console) error {
 	api, err := client.NewStorageAPI(ctx, flags.ProjectRef)
 	if err != nil {
 		return err
@@ -21,7 +21,6 @@ func Run(ctx context.Context) error {
 		return err
 	}
 	var exists []string
-	console := utils.NewConsole()
 	for _, b := range buckets {
 		props := NewBucketProps(b.Name)
 		if props == nil {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1027,7 +1027,10 @@ EOF
 		if err := start.WaitForHealthyService(ctx, serviceTimeout, utils.StorageId); err != nil {
 			return err
 		}
-		if err := buckets.Run(ctx); err != nil {
+		// Disable prompts when seeding
+		console := utils.NewConsole()
+		console.IsTTY = false
+		if err := buckets.Run(ctx, console); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/cli/pull/2460

## What is the current behavior?

Broke start with console waiting for input.

## What is the new behavior?

Disable interactive console when seeding on start.

## Additional context

Add any other context or screenshots.
