### PR TITLE
feat(typegen): add swift type generator

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -55,10 +55,18 @@ var (
 		Allowed: []string{
 			types.LangTypescript,
 			types.LangGo,
+			types.LangSwift,
 		},
 		Value: types.LangTypescript,
 	}
-	postgrestV9Compat bool
+	postgrestV9Compat  bool
+	swiftAccessControl = utils.EnumFlag{
+		Allowed: []string{
+			types.SwiftInternalAccessControl,
+			types.SwiftPublicAccessControl,
+		},
+		Value: types.SwiftInternalAccessControl,
+	}
 
 	genTypesCmd = &cobra.Command{
 		Use:   "types",
@@ -79,7 +87,7 @@ var (
 					return err
 				}
 			}
-			return types.Run(ctx, flags.ProjectRef, flags.DbConfig, lang.Value, schema, postgrestV9Compat, afero.NewOsFs())
+			return types.Run(ctx, flags.ProjectRef, flags.DbConfig, lang.Value, schema, postgrestV9Compat, swiftAccessControl.Value, afero.NewOsFs())
 		},
 		Example: `  supabase gen types --local
   supabase gen types --linked --lang=go
@@ -108,6 +116,7 @@ func init() {
 	genTypesCmd.MarkFlagsMutuallyExclusive("local", "linked", "project-id", "db-url")
 	genFlags.Var(&lang, "lang", "Output language of the generated types.")
 	genFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
+	genFlags.Var(&swiftAccessControl, "swift-access-control", "Access control for Swift generated types.")
 	genFlags.BoolVar(&postgrestV9Compat, "postgrest-v9-compat", false, "Generate types compatible with PostgREST v9 and below. Only use together with --db-url.")
 	genTypesCmd.AddCommand(genTypesTypescriptCmd)
 	genCmd.AddCommand(genTypesCmd)

--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -19,9 +19,15 @@ import (
 const (
 	LangTypescript = "typescript"
 	LangGo         = "go"
+	LangSwift      = "swift"
 )
 
-func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+const (
+	SwiftPublicAccessControl   = "public"
+	SwiftInternalAccessControl = "internal"
+)
+
+func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, swiftAccessControl string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	originalURL := utils.ToPostgresURL(dbConfig)
 	// Add default schemas if --schema flag is not specified
 	if len(schemas) == 0 {
@@ -86,6 +92,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang str
 				"PG_META_DB_URL=" + escaped,
 				"PG_META_GENERATE_TYPES=" + lang,
 				"PG_META_GENERATE_TYPES_INCLUDED_SCHEMAS=" + included,
+				"PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL=" + swiftAccessControl,
 				fmt.Sprintf("PG_META_GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS=%v", !postgrestV9Compat),
 			},
 			Cmd: []string{"node", "dist/server/server.js"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add swift type generation

Example
```sh
$ supabase gen types --lang=swift --local --schema public --swift-access-control public
```