### PR TITLE
fix: Bump Realtime image to 2.29.15

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -42,7 +42,7 @@ const (
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"
 	GotrueImage      = "supabase/gotrue:v2.151.0"
-	RealtimeImage    = "supabase/realtime:v2.29.13"
+	RealtimeImage    = "supabase/realtime:v2.29.15"
 	StorageImage     = "supabase/storage-api:v1.0.6"
 	LogflareImage    = "supabase/logflare:1.4.0"
 	// Should be kept in-sync with EdgeRuntimeImage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump Realtime image to 2.29.15
