### PR TITLE
fix: make dependent service schemas optional

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -325,12 +325,19 @@ func DockerRemove(containerId string) {
 	}
 }
 
+type DockerJob struct {
+	Image string
+	Env   []string
+	Cmd   []string
+}
+
+func DockerRunJob(ctx context.Context, job DockerJob, stdout, stderr io.Writer) error {
+	return DockerRunOnceWithStream(ctx, job.Image, job.Env, job.Cmd, stdout, stderr)
+}
+
 // Runs a container image exactly once, returning stdout and throwing error on non-zero exit code.
 func DockerRunOnce(ctx context.Context, image string, env []string, cmd []string) (string, error) {
-	stderr := io.Discard
-	if viper.GetBool("DEBUG") {
-		stderr = os.Stderr
-	}
+	stderr := GetDebugLogger()
 	var out bytes.Buffer
 	err := DockerRunOnceWithStream(ctx, image, env, cmd, &out, stderr)
 	return out.String(), err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2407

## What is the new behavior?

Don't initialise auth, storage, or realtime schemas if those services are disabled.

## Additional context

Add any other context or screenshots.
