### PR TITLE
fix: skip version check if user is offline

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,8 @@ func Execute() {
 func checkUpgrade(ctx context.Context, fsys afero.Fs) (string, error) {
 	if shouldFetchRelease(fsys) {
 		version, err := utils.GetLatestRelease(ctx)
-		if exists, _ := afero.DirExists(fsys, utils.SupabaseDirPath); exists && len(version) > 0 {
+		if exists, _ := afero.DirExists(fsys, utils.SupabaseDirPath); exists {
+			// If user is offline, write an empty file to skip subsequent checks
 			err = utils.WriteFile(utils.CliVersionPath, []byte(version), fsys)
 		}
 		return version, err

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -19,8 +19,7 @@ var (
 func GetGtihubClient(ctx context.Context) *github.Client {
 	githubOnce.Do(func() {
 		var client *http.Client
-		token := os.Getenv("GITHUB_TOKEN")
-		if len(token) > 0 {
+		if token := os.Getenv("GITHUB_TOKEN"); len(token) > 0 {
 			ts := oauth2.StaticTokenSource(
 				&oauth2.Token{AccessToken: token},
 			)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2470

## What is the new behavior?

If user is offline, version check will error and an empty file will be created to skip subsequent checks.

## Additional context

Add any other context or screenshots.
