### PR TITLE
fix: bump edge-runtime to 1.54.10

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -37,7 +37,7 @@ const (
 	PgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	StudioImage      = "supabase/studio:20240701-05dfbec"
 	ImageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.9"
+	EdgeRuntimeImage = "supabase/edge-runtime:v1.54.10"
 	VectorImage      = "timberio/vector:0.28.1-alpine"
 	SupavisorImage   = "supabase/supavisor:1.1.56"
 	PgProveImage     = "supabase/pg_prove:3.36"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.54.10

### Changes

### [1.54.10](https://github.com/supabase/edge-runtime/compare/v1.54.9...v1.54.10) (2024-07-08)

#### Bug Fixes

* missing early retire signal ([#384](https://github.com/supabase/edge-runtime/issues/384)) ([e84efc0](https://github.com/supabase/edge-runtime/commit/e84efc030467961a367b6983369e5051000472c2))
