### PR TITLE
fix: change openai api key name passed in start.go

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -929,7 +929,7 @@ EOF
 					"SUPABASE_ANON_KEY=" + utils.Config.Auth.AnonKey,
 					"SUPABASE_SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey,
 					"LOGFLARE_API_KEY=" + utils.Config.Analytics.ApiKey,
-					"OPENAI_KEY=" + utils.Config.Studio.OpenaiApiKey,
+					"OPENAI_API_KEY=" + utils.Config.Studio.OpenaiApiKey,
 					fmt.Sprintf("LOGFLARE_URL=http://%v:4000", utils.LogflareId),
 					fmt.Sprintf("NEXT_PUBLIC_ENABLE_LOGS=%v", utils.Config.Analytics.Enabled),
 					fmt.Sprintf("NEXT_ANALYTICS_BACKEND_PROVIDER=%v", utils.Config.Analytics.Backend),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix open ai key being passed in start.go to enable Supabase AI Assistant. 

Bug introduced in https://github.com/supabase/supabase/pull/21856
Riffs off of https://github.com/supabase/cli/pull/1986

## What is the current behavior?

See https://github.com/supabase/supabase/issues/27884

## What is the new behavior?

Hopefully can reestablish communication with our savior, the almighty GPT🤞

## Additional context

I'm creating this without any local tests as I understand that a beta release can be created by reading the CONTRIBUTION guide. I'm doing this because I'm lazy and don't want to setup my machine to be able to build and run this package. Hoping I can just `npx supabase@<my-beta-verion> start` and test if it works. Lmk if there's a more desirable way to do this. 
