### PR TITLE
fix: use http scheme for vector docker host

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -96,6 +96,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointDir, hostImpor
 		hostFuncDir += sep
 	}
 	dockerFuncDir := utils.ToDockerPath(hostFuncDir)
+	// TODO: bind ./supabase/functions:/home/deno/functions to hide PII?
 	binds := []string{
 		// Reuse deno cache directory, ie. DENO_DIR, between container restarts
 		// https://denolib.gitbook.io/guide/advanced/deno_dir-code-fetch-and-cache
@@ -128,6 +129,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointDir, hostImpor
 			binds = append(binds, hostEntrypointDir+":"+dockerEntrypointDir+":ro")
 		}
 	}
+	// Imports outside of ./supabase/functions will be bound by absolute path
 	if len(hostImportMapPath) > 0 {
 		if !filepath.IsAbs(hostImportMapPath) {
 			hostImportMapPath = filepath.Join(cwd, hostImportMapPath)

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -225,6 +225,7 @@ func populatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fs
 		}
 		binds = append(binds, modules...)
 		fc.ImportMap = utils.ToDockerPath(fc.ImportMap)
+		fc.Entrypoint = utils.ToDockerPath(fc.Entrypoint)
 		functionsConfig[slug] = fc
 	}
 	functionsConfigBytes, err := json.Marshal(functionsConfig)

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -50,6 +50,7 @@ func NewDocker() *client.Client {
 }
 
 const (
+	DinDHost            = "host.docker.internal"
 	CliProjectLabel     = "com.supabase.cli.project"
 	composeProjectLabel = "com.docker.compose.project"
 )

--- a/internal/utils/docker_linux.go
+++ b/internal/utils/docker_linux.go
@@ -5,7 +5,7 @@ package utils
 import "github.com/docker/docker/api/types/container"
 
 // Allows containers to resolve host network: https://stackoverflow.com/a/62431165
-var extraHosts = []string{"host.docker.internal:host-gateway"}
+var extraHosts = []string{DinDHost + ":host-gateway"}
 
 func isUserDefined(mode container.NetworkMode) bool {
 	return mode.IsUserDefined()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -151,8 +151,8 @@ func TestSigningJWT(t *testing.T) {
 	})
 
 	t.Run("signs default service_role key", func(t *testing.T) {
-		anonToken := CustomClaims{Role: "service_role"}.NewToken()
-		signed, err := anonToken.SignedString([]byte(defaultJwtSecret))
+		serviceToken := CustomClaims{Role: "service_role"}.NewToken()
+		signed, err := serviceToken.SignedString([]byte(defaultJwtSecret))
 		assert.NoError(t, err)
 		assert.Equal(t, defaultServiceRoleKey, signed)
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2538
relates to https://github.com/supabase/cli/issues/2531

## What is the new behavior?

Defaults to `DOCKER_HOST=tcp://localhost:2375` on windows.

## Additional context

Add any other context or screenshots.
