### PR TITLE
fix: ignore missing table when listing remote migrations

### DIFF
--- a/pkg/migration/list.go
+++ b/pkg/migration/list.go
@@ -18,10 +18,7 @@ import (
 
 func ListRemoteMigrations(ctx context.Context, conn *pgx.Conn) ([]string, error) {
 	// We query the version string only for backwards compatibility
-	rows, err := conn.Query(ctx, LIST_MIGRATION_VERSION)
-	if err != nil {
-		return nil, errors.Errorf("failed to query rows: %w", err)
-	}
+	rows, _ := conn.Query(ctx, LIST_MIGRATION_VERSION)
 	versions, err := pgxv5.CollectStrings(rows)
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/pkg/pgxv5/rows.go
+++ b/pkg/pgxv5/rows.go
@@ -11,6 +11,7 @@ import (
 )
 
 func CollectStrings(rows pgx.Rows) ([]string, error) {
+	defer rows.Close()
 	result := []string{}
 	for rows.Next() {
 		var version string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

pgxconn.Query error is safe to ignore.

## Additional context

Add any other context or screenshots.
