### PR TITLE
fix: bump edge-runtime to 1.55.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.55.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.55.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.151.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.55.1

### Changes

### [1.55.1](https://github.com/supabase/edge-runtime/compare/v1.55.0...v1.55.1) (2024-07-30)

#### Bug Fixes

* revisit `MemCheck` related logics ([#380](https://github.com/supabase/edge-runtime/issues/380)) ([0ff7ce0](https://github.com/supabase/edge-runtime/commit/0ff7ce010504091931b226c7c53ec9e78d42a93c))
