### PR TITLE
fix: bump edge-runtime to 1.55.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.55.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.55.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.151.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.55.2

### Changes

### [1.55.2](https://github.com/supabase/edge-runtime/compare/v1.55.1...v1.55.2) (2024-07-30)

#### Bug Fixes

* **sb_ai/gte:** cpu time should be accumulated correctly ([#388](https://github.com/supabase/edge-runtime/issues/388)) ([c4ce679](https://github.com/supabase/edge-runtime/commit/c4ce6795c0ca3e9308bbd25691986e9b2a2ab3a7))
