### PR TITLE
fix: bump edge-runtime to 1.56.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.55.2"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.56.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.151.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.56.0

### Changes

### [1.56.0](https://github.com/supabase/edge-runtime/compare/v1.55.2...v1.56.0) (2024-07-31)

#### Features

* support setting network permissions via allowNet option ([#386](https://github.com/supabase/edge-runtime/issues/386)) ([5d9d180](https://github.com/supabase/edge-runtime/commit/5d9d180c67014ff3ba8233a68e89055b3ca2d646))
