### PR TITLE
feat: add MFA (Phone) related config

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -616,8 +616,6 @@ EOF
 				env,
 				"GOTRUE_MFA_PHONE_ENROLL_ENABLED=true",
 				"GOTRUE_MFA_PHONE_VERIFY_ENABLED=true",
-				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
-
 			)
 		}
 		if utils.Config.Auth.MFA.TOTP.EnrollEnabled && utils.Config.Auth.MFA.TOTP.VerifyEnabled {
@@ -625,8 +623,6 @@ EOF
 				env,
 				"GOTRUE_MFA_TOTP_ENROLL_ENABLED=true",
 				"GOTRUE_MFA_TOTP_VERIFY_ENABLED=true",
-				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
-
 			)
 		}
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -611,6 +611,24 @@ EOF
 				"GOTRUE_HOOK_SEND_EMAIL_SECRETS="+utils.Config.Auth.Hook.SendEmail.Secrets,
 			)
 		}
+		if utils.Config.Auth.MFA.Phone.Enroll.Enabled && utils.Config.Auth.MFA.Phone.Verify.Enabled {
+			env = append(
+				env,
+				"GOTRUE_MFA_PHONE_ENROLL_ENABLED=true",
+				"GOTRUE_MFA_PHONE_VERIFY_ENABLED=true"
+				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
+
+			)
+		}
+		if utils.Config.Auth.MFA.TOTP.Enroll.Enabled && utils.Config.Auth.MFA.TOTP.Verify.Enabled {
+			env = append(
+				env,
+				"GOTRUE_MFA_TOTP_ENROLL_ENABLED=true",
+				"GOTRUE_MFA_TOTP_VERIFY_ENABLED=true"
+				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
+
+			)
+		}
 
 		for name, config := range utils.Config.Auth.External {
 			env = append(

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -497,6 +497,11 @@ EOF
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=%v", utils.Config.Auth.EnableRefreshTokenRotation),
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=%v", utils.Config.Auth.RefreshTokenReuseInterval),
 			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
+			fmt.Sprintf("GOTRUE_MFA_PHONE_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.Phone.EnrollEnabled),
+			fmt.Sprintf("GOTRUE_MFA_PHONE_VERIFY_ENABLED=%v", utils.Config.Auth.MFA.Phone.VerifyEnabled),
+			fmt.Sprintf("GOTRUE_MFA_TOTP_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.TOTP.EnrollEnabled),
+			fmt.Sprintf("GOTRUE_MFA_TOTP_VERIFY_ENABLED=%v", utils.Config.Auth.MFA.TOTP.VerifyEnabled),
+			fmt.Sprintf("GOTRUE_MFA_MAX_ENROLLED_FACTORS=%v", utils.Config.Auth.MFA.MaxEnrolledFactors),
 		}
 
 		if utils.Config.Auth.Sessions.Timebox > 0 {
@@ -611,18 +616,12 @@ EOF
 				"GOTRUE_HOOK_SEND_EMAIL_SECRETS="+utils.Config.Auth.Hook.SendEmail.Secrets,
 			)
 		}
-		if utils.Config.Auth.MFA.Phone.EnrollEnabled && utils.Config.Auth.MFA.Phone.VerifyEnabled {
+		if utils.Config.Auth.MFA.Phone.EnrollEnabled || utils.Config.Auth.MFA.Phone.VerifyEnabled {
 			env = append(
 				env,
-				"GOTRUE_MFA_PHONE_ENROLL_ENABLED=true",
-				"GOTRUE_MFA_PHONE_VERIFY_ENABLED=true",
-			)
-		}
-		if utils.Config.Auth.MFA.TOTP.EnrollEnabled && utils.Config.Auth.MFA.TOTP.VerifyEnabled {
-			env = append(
-				env,
-				"GOTRUE_MFA_TOTP_ENROLL_ENABLED=true",
-				"GOTRUE_MFA_TOTP_VERIFY_ENABLED=true",
+				"GOTRUE_MFA_PHONE_TEMPLATE="+utils.Config.Auth.MFA.Phone.Template,
+				fmt.Sprintf("GOTRUE_MFA_PHONE_OTP_LENGTH=%v", utils.Config.Auth.MFA.Phone.OtpLength),
+				fmt.Sprintf("GOTRUE_MFA_PHONE_MAX_FREQUENCY=%v", utils.Config.Auth.MFA.Phone.MaxFrequency),
 			)
 		}
 

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -611,20 +611,20 @@ EOF
 				"GOTRUE_HOOK_SEND_EMAIL_SECRETS="+utils.Config.Auth.Hook.SendEmail.Secrets,
 			)
 		}
-		if utils.Config.Auth.MFA.Phone.Enroll.Enabled && utils.Config.Auth.MFA.Phone.Verify.Enabled {
+		if utils.Config.Auth.MFA.Phone.EnrollEnabled && utils.Config.Auth.MFA.Phone.VerifyEnabled {
 			env = append(
 				env,
 				"GOTRUE_MFA_PHONE_ENROLL_ENABLED=true",
-				"GOTRUE_MFA_PHONE_VERIFY_ENABLED=true"
+				"GOTRUE_MFA_PHONE_VERIFY_ENABLED=true",
 				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
 
 			)
 		}
-		if utils.Config.Auth.MFA.TOTP.Enroll.Enabled && utils.Config.Auth.MFA.TOTP.Verify.Enabled {
+		if utils.Config.Auth.MFA.TOTP.EnrollEnabled && utils.Config.Auth.MFA.TOTP.VerifyEnabled {
 			env = append(
 				env,
 				"GOTRUE_MFA_TOTP_ENROLL_ENABLED=true",
-				"GOTRUE_MFA_TOTP_VERIFY_ENABLED=true"
+				"GOTRUE_MFA_TOTP_VERIFY_ENABLED=true",
 				// TODO: Revisit once we have connected the "Enabled" field with the Phone fields
 
 			)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -314,7 +314,7 @@ type (
 		TOTP  totpFactorTypeConfiguration  `toml:"totp"`
 		Phone phoneFactorTypeConfiguration `toml:"phone"`
 		// set to float64 for backward compatibility
-		MaxEnrolledFactors float64 `toml:"max_enrolled_factors"`
+		MaxEnrolledFactors uint `toml:"max_enrolled_factors"`
 	}
 
 	hookConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -238,6 +238,7 @@ type (
 		// Add MFA Config here
 
 		Hook     hook     `toml:"hook"`
+		MFA      mfa      `toml:"mfa"`
 		Sessions sessions `toml:"sessions"`
 
 		EnableSignup           bool  `toml:"enable_signup"`
@@ -294,6 +295,26 @@ type (
 		CustomAccessToken           hookConfig `toml:"custom_access_token"`
 		SendSMS                     hookConfig `toml:"send_sms"`
 		SendEmail                   hookConfig `toml:"send_email"`
+	}
+	factorTypeConfiguration struct {
+		EnrollEnabled bool `toml:"enroll_enabled"`
+		VerifyEnabled bool `toml:"verify_enabled"`
+	}
+	totpFactorTypeConfiguration struct {
+		factorTypeConfiguration
+	}
+
+	phoneFactorTypeConfiguration struct {
+		factorTypeConfiguration
+		OtpLength int    `toml:"otp_length"`
+		Template  string `toml:"template"`
+	}
+
+	mfa struct {
+		TOTP  totpFactorTypeConfiguration  `toml:"totp"`
+		Phone phoneFactorTypeConfiguration `toml:"phone"`
+		// set to float64 for backward compatibility
+		MaxEnrolledFactors float64 `toml:"max_enrolled_factors"`
 	}
 
 	hookConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,8 +305,9 @@ type (
 
 	phoneFactorTypeConfiguration struct {
 		factorTypeConfiguration
-		OtpLength int    `toml:"otp_length"`
-		Template  string `toml:"template"`
+		OtpLength    int           `toml:"otp_length"`
+		Template     string        `toml:"template"`
+		MaxFrequency time.Duration `toml:"max_frequency"`
 	}
 
 	mfa struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,7 +235,6 @@ type (
 		EnableRefreshTokenRotation bool `toml:"enable_refresh_token_rotation"`
 		RefreshTokenReuseInterval  uint `toml:"refresh_token_reuse_interval"`
 		EnableManualLinking        bool `toml:"enable_manual_linking"`
-		// Add MFA Config here
 
 		Hook     hook     `toml:"hook"`
 		MFA      mfa      `toml:"mfa"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -299,9 +299,6 @@ type (
 		EnrollEnabled bool `toml:"enroll_enabled"`
 		VerifyEnabled bool `toml:"verify_enabled"`
 	}
-	totpFactorTypeConfiguration struct {
-		factorTypeConfiguration
-	}
 
 	phoneFactorTypeConfiguration struct {
 		factorTypeConfiguration
@@ -311,7 +308,7 @@ type (
 	}
 
 	mfa struct {
-		TOTP  totpFactorTypeConfiguration  `toml:"totp"`
+		TOTP  factorTypeConfiguration      `toml:"totp"`
 		Phone phoneFactorTypeConfiguration `toml:"phone"`
 		// set to float64 for backward compatibility
 		MaxEnrolledFactors uint `toml:"max_enrolled_factors"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,7 +305,7 @@ type (
 
 	phoneFactorTypeConfiguration struct {
 		factorTypeConfiguration
-		OtpLength    int           `toml:"otp_length"`
+		OtpLength    uint          `toml:"otp_length"`
 		Template     string        `toml:"template"`
 		MaxFrequency time.Duration `toml:"max_frequency"`
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,6 +235,7 @@ type (
 		EnableRefreshTokenRotation bool `toml:"enable_refresh_token_rotation"`
 		RefreshTokenReuseInterval  uint `toml:"refresh_token_reuse_interval"`
 		EnableManualLinking        bool `toml:"enable_manual_linking"`
+		// Add MFA Config here
 
 		Hook     hook     `toml:"hook"`
 		Sessions sessions `toml:"sessions"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -308,10 +308,9 @@ type (
 	}
 
 	mfa struct {
-		TOTP  factorTypeConfiguration      `toml:"totp"`
-		Phone phoneFactorTypeConfiguration `toml:"phone"`
-		// set to float64 for backward compatibility
-		MaxEnrolledFactors uint `toml:"max_enrolled_factors"`
+		TOTP               factorTypeConfiguration      `toml:"totp"`
+		Phone              phoneFactorTypeConfiguration `toml:"phone"`
+		MaxEnrolledFactors uint                         `toml:"max_enrolled_factors"`
 	}
 
 	hookConfig struct {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -16,7 +16,7 @@ const (
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"
-	realtimeImage    = "supabase/realtime:v2.29.15"
+	realtimeImage    = "supabase/realtime:v2.30.23"
 	storageImage     = "supabase/storage-api:v1.0.6"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,8 +15,8 @@ const (
 	edgeRuntimeImage = "supabase/edge-runtime:v1.56.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
-	gotrueImage      = "supabase/gotrue:v2.157.1"
-	realtimeImage    = "supabase/realtime:v2.30.23"
+	gotrueImage      = "supabase/gotrue:v2.158.1"
+	realtimeImage    = "supabase/realtime:v2.29.15"
 	storageImage     = "supabase/storage-api:v1.0.6"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -160,6 +160,22 @@ message_service_sid = ""
 # DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
 auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
 
+# Configure MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true
+
+[auth.mfa]
+max_enrolled_factors = 10
+
+# Configure Multi-factor-authentication via Phone Messaging
+# [auth.mfa.phone]
+# enroll_enabled = true
+# verify_enabled = true
+# otp_length = 6
+# template = "Your Code is {{ .Code }}"
+# max_frequency = "10s"
+
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `slack`, `spotify`, `workos`, `zoom`.

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -160,13 +160,13 @@ message_service_sid = ""
 # DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
 auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
 
+[auth.mfa]
+max_enrolled_factors = 10
+
 # Configure MFA via App Authenticator (TOTP)
 [auth.mfa.totp]
 enroll_enabled = true
 verify_enabled = true
-
-[auth.mfa]
-max_enrolled_factors = 10
 
 # Configure Multi-factor-authentication via Phone Messaging
 # [auth.mfa.phone]

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -173,7 +173,7 @@ max_enrolled_factors = 10
 # enroll_enabled = true
 # verify_enabled = true
 # otp_length = 6
-# template = "Your Code is {{ .Code }}"
+# template = "Your code is {{ `{{ .Code }}` }} ."
 # max_frequency = "10s"
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -163,6 +163,22 @@ message_service_sid = "message_service_sid"
 # DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
 auth_token = "env(TWILIO_AUTH_TOKEN)"
 
+[auth.mfa]
+max_enrolled_factors = 10
+
+# Configure MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true
+
+# Configure Multi-factor-authentication via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = true
+verify_enabled = true
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }} ."
+max_frequency = "10s"
+
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `slack`, `spotify`, `workos`, `zoom`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces the supporting Auth configuration for  MFA (Phone). This include:

1. The respective enable / disable flows for each toggle `MFA.Phone.EnrollEnabled` and `MFA.Phone.VerifyEnabled`
2. `MFA.MaxEnrolledFactors`  which is already exposed on the platform
4. Phone also comes with a configurable OTP Length as well as Template. We don't include the provider specific configuration as they are derived from the primary provider. We also expose MaxFrequency