### PR TITLE
fix: upgrade auth version to v2.157.1 and add slack oidc config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -456,6 +456,7 @@ func NewConfig(editors ...ConfigEditor) config {
 				"twitch":        {},
 				"twitter":       {},
 				"slack":         {},
+				"slack_oidc":    {},
 				"spotify":       {},
 				"workos":        {},
 				"zoom":          {},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -455,7 +455,7 @@ func NewConfig(editors ...ConfigEditor) config {
 				"notion":        {},
 				"twitch":        {},
 				"twitter":       {},
-				"slack":         {},
+				"slack":         {}, // TODO: remove this field in v2
 				"slack_oidc":    {},
 				"spotify":       {},
 				"workos":        {},

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,7 +15,7 @@ const (
 	edgeRuntimeImage = "supabase/edge-runtime:v1.55.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
-	gotrueImage      = "supabase/gotrue:v2.151.0"
+	gotrueImage      = "supabase/gotrue:v2.157.1"
 	realtimeImage    = "supabase/realtime:v2.29.15"
 	storageImage     = "supabase/storage-api:v1.0.6"
 	logflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade auth version to v2.157.1

Prior art for external config: https://github.com/supabase/cli/pull/1858/files#diff-315c0e4898fa48b5e5394e5a8d8d65437eac539e6b363a7660c157055a166fa9

Relevant thread: https://supabase.slack.com/archives/C022071RB2L/p1722589931235649