### PR TITLE
fix: Bump studio to the latest image version 20240805

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -10,7 +10,7 @@ const (
 	inbucketImage    = "inbucket/inbucket:3.0.3"
 	postgrestImage   = "postgrest/postgrest:v12.2.0"
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
-	studioImage      = "supabase/studio:20240729-ce42139"
+	studioImage      = "supabase/studio:20240805"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	edgeRuntimeImage = "supabase/edge-runtime:v1.55.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
Updates service studio new version to 20240805