### PR TITLE
feat: support declaring objects path for seeding buckets

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/seed/buckets"
 	"github.com/supabase/cli/internal/utils"
@@ -27,7 +28,7 @@ var (
 		Short: "Seed buckets declared in [storage.buckets]",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return buckets.Run(cmd.Context(), flags.ProjectRef, utils.NewConsole())
+			return buckets.Run(cmd.Context(), flags.ProjectRef, true, afero.NewOsFs())
 		},
 	}
 )

--- a/internal/seed/buckets/buckets.go
+++ b/internal/seed/buckets/buckets.go
@@ -3,18 +3,22 @@ package buckets
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/storage/client"
+	"github.com/supabase/cli/internal/storage/cp"
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(ctx context.Context, projectRef string, console *utils.Console) error {
+func Run(ctx context.Context, projectRef string, interactive bool, fsys afero.Fs) error {
 	api, err := client.NewStorageAPI(ctx, projectRef)
 	if err != nil {
 		return err
 	}
-	if console == nil {
-		return api.UpsertBuckets(ctx, utils.Config.Storage.Buckets)
+	console := utils.NewConsole()
+	if !interactive {
+		console.IsTTY = false
 	}
 	filter := func(bucketId string) bool {
 		label := fmt.Sprintf("Bucket %s already exists. Do you want to overwrite its properties?", utils.Bold(bucketId))
@@ -24,5 +28,14 @@ func Run(ctx context.Context, projectRef string, console *utils.Console) error {
 		}
 		return shouldOverwrite
 	}
-	return api.UpsertBuckets(ctx, utils.Config.Storage.Buckets, filter)
+	if err := api.UpsertBuckets(ctx, utils.Config.Storage.Buckets, filter); err != nil {
+		return err
+	}
+	for _, bucket := range utils.Config.Storage.Buckets {
+		localPath := filepath.Join(utils.SupabaseDirPath, bucket.ObjectsPath)
+		if err := cp.UploadStorageObjectAll(ctx, api, "", localPath, 5, fsys); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1062,7 +1062,7 @@ EOF
 			return err
 		}
 		// Disable prompts when seeding
-		if err := buckets.Run(ctx, "", nil); err != nil {
+		if err := buckets.Run(ctx, "", false, fsys); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/cp/cp.go
+++ b/internal/storage/cp/cp.go
@@ -94,16 +94,19 @@ func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remoteP
 	// Check if directory exists on remote
 	dirExists := false
 	fileExists := false
-	if err := ls.IterateStoragePaths(ctx, api, noSlash, func(objectName string) error {
-		if objectName == path.Base(noSlash) {
-			fileExists = true
+	if len(noSlash) > 0 {
+		callback := func(objectName string) error {
+			if objectName == path.Base(noSlash) {
+				fileExists = true
+			}
+			if objectName == path.Base(noSlash)+"/" {
+				dirExists = true
+			}
+			return nil
 		}
-		if objectName == path.Base(noSlash)+"/" {
-			dirExists = true
+		if err := ls.IterateStoragePaths(ctx, api, noSlash, callback); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 	baseName := filepath.Base(localPath)
 	jq := utils.NewJobQueue(maxJobs)

--- a/internal/storage/cp/cp_test.go
+++ b/internal/storage/cp/cp_test.go
@@ -311,7 +311,7 @@ func TestUploadAll(t *testing.T) {
 			Get("/storage/v1/bucket").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "", ".", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "missing", ".", 1, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Error status 503:")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -211,6 +211,7 @@ type (
 		Public           *bool       `toml:"public"`
 		FileSizeLimit    sizeInBytes `toml:"file_size_limit"`
 		AllowedMimeTypes []string    `toml:"allowed_mime_types"`
+		ObjectsPath      string      `toml:"objects_path"`
 	}
 
 	imageTransformation struct {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -78,6 +78,7 @@ enabled = true
 # public = false
 # file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
 
 [auth]
 enabled = true

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -78,6 +78,7 @@ enabled = false
 public = false
 file_size_limit = "50MiB"
 allowed_mime_types = ["image/png", "image/jpeg"]
+objects_path = "./images"
 
 [auth]
 enabled = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Allows configuring an `objects_path` for seeding buckets. Files under the path will be uploaded to their respective bucket.

```
[storage.buckets.images]
objects_path = "./images"
```

Path will be resolved relative to `config.toml`, ie. the path above resolves to `supabase/images`.

Also seeds automatically when running the following commands locally
- `supabase start`
- `supabase db reset`

For hosted projects, a separate command needs to be run:
- `supabase seed buckets`

## Additional context

This works fine for small objects but large files will require a separate solution.
