### PR TITLE
fix: bump edge-runtime to 1.56.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.56.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.56.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.56.1

BREAKING CHANGE: This PR changes the way eszip is bundled. It should remain in draft status until it is determined to be stable enough.

### Changes

### [1.56.1](https://github.com/supabase/edge-runtime/compare/v1.56.0...v1.56.1) (2024-08-07)

#### Performance Improvements

* implement lazy load for eszip entities ([#343](https://github.com/supabase/edge-runtime/issues/343)) ([3f7863b](https://github.com/supabase/edge-runtime/commit/3f7863ba4b2f3b838934979cfb6fe2b0e7d6db3e))
