### PR TITLE
feat: add third-party auth support for local dev

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -166,6 +166,11 @@ func run(p utils.Program, ctx context.Context, fsys afero.Fs, excludedContainers
 		excluded[name] = true
 	}
 
+	jwks, err := utils.Config.Auth.ResolveJWKS()
+	if err != nil {
+		return err
+	}
+
 	// Start Postgres.
 	w := utils.StatusWriter{Program: p}
 	if dbConfig.Host == utils.DbId {
@@ -724,6 +729,7 @@ EOF
 					"DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime",
 					"DB_ENC_KEY=" + utils.Config.Realtime.EncryptionKey,
 					"API_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+					fmt.Sprintf("API_JWT_JWKS=%s", jwks),
 					"METRICS_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
 					"APP_NAME=realtime",
 					"SECRET_KEY_BASE=" + utils.Config.Realtime.SecretKeyBase,
@@ -774,7 +780,7 @@ EOF
 					"PGRST_DB_EXTRA_SEARCH_PATH=" + strings.Join(utils.Config.Api.ExtraSearchPath, ","),
 					fmt.Sprintf("PGRST_DB_MAX_ROWS=%d", utils.Config.Api.MaxRows),
 					"PGRST_DB_ANON_ROLE=anon",
-					"PGRST_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+					fmt.Sprintf("PGRST_JWT_SECRET=%s", jwks),
 					"PGRST_ADMIN_SERVER_PORT=3001",
 				},
 				// PostgREST does not expose a shell for health check
@@ -807,6 +813,7 @@ EOF
 					"ANON_KEY=" + utils.Config.Auth.AnonKey,
 					"SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey,
 					"AUTH_JWT_SECRET=" + utils.Config.Auth.JwtSecret,
+					fmt.Sprintf("AUTH_JWT_JWKS=%s", jwks),
 					fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:%d/%s", dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database),
 					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 					"STORAGE_BACKEND=file",

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -166,7 +166,7 @@ func run(p utils.Program, ctx context.Context, fsys afero.Fs, excludedContainers
 		excluded[name] = true
 	}
 
-	jwks, err := utils.Config.Auth.ResolveJWKS()
+	jwks, err := utils.Config.Auth.ResolveJWKS(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -176,6 +176,23 @@ url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
 
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
 [edge_runtime]
 enabled = true
 # Configure one of the supported request policies: `oneshot`, `per_worker`.


### PR DESCRIPTION
Adds support for configuring a Third-Party Auth provider to be used alongside Supabase Auth.

Internally both Storage, Realtime and PostgREST support this if they're configured with a JWKS.