### PR TITLE
fix(storage): configure and parse x-forwarded-for header

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -108,11 +108,14 @@ services:
           - /storage/v1/
     plugins:
       - name: cors
+    {{if .StorageForwardHeaders }}
       - name: request-transformer
         config:
           add:
             headers:
               - "Forwarded: host={{ .ApiHost }}:{{ .ApiPort }};proto=http"
+    {{end}}
+
   - name: pg-meta
     _comment: "pg-meta: /pg/* -> http://pg-meta:8080/*"
     url: http://{{ .PgmetaId }}:8080/

--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -108,14 +108,13 @@ services:
           - /storage/v1/
     plugins:
       - name: cors
-    {{if .StorageForwardHeaders }}
+{{if StorageVersionBelow "1.10.1" }}
       - name: request-transformer
         config:
           add:
             headers:
               - "Forwarded: host={{ .ApiHost }}:{{ .ApiPort }};proto=http"
-    {{end}}
-
+{{end}}
   - name: pg-meta
     _comment: "pg-meta: /pg/* -> http://pg-meta:8080/*"
     url: http://{{ .PgmetaId }}:8080/

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -201,6 +201,14 @@ func GetRegistryImageUrl(imageName string) string {
 	return registry + "/supabase/" + imageName
 }
 
+func GetImageTag(imageUrl string) string {
+	parts := strings.Split(imageUrl, ":")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
 func DockerImagePull(ctx context.Context, imageTag string, w io.Writer) error {
 	out, err := Docker.ImagePull(ctx, imageTag, image.PullOptions{
 		RegistryAuth: GetRegistryAuth(),

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -201,14 +201,6 @@ func GetRegistryImageUrl(imageName string) string {
 	return registry + "/supabase/" + imageName
 }
 
-func GetImageTag(imageUrl string) string {
-	parts := strings.Split(imageUrl, ":")
-	if len(parts) > 1 {
-		return parts[len(parts)-1]
-	}
-	return ""
-}
-
 func DockerImagePull(ctx context.Context, imageTag string, w io.Writer) error {
 	out, err := Docker.ImagePull(ctx, imageTag, image.PullOptions{
 		RegistryAuth: GetRegistryAuth(),

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -17,7 +17,7 @@ const (
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.157.1"
 	realtimeImage    = "supabase/realtime:v2.30.23"
-	storageImage     = "supabase/storage-api:v1.0.6"
+	storageImage     = "supabase/storage-api:v1.10.1"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below
 	DifferImage  = "supabase/pgadmin-schema-diff:cli-0.0.5"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature

## What is the current behavior?

Currently, we use the docker port forwarding feature to direct traffic from port: 54323 -> to 8000 which is the port kong is listening to.

In order for kong to provide the correct `x-forwarded-port` instead of 8080 we shoukd configure [port_maps](https://docs.konghq.com/gateway/latest/reference/configuration/#port_maps) 

## What is the new behavior?

This PR sets the `port_maps` and bumps the version of Storage to v1.10.1 which conforms better to the canonical x-forwarded headers
