### PR TITLE
fix: bump edge-runtime to 1.57.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.56.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.57.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.57.0

BREAKING CHANGE: This PR changes the way eszip is bundled. It should remain in draft status until it is determined to be stable enough.

### Changes

### [1.57.0](https://github.com/supabase/edge-runtime/compare/v1.56.1...v1.57.0) (2024-08-21)

#### Features

* version up the Deno codebase to 1.45.2 ([#389](https://github.com/supabase/edge-runtime/issues/389)) ([82588d6](https://github.com/supabase/edge-runtime/commit/82588d6def254a2dfe008faabfdcb9202fb858a1))
