### PR TITLE
chore: Fixed typo in 'GetGitHubClient()' function name

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -37,7 +37,7 @@ var (
 					viper.Set("WORKDIR", workdir)
 				}
 			}
-			client := utils.GetGtihubClient(ctx)
+			client := utils.GetGitHubClient(ctx)
 			templates, err := bootstrap.ListSamples(ctx, client)
 			if err != nil {
 				return err

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, starter StarterTemplate, fsys afero.Fs, options ..
 	}
 	// 0. Download starter template
 	if len(starter.Url) > 0 {
-		client := utils.GetGtihubClient(ctx)
+		client := utils.GetGitHubClient(ctx)
 		if err := downloadSample(ctx, client, starter.Url, fsys); err != nil {
 			return err
 		}

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -16,7 +16,7 @@ var (
 	githubOnce   sync.Once
 )
 
-func GetGtihubClient(ctx context.Context) *github.Client {
+func GetGitHubClient(ctx context.Context) *github.Client {
 	githubOnce.Do(func() {
 		var client *http.Client
 		if token := os.Getenv("GITHUB_TOKEN"); len(token) > 0 {
@@ -36,7 +36,7 @@ const (
 )
 
 func GetLatestRelease(ctx context.Context) (string, error) {
-	client := GetGtihubClient(ctx)
+	client := GetGitHubClient(ctx)
 	release, _, err := client.Repositories.GetLatestRelease(ctx, CLI_OWNER, CLI_REPO)
 	if err != nil {
 		return "", errors.Errorf("Failed to fetch latest release: %w", err)

--- a/tools/bumpdoc/main.go
+++ b/tools/bumpdoc/main.go
@@ -46,7 +46,7 @@ func updateRefDoc(ctx context.Context, path string, stdin io.Reader) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "Updating reference doc: %s\n", path)
-	client := utils.GetGtihubClient(ctx)
+	client := utils.GetGitHubClient(ctx)
 	branch := "cli/ref-doc"
 	master := "master"
 	if err := shared.CreateGitBranch(ctx, client, SUPABASE_OWNER, SUPABASE_REPO, branch, master); err != nil {

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -30,7 +30,7 @@ func main() {
 }
 
 func showChangeLog(ctx context.Context, slackChannel string) error {
-	client := utils.GetGtihubClient(ctx)
+	client := utils.GetGitHubClient(ctx)
 	releases, _, err := client.Repositories.ListReleases(ctx, utils.CLI_OWNER, utils.CLI_REPO, &github.ListOptions{})
 	if err != nil {
 		return err

--- a/tools/publish/main.go
+++ b/tools/publish/main.go
@@ -66,7 +66,7 @@ func publishPackages(ctx context.Context, version string, beta bool) error {
 		config.Description += " (Beta)"
 		filename += "-beta"
 	}
-	client := utils.GetGtihubClient(ctx)
+	client := utils.GetGitHubClient(ctx)
 	if err := updatePackage(ctx, client, HOMEBREW_REPO, filename+".rb", brewFormulaTemplate, config); err != nil {
 		return err
 	}

--- a/tools/selfhost/main.go
+++ b/tools/selfhost/main.go
@@ -43,7 +43,7 @@ type ComposeFile struct {
 }
 
 func updateSelfHosted(ctx context.Context, branch string) error {
-	client := utils.GetGtihubClient(ctx)
+	client := utils.GetGitHubClient(ctx)
 	master := "master"
 	if err := shared.CreateGitBranch(ctx, client, SUPABASE_OWNER, SUPABASE_REPO, branch, master); err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

I fixed the typo in the name of utils.GetGitHubClient()
It's currently named utils.GetGtiHubClient()

## What is the current behavior?

n/a

## What is the new behavior?

n/a

## Additional context

n/a