### PR TITLE
fix: bump edge-runtime to 1.58.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.56.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.0

BREAKING CHANGE: This PR changes the way eszip is bundled. It should remain in draft status until it is determined to be stable enough.

### Changes

### [1.58.0](https://github.com/supabase/edge-runtime/compare/v1.56.1...v1.58.0) (2024-08-23)


#### Features

* version up the Deno codebase to 1.45.2 ([#389](https://github.com/supabase/edge-runtime/issues/389)) ([82588d6](https://github.com/supabase/edge-runtime/commit/82588d6def254a2dfe008faabfdcb9202fb858a1))

* support declarative style fetch handler ([#400](https://github.com/supabase/edge-runtime/issues/400)) ([5d4a9b4](https://github.com/supabase/edge-runtime/commit/5d4a9b40ad1dfa58e35173e5c376eab6be899fe6))


#### Bug Fixes

* **deps:** bump openssl from 0.10.64 to 0.10.66 ([#397](https://github.com/supabase/edge-runtime/issues/397)) ([b27190c](https://github.com/supabase/edge-runtime/commit/b27190ca093e48df1c5768845cab09d7d7a06527))

* **sb_core:** expose web compression/decompression stream API ([#398](https://github.com/supabase/edge-runtime/issues/398)) ([14f3f92](https://github.com/supabase/edge-runtime/commit/14f3f92e46d20ec576723b81fbb7be2096b95b93))

* **base:** connections for inspector sessions should be upgradeable to the websocket ([#399](https://github.com/supabase/edge-runtime/issues/399)) ([53061f6](https://github.com/supabase/edge-runtime/commit/53061f60dbed8265071b014981e749d47dd7495a))
