### PR TITLE
fix(api): add external_url while a replacement is found for auth/studio

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,7 +145,7 @@ type (
 		MaxRows         uint     `toml:"max_rows"`
 		Tls             tlsKong  `toml:"tls"`
 		// TODO: replace [auth|studio].api_url
-		ExternalUrl string `toml:"-"`
+		ExternalUrl string `toml:"external_url"`
 	}
 
 	tlsKong struct {


### PR DESCRIPTION
Fixes https://github.com/supabase/cli/issues/2527

Currently, the external_api_url is not read from the config.toml. 

I know there is an ongoing subject about mutualizing auth/studio url but it requires too much changes. 

This is a quick fix that improves the features of the CLI without removing any