### PR TITLE
feat: add secure password change config

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -512,6 +512,7 @@ EOF
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=%v", utils.Config.Auth.EnableRefreshTokenRotation),
 			fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=%v", utils.Config.Auth.RefreshTokenReuseInterval),
 			fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
+			fmt.Sprintf("GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION=%v", utils.Config.Auth.Email.SecurePasswordChange),
 			fmt.Sprintf("GOTRUE_MFA_PHONE_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.Phone.EnrollEnabled),
 			fmt.Sprintf("GOTRUE_MFA_PHONE_VERIFY_ENABLED=%v", utils.Config.Auth.MFA.Phone.VerifyEnabled),
 			fmt.Sprintf("GOTRUE_MFA_TOTP_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.TOTP.EnrollEnabled),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -290,6 +290,7 @@ type (
 		EnableSignup         bool                     `toml:"enable_signup"`
 		DoubleConfirmChanges bool                     `toml:"double_confirm_changes"`
 		EnableConfirmations  bool                     `toml:"enable_confirmations"`
+		SecurePasswordChange bool                     `toml:"secure_password_change"`
 		Template             map[string]emailTemplate `toml:"template"`
 		Smtp                 smtp                     `toml:"smtp"`
 		MaxFrequency         time.Duration            `toml:"max_frequency"`

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -109,7 +109,7 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
-# if enabled, users will need to be recently logged in to change their password without requiring reauthentication.
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -109,6 +109,8 @@ enable_signup = true
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+# if enabled, users will need to be recently logged in to change their password without requiring reauthentication.
+secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This feature can be found in the Supabase Hosted Dashboard but doesn't have a way to configure it in the `config.toml`.

## What is the current behavior?

No way to set **Secure password change**

## What is the new behavior?

Can now set **Secure password change** in the `config.toml` file.

## Additional context

Add any other context or screenshots.
