### PR TITLE
fix(realtime): Bump up docker image to 2.30.34

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -16,7 +16,7 @@ const (
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"
-	realtimeImage    = "supabase/realtime:v2.30.23"
+	realtimeImage    = "supabase/realtime:v2.30.34"
 	storageImage     = "supabase/storage-api:v1.10.1"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up docker image to 2.30.34