### PR TITLE
fix: Use discoveryURL when fetching third-party OIDC config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1144,7 +1144,7 @@ func (a *auth) ResolveJWKS(ctx context.Context) (string, error) {
 
 		t := &http.Client{Timeout: 10 * time.Second}
 		client := fetcher.NewFetcher(
-			issuerURL,
+			discoveryURL,
 			fetcher.WithHTTPClient(t),
 			fetcher.WithExpectedStatus(http.StatusOK),
 		)


### PR DESCRIPTION
## What kind of change does this PR introduce?

When fetching the well-known configuration for an OIDC third-party auth provider, we used the issuerURL which is just the baseURL instead of the discoveryURL as seems intended. This caused Auth0 configurations to try to parse HTML instead of the correct configuration, and I suspect this is the case for all the other providers as well.

With this bugfix it should work as expected for at least Auth0.

## What is the current behavior?

The `supabase start --debug` command fails with: `failed to parse response body: invalid character '<' looking for beginning of value`


Debug output:
```
supabase start --debug
Using workdir /Users/daginge/code/draum/frontend
Supabase CLI 1.191.3
2024/09/03 10:37:35 DNS Start: {Host:dev-kk0wnodjovc335tb.eu.auth0.com}
2024/09/03 10:37:35 DNS Done: {Addrs:[{IP:104.19.152.19 Zone:} {IP:104.19.153.19 Zone:} {IP:2606:4700::6813:9813 Zone:} {IP:2606:4700::6813:9913 Zone:}] Err:<nil> Coalesced:false}
2024/09/03 10:37:35 Connect Start: tcp 104.19.152.19:443
2024/09/03 10:37:35 Connect Done: tcp 104.19.152.19:443
2024/09/03 10:37:35 TLS Start
2024/09/03 10:37:35 TLS Done: {Version:772 HandshakeComplete:true DidResume:false CipherSuite:4865 NegotiatedProtocol:h2 NegotiatedProtocolIsMutual:true ServerName:dev-kk0wnodjovc335tb.eu.auth0.com PeerCertificates:[0x1400035b608 0x1400035bb88 0x1400035c108] VerifiedChains:[[0x1400035c688 0x1400035cc08 0x1400035d708]] SignedCertificateTimestamps:[] OCSPResponse:[48 130 1 85 10 1 0 160 130 1 78 48 130 1 74 6 9 43 6 1 5 5 7 48 1 1 4 130 1 59 48 130 1 55 48 129 190 161 52 48 50 49 11 48 9 6 3 85 4 6 19 2 85 83 49 22 48 20 6 3 85 4 10 19 13 76 101 116 39 115 32 69 110 99 114 121 112 116 49 11 48 9 6 3 85 4 3 19 2 69 53 24 15 50 48 50 52 48 57 48 50 49 53 48 57 48 48 90 48 117 48 115 48 75 48 9 6 5 43 14 3 2 26 5 0 4 20 30 17 192 201 172 253 164 83 239 75 47 106 115 33 21 96 77 84 173 185 4 20 153 205 41 195 161 88 38 175 122 122 76 132 90 143 115 136 96 176 223 222 2 18 4 61 202 161 33 67 203 61 180 118 61 110 142 98 255 161 114 196 128 0 24 15 50 48 50 52 48 57 48 50 49 53 48 57 48 48 90 160 17 24 15 50 48 50 52 48 57 48 57 49 53 48 56 53 56 90 48 10 6 8 42 134 72 206 61 4 3 3 3 104 0 48 101 2 48 69 186 140 19 67 7 167 13 109 94 251 65 143 118 130 6 26 134 41 137 119 203 200 71 96 115 80 122 53 153 125 1 170 91 16 130 13 81 26 60 102 113 31 87 208 122 115 102 2 49 0 163 101 39 62 241 214 255 91 104 150 74 105 92 43 82 159 31 248 239 76 221 82 182 182 65 174 59 77 98 195 224 177 129 192 161 13 24 165 156 30 92 165 29 53 193 228 144 6] TLSUnique:[] ekm:0x105087c70}
2024/09/03 10:37:35 Sent Header: :authority [dev-kk0wnodjovc335tb.eu.auth0.com]
2024/09/03 10:37:35 Sent Header: :method [GET]
2024/09/03 10:37:35 Sent Header: :path [/]
2024/09/03 10:37:35 Sent Header: :scheme [https]
2024/09/03 10:37:35 Sent Header: accept-encoding [gzip]
2024/09/03 10:37:35 Sent Header: user-agent [Go-http-client/2.0]
2024/09/03 10:37:35 Send Done
2024/09/03 10:37:35 Recv First Byte
2024/09/03 10:37:35 DNS Start: {Host:eu.auth0.com}
2024/09/03 10:37:35 DNS Done: {Addrs:[{IP:104.19.153.19 Zone:} {IP:104.19.152.19 Zone:} {IP:2606:4700::6813:9913 Zone:} {IP:2606:4700::6813:9813 Zone:}] Err:<nil> Coalesced:false}
2024/09/03 10:37:35 Connect Start: tcp 104.19.153.19:443
2024/09/03 10:37:35 Connect Done: tcp 104.19.153.19:443
2024/09/03 10:37:35 TLS Start
2024/09/03 10:37:35 TLS Done: {Version:772 HandshakeComplete:true DidResume:false CipherSuite:4865 NegotiatedProtocol:h2 NegotiatedProtocolIsMutual:true ServerName:eu.auth0.com PeerCertificates:[0x1400035b608 0x1400035bb88 0x1400035c108] VerifiedChains:[[0x140004f2b08 0x140003cf608 0x140003d1708]] SignedCertificateTimestamps:[] OCSPResponse:[48 130 1 85 10 1 0 160 130 1 78 48 130 1 74 6 9 43 6 1 5 5 7 48 1 1 4 130 1 59 48 130 1 55 48 129 190 161 52 48 50 49 11 48 9 6 3 85 4 6 19 2 85 83 49 22 48 20 6 3 85 4 10 19 13 76 101 116 39 115 32 69 110 99 114 121 112 116 49 11 48 9 6 3 85 4 3 19 2 69 53 24 15 50 48 50 52 48 57 48 50 49 53 48 57 48 48 90 48 117 48 115 48 75 48 9 6 5 43 14 3 2 26 5 0 4 20 30 17 192 201 172 253 164 83 239 75 47 106 115 33 21 96 77 84 173 185 4 20 153 205 41 195 161 88 38 175 122 122 76 132 90 143 115 136 96 176 223 222 2 18 4 61 202 161 33 67 203 61 180 118 61 110 142 98 255 161 114 196 128 0 24 15 50 48 50 52 48 57 48 50 49 53 48 57 48 48 90 160 17 24 15 50 48 50 52 48 57 48 57 49 53 48 56 53 56 90 48 10 6 8 42 134 72 206 61 4 3 3 3 104 0 48 101 2 48 69 186 140 19 67 7 167 13 109 94 251 65 143 118 130 6 26 134 41 137 119 203 200 71 96 115 80 122 53 153 125 1 170 91 16 130 13 81 26 60 102 113 31 87 208 122 115 102 2 49 0 163 101 39 62 241 214 255 91 104 150 74 105 92 43 82 159 31 248 239 76 221 82 182 182 65 174 59 77 98 195 224 177 129 192 161 13 24 165 156 30 92 165 29 53 193 228 144 6] TLSUnique:[] ekm:0x105087c70}
2024/09/03 10:37:35 Sent Header: :authority [eu.auth0.com]
2024/09/03 10:37:35 Sent Header: :method [GET]
2024/09/03 10:37:35 Sent Header: :path [/]
2024/09/03 10:37:35 Sent Header: :scheme [https]
2024/09/03 10:37:35 Sent Header: referer [https://dev-kk0wnodjovc335tb.eu.auth0.com]
2024/09/03 10:37:35 Sent Header: accept-encoding [gzip]
2024/09/03 10:37:35 Sent Header: user-agent [Go-http-client/2.0]
2024/09/03 10:37:35 Send Done
2024/09/03 10:37:35 Recv First Byte
2024/09/03 10:37:35 DNS Start: {Host:auth0.com}
2024/09/03 10:37:35 DNS Done: {Addrs:[{IP:104.17.254.182 Zone:} {IP:104.17.255.182 Zone:} {IP:2606:4700::6811:ffb6 Zone:} {IP:2606:4700::6811:feb6 Zone:}] Err:<nil> Coalesced:false}
2024/09/03 10:37:35 Connect Start: tcp 104.17.254.182:443
2024/09/03 10:37:35 Connect Done: tcp 104.17.254.182:443
2024/09/03 10:37:35 TLS Start
2024/09/03 10:37:35 TLS Done: {Version:772 HandshakeComplete:true DidResume:false CipherSuite:4865 NegotiatedProtocol:h2 NegotiatedProtocolIsMutual:true ServerName:auth0.com PeerCertificates:[0x140001d5608 0x140001d6c08 0x1400035c108] VerifiedChains:[[0x140007ce008 0x140007ce588 0x140007ceb08]] SignedCertificateTimestamps:[[0 118 255 136 63 10 182 251 149 81 194 97 204 245 135 186 52 180 164 205 187 41 220 104 66 10 159 230 103 76 90 58 116 0 0 1 144 189 37 151 19 0 0 4 3 0 71 48 69 2 32 122 234 146 61 141 80 75 46 46 30 175 68 24 249 236 150 67 232 138 59 96 55 78 148 132 93 159 215 149 254 109 75 2 33 0 239 140 143 222 249 157 73 99 8 168 82 119 115 126 69 48 128 106 252 145 67 122 97 60 169 221 188 53 235 52 243 202] [0 238 205 208 100 213 219 26 206 197 92 183 157 180 205 19 162 50 135 70 124 188 236 222 195 81 72 89 70 113 31 181 155 0 0 1 144 189 37 150 203 0 0 4 3 0 70 48 68 2 32 36 51 206 205 19 61 42 51 244 195 181 93 122 31 220 56 237 214 5 18 133 80 201 181 73 134 251 51 254 51 165 173 2 32 21 11 154 184 89 230 190 12 121 99 92 35 146 112 160 136 97 18 33 200 131 22 206 6 162 99 149 98 151 46 218 159]] OCSPResponse:[48 130 1 86 10 1 0 160 130 1 79 48 130 1 75 6 9 43 6 1 5 5 7 48 1 1 4 130 1 60 48 130 1 56 48 129 190 161 52 48 50 49 11 48 9 6 3 85 4 6 19 2 85 83 49 22 48 20 6 3 85 4 10 19 13 76 101 116 39 115 32 69 110 99 114 121 112 116 49 11 48 9 6 3 85 4 3 19 2 69 54 24 15 50 48 50 52 48 56 51 49 48 50 52 53 48 48 90 48 117 48 115 48 75 48 9 6 5 43 14 3 2 26 5 0 4 20 212 122 56 128 65 232 233 141 7 56 124 236 246 182 216 242 15 165 100 49 4 20 13 197 204 253 155 238 20 5 161 76 48 130 165 62 94 138 195 88 9 210 2 18 3 4 75 196 162 34 116 194 112 22 197 71 113 154 30 109 111 26 128 0 24 15 50 48 50 52 48 56 51 49 48 50 52 53 48 48 90 160 17 24 15 50 48 50 52 48 57 48 55 48 50 52 52 53 56 90 48 10 6 8 42 134 72 206 61 4 3 3 3 105 0 48 102 2 49 0 172 212 206 165 66 195 64 174 114 81 103 45 225 33 186 63 111 96 37 183 108 111 52 46 68 110 126 71 199 187 194 4 84 127 4 156 192 20 48 91 60 20 237 175 45 126 154 74 2 49 0 212 147 146 135 138 216 42 173 17 199 162 16 154 208 120 191 37 35 180 208 248 153 109 215 168 184 140 153 126 20 228 168 98 28 226 200 76 166 6 154 226 113 72 223 105 84 73 247] TLSUnique:[] ekm:0x105087c70}
2024/09/03 10:37:35 Sent Header: :authority [auth0.com]
2024/09/03 10:37:35 Sent Header: :method [GET]
2024/09/03 10:37:35 Sent Header: :path [/]
2024/09/03 10:37:35 Sent Header: :scheme [https]
2024/09/03 10:37:35 Sent Header: referer [https://eu.auth0.com/]
2024/09/03 10:37:35 Sent Header: accept-encoding [gzip]
2024/09/03 10:37:35 Sent Header: user-agent [Go-http-client/2.0]
2024/09/03 10:37:35 Send Done
2024/09/03 10:37:36 Recv First Byte
Stopping containers...
Pruned containers: []
Pruned network: []
failed to parse response body: invalid character '<' looking for beginning of value
```

## What is the new behavior?

The `supabase start` command correctly fetches the well-known OIDC config for Auth0.
