### PR TITLE
fix: bump edge-runtime to 1.58.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.2

### Changes

### [1.58.2](https://github.com/supabase/edge-runtime/compare/v1.58.1...v1.58.2) (2024-09-04)

#### Bug Fixes

* inspector causes panic ([#404](https://github.com/supabase/edge-runtime/issues/404)) ([8b29aa1](https://github.com/supabase/edge-runtime/commit/8b29aa16c6985a3911beb510ce7103cb3cee060c)) (Fixes #2646)