### PR TITLE
feat: allow Cognito configuration from env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1072,9 +1072,16 @@ func (c *tpaCognito) validate() error {
 	if c.UserPoolID == "" {
 		return errors.New("Invalid config: auth.third_party.cognito is enabled but without a user_pool_id.")
 	}
+	var err error
+	if c.UserPoolID, err = maybeLoadEnv(c.UserPoolID); err != nil {
+		return err
+	}
 
 	if c.UserPoolRegion == "" {
 		return errors.New("Invalid config: auth.third_party.cognito is enabled but without a user_pool_region.")
+	}
+	if c.UserPoolRegion, err = maybeLoadEnv(c.UserPoolRegion); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small update to the configuration processing to allow AWS Cognito configuration values to be injected into `config.toml` using environment variables.

## What is the current behavior?

In order to use Cognito as a third party auth provider, configuration values must be added to `config.toml` in plain text.
```
[auth.third_party.aws_cognito]
enabled = true
user_pool_id = "my-user-pool-id"
user_pool_region = "us-east-1"
```

## What is the new behavior?

AWS Cognito configuration can now be injected via environment variables.
```
[auth.third_party.aws_cognito]
enabled = true
user_pool_id = "env(SUPABASE_AUTH_AWS_COGNITO_POOL_ID)"
user_pool_region = "env(SUPABASE_AUTH_AWS_COGNITO_REGION)"
```

## Additional context

AWS Cognito configuration is slightly broken (or at least confusing) until https://github.com/supabase/cli/pull/2655 is fixed.
