### PR TITLE
fix: db reset with disabled services

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -208,7 +208,6 @@ func RestartDatabase(ctx context.Context, w io.Writer) error {
 func restartServices(ctx context.Context) error {
 	// No need to restart PostgREST because it automatically reconnects and listens for schema changes
 	services := listServicesToRestart()
-
 	result := utils.WaitAll(services, func(id string) error {
 		if err := utils.Docker.ContainerRestart(ctx, id, container.StopOptions{}); err != nil && !errdefs.IsNotFound(err) {
 			return errors.Errorf("Failed to restart %s: %w", id, err)

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -220,22 +220,7 @@ func restartServices(ctx context.Context) error {
 }
 
 func listServicesToRestart() []string {
-	var services []string
-
-	if utils.Config.Storage.Enabled {
-		services = append(services, utils.StorageId)
-	}
-	if utils.Config.Realtime.Enabled {
-		services = append(services, utils.RealtimeId)
-	}
-	if utils.Config.Db.Pooler.Enabled {
-		services = append(services, utils.PoolerId)
-	}
-	if utils.Config.Auth.Enabled {
-		services = append(services, utils.GotrueId)
-	}
-
-	return services
+	return []string{utils.StorageId, utils.GotrueId, utils.RealtimeId, utils.PoolerId}
 }
 
 func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -206,10 +206,8 @@ func RestartDatabase(ctx context.Context, w io.Writer) error {
 }
 
 func restartServices(ctx context.Context) error {
-	debug := utils.GetDebugLogger()
 	// No need to restart PostgREST because it automatically reconnects and listens for schema changes
 	services := listServicesToRestart()
-	fmt.Fprintf(debug, "Enabled services to restart: %v\n", services)
 
 	result := utils.WaitAll(services, func(id string) error {
 		if err := utils.Docker.ContainerRestart(ctx, id, container.StopOptions{}); err != nil && !errdefs.IsNotFound(err) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

When performing the "reset db" check against the config to find "enabled" services and only restart the ones that are enabled. Also only "seed storage" service if the storage service is actually enabled.

## What is the current behavior?

Fixes https://github.com/supabase/cli/issues/2658

## What is the new behavior?

- Make "restartServices" only restart enabled services
- Skip the bucket seeding phase if "storage" service isn't enabled.

In terms of output there should be no differences.

## Additional context

