### PR TITLE
feat: add db lint fail-on flag

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -315,7 +315,7 @@ func init() {
 	dbLintCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	lintFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	lintFlags.Var(&level, "level", "Error level to emit.")
-	lintFlags.Var(&lintFailOn, "fail-on", "Exit with non-zero status on (none|warning|error)")
+	lintFlags.Var(&lintFailOn, "fail-on", "Error level to exit with non-zero status.")
 	dbCmd.AddCommand(dbLintCmd)
 	// Build start command
 	dbCmd.AddCommand(dbStartCmd)

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -196,11 +196,16 @@ var (
 		Value:   lint.AllowedLevels[0],
 	}
 
+	lintFailOn = utils.EnumFlag{
+		Allowed: append([]string{"none"}, lint.AllowedLevels...),
+		Value:   "none",
+	}
+
 	dbLintCmd = &cobra.Command{
 		Use:   "lint",
 		Short: "Checks local database for typing error",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return lint.Run(cmd.Context(), schema, level.Value, flags.DbConfig, afero.NewOsFs())
+			return lint.Run(cmd.Context(), schema, level.Value, lintFailOn.Value, flags.DbConfig, afero.NewOsFs())
 		},
 	}
 
@@ -310,7 +315,7 @@ func init() {
 	dbLintCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	lintFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	lintFlags.Var(&level, "level", "Error level to emit.")
-	lintFlags.String("fail-on", "none", "Exit with non-zero status on (error|warning|none)")
+	lintFlags.Var(&lintFailOn, "fail-on", "Exit with non-zero status on (none|warning|error)")
 	dbCmd.AddCommand(dbLintCmd)
 	// Build start command
 	dbCmd.AddCommand(dbStartCmd)

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -310,6 +310,7 @@ func init() {
 	dbLintCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	lintFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	lintFlags.Var(&level, "level", "Error level to emit.")
+	lintFlags.String("fail-on", "none", "Exit with non-zero status on (error|warning|none)")
 	dbCmd.AddCommand(dbLintCmd)
 	// Build start command
 	dbCmd.AddCommand(dbStartCmd)

--- a/docs/supabase/db/lint.md
+++ b/docs/supabase/db/lint.md
@@ -7,3 +7,11 @@ Requires the local development stack to be running when linting against the loca
 Runs `plpgsql_check` extension in the local Postgres container to check for errors in all schemas. The default lint level is `warning` and can be raised to error via the `--level` flag.
 
 To lint against specific schemas only, pass in the `--schema` flag.
+
+The `--fail-on` flag can be used to control when the command should exit with a non-zero status code. The possible values are:
+
+- `none` (default): Always exit with a zero status code, regardless of lint results.
+- `warning`: Exit with a non-zero status code if any warnings or errors are found.
+- `error`: Exit with a non-zero status code only if errors are found.
+
+This flag is particularly useful in CI/CD pipelines where you want to fail the build based on certain lint conditions.

--- a/internal/db/lint/lint.go
+++ b/internal/db/lint/lint.go
@@ -89,7 +89,7 @@ func printResultJSON(result []Result, minLevel LintLevel, failOn LintLevel, stdo
 		for _, r := range filtered {
 			for _, issue := range r.Issues {
 				if toEnum(issue.Level) >= failOn {
-					return errors.New(fmt.Sprintf("failOn is set to %s and the following lint was found: %s", AllowedLevels[failOn], issue.Message))
+					return errors.New(fmt.Sprintf("fail-on is set to %s, non-zero exit", AllowedLevels[failOn]))
 				}
 			}
 		}

--- a/internal/db/lint/lint_test.go
+++ b/internal/db/lint/lint_test.go
@@ -65,7 +65,7 @@ func TestLintCommand(t *testing.T) {
 		Reply("SELECT 1", []interface{}{"f1", string(data)}).
 		Query("rollback").Reply("ROLLBACK")
 	// Run test
-	err = Run(context.Background(), []string{"public"}, "warning", dbConfig, fsys, conn.Intercept)
+	err = Run(context.Background(), []string{"public"}, "warning", "none", dbConfig, fsys, conn.Intercept)
 	// Check error
 	assert.NoError(t, err)
 	assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -221,7 +221,7 @@ func TestPrintResult(t *testing.T) {
 	t.Run("filters warning level", func(t *testing.T) {
 		// Run test
 		var out bytes.Buffer
-		assert.NoError(t, printResultJSON(result, toEnum("warning"), &out))
+		assert.NoError(t, printResultJSON(result, toEnum("warning"), toEnum("none"), &out))
 		// Validate output
 		var actual []Result
 		assert.NoError(t, json.Unmarshal(out.Bytes(), &actual))
@@ -231,7 +231,7 @@ func TestPrintResult(t *testing.T) {
 	t.Run("filters error level", func(t *testing.T) {
 		// Run test
 		var out bytes.Buffer
-		assert.NoError(t, printResultJSON(result, toEnum("error"), &out))
+		assert.NoError(t, printResultJSON(result, toEnum("error"), toEnum("none"), &out))
 		// Validate output
 		var actual []Result
 		assert.NoError(t, json.Unmarshal(out.Bytes(), &actual))
@@ -239,5 +239,59 @@ func TestPrintResult(t *testing.T) {
 			Function: result[0].Function,
 			Issues:   []Issue{result[0].Issues[1]},
 		}}, actual)
+	})
+
+	t.Run("exits with non-zero status on warning", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("begin").Reply("BEGIN").
+			Query(ENABLE_PGSQL_CHECK).
+			Reply("CREATE EXTENSION").
+			Query(checkSchemaScript, "public").
+			Reply("SELECT 1", []interface{}{"f1", `{"function":"22751","issues":[{"level":"warning","message":"test warning"}]}`}).
+			Query("rollback").Reply("ROLLBACK")
+		// Run test
+		err := Run(context.Background(), []string{"public"}, "warning", "warning", dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "fail-on is set to warning, non-zero exit")
+	})
+
+	t.Run("exits with non-zero status on error", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("begin").Reply("BEGIN").
+			Query(ENABLE_PGSQL_CHECK).
+			Reply("CREATE EXTENSION").
+			Query(checkSchemaScript, "public").
+			Reply("SELECT 1", []interface{}{"f1", `{"function":"22751","issues":[{"level":"error","message":"test error"}]}`}).
+			Query("rollback").Reply("ROLLBACK")
+		// Run test
+		err := Run(context.Background(), []string{"public"}, "warning", "error", dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorContains(t, err, "fail-on is set to error, non-zero exit")
+	})
+
+	t.Run("does not exit with non-zero status when fail-on is none", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query("begin").Reply("BEGIN").
+			Query(ENABLE_PGSQL_CHECK).
+			Reply("CREATE EXTENSION").
+			Query(checkSchemaScript, "public").
+			Reply("SELECT 1", []interface{}{"f1", `{"function":"22751","issues":[{"level":"error","message":"test error"}]}`}).
+			Query("rollback").Reply("ROLLBACK")
+		// Run test
+		err := Run(context.Background(), []string{"public"}, "warning", "none", dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.NoError(t, err)
 	})
 }

--- a/internal/db/lint/lint_test.go
+++ b/internal/db/lint/lint_test.go
@@ -221,7 +221,8 @@ func TestPrintResult(t *testing.T) {
 	t.Run("filters warning level", func(t *testing.T) {
 		// Run test
 		var out bytes.Buffer
-		assert.NoError(t, printResultJSON(result, toEnum("warning"), toEnum("none"), &out))
+		filtered := filterResult(result, toEnum("warning"))
+		assert.NoError(t, printResultJSON(filtered, &out))
 		// Validate output
 		var actual []Result
 		assert.NoError(t, json.Unmarshal(out.Bytes(), &actual))
@@ -231,7 +232,8 @@ func TestPrintResult(t *testing.T) {
 	t.Run("filters error level", func(t *testing.T) {
 		// Run test
 		var out bytes.Buffer
-		assert.NoError(t, printResultJSON(result, toEnum("error"), toEnum("none"), &out))
+		filtered := filterResult(result, toEnum("error"))
+		assert.NoError(t, printResultJSON(filtered, &out))
 		// Validate output
 		var actual []Result
 		assert.NoError(t, json.Unmarshal(out.Bytes(), &actual))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: Adds a `--fail-on` flag to the `db lint` command in the Supabase CLI.

## What is the current behavior?

Currently, `db lint` does not provide an option to exit with a non-zero status code on lint errors, limiting its use in CI/CD pipelines.

See: #1812

## What is the new behavior?

Introduces a `--fail-on` flag with options (`error`, `warning`, `none`) to control the exit status of `db lint` based on lint results.

## How has this been tested?

Tested by running `db lint` with different `--fail-on` options to ensure correct exit statuses are returned.
