### PR TITLE
fix: bump edge-runtime to 1.58.3

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240729-ce42139"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.2"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.3"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.3

### Changes

### [1.58.3](https://github.com/supabase/edge-runtime/compare/v1.58.2...v1.58.3) (2024-09-10)

#### Bug Fixes

* improve stability ([#406](https://github.com/supabase/edge-runtime/issues/406)) ([50eb636](https://github.com/supabase/edge-runtime/commit/50eb636b9d7313f33939f324da93813ef662e721))