### PR TITLE
fix: update deno.unstable settings in VS Code settings.json template

### DIFF
--- a/internal/init/templates/.vscode/settings.json
+++ b/internal/init/templates/.vscode/settings.json
@@ -3,7 +3,21 @@
     "supabase/functions"
   ],
   "deno.lint": true,
-  "deno.unstable": true,
+  "deno.unstable": [
+    "bare-node-builtins",
+    "byonm",
+    "sloppy-imports",
+    "unsafe-proto",
+    "webgpu",
+    "broadcast-channel",
+    "worker-options",
+    "cron",
+    "kv",
+    "ffi",
+    "fs",
+    "http",
+    "net"
+  ],
   "[typescript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

VS Code `settings.json` uses deprecated boolean option for ´deno.unstable´ flag.

## What is the new behavior?

VS Code `settings.json` now uses the granular flags while maintaining the same behavior.

## Additional context

Fixes #2682.

Before merging this PR, consider updating the code snippet in https://supabase.com/docs/guides/functions/import-maps#configuring-vscode to use the granular unstable flags too.