### PR TITLE
chore: start command validate exclude arguments

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,14 +18,7 @@ func validateExcludedContainers(excludedContainers []string) {
 	var invalidContainers []string
 
 	for _, e := range excludedContainers {
-		found := false
-		for _, v := range validContainers {
-			if strings.EqualFold(e, v) {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !utils.SliceContains(validContainers, e) {
 			invalidContainers = append(invalidContainers, e)
 		}
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,12 +1,45 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/start"
+	"github.com/supabase/cli/internal/utils"
 )
+
+func validateExcludedContainers(excludedContainers []string) {
+	// Validate excluded containers
+	validContainers := start.ExcludableContainers()
+	var invalidContainers []string
+
+	for _, e := range excludedContainers {
+		found := false
+		for _, v := range validContainers {
+			if strings.EqualFold(e, v) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			invalidContainers = append(invalidContainers, e)
+		}
+	}
+
+	if len(invalidContainers) > 0 {
+		// Sort the names list so it's easier to visually spot the one you looking for
+		sort.Strings(validContainers)
+		warning := fmt.Sprintf("%s The following container names are not valid to exclude: %s\nValid containers to exclude are: %s\n",
+			utils.Yellow("Warning:"),
+			utils.Aqua(strings.Join(invalidContainers, ", ")),
+			utils.Aqua(strings.Join(validContainers, ", ")))
+		fmt.Fprint(os.Stderr, warning)
+	}
+}
 
 var (
 	allowedContainers  = start.ExcludableContainers()
@@ -19,6 +52,7 @@ var (
 		Use:     "start",
 		Short:   "Start containers for Supabase local development",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			validateExcludedContainers(excludedContainers)
 			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers, ignoreHealthCheck)
 		},
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

When providing --exclude flags, check the arguments match actuals images names show a warning otherwise.
Also fix a bug where stack couldnt start if storage was enabled in config but excluded in the arguments

Related: https://www.notion.so/supabase/exclude-doesnt-seem-to-work-f38b8444b62f4308aef657a52d51692b

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

<img width="1174" alt="Screenshot 2024-09-19 at 15 33 59" src="https://github.com/user-attachments/assets/9992f74a-2ea1-4cff-9c7b-f3dedfa44749">


## Additional context

Also might be worth considering allowing to alias between config services names and "containers exclusions" names. As it's not clear for instance that "gotrue" container relate to the "auth" service.
