### PR TITLE
feat: add custom seed path to config

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -276,7 +276,7 @@ func init() {
 	pushFlags := dbPushCmd.Flags()
 	pushFlags.BoolVar(&includeAll, "include-all", false, "Include all migrations not found on remote history table.")
 	pushFlags.BoolVar(&includeRoles, "include-roles", false, "Include custom roles from "+utils.CustomRolesPath+".")
-	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.GetSeedsFilepaths()+".")
+	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from your config.")
 	pushFlags.BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	pushFlags.String("db-url", "", "Pushes to the database specified by the connection string (must be percent-encoded).")
 	pushFlags.Bool("linked", true, "Pushes to the linked project.")

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -276,7 +276,7 @@ func init() {
 	pushFlags := dbPushCmd.Flags()
 	pushFlags.BoolVar(&includeAll, "include-all", false, "Include all migrations not found on remote history table.")
 	pushFlags.BoolVar(&includeRoles, "include-roles", false, "Include custom roles from "+utils.CustomRolesPath+".")
-	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.DefaultSeedDataPath+".")
+	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.GetSeedsFilepaths()+".")
 	pushFlags.BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	pushFlags.String("db-url", "", "Pushes to the database specified by the connection string (must be percent-encoded).")
 	pushFlags.Bool("linked", true, "Pushes to the linked project.")

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -276,7 +276,7 @@ func init() {
 	pushFlags := dbPushCmd.Flags()
 	pushFlags.BoolVar(&includeAll, "include-all", false, "Include all migrations not found on remote history table.")
 	pushFlags.BoolVar(&includeRoles, "include-roles", false, "Include custom roles from "+utils.CustomRolesPath+".")
-	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.SeedDataPath+".")
+	pushFlags.BoolVar(&includeSeed, "include-seed", false, "Include seed data from "+utils.DefaultSeedDataPath+".")
 	pushFlags.BoolVar(&dryRun, "dry-run", false, "Print the migrations that would be applied, but don't actually apply them.")
 	pushFlags.String("db-url", "", "Pushes to the database specified by the connection string (must be percent-encoded).")
 	pushFlags.Bool("linked", true, "Pushes to the linked project.")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,7 +27,7 @@ func validateExcludedContainers(excludedContainers []string) {
 		// Sort the names list so it's easier to visually spot the one you looking for
 		sort.Strings(validContainers)
 		warning := fmt.Sprintf("%s The following container names are not valid to exclude: %s\nValid containers to exclude are: %s\n",
-			utils.Yellow("Warning:"),
+			utils.Yellow("WARNING:"),
 			utils.Aqua(strings.Join(invalidContainers, ", ")),
 			utils.Aqua(strings.Join(validContainers, ", ")))
 		fmt.Fprint(os.Stderr, warning)

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -41,7 +41,11 @@ func Run(ctx context.Context, dryRun, ignoreVersionMismatch bool, includeRoles, 
 		fmt.Fprintln(os.Stderr, "Would push these migrations:")
 		fmt.Fprint(os.Stderr, utils.Bold(confirmPushAll(pending)))
 		if includeSeed {
-			fmt.Fprintln(os.Stderr, "Would seed data "+utils.Bold(utils.GetSeedsFilepaths())+"...")
+			seedPaths, err := utils.GetSeedFiles(fsys)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Would seed data %v...\n", seedPaths)
 		}
 	} else {
 		msg := fmt.Sprintf("Do you want to push these migrations to the remote database?\n%s\n", confirmPushAll(pending))

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, dryRun, ignoreVersionMismatch bool, includeRoles, 
 		fmt.Fprintln(os.Stderr, "Would push these migrations:")
 		fmt.Fprint(os.Stderr, utils.Bold(confirmPushAll(pending)))
 		if includeSeed {
-			fmt.Fprintln(os.Stderr, "Would seed data "+utils.Bold(utils.SeedDataPath)+"...")
+			fmt.Fprintln(os.Stderr, "Would seed data "+utils.Bold(utils.DefaultSeedDataPath)+"...")
 		}
 	} else {
 		msg := fmt.Sprintf("Do you want to push these migrations to the remote database?\n%s\n", confirmPushAll(pending))

--- a/internal/db/push/push.go
+++ b/internal/db/push/push.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, dryRun, ignoreVersionMismatch bool, includeRoles, 
 		fmt.Fprintln(os.Stderr, "Would push these migrations:")
 		fmt.Fprint(os.Stderr, utils.Bold(confirmPushAll(pending)))
 		if includeSeed {
-			fmt.Fprintln(os.Stderr, "Would seed data "+utils.Bold(utils.DefaultSeedDataPath)+"...")
+			fmt.Fprintln(os.Stderr, "Would seed data "+utils.Bold(utils.GetSeedsFilepaths())+"...")
 		}
 	} else {
 		msg := fmt.Sprintf("Do you want to push these migrations to the remote database?\n%s\n", confirmPushAll(pending))

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -162,7 +162,7 @@ func TestPushAll(t *testing.T) {
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.SeedDataPath}
+		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -163,6 +163,7 @@ func TestPushAll(t *testing.T) {
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
+		fsys.Create(utils.DefaultSeedDataPath)
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -162,8 +162,9 @@ func TestPushAll(t *testing.T) {
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: filepath.Join(utils.SupabaseDirPath, "seed.sql")}
-		_, _ = fsys.Create(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
+		seedPath := filepath.Join(utils.SupabaseDirPath, "seed.sql")
+		fsys := &fstest.OpenErrorFs{DenyPath: seedPath}
+		_, _ = fsys.Create(seedPath)
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -163,7 +163,7 @@ func TestPushAll(t *testing.T) {
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
-		fsys.Create(utils.DefaultSeedDataPath)
+		_, _ = fsys.Create(utils.DefaultSeedDataPath)
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -162,8 +162,8 @@ func TestPushAll(t *testing.T) {
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
-		_, _ = fsys.Create(utils.DefaultSeedDataPath)
+		fsys := &fstest.OpenErrorFs{DenyPath: filepath.Join(utils.SupabaseDirPath, "seed.sql")}
+		_, _ = fsys.Create(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -362,7 +362,7 @@ func TestResetRemote(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		path := filepath.Join(utils.MigrationsDir, "0_schema.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, nil, 0644))
-		seedPath := filepath.Join(utils.SeedDataPath)
+		seedPath := filepath.Join(utils.DefaultSeedDataPath)
 		// Will raise an error when seeding
 		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte("INSERT INTO test_table;"), 0644))
 		// Setup mock postgres

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -362,7 +362,7 @@ func TestResetRemote(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		path := filepath.Join(utils.MigrationsDir, "0_schema.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, nil, 0644))
-		seedPath := filepath.Join(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
+		seedPath := filepath.Join(utils.SupabaseDirPath, "seed.sql")
 		// Will raise an error when seeding
 		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte("INSERT INTO test_table;"), 0644))
 		// Setup mock postgres

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -362,7 +362,7 @@ func TestResetRemote(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		path := filepath.Join(utils.MigrationsDir, "0_schema.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, nil, 0644))
-		seedPath := filepath.Join(utils.DefaultSeedDataPath)
+		seedPath := filepath.Join(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
 		// Will raise an error when seeding
 		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte("INSERT INTO test_table;"), 0644))
 		// Setup mock postgres

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -60,7 +61,7 @@ func TestStartDatabase(t *testing.T) {
 		roles := "create role test"
 		require.NoError(t, afero.WriteFile(fsys, utils.CustomRolesPath, []byte(roles), 0644))
 		seed := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(seed), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.SupabaseDirPath, "seed.sql"), []byte(seed), 0644))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -60,7 +60,7 @@ func TestStartDatabase(t *testing.T) {
 		roles := "create role test"
 		require.NoError(t, afero.WriteFile(fsys, utils.CustomRolesPath, []byte(roles), 0644))
 		seed := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(seed), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(seed), 0644))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -40,19 +40,14 @@ func Run(ctx context.Context, fsys afero.Fs, createVscodeSettings, createIntelli
 		return err
 	}
 
-	// 2. Create `seed.sql`.
-	if err := initSeed(fsys); err != nil {
-		return err
-	}
-
-	// 3. Append to `.gitignore`.
+	// 2. Append to `.gitignore`.
 	if utils.IsGitRepo() {
 		if err := updateGitIgnore(utils.GitIgnorePath, fsys); err != nil {
 			return err
 		}
 	}
 
-	// 4. Generate VS Code settings.
+	// 3. Generate VS Code settings.
 	if createVscodeSettings != nil {
 		if *createVscodeSettings {
 			return writeVscodeConfig(fsys)
@@ -74,15 +69,6 @@ func Run(ctx context.Context, fsys afero.Fs, createVscodeSettings, createIntelli
 			return writeIntelliJConfig(fsys)
 		}
 	}
-	return nil
-}
-
-func initSeed(fsys afero.Fs) error {
-	f, err := fsys.OpenFile(utils.DefaultSeedDataPath, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return errors.Errorf("failed to create seed file: %w", err)
-	}
-	defer f.Close()
 	return nil
 }
 

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, fsys afero.Fs, createVscodeSettings, createIntelli
 }
 
 func initSeed(fsys afero.Fs) error {
-	f, err := fsys.OpenFile(utils.SeedDataPath, os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := fsys.OpenFile(utils.DefaultSeedDataPath, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return errors.Errorf("failed to create seed file: %w", err)
 	}

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -28,10 +28,6 @@ func TestInitCommand(t *testing.T) {
 		exists, err = afero.Exists(fsys, utils.GitIgnorePath)
 		assert.NoError(t, err)
 		assert.True(t, exists)
-		// Validate generated seed.sql
-		exists, err = afero.Exists(fsys, utils.DefaultSeedDataPath)
-		assert.NoError(t, err)
-		assert.True(t, exists)
 		// Validate vscode settings file isn't generated
 		exists, err = afero.Exists(fsys, settingsPath)
 		assert.NoError(t, err)
@@ -68,16 +64,6 @@ func TestInitCommand(t *testing.T) {
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
 		assert.Error(t, Run(context.Background(), fsys, nil, nil, utils.InitParams{}))
-	})
-
-	t.Run("throws error on seed failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
-		_, _ = fsys.Create(utils.DefaultSeedDataPath)
-		// Run test
-		err := Run(context.Background(), fsys, nil, nil, utils.InitParams{})
-		// Check error
-		assert.ErrorIs(t, err, os.ErrPermission)
 	})
 
 	t.Run("creates vscode settings file", func(t *testing.T) {

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -73,7 +73,7 @@ func TestInitCommand(t *testing.T) {
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
-		fsys.Create(utils.DefaultSeedDataPath)
+		_, _ = fsys.Create(utils.DefaultSeedDataPath)
 		// Run test
 		err := Run(context.Background(), fsys, nil, nil, utils.InitParams{})
 		// Check error

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -29,7 +29,7 @@ func TestInitCommand(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		// Validate generated seed.sql
-		exists, err = afero.Exists(fsys, utils.SeedDataPath)
+		exists, err = afero.Exists(fsys, utils.DefaultSeedDataPath)
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		// Validate vscode settings file isn't generated
@@ -72,7 +72,7 @@ func TestInitCommand(t *testing.T) {
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.SeedDataPath}
+		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
 		// Run test
 		err := Run(context.Background(), fsys, nil, nil, utils.InitParams{})
 		// Check error

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -73,6 +73,7 @@ func TestInitCommand(t *testing.T) {
 	t.Run("throws error on seed failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
+		fsys.Create(utils.DefaultSeedDataPath)
 		// Run test
 		err := Run(context.Background(), fsys, nil, nil, utils.InitParams{})
 		// Check error

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -27,15 +27,11 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	if seedPaths, err := utils.GetSeedFiles(fsys); err != nil {
-		return err
-	} else {
-		err := migration.SeedData(ctx, seedPaths, conn, afero.NewIOFS(fsys))
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
+	seedPaths, err := utils.GetSeedFiles(fsys)
+	if err != nil {
 		return err
 	}
+	return migration.SeedData(ctx, seedPaths, conn, afero.NewIOFS(fsys))
 }
 
 func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -27,11 +27,15 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	err := migration.SeedData(ctx, []string{utils.DefaultSeedDataPath}, conn, afero.NewIOFS(fsys))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	if seedPaths, err := utils.GetSeedFiles(fsys); err != nil {
+		return err
+	} else {
+		err := migration.SeedData(ctx, seedPaths, conn, afero.NewIOFS(fsys))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
 	}
-	return err
 }
 
 func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -27,7 +27,7 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	err := migration.SeedData(ctx, []string{utils.SeedDataPath}, conn, afero.NewIOFS(fsys))
+	err := migration.SeedData(ctx, []string{utils.DefaultSeedDataPath}, conn, afero.NewIOFS(fsys))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -99,10 +99,15 @@ func TestSeedDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on read failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
+		// Wrap the fs with OpenErrorFs
+		errorFs := &fstest.OpenErrorFs{
+			DenyPath: utils.DefaultSeedDataPath,
+		}
+		errorFs.Create(utils.DefaultSeedDataPath)
+
 		// Run test
-		err := SeedDatabase(context.Background(), nil, fsys)
+		err := SeedDatabase(context.Background(), nil, errorFs)
+
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -44,7 +44,7 @@ func TestMigrateDatabase(t *testing.T) {
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		sql := "create schema public"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(sql), 0644))
-		seedPath := filepath.Join(utils.SeedDataPath)
+		seedPath := filepath.Join(utils.DefaultSeedDataPath)
 		// This will raise an error when seeding
 		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte("INSERT INTO test_table;"), 0644))
 		// Setup mock postgres
@@ -82,7 +82,7 @@ func TestSeedDatabase(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup seed file
 		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(sql), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -100,7 +100,7 @@ func TestSeedDatabase(t *testing.T) {
 
 	t.Run("throws error on read failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.SeedDataPath}
+		fsys := &fstest.OpenErrorFs{DenyPath: utils.DefaultSeedDataPath}
 		// Run test
 		err := SeedDatabase(context.Background(), nil, fsys)
 		// Check error
@@ -112,7 +112,7 @@ func TestSeedDatabase(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup seed file
 		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.SeedDataPath, []byte(sql), 0644))
+		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(sql), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -99,15 +99,12 @@ func TestSeedDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on read failure", func(t *testing.T) {
-		// Wrap the fs with OpenErrorFs
-		errorFs := &fstest.OpenErrorFs{
-			DenyPath: filepath.Join(utils.SupabaseDirPath, "seed.sql"),
-		}
-		_, _ = errorFs.Create(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
-
+		// Setup in-memory fs
+		seedPath := filepath.Join(utils.SupabaseDirPath, "seed.sql")
+		fsys := &fstest.OpenErrorFs{DenyPath: seedPath}
+		_, _ = fsys.Create(seedPath)
 		// Run test
-		err := SeedDatabase(context.Background(), nil, errorFs)
-
+		err := SeedDatabase(context.Background(), nil, fsys)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -103,7 +103,7 @@ func TestSeedDatabase(t *testing.T) {
 		errorFs := &fstest.OpenErrorFs{
 			DenyPath: utils.DefaultSeedDataPath,
 		}
-		errorFs.Create(utils.DefaultSeedDataPath)
+		_, _ = errorFs.Create(utils.DefaultSeedDataPath)
 
 		// Run test
 		err := SeedDatabase(context.Background(), nil, errorFs)

--- a/internal/migration/apply/apply_test.go
+++ b/internal/migration/apply/apply_test.go
@@ -44,7 +44,7 @@ func TestMigrateDatabase(t *testing.T) {
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		sql := "create schema public"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(sql), 0644))
-		seedPath := filepath.Join(utils.DefaultSeedDataPath)
+		seedPath := filepath.Join(utils.SupabaseDirPath, "seed.sql")
 		// This will raise an error when seeding
 		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte("INSERT INTO test_table;"), 0644))
 		// Setup mock postgres
@@ -82,7 +82,7 @@ func TestSeedDatabase(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup seed file
 		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(sql), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.SupabaseDirPath, "seed.sql"), []byte(sql), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -101,9 +101,9 @@ func TestSeedDatabase(t *testing.T) {
 	t.Run("throws error on read failure", func(t *testing.T) {
 		// Wrap the fs with OpenErrorFs
 		errorFs := &fstest.OpenErrorFs{
-			DenyPath: utils.DefaultSeedDataPath,
+			DenyPath: filepath.Join(utils.SupabaseDirPath, "seed.sql"),
 		}
-		_, _ = errorFs.Create(utils.DefaultSeedDataPath)
+		_, _ = errorFs.Create(filepath.Join(utils.SupabaseDirPath, "seed.sql"))
 
 		// Run test
 		err := SeedDatabase(context.Background(), nil, errorFs)
@@ -117,7 +117,7 @@ func TestSeedDatabase(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		// Setup seed file
 		sql := "INSERT INTO employees(name) VALUES ('Alice')"
-		require.NoError(t, afero.WriteFile(fsys, utils.DefaultSeedDataPath, []byte(sql), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.SupabaseDirPath, "seed.sql"), []byte(sql), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -157,18 +157,8 @@ var (
 	ErrNotRunning  = errors.Errorf("%s is not running.", Aqua("supabase start"))
 )
 
-func GetSeedsFilepaths() string {
-	if seedPaths, _ := GetSeedFiles(afero.NewOsFs()); seedPaths != nil {
-		return fmt.Sprintf("%v", seedPaths)
-	}
-	return ""
-}
-
-/*
-** Match the glob patterns from the config to get
-** a deduplicated array of all migrations files to apply
-** in the declared order
- */
+// Match the glob patterns from the config to get a deduplicated
+// array of all migrations files to apply in the declared order.
 func GetSeedFiles(fsys afero.Fs) ([]string, error) {
 	seedPaths := Config.Db.Seed.SqlPaths
 	var files []string

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -149,7 +149,6 @@ var (
 	FallbackImportMapPath = filepath.Join(FunctionsDir, "import_map.json")
 	FallbackEnvFilePath   = filepath.Join(FunctionsDir, ".env")
 	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
-	DefaultSeedDataPath   = filepath.Join(SupabaseDirPath, "seed.sql")
 	CustomRolesPath       = filepath.Join(SupabaseDirPath, "roles.sql")
 
 	ErrNotLinked   = errors.Errorf("Cannot find project ref. Have you run %s?", Aqua("supabase link"))

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -179,7 +179,7 @@ func GetSeedFiles(fsys afero.Fs) ([]string, error) {
 			return nil, errors.Errorf("failed to apply glob pattern for %w", err)
 		}
 		if len(matches) == 0 {
-			fmt.Fprintf(os.Stderr, "%s Your pattern %s matched 0 seed files.\n", Yellow("Warning:"), pattern)
+			fmt.Fprintf(os.Stderr, "%s Your pattern %s matched 0 seed files.\n", Yellow("WARNING:"), pattern)
 		}
 		sort.Strings(matches)
 		files = append(files, matches...)

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -148,7 +148,7 @@ var (
 	FallbackImportMapPath = filepath.Join(FunctionsDir, "import_map.json")
 	FallbackEnvFilePath   = filepath.Join(FunctionsDir, ".env")
 	DbTestsDir            = filepath.Join(SupabaseDirPath, "tests")
-	SeedDataPath          = filepath.Join(SupabaseDirPath, "seed.sql")
+	DefaultSeedDataPath   = filepath.Join(SupabaseDirPath, "seed.sql")
 	CustomRolesPath       = filepath.Join(SupabaseDirPath, "roles.sql")
 
 	ErrNotLinked   = errors.Errorf("Cannot find project ref. Have you run %s?", Aqua("supabase link"))

--- a/internal/utils/misc_test.go
+++ b/internal/utils/misc_test.go
@@ -87,7 +87,7 @@ func TestGetSeedFiles(t *testing.T) {
 		require.NoError(t, afero.WriteFile(fsys, "supabase/seeds/another.sql", []byte("INSERT INTO table2 VALUES (2);"), 0644))
 		require.NoError(t, afero.WriteFile(fsys, "supabase/seeds/ignore.sql", []byte("INSERT INTO table3 VALUES (3);"), 0644))
 		// Mock config patterns
-		Config.Db.Seed.Path = []string{"seeds/seed[12].sql", "seeds/ano*.sql"}
+		Config.Db.Seed.SqlPaths = []string{"seeds/seed[12].sql", "seeds/ano*.sql"}
 
 		// Run test
 		files, err := GetSeedFiles(fsys)
@@ -107,7 +107,7 @@ func TestGetSeedFiles(t *testing.T) {
 		require.NoError(t, afero.WriteFile(fsys, "supabase/seeds/another.sql", []byte("INSERT INTO table2 VALUES (2);"), 0644))
 		require.NoError(t, afero.WriteFile(fsys, "supabase/seeds/ignore.sql", []byte("INSERT INTO table3 VALUES (3);"), 0644))
 		// Mock config patterns
-		Config.Db.Seed.Path = []string{"seeds/seed[12].sql", "seeds/ano*.sql", "seeds/seed*.sql"}
+		Config.Db.Seed.SqlPaths = []string{"seeds/seed[12].sql", "seeds/ano*.sql", "seeds/seed*.sql"}
 
 		// Run test
 		files, err := GetSeedFiles(fsys)
@@ -122,7 +122,7 @@ func TestGetSeedFiles(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Mock config patterns
-		Config.Db.Seed.Path = []string{"[*!#@D#"}
+		Config.Db.Seed.SqlPaths = []string{"[*!#@D#"}
 
 		// Run test
 		files, err := GetSeedFiles(fsys)
@@ -137,7 +137,7 @@ func TestGetSeedFiles(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Mock config patterns
-		Config.Db.Seed.Path = []string{"seeds/*.sql"}
+		Config.Db.Seed.SqlPaths = []string{"seeds/*.sql"}
 
 		// Run test
 		files, err := GetSeedFiles(fsys)

--- a/internal/utils/misc_test.go
+++ b/internal/utils/misc_test.go
@@ -75,3 +75,56 @@ func TestProjectRoot(t *testing.T) {
 		assert.Equal(t, cwd, path)
 	})
 }
+
+func TestGetSeedFiles(t *testing.T) {
+	t.Run("returns seed files matching patterns", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Create seed files
+		require.NoError(t, afero.WriteFile(fsys, "seeds/seed1.sql", []byte("INSERT INTO table1 VALUES (1);"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, "seeds/seed2.sql", []byte("INSERT INTO table2 VALUES (2);"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, "seeds/seed3.sql", []byte("INSERT INTO table2 VALUES (2);"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, "seeds/another.sql", []byte("INSERT INTO table2 VALUES (2);"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, "seeds/ignore.sql", []byte("INSERT INTO table3 VALUES (3);"), 0644))
+		// Mock config patterns
+		Config.Db.Seed.Path = []string{"seeds/seed[12].sql", "seeds/ano*.sql"}
+
+		// Run test
+		files, err := GetSeedFiles(fsys)
+
+		// Check error
+		assert.NoError(t, err)
+		// Validate files
+		assert.ElementsMatch(t, []string{"seeds/seed1.sql", "seeds/seed2.sql", "seeds/another.sql"}, files)
+	})
+
+	t.Run("returns error on invalid pattern", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Mock config patterns
+		Config.Db.Seed.Path = []string{"[invalid pattern"}
+
+		// Run test
+		files, err := GetSeedFiles(fsys)
+
+		// Check error
+		assert.Nil(t, err)
+		// The resuling seed list should be empty
+		assert.ElementsMatch(t, []string{}, files)
+	})
+
+	t.Run("returns empty list if no files match", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Mock config patterns
+		Config.Db.Seed.Path = []string{"seeds/*.sql"}
+
+		// Run test
+		files, err := GetSeedFiles(fsys)
+
+		// Check error
+		assert.NoError(t, err)
+		// Validate files
+		assert.Empty(t, files)
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,7 +164,8 @@ type (
 	}
 
 	seed struct {
-		Enabled bool `toml:"enabled"`
+		Enabled bool     `toml:"enabled"`
+		Path    []string `toml:"path"`
 	}
 
 	pooler struct {
@@ -465,6 +466,7 @@ func NewConfig(editors ...ConfigEditor) config {
 			},
 			Seed: seed{
 				Enabled: true,
+				Path:    []string{"./seed.sql"},
 			},
 		},
 		Realtime: realtime{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,8 +164,8 @@ type (
 	}
 
 	seed struct {
-		Enabled bool     `toml:"enabled"`
-		Path    []string `toml:"path"`
+		Enabled  bool     `toml:"enabled"`
+		SqlPaths []string `toml:"sql_paths"`
 	}
 
 	pooler struct {
@@ -466,7 +466,6 @@ func NewConfig(editors ...ConfigEditor) config {
 			},
 			Seed: seed{
 				Enabled: true,
-				Path:    []string{"./seed.sql"},
 			},
 		},
 		Realtime: realtime{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -483,7 +483,8 @@ func NewConfig(editors ...ConfigEditor) config {
 				SecretKeyBase: "EAx3IQ/wRG1v47ZD4NE4/9RzBI8Jmil3x0yhcW4V2NHBP6c2iPIzwjofi2Ep4HIG",
 			},
 			Seed: seed{
-				Enabled: true,
+				Enabled:  true,
+				SqlPaths: []string{"./seed.sql"},
 			},
 		},
 		Realtime: realtime{

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -44,8 +44,8 @@ max_client_conn = 100
 enabled = true
 # Specifies seed files to load during db reset using glob patterns
 # Base path is the Supabase project folder
-# Example: path = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
-path = ['./seed.sql']
+# Example: sql_paths = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
+sql_paths = ['./seed.sql']
 
 [realtime]
 enabled = true

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -40,11 +40,11 @@ default_pool_size = 20
 max_client_conn = 100
 
 [db.seed]
-# Determines whether to seed the database after migrations during a db reset
+# If enabled, seeds the database after migrations during a db reset.
 enabled = true
-# Specifies seed files to load during db reset using glob patterns
-# Base path is the Supabase project folder
-# Example: sql_paths = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory. For example:
+# sql_paths = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
 sql_paths = ['./seed.sql']
 
 [realtime]

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -39,6 +39,14 @@ default_pool_size = 20
 # Maximum number of client connections allowed.
 max_client_conn = 100
 
+[db.seed]
+# Allow to decide if db reset should seed your database after migrations or not
+enabled = true
+# A list of glob patterns where base path is supabase folder allowing to load 
+# specific seeds scripts at reset time
+# example: path = ['./seeds/*.sql', '../project-src/seeds/.*-load-testing.sql']
+path = ['./seed.sql']
+
 [realtime]
 enabled = true
 # Bind realtime via either IPv4 or IPv6. (default: IPv4)

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -40,11 +40,11 @@ default_pool_size = 20
 max_client_conn = 100
 
 [db.seed]
-# Allow to decide if db reset should seed your database after migrations or not
+# Determines whether to seed the database after migrations during a db reset
 enabled = true
-# A list of glob patterns where base path is supabase folder allowing to load 
-# specific seeds scripts at reset time
-# example: path = ['./seeds/*.sql', '../project-src/seeds/.*-load-testing.sql']
+# Specifies seed files to load during db reset using glob patterns
+# Base path is the Supabase project folder
+# Example: path = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
 path = ['./seed.sql']
 
 [realtime]

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -39,6 +39,14 @@ default_pool_size = 20
 # Maximum number of client connections allowed.
 max_client_conn = 100
 
+[db.seed]
+# Allow to decide if db reset should seed your database after migrations or not
+enabled = true
+# A list of glob patterns where base path is supabase folder allowing to load 
+# specific seeds scripts at reset time
+# example: path = ['./seeds/*.sql', '../project-src/seeds/.*-load-testing.sql']
+path = ['./seed.sql']
+
 [realtime]
 enabled = true
 # Bind realtime via either IPv4 or IPv6. (default: IPv6)

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -40,11 +40,11 @@ default_pool_size = 20
 max_client_conn = 100
 
 [db.seed]
-# Allow to decide if db reset should seed your database after migrations or not
+# Determines whether to seed the database after migrations during a db reset
 enabled = true
-# A list of glob patterns where base path is supabase folder allowing to load 
-# specific seeds scripts at reset time
-# example: path = ['./seeds/*.sql', '../project-src/seeds/.*-load-testing.sql']
+# Specifies seed files to load during db reset using glob patterns
+# Base path is the Supabase project folder
+# Example: path = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
 path = ['./seed.sql']
 
 [realtime]

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -40,12 +40,12 @@ default_pool_size = 20
 max_client_conn = 100
 
 [db.seed]
-# Determines whether to seed the database after migrations during a db reset
+# If enabled, seeds the database after migrations during a db reset.
 enabled = true
-# Specifies seed files to load during db reset using glob patterns
-# Base path is the Supabase project folder
-# Example: path = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
-path = ['./seed.sql']
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory. For example:
+# sql_paths = ['./seeds/*.sql', '../project-src/seeds/*-load-testing.sql']
+sql_paths = ['./seed.sql']
 
 [realtime]
 enabled = true

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -29,7 +29,7 @@ type pathBuilder struct {
 	FallbackImportMapPath string
 	FallbackEnvFilePath   string
 	DbTestsDir            string
-	SeedDataPath          string
+	DefaultSeedDataPath   string
 	CustomRolesPath       string
 }
 
@@ -63,7 +63,7 @@ func NewPathBuilder(configPath string) pathBuilder {
 		FallbackImportMapPath: filepath.Join(base, "functions", "import_map.json"),
 		FallbackEnvFilePath:   filepath.Join(base, "functions", ".env"),
 		DbTestsDir:            filepath.Join(base, "tests"),
-		SeedDataPath:          filepath.Join(base, "seed.sql"),
+		DefaultSeedDataPath:   filepath.Join(base, "seed.sql"),
 		CustomRolesPath:       filepath.Join(base, "roles.sql"),
 	}
 }

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -29,7 +29,6 @@ type pathBuilder struct {
 	FallbackImportMapPath string
 	FallbackEnvFilePath   string
 	DbTestsDir            string
-	DefaultSeedDataPath   string
 	CustomRolesPath       string
 }
 
@@ -63,7 +62,6 @@ func NewPathBuilder(configPath string) pathBuilder {
 		FallbackImportMapPath: filepath.Join(base, "functions", "import_map.json"),
 		FallbackEnvFilePath:   filepath.Join(base, "functions", ".env"),
 		DbTestsDir:            filepath.Join(base, "tests"),
-		DefaultSeedDataPath:   filepath.Join(base, "seed.sql"),
 		CustomRolesPath:       filepath.Join(base, "roles.sql"),
 	}
 }

--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -12,8 +12,7 @@ import (
 
 func SeedData(ctx context.Context, pending []string, conn *pgx.Conn, fsys fs.FS) error {
 	for _, path := range pending {
-		filename := filepath.Base(path)
-		fmt.Fprintf(os.Stderr, "Seeding data from %s...\n", filename)
+		fmt.Fprintf(os.Stderr, "Seeding data from %s...\n", path)
 		// Batch seed commands, safe to use statement cache
 		if seed, err := NewMigrationFromFile(path, fsys); err != nil {
 			return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature enhancement: Improved seed data handling and configuration

## What is the current behavior?

Currently, the system uses a single, fixed seed file path (`utils.SeedDataPath`) for database seeding. This limits flexibility in organizing and applying seed data.

## What is the new behavior?

1. Introduces a new configuration option in `config.toml` for specifying multiple seed file paths using glob patterns:

```toml
[db.seed]
enabled = true
path = ['./seed.sql', './seeds/*.sql']
```

2. Implements a new function `GetSeedFiles` that:
   - Matches files based on the configured glob patterns
   - Deduplicates matched files to avoid duplicate seeding
   - Sorts the files to ensure consistent application order

3. Updates various parts of the codebase to use the new seeding mechanism:
   - Modifies the `SeedDatabase` function to use the new `GetSeedFiles` function
   - Updates error handling and logging related to seed file operations
   - Adjusts test cases to accommodate the new seeding behavior

4. Change the logging to display the seed file paths being used

## Additional context

This change allows for more flexible organization of seed data, enabling users to split seed data across multiple files and use patterns to include them. It maintains backwards compatibility by defaulting to the previous behavior if no custom configuration is provided.

I'm just wondering about how this should work with supabase "branch deployments" and so on. Locally we'll always find the seeds files at the right location. I wonder how the branching approach work with that. From my understanding it does "clone" the user repository so it should work the same as locally but I might need some help to get that behavior tested.