### PR TITLE
fix: disable security opts for db test on bitbucket runner

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -287,6 +287,9 @@ func DockerStart(ctx context.Context, config container.Config, hostConfig contai
 	// Skip named volume for BitBucket pipeline
 	if os.Getenv("BITBUCKET_CLONE_DIR") != "" {
 		hostConfig.Binds = binds
+		// Bitbucket doesn't allow for --security-opt option to be set
+		// https://support.atlassian.com/bitbucket-cloud/docs/run-docker-commands-in-bitbucket-pipelines/#Full-list-of-restricted-commands
+		hostConfig.SecurityOpt = nil
 	} else {
 		// Create named volumes with labels
 		for _, name := range sources {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Skip unsupported `SecurityOpt` on bitbucket runners.

Fixes #2703 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Tested with the `setup-cli` on bitbucket platform using the current branch.