### PR TITLE
fix: refactor find seed files for reuse

### DIFF
--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -6,9 +6,39 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgx/v4"
 )
+
+// Find all files that match the specified glob patterns without duplicates.
+// Results are ordered by input glob pattern, followed by lexical order.
+func FindSeedFiles(globs []string, fsys fs.FS) ([]string, error) {
+	var files []string
+	for _, pattern := range globs {
+		matches, err := fs.Glob(fsys, pattern)
+		if err != nil {
+			return nil, errors.Errorf("failed to apply glob pattern: %w", err)
+		}
+		sort.Strings(matches)
+		files = append(files, matches...)
+	}
+	return removeDuplicates(files), nil
+}
+
+func removeDuplicates[T comparable](slice []T) []T {
+	// Remove elements in-place
+	result := slice[:0]
+	set := make(map[T]struct{})
+	for _, item := range slice {
+		if _, exists := set[item]; !exists {
+			set[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+	return result
+}
 
 func SeedData(ctx context.Context, pending []string, conn *pgx.Conn, fsys fs.FS) error {
 	for _, path := range pending {


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/cli/pull/2702

## What is the new behavior?

Allows packages to import `FindSeedFiles`.

## Additional context

Add any other context or screenshots.
