### PR TITLE
feat: add project unpause command

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -1726,6 +1726,28 @@ paths:
         - Auth
       security:
         - bearer: []
+  /v1/projects/{ref}/unpause:
+    post:
+      operationId: v1-unpause-a-project
+      summary: Unpause the given project
+      parameters:
+        - name: ref
+          required: true
+          in: path
+          description: Project ref
+          schema:
+            minLength: 20
+            maxLength: 20
+            type: string
+      responses:
+        '201':
+          description: ''
+        '403':
+          description: ''
+      tags:
+        - Projects
+      security:
+        - bearer: []
   /v1/projects/{ref}/database/query:
     post:
       operationId: v1-run-a-query

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -43,18 +43,19 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 
 	if utils.OutputFormat.Value == utils.OutputPretty {
-		table := `LINKED|ORG ID|REFERENCE ID|NAME|REGION|CREATED AT (UTC)
-|-|-|-|-|-|-|
+		table := `LINKED|ORG ID|REFERENCE ID|NAME|REGION|CREATED AT (UTC)|STATUS
+|-|-|-|-|-|-|-|
 `
 		for _, project := range projects {
 			table += fmt.Sprintf(
-				"|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|\n",
+				"|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|\n",
 				formatBullet(project.Linked),
 				project.OrganizationId,
 				project.Id,
 				strings.ReplaceAll(project.Name, "|", "\\|"),
 				formatRegion(project.Region),
 				utils.FormatTimestamp(project.CreatedAt),
+				project.Status,
 			)
 		}
 		return list.RenderTable(table)

--- a/internal/projects/unpause/unpause.go
+++ b/internal/projects/unpause/unpause.go
@@ -1,0 +1,42 @@
+package unpause
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-errors/errors"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func PreRun(ctx context.Context, ref string) error {
+	if err := utils.AssertProjectRefIsValid(ref); err != nil {
+		return err
+	}
+	title := fmt.Sprintf("Do you want to unpause project %s?", utils.Aqua(ref))
+	if shouldUnpause, err := utils.NewConsole().PromptYesNo(ctx, title, false); err != nil {
+		return err
+	} else if !shouldUnpause {
+		return errors.New(context.Canceled)
+	}
+	return nil
+}
+
+func Run(ctx context.Context, ref string) error {
+	resp, err := utils.GetSupabase().V1UnpauseAProjectWithResponse(ctx, ref)
+	if err != nil {
+		return errors.Errorf("failed to unpause project: %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusNotFound:
+		return errors.New("Project does not exist:" + utils.Aqua(ref))
+	case http.StatusCreated:
+		break
+	default:
+		return errors.Errorf("Failed to unpause project %s: %s", utils.Aqua(ref), string(resp.Body))
+	}
+
+	fmt.Println("Unpausing project: " + utils.Aqua(ref) + " it should be ready in a few minutes.\nRun: " + utils.Bold("supabase projects list") + " to see your projects status.")
+	return nil
+}

--- a/internal/projects/unpause/unpause_test.go
+++ b/internal/projects/unpause/unpause_test.go
@@ -1,0 +1,78 @@
+package unpause
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+	"github.com/zalando/go-keyring"
+)
+
+func TestUnpauseCommand(t *testing.T) {
+	ref := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+	// Mock credentials store
+	keyring.MockInit()
+
+	t.Run("unpause project", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(ref), 0644))
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/unpause").
+			Reply(http.StatusCreated).
+			JSON(api.V1UnpauseAProjectResponse{})
+		// Run test
+		err := Run(context.Background(), ref)
+		// Check error
+		assert.NoError(t, err)
+	})
+
+	t.Run("throws error on network failure", func(t *testing.T) {
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/unpause").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := Run(context.Background(), ref)
+		// Check error
+		assert.ErrorContains(t, err, "network error")
+	})
+
+	t.Run("throws error on project not found", func(t *testing.T) {
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/unpause").
+			Reply(http.StatusNotFound)
+		// Run test
+		err := Run(context.Background(), ref)
+		// Check error
+		assert.ErrorContains(t, err, "Project does not exist:")
+	})
+
+	t.Run("throws error on service unavailable", func(t *testing.T) {
+		// Setup api mock
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/projects/" + ref + "/unpause").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := Run(context.Background(), ref)
+		// Check error
+		assert.ErrorContains(t, err, "Failed to unpause project")
+	})
+}

--- a/internal/utils/flags/project_ref_test.go
+++ b/internal/utils/flags/project_ref_test.go
@@ -80,7 +80,7 @@ func TestProjectPrompt(t *testing.T) {
 				OrganizationId: "test-org",
 			}})
 		// Run test
-		err := PromptProjectRef(context.Background(), "")
+		err := PromptProjectRef(context.Background(), "", nil)
 		// Check error
 		assert.ErrorContains(t, err, "failed to prompt choice:")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -94,7 +94,7 @@ func TestProjectPrompt(t *testing.T) {
 			Get("/v1/projects").
 			ReplyError(errNetwork)
 		// Run test
-		err := PromptProjectRef(context.Background(), "")
+		err := PromptProjectRef(context.Background(), "", nil)
 		// Check error
 		assert.ErrorIs(t, err, errNetwork)
 	})
@@ -106,7 +106,7 @@ func TestProjectPrompt(t *testing.T) {
 			Get("/v1/projects").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := PromptProjectRef(context.Background(), "")
+		err := PromptProjectRef(context.Background(), "", nil)
 		// Check error
 		assert.ErrorContains(t, err, "Unexpected error retrieving projects:")
 	})

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -343,6 +343,9 @@ type ClientInterface interface {
 	// V1GenerateTypescriptTypes request
 	V1GenerateTypescriptTypes(ctx context.Context, ref string, params *V1GenerateTypescriptTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// V1UnpauseAProject request
+	V1UnpauseAProject(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// V1UpgradePostgresVersionWithBody request with any body
 	V1UpgradePostgresVersionWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1483,6 +1486,18 @@ func (c *Client) V1ListAllBuckets(ctx context.Context, ref string, reqEditors ..
 
 func (c *Client) V1GenerateTypescriptTypes(ctx context.Context, ref string, params *V1GenerateTypescriptTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewV1GenerateTypescriptTypesRequest(c.Server, ref, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1UnpauseAProject(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1UnpauseAProjectRequest(c.Server, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -4677,6 +4692,40 @@ func NewV1GenerateTypescriptTypesRequest(server string, ref string, params *V1Ge
 	return req, nil
 }
 
+// NewV1UnpauseAProjectRequest generates requests for V1UnpauseAProject
+func NewV1UnpauseAProjectRequest(server string, ref string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/unpause", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewV1UpgradePostgresVersionRequest calls the generic V1UpgradePostgresVersion builder with application/json body
 func NewV1UpgradePostgresVersionRequest(server string, ref string, body V1UpgradePostgresVersionJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -5333,6 +5382,9 @@ type ClientWithResponsesInterface interface {
 
 	// V1GenerateTypescriptTypesWithResponse request
 	V1GenerateTypescriptTypesWithResponse(ctx context.Context, ref string, params *V1GenerateTypescriptTypesParams, reqEditors ...RequestEditorFn) (*V1GenerateTypescriptTypesResponse, error)
+
+	// V1UnpauseAProjectWithResponse request
+	V1UnpauseAProjectWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*V1UnpauseAProjectResponse, error)
 
 	// V1UpgradePostgresVersionWithBodyWithResponse request with any body
 	V1UpgradePostgresVersionWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1UpgradePostgresVersionResponse, error)
@@ -6852,6 +6904,27 @@ func (r V1GenerateTypescriptTypesResponse) StatusCode() int {
 	return 0
 }
 
+type V1UnpauseAProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r V1UnpauseAProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r V1UnpauseAProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type V1UpgradePostgresVersionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -7859,6 +7932,15 @@ func (c *ClientWithResponses) V1GenerateTypescriptTypesWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseV1GenerateTypescriptTypesResponse(rsp)
+}
+
+// V1UnpauseAProjectWithResponse request returning *V1UnpauseAProjectResponse
+func (c *ClientWithResponses) V1UnpauseAProjectWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*V1UnpauseAProjectResponse, error) {
+	rsp, err := c.V1UnpauseAProject(ctx, ref, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1UnpauseAProjectResponse(rsp)
 }
 
 // V1UpgradePostgresVersionWithBodyWithResponse request with arbitrary body returning *V1UpgradePostgresVersionResponse
@@ -9609,6 +9691,22 @@ func ParseV1GenerateTypescriptTypesResponse(rsp *http.Response) (*V1GenerateType
 		}
 		response.JSON200 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseV1UnpauseAProjectResponse parses an HTTP response from a V1UnpauseAProjectWithResponse call
+func ParseV1UnpauseAProjectResponse(rsp *http.Response) (*V1UnpauseAProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &V1UnpauseAProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, there is no functionality to unpause a paused Supabase project through the CLI.

## What is the new behavior?

This PR introduces a new command `supabase projects unpause` that allows users to unpause a paused Supabase project. The new features include:

1. A new API endpoint `/v1/projects/{ref}/unpause` for unpausing projects. (see: https://github.com/supabase/infrastructure/pull/20022)
2. A new CLI command `supabase projects unpause <ref>` to unpause a project.
3. The ability to list and select only inactive projects when unpausing.
4. Updated project listing to include the project status.
5. New tests for the unpause functionality.

Key changes:
- Added a new `unpause` package with the main logic for unpausing a project.
- Modified the project listing to show the project status.
- Added filtering capability to show only inactive projects when unpausing.

## Additional context

Closes: https://github.com/supabase/cli/issues/2715
Related: https://www.notion.so/supabase/resume-project-from-cli-10d5004b775f80f6bbc2e12a29fa80c5