### PR TITLE
fix: bump edge-runtime to 1.58.11

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240923-2e3e90c"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.3"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.11"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.11

### Changes

### [1.58.11](https://github.com/supabase/edge-runtime/compare/v1.58.3...v1.58.11) (2024-09-30)

#### Bug Fixes

* **node:** mitigate denoland/deno[#24678](https://github.com/supabase/edge-runtime/issues/24678) ([#407](https://github.com/supabase/edge-runtime/issues/407)) ([fbcd8c5](https://github.com/supabase/edge-runtime/commit/fbcd8c5c0ce850cc20f9239218c3f969dc0ed4e8))
* **node:** mitigate denoland/deno[#25279](https://github.com/supabase/edge-runtime/issues/25279) ([#412](https://github.com/supabase/edge-runtime/issues/412)) ([41c7624](https://github.com/supabase/edge-runtime/commit/41c7624fd3c0659c78f0dd2b8725e8dfd9e24fa1))
* **sb_core:** add an API for chaos testing ([#411](https://github.com/supabase/edge-runtime/issues/411)) ([1c19701](https://github.com/supabase/edge-runtime/commit/1c19701acd71a676f884b21a0d48b84b473a1cb3))
* **base:** partial revert some changes that were introduced from deno upgrade PR ([#415](https://github.com/supabase/edge-runtime/issues/415)) ([db2cc41](https://github.com/supabase/edge-runtime/commit/db2cc413ff1b8353d322ea156ea972aed8788181))
* triggers the release action ([#419](https://github.com/supabase/edge-runtime/issues/419)) ([e8759ec](https://github.com/supabase/edge-runtime/commit/e8759ecff99dc15c9fba3e17a1f28bdcb3c8aebe))
* **base:** thread-local state of `v8::Isolate` can be corrupted while initializing DenoRuntime in `Worker::start` ([#416](https://github.com/supabase/edge-runtime/issues/416)) ([539b706](https://github.com/supabase/edge-runtime/commit/539b706b2283484b89d4b53e93e891a4f8882ae3)), closes [#415](https://github.com/supabase/edge-runtime/issues/415)
* **base:** pass import meta resolve callback when initialize `JsRuntime` ([#421](https://github.com/supabase/edge-runtime/issues/421)) ([6edf6c3](https://github.com/supabase/edge-runtime/commit/6edf6c3d43be69e00a44c1b781e9abe1d84e0137))
* render detailed error message for failed to create a graph ([#418](https://github.com/supabase/edge-runtime/issues/418)) ([676a07c](https://github.com/supabase/edge-runtime/commit/676a07c9f438ab31d30f7a2133329559a2e8285a))