### PR TITLE
feat: track seeded files in migration table

### DIFF
--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -148,7 +148,7 @@ func TestPushAll(t *testing.T) {
 
 	t.Run("throws error on roles failure", func(t *testing.T) {
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: utils.CustomRolesPath}
+		fsys := &fstest.StatErrorFs{DenyPath: utils.CustomRolesPath}
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -180,7 +180,8 @@ func TestPushAll(t *testing.T) {
 			Reply("SELECT 0")
 		helper.MockMigrationHistory(conn).
 			Query(migration.INSERT_MIGRATION_VERSION, "0", "test", nil).
-			Reply("INSERT 0 1").
+			Reply("INSERT 0 1")
+		helper.MockSeedHistory(conn).
 			Query(migration.UPSERT_SEED_FILE, seedPath, digest).
 			ReplyError(pgerrcode.NotNullViolation, `null value in column "hash" of relation "seed_files"`)
 		// Run test

--- a/internal/db/push/push_test.go
+++ b/internal/db/push/push_test.go
@@ -2,6 +2,8 @@ package push
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,24 +163,29 @@ func TestPushAll(t *testing.T) {
 	})
 
 	t.Run("throws error on seed failure", func(t *testing.T) {
+		digest := hex.EncodeToString(sha256.New().Sum(nil))
 		seedPath := filepath.Join(utils.SupabaseDirPath, "seed.sql")
 		utils.Config.Db.Seed.SqlPaths = []string{seedPath}
 		// Setup in-memory fs
-		fsys := &fstest.OpenErrorFs{DenyPath: seedPath}
-		_, _ = fsys.Create(seedPath)
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, seedPath, []byte{}, 0644))
 		path := filepath.Join(utils.MigrationsDir, "0_test.sql")
 		require.NoError(t, afero.WriteFile(fsys, path, []byte{}, 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		conn.Query(migration.LIST_MIGRATION_VERSION).
+			Reply("SELECT 0").
+			Query(migration.SELECT_SEED_TABLE).
 			Reply("SELECT 0")
 		helper.MockMigrationHistory(conn).
 			Query(migration.INSERT_MIGRATION_VERSION, "0", "test", nil).
-			Reply("INSERT 0 1")
+			Reply("INSERT 0 1").
+			Query(migration.UPSERT_SEED_FILE, seedPath, digest).
+			ReplyError(pgerrcode.NotNullViolation, `null value in column "hash" of relation "seed_files"`)
 		// Run test
 		err := Run(context.Background(), false, false, false, true, dbConfig, fsys, conn.Intercept)
 		// Check error
-		assert.ErrorIs(t, err, os.ErrPermission)
+		assert.ErrorContains(t, err, `ERROR: null value in column "hash" of relation "seed_files" (SQLSTATE 23502)`)
 	})
 }

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -97,11 +97,6 @@ func resetDatabase14(ctx context.Context, version string, fsys afero.Fs, options
 		return err
 	}
 	defer conn.Close(context.Background())
-	if utils.Config.Db.MajorVersion > 14 {
-		if err := start.SetupDatabase(ctx, conn, utils.DbId, os.Stderr, fsys); err != nil {
-			return err
-		}
-	}
 	return apply.MigrateAndSeed(ctx, version, conn, fsys)
 }
 
@@ -132,15 +127,7 @@ func resetDatabase15(ctx context.Context, version string, fsys afero.Fs, options
 	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, utils.DbId); err != nil {
 		return err
 	}
-	conn, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{}, options...)
-	if err != nil {
-		return err
-	}
-	defer conn.Close(context.Background())
-	if err := start.SetupDatabase(ctx, conn, utils.DbId, os.Stderr, fsys); err != nil {
-		return err
-	}
-	if err := apply.MigrateAndSeed(ctx, version, conn, fsys); err != nil {
+	if err := start.SetupLocalDatabase(ctx, version, fsys, os.Stderr, options...); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Restarting containers...")

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -149,7 +149,7 @@ EOF
 	}
 	// Initialize if we are on PG14 and there's no existing db volume
 	if utils.NoBackupVolume {
-		if err := setupDatabase(ctx, fsys, w, options...); err != nil {
+		if err := SetupLocalDatabase(ctx, "", fsys, w, options...); err != nil {
 			return err
 		}
 	}
@@ -310,7 +310,7 @@ func initSchema15(ctx context.Context, host string) error {
 	return nil
 }
 
-func setupDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...func(*pgx.ConnConfig)) error {
+func SetupLocalDatabase(ctx context.Context, version string, fsys afero.Fs, w io.Writer, options ...func(*pgx.ConnConfig)) error {
 	conn, err := utils.ConnectLocalPostgres(ctx, pgconn.Config{}, options...)
 	if err != nil {
 		return err
@@ -319,7 +319,7 @@ func setupDatabase(ctx context.Context, fsys afero.Fs, w io.Writer, options ...f
 	if err := SetupDatabase(ctx, conn, utils.DbId, w, fsys); err != nil {
 		return err
 	}
-	return apply.MigrateAndSeed(ctx, "", conn, fsys)
+	return apply.MigrateAndSeed(ctx, version, conn, fsys)
 }
 
 func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer, fsys afero.Fs) error {

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -326,5 +326,9 @@ func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer
 	if err := initSchema(ctx, conn, host, w); err != nil {
 		return err
 	}
-	return apply.CreateCustomRoles(ctx, conn, fsys)
+	err := migration.SeedGlobals(ctx, []string{utils.CustomRolesPath}, conn, afero.NewIOFS(fsys))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -259,7 +259,7 @@ func TestSetupDatabase(t *testing.T) {
 			Query(roles).
 			Reply("CREATE ROLE")
 		// Run test
-		err := setupDatabase(context.Background(), fsys, io.Discard, conn.Intercept)
+		err := SetupLocalDatabase(context.Background(), "", fsys, io.Discard, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -268,7 +268,7 @@ func TestSetupDatabase(t *testing.T) {
 	t.Run("throws error on connect failure", func(t *testing.T) {
 		utils.Config.Db.Port = 0
 		// Run test
-		err := setupDatabase(context.Background(), nil, io.Discard)
+		err := SetupLocalDatabase(context.Background(), "", nil, io.Discard)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
@@ -285,7 +285,7 @@ func TestSetupDatabase(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		err := setupDatabase(context.Background(), nil, io.Discard, conn.Intercept)
+		err := SetupLocalDatabase(context.Background(), "", nil, io.Discard, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -308,7 +308,7 @@ func TestSetupDatabase(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		err := setupDatabase(context.Background(), fsys, io.Discard, conn.Intercept)
+		err := SetupLocalDatabase(context.Background(), "", fsys, io.Discard, conn.Intercept)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrPermission)
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -183,7 +183,10 @@ func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pg
 	defer conn.Close(context.Background())
 	updatePostgresConfig(conn)
 	// If `schema_migrations` doesn't exist on the remote database, create it.
-	return migration.CreateMigrationTable(ctx, conn)
+	if err := migration.CreateMigrationTable(ctx, conn); err != nil {
+		return err
+	}
+	return migration.CreateSeedTable(ctx, conn)
 }
 
 func linkDatabaseVersion(ctx context.Context, projectRef string, fsys afero.Fs) error {

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -46,6 +46,7 @@ func TestLinkCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		helper.MockMigrationHistory(conn)
+		helper.MockSeedHistory(conn)
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -279,6 +280,7 @@ func TestLinkDatabase(t *testing.T) {
 		})
 		defer conn.Close(t)
 		helper.MockMigrationHistory(conn)
+		helper.MockSeedHistory(conn)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -294,6 +296,7 @@ func TestLinkDatabase(t *testing.T) {
 		})
 		defer conn.Close(t)
 		helper.MockMigrationHistory(conn)
+		helper.MockSeedHistory(conn)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error
@@ -313,8 +316,7 @@ func TestLinkDatabase(t *testing.T) {
 			Query(migration.CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(migration.ADD_STATEMENTS_COLUMN).
-			Query(migration.ADD_NAME_COLUMN).
-			Query(migration.CREATE_SEED_TABLE)
+			Query(migration.ADD_NAME_COLUMN)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -313,7 +313,8 @@ func TestLinkDatabase(t *testing.T) {
 			Query(migration.CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(migration.ADD_STATEMENTS_COLUMN).
-			Query(migration.ADD_NAME_COLUMN)
+			Query(migration.ADD_NAME_COLUMN).
+			Query(migration.CREATE_SEED_TABLE)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -2,9 +2,7 @@ package apply
 
 import (
 	"context"
-	"os"
 
-	"github.com/go-errors/errors"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
@@ -32,12 +30,4 @@ func applySeedFiles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 		return err
 	}
 	return migration.SeedData(ctx, seeds, conn, afero.NewIOFS(fsys))
-}
-
-func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	err := migration.SeedGlobals(ctx, []string{utils.CustomRolesPath}, conn, afero.NewIOFS(fsys))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
 }

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -20,10 +20,10 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 	if err := migration.ApplyMigrations(ctx, migrations, conn, afero.NewIOFS(fsys)); err != nil {
 		return err
 	}
-	return SeedDatabase(ctx, conn, fsys)
+	return applySeedFiles(ctx, conn, fsys)
 }
 
-func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
+func applySeedFiles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
 	if !utils.Config.Db.Seed.Enabled {
 		return nil
 	}

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -27,7 +27,11 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	return migration.SeedData(ctx, utils.Config.Db.Seed.SqlPaths, conn, afero.NewIOFS(fsys))
+	seeds, err := migration.GetPendingSeeds(ctx, utils.Config.Db.Seed.SqlPaths, conn, afero.NewIOFS(fsys))
+	if err != nil {
+		return err
+	}
+	return migration.SeedData(ctx, seeds, conn, afero.NewIOFS(fsys))
 }
 
 func CreateCustomRoles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -20,13 +20,13 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 	if err := migration.ApplyMigrations(ctx, migrations, conn, afero.NewIOFS(fsys)); err != nil {
 		return err
 	}
-	if !utils.Config.Db.Seed.Enabled {
-		return nil
-	}
 	return SeedDatabase(ctx, conn, fsys)
 }
 
 func SeedDatabase(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
+	if !utils.Config.Db.Seed.Enabled {
+		return nil
+	}
 	seeds, err := migration.GetPendingSeeds(ctx, utils.Config.Db.Seed.SqlPaths, conn, afero.NewIOFS(fsys))
 	if err != nil {
 		return err

--- a/internal/testing/helper/history.go
+++ b/internal/testing/helper/history.go
@@ -14,6 +14,8 @@ func MockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(migration.ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(migration.ADD_NAME_COLUMN).
-		Reply("ALTER TABLE")
+		Reply("ALTER TABLE").
+		Query(migration.CREATE_SEED_TABLE).
+		Reply("CREATE TABLE")
 	return conn
 }

--- a/internal/testing/helper/history.go
+++ b/internal/testing/helper/history.go
@@ -14,7 +14,14 @@ func MockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(migration.ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(migration.ADD_NAME_COLUMN).
-		Reply("ALTER TABLE").
+		Reply("ALTER TABLE")
+	return conn
+}
+
+func MockSeedHistory(conn *pgtest.MockConn) *pgtest.MockConn {
+	conn.Query(migration.SET_LOCK_TIMEOUT).
+		Query(migration.CREATE_VERSION_SCHEMA).
+		Reply("CREATE SCHEMA").
 		Query(migration.CREATE_SEED_TABLE).
 		Reply("CREATE TABLE")
 	return conn

--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -50,6 +50,11 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 	// Update connection config
 	switch connType {
 	case direct:
+		if err := utils.Config.Load("", utils.NewRootFS(fsys)); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
 		if flag := flagSet.Lookup("db-url"); flag != nil {
 			config, err := pgconn.ParseConfig(flag.Value.String())
 			if err != nil {

--- a/pkg/migration/apply_test.go
+++ b/pkg/migration/apply_test.go
@@ -130,8 +130,7 @@ func TestApplyMigrations(t *testing.T) {
 			Query(CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(ADD_STATEMENTS_COLUMN).
-			Query(ADD_NAME_COLUMN).
-			Query(CREATE_SEED_TABLE)
+			Query(ADD_NAME_COLUMN)
 		// Run test
 		err := ApplyMigrations(context.Background(), pending, conn.MockClient(t), fsys)
 		// Check error
@@ -176,8 +175,6 @@ func mockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(ADD_NAME_COLUMN).
-		Reply("ALTER TABLE").
-		Query(CREATE_SEED_TABLE).
-		Reply("CREATE TABLE")
+		Reply("ALTER TABLE")
 	return conn
 }

--- a/pkg/migration/apply_test.go
+++ b/pkg/migration/apply_test.go
@@ -130,7 +130,8 @@ func TestApplyMigrations(t *testing.T) {
 			Query(CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(ADD_STATEMENTS_COLUMN).
-			Query(ADD_NAME_COLUMN)
+			Query(ADD_NAME_COLUMN).
+			Query(CREATE_SEED_TABLE)
 		// Run test
 		err := ApplyMigrations(context.Background(), pending, conn.MockClient(t), fsys)
 		// Check error
@@ -175,6 +176,8 @@ func mockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(ADD_NAME_COLUMN).
-		Reply("ALTER TABLE")
+		Reply("ALTER TABLE").
+		Query(CREATE_SEED_TABLE).
+		Reply("CREATE TABLE")
 	return conn
 }

--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -19,9 +19,9 @@ func getRemoteSeeds(ctx context.Context, conn *pgx.Conn) (map[string]string, err
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UndefinedTable {
 			// If seed table is undefined, the remote project has no migrations
-			return map[string]string{}, nil
+			return nil, nil
 		}
-		return map[string]string{}, err
+		return nil, err
 	}
 	applied := make(map[string]string, len(remotes))
 	for _, seed := range remotes {
@@ -31,6 +31,9 @@ func getRemoteSeeds(ctx context.Context, conn *pgx.Conn) (map[string]string, err
 }
 
 func GetPendingSeeds(ctx context.Context, locals []string, conn *pgx.Conn, fsys fs.FS) ([]SeedFile, error) {
+	if len(locals) == 0 {
+		return nil, nil
+	}
 	applied, err := getRemoteSeeds(ctx, conn)
 	if err != nil {
 		return nil, err

--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -58,6 +58,11 @@ func GetPendingSeeds(ctx context.Context, locals []string, conn *pgx.Conn, fsys 
 }
 
 func SeedData(ctx context.Context, pending []SeedFile, conn *pgx.Conn, fsys fs.FS) error {
+	if len(pending) > 0 {
+		if err := CreateSeedTable(ctx, conn); err != nil {
+			return err
+		}
+	}
 	for _, seed := range pending {
 		if seed.Dirty {
 			fmt.Fprintf(os.Stderr, "Updating seed hash to %s...\n", seed.Path)

--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -60,7 +60,7 @@ func GetPendingSeeds(ctx context.Context, locals []string, conn *pgx.Conn, fsys 
 func SeedData(ctx context.Context, pending []SeedFile, conn *pgx.Conn, fsys fs.FS) error {
 	for _, seed := range pending {
 		if seed.Dirty {
-			fmt.Fprintf(os.Stderr, "Updating seed file hash %s...\n", seed.Path)
+			fmt.Fprintf(os.Stderr, "Updating seed hash to %s...\n", seed.Path)
 		} else {
 			fmt.Fprintf(os.Stderr, "Seeding data from %s...\n", seed.Path)
 		}

--- a/pkg/migration/seed_test.go
+++ b/pkg/migration/seed_test.go
@@ -65,7 +65,7 @@ func TestPendingSeeds(t *testing.T) {
 		require.Empty(t, seeds)
 	})
 
-	t.Run("throws error on missing seed table", func(t *testing.T) {
+	t.Run("ignores missing seed table", func(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -74,7 +74,7 @@ func TestPendingSeeds(t *testing.T) {
 		// Run test
 		_, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), testMigrations)
 		// Check error
-		assert.ErrorContains(t, err, `ERROR: relation "seed_files" does not exist (SQLSTATE 42P01)`)
+		assert.NoError(t, err)
 	})
 
 	t.Run("throws error on missing file", func(t *testing.T) {

--- a/pkg/migration/seed_test.go
+++ b/pkg/migration/seed_test.go
@@ -8,45 +8,122 @@ import (
 	fs "testing/fstest"
 
 	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/pkg/pgtest"
 )
 
 //go:embed testdata/seed.sql
 var testSeed string
 
-func TestSeedData(t *testing.T) {
+func TestPendingSeeds(t *testing.T) {
 	pending := []string{"testdata/seed.sql"}
 
-	t.Run("seeds from file", func(t *testing.T) {
+	t.Run("finds new seeds", func(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(testSeed).
+		conn.Query(SELECT_SEED_TABLE).
+			Reply("SELECT 0")
+		// Run test
+		seeds, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), testMigrations)
+		// Check error
+		assert.NoError(t, err)
+		require.Len(t, seeds, 1)
+		assert.Equal(t, seeds[0].Path, pending[0])
+		assert.Equal(t, seeds[0].Hash, "61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3")
+		assert.False(t, seeds[0].Dirty)
+	})
+
+	t.Run("finds dirty seeds", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(SELECT_SEED_TABLE).
+			Reply("SELECT 1", SeedFile{Path: pending[0], Hash: "outdated"})
+		// Run test
+		seeds, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), testMigrations)
+		// Check error
+		assert.NoError(t, err)
+		require.Len(t, seeds, 1)
+		assert.Equal(t, seeds[0].Path, pending[0])
+		assert.Equal(t, seeds[0].Hash, "61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3")
+		assert.True(t, seeds[0].Dirty)
+	})
+
+	t.Run("skips applied seed", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(SELECT_SEED_TABLE).
+			Reply("SELECT 1", SeedFile{Path: pending[0], Hash: "61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3"})
+		// Run test
+		seeds, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), testMigrations)
+		// Check error
+		assert.NoError(t, err)
+		require.Empty(t, seeds)
+	})
+
+	t.Run("throws error on missing seed table", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(SELECT_SEED_TABLE).
+			ReplyError(pgerrcode.UndefinedTable, `relation "seed_files" does not exist`)
+		// Run test
+		_, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), testMigrations)
+		// Check error
+		assert.ErrorContains(t, err, `ERROR: relation "seed_files" does not exist (SQLSTATE 42P01)`)
+	})
+
+	t.Run("throws error on missing file", func(t *testing.T) {
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(SELECT_SEED_TABLE).
+			Reply("SELECT 0")
+		// Setup in-memory fs
+		fsys := fs.MapFS{}
+		// Run test
+		_, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), fsys)
+		// Check error
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestSeedData(t *testing.T) {
+	t.Run("seeds from file", func(t *testing.T) {
+		seed := SeedFile{
+			Path:  "testdata/seed.sql",
+			Hash:  "61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3",
+			Dirty: true,
+		}
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(UPSERT_SEED_FILE, seed.Path, seed.Hash).
 			Reply("INSERT 0 1")
 		// Run test
-		err := SeedData(context.Background(), pending, conn.MockClient(t), testMigrations)
+		err := SeedData(context.Background(), []SeedFile{seed}, conn.MockClient(t), testMigrations)
 		// Check error
 		assert.NoError(t, err)
 	})
 
-	t.Run("throws error on missing file", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := fs.MapFS{}
-		// Run test
-		err := SeedData(context.Background(), pending, nil, fsys)
-		// Check error
-		assert.ErrorIs(t, err, os.ErrNotExist)
-	})
-
-	t.Run("throws error on insert failure", func(t *testing.T) {
+	t.Run("throws error on upsert failure", func(t *testing.T) {
+		seed := SeedFile{
+			Path: "testdata/seed.sql",
+			Hash: "61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3",
+		}
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query(testSeed).
+		conn.Query(testSeed+`;INSERT INTO supabase_migrations.seed_files(path, hash) VALUES( 'testdata/seed.sql' ,  '61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3' ) ON CONFLICT (path) DO UPDATE SET hash = EXCLUDED.hash`).
 			ReplyError(pgerrcode.NotNullViolation, `null value in column "age" of relation "employees"`)
 		// Run test
-		err := SeedData(context.Background(), pending, conn.MockClient(t), testMigrations)
+		err := SeedData(context.Background(), []SeedFile{seed}, conn.MockClient(t, func(cc *pgx.ConnConfig) {
+			cc.PreferSimpleProtocol = true
+		}), testMigrations)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: null value in column "age" of relation "employees" (SQLSTATE 23502)`)
 	})

--- a/pkg/pgtest/mock.go
+++ b/pkg/pgtest/mock.go
@@ -153,7 +153,10 @@ func (r *MockConn) Reply(tag string, rows ...interface{}) *MockConn {
 		} else if t := reflect.TypeOf(rows[0]); t.Kind() == reflect.Struct {
 			s := reflect.ValueOf(rows[0])
 			for i := 0; i < s.NumField(); i++ {
-				name := t.Field(i).Name
+				name := pgxv5.GetColumnName(t.Field(i))
+				if len(name) == 0 {
+					continue
+				}
 				v := s.Field(i).Interface()
 				if fd := toFieldDescription(v); fd != nil {
 					fd.Name = []byte(name)
@@ -182,6 +185,9 @@ func (r *MockConn) Reply(tag string, rows ...interface{}) *MockConn {
 		} else if t := reflect.TypeOf(data); t.Kind() == reflect.Struct {
 			s := reflect.ValueOf(rows[0])
 			for i := 0; i < s.NumField(); i++ {
+				if name := pgxv5.GetColumnName(t.Field(i)); len(name) == 0 {
+					continue
+				}
 				v := s.Field(i).Interface()
 				if value, oid := r.encodeValueArg(v); oid > 0 {
 					dr.Values = append(dr.Values, value)

--- a/pkg/pgxv5/rows.go
+++ b/pkg/pgxv5/rows.go
@@ -104,17 +104,10 @@ func appendScanTargets(dstElemValue reflect.Value, scanTargets []any, fldDescs [
 				return nil, err
 			}
 		} else {
-			dbTag, dbTagPresent := sf.Tag.Lookup(structTagKey)
-			if dbTagPresent {
-				dbTag = strings.Split(dbTag, ",")[0]
-			}
-			if dbTag == "-" {
+			colName := GetColumnName(sf)
+			if len(colName) == 0 {
 				// Field is ignored, skip it.
 				continue
-			}
-			colName := dbTag
-			if !dbTagPresent {
-				colName = sf.Name
 			}
 			fpos := fieldPosByName(fldDescs, colName)
 			if fpos == -1 || fpos >= len(scanTargets) {
@@ -125,4 +118,15 @@ func appendScanTargets(dstElemValue reflect.Value, scanTargets []any, fldDescs [
 	}
 
 	return scanTargets, err
+}
+
+func GetColumnName(sf reflect.StructField) string {
+	dbTag, dbTagPresent := sf.Tag.Lookup(structTagKey)
+	if !dbTagPresent {
+		return sf.Name
+	}
+	if dbTag = strings.Split(dbTag, ",")[0]; dbTag != "-" {
+		return dbTag
+	}
+	return ""
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Track seed files in a history table.

- `path` resolves to local seed file and is also they primary key
- `hash` is the sha256 checksum of the seed file

When loading seed files, we check the history table for path and hash match. Any unmatched files will be seeded next.

If file path exists in history but checksum doesn't match, the seed file will be marked dirty. Dirty files are not seeded, only their hash column will be updated.

If both path and hash match, the seed file is skipped, as it has been applied before.

```
$ supabase db push --local --include-seed
Connecting to local database...
Schema migrations are up to date.
Do you want to seed the remote database with these files?
 • supabase/seeds/buckets.sql
 • supabase/seeds/users.sql

 [Y/n] n
context canceled
exit status 1
```

## Additional context

Also prompts before creating custom roles.
```
$ supabase db push --local --include-seed --include-roles
Connecting to local database...
Do you want to create custom roles in the database cluster? [Y/n]
Seeding globals from roles.sql...
Schema migrations are up to date.
Seed files are up to date.
Finished supabase db push.
```
