### PR TITLE
fix: bump edge-runtime to 1.58.12

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240930-16f2b8e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.11"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.12"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.12

### Changes

### [1.58.12](https://github.com/supabase/edge-runtime/compare/v1.58.11...v1.58.12) (2024-10-07)

#### Bug Fixes

* make sure that we can use various exts as an entrypoint when bundling ([#425](https://github.com/supabase/edge-runtime/issues/425)) ([5f87d9a](https://github.com/supabase/edge-runtime/commit/5f87d9aa3dbc450f2f768e4435b31c5ed982b784))
