### PR TITLE
fix: update path separator for windows glob

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1061,8 +1062,10 @@ func (c *seed) loadSeedPaths(basePath string, fsys fs.FS) error {
 	}
 	set := make(map[string]struct{})
 	for _, pattern := range c.GlobPatterns {
+		// Glob expects / as path separator on windows
+		pattern = filepath.ToSlash(pattern)
 		if !filepath.IsAbs(pattern) {
-			pattern = filepath.Join(basePath, pattern)
+			pattern = path.Join(basePath, pattern)
 		}
 		matches, err := fs.Glob(fsys, pattern)
 		if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2734

## What is the new behavior?

Convert path separator to `/` on windows.

## Additional context

Tested in VM.
