### PR TITLE
fix(storage): update default storage version to 1.11.13

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -263,6 +263,7 @@ func initStorageJob(host string) utils.DockerJob {
 			fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:5432/postgres", utils.Config.Db.Password, host),
 			fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 			"STORAGE_BACKEND=file",
+			"STORAGE_FILE_BACKEND_PATH=/mnt",
 			"TENANT_ID=stub",
 			// TODO: https://github.com/supabase/storage-api/issues/55
 			"REGION=stub",

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -17,7 +17,7 @@ const (
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"
 	realtimeImage    = "supabase/realtime:v2.30.34"
-	storageImage     = "supabase/storage-api:v1.10.1"
+	storageImage     = "supabase/storage-api:v1.11.13"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below
 	DifferImage  = "supabase/pgadmin-schema-diff:cli-0.0.5"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2738

## What is the new behavior?

`STORAGE_FILE_BACKEND_PATH` is now required if `STORAGE_BACKEND=file` is set.

## Additional context

Add any other context or screenshots.
