### PR TITLE
feat: read env in auth.additional_redirect_urls values

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -833,6 +833,11 @@ func (c *baseConfig) Validate(fsys fs.FS) error {
 		if c.Auth.SiteUrl, err = maybeLoadEnv(c.Auth.SiteUrl); err != nil {
 			return err
 		}
+		for i, url := range c.Auth.AdditionalRedirectUrls {
+			if c.Auth.AdditionalRedirectUrls[i], err = maybeLoadEnv(url); err != nil {
+				return errors.Errorf("Invalid config for auth.additional_redirect_urls[%d]: %v", i, err)
+			}
+		}
 		// Validate email config
 		for name, tmpl := range c.Auth.Email.Template {
 			if len(tmpl.ContentPath) > 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -75,6 +75,7 @@ func TestConfigParsing(t *testing.T) {
 		t.Setenv("AZURE_SECRET", "this is cool")
 		t.Setenv("AUTH_SEND_SMS_SECRETS", "v1,whsec_aWxpa2VzdXBhYmFzZXZlcnltdWNoYW5kaWhvcGV5b3Vkb3Rvbw==")
 		t.Setenv("SENDGRID_API_KEY", "sendgrid")
+		t.Setenv("AUTH_CALLBACK_URL", "http://localhost:3000/auth/callback")
 		assert.NoError(t, config.Load("", fsys))
 		// Check the default value in the config
 		assert.Equal(t, "http://127.0.0.1:3000", config.Auth.SiteUrl)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,10 +41,15 @@ func TestConfigParsing(t *testing.T) {
 		t.Setenv("AZURE_SECRET", "this is cool")
 		t.Setenv("AUTH_SEND_SMS_SECRETS", "v1,whsec_aWxpa2VzdXBhYmFzZXZlcnltdWNoYW5kaWhvcGV5b3Vkb3Rvbw==")
 		t.Setenv("SENDGRID_API_KEY", "sendgrid")
+		t.Setenv("AUTH_CALLBACK_URL", "http://localhost:3000/auth/callback")
 		assert.NoError(t, config.Load("", fsys))
 		// Check error
 		assert.Equal(t, "hello", config.Auth.External["azure"].ClientId)
 		assert.Equal(t, "this is cool", config.Auth.External["azure"].Secret)
+		assert.Equal(t, []string{
+			"https://127.0.0.1:3000",
+			"http://localhost:3000/auth/callback",
+		}, config.Auth.AdditionalRedirectUrls)
 	})
 
 	t.Run("config file with environment variables fails when unset", func(t *testing.T) {

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -94,7 +94,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "env(AUTH_CALLBACK_URL)"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

The values in `auth.additional_redirect_urls` can't read from the env.

## What is the new behavior?

The values in `auth.additional_redirect_urls` can read from the env. 😄 

## Additional context

I need that in order to have an environment agnostic configuration for the example I'm building showcasing social login in a Next.js app using `@supabase-labs/nextjs`.

In principle every time we have a config value being URL related, it should be able to read from the env.
