### PR TITLE
fix: bump edge-runtime to 1.58.13

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20240930-16f2b8e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.12"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.58.13"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.58.13

### Changes

### [1.58.13](https://github.com/supabase/edge-runtime/compare/v1.58.12...v1.58.13) (2024-10-13)

#### Bug Fixes

* graceful shutdown should wait until the event worker has finished all its work ([#426](https://github.com/supabase/edge-runtime/issues/426)) ([fbddb16](https://github.com/supabase/edge-runtime/commit/fbddb1620732e0490b170d2c081361bc834fe124))

