### PR TITLE
feat: Option to create Edge Functions with JavaScript syntax

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -68,6 +68,7 @@ var (
 		},
 	}
 
+	flang           string
 	functionsNewCmd = &cobra.Command{
 		Use:   "new <Function name>",
 		Short: "Create a new Function locally",
@@ -77,7 +78,7 @@ var (
 			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return new_.Run(cmd.Context(), args[0], afero.NewOsFs())
+			return new_.Run(cmd.Context(), args[0], flang, afero.NewOsFs())
 		},
 	}
 
@@ -138,6 +139,7 @@ func init() {
 	cobra.CheckErr(functionsServeCmd.Flags().MarkHidden("all"))
 	functionsDownloadCmd.Flags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	functionsDownloadCmd.Flags().BoolVar(&useLegacyBundle, "legacy-bundle", false, "Use legacy bundling mechanism.")
+	functionsNewCmd.Flags().StringVar(&flang, "lang", "", "Language of the Function.")
 	functionsCmd.AddCommand(functionsListCmd)
 	functionsCmd.AddCommand(functionsDeleteCmd)
 	functionsCmd.AddCommand(functionsDeployCmd)

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -28,6 +28,8 @@ func TestDeployCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "test-func", "index.ts"), []byte("{}"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "test-func-2", "index.js"), []byte("{}"), 0644))
 		// Setup valid project ref
 		project := apitest.RandomProjectRef()
 		// Setup valid access token
@@ -290,6 +292,7 @@ func TestImportMapPath(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "test", "index.ts"), []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{"test"}, "", nil, fsys)
 		// Check error
@@ -306,6 +309,7 @@ func TestImportMapPath(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "hello", "index.ts"), []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{slug}, "", nil, fsys)
 		// Check error
@@ -322,6 +326,7 @@ func TestImportMapPath(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "hello", "index.ts"), []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{slug}, utils.FallbackImportMapPath, utils.Ptr(false), fsys)
 		// Check error
@@ -332,6 +337,7 @@ func TestImportMapPath(t *testing.T) {
 	t.Run("returns empty string if no fallback", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "test", "index.ts"), []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{"test"}, "", nil, fsys)
 		// Check error
@@ -344,6 +350,7 @@ func TestImportMapPath(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, "test", "index.ts"), []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{"test"}, path, nil, fsys)
 		// Check error

--- a/internal/functions/new/new_test.go
+++ b/internal/functions/new/new_test.go
@@ -15,8 +15,10 @@ func TestNewCommand(t *testing.T) {
 	t.Run("creates new function", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		require.NoError(t, fsys.MkdirAll(utils.FunctionsDir, 0755))
+		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test"}, fsys))
 		// Run test
-		assert.NoError(t, Run(context.Background(), "test-func", fsys))
+		assert.NoError(t, Run(context.Background(), "test-func", "", fsys))
 		// Validate output
 		funcPath := filepath.Join(utils.FunctionsDir, "test-func", "index.ts")
 		content, err := afero.ReadFile(fsys, funcPath)
@@ -26,23 +28,56 @@ func TestNewCommand(t *testing.T) {
 		)
 	})
 
+	t.Run("creates new JS function when lang==js flag is set", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test"}, fsys))
+		// Run test
+		assert.NoError(t, Run(context.Background(), "test-func", "js", fsys))
+		// Validate output
+		funcPath := filepath.Join(utils.FunctionsDir, "test-func", "index.js")
+		content, err := afero.ReadFile(fsys, funcPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content),
+			"curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/test-func'",
+		)
+	})
+
+	t.Run("creates new JS function when default language is set to javascript in config", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, fsys.MkdirAll(utils.FunctionsDir, 0755))
+		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test", EdgeRuntimeDefaultLanguage: "javascript"}, fsys))
+
+		// Run test
+		assert.NoError(t, Run(context.Background(), "test-func", "", fsys))
+		// Validate output
+		funcPath := filepath.Join(utils.FunctionsDir, "test-func", "index.js")
+		content, err := afero.ReadFile(fsys, funcPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content),
+			"curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/test-func'",
+		)
+	})
+
 	t.Run("throws error on malformed slug", func(t *testing.T) {
-		assert.Error(t, Run(context.Background(), "@", afero.NewMemMapFs()))
+		assert.Error(t, Run(context.Background(), "@", "", afero.NewMemMapFs()))
 	})
 
 	t.Run("throws error on duplicate slug", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test"}, fsys))
 		funcPath := filepath.Join(utils.FunctionsDir, "test-func", "index.ts")
 		require.NoError(t, afero.WriteFile(fsys, funcPath, []byte{}, 0644))
 		// Run test
-		assert.Error(t, Run(context.Background(), "test-func", fsys))
+		assert.Error(t, Run(context.Background(), "test-func", "", fsys))
 	})
 
 	t.Run("throws error on permission denied", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
 		// Run test
-		assert.Error(t, Run(context.Background(), "test-func", fsys))
+		assert.Error(t, Run(context.Background(), "test-func", "", fsys))
 	})
 }

--- a/internal/functions/new/templates/index.js
+++ b/internal/functions/new/templates/index.js
@@ -1,0 +1,29 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+console.log("Hello from Functions!");
+
+Deno.serve(async (req) => {
+  const { name } = await req.json();
+  const data = {
+    message: `Hello ${name}!`,
+  };
+
+  return new Response(
+    JSON.stringify(data),
+    { headers: { "Content-Type": "application/json" } },
+  );
+});
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST '{{ .URL }}' \
+    --header 'Authorization: Bearer {{ .Token }}' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -58,7 +58,7 @@ func Run(ctx context.Context, fsys afero.Fs, createVscodeSettings, createIntelli
 		}
 	} else {
 		console := utils.NewConsole()
-		if isVscode, err := console.PromptYesNo(ctx, "Generate VS Code settings for Deno?", false); err != nil {
+		if isVscode, err := console.PromptYesNo(ctx, "Generate VS Code settings for Deno (recommended if you plan to write Edge Functions)?", false); err != nil {
 			return err
 		} else if isVscode {
 			return writeVscodeConfig(fsys)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -133,9 +133,10 @@ func ToRealtimeEnv(addr config.AddressFamily) string {
 }
 
 type InitParams struct {
-	ProjectId   string
-	UseOrioleDB bool
-	Overwrite   bool
+	ProjectId                  string
+	UseOrioleDB                bool
+	EdgeRuntimeDefaultLanguage string
+	Overwrite                  bool
 }
 
 func InitConfig(params InitParams, fsys afero.Fs) error {
@@ -143,6 +144,10 @@ func InitConfig(params InitParams, fsys afero.Fs) error {
 	c.ProjectId = params.ProjectId
 	if params.UseOrioleDB {
 		c.Experimental.OrioleDBVersion = "15.1.0.150"
+	}
+	c.EdgeRuntime.DefaultLanguage = "typescript"
+	if params.EdgeRuntimeDefaultLanguage != "" {
+		c.EdgeRuntime.DefaultLanguage = params.EdgeRuntimeDefaultLanguage
 	}
 	// Create config file
 	if err := MkdirIfNotExistFS(fsys, SupabaseDirPath); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -412,10 +412,11 @@ type (
 	}
 
 	edgeRuntime struct {
-		Enabled       bool          `toml:"enabled"`
-		Image         string        `toml:"-"`
-		Policy        RequestPolicy `toml:"policy"`
-		InspectorPort uint16        `toml:"inspector_port"`
+		Enabled         bool          `toml:"enabled"`
+		Image           string        `toml:"-"`
+		Policy          RequestPolicy `toml:"policy"`
+		InspectorPort   uint16        `toml:"inspector_port"`
+		DefaultLanguage string        `toml:"default_language"`
 	}
 
 	FunctionConfig map[string]function

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -226,6 +226,7 @@ enabled = true
 # Use `oneshot` for hot reload, or `per_worker` for load testing.
 policy = "oneshot"
 inspector_port = 8083
+default_language = "{{ .EdgeRuntime.DefaultLanguage }}"
 
 [analytics]
 enabled = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the option to create, serve, and deploy pure JS functions instead of using TypeScript.

Users can set `EdgeRuntime.default_language` to either JavaScript or TypeScript to set the language template they want to use. This can be overridden with `lang` flag when using `functions new`.

`functions serve` and `functions deploy` will now treat for both `index.js` and `index.ts` as valid entrypoints.
