### PR TITLE
feat: load fallback import map with config

### DIFF
--- a/examples/functions-deploy/main.go
+++ b/examples/functions-deploy/main.go
@@ -25,9 +25,10 @@ func deploy(ctx context.Context, fsys fs.FS) error {
 	apiClient := newAPIClient(os.Getenv("SUPABASE_ACCESS_TOKEN"))
 	eszipBundler := function.NewNativeBundler(".", fsys)
 	functionClient := function.NewEdgeRuntimeAPI(project, apiClient, eszipBundler)
+	importMapPath := "supabase/functions/import_map.json"
 	fc := config.FunctionConfig{"my-slug": {
 		Entrypoint: "supabase/functions/my-slug/index.ts",
-		ImportMap:  "supabase/functions/import_map.json",
+		ImportMap:  &importMapPath,
 	}}
 	return functionClient.UpsertFunctions(ctx, fc)
 }

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -223,12 +223,12 @@ func populatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fs
 			fmt.Fprintln(os.Stderr, "Skipped serving Function:", slug)
 			continue
 		}
-		modules, err := deploy.GetBindMounts(cwd, utils.FunctionsDir, "", fc.Entrypoint, fc.ImportMap, fsys)
+		modules, err := deploy.GetBindMounts(cwd, utils.FunctionsDir, "", fc.Entrypoint, *fc.ImportMap, fsys)
 		if err != nil {
 			return nil, "", err
 		}
 		binds = append(binds, modules...)
-		fc.ImportMap = utils.ToDockerPath(fc.ImportMap)
+		fc.ImportMap = utils.Ptr(utils.ToDockerPath(*fc.ImportMap))
 		fc.Entrypoint = utils.ToDockerPath(fc.Entrypoint)
 		functionsConfig[slug] = fc
 	}

--- a/pkg/function/api.go
+++ b/pkg/function/api.go
@@ -14,7 +14,7 @@ type EdgeRuntimeAPI struct {
 }
 
 type EszipBundler interface {
-	Bundle(ctx context.Context, entrypoint string, importMap string, output io.Writer) error
+	Bundle(ctx context.Context, entrypoint, importMap string, output io.Writer) error
 }
 
 func NewEdgeRuntimeAPI(project string, client api.ClientWithResponses, bundler EszipBundler) EdgeRuntimeAPI {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Not sure if this is the desired approach because `functions/import_map.json` is a local fallback that's primarily useful for development. When deploying to platform, each function should only declare the import map it needs.

## Additional context

Add any other context or screenshots.
