### PR TITLE
fix: bump edge-runtime to 1.59.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20241014-c083b3b"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.13"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.59.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.59.0

### Changes

### [1.59.0](https://github.com/supabase/edge-runtime/compare/v1.58.13...v1.59.0) (2024-10-17)

#### Features

* support specifying npm registries via .npmrc ([#427](https://github.com/supabase/edge-runtime/issues/427)) ([051a276](https://github.com/supabase/edge-runtime/commit/051a2766f5859f8ed0071829d0e4928586fd702b))

See: https://supabase.slack.com/archives/C02KMRX22NR/p1729129599200949?thread_ts=1729052150.094779&cid=C02KMRX22NR