### PR TITLE
drop user created publications

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -220,6 +220,9 @@ func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys
 	if err := migration.DropUserSchemas(ctx, conn); err != nil {
 		return err
 	}
+	if err := migration.DropUserPublication(ctx, conn); err != nil {
+		return err
+	}
 	return apply.MigrateAndSeed(ctx, version, conn, fsys)
 }
 

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -418,7 +418,11 @@ func TestResetRemote(t *testing.T) {
 			Query("DROP SCHEMA IF EXISTS private CASCADE").
 			Reply("DROP SCHEMA").
 			Query(migration.DropObjects).
-			Reply("INSERT 0")
+			Reply("INSERT 0").
+			Query(migration.ListPublications, migration.ManagedPublications).
+			Reply("SELECT pubname", []interface{}{"pub1"}).
+			Query("DROP PUBLICATION IF EXISTS pub1").
+			Reply("DROP PUBLICATION")
 		helper.MockMigrationHistory(conn).
 			Query(migration.INSERT_MIGRATION_VERSION, "0", "schema", nil).
 			Reply("INSERT 0 1")
@@ -444,7 +448,12 @@ func TestResetRemote(t *testing.T) {
 			Query("DROP SCHEMA IF EXISTS private CASCADE").
 			Reply("DROP SCHEMA").
 			Query(migration.DropObjects).
-			Reply("INSERT 0")
+			Reply("INSERT 0").
+			Query(migration.ListPublications, migration.ManagedPublications).
+			Reply("SELECT pubname", []interface{}{"pub1"}).
+			Query("DROP PUBLICATION IF EXISTS pub1").
+			Reply("DROP PUBLICATION")
+
 		helper.MockMigrationHistory(conn).
 			Query(migration.INSERT_MIGRATION_VERSION, "0", "schema", nil).
 			Reply("INSERT 0 1")

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.83.2"
 	studioImage      = "supabase/studio:20241014-c083b3b"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.58.13"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.59.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.158.1"

--- a/pkg/migration/drop.go
+++ b/pkg/migration/drop.go
@@ -14,8 +14,9 @@ var (
 	//go:embed queries/drop.sql
 	DropObjects string
 	//go:embed queries/list.sql
-	ListSchemas      string
-	ListPublications = "SELECT pubname FROM pg_publication WHERE pubname NOT LIKE ANY($1)"
+	ListSchemas string
+	//go:embed queries/publications.sql
+	ListPublications string
 
 	// Initialised by postgres image and owned by postgres role
 	ManagedSchemas = []string{

--- a/pkg/migration/drop.go
+++ b/pkg/migration/drop.go
@@ -28,7 +28,6 @@ var (
 		"pgtle",
 		`supabase\_migrations`,
 		"vault",
-		"publication",
 	}
 )
 

--- a/pkg/migration/queries/publications.sql
+++ b/pkg/migration/queries/publications.sql
@@ -1,0 +1,2 @@
+-- List user defined publications
+select pubname from pg_publication where pubname not like any($1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix https://github.com/supabase/cli/issues/2640

## What is the current behavior?

Failed to delete user-created publications, causing the migration to create publications to fail.

## What is the new behavior?

Add a function to drop user-created publications, excluding `supabase_realtime`.
