### PR TITLE
fix: prune volumes without all flag for pre-Docker v1.42

### DIFF
--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
@@ -125,10 +126,12 @@ func DockerRemoveAll(ctx context.Context, w io.Writer, projectId string) error {
 	}
 	// Remove named volumes
 	if NoBackupVolume {
-		// Since docker engine 25.0.3, all flag is required to include named volumes.
-		// https://github.com/docker/cli/blob/master/cli/command/volume/prune.go#L76
 		vargs := args.Clone()
-		vargs.Add("all", "true")
+		if versions.GreaterThanOrEqualTo(Docker.ClientVersion(), "1.42") {
+			// Since docker engine 25.0.3, all flag is required to include named volumes.
+			// https://github.com/docker/cli/blob/master/cli/command/volume/prune.go#L76
+			vargs.Add("all", "true")
+		}
 		if report, err := Docker.VolumesPrune(ctx, vargs); err != nil {
 			return errors.Errorf("failed to prune volumes: %w", err)
 		} else if viper.GetBool("DEBUG") {


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix** for `supabase stop --no-backup` for users on old versions of Docker or on Podman.

## What is the current behavior?

Before Docker API version 1.42, the `all` flag in `Docker.VolumePrune` is not required.

Podman prints an error like the following when the `all` flag is passed ([Podman's only compatible with Docker API v1.41][1]), e.g. when running `supabase stop --no-backup`:

```console
alois@pc:~/app (develop)$ npx supabase@1.207.4 stop --no-backup
failed to prune volumes: Error response from daemon: failed to parse filters for all=true&label=com.supabase.cli.project%3Dapp: "all" is an invalid volume filter
Try rerunning the command with --debug to troubleshoot the error.
```

[1]: https://github.com/containers/podman/blob/290d94d3c00857dd582ffbee6bd0677a0904c783/version/version.go#L46

See: https://github.com/supabase/cli/issues/2348#issuecomment-2149936472, who had this same issue.
See: https://github.com/supabase/cli/pull/1989 (which added the `all` flag)

## What is the new behavior?

I've added an `if versions.GreaterThanOrEqualTo(Docker.ClientVersion(), "1.42")` check before adding the `all` flag.

A similar check is done by the official Docker CLI: https://github.com/docker/cli/blob/062eecf14af34d7295da16c23c2578fcf4aa0196/cli/command/volume/prune.go#L67-L78

This works on Podman. I suspect it would work on older versions of Docker too, but I don't have one of those environments to test with!

## Additional context

**I'm a complete beginner in golang** (this is only my second time writing a golang PR), **so please review my code carefully**. It's very likely I made a dumb mistake since I didn't know any better.