### PR TITLE
fix: empty array is valid api config

### DIFF
--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -38,16 +38,10 @@ func (a *api) ToUpdatePostgrestConfigBody() v1API.UpdatePostgrestConfigBody {
 	}
 
 	// Convert Schemas to a comma-separated string
-	if len(a.Schemas) > 0 {
-		schemas := strings.Join(a.Schemas, ",")
-		body.DbSchema = &schemas
-	}
+	body.DbSchema = cast.Ptr(strings.Join(a.Schemas, ","))
 
 	// Convert ExtraSearchPath to a comma-separated string
-	if len(a.ExtraSearchPath) > 0 {
-		extraSearchPath := strings.Join(a.ExtraSearchPath, ",")
-		body.DbExtraSearchPath = &extraSearchPath
-	}
+	body.DbExtraSearchPath = cast.Ptr(strings.Join(a.ExtraSearchPath, ","))
 
 	// Convert MaxRows to int pointer
 	if a.MaxRows > 0 {

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -39,9 +39,9 @@ func (a *api) ToUpdatePostgrestConfigBody() v1API.UpdatePostgrestConfigBody {
 
 	// Convert Schemas to a comma-separated string
 	if len(a.Schemas) > 0 {
- 		schemas := strings.Join(a.Schemas, ",")
- 		body.DbSchema = &schemas
- 	}
+		schemas := strings.Join(a.Schemas, ",")
+		body.DbSchema = &schemas
+	}
 
 	// Convert ExtraSearchPath to a comma-separated string
 	body.DbExtraSearchPath = cast.Ptr(strings.Join(a.ExtraSearchPath, ","))

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -38,7 +38,10 @@ func (a *api) ToUpdatePostgrestConfigBody() v1API.UpdatePostgrestConfigBody {
 	}
 
 	// Convert Schemas to a comma-separated string
-	body.DbSchema = cast.Ptr(strings.Join(a.Schemas, ","))
+	if len(a.Schemas) > 0 {
+ 		schemas := strings.Join(a.Schemas, ",")
+ 		body.DbSchema = &schemas
+ 	}
 
 	// Convert ExtraSearchPath to a comma-separated string
 	body.DbExtraSearchPath = cast.Ptr(strings.Join(a.ExtraSearchPath, ","))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Empty array is a valid config if user doesn't want to expose any schemas or search paths.

```
[api]
schemas = []
extra_search_path = []
```

## Additional context

Add any other context or screenshots.
