### PR TITLE
fix: drop user created publications during reset

### DIFF
--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -74,4 +74,14 @@ begin
   loop
     execute format('drop policy if exists %I on %I.%I cascade', rec.policyname, rec.schemaname, rec.tablename);
   end loop;
+
+  -- publications
+  for rec in
+    select *
+    from pg_publication p
+    where
+      p.pubname != 'supabase_realtime'
+  loop
+    execute format('drop publication if exists %I', rec.pubname);
+  end loop;
 end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #2640 
supersedes https://github.com/supabase/cli/pull/2780

## What is the current behavior?

Failed to delete user-created publications, causing the migration to create publications to fail.

## What is the new behavior?

Add a function to drop user-created publications, excluding `supabase_realtime`.
