### PR TITLE
chore: refactor use cast ptr

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supabase/cli/internal/functions/serve"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 var (
@@ -106,9 +107,9 @@ var (
 			}
 
 			if len(inspectMode.Value) > 0 {
-				runtimeOption.InspectMode = utils.Ptr(serve.InspectMode(inspectMode.Value))
+				runtimeOption.InspectMode = cast.Ptr(serve.InspectMode(inspectMode.Value))
 			} else if inspectBrk {
-				runtimeOption.InspectMode = utils.Ptr(serve.InspectModeBrk)
+				runtimeOption.InspectMode = cast.Ptr(serve.InspectModeBrk)
 			}
 			if runtimeOption.InspectMode == nil && runtimeOption.InspectMain {
 				return fmt.Errorf("--inspect-main must be used together with one of these flags: [inspect inspect-mode]")

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golangci/golangci-lint v1.61.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
@@ -169,7 +170,6 @@ require (
 	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/golangci/revgrep v0.5.3 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/internal/branches/create/create_test.go
+++ b/internal/branches/create/create_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestCreateCommand(t *testing.T) {
@@ -36,7 +37,7 @@ func TestCreateCommand(t *testing.T) {
 			})
 		// Run test
 		err := Run(context.Background(), api.CreateBranchBody{
-			Region: utils.Ptr("sin"),
+			Region: cast.Ptr("sin"),
 		}, fsys)
 		// Check error
 		assert.NoError(t, err)
@@ -53,7 +54,7 @@ func TestCreateCommand(t *testing.T) {
 			ReplyError(net.ErrClosed)
 		// Run test
 		err := Run(context.Background(), api.CreateBranchBody{
-			Region: utils.Ptr("sin"),
+			Region: cast.Ptr("sin"),
 		}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, net.ErrClosed)
@@ -70,7 +71,7 @@ func TestCreateCommand(t *testing.T) {
 			Reply(http.StatusServiceUnavailable)
 		// Run test
 		err := Run(context.Background(), api.CreateBranchBody{
-			Region: utils.Ptr("sin"),
+			Region: cast.Ptr("sin"),
 		}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Unexpected error creating preview branch:")

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/function"
 )
@@ -86,7 +87,7 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 			function.ImportMap = utils.FallbackImportMapPath
 		}
 		if noVerifyJWT != nil {
-			function.VerifyJWT = utils.Ptr(!*noVerifyJWT)
+			function.VerifyJWT = cast.Ptr(!*noVerifyJWT)
 		}
 		functionConfig[name] = function
 	}

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/config"
 )
 
@@ -323,7 +324,7 @@ func TestImportMapPath(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
 		// Run test
-		fc, err := GetFunctionConfig([]string{slug}, utils.FallbackImportMapPath, utils.Ptr(false), fsys)
+		fc, err := GetFunctionConfig([]string{slug}, utils.FallbackImportMapPath, cast.Ptr(false), fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Equal(t, utils.FallbackImportMapPath, fc[slug].ImportMap)

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestServeCommand(t *testing.T) {
@@ -100,7 +101,7 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
 		// Run test
-		err := Run(context.Background(), ".env", utils.Ptr(true), "import_map.json", RuntimeOption{}, fsys)
+		err := Run(context.Background(), ".env", cast.Ptr(true), "import_map.json", RuntimeOption{}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestInitCommand(t *testing.T) {
@@ -70,7 +71,7 @@ func TestInitCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
 		// Run test
-		assert.NoError(t, Run(context.Background(), fsys, utils.Ptr(true), nil, utils.InitParams{}))
+		assert.NoError(t, Run(context.Background(), fsys, cast.Ptr(true), nil, utils.InitParams{}))
 		// Validate generated vscode settings
 		exists, err := afero.Exists(fsys, settingsPath)
 		assert.NoError(t, err)
@@ -84,7 +85,7 @@ func TestInitCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
 		// Run test
-		assert.NoError(t, Run(context.Background(), fsys, utils.Ptr(false), nil, utils.InitParams{}))
+		assert.NoError(t, Run(context.Background(), fsys, cast.Ptr(false), nil, utils.InitParams{}))
 		// Validate vscode settings file isn't generated
 		exists, err := afero.Exists(fsys, settingsPath)
 		assert.NoError(t, err)
@@ -98,7 +99,7 @@ func TestInitCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
 		// Run test
-		assert.NoError(t, Run(context.Background(), fsys, nil, utils.Ptr(true), utils.InitParams{}))
+		assert.NoError(t, Run(context.Background(), fsys, nil, cast.Ptr(true), utils.InitParams{}))
 		// Validate generated intellij deno config
 		exists, err := afero.Exists(fsys, denoPath)
 		assert.NoError(t, err)
@@ -109,7 +110,7 @@ func TestInitCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := &afero.MemMapFs{}
 		// Run test
-		assert.NoError(t, Run(context.Background(), fsys, nil, utils.Ptr(false), utils.InitParams{}))
+		assert.NoError(t, Run(context.Background(), fsys, nil, cast.Ptr(false), utils.InitParams{}))
 		// Validate intellij deno config file isn't generated
 		exists, err := afero.Exists(fsys, denoPath)
 		assert.NoError(t, err)

--- a/internal/storage/cp/cp_test.go
+++ b/internal/storage/cp/cp_test.go
@@ -14,16 +14,17 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
 	"github.com/supabase/cli/pkg/storage"
 )
 
 var mockFile = storage.ObjectResponse{
 	Name:           "abstract.pdf",
-	Id:             utils.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
-	UpdatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	CreatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	LastAccessedAt: utils.Ptr("2023-10-13T18:08:22.068Z"),
+	Id:             cast.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
+	UpdatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	CreatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	LastAccessedAt: cast.Ptr("2023-10-13T18:08:22.068Z"),
 	Metadata: &storage.ObjectMetadata{
 		ETag:           `"887ea9be3c68e6f2fca7fd2d7c77d8fe"`,
 		Size:           82702,

--- a/internal/storage/ls/ls_test.go
+++ b/internal/storage/ls/ls_test.go
@@ -14,16 +14,17 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
 	"github.com/supabase/cli/pkg/storage"
 )
 
 var mockFile = storage.ObjectResponse{
 	Name:           "abstract.pdf",
-	Id:             utils.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
-	UpdatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	CreatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	LastAccessedAt: utils.Ptr("2023-10-13T18:08:22.068Z"),
+	Id:             cast.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
+	UpdatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	CreatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	LastAccessedAt: cast.Ptr("2023-10-13T18:08:22.068Z"),
 	Metadata: &storage.ObjectMetadata{
 		ETag:           `"887ea9be3c68e6f2fca7fd2d7c77d8fe"`,
 		Size:           82702,

--- a/internal/storage/mv/mv_test.go
+++ b/internal/storage/mv/mv_test.go
@@ -12,16 +12,17 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
 	"github.com/supabase/cli/pkg/storage"
 )
 
 var mockFile = storage.ObjectResponse{
 	Name:           "abstract.pdf",
-	Id:             utils.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
-	UpdatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	CreatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	LastAccessedAt: utils.Ptr("2023-10-13T18:08:22.068Z"),
+	Id:             cast.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
+	UpdatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	CreatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	LastAccessedAt: cast.Ptr("2023-10-13T18:08:22.068Z"),
 	Metadata: &storage.ObjectMetadata{
 		ETag:           `"887ea9be3c68e6f2fca7fd2d7c77d8fe"`,
 		Size:           82702,

--- a/internal/storage/rm/rm_test.go
+++ b/internal/storage/rm/rm_test.go
@@ -13,16 +13,17 @@ import (
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
 	"github.com/supabase/cli/pkg/storage"
 )
 
 var mockFile = storage.ObjectResponse{
 	Name:           "abstract.pdf",
-	Id:             utils.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
-	UpdatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	CreatedAt:      utils.Ptr("2023-10-13T18:08:22.068Z"),
-	LastAccessedAt: utils.Ptr("2023-10-13T18:08:22.068Z"),
+	Id:             cast.Ptr("9b7f9f48-17a6-4ca8-b14a-39b0205a63e9"),
+	UpdatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	CreatedAt:      cast.Ptr("2023-10-13T18:08:22.068Z"),
+	LastAccessedAt: cast.Ptr("2023-10-13T18:08:22.068Z"),
 	Metadata: &storage.ObjectMetadata{
 		ETag:           `"887ea9be3c68e6f2fca7fd2d7c77d8fe"`,
 		Size:           82702,

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils/cloudflare"
 	supabase "github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 const (
@@ -60,7 +61,7 @@ func FallbackLookupIP(ctx context.Context, host string) ([]string, error) {
 func ResolveCNAME(ctx context.Context, host string) (string, error) {
 	// Ref: https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json
 	cf := cloudflare.NewCloudflareAPI()
-	data, err := cf.DNSQuery(ctx, cloudflare.DNSParams{Name: host, Type: Ptr(cloudflare.TypeCNAME)})
+	data, err := cf.DNSQuery(ctx, cloudflare.DNSParams{Name: host, Type: cast.Ptr(cloudflare.TypeCNAME)})
 	if err != nil {
 		return "", err
 	}

--- a/internal/utils/console.go
+++ b/internal/utils/console.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
+	"github.com/supabase/cli/pkg/cast"
 	"golang.org/x/term"
 )
 
@@ -78,10 +79,10 @@ func (c *Console) PromptYesNo(ctx context.Context, label string, def bool) (bool
 func parseYesNo(s string) *bool {
 	s = strings.ToLower(s)
 	if s == "y" || s == "yes" {
-		return Ptr(true)
+		return cast.Ptr(true)
 	}
 	if s == "n" || s == "no" {
-		return Ptr(false)
+		return cast.Ptr(false)
 	}
 	return nil
 }

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -295,10 +295,6 @@ func ValidateFunctionSlug(slug string) error {
 	return nil
 }
 
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 func GetHostname() string {
 	host := Docker.DaemonHost()
 	if parsed, err := client.ParseHostURL(host); err == nil && parsed.Scheme == "tcp" {

--- a/internal/utils/release_test.go
+++ b/internal/utils/release_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestLatestRelease(t *testing.T) {
@@ -19,7 +20,7 @@ func TestLatestRelease(t *testing.T) {
 		gock.New("https://api.github.com").
 			Get("/repos/supabase/cli/releases/latest").
 			Reply(http.StatusOK).
-			JSON(github.RepositoryRelease{TagName: Ptr("v2")})
+			JSON(github.RepositoryRelease{TagName: cast.Ptr("v2")})
 		// Run test
 		version, err := GetLatestRelease(context.Background())
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

- refactor `utis.Ptr` to `cast.Ptr`
- make `go-cmp` direct dependency (`go mod tidy`)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
