### PR TITLE
fix(config): default value for seed remote

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -697,6 +697,8 @@ func (c *config) Load(path string, fsys fs.FS) error {
 	c.Remotes = make(map[string]baseConfig, len(c.Overrides))
 	for name, remote := range c.Overrides {
 		base := c.baseConfig.Clone()
+		// On remotes branches set seed as disabled by default
+		base.Db.Seed.Enabled = false
 		// Encode a toml file with only config overrides
 		var buf bytes.Buffer
 		if err := toml.NewEncoder(&buf).Encode(remote); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -93,9 +93,12 @@ func TestConfigParsing(t *testing.T) {
 		assert.Equal(t, false, production.Auth.EnableSignup)
 		assert.Equal(t, false, production.Auth.External["azure"].Enabled)
 		assert.Equal(t, "nope", production.Auth.External["azure"].ClientId)
+		// Check seed should be disabled by default for remote configs
+		assert.Equal(t, false, production.Db.Seed.Enabled)
 		// Check the values for the staging override
 		assert.Equal(t, "staging-project", staging.ProjectId)
 		assert.Equal(t, []string{"image/png"}, staging.Storage.Buckets["images"].AllowedMimeTypes)
+		assert.Equal(t, true, staging.Db.Seed.Enabled)
 	})
 }
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -237,5 +237,8 @@ client_id = "nope"
 [remotes.staging]
 project_id = "staging-project"
 
+[remotes.staging.db.seed]
+enabled = true
+
 [remotes.staging.storage.buckets.images]
 allowed_mime_types = ["image/png"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bugfix: set the default value of seed for declared remotes to false


Related:
https://github.com/supabase/branching/pull/187

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
