### PR TITLE
fix: node-fetch hanging issue when fetching checksum after fetching binary

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -98,45 +98,53 @@ async function main() {
     throw errUnsupported;
   }
 
+  // Read from package.json and prepare for the installation.
   const pkg = await readPackageJson();
   if (platform === "windows") {
     // Update bin path in package.json
     pkg.bin[pkg.name] += ".exe";
   }
 
+  // Prepare the installation path by creating the directory if it doesn't exist.
   const binPath = pkg.bin[pkg.name];
   const binDir = path.dirname(binPath);
   await fs.promises.mkdir(binDir, { recursive: true });
 
-  // First we will Un-GZip, then we will untar.
-  const ungz = zlib.createGunzip();
-  const binName = path.basename(binPath);
-  const untar = extract({ cwd: binDir }, [binName]);
-
-  const url = getDownloadUrl(pkg);
-  console.info("Downloading", url);
+  // Create the agent that will be used for all the fetch requests later.
   const proxyUrl =
     process.env.npm_config_https_proxy ||
     process.env.npm_config_http_proxy ||
     process.env.npm_config_proxy;
-
   // Keeps the TCP connection alive when sending multiple requests
   // Ref: https://github.com/node-fetch/node-fetch/issues/1735
   const agent = proxyUrl
     ? new HttpsProxyAgent(proxyUrl, { keepAlive: true })
     : new Agent({ keepAlive: true });
-  const resp = await fetch(url, { agent });
 
-  const hash = createHash("sha256");
-  const pkgNameWithPlatform = `${pkg.name}_${platform}_${arch}.tar.gz`;
+  // First, fetch the checksum map.
   const checksumMap = await fetchAndParseCheckSumFile(pkg, agent);
 
+  // Then, download the binary.
+  const url = getDownloadUrl(pkg);
+  console.info("Downloading", url);
+  const resp = await fetch(url, { agent });
+  const hash = createHash("sha256");
+  const pkgNameWithPlatform = `${pkg.name}_${platform}_${arch}.tar.gz`;
+
+  // Then, decompress the binary -- we will first Un-GZip, then we will untar.
+  const ungz = zlib.createGunzip();
+  const binName = path.basename(binPath);
+  const untar = extract({ cwd: binDir }, [binName]);
+
+  // Update the hash with the binary data as it's being downloaded.
   resp.body
     .on("data", (chunk) => {
       hash.update(chunk);
     })
+    // Pipe the data to the ungz stream.
     .pipe(ungz);
 
+  // After the ungz stream has ended, verify the checksum.
   ungz
     .on("end", () => {
       const expectedChecksum = checksumMap?.[pkgNameWithPlatform];
@@ -151,8 +159,10 @@ async function main() {
       }
       console.info("Checksum verified.");
     })
+    // Pipe the data to the untar stream.
     .pipe(untar);
 
+  // Wait for the untar stream to finish.
   await new Promise((resolve, reject) => {
     untar.on("error", reject);
     untar.on("end", () => resolve());


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bug fix: 

Fix `node-fetch` `fetch` command hangs indefinitely when fetching the checksum file after fetching the binary, on some macOS devices that have stricter network restrictions. This PR will fix #2798 

- Misc:

Added some comments to explain the process clearly.

## What is the current behavior?

#2798 : running `npm install supabase@latest --save-dev` hangs and failed after waiting for a long time, the error happens at the fetching of the checksum file. However, running `sudo npm install ...` works.

Some investigation shows that this error starts happening from version `1.90.0`, version `1.89.1` did not have such issue. The change that was made between these two version is in this commit: https://github.com/supabase/cli/commit/571f336c117c182f015b6f6ba270c726a01732a7

By examining the commit, it shows that checksum verification was added as a result, and since then the checksum fetch was run after the fetching of the binary. 

## What is the new behavior?

By fetching the checksum file (small in size) before fetching the binary file (big in size), both fetch succeeded without error.
