### PR TITLE
fix: bump edge-runtime to 1.59.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241029-46e1e40"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.59.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.59.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.59.1

### Changes

### [1.59.1](https://github.com/supabase/edge-runtime/compare/v1.59.0...v1.59.1) (2024-10-31)

#### Bug Fixes

* **sb_graph:** checksum size is not a constant ([#433](https://github.com/supabase/edge-runtime/issues/433)) ([d06b556](https://github.com/supabase/edge-runtime/commit/d06b556cb0cdfd8af404d24ebb3e1366be549f23))


