### PR TITLE
fix: bump edge-runtime to 1.60.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241029-46e1e40"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.59.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.60.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.60.1

### Changes

### [1.60.1](https://github.com/supabase/edge-runtime/compare/v1.59.1...v1.60.1) (2024-11-01)

#### Features

* onnx runtime shared sessions  ([#430](https://github.com/supabase/edge-runtime/issues/430)) ([fc80ebb](https://github.com/supabase/edge-runtime/commit/fc80ebba747cc411dde3a737575b3a478984c1f6)) (@kallebysantos)


#### Bug Fixes

* **sb_core:** expose web MessageChannel API ([#434](https://github.com/supabase/edge-runtime/issues/434)) ([ec9b270](https://github.com/supabase/edge-runtime/commit/ec9b270e33a1fcdd1b195cb3427fa76f269a5de9))
* **cli:** `--static` flag could not be used multiple times ([#432](https://github.com/supabase/edge-runtime/issues/432)) ([f2556c7](https://github.com/supabase/edge-runtime/commit/f2556c74bda04ee8a099fe3c478271f3d979c0e0))



