### PR TITLE
feat(config): load local deno.json file as import map

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -81,20 +81,12 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 	functionConfig := make(config.FunctionConfig, len(slugs))
 	for _, name := range slugs {
 		function := utils.Config.Functions[name]
-		functionDir := filepath.Join(utils.FunctionsDir, name)
 		// Precedence order: flag > config > fallback
 		if len(function.Entrypoint) == 0 {
-			function.Entrypoint = filepath.Join(functionDir, "index.ts")
+			function.Entrypoint = filepath.Join(utils.FunctionsDir, name, "index.ts")
 		}
-		// Check for deno.json or deno.jsonc in functionDir
-		denoJsonPath := filepath.Join(functionDir, "deno.json")
-		denoJsoncPath := filepath.Join(functionDir, "deno.jsonc")
 		if len(importMapPath) > 0 {
 			function.ImportMap = importMapPath
-		} else if _, err := fsys.Stat(denoJsonPath); err == nil {
-			function.ImportMap = denoJsonPath
-		} else if _, err := fsys.Stat(denoJsoncPath); err == nil {
-			function.ImportMap = denoJsoncPath
 		} else if len(function.ImportMap) == 0 && fallbackExists {
 			function.ImportMap = utils.FallbackImportMapPath
 		}

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -81,12 +81,20 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 	functionConfig := make(config.FunctionConfig, len(slugs))
 	for _, name := range slugs {
 		function := utils.Config.Functions[name]
+		functionDir := filepath.Join(utils.FunctionsDir, name)
 		// Precedence order: flag > config > fallback
 		if len(function.Entrypoint) == 0 {
-			function.Entrypoint = filepath.Join(utils.FunctionsDir, name, "index.ts")
+			function.Entrypoint = filepath.Join(functionDir, "index.ts")
 		}
+		// Check for deno.json or deno.jsonc in functionDir
+		denoJsonPath := filepath.Join(functionDir, "deno.json")
+		denoJsoncPath := filepath.Join(functionDir, "deno.jsonc")
 		if len(importMapPath) > 0 {
 			function.ImportMap = importMapPath
+		} else if _, err := fsys.Stat(denoJsonPath); err == nil {
+			function.ImportMap = denoJsonPath
+		} else if _, err := fsys.Stat(denoJsoncPath); err == nil {
+			function.ImportMap = denoJsoncPath
 		} else if len(function.ImportMap) == 0 && fallbackExists {
 			function.ImportMap = utils.FallbackImportMapPath
 		}

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -314,53 +314,6 @@ func TestImportMapPath(t *testing.T) {
 		assert.Equal(t, "import_map.json", fc[slug].ImportMap)
 	})
 
-	t.Run("loads local deno.json", func(t *testing.T) {
-		t.Cleanup(func() { clear(utils.Config.Functions) })
-		slug := "hello"
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Create deno.json in function folder
-		denoConfigPath := filepath.Join(utils.FunctionsDir, slug, "deno.json")
-		require.NoError(t, afero.WriteFile(fsys, denoConfigPath, []byte("{}"), 0644))
-		// Run test
-		fc, err := GetFunctionConfig([]string{slug}, "", nil, fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Equal(t, denoConfigPath, fc[slug].ImportMap)
-	})
-
-	t.Run("loads local deno.jsonc", func(t *testing.T) {
-		t.Cleanup(func() { clear(utils.Config.Functions) })
-		slug := "hello"
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Create deno.jsonc in function folder
-		denoConfigPath := filepath.Join(utils.FunctionsDir, slug, "deno.jsonc")
-		require.NoError(t, afero.WriteFile(fsys, denoConfigPath, []byte("{}"), 0644))
-		// Run test
-		fc, err := GetFunctionConfig([]string{slug}, "", nil, fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Equal(t, denoConfigPath, fc[slug].ImportMap)
-	})
-
-	t.Run("local deno.json takes precedence over fallback", func(t *testing.T) {
-		t.Cleanup(func() { clear(utils.Config.Functions) })
-		slug := "hello"
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Create fallback import map to test precedence order
-		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
-		// Create deno.json in function folder to test precedence order
-		denoConfigPath := filepath.Join(utils.FunctionsDir, slug, "deno.json")
-		require.NoError(t, afero.WriteFile(fsys, denoConfigPath, []byte("{}"), 0644))
-		// Run test
-		fc, err := GetFunctionConfig([]string{slug}, "", cast.Ptr(false), fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Equal(t, denoConfigPath, fc[slug].ImportMap)
-	})
-
 	t.Run("overrides with cli flag", func(t *testing.T) {
 		t.Cleanup(func() { clear(utils.Config.Functions) })
 		slug := "hello"
@@ -374,9 +327,6 @@ func TestImportMapPath(t *testing.T) {
 		require.NoError(t, afero.WriteFile(fsys, customImportMapPath, []byte("{}"), 0644))
 		// Create fallback import map to test precedence order
 		require.NoError(t, afero.WriteFile(fsys, utils.FallbackImportMapPath, []byte("{}"), 0644))
-		// Create deno.json in function folder to test precedence order
-		denoConfigPath := filepath.Join(utils.FunctionsDir, slug, "deno.json")
-		require.NoError(t, afero.WriteFile(fsys, denoConfigPath, []byte("{}"), 0644))
 		// Run test
 		fc, err := GetFunctionConfig([]string{slug}, customImportMapPath, cast.Ptr(false), fsys)
 		// Check error

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -361,7 +361,10 @@ func TestLoadFunctionImportMap(t *testing.T) {
 	t.Run("uses deno.json as import map when present", func(t *testing.T) {
 		config := NewConfig()
 		fsys := fs.MapFS{
-			"supabase/config.toml":               &fs.MapFile{Data: []byte("project_id = \"test\"")},
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "test"
+			[functions.hello]
+			`)},
 			"supabase/functions/hello/deno.json": &fs.MapFile{},
 			"supabase/functions/hello/index.ts":  &fs.MapFile{},
 		}
@@ -370,10 +373,14 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		// Check that deno.json was set as import map
 		assert.Equal(t, "supabase/functions/hello/deno.json", config.Functions["hello"].ImportMap)
 	})
+
 	t.Run("uses deno.jsonc as import map when present", func(t *testing.T) {
 		config := NewConfig()
 		fsys := fs.MapFS{
-			"supabase/config.toml":                &fs.MapFile{Data: []byte("project_id = \"test\"")},
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "test"
+			[functions.hello]
+			`)},
 			"supabase/functions/hello/deno.jsonc": &fs.MapFile{},
 			"supabase/functions/hello/index.ts":   &fs.MapFile{},
 		}
@@ -382,6 +389,7 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		// Check that deno.json was set as import map
 		assert.Equal(t, "supabase/functions/hello/deno.jsonc", config.Functions["hello"].ImportMap)
 	})
+
 	t.Run("config.toml takes precedence over deno.json", func(t *testing.T) {
 		config := NewConfig()
 		fsys := fs.MapFS{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -363,6 +363,7 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		fsys := fs.MapFS{
 			"supabase/config.toml":               &fs.MapFile{Data: []byte("project_id = \"test\"")},
 			"supabase/functions/hello/deno.json": &fs.MapFile{},
+			"supabase/functions/hello/index.ts":  &fs.MapFile{},
 		}
 		// Run test
 		assert.NoError(t, config.Load("", fsys))
@@ -374,6 +375,7 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		fsys := fs.MapFS{
 			"supabase/config.toml":                &fs.MapFile{Data: []byte("project_id = \"test\"")},
 			"supabase/functions/hello/deno.jsonc": &fs.MapFile{},
+			"supabase/functions/hello/index.ts":   &fs.MapFile{},
 		}
 		// Run test
 		assert.NoError(t, config.Load("", fsys))
@@ -389,6 +391,7 @@ func TestLoadFunctionImportMap(t *testing.T) {
 			hello.import_map = "custom_import_map.json"
 			`)},
 			"supabase/functions/hello/deno.json": &fs.MapFile{},
+			"supabase/functions/hello/index.ts":  &fs.MapFile{},
 		}
 		// Run test
 		assert.NoError(t, config.Load("", fsys))


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Currently each edge function shares a global `import_map.json` by default.
To use one particular import map per function the user has to define it manually in `config.toml`

## What is the new behavior?

We now automatically load `deno.json` and `deno.jsonc` under the `supabase/functions/<slug>` directory.
Each function should be treated as a different project with its own set of dependencies.

## Additional context

`import_map.json` disappeared from Deno's doc since as of v1.19.2: https://deno.land/x/manual@v1.19.1/npm_nodejs/import_maps.md?source

Imports should now be declared as part of deno's config file `deno.json`.

We might want to deprecate `import_map.json`, especially when we will ship deno v2 support.
