### PR TITLE
chore: update NPM publishing blog link

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Ref 1: https://github.com/sanathkr/go-npm
-// Ref 2: https://blog.xendit.engineer/how-we-repurposed-npm-to-publish-and-distribute-our-go-binaries-for-internal-cli-23981b80911b
+// Ref 2: https://medium.com/xendit-engineering/how-we-repurposed-npm-to-publish-and-distribute-our-go-binaries-for-internal-cli-23981b80911b
 "use strict";
 
 import binLinks from "bin-links";


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## Additional context

The technique for publishing a Go CLI on NPM is very interesting. However, the link is no longer valid. It looks like Xendit has moved its technical blog to Medium.