### PR TITLE
fix: bump edge-runtime to 1.61.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241029-46e1e40"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.60.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.61.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.61.0

### Changes

### [1.61.0](https://github.com/supabase/edge-runtime/compare/v1.60.1...v1.61.0) (2024-11-05)

#### Features

* partial enable s3 and tmp file system ([#429](https://github.com/supabase/edge-runtime/issues/429)) ([b10fb3d](https://github.com/supabase/edge-runtime/commit/b10fb3dcbc5c673f554da873172db2def3b3bc95))
