### PR TITLE
chore: refactor let api decide for restart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golangci/golangci-lint v1.61.0
-	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
@@ -170,6 +169,7 @@ require (
 	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/golangci/revgrep v0.5.3 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 
-	"github.com/google/go-cmp/cmp"
 	v1API "github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/diff"
@@ -80,16 +79,6 @@ type (
 		SecretKeyBase    string   `toml:"-"`
 	}
 )
-
-// Compare two db config, if changes requires restart return true, return false otherwise
-func (a settings) requireDbRestart(b settings) bool {
-	return !cmp.Equal(a.MaxConnections, b.MaxConnections) ||
-		!cmp.Equal(a.MaxWorkerProcesses, b.MaxWorkerProcesses) ||
-		!cmp.Equal(a.MaxParallelWorkers, b.MaxParallelWorkers) ||
-		!cmp.Equal(a.MaxWalSenders, b.MaxWalSenders) ||
-		!cmp.Equal(a.MaxReplicationSlots, b.MaxReplicationSlots) ||
-		!cmp.Equal(a.SharedBuffers, b.SharedBuffers)
-}
 
 func (a *settings) ToUpdatePostgresConfigBody() v1API.UpdatePostgresConfigBody {
 	body := v1API.UpdatePostgresConfigBody{}

--- a/pkg/config/updater.go
+++ b/pkg/config/updater.go
@@ -75,14 +75,7 @@ func (u *ConfigUpdater) UpdateDbSettingsConfig(ctx context.Context, projectRef s
 		return nil
 	}
 	fmt.Fprintln(os.Stderr, "Updating DB service with config:", string(dbDiff))
-
-	remoteConfig := s.fromRemoteConfig(*dbConfig.JSON200)
-	restartRequired := s.requireDbRestart(remoteConfig)
-	if restartRequired {
-		fmt.Fprintln(os.Stderr, "Database will be restarted to apply config updates...")
-	}
 	updateBody := s.ToUpdatePostgresConfigBody()
-	updateBody.RestartDatabase = &restartRequired
 	if resp, err := u.client.V1UpdatePostgresConfigWithResponse(ctx, projectRef, updateBody); err != nil {
 		return errors.Errorf("failed to update DB config: %w", err)
 	} else if resp.JSON200 == nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Following: https://github.com/supabase/infrastructure/pull/20462

Let the api decide if the service restart is necessary.

**caution**
Deduplicating the logic remove our ability to log a message to the user but since we didn't allowed to act on it (agree / refute) I think it's alright to let the API be the source of truth.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
