### PR TITLE
fix(functions): create new reader for retrying deploy

### DIFF
--- a/pkg/function/batch.go
+++ b/pkg/function/batch.go
@@ -55,7 +55,7 @@ func (s *EdgeRuntimeAPI) UpsertFunctions(ctx context.Context, functionConfig con
 					VerifyJwt:      function.VerifyJWT,
 					ImportMapPath:  toFileURL(function.ImportMap),
 					EntrypointPath: toFileURL(function.Entrypoint),
-				}, eszipContentType, &body); err != nil {
+				}, eszipContentType, bytes.NewReader(body.Bytes())); err != nil {
 					return errors.Errorf("failed to update function: %w", err)
 				} else if resp.JSON200 == nil {
 					return errors.Errorf("unexpected status %d: %s", resp.StatusCode(), string(resp.Body))
@@ -67,7 +67,7 @@ func (s *EdgeRuntimeAPI) UpsertFunctions(ctx context.Context, functionConfig con
 					VerifyJwt:      function.VerifyJWT,
 					ImportMapPath:  toFileURL(function.ImportMap),
 					EntrypointPath: toFileURL(function.Entrypoint),
-				}, eszipContentType, &body); err != nil {
+				}, eszipContentType, bytes.NewReader(body.Bytes())); err != nil {
 					return errors.Errorf("failed to create function: %w", err)
 				} else if resp.JSON201 == nil {
 					return errors.Errorf("unexpected status %d: %s", resp.StatusCode(), string(resp.Body))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

When initiating a retry, reusing the buffer reader results in 0 length body. Instantiate a new reader instead.

## Additional context

Add any other context or screenshots.
