### PR TITLE
fix(studio): bump studio image to 20241106-f29003e

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -10,7 +10,7 @@ const (
 	inbucketImage    = "inbucket/inbucket:3.0.3"
 	postgrestImage   = "postgrest/postgrest:v12.2.0"
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
-	studioImage      = "supabase/studio:20241106-fe0e32d"
+	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	edgeRuntimeImage = "supabase/edge-runtime:v1.61.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"


### PR DESCRIPTION
Bump studio to the latest version. This studio version contains [the PR](https://github.com/supabase/supabase/pull/30332) to fix an issue with [auth, storage and realtime](https://github.com/supabase/cli/issues/2834).