### PR TITLE
feat: support tracking commit timestamp

### DIFF
--- a/internal/postgresConfig/update/update.go
+++ b/internal/postgresConfig/update/update.go
@@ -39,11 +39,12 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 		for k, v := range newConfigOverrides {
 			// this is hacky - if we're able to convert the value to an integer, we do so
 			// if we start supporting config fields with e.g. floating pt overrides this'll need to be updated
-			attemptedConvert, err := strconv.Atoi(v)
-			if err != nil {
-				finalOverrides[k] = v
+			if vInt, err := strconv.Atoi(v); err == nil {
+				finalOverrides[k] = vInt
+			} else if vBool, err := strconv.ParseBool(v); err == nil {
+				finalOverrides[k] = vBool
 			} else {
-				finalOverrides[k] = attemptedConvert
+				finalOverrides[k] = v
 			}
 		}
 	}

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -43,6 +43,7 @@ type (
 		SessionReplicationRole        *SessionReplicationRole `toml:"session_replication_role"`
 		SharedBuffers                 *string                 `toml:"shared_buffers"`
 		StatementTimeout              *string                 `toml:"statement_timeout"`
+		TrackCommitTimestamp          *bool                   `toml:"track_commit_timestamp"`
 		WalKeepSize                   *string                 `toml:"wal_keep_size"`
 		WalSenderTimeout              *string                 `toml:"wal_sender_timeout"`
 		WorkMem                       *string                 `toml:"work_mem"`
@@ -104,6 +105,7 @@ func (a *settings) ToUpdatePostgresConfigBody() v1API.UpdatePostgresConfigBody {
 	body.MaxWalSize = a.MaxWalSize
 	body.SessionReplicationRole = (*v1API.UpdatePostgresConfigBodySessionReplicationRole)(a.SessionReplicationRole)
 	body.StatementTimeout = a.StatementTimeout
+	body.TrackCommitTimestamp = a.TrackCommitTimestamp
 	body.WalKeepSize = a.WalKeepSize
 	body.WalSenderTimeout = a.WalSenderTimeout
 	body.WorkMem = a.WorkMem
@@ -131,6 +133,7 @@ func (a *settings) fromRemoteConfig(remoteConfig v1API.PostgresConfigResponse) s
 	result.SessionReplicationRole = (*SessionReplicationRole)(remoteConfig.SessionReplicationRole)
 	result.SharedBuffers = remoteConfig.SharedBuffers
 	result.StatementTimeout = remoteConfig.StatementTimeout
+	result.TrackCommitTimestamp = remoteConfig.TrackCommitTimestamp
 	result.WalKeepSize = remoteConfig.WalKeepSize
 	result.WalSenderTimeout = remoteConfig.WalSenderTimeout
 	result.WorkMem = remoteConfig.WorkMem


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Support new postgres config option.

```
supabase --experimental postgres-config update --config track_commit_timestamp=true
```

## Additional context

At some point, we probably want to transition to using `[db.settings]` in config.toml for config updates.
