### PR TITLE
fix: link fails due to wrong api key type

### DIFF
--- a/api/beta.yaml
+++ b/api/beta.yaml
@@ -1519,6 +1519,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/V1ServiceHealthResponse'
+        '403':
+          description: ''
         '500':
           description: Failed to retrieve project's service health status
       tags:
@@ -3063,6 +3065,13 @@ components:
     ApiKeyResponse:
       type: object
       properties:
+        type:
+          nullable: true
+          type: string
+          enum:
+            - publishable
+            - secret
+            - legacy
         name:
           type: string
         api_key:
@@ -3070,9 +3079,6 @@ components:
         id:
           type: string
           nullable: true
-        type:
-          nullable: true
-          type: object
         prefix:
           type: string
           nullable: true
@@ -3786,6 +3792,8 @@ components:
           type: string
         statement_timeout:
           type: string
+        track_commit_timestamp:
+          type: boolean
         wal_keep_size:
           type: string
         wal_sender_timeout:
@@ -3847,6 +3855,8 @@ components:
           type: string
         statement_timeout:
           type: string
+        track_commit_timestamp:
+          type: boolean
         wal_keep_size:
           type: string
         wal_sender_timeout:

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -14,6 +14,13 @@ const (
 	Oauth2Scopes = "oauth2.Scopes"
 )
 
+// Defines values for ApiKeyResponseType.
+const (
+	ApiKeyResponseTypeLegacy      ApiKeyResponseType = "legacy"
+	ApiKeyResponseTypePublishable ApiKeyResponseType = "publishable"
+	ApiKeyResponseTypeSecret      ApiKeyResponseType = "secret"
+)
+
 // Defines values for AuthHealthResponseName.
 const (
 	GoTrue AuthHealthResponseName = "GoTrue"
@@ -58,8 +65,8 @@ const (
 
 // Defines values for CreateApiKeyBodyType.
 const (
-	Publishable CreateApiKeyBodyType = "publishable"
-	Secret      CreateApiKeyBodyType = "secret"
+	CreateApiKeyBodyTypePublishable CreateApiKeyBodyType = "publishable"
+	CreateApiKeyBodyTypeSecret      CreateApiKeyBodyType = "secret"
 )
 
 // Defines values for CreateProviderBodyType.
@@ -412,9 +419,12 @@ type ApiKeyResponse struct {
 	Name              string                   `json:"name"`
 	Prefix            *string                  `json:"prefix"`
 	SecretJwtTemplate *ApiKeySecretJWTTemplate `json:"secret_jwt_template"`
-	Type              *map[string]interface{}  `json:"type"`
+	Type              *ApiKeyResponseType      `json:"type"`
 	UpdatedAt         *string                  `json:"updated_at"`
 }
+
+// ApiKeyResponseType defines model for ApiKeyResponse.Type.
+type ApiKeyResponseType string
 
 // ApiKeySecretJWTTemplate defines model for ApiKeySecretJWTTemplate.
 type ApiKeySecretJWTTemplate struct {
@@ -950,6 +960,7 @@ type PostgresConfigResponse struct {
 	SessionReplicationRole        *PostgresConfigResponseSessionReplicationRole `json:"session_replication_role,omitempty"`
 	SharedBuffers                 *string                                       `json:"shared_buffers,omitempty"`
 	StatementTimeout              *string                                       `json:"statement_timeout,omitempty"`
+	TrackCommitTimestamp          *bool                                         `json:"track_commit_timestamp,omitempty"`
 	WalKeepSize                   *string                                       `json:"wal_keep_size,omitempty"`
 	WalSenderTimeout              *string                                       `json:"wal_sender_timeout,omitempty"`
 	WorkMem                       *string                                       `json:"work_mem,omitempty"`
@@ -1440,6 +1451,7 @@ type UpdatePostgresConfigBody struct {
 	SessionReplicationRole        *UpdatePostgresConfigBodySessionReplicationRole `json:"session_replication_role,omitempty"`
 	SharedBuffers                 *string                                         `json:"shared_buffers,omitempty"`
 	StatementTimeout              *string                                         `json:"statement_timeout,omitempty"`
+	TrackCommitTimestamp          *bool                                           `json:"track_commit_timestamp,omitempty"`
 	WalKeepSize                   *string                                         `json:"wal_keep_size,omitempty"`
 	WalSenderTimeout              *string                                         `json:"wal_sender_timeout,omitempty"`
 	WorkMem                       *string                                         `json:"work_mem,omitempty"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Could not link project after updating cli.

## What is the new behavior?

Fixes generated api type.

## Additional context

Add any other context or screenshots.
