### PR TITLE
fix: bump edge-runtime to 1.61.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.61.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.61.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.61.2

### Changes

### [1.61.2](https://github.com/supabase/edge-runtime/compare/v1.61.1...v1.61.2) (2024-11-09)

#### Bug Fixes

* **sb_workers:** allow extra context to be passed in from js land ([#440](https://github.com/supabase/edge-runtime/issues/440)) ([1bb7f70](https://github.com/supabase/edge-runtime/commit/1bb7f70bc9a9f4312ca3bbe5d249157ad5da13a8))