### PR TITLE
fix: bump edge-runtime to 1.62.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.61.2"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.62.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.62.1

### Changes

### [1.62.1](https://github.com/supabase/edge-runtime/compare/v1.61.2...v1.62.1) (2024-11-12)

#### Features

* exposing onnx backend to JS land ([#436](https://github.com/supabase/edge-runtime/issues/436)) ([1052be2](https://github.com/supabase/edge-runtime/commit/1052be2bfba9a357609dd330f5f1b552687e2f18)) (@kallebysantos)

#### Bug Fixes

* **ci:** release workflow failure ([#442](https://github.com/supabase/edge-runtime/issues/442)) ([390a5c1](https://github.com/supabase/edge-runtime/commit/390a5c160b324ccc336fd0cf8e68d525fdaab1d0))