### PR TITLE
fix(config): diff email template content with remote

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -552,10 +552,10 @@ EOF
 					id+filepath.Ext(tmpl.ContentPath),
 				))
 			}
-			if len(tmpl.Subject) > 0 {
+			if tmpl.Subject != nil {
 				env = append(env, fmt.Sprintf("GOTRUE_MAILER_SUBJECTS_%s=%s",
 					strings.ToUpper(id),
-					tmpl.Subject,
+					*tmpl.Subject,
 				))
 			}
 		}

--- a/pkg/config/api_test.go
+++ b/pkg/config/api_test.go
@@ -33,7 +33,7 @@ func TestApiToUpdatePostgrestConfigBody(t *testing.T) {
 	})
 }
 
-func TestApiDiffWithRemote(t *testing.T) {
+func TestApiDiff(t *testing.T) {
 	t.Run("detects differences", func(t *testing.T) {
 		api := &api{
 			Enabled:         true,
@@ -49,14 +49,9 @@ func TestApiDiffWithRemote(t *testing.T) {
 		}
 
 		diff, err := api.DiffWithRemote(remoteConfig)
-		assert.NoError(t, err, string(diff))
+		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "-schemas = [\"public\"]")
-		assert.Contains(t, string(diff), "+schemas = [\"public\", \"private\"]")
-		assert.Contains(t, string(diff), "-extra_search_path = [\"public\"]")
-		assert.Contains(t, string(diff), "+extra_search_path = [\"extensions\", \"public\"]")
-		assert.Contains(t, string(diff), "-max_rows = 500")
-		assert.Contains(t, string(diff), "+max_rows = 1000")
+		assertSnapshotEqual(t, diff)
 	})
 
 	t.Run("handles no differences", func(t *testing.T) {
@@ -114,10 +109,9 @@ func TestApiDiffWithRemote(t *testing.T) {
 		}
 
 		diff, err := api.DiffWithRemote(remoteConfig)
-		assert.NoError(t, err, string(diff))
+		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "-enabled = false")
-		assert.Contains(t, string(diff), "+enabled = true")
+		assertSnapshotEqual(t, diff)
 	})
 
 	t.Run("handles api disabled on local side", func(t *testing.T) {
@@ -135,9 +129,8 @@ func TestApiDiffWithRemote(t *testing.T) {
 		}
 
 		diff, err := api.DiffWithRemote(remoteConfig)
-		assert.NoError(t, err, string(diff))
+		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "-enabled = true")
-		assert.Contains(t, string(diff), "+enabled = false")
+		assertSnapshotEqual(t, diff)
 	})
 }

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -89,10 +89,10 @@ type (
 	}
 
 	emailTemplate struct {
-		Subject     string `toml:"subject"`
+		Subject *string `toml:"subject"`
+		Content *string `toml:"content"`
+		// Only content path is accepted in config.toml
 		ContentPath string `toml:"content_path"`
-		// Exposed for remote diff only, not valid in config.toml
-		Content string `toml:"content"`
 	}
 
 	sms struct {
@@ -332,49 +332,24 @@ func (e email) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
 		return
 	}
 	var tmpl *emailTemplate
-	// When local config is not set, we assume platform defaults should not change
 	tmpl = cast.Ptr(e.Template["invite"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsInvite = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesInviteContent = &tmpl.Content
-	}
+	body.MailerSubjectsInvite = tmpl.Subject
+	body.MailerTemplatesInviteContent = tmpl.Content
 	tmpl = cast.Ptr(e.Template["confirmation"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsConfirmation = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesConfirmationContent = &tmpl.Content
-	}
+	body.MailerSubjectsConfirmation = tmpl.Subject
+	body.MailerTemplatesConfirmationContent = tmpl.Content
 	tmpl = cast.Ptr(e.Template["recovery"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsRecovery = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesRecoveryContent = &tmpl.Content
-	}
+	body.MailerSubjectsRecovery = tmpl.Subject
+	body.MailerTemplatesRecoveryContent = tmpl.Content
 	tmpl = cast.Ptr(e.Template["magic_link"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsMagicLink = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesMagicLinkContent = &tmpl.Content
-	}
+	body.MailerSubjectsMagicLink = tmpl.Subject
+	body.MailerTemplatesMagicLinkContent = tmpl.Content
 	tmpl = cast.Ptr(e.Template["email_change"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsEmailChange = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesEmailChangeContent = &tmpl.Content
-	}
+	body.MailerSubjectsEmailChange = tmpl.Subject
+	body.MailerTemplatesEmailChangeContent = tmpl.Content
 	tmpl = cast.Ptr(e.Template["reauthentication"])
-	if len(tmpl.Subject) > 0 {
-		body.MailerSubjectsReauthentication = &tmpl.Subject
-	}
-	if len(tmpl.Content) > 0 {
-		body.MailerTemplatesReauthenticationContent = &tmpl.Content
-	}
+	body.MailerSubjectsReauthentication = tmpl.Subject
+	body.MailerTemplatesReauthenticationContent = tmpl.Content
 }
 
 func (e *email) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
@@ -405,57 +380,58 @@ func (e *email) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 		return
 	}
 	var tmpl emailTemplate
+	// When local config is not set, we assume platform defaults should not change
 	tmpl = e.Template["invite"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsInvite, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsInvite
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesInviteContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesInviteContent
 	}
 	e.Template["invite"] = tmpl
 
 	tmpl = e.Template["confirmation"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsConfirmation, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsConfirmation
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesConfirmationContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesConfirmationContent
 	}
 	e.Template["confirmation"] = tmpl
 
 	tmpl = e.Template["recovery"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsRecovery, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsRecovery
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesRecoveryContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesRecoveryContent
 	}
 	e.Template["recovery"] = tmpl
 
 	tmpl = e.Template["magic_link"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsMagicLink, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsMagicLink
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesMagicLinkContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesMagicLinkContent
 	}
 	e.Template["magic_link"] = tmpl
 
 	tmpl = e.Template["email_change"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsEmailChange, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsEmailChange
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesEmailChangeContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesEmailChangeContent
 	}
 	e.Template["email_change"] = tmpl
 
 	tmpl = e.Template["reauthentication"]
-	if len(tmpl.Subject) > 0 {
-		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsReauthentication, "")
+	if tmpl.Subject != nil {
+		tmpl.Subject = remoteConfig.MailerSubjectsReauthentication
 	}
-	if len(tmpl.Content) > 0 {
-		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesReauthenticationContent, "")
+	if tmpl.Content != nil {
+		tmpl.Content = remoteConfig.MailerTemplatesReauthenticationContent
 	}
 	e.Template["reauthentication"] = tmpl
 }

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -91,6 +91,8 @@ type (
 	emailTemplate struct {
 		Subject     string `toml:"subject"`
 		ContentPath string `toml:"content_path"`
+		// Exposed for remote diff only, not valid in config.toml
+		Content string `toml:"content"`
 	}
 
 	sms struct {
@@ -326,6 +328,53 @@ func (e email) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
 		// Setting a single empty string disables SMTP
 		body.SmtpHost = cast.Ptr("")
 	}
+	if len(e.Template) == 0 {
+		return
+	}
+	var tmpl *emailTemplate
+	// When local config is not set, we assume platform defaults should not change
+	tmpl = cast.Ptr(e.Template["invite"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsInvite = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesInviteContent = &tmpl.Content
+	}
+	tmpl = cast.Ptr(e.Template["confirmation"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsConfirmation = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesConfirmationContent = &tmpl.Content
+	}
+	tmpl = cast.Ptr(e.Template["recovery"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsRecovery = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesRecoveryContent = &tmpl.Content
+	}
+	tmpl = cast.Ptr(e.Template["magic_link"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsMagicLink = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesMagicLinkContent = &tmpl.Content
+	}
+	tmpl = cast.Ptr(e.Template["email_change"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsEmailChange = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesEmailChangeContent = &tmpl.Content
+	}
+	tmpl = cast.Ptr(e.Template["reauthentication"])
+	if len(tmpl.Subject) > 0 {
+		body.MailerSubjectsReauthentication = &tmpl.Subject
+	}
+	if len(tmpl.Content) > 0 {
+		body.MailerTemplatesReauthenticationContent = &tmpl.Content
+	}
 }
 
 func (e *email) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
@@ -352,6 +401,63 @@ func (e *email) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	} else {
 		e.Smtp = nil
 	}
+	if len(e.Template) == 0 {
+		return
+	}
+	var tmpl emailTemplate
+	tmpl = e.Template["invite"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsInvite, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesInviteContent, "")
+	}
+	e.Template["invite"] = tmpl
+
+	tmpl = e.Template["confirmation"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsConfirmation, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesConfirmationContent, "")
+	}
+	e.Template["confirmation"] = tmpl
+
+	tmpl = e.Template["recovery"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsRecovery, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesRecoveryContent, "")
+	}
+	e.Template["recovery"] = tmpl
+
+	tmpl = e.Template["magic_link"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsMagicLink, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesMagicLinkContent, "")
+	}
+	e.Template["magic_link"] = tmpl
+
+	tmpl = e.Template["email_change"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsEmailChange, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesEmailChangeContent, "")
+	}
+	e.Template["email_change"] = tmpl
+
+	tmpl = e.Template["reauthentication"]
+	if len(tmpl.Subject) > 0 {
+		tmpl.Subject = cast.Val(remoteConfig.MailerSubjectsReauthentication, "")
+	}
+	if len(tmpl.Content) > 0 {
+		tmpl.Content = cast.Val(remoteConfig.MailerTemplatesReauthenticationContent, "")
+	}
+	e.Template["reauthentication"] = tmpl
 }
 
 func (s sms) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -228,11 +228,30 @@ func TestEmailDiff(t *testing.T) {
 			EnableConfirmations:  true,
 			SecurePasswordChange: true,
 			Template: map[string]emailTemplate{
-				"invite":       {},
-				"confirmation": {},
-				"recovery":     {},
-				"magic_link":   {},
-				"email_change": {},
+				"invite": {
+					Subject: "invite-subject",
+					Content: "invite-content",
+				},
+				"confirmation": {
+					Subject: "confirmation-subject",
+					Content: "confirmation-content",
+				},
+				"recovery": {
+					Subject: "recovery-subject",
+					Content: "recovery-content",
+				},
+				"magic_link": {
+					Subject: "magic-link-subject",
+					Content: "magic-link-content",
+				},
+				"email_change": {
+					Subject: "email-change-subject",
+					Content: "email-change-content",
+				},
+				"reauthentication": {
+					Subject: "reauthentication-subject",
+					Content: "reauthentication-content",
+				},
 			},
 			Smtp: &smtp{
 				Host:       "smtp.sendgrid.net",
@@ -261,6 +280,19 @@ func TestEmailDiff(t *testing.T) {
 			SmtpAdminEmail:   cast.Ptr("admin@email.com"),
 			SmtpSenderName:   cast.Ptr("Admin"),
 			SmtpMaxFrequency: cast.Ptr(1),
+			// Custom templates
+			MailerSubjectsInvite:                   cast.Ptr("invite-subject"),
+			MailerTemplatesInviteContent:           cast.Ptr("invite-content"),
+			MailerSubjectsConfirmation:             cast.Ptr("confirmation-subject"),
+			MailerTemplatesConfirmationContent:     cast.Ptr("confirmation-content"),
+			MailerSubjectsRecovery:                 cast.Ptr("recovery-subject"),
+			MailerTemplatesRecoveryContent:         cast.Ptr("recovery-content"),
+			MailerSubjectsMagicLink:                cast.Ptr("magic-link-subject"),
+			MailerTemplatesMagicLinkContent:        cast.Ptr("magic-link-content"),
+			MailerSubjectsEmailChange:              cast.Ptr("email-change-subject"),
+			MailerTemplatesEmailChangeContent:      cast.Ptr("email-change-content"),
+			MailerSubjectsReauthentication:         cast.Ptr("reauthentication-subject"),
+			MailerTemplatesReauthenticationContent: cast.Ptr("reauthentication-content"),
 		})
 		// Check error
 		assert.NoError(t, err)
@@ -275,11 +307,28 @@ func TestEmailDiff(t *testing.T) {
 			EnableConfirmations:  true,
 			SecurePasswordChange: true,
 			Template: map[string]emailTemplate{
-				"invite":       {},
-				"confirmation": {},
-				"recovery":     {},
-				"magic_link":   {},
-				"email_change": {},
+				"invite": {
+					Subject: "invite-subject",
+					Content: "invite-content",
+				},
+				"confirmation": {
+					Subject: "confirmation-subject",
+				},
+				"recovery": {
+					Content: "recovery-content",
+				},
+				"magic_link": {
+					Subject: "magic-link-subject",
+					Content: "magic-link-content",
+				},
+				"email_change": {
+					Subject: "email-change-subject",
+					Content: "email-change-content",
+				},
+				"reauthentication": {
+					Subject: "reauthentication-subject",
+					Content: "reauthentication-content",
+				},
 			},
 			Smtp: &smtp{
 				Host:       "smtp.sendgrid.net",
@@ -302,9 +351,15 @@ func TestEmailDiff(t *testing.T) {
 			MailerOtpExp:                   3600,
 			SecurityUpdatePasswordRequireReauthentication: cast.Ptr(false),
 			SmtpMaxFrequency: cast.Ptr(60),
+			// Custom templates
+			MailerTemplatesConfirmationContent: cast.Ptr("confirmation-content"),
+			MailerSubjectsRecovery:             cast.Ptr("recovery-subject"),
+			MailerSubjectsMagicLink:            cast.Ptr("magic-link-subject"),
+			MailerTemplatesEmailChangeContent:  cast.Ptr("email-change-content"),
 		})
 		// Check error
 		assert.NoError(t, err)
+
 		assert.Contains(t, string(diff), ` [email]`)
 		assert.Contains(t, string(diff), `-enable_signup = false`)
 		assert.Contains(t, string(diff), `-double_confirm_changes = false`)
@@ -320,6 +375,43 @@ func TestEmailDiff(t *testing.T) {
 		assert.Contains(t, string(diff), `+max_frequency = "1s"`)
 		assert.Contains(t, string(diff), `+otp_length = 8`)
 		assert.Contains(t, string(diff), `+otp_expiry = 86400`)
+
+		assert.Contains(t, string(diff), `+[email.smtp]`)
+		assert.Contains(t, string(diff), `+host = "smtp.sendgrid.net"`)
+		assert.Contains(t, string(diff), `+port = 587`)
+		assert.Contains(t, string(diff), `+user = "apikey"`)
+		assert.Contains(t, string(diff), `+pass = "hash:ed64b7695a606bc6ab4fcb41fe815b5ddf1063ccbc87afe1fa89756635db520e"`)
+		assert.Contains(t, string(diff), `+admin_email = "admin@email.com"`)
+		assert.Contains(t, string(diff), `+sender_name = "Admin"`)
+
+		assert.Contains(t, string(diff), ` [email.template]`)
+		assert.Contains(t, string(diff), ` [email.template.confirmation]`)
+		assert.Contains(t, string(diff), `-subject = ""`)
+		assert.Contains(t, string(diff), `+subject = "confirmation-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), ` content = ""`)
+		assert.Contains(t, string(diff), ` [email.template.email_change]`)
+		assert.Contains(t, string(diff), `-subject = ""`)
+		assert.Contains(t, string(diff), `+subject = "email-change-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), ` content = "email-change-content"`)
+		assert.Contains(t, string(diff), ` [email.template.invite]`)
+		assert.Contains(t, string(diff), `-subject = ""`)
+		assert.Contains(t, string(diff), `-content_path = ""`)
+		assert.Contains(t, string(diff), `-content = ""`)
+		assert.Contains(t, string(diff), `+subject = "invite-subject"`)
+		assert.Contains(t, string(diff), `+content_path = ""`)
+		assert.Contains(t, string(diff), `+content = "invite-content"`)
+		assert.Contains(t, string(diff), ` [email.template.magic_link]`)
+		assert.Contains(t, string(diff), ` subject = "magic-link-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), `-content = ""`)
+		assert.Contains(t, string(diff), `+content = "magic-link-content"`)
+		assert.Contains(t, string(diff), ` [email.template.recovery]`)
+		assert.Contains(t, string(diff), ` subject = ""`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), `-content = ""`)
+		assert.Contains(t, string(diff), `+content = "recovery-content"`)
 	})
 
 	t.Run("local disabled remote enabled", func(t *testing.T) {
@@ -327,11 +419,12 @@ func TestEmailDiff(t *testing.T) {
 		c.Email = email{
 			EnableConfirmations: false,
 			Template: map[string]emailTemplate{
-				"invite":       {},
-				"confirmation": {},
-				"recovery":     {},
-				"magic_link":   {},
-				"email_change": {},
+				"invite":           {},
+				"confirmation":     {},
+				"recovery":         {},
+				"magic_link":       {},
+				"email_change":     {},
+				"reauthentication": {},
 			},
 			MaxFrequency: time.Minute,
 			OtpLength:    8,
@@ -352,6 +445,19 @@ func TestEmailDiff(t *testing.T) {
 			SmtpAdminEmail:   cast.Ptr("admin@email.com"),
 			SmtpSenderName:   cast.Ptr("Admin"),
 			SmtpMaxFrequency: cast.Ptr(1),
+			// Custom templates
+			MailerSubjectsInvite:                   cast.Ptr("invite-subject"),
+			MailerTemplatesInviteContent:           cast.Ptr("invite-content"),
+			MailerSubjectsConfirmation:             cast.Ptr("confirmation-subject"),
+			MailerTemplatesConfirmationContent:     cast.Ptr("confirmation-content"),
+			MailerSubjectsRecovery:                 cast.Ptr("recovery-subject"),
+			MailerTemplatesRecoveryContent:         cast.Ptr("recovery-content"),
+			MailerSubjectsMagicLink:                cast.Ptr("magic-link-subject"),
+			MailerTemplatesMagicLinkContent:        cast.Ptr("magic-link-content"),
+			MailerSubjectsEmailChange:              cast.Ptr("email-change-subject"),
+			MailerTemplatesEmailChangeContent:      cast.Ptr("email-change-content"),
+			MailerSubjectsReauthentication:         cast.Ptr("reauthentication-subject"),
+			MailerTemplatesReauthenticationContent: cast.Ptr("reauthentication-content"),
 		})
 		// Check error
 		assert.NoError(t, err)
@@ -386,11 +492,12 @@ func TestEmailDiff(t *testing.T) {
 		c.Email = email{
 			EnableConfirmations: false,
 			Template: map[string]emailTemplate{
-				"invite":       {},
-				"confirmation": {},
-				"recovery":     {},
-				"magic_link":   {},
-				"email_change": {},
+				"invite":           {},
+				"confirmation":     {},
+				"recovery":         {},
+				"magic_link":       {},
+				"email_change":     {},
+				"reauthentication": {},
 			},
 			MaxFrequency: time.Minute,
 			OtpLength:    6,

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -229,28 +229,28 @@ func TestEmailDiff(t *testing.T) {
 			SecurePasswordChange: true,
 			Template: map[string]emailTemplate{
 				"invite": {
-					Subject: "invite-subject",
-					Content: "invite-content",
+					Subject: cast.Ptr("invite-subject"),
+					Content: cast.Ptr("invite-content"),
 				},
 				"confirmation": {
-					Subject: "confirmation-subject",
-					Content: "confirmation-content",
+					Subject: cast.Ptr("confirmation-subject"),
+					Content: cast.Ptr("confirmation-content"),
 				},
 				"recovery": {
-					Subject: "recovery-subject",
-					Content: "recovery-content",
+					Subject: cast.Ptr("recovery-subject"),
+					Content: cast.Ptr("recovery-content"),
 				},
 				"magic_link": {
-					Subject: "magic-link-subject",
-					Content: "magic-link-content",
+					Subject: cast.Ptr("magic-link-subject"),
+					Content: cast.Ptr("magic-link-content"),
 				},
 				"email_change": {
-					Subject: "email-change-subject",
-					Content: "email-change-content",
+					Subject: cast.Ptr("email-change-subject"),
+					Content: cast.Ptr("email-change-content"),
 				},
 				"reauthentication": {
-					Subject: "reauthentication-subject",
-					Content: "reauthentication-content",
+					Subject: cast.Ptr("reauthentication-subject"),
+					Content: cast.Ptr("reauthentication-content"),
 				},
 			},
 			Smtp: &smtp{
@@ -308,26 +308,26 @@ func TestEmailDiff(t *testing.T) {
 			SecurePasswordChange: true,
 			Template: map[string]emailTemplate{
 				"invite": {
-					Subject: "invite-subject",
-					Content: "invite-content",
+					Subject: cast.Ptr("invite-subject"),
+					Content: cast.Ptr("invite-content"),
 				},
 				"confirmation": {
-					Subject: "confirmation-subject",
+					Subject: cast.Ptr("confirmation-subject"),
 				},
 				"recovery": {
-					Content: "recovery-content",
+					Content: cast.Ptr("recovery-content"),
 				},
 				"magic_link": {
-					Subject: "magic-link-subject",
-					Content: "magic-link-content",
+					Subject: cast.Ptr("magic-link-subject"),
+					Content: cast.Ptr("magic-link-content"),
 				},
 				"email_change": {
-					Subject: "email-change-subject",
-					Content: "email-change-content",
+					Subject: cast.Ptr("email-change-subject"),
+					Content: cast.Ptr("email-change-content"),
 				},
 				"reauthentication": {
-					Subject: "reauthentication-subject",
-					Content: "reauthentication-content",
+					Subject: cast.Ptr(""),
+					Content: cast.Ptr(""),
 				},
 			},
 			Smtp: &smtp{
@@ -376,6 +376,32 @@ func TestEmailDiff(t *testing.T) {
 		assert.Contains(t, string(diff), `+otp_length = 8`)
 		assert.Contains(t, string(diff), `+otp_expiry = 86400`)
 
+		assert.Contains(t, string(diff), ` [email.template]`)
+		assert.Contains(t, string(diff), ` [email.template.confirmation]`)
+		assert.Contains(t, string(diff), `+subject = "confirmation-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), ` [email.template.email_change]`)
+		assert.Contains(t, string(diff), `+subject = "email-change-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), ` content = "email-change-content"`)
+		assert.Contains(t, string(diff), ` [email.template.invite]`)
+		assert.Contains(t, string(diff), `-content_path = ""`)
+		assert.Contains(t, string(diff), `+subject = "invite-subject"`)
+		assert.Contains(t, string(diff), `+content_path = ""`)
+		assert.Contains(t, string(diff), `+content = "invite-content"`)
+		assert.Contains(t, string(diff), ` [email.template.magic_link]`)
+		assert.Contains(t, string(diff), ` subject = "magic-link-subject"`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), `+content = "magic-link-content"`)
+		assert.Contains(t, string(diff), ` [email.template.reauthentication]`)
+		assert.Contains(t, string(diff), `-content_path = ""`)
+		assert.Contains(t, string(diff), `+subject = ""`)
+		assert.Contains(t, string(diff), `+content_path = ""`)
+		assert.Contains(t, string(diff), `+content = ""`)
+		assert.Contains(t, string(diff), ` [email.template.recovery]`)
+		assert.Contains(t, string(diff), ` content_path = ""`)
+		assert.Contains(t, string(diff), `+content = "recovery-content"`)
+
 		assert.Contains(t, string(diff), `+[email.smtp]`)
 		assert.Contains(t, string(diff), `+host = "smtp.sendgrid.net"`)
 		assert.Contains(t, string(diff), `+port = 587`)
@@ -383,35 +409,6 @@ func TestEmailDiff(t *testing.T) {
 		assert.Contains(t, string(diff), `+pass = "hash:ed64b7695a606bc6ab4fcb41fe815b5ddf1063ccbc87afe1fa89756635db520e"`)
 		assert.Contains(t, string(diff), `+admin_email = "admin@email.com"`)
 		assert.Contains(t, string(diff), `+sender_name = "Admin"`)
-
-		assert.Contains(t, string(diff), ` [email.template]`)
-		assert.Contains(t, string(diff), ` [email.template.confirmation]`)
-		assert.Contains(t, string(diff), `-subject = ""`)
-		assert.Contains(t, string(diff), `+subject = "confirmation-subject"`)
-		assert.Contains(t, string(diff), ` content_path = ""`)
-		assert.Contains(t, string(diff), ` content = ""`)
-		assert.Contains(t, string(diff), ` [email.template.email_change]`)
-		assert.Contains(t, string(diff), `-subject = ""`)
-		assert.Contains(t, string(diff), `+subject = "email-change-subject"`)
-		assert.Contains(t, string(diff), ` content_path = ""`)
-		assert.Contains(t, string(diff), ` content = "email-change-content"`)
-		assert.Contains(t, string(diff), ` [email.template.invite]`)
-		assert.Contains(t, string(diff), `-subject = ""`)
-		assert.Contains(t, string(diff), `-content_path = ""`)
-		assert.Contains(t, string(diff), `-content = ""`)
-		assert.Contains(t, string(diff), `+subject = "invite-subject"`)
-		assert.Contains(t, string(diff), `+content_path = ""`)
-		assert.Contains(t, string(diff), `+content = "invite-content"`)
-		assert.Contains(t, string(diff), ` [email.template.magic_link]`)
-		assert.Contains(t, string(diff), ` subject = "magic-link-subject"`)
-		assert.Contains(t, string(diff), ` content_path = ""`)
-		assert.Contains(t, string(diff), `-content = ""`)
-		assert.Contains(t, string(diff), `+content = "magic-link-content"`)
-		assert.Contains(t, string(diff), ` [email.template.recovery]`)
-		assert.Contains(t, string(diff), ` subject = ""`)
-		assert.Contains(t, string(diff), ` content_path = ""`)
-		assert.Contains(t, string(diff), `-content = ""`)
-		assert.Contains(t, string(diff), `+content = "recovery-content"`)
 	})
 
 	t.Run("local disabled remote enabled", func(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
 	"golang.org/x/mod/semver"
 )
@@ -819,16 +820,15 @@ func (c *seed) loadSeedPaths(basePath string, fsys fs.FS) error {
 func (e *email) validate(fsys fs.FS) (err error) {
 	for name, tmpl := range e.Template {
 		if len(tmpl.ContentPath) == 0 {
-			if len(tmpl.Content) > 0 {
+			if tmpl.Content != nil {
 				return errors.Errorf("Invalid config for auth.email.%s.content: please use content_path instead", name)
 			}
 			continue
 		}
-		// Load the file content of the template within the config
 		if content, err := fs.ReadFile(fsys, filepath.Clean(tmpl.ContentPath)); err != nil {
 			return errors.Errorf("Invalid config for auth.email.%s.content_path: %w", name, err)
 		} else {
-			tmpl.Content = string(content)
+			tmpl.Content = cast.Ptr(string(content))
 		}
 		e.Template[name] = tmpl
 	}

--- a/pkg/config/db_test.go
+++ b/pkg/config/db_test.go
@@ -42,7 +42,7 @@ func TestDbSettingsToUpdatePostgresConfigBody(t *testing.T) {
 	})
 }
 
-func TestDbSettingsDiffWithRemote(t *testing.T) {
+func TestDbSettingsDiff(t *testing.T) {
 	t.Run("detects differences", func(t *testing.T) {
 		db := &db{
 			Settings: settings{
@@ -61,12 +61,7 @@ func TestDbSettingsDiffWithRemote(t *testing.T) {
 		diff, err := db.Settings.DiffWithRemote(remoteConfig)
 		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "-effective_cache_size = \"8GB\"")
-		assert.Contains(t, string(diff), "+effective_cache_size = \"4GB\"")
-		assert.Contains(t, string(diff), "-max_connections = 200")
-		assert.Contains(t, string(diff), "+max_connections = 100")
-		assert.Contains(t, string(diff), "-shared_buffers = \"2GB\"")
-		assert.Contains(t, string(diff), "+shared_buffers = \"1GB\"")
+		assertSnapshotEqual(t, diff)
 	})
 
 	t.Run("handles no differences", func(t *testing.T) {
@@ -127,9 +122,7 @@ func TestDbSettingsDiffWithRemote(t *testing.T) {
 		diff, err := db.Settings.DiffWithRemote(remoteConfig)
 		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "+effective_cache_size = \"4GB\"")
-		assert.Contains(t, string(diff), "+max_connections = 100")
-		assert.Contains(t, string(diff), "+shared_buffers = \"1GB\"")
+		assertSnapshotEqual(t, diff)
 	})
 
 	t.Run("handles api disabled on local side", func(t *testing.T) {
@@ -148,9 +141,7 @@ func TestDbSettingsDiffWithRemote(t *testing.T) {
 		diff, err := db.Settings.DiffWithRemote(remoteConfig)
 		assert.NoError(t, err)
 
-		assert.Contains(t, string(diff), "-effective_cache_size = \"4GB\"")
-		assert.Contains(t, string(diff), "-max_connections = 100")
-		assert.Contains(t, string(diff), "-shared_buffers = \"1GB\"")
+		assertSnapshotEqual(t, diff)
 	})
 }
 

--- a/pkg/config/testdata/TestApiDiff/detects_differences.diff
+++ b/pkg/config/testdata/TestApiDiff/detects_differences.diff
@@ -1,0 +1,14 @@
+diff remote[api] local[api]
+--- remote[api]
++++ local[api]
+@@ -1,7 +1,7 @@
+ enabled = true
+-schemas = ["public"]
+-extra_search_path = ["public"]
+-max_rows = 500
++schemas = ["public", "private"]
++extra_search_path = ["extensions", "public"]
++max_rows = 1000
+ port = 0
+ external_url = ""
+ 

--- a/pkg/config/testdata/TestApiDiff/handles_api_disabled_on_local_side.diff
+++ b/pkg/config/testdata/TestApiDiff/handles_api_disabled_on_local_side.diff
@@ -1,0 +1,9 @@
+diff remote[api] local[api]
+--- remote[api]
++++ local[api]
+@@ -1,4 +1,4 @@
+-enabled = true
++enabled = false
+ schemas = ["public"]
+ extra_search_path = ["public"]
+ max_rows = 500

--- a/pkg/config/testdata/TestApiDiff/handles_api_disabled_on_remote_side.diff
+++ b/pkg/config/testdata/TestApiDiff/handles_api_disabled_on_remote_side.diff
@@ -1,0 +1,9 @@
+diff remote[api] local[api]
+--- remote[api]
++++ local[api]
+@@ -1,4 +1,4 @@
+-enabled = false
++enabled = true
+ schemas = ["public", "private"]
+ extra_search_path = ["extensions", "public"]
+ max_rows = 500

--- a/pkg/config/testdata/TestDbSettingsDiff/detects_differences.diff
+++ b/pkg/config/testdata/TestDbSettingsDiff/detects_differences.diff
@@ -1,0 +1,10 @@
+diff remote[db.settings] local[db.settings]
+--- remote[db.settings]
++++ local[db.settings]
+@@ -1,3 +1,3 @@
+-effective_cache_size = "8GB"
+-max_connections = 200
+-shared_buffers = "2GB"
++effective_cache_size = "4GB"
++max_connections = 100
++shared_buffers = "1GB"

--- a/pkg/config/testdata/TestDbSettingsDiff/handles_api_disabled_on_local_side.diff
+++ b/pkg/config/testdata/TestDbSettingsDiff/handles_api_disabled_on_local_side.diff
@@ -1,0 +1,7 @@
+diff remote[db.settings] local[db.settings]
+--- remote[db.settings]
++++ local[db.settings]
+@@ -1,3 +0,0 @@
+-effective_cache_size = "4GB"
+-max_connections = 100
+-shared_buffers = "1GB"

--- a/pkg/config/testdata/TestDbSettingsDiff/handles_api_disabled_on_remote_side.diff
+++ b/pkg/config/testdata/TestDbSettingsDiff/handles_api_disabled_on_remote_side.diff
@@ -1,0 +1,7 @@
+diff remote[db.settings] local[db.settings]
+--- remote[db.settings]
++++ local[db.settings]
+@@ -0,0 +1,3 @@
++effective_cache_size = "4GB"
++max_connections = 100
++shared_buffers = "1GB"

--- a/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
+++ b/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
@@ -1,0 +1,38 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -49,13 +49,13 @@
+ inactivity_timeout = "0s"
+ 
+ [email]
+-enable_signup = true
+-double_confirm_changes = true
+-enable_confirmations = true
+-secure_password_change = true
+-max_frequency = "1s"
+-otp_length = 6
+-otp_expiry = 3600
++enable_signup = false
++double_confirm_changes = false
++enable_confirmations = false
++secure_password_change = false
++max_frequency = "1m0s"
++otp_length = 8
++otp_expiry = 86400
+ [email.template]
+ [email.template.confirmation]
+ content_path = ""
+@@ -69,13 +69,6 @@
+ content_path = ""
+ [email.template.recovery]
+ content_path = ""
+-[email.smtp]
+-host = "smtp.sendgrid.net"
+-port = 587
+-user = "apikey"
+-pass = "hash:ed64b7695a606bc6ab4fcb41fe815b5ddf1063ccbc87afe1fa89756635db520e"
+-admin_email = "admin@email.com"
+-sender_name = "Admin"
+ 
+ [sms]
+ enable_signup = false

--- a/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
+++ b/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
@@ -1,0 +1,55 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -49,28 +49,43 @@
+ inactivity_timeout = "0s"
+ 
+ [email]
+-enable_signup = false
+-double_confirm_changes = false
+-enable_confirmations = false
+-secure_password_change = false
+-max_frequency = "1m0s"
+-otp_length = 6
+-otp_expiry = 3600
++enable_signup = true
++double_confirm_changes = true
++enable_confirmations = true
++secure_password_change = true
++max_frequency = "1s"
++otp_length = 8
++otp_expiry = 86400
+ [email.template]
+ [email.template.confirmation]
++subject = "confirmation-subject"
+ content_path = ""
+ [email.template.email_change]
++subject = "email-change-subject"
+ content = "email-change-content"
+ content_path = ""
+ [email.template.invite]
++subject = "invite-subject"
++content = "invite-content"
+ content_path = ""
+ [email.template.magic_link]
+ subject = "magic-link-subject"
++content = "magic-link-content"
+ content_path = ""
+ [email.template.reauthentication]
++subject = ""
++content = ""
+ content_path = ""
+ [email.template.recovery]
+-content_path = ""
++content = "recovery-content"
++content_path = ""
++[email.smtp]
++host = "smtp.sendgrid.net"
++port = 587
++user = "apikey"
++pass = "hash:ed64b7695a606bc6ab4fcb41fe815b5ddf1063ccbc87afe1fa89756635db520e"
++admin_email = "admin@email.com"
++sender_name = "Admin"
+ 
+ [sms]
+ enable_signup = false

--- a/pkg/config/testdata/TestExternalDiff/local_enabled_and_disabled.diff
+++ b/pkg/config/testdata/TestExternalDiff/local_enabled_and_disabled.diff
@@ -1,0 +1,21 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -88,7 +88,7 @@
+ 
+ [external]
+ [external.apple]
+-enabled = false
++enabled = true
+ client_id = "test-client-1,test-client-2"
+ secret = "hash:ce62bb9bcced294fd4afe668f8ab3b50a89cf433093c526fffa3d0e46bf55252"
+ url = ""
+@@ -144,7 +144,7 @@
+ redirect_uri = ""
+ skip_nonce_check = false
+ [external.google]
+-enabled = true
++enabled = false
+ client_id = ""
+ secret = ""
+ url = ""

--- a/pkg/config/testdata/TestHookDiff/local_enabled_and_disabled.diff
+++ b/pkg/config/testdata/TestHookDiff/local_enabled_and_disabled.diff
@@ -1,0 +1,21 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -9,7 +9,7 @@
+ 
+ [hook]
+ [hook.mfa_verification_attempt]
+-enabled = true
++enabled = false
+ uri = ""
+ secrets = ""
+ [hook.password_verification_attempt]
+@@ -17,7 +17,7 @@
+ uri = ""
+ secrets = ""
+ [hook.custom_access_token]
+-enabled = false
++enabled = true
+ uri = ""
+ secrets = "hash:b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad"
+ [hook.send_sms]

--- a/pkg/config/testdata/TestMfaDiff/local_enabled_and_disabled.diff
+++ b/pkg/config/testdata/TestMfaDiff/local_enabled_and_disabled.diff
@@ -1,0 +1,26 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -30,16 +30,16 @@
+ secrets = ""
+ 
+ [mfa]
+-max_enrolled_factors = 10
++max_enrolled_factors = 0
+ [mfa.totp]
+ enroll_enabled = false
+ verify_enabled = false
+ [mfa.phone]
+-enroll_enabled = false
+-verify_enabled = false
+-otp_length = 6
+-template = "Your code is {{ .Code }}"
+-max_frequency = "5s"
++enroll_enabled = true
++verify_enabled = true
++otp_length = 0
++template = ""
++max_frequency = "0s"
+ [mfa.web_authn]
+ enroll_enabled = false
+ verify_enabled = false

--- a/pkg/config/testdata/TestSmsDiff/enable_sign_up_without_provider.diff
+++ b/pkg/config/testdata/TestSmsDiff/enable_sign_up_without_provider.diff
@@ -1,0 +1,12 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -58,7 +58,7 @@
+ otp_expiry = 0
+ 
+ [sms]
+-enable_signup = false
++enable_signup = true
+ enable_confirmations = false
+ template = ""
+ max_frequency = "0s"

--- a/pkg/config/testdata/TestSmsDiff/local_disabled_remote_enabled.diff
+++ b/pkg/config/testdata/TestSmsDiff/local_disabled_remote_enabled.diff
@@ -1,0 +1,31 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -58,12 +58,12 @@
+ otp_expiry = 0
+ 
+ [sms]
+-enable_signup = true
+-enable_confirmations = true
+-template = "Your code is {{ .Code }}"
+-max_frequency = "1m0s"
++enable_signup = false
++enable_confirmations = false
++template = ""
++max_frequency = "0s"
+ [sms.twilio]
+-enabled = true
++enabled = false
+ account_sid = ""
+ message_service_sid = ""
+ auth_token = ""
+@@ -85,9 +85,6 @@
+ from = ""
+ api_key = ""
+ api_secret = ""
+-[sms.test_otp]
+-123 = "456"
+-456 = "123"
+ 
+ [third_party]
+ [third_party.firebase]

--- a/pkg/config/testdata/TestSmsDiff/local_enabled_remote_disabled.diff
+++ b/pkg/config/testdata/TestSmsDiff/local_enabled_remote_disabled.diff
@@ -1,0 +1,43 @@
+diff remote[auth] local[auth]
+--- remote[auth]
++++ local[auth]
+@@ -58,12 +58,12 @@
+ otp_expiry = 0
+ 
+ [sms]
+-enable_signup = false
+-enable_confirmations = false
+-template = ""
+-max_frequency = "0s"
++enable_signup = true
++enable_confirmations = true
++template = "Your code is {{ .Code }}"
++max_frequency = "1m0s"
+ [sms.twilio]
+-enabled = true
++enabled = false
+ account_sid = ""
+ message_service_sid = ""
+ auth_token = ""
+@@ -73,9 +73,9 @@
+ message_service_sid = ""
+ auth_token = ""
+ [sms.messagebird]
+-enabled = false
+-originator = ""
+-access_key = "hash:"
++enabled = true
++originator = "test-originator"
++access_key = "hash:ab60d03fc809fb02dae838582f3ddc13d1d6cb32ffba77c4b969dd3caa496f13"
+ [sms.textlocal]
+ enabled = false
+ sender = ""
+@@ -85,6 +85,8 @@
+ from = ""
+ api_key = ""
+ api_secret = ""
++[sms.test_otp]
++123 = "456"
+ 
+ [third_party]
+ [third_party.firebase]


### PR DESCRIPTION
## What kind of change does this PR introduce?

part 6 of https://github.com/supabase/cli/pull/2814

## What is the new behavior?

Loads email template from `content_path` to `Content` field for remote diff.

## Additional context

Added `assertSnapshotEqual` test utility.
- Run tests after `rm -rf testdata/**/*.diff` to initialise snapshot files
- Run tests again to assert equality on subsequent changes
