### PR TITLE
fix(postgres-config): always restart if --no-restart is omitted

### DIFF
--- a/internal/postgresConfig/update/update.go
+++ b/internal/postgresConfig/update/update.go
@@ -50,9 +50,8 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 	}
 	// 4. update config overrides and print out final result
 	{
-		if noRestart {
-			finalOverrides["restart_database"] = false
-		}
+		// Should always restart database except if --no-restart flag is provided
+		finalOverrides["restart_database"] = !noRestart
 		bts, err := json.Marshal(finalOverrides)
 		if err != nil {
 			return errors.Errorf("failed to serialize config overrides: %w", err)


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the new api changes: https://github.com/supabase/infrastructure/pull/20462

We must always the `restart_database` setting to the endpoint. Otherwise we go from the logic of "always restart except if --no-restart is specified" to a "restart only if the changed settings require a restart and --no-restart is not specified".

Which in the case of `maintenance_work_mem` might sometimes don't work as expected


Related: https://app.hubspot.com/live-messages/19953346/inbox/8348874005#comment


PS: An alternative would be to mark `maintenance_work_mem` as a parameter requiring restart on api side, but according to this documentation: https://postgresqlco.nf/doc/en/param/maintenance_work_mem/ it isn't the case.


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
