### PR TITLE
feat: support config push command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"os"
+	"os/signal"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/config/push"
+	"github.com/supabase/cli/internal/utils/flags"
+)
+
+var (
+	configCmd = &cobra.Command{
+		GroupID: groupManagementAPI,
+		Use:     "config",
+		Short:   "Manage Supabase project configurations",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			cmd.SetContext(ctx)
+			return cmd.Root().PersistentPreRunE(cmd, args)
+		},
+	}
+
+	configPushCmd = &cobra.Command{
+		Use:   "push",
+		Short: "Pushes local config.toml to the linked project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return push.Run(cmd.Context(), flags.ProjectRef, afero.NewOsFs())
+		},
+	}
+)
+
+func init() {
+	configCmd.PersistentFlags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
+	configCmd.AddCommand(configPushCmd)
+	rootCmd.AddCommand(configCmd)
+}

--- a/internal/config/push/push.go
+++ b/internal/config/push/push.go
@@ -1,0 +1,30 @@
+package push
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/config"
+)
+
+func Run(ctx context.Context, ref string, fsys afero.Fs) error {
+	if err := utils.LoadConfigFS(fsys); err != nil {
+		return err
+	}
+	client := config.NewConfigUpdater(*utils.GetSupabase())
+	fmt.Fprintln(os.Stderr, "Pushing config to project:", ref)
+	remote, _ := utils.Config.GetRemoteByProjectRef(ref)
+	console := utils.NewConsole()
+	keep := func(name string) bool {
+		title := fmt.Sprintf("Do you want to push %s config to remote?", name)
+		shouldPush, err := console.PromptYesNo(ctx, title, true)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		return shouldPush
+	}
+	return client.UpdateRemoteConfig(ctx, remote, keep)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Running `supabase config push` will prompt user to update linked project's config to match local config.toml. For eg.

```
Pushing config to project: vpefcjyosynxeiebfscx
Updating API service with config: diff remote[api] local[api]
--- remote[api]
+++ local[api]
@@ -1,7 +1,7 @@
 enabled = true
 schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
-max_rows = 1000
+max_rows = 100
 port = 54321
 external_url = "https://127.0.0.1:54321"


Do you want to push api config to remote? [Y/n]
```

Answering `Y` (default) will call mgmt-api to update config, `n` will skip to next config, and ctrl + c will abort the update.

## Additional context

Add any other context or screenshots.
