### PR TITLE
fix: do not abort function reqs after 200s

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -187,14 +187,7 @@ Deno.serve({
         maybeEntrypoint
       });
 
-      const controller = new AbortController();
-      const { signal } = controller;
-
-      // Note: Requests are aborted after 200s (same config as in production)
-      // TODO: make this configuarable
-      setTimeout(() => controller.abort(), 200 * 1000);
-
-      return await worker.fetch(req, { signal });
+      return await worker.fetch(req);
     } catch (e) {
       console.error(e);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hosted platform doesn't do this anymore. There's a request idle timeout of 150s (https://supabase.com/docs/guides/functions/limits). This is built into the edge-runtime itself.
