### PR TITLE
fix: bump edge-runtime to 1.62.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.62.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.62.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.163.2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.62.2

### Changes

### [1.62.2](https://github.com/supabase/edge-runtime/compare/v1.62.1...v1.62.2) (2024-11-13)

#### Bug Fixes

* **sb_ai:** Sessions are dropped while still in use ([#443](https://github.com/supabase/edge-runtime/issues/443)) ([e522925](https://github.com/supabase/edge-runtime/commit/e522925c480951576d6f3e732f0bf7881b94c063)) (@kallebysantos)