### PR TITLE
fix: use base config when no remote is declared

### DIFF
--- a/internal/config/push/push.go
+++ b/internal/config/push/push.go
@@ -15,8 +15,12 @@ func Run(ctx context.Context, ref string, fsys afero.Fs) error {
 		return err
 	}
 	client := config.NewConfigUpdater(*utils.GetSupabase())
-	fmt.Fprintln(os.Stderr, "Pushing config to project:", ref)
-	remote, _ := utils.Config.GetRemoteByProjectRef(ref)
+	remote, err := utils.Config.GetRemoteByProjectRef(ref)
+	if err != nil {
+		// Use base config when no remote is declared
+		remote.ProjectId = ref
+	}
+	fmt.Fprintln(os.Stderr, "Pushing config to project:", remote.ProjectId)
 	console := utils.NewConsole()
 	keep := func(name string) bool {
 		title := fmt.Sprintf("Do you want to push %s config to remote?", name)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Overrides local project id when no remote is declared.

## Additional context

Add any other context or screenshots.
