### PR TITLE
fix: enable readFileSyncAPI in user workers

### DIFF
--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -184,7 +184,10 @@ Deno.serve({
         cpuTimeSoftLimitMs,
         cpuTimeHardLimitMs,
         decoratorType,
-        maybeEntrypoint
+        maybeEntrypoint,
+        context: {
+          useReadSyncFileAPI: true,
+        },
       });
 
       return await worker.fetch(req);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Need to enable readFileSync API since edge-runtime 1.62.1 explicitly
