### PR TITLE
fix: account for remotes when resetting local db

### DIFF
--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -2,11 +2,14 @@ package apply
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
@@ -22,10 +25,12 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 }
 
 func applySeedFiles(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
-	if !utils.Config.Db.Seed.Enabled {
+	remote, _ := utils.Config.GetRemoteByProjectRef(flags.ProjectRef)
+	if !remote.Db.Seed.Enabled {
+		fmt.Fprintln(os.Stderr, "Skipping seed because it is disabled in config.toml for project:", remote.ProjectId)
 		return nil
 	}
-	seeds, err := migration.GetPendingSeeds(ctx, utils.Config.Db.Seed.SqlPaths, conn, afero.NewIOFS(fsys))
+	seeds, err := migration.GetPendingSeeds(ctx, remote.Db.Seed.SqlPaths, conn, afero.NewIOFS(fsys))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2774

## What is the new behavior?

`db start | reset` should account for remotes declared in config.toml.

```
[remotes.staging]
project_id = "staging-project-ref"

[remotes.staging.db.seed]
enabled = true
sql_paths = ["seeds/*.sql"]
```

## Additional context

Add any other context or screenshots.
