### PR TITLE
fix: increment auth version to v2.164.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,7 +15,7 @@ const (
 	edgeRuntimeImage = "supabase/edge-runtime:v1.61.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
-	gotrueImage      = "supabase/gotrue:v2.163.2"
+	gotrueImage      = "supabase/gotrue:v2.164.0"
 	realtimeImage    = "supabase/realtime:v2.30.34"
 	storageImage     = "supabase/storage-api:v1.11.13"
 	logflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Main changes described here: https://github.com/supabase/auth/compare/v2.163.2...v2.164.0