### PR TITLE
fix: drop webhooks request history on remote reset

### DIFF
--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -33,12 +33,13 @@ begin
     execute format('drop table if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
   end loop;
 
-  -- truncate tables in auth and migrations schema
+  -- truncate tables in auth, webhooks, and migrations schema
   for rec in
     select *
     from pg_class c
     where
       (c.relnamespace::regnamespace::name = 'auth' and c.relname != 'schema_migrations'
+      or c.relnamespace::regnamespace::name = 'supabase_functions' and c.relname != 'migrations'
       or c.relnamespace::regnamespace::name = 'supabase_migrations')
       and c.relkind = 'r'
   loop


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2696

## What is the new behavior?

Also clears `supabase_functions.hooks` table on reset.

## Additional context

Add any other context or screenshots.
