### PR TITLE
feat: diff auth and storage config on link

### DIFF
--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -51,19 +51,38 @@ func TestLinkCommand(t *testing.T) {
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		// Mock project status
+		postgres := api.V1DatabaseResponse{
+			Host:    utils.GetSupabaseDbHost(project),
+			Version: "15.1.0.117",
+		}
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project).
 			Reply(200).
-			JSON(api.V1ProjectResponse{Status: api.V1ProjectResponseStatusACTIVEHEALTHY})
+			JSON(api.V1ProjectResponse{
+				Status:   api.V1ProjectResponseStatusACTIVEHEALTHY,
+				Database: &postgres,
+			})
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
 			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		// Link configs
 		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/database/postgres").
+			Reply(200).
+			JSON(api.PostgresConfigResponse{})
+		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/postgrest").
 			Reply(200).
 			JSON(api.V1PostgrestConfigResponse{})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/auth").
+			Reply(200).
+			JSON(api.AuthConfigResponse{})
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/storage").
+			Reply(200).
+			JSON(api.StorageConfigResponse{})
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/config/database/pooler").
 			Reply(200).
@@ -83,23 +102,6 @@ func TestLinkCommand(t *testing.T) {
 			Get("/storage/v1/version").
 			Reply(200).
 			BodyString("0.40.4")
-		postgres := api.V1DatabaseResponse{
-			Host:    utils.GetSupabaseDbHost(project),
-			Version: "15.1.0.117",
-		}
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects").
-			Reply(200).
-			JSON([]api.V1ProjectResponse{
-				{
-					Id:             project,
-					Database:       &postgres,
-					OrganizationId: "combined-fuchsia-lion",
-					Name:           "Test Project",
-					Region:         "us-west-1",
-					CreatedAt:      "2022-04-25T02:14:55.906498Z",
-				},
-			})
 		// Run test
 		err := Run(context.Background(), project, fsys, conn.Intercept)
 		// Check error
@@ -130,14 +132,26 @@ func TestLinkCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project).
 			Reply(200).
-			JSON(api.V1ProjectResponse{Status: api.V1ProjectResponseStatusACTIVEHEALTHY})
+			JSON(api.V1ProjectResponse{
+				Status:   api.V1ProjectResponseStatusACTIVEHEALTHY,
+				Database: &api.V1DatabaseResponse{},
+			})
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
 			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		// Link configs
 		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/database/postgres").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/postgrest").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/auth").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/storage").
 			ReplyError(errors.New("network error"))
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/config/database/pooler").
@@ -151,9 +165,6 @@ func TestLinkCommand(t *testing.T) {
 			ReplyError(errors.New("network error"))
 		gock.New("https://" + utils.GetSupabaseHost(project)).
 			Get("/storage/v1/version").
-			ReplyError(errors.New("network error"))
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects").
 			ReplyError(errors.New("network error"))
 		// Run test
 		err := Run(context.Background(), project, fsys, func(cc *pgx.ConnConfig) {
@@ -175,14 +186,26 @@ func TestLinkCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project).
 			Reply(200).
-			JSON(api.V1ProjectResponse{Status: api.V1ProjectResponseStatusACTIVEHEALTHY})
+			JSON(api.V1ProjectResponse{
+				Status:   api.V1ProjectResponseStatusACTIVEHEALTHY,
+				Database: &api.V1DatabaseResponse{},
+			})
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/api-keys").
 			Reply(200).
 			JSON([]api.ApiKeyResponse{{Name: "anon", ApiKey: "anon-key"}})
 		// Link configs
 		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/database/postgres").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/postgrest").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/auth").
+			ReplyError(errors.New("network error"))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/config/storage").
 			ReplyError(errors.New("network error"))
 		gock.New(utils.DefaultApiHost).
 			Get("/v1/projects/" + project + "/config/database/pooler").
@@ -215,7 +238,32 @@ func TestLinkCommand(t *testing.T) {
 func TestStatusCheck(t *testing.T) {
 	project := "test-project"
 
+	t.Run("updates postgres version when healthy", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		// Mock project status
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project).
+			Reply(http.StatusOK).
+			JSON(api.V1ProjectResponse{
+				Status:   api.V1ProjectResponseStatusACTIVEHEALTHY,
+				Database: &api.V1DatabaseResponse{Version: "15.6.1.139"},
+			})
+		// Run test
+		err := checkRemoteProjectStatus(context.Background(), project, fsys)
+		// Check error
+		assert.NoError(t, err)
+		version, err := afero.ReadFile(fsys, utils.PostgresVersionPath)
+		assert.NoError(t, err)
+		assert.Equal(t, "15.6.1.139", string(version))
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
 	t.Run("ignores project not found", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		// Mock project status
@@ -223,13 +271,18 @@ func TestStatusCheck(t *testing.T) {
 			Get("/v1/projects/" + project).
 			Reply(http.StatusNotFound)
 		// Run test
-		err := checkRemoteProjectStatus(context.Background(), project)
+		err := checkRemoteProjectStatus(context.Background(), project, fsys)
 		// Check error
 		assert.NoError(t, err)
+		exists, err := afero.Exists(fsys, utils.PostgresVersionPath)
+		assert.NoError(t, err)
+		assert.False(t, exists)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
 	t.Run("throws error on project inactive", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		// Mock project status
@@ -238,9 +291,12 @@ func TestStatusCheck(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(api.V1ProjectResponse{Status: api.V1ProjectResponseStatusINACTIVE})
 		// Run test
-		err := checkRemoteProjectStatus(context.Background(), project)
+		err := checkRemoteProjectStatus(context.Background(), project, fsys)
 		// Check error
 		assert.ErrorIs(t, err, errProjectPaused)
+		exists, err := afero.Exists(fsys, utils.PostgresVersionPath)
+		assert.NoError(t, err)
+		assert.False(t, exists)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }
@@ -309,7 +365,7 @@ func TestLinkPostgrest(t *testing.T) {
 		// Run test
 		err := linkPostgrest(context.Background(), project)
 		// Validate api
-		assert.ErrorIs(t, err, tenant.ErrAuthToken)
+		assert.ErrorContains(t, err, `unexpected API config status 500: {"message":"unavailable"}`)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -55,7 +55,7 @@ func (a *api) ToUpdatePostgrestConfigBody() v1API.UpdatePostgrestConfigBody {
 	return body
 }
 
-func (a *api) fromRemoteApiConfig(remoteConfig v1API.PostgrestConfigWithJWTSecretResponse) {
+func (a *api) FromRemoteApiConfig(remoteConfig v1API.PostgrestConfigWithJWTSecretResponse) {
 	if a.Enabled = len(remoteConfig.DbSchema) > 0; !a.Enabled {
 		return
 	}
@@ -84,7 +84,7 @@ func (a *api) DiffWithRemote(remoteConfig v1API.PostgrestConfigWithJWTSecretResp
 	if err != nil {
 		return nil, err
 	}
-	copy.fromRemoteApiConfig(remoteConfig)
+	copy.FromRemoteApiConfig(remoteConfig)
 	remoteCompare, err := ToTomlBytes(copy)
 	if err != nil {
 		return nil, err

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -202,7 +202,7 @@ func (a *auth) ToUpdateAuthConfigBody() v1API.UpdateAuthConfigBody {
 	return body
 }
 
-func (a *auth) fromRemoteAuthConfig(remoteConfig v1API.AuthConfigResponse) {
+func (a *auth) FromRemoteAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	a.SiteUrl = cast.Val(remoteConfig.SiteUrl, "")
 	a.AdditionalRedirectUrls = strToArr(cast.Val(remoteConfig.UriAllowList, ""))
 	a.JwtExpiry = cast.IntToUint(cast.Val(remoteConfig.JwtExp, 0))
@@ -775,13 +775,13 @@ func (e external) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 
 func (a *auth) DiffWithRemote(projectRef string, remoteConfig v1API.AuthConfigResponse) ([]byte, error) {
 	copy := a.Clone()
-	copy.hashSecrets(projectRef)
+	copy.HashSecrets(projectRef)
 	// Convert the config values into easily comparable remoteConfig values
 	currentValue, err := ToTomlBytes(copy)
 	if err != nil {
 		return nil, err
 	}
-	copy.fromRemoteAuthConfig(remoteConfig)
+	copy.FromRemoteAuthConfig(remoteConfig)
 	remoteCompare, err := ToTomlBytes(copy)
 	if err != nil {
 		return nil, err
@@ -791,7 +791,7 @@ func (a *auth) DiffWithRemote(projectRef string, remoteConfig v1API.AuthConfigRe
 
 const hashPrefix = "hash:"
 
-func (a *auth) hashSecrets(key string) {
+func (a *auth) HashSecrets(key string) {
 	hash := func(v string) string {
 		return hashPrefix + sha256Hmac(key, v)
 	}

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -112,7 +112,7 @@ func (a *settings) ToUpdatePostgresConfigBody() v1API.UpdatePostgresConfigBody {
 	return body
 }
 
-func (a *settings) fromRemoteConfig(remoteConfig v1API.PostgresConfigResponse) {
+func (a *settings) FromRemotePostgresConfig(remoteConfig v1API.PostgresConfigResponse) {
 	a.EffectiveCacheSize = remoteConfig.EffectiveCacheSize
 	a.LogicalDecodingWorkMem = remoteConfig.LogicalDecodingWorkMem
 	a.MaintenanceWorkMem = remoteConfig.MaintenanceWorkMem
@@ -155,7 +155,7 @@ func (a *settings) DiffWithRemote(remoteConfig v1API.PostgresConfigResponse) ([]
 	if err != nil {
 		return nil, err
 	}
-	copy.fromRemoteConfig(remoteConfig)
+	copy.FromRemotePostgresConfig(remoteConfig)
 	remoteCompare, err := ToTomlBytes(copy)
 	if err != nil {
 		return nil, err

--- a/pkg/config/storage.go
+++ b/pkg/config/storage.go
@@ -44,7 +44,7 @@ func (s *storage) ToUpdateStorageConfigBody() v1API.UpdateStorageConfigBody {
 	return body
 }
 
-func (s *storage) fromRemoteStorageConfig(remoteConfig v1API.StorageConfigResponse) {
+func (s *storage) FromRemoteStorageConfig(remoteConfig v1API.StorageConfigResponse) {
 	s.FileSizeLimit = sizeInBytes(remoteConfig.FileSizeLimit)
 	s.ImageTransformation.Enabled = remoteConfig.Features.ImageTransformation.Enabled
 }
@@ -56,7 +56,7 @@ func (s *storage) DiffWithRemote(remoteConfig v1API.StorageConfigResponse) ([]by
 	if err != nil {
 		return nil, err
 	}
-	copy.fromRemoteStorageConfig(remoteConfig)
+	copy.FromRemoteStorageConfig(remoteConfig)
 	remoteCompare, err := ToTomlBytes(copy)
 	if err != nil {
 		return nil, err

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -146,7 +146,7 @@ enable_signup = false
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ `{{ .Code }}` }} ."
+template = "Your code is {{ `{{ .Code }}` }}"
 # Controls the minimum amount of time that must pass before sending another sms otp.
 max_frequency = "5s"
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -142,7 +142,7 @@ enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ `{{ .Code }}` }} ."
+template = "Your code is {{ `{{ .Code }}` }}"
 # Controls the minimum amount of time that must pass before sending another sms otp.
 max_frequency = "5s"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Diff configs by merging mgmt-api response to local struct.

```
WARNING: Project status is RESTORING instead of Active Healthy. Some operations might fail.
Enter your database password (or leave blank to skip):
Finished supabase link.
WARNING: Local config differs from linked project. Try updating supabase/config.toml
diff supabase/config.toml ljkpogxamxkdhowzcjvo
--- supabase/config.toml
+++ ljkpogxamxkdhowzcjvo
@@ -2,7 +2,7 @@

 [api]
 enabled = true
-schemas = ["public", "graphql_public"]
+schemas = ["public", "storage", "graphql_public"]
```

## Additional context

A simpler change than https://github.com/supabase/cli/pull/2895