### PR TITLE
fix(reset): ensure _supabase connections disconnect before reset

### DIFF
--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -46,6 +46,10 @@ func TestSwitchCommand(t *testing.T) {
 			Reply("ALTER DATABASE").
 			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
 			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
+			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").
 			Query("ALTER DATABASE " + branch + " RENAME TO postgres;").
@@ -238,6 +242,10 @@ func TestSwitchDatabase(t *testing.T) {
 			Reply("ALTER DATABASE").
 			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
 			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
+			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			ReplyError(pgerrcode.DuplicateDatabase, `database "main" already exists`)
 		// Setup mock docker
@@ -263,6 +271,10 @@ func TestSwitchDatabase(t *testing.T) {
 		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
 			Reply("ALTER DATABASE").
 			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
 			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").

--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -42,13 +42,9 @@ func TestSwitchCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
-			Reply("DO").
-			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").
@@ -222,7 +218,7 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
 			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
 		// Run test
 		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
@@ -238,13 +234,9 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
-			Reply("DO").
-			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			ReplyError(pgerrcode.DuplicateDatabase, `database "main" already exists`)
@@ -268,13 +260,9 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
-			Reply("DO").
-			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			Reply("DO").
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").

--- a/internal/db/branch/switch_/switch__test.go
+++ b/internal/db/branch/switch_/switch__test.go
@@ -2,7 +2,6 @@ package switch_
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/db/reset"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/pgtest"
@@ -42,10 +42,14 @@ func TestSwitchCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			Reply("DO").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query(reset.TERMINATE_BACKENDS).
+			Reply("SELECT 1").
+			Query(reset.COUNT_REPLICATION_SLOTS).
+			Reply("SELECT 1", []interface{}{0}).
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").
 			Query("ALTER DATABASE " + branch + " RENAME TO postgres;").
@@ -218,8 +222,10 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`).
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Query(reset.TERMINATE_BACKENDS)
 		// Run test
 		err := switchDatabase(context.Background(), "main", "target", conn.Intercept)
 		// Check error
@@ -234,10 +240,14 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			Reply("DO").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query(reset.TERMINATE_BACKENDS).
+			Reply("SELECT 1").
+			Query(reset.COUNT_REPLICATION_SLOTS).
+			Reply("SELECT 1", []interface{}{0}).
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			ReplyError(pgerrcode.DuplicateDatabase, `database "main" already exists`)
 		// Setup mock docker
@@ -260,10 +270,14 @@ func TestSwitchDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			Reply("DO").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query(reset.TERMINATE_BACKENDS).
+			Reply("SELECT 1").
+			Query(reset.COUNT_REPLICATION_SLOTS).
+			Reply("SELECT 1", []interface{}{0}).
 			Query("ALTER DATABASE postgres RENAME TO main;").
 			Reply("ALTER DATABASE").
 			Query("ALTER DATABASE target RENAME TO postgres;").

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -146,12 +146,12 @@ func CreateShadowDatabase(ctx context.Context, port uint16) (string, error) {
 
 func ConnectShadowDatabase(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {
 	// Retry until connected, cancelled, or timeout
-	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), uint64(timeout.Seconds()))
+	policy := start.NewBackoffPolicy(ctx, timeout)
 	config := pgconn.Config{Port: utils.Config.Db.ShadowPort}
 	connect := func() (*pgx.Conn, error) {
 		return utils.ConnectLocalPostgres(ctx, config, options...)
 	}
-	return backoff.RetryWithData(connect, backoff.WithContext(policy, ctx))
+	return backoff.RetryWithData(connect, policy)
 }
 
 func MigrateShadowDatabase(ctx context.Context, container string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -166,16 +166,18 @@ func recreateDatabase(ctx context.Context, options ...func(*pgx.ConnConfig)) err
 
 func DisconnectClients(ctx context.Context, conn *pgx.Conn) error {
 	// Must be executed separately because running in transaction is unsupported
-	disconn := "ALTER DATABASE postgres ALLOW_CONNECTIONS false;"
-	if _, err := conn.Exec(ctx, disconn); err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code != pgerrcode.InvalidCatalogName {
-			return errors.Errorf("failed to disconnect clients: %w", err)
+	for _, dbName := range []string{"postgres", "_supabase"} {
+		disconn := fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS false;", dbName)
+		if _, err := conn.Exec(ctx, disconn); err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code != pgerrcode.InvalidCatalogName {
+				return errors.Errorf("failed to disconnect clients from %s: %w", dbName, err)
+			}
 		}
-	}
-	term := fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")
-	if _, err := conn.Exec(ctx, term); err != nil {
-		return errors.Errorf("failed to terminate backend: %w", err)
+		term := fmt.Sprintf(utils.TerminateDbSqlFmt, dbName)
+		if _, err := conn.Exec(ctx, term); err != nil {
+			return errors.Errorf("failed to terminate backend for %s: %w", dbName, err)
+		}
 	}
 	return nil
 }

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -3,7 +3,6 @@ package reset
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -202,10 +201,14 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
 			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query(TERMINATE_BACKENDS).
+			Reply("SELECT 1").
+			Query(COUNT_REPLICATION_SLOTS).
+			Reply("SELECT 1", []interface{}{0}).
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			Reply("DROP DATABASE").
 			Query("CREATE DATABASE postgres WITH OWNER postgres").
@@ -228,14 +231,17 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			ReplyError(pgerrcode.UndefinedTable, `relation "pg_stat_activity" does not exist`)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			ReplyError(pgerrcode.InvalidCatalogName, `database "_supabase" does not exist`).
+			Query(TERMINATE_BACKENDS).
+			Query(COUNT_REPLICATION_SLOTS).
+			ReplyError(pgerrcode.UndefinedTable, `relation "pg_replication_slots" does not exist`)
 		// Run test
 		err := recreateDatabase(context.Background(), conn.Intercept)
 		// Check error
-		assert.ErrorContains(t, err, `ERROR: relation "pg_stat_activity" does not exist (SQLSTATE 42P01)`)
+		assert.ErrorContains(t, err, `ERROR: relation "pg_replication_slots" does not exist (SQLSTATE 42P01)`)
 	})
 
 	t.Run("throws error on failure to disconnect", func(t *testing.T) {
@@ -243,8 +249,10 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
+			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`).
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Query(TERMINATE_BACKENDS)
 		// Run test
 		err := recreateDatabase(context.Background(), conn.Intercept)
 		// Check error
@@ -256,11 +264,14 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false").
 			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
-			Reply("DO").
-			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false").
+			Reply("ALTER DATABASE").
+			Query(TERMINATE_BACKENDS).
+			Reply("SELECT 1").
+			Query(COUNT_REPLICATION_SLOTS).
+			Reply("SELECT 1", []interface{}{0}).
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			ReplyError(pgerrcode.ObjectInUse, `database "postgres" is used by an active logical replication slot`).
 			Query("CREATE DATABASE postgres WITH OWNER postgres").

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -202,13 +202,10 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
 			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			Reply("DO").
-			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			Reply("DROP DATABASE").
 			Query("CREATE DATABASE postgres WITH OWNER postgres").
@@ -231,9 +228,9 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
 			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`).
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			ReplyError(pgerrcode.UndefinedTable, `relation "pg_stat_activity" does not exist`)
 		// Run test
 		err := recreateDatabase(context.Background(), conn.Intercept)
@@ -246,7 +243,7 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
 			ReplyError(pgerrcode.InvalidParameterValue, `cannot disallow connections for current database`)
 		// Run test
 		err := recreateDatabase(context.Background(), conn.Intercept)
@@ -259,13 +256,10 @@ func TestRecreateDatabase(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
-		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
+		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false; ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
 			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres", "_supabase")).
 			Reply("DO").
-			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
-			Reply("ALTER DATABASE").
-			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
 			Reply("DO").
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			ReplyError(pgerrcode.ObjectInUse, `database "postgres" is used by an active logical replication slot`).

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -206,6 +206,9 @@ func TestRecreateDatabase(t *testing.T) {
 			Reply("ALTER DATABASE").
 			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
 			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			Reply("DROP DATABASE").
 			Query("CREATE DATABASE postgres WITH OWNER postgres").
@@ -259,6 +262,10 @@ func TestRecreateDatabase(t *testing.T) {
 		conn.Query("ALTER DATABASE postgres ALLOW_CONNECTIONS false;").
 			Reply("ALTER DATABASE").
 			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "postgres")).
+			Reply("DO").
+			Query("ALTER DATABASE _supabase ALLOW_CONNECTIONS false;").
+			Reply("ALTER DATABASE").
+			Query(fmt.Sprintf(utils.TerminateDbSqlFmt, "_supabase")).
 			Reply("DO").
 			Query("DROP DATABASE IF EXISTS postgres WITH (FORCE)").
 			ReplyError(pgerrcode.ObjectInUse, `database "postgres" is used by an active logical replication slot`).

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -31,18 +31,7 @@ func ShortContainerImageName(imageName string) string {
 	return matches[1]
 }
 
-const (
-	// https://dba.stackexchange.com/a/11895
-	// Args: dbname
-	TerminateDbSqlFmt = `
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('%[1]s', '%[2]s');
--- Wait for WAL sender to drop replication slot.
-DO 'BEGIN WHILE (
-	SELECT COUNT(*) FROM pg_replication_slots WHERE database IN (''%[1]s'', ''%[2]s'')
-) > 0 LOOP END LOOP; END';`
-
-	SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot the error."
-)
+const SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot the error."
 
 var (
 	CmdSuggestion string

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -35,11 +35,12 @@ const (
 	// https://dba.stackexchange.com/a/11895
 	// Args: dbname
 	TerminateDbSqlFmt = `
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%[1]s';
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('%[1]s', '%[2]s');
 -- Wait for WAL sender to drop replication slot.
 DO 'BEGIN WHILE (
-	SELECT COUNT(*) FROM pg_replication_slots WHERE database = ''%[1]s''
+	SELECT COUNT(*) FROM pg_replication_slots WHERE database IN (''%[1]s'', ''%[2]s'')
 ) > 0 LOOP END LOOP; END';`
+
 	SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot the error."
 )
 


### PR DESCRIPTION

## What kind of change does this PR introduce?

- Ensure `db reset` command work properly on postgres v14

The root cause is that while in pg15+ `DATABASE DROP FORCE` kill all connections, it's not the case for pg14. Requiring to manually disconnect all connections before performing the reset.

## Additional context

Closes #2903
