### PR TITLE
fix(realtime): bump realtime image to 2.33.51

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -16,7 +16,7 @@ const (
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"
-	realtimeImage    = "supabase/realtime:v2.30.34"
+	realtimeImage    = "supabase/realtime:v2.33.51"
 	storageImage     = "supabase/storage-api:v1.11.13"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below


### PR DESCRIPTION
Bump realtime image to the latest [version](https://github.com/supabase/realtime/releases/tag/v2.33.51) 