### PR TITLE
chore: remove trailing semicolon from role_configs.sql

### DIFF
--- a/internal/inspect/role_configs/role_configs.sql
+++ b/internal/inspect/role_configs/role_configs.sql
@@ -2,4 +2,4 @@ select
   rolname as role_name,
   array_to_string(rolconfig, ',', '*') as custom_config
 from
-  pg_roles where rolconfig is not null;
+  pg_roles where rolconfig is not null


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Hanging `;` in role-configs

## What is the new behavior?

Fixed

## Additional context

Add any other context or screenshots.
