### PR TITLE
feat(config): allow custom admin and sendername for inbucket

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -532,7 +532,8 @@ EOF
 			env = append(env,
 				"GOTRUE_SMTP_HOST="+utils.InbucketId,
 				"GOTRUE_SMTP_PORT=2500",
-				"GOTRUE_SMTP_ADMIN_EMAIL=admin@email.com",
+				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", utils.Config.Inbucket.AdminEmail),
+				fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", utils.Config.Inbucket.SenderName),
 			)
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,11 +159,13 @@ type (
 	}
 
 	inbucket struct {
-		Enabled  bool   `toml:"enabled"`
-		Image    string `toml:"-"`
-		Port     uint16 `toml:"port"`
-		SmtpPort uint16 `toml:"smtp_port"`
-		Pop3Port uint16 `toml:"pop3_port"`
+		Enabled    bool   `toml:"enabled"`
+		Image      string `toml:"-"`
+		Port       uint16 `toml:"port"`
+		SmtpPort   uint16 `toml:"smtp_port"`
+		Pop3Port   uint16 `toml:"pop3_port"`
+		AdminEmail string `toml:"admin_email"`
+		SenderName string `toml:"sender_name"`
 	}
 
 	edgeRuntime struct {
@@ -327,7 +329,9 @@ func NewConfig(editors ...ConfigEditor) config {
 			JwtSecret: defaultJwtSecret,
 		},
 		Inbucket: inbucket{
-			Image: inbucketImage,
+			Image:      inbucketImage,
+			AdminEmail: "admin@email.com",
+			SenderName: "Admin",
 		},
 		Studio: studio{
 			Image:       studioImage,

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -72,8 +72,8 @@ port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326
-# admin_email = "admin_inbucket@email.com"
-# sender_name = "Admin Inbucket"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
 
 [storage]
 enabled = true

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -72,6 +72,8 @@ port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326
+# admin_email = "admin_inbucket@email.com"
+# sender_name = "Admin Inbucket"
 
 [storage]
 enabled = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add sender_name and admin_email for inbucket service configuration

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Related #2899