### PR TITLE
fix: bump edge-runtime to 1.64.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.62.2"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.64.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.64.1

### Changes

### [1.64.1](https://github.com/supabase/edge-runtime/compare/v1.62.2...v1.64.1) (2024-11-25)

#### Performance Improvements

* **base:** sent low memory notification when worker switches to retired state ([#450](https://github.com/supabase/edge-runtime/issues/450)) ([388d2ea](https://github.com/supabase/edge-runtime/commit/388d2ea69729777f31426bb16d9766d67d902cee))

#### Features

* support dispatching the runtime events ([#351](https://github.com/supabase/edge-runtime/issues/351)) ([997f2d9](https://github.com/supabase/edge-runtime/commit/997f2d9ede86169ceb0651d7560b6f4d966ea0b8))
* exposing `deno_cache` + `ai cache interceptor` ([#446](https://github.com/supabase/edge-runtime/issues/446)) ([13ee2a2](https://github.com/supabase/edge-runtime/commit/13ee2a29dc41b1b049ee9a86ef06c46cf8eb0cfa)) (@kallebysantos)

#### Bug Fixes

* polishing tmp fs and s3 fs ([#444](https://github.com/supabase/edge-runtime/issues/444)) ([8f81f37](https://github.com/supabase/edge-runtime/commit/8f81f376e64f89c9befae46a74243784784ab280))
* **sb_fs:** make s3 fs proxy capability to unsafe feature ([#448](https://github.com/supabase/edge-runtime/issues/448)) ([e19cac9](https://github.com/supabase/edge-runtime/commit/e19cac9d533623d3f17724c9cf9f1c1236bde7ce))
