### PR TITLE
fix: initialise test otp to an empty map

### DIFF
--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -18,6 +18,9 @@ func newWithDefaults() auth {
 		Email: email{
 			EnableConfirmations: true,
 		},
+		Sms: sms{
+			TestOTP: map[string]string{},
+		},
 	}
 }
 
@@ -563,9 +566,7 @@ func TestSmsDiff(t *testing.T) {
 		// This is not a valid config because platform requires a SMS provider.
 		// For consistency, we handle this in config.Load and emit a warning.
 		c := newWithDefaults()
-		c.Sms = sms{
-			EnableSignup: true,
-		}
+		c.Sms.EnableSignup = true
 		// Run test
 		diff, err := c.DiffWithRemote("", v1API.AuthConfigResponse{
 			ExternalPhoneEnabled: cast.Ptr(false),
@@ -578,11 +579,7 @@ func TestSmsDiff(t *testing.T) {
 
 	t.Run("enable provider without sign up", func(t *testing.T) {
 		c := newWithDefaults()
-		c.Sms = sms{
-			Messagebird: messagebirdConfig{
-				Enabled: true,
-			},
-		}
+		c.Sms.Messagebird.Enabled = true
 		// Run test
 		diff, err := c.DiffWithRemote("", v1API.AuthConfigResponse{
 			ExternalPhoneEnabled:    cast.Ptr(false),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -303,6 +303,9 @@ func NewConfig(editors ...ConfigEditor) config {
 					"reauthentication": {},
 				},
 			},
+			Sms: sms{
+				TestOTP: map[string]string{},
+			},
 			External: map[string]provider{
 				"apple":         {},
 				"azure":         {},

--- a/pkg/config/testdata/TestExternalDiff/local_enabled_and_disabled.diff
+++ b/pkg/config/testdata/TestExternalDiff/local_enabled_and_disabled.diff
@@ -1,7 +1,7 @@
 diff remote[auth] local[auth]
 --- remote[auth]
 +++ local[auth]
-@@ -88,7 +88,7 @@
+@@ -89,7 +89,7 @@
  
  [external]
  [external.apple]
@@ -10,7 +10,7 @@ diff remote[auth] local[auth]
  client_id = "test-client-1,test-client-2"
  secret = "hash:ce62bb9bcced294fd4afe668f8ab3b50a89cf433093c526fffa3d0e46bf55252"
  url = ""
-@@ -144,7 +144,7 @@
+@@ -145,7 +145,7 @@
  redirect_uri = ""
  skip_nonce_check = false
  [external.google]

--- a/pkg/config/testdata/TestSmsDiff/local_disabled_remote_enabled.diff
+++ b/pkg/config/testdata/TestSmsDiff/local_disabled_remote_enabled.diff
@@ -19,11 +19,10 @@ diff remote[auth] local[auth]
  account_sid = ""
  message_service_sid = ""
  auth_token = ""
-@@ -85,9 +85,6 @@
- from = ""
+@@ -86,8 +86,6 @@
  api_key = ""
  api_secret = ""
--[sms.test_otp]
+ [sms.test_otp]
 -123 = "456"
 -456 = "123"
  

--- a/pkg/config/testdata/TestSmsDiff/local_enabled_remote_disabled.diff
+++ b/pkg/config/testdata/TestSmsDiff/local_enabled_remote_disabled.diff
@@ -32,11 +32,10 @@ diff remote[auth] local[auth]
  [sms.textlocal]
  enabled = false
  sender = ""
-@@ -85,6 +85,8 @@
- from = ""
+@@ -86,6 +86,7 @@
  api_key = ""
  api_secret = ""
-+[sms.test_otp]
+ [sms.test_otp]
 +123 = "456"
  
  [third_party]

--- a/pkg/config/updater_test.go
+++ b/pkg/config/updater_test.go
@@ -193,6 +193,7 @@ func TestUpdateAuthConfig(t *testing.T) {
 			Enabled:      true,
 			EnableSignup: true,
 			Email:        email{EnableConfirmations: true},
+			Sms:          sms{TestOTP: map[string]string{}},
 		})
 		// Check result
 		assert.NoError(t, err)

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -103,9 +103,6 @@ func mapToEnv(input map[string]string) string {
 
 func envToMap(input string) map[string]string {
 	env := strToArr(input)
-	if len(env) == 0 {
-		return nil
-	}
 	result := make(map[string]string, len(env))
 	for _, kv := range env {
 		if parts := strings.Split(kv, "="); len(parts) > 1 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If user declares an empty `[sms.test_otp]` without any entries, auth config would show a diff with remote set to nil.

This causes unnecessary config update being enqueued on api.

## What is the new behavior?

Always initialise a non-nil map to avoid this problem.

## Additional context

Add any other context or screenshots.
