### PR TITLE
feat(storage): allow assets filetype upload via seeding

### DIFF
--- a/internal/storage/cp/cp.go
+++ b/internal/storage/cp/cp.go
@@ -52,7 +52,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, fsy
 		if recursive {
 			return UploadStorageObjectAll(ctx, api, dstParsed.Path, localPath, maxJobs, fsys, opts...)
 		}
-		return api.UploadObject(ctx, dstParsed.Path, src, fsys, opts...)
+		return api.UploadObject(ctx, dstParsed.Path, src, fsys, false, opts...)
 	} else if strings.EqualFold(srcParsed.Scheme, client.STORAGE_SCHEME) && strings.EqualFold(dstParsed.Scheme, client.STORAGE_SCHEME) {
 		return errors.New("Copying between buckets is not supported")
 	}
@@ -148,7 +148,7 @@ func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remoteP
 		}
 		fmt.Fprintln(os.Stderr, "Uploading:", filePath, "=>", dstPath)
 		job := func() error {
-			err := api.UploadObject(ctx, dstPath, filePath, fsys, opts...)
+			err := api.UploadObject(ctx, dstPath, filePath, fsys, false, opts...)
 			if err != nil && strings.Contains(err.Error(), `"error":"Bucket not found"`) {
 				// Retry after creating bucket
 				if bucket, prefix := client.SplitBucketPrefix(dstPath); len(prefix) > 0 {
@@ -161,7 +161,7 @@ func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remoteP
 					if _, err := api.CreateBucket(ctx, body); err != nil {
 						return err
 					}
-					err = api.UploadObject(ctx, dstPath, filePath, fsys, opts...)
+					err = api.UploadObject(ctx, dstPath, filePath, fsys, false, opts...)
 				}
 			}
 			return err

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -10,7 +10,7 @@ const (
 	inbucketImage    = "inbucket/inbucket:3.0.3"
 	postgrestImage   = "postgrest/postgrest:v12.2.0"
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
-	studioImage      = "supabase/studio:20241106-f29003e"
+	studioImage      = "supabase/studio:20241111-d7c6eb1"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
 	edgeRuntimeImage = "supabase/edge-runtime:v1.64.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"

--- a/pkg/config/storage.go
+++ b/pkg/config/storage.go
@@ -30,10 +30,11 @@ type (
 	BucketConfig map[string]bucket
 
 	bucket struct {
-		Public           *bool       `toml:"public"`
-		FileSizeLimit    sizeInBytes `toml:"file_size_limit"`
-		AllowedMimeTypes []string    `toml:"allowed_mime_types"`
-		ObjectsPath      string      `toml:"objects_path"`
+		Public            *bool       `toml:"public"`
+		FileSizeLimit     sizeInBytes `toml:"file_size_limit"`
+		AllowedMimeTypes  []string    `toml:"allowed_mime_types"`
+		ObjectsPath       string      `toml:"objects_path"`
+		ExtensionDetector bool        `toml:"extension_detector"`
 	}
 )
 

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -96,7 +96,7 @@ func (s *StorageAPI) UpsertObjects(ctx context.Context, bucketConfig config.Buck
 					return errors.Errorf("failed to open file: %w", err)
 				}
 				defer f.Close()
-				fo, err := ParseFileOptions(f)
+				fo, err := ParseFileOptions(f, filePath, bucket.ExtensionDetector)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Enables seeding "assets" file types via the CLI locally.  
- Improves consistency between Studio upload behavior and CLI bucket seeding behavior.

## What is the current behavior?

While using storage seeding on a project, I noticed an issue with the CLI's behavior. My goal was to seed some "assets" into a public bucket. Although this worked in staging via the dashboard, the generated URL locally always had a `text/plain` content-type instead of `text/javascript`.

The bug stemmed from two issues:

1. **Outdated Studio image:** The Studio image was out of date and was fixed in a version where the generated URL for a file didn't account for the file's "content-type." This has been resolved in the latest Studio container image release.

2. **Inconsistent file type inference:** Depending on the upload method (via the Studio web app or `db reset` and seeding), file types were inferred differently. The web app properly assigned the correct file type (e.g., `text/javascript`, `text/html`), while seeding did not.  

   This discrepancy occurs because, at seed time in the CLI, we use `http.DetectContentType`, which follows the `mimesniff` convention. This convention intentionally avoids assigning certain MIME types, such as `text/javascript`, for [security reasons](https://stackoverflow.com/questions/70695214/net-http-does-detectcontenttype-support-javascript)
However, these restrictions don't apply in our case because:  
1. We already allow this content type to be uploaded via the platform.  
2. We control who can upload files to a dedicated bucket.  

## What is the new behavior?

To enable automatic seeding of these file types without disrupting existing setups, I've introduced a new `extension_detector` option in the bucket definition. When enabled, this option attempts to detect the file type based on the file's extension. If successful, it overrides the type detected via content sniffing.

This solution was chosen after evaluating multiple alternative packages, which did not outperform our current file type detection approach (`mimetypes`, `filetype`).

## Additional context

The motivation behind uploading `text/javascript` files was to experiment with using Supabase buckets as both storage and a hosting provider. The goal was to rely solely on Supabase to deploy a website, without needing additional services like Vercel or other hosting providers.  
