### PR TITLE
chore(docs): add link to the config reference in toml template

### DIFF
--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -1,3 +1,5 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "{{ .ProjectId }}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add url to the docs reference on top of config.toml template

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
