### PR TITLE
fix: bump edge-runtime to 1.65.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.65.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.65.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.65.1.

### Changes

### [1.65.1](https://github.com/supabase/edge-runtime/compare/v1.65.0...v1.65.1) (2024-11-28)

#### Bug Fixes

* move `markAsBackground` to `EdgeRuntime.waitUntil` ([#454](https://github.com/supabase/edge-runtime/issues/454)) ([954ab6d](https://github.com/supabase/edge-runtime/commit/954ab6d027736f0de499233f729f22917155f0c9))
