### PR TITLE
fix: bump edge-runtime to 1.65.3

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241106-f29003e"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.65.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.65.3"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.65.3

### Changes

### [1.65.3](https://github.com/supabase/edge-runtime/compare/v1.65.1...v1.65.3) (2024-11-29)

#### Bug Fixes

* polishing the worker bootstrap phase and ridding annoying cache adaptor errors emitted from `transformers.js` ([#453](https://github.com/supabase/edge-runtime/issues/453)) ([18d8f69](https://github.com/supabase/edge-runtime/commit/18d8f69b0d8456ac9108ee6c39447b3f244008df)) (@kallebysantos)
* `beforeunload` event didn't trigger on the early drop state ([#455](https://github.com/supabase/edge-runtime/issues/455)) ([5707665](https://github.com/supabase/edge-runtime/commit/5707665873fee6938a84c3a56007cdabaf75b9c8))
