### PR TITLE
chore: update docs for remote db reset

### DIFF
--- a/docs/supabase/db/reset.md
+++ b/docs/supabase/db/reset.md
@@ -6,4 +6,4 @@ Requires the local development stack to be started by running `supabase start`.
 
 Recreates the local Postgres container and applies all local migrations found in `supabase/migrations` directory. If test data is defined in `supabase/seed.sql`, it will be seeded after the migrations are run. Any other data or schema changes made during local development will be discarded.
 
-When running db reset with `--linked` or `--db-url` flag, a SQL script is executed to identify and drop all user created entities in the remote database. Since Postgres roles are cluster level entities, any custom roles created through the dashboard or `supabase/roles.sql` will persist between remote resets.
+When running db reset with `--linked` or `--db-url` flag, a SQL script is executed to identify and drop all user created entities in the remote database. Since Postgres roles are cluster level entities, any custom roles created through the dashboard or `supabase/roles.sql` will not be deleted by remote reset.

--- a/docs/supabase/db/reset.md
+++ b/docs/supabase/db/reset.md
@@ -6,4 +6,4 @@ Requires the local development stack to be started by running `supabase start`.
 
 Recreates the local Postgres container and applies all local migrations found in `supabase/migrations` directory. If test data is defined in `supabase/seed.sql`, it will be seeded after the migrations are run. Any other data or schema changes made during local development will be discarded.
 
-Note that since Postgres roles are cluster level entities, those changes will persist between resets. In order to reset custom roles, you need to restart the local development stack.
+When running db reset with `--linked` or `--db-url` flag, a SQL script is executed to identify and drop all user created entities in the remote database. Since Postgres roles are cluster level entities, any custom roles created through the dashboard or `supabase/roles.sql` will persist between remote resets.


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/2933

## What is the new behavior?

- Removes misleading comment about local reset behaviour.
- Briefly documents the remote reset behaviour

## Additional context

Add any other context or screenshots.
