### PR TITLE
fix: bump edge-runtime to 1.65.4

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241202-71e5240"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.65.3"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.65.4"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.65.4

### Changes

### [1.65.4](https://github.com/supabase/edge-runtime/compare/v1.65.3...v1.65.4) (2024-12-04)

#### Bug Fixes

* **base:** don't wrap `JsRuntime` with `ManuallyDrop` early ([#457](https://github.com/supabase/edge-runtime/issues/457)) ([4cbeee8](https://github.com/supabase/edge-runtime/commit/4cbeee8424398a06a8a1b97b166a273199d7013b))
