### PR TITLE
Add `supabase studio` command

### DIFF
--- a/cmd/studio.go
+++ b/cmd/studio.go
@@ -4,23 +4,41 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
+	"github.com/supabase/cli/internal/login"
 )
 
 var studioCmd = &cobra.Command{
 	Use:   "studio",
 	Short: "Opens Supabase Studio in your browser",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		url := utils.GetSupabaseDashboardURL()
+
+		fsys := afero.NewOsFs()
+		if err := flags.LoadConfig(fsys); err != nil {
+			return err
+		}
+		
+		var url string
+		if utils.Config.Studio.Enabled {
+			url = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Studio.Port)
+		} else {
+			fmt.Fprintln(os.Stderr, "Can't open studio because it is disabled in config.toml for project:", flags.ProjectRef)
+			return nil
+		}
+
 		var err error
+		ctx := cmd.Context()
 
 		switch runtime.GOOS {
 		case "darwin":
 			err = exec.Command("open", url).Start()
-		case "windows":
-			err = exec.Command("cmd", "/c", "start", url).Start()
+		case "windows", "linux":
+			err = login.RunOpenCmd(ctx, url)
 		default:
 			err = exec.Command("xdg-open", url).Start()
 		}

--- a/cmd/studio.go
+++ b/cmd/studio.go
@@ -2,15 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
-	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/login"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
-	"github.com/supabase/cli/internal/login"
 )
 
 var studioCmd = &cobra.Command{
@@ -22,7 +22,6 @@ var studioCmd = &cobra.Command{
 		if err := flags.LoadConfig(fsys); err != nil {
 			return err
 		}
-		
 		var url string
 		if utils.Config.Studio.Enabled {
 			url = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Studio.Port)

--- a/cmd/studio.go
+++ b/cmd/studio.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/utils"
+)
+
+var studioCmd = &cobra.Command{
+	Use:   "studio",
+	Short: "Opens Supabase Studio in your browser",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url := utils.GetSupabaseDashboardURL()
+		var err error
+
+		switch runtime.GOOS {
+		case "darwin":
+			err = exec.Command("open", url).Start()
+		case "windows":
+			err = exec.Command("cmd", "/c", "start", url).Start()
+		default:
+			err = exec.Command("xdg-open", url).Start()
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to open browser: %w", err)
+		}
+
+		fmt.Printf("Opening Supabase Studio at %s\n", utils.Aqua(url))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(studioCmd)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature - Adds a new CLI command `supabase studio` to open Supabase Studio directly from the terminal

## What is the current behavior?
Currently, users need to manually open their browser and navigate to the Supabase Studio dashboard.

## What is the new behavior?
This PR adds a new `studio` command that automatically opens the Supabase Studio dashboard in the user's default browser. The command:
- Works cross-platform (macOS, Windows, and Linux)
- Uses the appropriate system command to open the browser (`open` for macOS, `start` for Windows, `xdg-open` for Linux)
- Provides feedback to the user by displaying the URL being opened
- Handles errors gracefully with descriptive error messages

Example usage:
```bash
supabase studio