### PR TITLE
fix: substitute remote env from its own file

### DIFF
--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -48,7 +48,7 @@ type (
 		Enabled bool   `toml:"enabled"`
 		Image   string `toml:"-"`
 
-		SiteUrl                    string               `toml:"site_url"`
+		SiteUrl                    string               `toml:"site_url" mapstructure:"site_url"`
 		AdditionalRedirectUrls     []string             `toml:"additional_redirect_urls"`
 		JwtExpiry                  uint                 `toml:"jwt_expiry"`
 		EnableRefreshTokenRotation bool                 `toml:"enable_refresh_token_rotation"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Env vars from remotes are substituted using the current env, instead of `.env.staging`.

```
[remotes.staging.auth]
site_url = "env(TEST_ENV)"
```

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
