### PR TITLE
fix: optional project ref flag for snippets command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/supabase/cli/internal/services"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"golang.org/x/mod/semver"
@@ -250,7 +249,7 @@ func GetRootCmd() *cobra.Command {
 }
 
 func addSentryScope(scope *sentry.Scope) {
-	serviceImages := services.GetServiceImages()
+	serviceImages := utils.Config.GetServiceImages()
 	imageToVersion := make(map[string]interface{}, len(serviceImages))
 	for _, image := range serviceImages {
 		parts := strings.Split(image, ":")

--- a/cmd/snippets.go
+++ b/cmd/snippets.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/snippets/download"
 	"github.com/supabase/cli/internal/snippets/list"
+	"github.com/supabase/cli/internal/utils/flags"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 )
 
 func init() {
+	snippetsCmd.PersistentFlags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	snippetsCmd.AddCommand(snippetsListCmd)
 	snippetsCmd.AddCommand(snippetsDownloadCmd)
 	rootCmd.AddCommand(snippetsCmd)

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -13,50 +15,56 @@ import (
 	"github.com/supabase/cli/internal/utils/tenant"
 )
 
-var suggestLinkCommand = fmt.Sprintf("Run %s to sync your local image versions with the linked project.", utils.Aqua("supabase link"))
-
 func Run(ctx context.Context, fsys afero.Fs) error {
-	_ = utils.LoadConfigFS(fsys)
-	serviceImages := GetServiceImages()
-
-	var linked map[string]string
-	if projectRef, err := flags.LoadProjectRef(fsys); err == nil {
-		linked = GetRemoteImages(ctx, projectRef)
+	if _, err := flags.LoadProjectRef(fsys); err != nil && !errors.Is(err, utils.ErrNotLinked) {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	if err := utils.Config.Load("", utils.NewRootFS(fsys)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintln(os.Stderr, err)
 	}
 
+	serviceImages := CheckVersions(ctx, fsys)
 	table := `|SERVICE IMAGE|LOCAL|LINKED|
 |-|-|-|
 `
 	for _, image := range serviceImages {
-		parts := strings.Split(image, ":")
-		version, ok := linked[image]
-		if !ok {
-			version = "-"
-		} else if parts[1] != version && image != utils.Config.Db.Image {
-			utils.CmdSuggestion = suggestLinkCommand
+		remote := image.Remote
+		if len(remote) == 0 {
+			remote = "-"
 		}
-		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", parts[0], parts[1], version)
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", image.Name, image.Local, remote)
 	}
 
 	return list.RenderTable(table)
 }
 
-func GetServiceImages() []string {
-	return []string{
-		utils.Config.Db.Image,
-		utils.Config.Auth.Image,
-		utils.Config.Api.Image,
-		utils.Config.Realtime.Image,
-		utils.Config.Storage.Image,
-		utils.Config.EdgeRuntime.Image,
-		utils.Config.Studio.Image,
-		utils.Config.Studio.PgmetaImage,
-		utils.Config.Analytics.Image,
-		utils.Config.Db.Pooler.Image,
-	}
+type imageVersion struct {
+	Name   string `json:"name"`
+	Local  string `json:"local"`
+	Remote string `json:"remote"`
 }
 
-func GetRemoteImages(ctx context.Context, projectRef string) map[string]string {
+func CheckVersions(ctx context.Context, fsys afero.Fs) []imageVersion {
+	var remote map[string]string
+	if _, err := utils.LoadAccessTokenFS(fsys); err == nil && len(flags.ProjectRef) > 0 {
+		remote = listRemoteImages(ctx, flags.ProjectRef)
+	}
+	var result []imageVersion
+	for _, image := range utils.Config.GetServiceImages() {
+		parts := strings.Split(image, ":")
+		v := imageVersion{Name: parts[0], Local: parts[1]}
+		if v.Remote = remote[image]; v.Remote == v.Local {
+			delete(remote, image)
+		}
+		result = append(result, v)
+	}
+	if len(remote) > 0 {
+		fmt.Fprintln(os.Stderr, suggestUpdateCmd(remote))
+	}
+	return result
+}
+
+func listRemoteImages(ctx context.Context, projectRef string) map[string]string {
 	linked := make(map[string]string, 4)
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -93,4 +101,13 @@ func GetRemoteImages(ctx context.Context, projectRef string) map[string]string {
 	}()
 	wg.Wait()
 	return linked
+}
+
+func suggestUpdateCmd(serviceImages map[string]string) string {
+	cmd := fmt.Sprintln(utils.Yellow("WARNING:"), "You are running different service versions locally than your linked project:")
+	for k, v := range serviceImages {
+		cmd += fmt.Sprintf("%s => %s\n", k, v)
+	}
+	cmd += fmt.Sprintf("Run %s to update them.", utils.Aqua("supabase link"))
+	return cmd
 }

--- a/internal/snippets/list/list.go
+++ b/internal/snippets/list/list.go
@@ -14,11 +14,8 @@ import (
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	ref, err := flags.LoadProjectRef(fsys)
-	if err != nil {
-		return err
-	}
-	resp, err := utils.GetSupabase().V1ListAllSnippetsWithResponse(ctx, &api.V1ListAllSnippetsParams{ProjectRef: &ref})
+	opts := api.V1ListAllSnippetsParams{ProjectRef: &flags.ProjectRef}
+	resp, err := utils.GetSupabase().V1ListAllSnippetsWithResponse(ctx, &opts)
 	if err != nil {
 		return errors.Errorf("failed to list snippets: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1234,6 +1234,21 @@ func (a *auth) ResolveJWKS(ctx context.Context) (string, error) {
 	return string(jwksEncoded), nil
 }
 
+func (c *baseConfig) GetServiceImages() []string {
+	return []string{
+		c.Db.Image,
+		c.Auth.Image,
+		c.Api.Image,
+		c.Realtime.Image,
+		c.Storage.Image,
+		c.EdgeRuntime.Image,
+		c.Studio.Image,
+		c.Studio.PgmetaImage,
+		c.Analytics.Image,
+		c.Db.Pooler.Image,
+	}
+}
+
 // Retrieve the final base config to use taking into account the remotes override
 func (c *config) GetRemoteByProjectRef(projectRef string) (baseConfig, error) {
 	var result []string


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Supports `supabase snippets list --project-ref <ref>` flag.

Also refactors services command for consistent version check.

## Additional context

Add any other context or screenshots.
