### PR TITLE
fix: optional smtp block should not override remote

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -500,7 +500,7 @@ EOF
 			fmt.Sprintf("GOTRUE_MFA_MAX_ENROLLED_FACTORS=%v", utils.Config.Auth.MFA.MaxEnrolledFactors),
 		}
 
-		if utils.Config.Auth.Email.Smtp != nil {
+		if utils.Config.Auth.Email.Smtp != nil && utils.Config.Auth.Email.Smtp.IsEnabled() {
 			env = append(env,
 				fmt.Sprintf("GOTRUE_SMTP_HOST=%s", utils.Config.Auth.Email.Smtp.Host),
 				fmt.Sprintf("GOTRUE_SMTP_PORT=%d", utils.Config.Auth.Email.Smtp.Port),

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -365,6 +365,7 @@ func TestEmailDiff(t *testing.T) {
 				},
 			},
 			Smtp: &smtp{
+				Enabled:    cast.Ptr(true),
 				Host:       "smtp.sendgrid.net",
 				Port:       587,
 				User:       "apikey",
@@ -534,6 +535,15 @@ func TestEmailDiff(t *testing.T) {
 				"magic_link":       {},
 				"email_change":     {},
 				"reauthentication": {},
+			},
+			Smtp: &smtp{
+				Enabled:    cast.Ptr(false),
+				Host:       "smtp.sendgrid.net",
+				Port:       587,
+				User:       "apikey",
+				Pass:       "test-key",
+				AdminEmail: "admin@email.com",
+				SenderName: "Admin",
 			},
 			MaxFrequency: time.Minute,
 			OtpLength:    6,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -843,7 +843,7 @@ func (e *email) validate(fsys fs.FS) (err error) {
 		}
 		e.Template[name] = tmpl
 	}
-	if e.Smtp != nil {
+	if e.Smtp != nil && e.Smtp.IsEnabled() {
 		if len(e.Smtp.Host) == 0 {
 			return errors.New("Missing required field in config: auth.email.smtp.host")
 		}

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -137,6 +137,7 @@ otp_expiry = 3600
 
 # Use a production-ready SMTP server
 # [auth.email.smtp]
+# enabled = true
 # host = "smtp.sendgrid.net"
 # port = 587
 # user = "apikey"

--- a/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
+++ b/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
@@ -22,17 +22,3 @@ diff remote[auth] local[auth]
  [email.template]
  [email.template.confirmation]
  content_path = ""
-@@ -71,13 +71,6 @@
- content_path = ""
- [email.template.recovery]
- content_path = ""
--[email.smtp]
--host = "smtp.sendgrid.net"
--port = 587
--user = "apikey"
--pass = "hash:ed64b7695a606bc6ab4fcb41fe815b5ddf1063ccbc87afe1fa89756635db520e"
--admin_email = "admin@email.com"
--sender_name = "Admin"
- 
- [sms]
- enable_signup = false

--- a/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
+++ b/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
@@ -1,7 +1,7 @@
 diff remote[auth] local[auth]
 --- remote[auth]
 +++ local[auth]
-@@ -51,28 +51,43 @@
+@@ -51,35 +51,43 @@
  inactivity_timeout = "0s"
  
  [email]
@@ -40,10 +40,15 @@ diff remote[auth] local[auth]
 +content = ""
  content_path = ""
  [email.template.recovery]
--content_path = ""
 +content = "recovery-content"
-+content_path = ""
-+[email.smtp]
+ content_path = ""
+ [email.smtp]
+-host = ""
+-port = 0
+-user = ""
+-pass = "hash:"
+-admin_email = ""
+-sender_name = ""
 +host = "smtp.sendgrid.net"
 +port = 587
 +user = "apikey"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

If `[auth.email.smtp]` is not declared in config.toml, skip pushing the config to remote.

Also adds a `enabled` field to allow explicit disabling of smtp.

## Additional context

Add any other context or screenshots.
