### PR TITLE
fix: rewrite content template path in nested directory

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -495,6 +495,15 @@ func (c *config) Load(path string, fsys fs.FS) error {
 	if version, err := fs.ReadFile(fsys, builder.PgmetaVersionPath); err == nil && len(version) > 0 {
 		c.Studio.PgmetaImage = replaceImageTag(pgmetaImage, string(version))
 	}
+	// Update content paths
+	for name, tmpl := range c.Auth.Email.Template {
+		// FIXME: only email template is relative to repo directory
+		cwd := filepath.Dir(builder.SupabaseDirPath)
+		if len(tmpl.ContentPath) > 0 && !filepath.IsAbs(tmpl.ContentPath) {
+			tmpl.ContentPath = filepath.Join(cwd, tmpl.ContentPath)
+		}
+		c.Auth.Email.Template[name] = tmpl
+	}
 	// Update fallback configs
 	for name, bucket := range c.Storage.Buckets {
 		if bucket.FileSizeLimit == 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -843,7 +843,7 @@ func (e *email) validate(fsys fs.FS) (err error) {
 			}
 			continue
 		}
-		if content, err := fs.ReadFile(fsys, filepath.Clean(tmpl.ContentPath)); err != nil {
+		if content, err := fs.ReadFile(fsys, tmpl.ContentPath); err != nil {
 			return errors.Errorf("Invalid config for auth.email.%s.content_path: %w", name, err)
 		} else {
 			tmpl.Content = cast.Ptr(string(content))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2963

## What is the new behavior?

Update `content_path` to always be relative to supabase directory.

## Additional context

Add any other context or screenshots.
