### PR TITLE
feat(dump): print complete filedist path for dump

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -126,8 +126,7 @@ var (
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			if len(file) > 0 {
-				absPath, err := filepath.Abs(file)
-				if err != nil {
+				if absPath, err := filepath.Abs(file); err != nil {
 					fmt.Fprintln(os.Stderr, "Dumped schema to "+utils.Bold(file)+".")
 				} else {
 					fmt.Fprintln(os.Stderr, "Dumped schema to "+utils.Bold(absPath)+".")

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -125,7 +126,12 @@ var (
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			if len(file) > 0 {
-				fmt.Fprintln(os.Stderr, "Dumped schema to "+utils.Bold(file)+".")
+				absPath, err := filepath.Abs(file)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "Dumped schema to "+utils.Bold(file)+".")
+				} else {
+					fmt.Fprintln(os.Stderr, "Dumped schema to "+utils.Bold(absPath)+".")
+				}
 			}
 		},
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Show the absolute path when dump commande is directed to a file