### PR TITLE
feat(start): automatically run the status command if already started

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -42,8 +42,8 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignore
 		}
 		if err := utils.AssertSupabaseDbIsRunning(); err == nil {
 			fmt.Fprintln(os.Stderr, utils.Aqua("supabase start")+" is already running.")
-			utils.CmdSuggestion = fmt.Sprintf("Run %s to show status of local Supabase containers.", utils.Aqua("supabase status"))
-			return nil
+			names := status.CustomName{}
+			return status.Run(ctx, names, utils.OutputPretty, fsys)
 		} else if !errors.Is(err, utils.ErrNotRunning) {
 			return err
 		}

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -76,7 +76,7 @@ func TestStartCommand(t *testing.T) {
 			JSON(types.ContainerJSON{})
 
 		gock.New(utils.Docker.DaemonHost()).
-			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_start/json").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
 				State: &types.ContainerState{Running: true},

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -57,7 +57,13 @@ func TestStartCommand(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
-	t.Run("noop if database is already running", func(t *testing.T) {
+	t.Run("show status if database is already running", func(t *testing.T) {
+		var running []types.Container
+		for _, name := range utils.GetDockerIds() {
+			running = append(running, types.Container{
+				Names: []string{name + "_test"},
+			})
+		}
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.WriteConfig(fsys, false))
@@ -68,6 +74,17 @@ func TestStartCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
 			JSON(types.ContainerJSON{})
+
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
+			Reply(http.StatusOK).
+			JSON(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
+				State: &types.ContainerState{Running: true},
+			}})
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON(running)
 		// Run test
 		err := Run(context.Background(), fsys, []string{}, false)
 		// Check error


### PR DESCRIPTION

## What kind of change does this PR introduce?

Rather than asking the user to run the command to get the values Run the command for him so start command always return the infos of the running stack.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
