### PR TITLE
fix: bump realtime image to 2.33.70

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -16,7 +16,7 @@ const (
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"
-	realtimeImage    = "supabase/realtime:v2.33.58"
+	realtimeImage    = "supabase/realtime:v2.33.70"
 	storageImage     = "supabase/storage-api:v1.14.5"
 	logflareImage    = "supabase/logflare:1.4.0"
 	// Append to JobImages when adding new dependencies below


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump image to 2.33.70