### PR TITLE
feat(cli): add shadow database host configuration

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -147,7 +147,10 @@ func CreateShadowDatabase(ctx context.Context, port uint16) (string, error) {
 func ConnectShadowDatabase(ctx context.Context, timeout time.Duration, options ...func(*pgx.ConnConfig)) (conn *pgx.Conn, err error) {
 	// Retry until connected, cancelled, or timeout
 	policy := start.NewBackoffPolicy(ctx, timeout)
-	config := pgconn.Config{Port: utils.Config.Db.ShadowPort}
+	config := pgconn.Config{
+		Host: utils.Config.Db.ShadowHost,
+		Port: utils.Config.Db.ShadowPort,
+	}
 	connect := func() (*pgx.Conn, error) {
 		return utils.ConnectLocalPostgres(ctx, config, options...)
 	}
@@ -201,7 +204,7 @@ func DiffDatabase(ctx context.Context, schema []string, config pgconn.Config, w 
 	}
 	fmt.Fprintln(w, "Diffing schemas:", strings.Join(schema, ","))
 	source := utils.ToPostgresURL(pgconn.Config{
-		Host:     utils.Config.Hostname,
+		Host:     utils.Config.Db.ShadowHost,
 		Port:     utils.Config.Db.ShadowPort,
 		User:     "postgres",
 		Password: utils.Config.Db.Password,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -290,6 +290,8 @@ func NewConfig(editors ...ConfigEditor) config {
 				Enabled:      true,
 				GlobPatterns: []string{"./seed.sql"},
 			},
+			ShadowHost: "127.0.0.1",
+			ShadowPort: 54320,
 		},
 		Realtime: realtime{
 			Image:           realtimeImage,

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -53,6 +53,7 @@ type (
 		Image        string   `toml:"-"`
 		Port         uint16   `toml:"port"`
 		ShadowPort   uint16   `toml:"shadow_port"`
+		ShadowHost   string   `toml:"shadow_host"`
 		MajorVersion uint     `toml:"major_version"`
 		Password     string   `toml:"-"`
 		RootKey      string   `toml:"-" mapstructure:"root_key"`


### PR DESCRIPTION
- Add ShadowHost config option to control shadow database connection
- Default to Hostname if ShadowHost not set
---
The scenario is the following:
- local supabase deployment, self hosted.
- running migrations inside our own container which has supa running via docker compose.
- attempt supabase `db diff --db-url` ...

This does not work since the docker running the shadow database is created on host, and 127.0.0.1 for host network is not accessible from inside our container.

In my case, i set the following in the config.toml >> `shadow_host = "172.18.0.1"` and now db diff works.

(open to alternative solutions!)
