### PR TITLE
fix: bump edge-runtime to 1.66.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241202-71e5240"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.65.6"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.0"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.0

### Changes
 
### [1.66.0](https://github.com/supabase/edge-runtime/compare/v1.65.6...v1.66.0) (2024-12-25)

#### Features

* **base:** make able to trigger early drop with other resources ([#465](https://github.com/supabase/edge-runtime/issues/465)) ([667db65](https://github.com/supabase/edge-runtime/commit/667db65abdefaacfaa7e0427bb0aefa3be1aa34f))
