### PR TITLE
fix: bump edge-runtime to 1.66.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241202-71e5240"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.66.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.164.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.1

### Changes

### [1.66.1](https://github.com/supabase/edge-runtime/compare/v1.66.0...v1.66.1) (2024-12-30)

#### Bug Fixes
* **ext/core:** missing `Supabase` namespace ([#467](https://github.com/supabase/edge-runtime/issues/467)) ([65c4e17](https://github.com/supabase/edge-runtime/commit/65c4e17736676e341e2fb32e82b8e3d7c737d6df))

