### PR TITLE
fix: bump gotrue to 2.167.0

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,7 +15,7 @@ const (
 	edgeRuntimeImage = "supabase/edge-runtime:v1.66.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
-	gotrueImage      = "supabase/gotrue:v2.164.0"
+	gotrueImage      = "supabase/gotrue:v2.166.0"
 	realtimeImage    = "supabase/realtime:v2.33.70"
 	storageImage     = "supabase/storage-api:v1.14.5"
 	logflareImage    = "supabase/logflare:1.4.0"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,7 +15,7 @@ const (
 	edgeRuntimeImage = "supabase/edge-runtime:v1.66.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
-	gotrueImage      = "supabase/gotrue:v2.166.0"
+	gotrueImage      = "supabase/gotrue:v2.167.0"
 	realtimeImage    = "supabase/realtime:v2.33.70"
 	storageImage     = "supabase/storage-api:v1.14.5"
 	logflareImage    = "supabase/logflare:1.4.0"


### PR DESCRIPTION
## Additional context

PR to update the version of gotrue. The change aligns with the existing version outlined in [line 27 of bump-gotrue-generic.yml](https://github.com/supabase/helper-scripts/blob/master/ansible/bump-gotrue-generic.yml#L27).
