### PR TITLE
fix: bump edge-runtime to 1.66.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241202-71e5240"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.66.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.2

### Changes

### [1.66.2](https://github.com/supabase/edge-runtime/compare/v1.66.1...v1.66.2) (2025-01-03)

#### Bug Fixes
* **ext/event_worker:** don't use `tracing` as the log backend if `cli/tracing` feature flag is not enabled ([#469](https://github.com/supabase/edge-runtime/issues/469)) ([6246a6f](https://github.com/supabase/edge-runtime/commit/6246a6f37d50368c3553621bf5fdeec3fab7c67d))

### Description

Fixes #3006 

