### PR TITLE
fix: pass NPM_CONFIG_REGISTRY env variable when bundling functions

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -57,12 +57,16 @@ func (b *dockerBundler) Bundle(ctx context.Context, entrypoint string, importMap
 	if viper.GetBool("DEBUG") {
 		cmd = append(cmd, "--verbose")
 	}
+	env := []string{}
+	if custom_registry := os.Getenv("NPM_CONFIG_REGISTRY"); custom_registry != "" {
+		env = append(env, "NPM_CONFIG_REGISTRY="+custom_registry)
+	}
 	// Run bundle
 	if err := utils.DockerRunOnceWithConfig(
 		ctx,
 		container.Config{
 			Image:      utils.Config.EdgeRuntime.Image,
-			Env:        []string{},
+			Env:        env,
 			Cmd:        cmd,
 			WorkingDir: utils.ToDockerPath(cwd),
 		},


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR provides the option to set a custom NPM registry using the `NPM_CONFIG_REGISTRY` environment variable. This is used when deploying functions.