### PR TITLE
feat(storage): autodetect narrow down text/plain contentype

### DIFF
--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -96,7 +96,7 @@ func (s *StorageAPI) UpsertObjects(ctx context.Context, bucketConfig config.Buck
 					return errors.Errorf("failed to open file: %w", err)
 				}
 				defer f.Close()
-				fo, err := ParseFileOptions(f)
+				fo, err := ParseFileOptions(f, filePath)
 				if err != nil {
 					return err
 				}

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -91,17 +91,9 @@ func (s *StorageAPI) UpsertObjects(ctx context.Context, bucketConfig config.Buck
 			}
 			fmt.Fprintln(os.Stderr, "Uploading:", filePath, "=>", dstPath)
 			job := func() error {
-				f, err := fsys.Open(filePath)
-				if err != nil {
-					return errors.Errorf("failed to open file: %w", err)
-				}
-				defer f.Close()
-				fo, err := ParseFileOptions(f, filePath)
-				if err != nil {
-					return err
-				}
-				fo.Overwrite = true
-				return s.UploadObjectStream(ctx, dstPath, f, *fo)
+				return s.UploadObject(ctx, dstPath, filePath, fsys, func(fo *FileOptions) {
+					fo.Overwrite = true
+				})
 			}
 			return jq.Put(job)
 		}

--- a/pkg/storage/objects.go
+++ b/pkg/storage/objects.go
@@ -63,7 +63,7 @@ type FileOptions struct {
 	Overwrite    bool
 }
 
-func ParseFileOptions(f fs.File, localPath string, opts ...func(*FileOptions)) (*FileOptions, error) {
+func ParseFileOptions(f fs.File, opts ...func(*FileOptions)) (*FileOptions, error) {
 	// Customise file options
 	fo := &FileOptions{}
 	for _, apply := range opts {
@@ -86,26 +86,26 @@ func ParseFileOptions(f fs.File, localPath string, opts ...func(*FileOptions)) (
 		} else if _, err = s.Seek(0, io.SeekStart); err != nil {
 			return nil, errors.Errorf("failed to seek file: %w", err)
 		}
-		// For text/plain content types, we try to determine a more specific type
-		// based on the file extension, as the initial detection might be too generic
-		if strings.Contains(fo.ContentType, "text/plain") {
-			if extensionType := mime.TypeByExtension(filepath.Ext(localPath)); extensionType != "" {
-				fo.ContentType = extensionType
-			}
-		}
 	}
 	return fo, nil
 }
 
-func (s *StorageAPI) UploadObject(ctx context.Context, remotePath, localPath string, fsys afero.Fs, opts ...func(*FileOptions)) error {
+func (s *StorageAPI) UploadObject(ctx context.Context, remotePath, localPath string, fsys fs.FS, opts ...func(*FileOptions)) error {
 	f, err := fsys.Open(localPath)
 	if err != nil {
 		return errors.Errorf("failed to open file: %w", err)
 	}
 	defer f.Close()
-	fo, err := ParseFileOptions(f, localPath, opts...)
+	fo, err := ParseFileOptions(f, opts...)
 	if err != nil {
 		return err
+	}
+	// For text/plain content types, we try to determine a more specific type
+	// based on the file extension, as the initial detection might be too generic
+	if strings.Contains(fo.ContentType, "text/plain") {
+		if extensionType := mime.TypeByExtension(filepath.Ext(localPath)); extensionType != "" {
+			fo.ContentType = extensionType
+		}
 	}
 	return s.UploadObjectStream(ctx, remotePath, f, *fo)
 }

--- a/pkg/storage/objects_test.go
+++ b/pkg/storage/objects_test.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFileOptionsContentTypeDetection(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       []byte
+		filename      string
+		opts          []func(*FileOptions)
+		wantMimeType  string
+		wantCacheCtrl string
+	}{
+		{
+			name:          "detects PNG image",
+			content:       []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, // PNG header
+			filename:      "test.png",
+			wantMimeType:  "image/png",
+			wantCacheCtrl: "max-age=3600",
+		},
+		{
+			name:          "detects JavaScript file",
+			content:       []byte("const hello = () => console.log('Hello, World!');"),
+			filename:      "script.js",
+			wantMimeType:  "text/javascript; charset=utf-8",
+			wantCacheCtrl: "max-age=3600",
+		},
+		{
+			name:          "detects CSS file",
+			content:       []byte(".header { color: #333; font-size: 16px; }"),
+			filename:      "styles.css",
+			wantMimeType:  "text/css; charset=utf-8",
+			wantCacheCtrl: "max-age=3600",
+		},
+		{
+			name:          "detects SQL file",
+			content:       []byte("SELECT * FROM users WHERE id = 1;"),
+			filename:      "query.sql",
+			wantMimeType:  "application/x-sql",
+			wantCacheCtrl: "max-age=3600",
+		},
+		{
+			name:          "detects Go file",
+			content:       []byte("package main\n\nfunc main() { println(\"Hello\") }"),
+			filename:      "main.go",
+			wantMimeType:  "text/plain; charset=utf-8",
+			wantCacheCtrl: "max-age=3600",
+		},
+		{
+			name:          "respects custom content type",
+			content:       []byte("const hello = () => console.log('Hello, World!');"),
+			filename:      "script.js",
+			wantMimeType:  "application/custom",
+			wantCacheCtrl: "max-age=3600",
+			opts:          []func(*FileOptions){func(fo *FileOptions) { fo.ContentType = "application/custom" }},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary file with test content
+			fs := afero.NewMemMapFs()
+			require.NoError(t, afero.WriteFile(fs, tt.filename, tt.content, 0644))
+
+			f, err := fs.Open(tt.filename)
+			require.NoError(t, err)
+			defer f.Close()
+
+			// Parse options
+			fo, err := ParseFileOptions(f, tt.filename, tt.opts...)
+			require.NoError(t, err)
+
+			// Assert results
+			assert.Equal(t, tt.wantMimeType, fo.ContentType)
+			assert.Equal(t, tt.wantCacheCtrl, fo.CacheControl)
+		})
+	}
+}

--- a/pkg/storage/objects_test.go
+++ b/pkg/storage/objects_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"mime"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -20,7 +21,7 @@ func TestParseFileOptionsContentTypeDetection(t *testing.T) {
 		{
 			name:          "detects PNG image",
 			content:       []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, // PNG header
-			filename:      "test.png",
+			filename:      "test.image",
 			wantMimeType:  "image/png",
 			wantCacheCtrl: "max-age=3600",
 		},
@@ -28,27 +29,27 @@ func TestParseFileOptionsContentTypeDetection(t *testing.T) {
 			name:          "detects JavaScript file",
 			content:       []byte("const hello = () => console.log('Hello, World!');"),
 			filename:      "script.js",
-			wantMimeType:  "text/javascript; charset=utf-8",
+			wantMimeType:  mime.TypeByExtension(".js"),
 			wantCacheCtrl: "max-age=3600",
 		},
 		{
 			name:          "detects CSS file",
 			content:       []byte(".header { color: #333; font-size: 16px; }"),
 			filename:      "styles.css",
-			wantMimeType:  "text/css; charset=utf-8",
+			wantMimeType:  mime.TypeByExtension(".css"),
 			wantCacheCtrl: "max-age=3600",
 		},
 		{
 			name:          "detects SQL file",
 			content:       []byte("SELECT * FROM users WHERE id = 1;"),
 			filename:      "query.sql",
-			wantMimeType:  "application/x-sql",
+			wantMimeType:  mime.TypeByExtension(".sql"),
 			wantCacheCtrl: "max-age=3600",
 		},
 		{
-			name:          "detects Go file",
-			content:       []byte("package main\n\nfunc main() { println(\"Hello\") }"),
-			filename:      "main.go",
+			name:          "use text/plain as fallback for unrecognized extensions",
+			content:       []byte("const hello = () => console.log('Hello, World!');"),
+			filename:      "main.nonexistent",
 			wantMimeType:  "text/plain; charset=utf-8",
 			wantCacheCtrl: "max-age=3600",
 		},


### PR DESCRIPTION
Based on the filename extension on top of the content reading autodetect to have a behavior similar with what happen when uploading files via studio.

- Add content type detection for JavaScript (text/javascript)
- Add content type detection for CSS (text/css)
- Add content type detection for SQL (application/x-sql)
- Default to text/plain for unrecognized text files like .go


Add some unit testings for the ParseFileOptions function.