### PR TITLE
fix: bump edge-runtime to 1.66.3

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20241202-71e5240"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.66.2"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.3"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.3

### Changes

### [1.66.3](https://github.com/supabase/edge-runtime/compare/v1.66.2...v1.66.3) (2025-01-09)

#### Bug Fixes
* allow setting static patterns when creating a user worker ([#471](https://github.com/supabase/edge-runtime/issues/471)) ([d2c21c1](https://github.com/supabase/edge-runtime/commit/d2c21c16ca075eee86f677e451eb8388cdfb9fd3))

