### PR TITLE
fix: exclude pgmq schema from db dump and pull

### DIFF
--- a/internal/db/dump/dump.go
+++ b/internal/db/dump/dump.go
@@ -82,6 +82,7 @@ func dumpData(ctx context.Context, config pgconn.Config, schema, excludeTable []
 		"graphql",
 		"graphql_public",
 		// "net",
+		// "pgmq",
 		// "pgsodium",
 		// "pgsodium_masks",
 		"pgtle",

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -74,6 +74,7 @@ var (
 		"graphql",
 		"graphql_public",
 		"net",
+		"pgmq",
 		"pgsodium",
 		"pgsodium_masks",
 		"pgtle",

--- a/pkg/migration/drop.go
+++ b/pkg/migration/drop.go
@@ -24,6 +24,7 @@ var (
 		`\_realtime`,
 		`\_supavisor`,
 		"pgbouncer",
+		"pgmq",
 		"pgsodium",
 		"pgtle",
 		`supabase\_migrations`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2998

## What is the current behavior?

pgmq causes seg fault when running pg_dump. Steps to reproduce

1. Create `supabase/migrations/0_schema.sql`

```sql
CREATE EXTENSION pgmq;
SELECT pgmq.create('my_queue');
```

2. Run `supabase db dump --local`

```bash
Dumping schemas from local database...
--: line 47:     7 Segmentation fault      pg_dump --schema-only --quote-all-identifier --exclude-schema "${EXCLUDED_SCHEMAS:-}" ${EXTRA_FLAGS:-}
...
error running container: exit 139
```

## What is the new behavior?

Exclude `pgmq` schema to unblock db dump.

Schema diffing for pgmq queues wouldn't work anyway because it inserts into pgmq.meta table.

The workaround is to manage those queues manually with migration files like (1).

## Additional context

Add any other context or screenshots.
