### PR TITLE
fix: bump edge-runtime to 1.66.5

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20250113-83c9420"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.66.4"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.5"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.5

### Changes

### [1.66.5](https://github.com/supabase/edge-runtime/compare/v1.66.4...v1.66.5) (2025-01-15)

#### Bug Fixes
* **graph:** make barrier more robust ([#474](https://github.com/supabase/edge-runtime/issues/474))
