### PR TITLE
feat(cli): add repeatable migrations

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -152,7 +152,7 @@ func init() {
 	migrationCmd.AddCommand(migrationFetchCmd)
 	// Build new command
 	newFlags := migrationNewCmd.Flags()
-	newFlags.BoolVarP(&repeatable, "repeatable", "r", false, "Creates a repeatable migration instead of a common migration.")
+	newFlags.BoolVarP(&repeatable, "repeatable", "r", false, "Creates a repeatable migration instead of a versioned migration.")
 	migrationCmd.AddCommand(migrationNewCmd)
 	rootCmd.AddCommand(migrationCmd)
 }

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -39,12 +39,14 @@ var (
 		},
 	}
 
+	repeatable bool
+
 	migrationNewCmd = &cobra.Command{
 		Use:   "new <migration name>",
 		Short: "Create an empty migration script",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return new.Run(args[0], os.Stdin, afero.NewOsFs())
+			return new.Run(repeatable, args[0], os.Stdin, afero.NewOsFs())
 		},
 	}
 
@@ -149,6 +151,8 @@ func init() {
 	migrationFetchCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	migrationCmd.AddCommand(migrationFetchCmd)
 	// Build new command
+	newFlags := migrationNewCmd.Flags()
+	newFlags.BoolVarP(&repeatable, "repeatable", "r", false, "Creates a repeatable migration instead of a common migration.")
 	migrationCmd.AddCommand(migrationNewCmd)
 	rootCmd.AddCommand(migrationCmd)
 }

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -15,11 +15,6 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 	if err != nil {
 		return err
 	}
-	repeatableMigrations, err := list.LoadRepeatableMigrations(fsys)
-	if err != nil {
-		return err
-	}
-	migrations = append(migrations, repeatableMigrations...)
 	if err := migration.ApplyMigrations(ctx, migrations, conn, afero.NewIOFS(fsys)); err != nil {
 		return err
 	}

--- a/internal/migration/apply/apply.go
+++ b/internal/migration/apply/apply.go
@@ -15,6 +15,11 @@ func MigrateAndSeed(ctx context.Context, version string, conn *pgx.Conn, fsys af
 	if err != nil {
 		return err
 	}
+	repeatableMigrations, err := list.LoadRepeatableMigrations(fsys)
+	if err != nil {
+		return err
+	}
+	migrations = append(migrations, repeatableMigrations...)
 	if err := migration.ApplyMigrations(ctx, migrations, conn, afero.NewIOFS(fsys)); err != nil {
 		return err
 	}

--- a/internal/migration/list/list.go
+++ b/internal/migration/list/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/go-errors/errors"
@@ -68,6 +69,40 @@ func makeTable(remoteMigrations, localMigrations []string) string {
 			j++
 		}
 	}
+
+	for i, j := 0, 0; i < len(remoteMigrations) || j < len(localMigrations); {
+		if i < len(remoteMigrations) && !strings.HasPrefix(remoteMigrations[i], "r_") {
+			i++
+			continue
+		}
+
+		if j < len(localMigrations) && !strings.HasPrefix(localMigrations[j], "r_") {
+			j++
+			continue
+		}
+
+		// Append repeatable migrations to table
+		if i >= len(remoteMigrations) {
+			table += fmt.Sprintf("|`%s`|` `|` `|\n", localMigrations[j])
+			j++
+		} else if j >= len(localMigrations) {
+			table += fmt.Sprintf("|` `|`%s`|` `|\n", remoteMigrations[i])
+			i++
+		} else {
+			if localMigrations[j] < remoteMigrations[i] {
+				table += fmt.Sprintf("|`%s`|` `|` `|\n", localMigrations[j])
+				j++
+			} else if remoteMigrations[i] < localMigrations[j] {
+				table += fmt.Sprintf("|` `|`%s`|` `|\n", remoteMigrations[i])
+				i++
+			} else {
+				table += fmt.Sprintf("|`%s`|`%s`|` `|\n", localMigrations[j], remoteMigrations[i])
+				i++
+				j++
+			}
+		}
+	}
+
 	return table
 }
 
@@ -99,11 +134,7 @@ func LoadLocalVersions(fsys afero.Fs) ([]string, error) {
 
 func LoadPartialMigrations(version string, fsys afero.Fs) ([]string, error) {
 	filter := func(v string) bool {
-		return version == "" || v <= version
+		return version == "" || strings.HasPrefix(version, "r_") || v <= version
 	}
 	return migration.ListLocalMigrations(utils.MigrationsDir, afero.NewIOFS(fsys), filter)
-}
-
-func LoadRepeatableMigrations(fsys afero.Fs) ([]string, error) {
-	return migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
 }

--- a/internal/migration/list/list.go
+++ b/internal/migration/list/list.go
@@ -103,3 +103,7 @@ func LoadPartialMigrations(version string, fsys afero.Fs) ([]string, error) {
 	}
 	return migration.ListLocalMigrations(utils.MigrationsDir, afero.NewIOFS(fsys), filter)
 }
+
+func LoadRepeatableMigrations(fsys afero.Fs) ([]string, error) {
+	return migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
+}

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -11,8 +11,16 @@ import (
 	"github.com/supabase/cli/internal/utils"
 )
 
-func Run(migrationName string, stdin afero.File, fsys afero.Fs) error {
-	path := GetMigrationPath(utils.GetCurrentTimestamp(), migrationName)
+func Run(repeatable bool, migrationName string, stdin afero.File, fsys afero.Fs) error {
+	path := ""
+
+	if repeatable {
+		// if migration name already exists, repeatable migration will be overwritten
+		path = GetRepeatableMigrationPath(migrationName)
+	} else {
+		path = GetMigrationPath(utils.GetCurrentTimestamp(), migrationName)
+	}
+
 	if err := utils.MkdirIfNotExistFS(fsys, filepath.Dir(path)); err != nil {
 		return err
 	}
@@ -30,6 +38,11 @@ func Run(migrationName string, stdin afero.File, fsys afero.Fs) error {
 
 func GetMigrationPath(timestamp, name string) string {
 	fullName := fmt.Sprintf("%s_%s.sql", timestamp, name)
+	return filepath.Join(utils.MigrationsDir, fullName)
+}
+
+func GetRepeatableMigrationPath(name string) string {
+	fullName := fmt.Sprintf("r_%s.sql", name)
 	return filepath.Join(utils.MigrationsDir, fullName)
 }
 

--- a/internal/migration/new/new.go
+++ b/internal/migration/new/new.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Run(repeatable bool, migrationName string, stdin afero.File, fsys afero.Fs) error {
-	path := ""
+	var path string
 
 	if repeatable {
 		// if migration name already exists, repeatable migration will be overwritten

--- a/internal/migration/new/new_test.go
+++ b/internal/migration/new/new_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
-	t.Run("creates new migration file", func(t *testing.T) {
+	t.Run("creates new common migration file", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup empty stdin
 		stdin, err := fsys.Create("/dev/stdin")
 		require.NoError(t, err)
 		// Run test
-		assert.NoError(t, Run("test_migrate", stdin, fsys))
+		assert.NoError(t, Run(false, "test_migrate", stdin, fsys))
 		// Validate output
 		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
 		assert.NoError(t, err)
@@ -27,7 +27,22 @@ func TestNewCommand(t *testing.T) {
 		assert.Regexp(t, `([0-9]{14})_test_migrate\.sql`, files[0].Name())
 	})
 
-	t.Run("streams content from pipe", func(t *testing.T) {
+	t.Run("creates new repeatable migration file", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup empty stdin
+		stdin, err := fsys.Create("/dev/stdin")
+		require.NoError(t, err)
+		// Run test
+		assert.NoError(t, Run(true, "repeatable_test_migrate", stdin, fsys))
+		// Validate output
+		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(files))
+		assert.Regexp(t, `r_repeatable_test_migrate\.sql`, files[0].Name())
+	})
+
+	t.Run("streams content from pipe to common migration", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup stdin
@@ -38,7 +53,29 @@ func TestNewCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, w.Close())
 		// Run test
-		assert.NoError(t, Run("test_migrate", r, fsys))
+		assert.NoError(t, Run(false, "test_migrate", r, fsys))
+		// Validate output
+		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(files))
+		path := filepath.Join(utils.MigrationsDir, files[0].Name())
+		contents, err := afero.ReadFile(fsys, path)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(script), contents)
+	})
+
+	t.Run("streams content from pipe to repeatable migration", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup stdin
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		script := "create table pet;\ndrop table pet;\n"
+		_, err = w.WriteString(script)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		// Run test
+		assert.NoError(t, Run(true, "repeatable_test_migrate", r, fsys))
 		// Validate output
 		files, err := afero.ReadDir(fsys, utils.MigrationsDir)
 		assert.NoError(t, err)
@@ -56,7 +93,8 @@ func TestNewCommand(t *testing.T) {
 		stdin, err := fsys.Create("/dev/stdin")
 		require.NoError(t, err)
 		// Run test
-		assert.Error(t, Run("test_migrate", stdin, afero.NewReadOnlyFs(fsys)))
+		assert.Error(t, Run(false, "test_migrate", stdin, afero.NewReadOnlyFs(fsys)))
+		assert.Error(t, Run(true, "repeatable_test_migrate", stdin, afero.NewReadOnlyFs(fsys)))
 	})
 
 	t.Run("throws error on closed pipe", func(t *testing.T) {
@@ -67,6 +105,7 @@ func TestNewCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, r.Close())
 		// Run test
-		assert.Error(t, Run("test_migrate", r, fsys))
+		assert.Error(t, Run(false, "test_migrate", r, fsys))
+		assert.Error(t, Run(true, "repeatable_test_migrate", r, fsys))
 	})
 }

--- a/internal/migration/up/up.go
+++ b/internal/migration/up/up.go
@@ -46,14 +46,6 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 		}
 		utils.CmdSuggestion = suggestIgnoreFlag(diff)
 	}
-	if err != nil {
-		return diff, err
-	}
-	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
-	if err != nil {
-		return nil, err
-	}
-	diff = append(diff, repeatableMigrations...)
 	return diff, err
 }
 

--- a/internal/migration/up/up.go
+++ b/internal/migration/up/up.go
@@ -24,17 +24,7 @@ func Run(ctx context.Context, includeAll bool, config pgconn.Config, fsys afero.
 		return err
 	}
 
-	err = migration.ApplyMigrations(ctx, pending, conn, afero.NewIOFS(fsys))
-	if err != nil {
-		return err
-	}
-
-	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
-	if err != nil {
-		return err
-	}
-
-	return migration.ApplyMigrations(ctx, repeatableMigrations, conn, afero.NewIOFS(fsys))
+	return migration.ApplyMigrations(ctx, pending, conn, afero.NewIOFS(fsys))
 }
 
 func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, fsys afero.Fs) ([]string, error) {
@@ -56,6 +46,11 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 		}
 		utils.CmdSuggestion = suggestIgnoreFlag(diff)
 	}
+	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
+	if err != nil {
+		return nil, err
+	}
+	diff = append(diff, repeatableMigrations...)
 	return diff, err
 }
 

--- a/internal/migration/up/up.go
+++ b/internal/migration/up/up.go
@@ -46,6 +46,9 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 		}
 		utils.CmdSuggestion = suggestIgnoreFlag(diff)
 	}
+	if err != nil {
+		return diff, err
+	}
 	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
 	if err != nil {
 		return nil, err

--- a/internal/migration/up/up.go
+++ b/internal/migration/up/up.go
@@ -24,7 +24,17 @@ func Run(ctx context.Context, includeAll bool, config pgconn.Config, fsys afero.
 		return err
 	}
 
-	return migration.ApplyMigrations(ctx, pending, conn, afero.NewIOFS(fsys))
+	err = migration.ApplyMigrations(ctx, pending, conn, afero.NewIOFS(fsys))
+	if err != nil {
+		return err
+	}
+
+	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
+	if err != nil {
+		return err
+	}
+
+	return migration.ApplyMigrations(ctx, repeatableMigrations, conn, afero.NewIOFS(fsys))
 }
 
 func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, fsys afero.Fs) ([]string, error) {
@@ -46,11 +56,6 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 		}
 		utils.CmdSuggestion = suggestIgnoreFlag(diff)
 	}
-	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
-	if err != nil {
-		return nil, err
-	}
-	diff = append(diff, repeatableMigrations...)
 	return diff, err
 }
 

--- a/internal/migration/up/up.go
+++ b/internal/migration/up/up.go
@@ -23,6 +23,7 @@ func Run(ctx context.Context, includeAll bool, config pgconn.Config, fsys afero.
 	if err != nil {
 		return err
 	}
+
 	return migration.ApplyMigrations(ctx, pending, conn, afero.NewIOFS(fsys))
 }
 
@@ -45,6 +46,11 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 		}
 		utils.CmdSuggestion = suggestIgnoreFlag(diff)
 	}
+	repeatableMigrations, err := migration.ListRepeatableMigrations(utils.MigrationsDir, afero.NewIOFS(fsys))
+	if err != nil {
+		return nil, err
+	}
+	diff = append(diff, repeatableMigrations...)
 	return diff, err
 }
 

--- a/pkg/migration/file.go
+++ b/pkg/migration/file.go
@@ -23,7 +23,7 @@ type MigrationFile struct {
 	Statements []string
 }
 
-var migrateFilePattern = regexp.MustCompile(`^([0-9]+)_(.*)\.sql$`)
+var migrateFilePattern = regexp.MustCompile(`^([0-9]+|r)_(.*)\.sql$`)
 
 func NewMigrationFromFile(path string, fsys fs.FS) (*MigrationFile, error) {
 	lines, err := parseFile(path, fsys)
@@ -37,6 +37,10 @@ func NewMigrationFromFile(path string, fsys fs.FS) (*MigrationFile, error) {
 	if len(matches) > 2 {
 		file.Version = matches[1]
 		file.Name = matches[2]
+	}
+	// Repeatable migration version => r_name
+	if file.Version == "r" {
+		file.Version += "_" + file.Name
 	}
 	return &file, nil
 }

--- a/pkg/migration/list.go
+++ b/pkg/migration/list.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
@@ -46,41 +45,23 @@ func ListLocalMigrations(migrationsDir string, fsys fs.FS, filter ...func(string
 			fmt.Fprintf(os.Stderr, "Skipping migration %s... (replace \"init\" with a different file name to apply this migration)\n", filename)
 			continue
 		}
-		if strings.HasPrefix(filename, "r_") {
-			// silently skip repeatable migrations
-			continue
-		}
 		matches := migrateFilePattern.FindStringSubmatch(filename)
 		if len(matches) == 0 {
-			fmt.Fprintf(os.Stderr, "Skipping migration %s... (file name must match pattern \"<timestamp>_name.sql\")\n", filename)
+			fmt.Fprintf(os.Stderr, "Skipping migration %s... (file name must match pattern \"<timestamp>_name.sql\" or \"r_name.sql\")\n", filename)
 			continue
 		}
 		path := filepath.Join(migrationsDir, filename)
 		for _, keep := range filter {
-			if version := matches[1]; keep(version) {
+			version := matches[1]
+			if version == "r" && len(matches) > 2 {
+				version += "_" + matches[2]
+			}
+			if keep(version) {
 				clean = append(clean, path)
 			}
 		}
 	}
 	return clean, nil
-}
-
-func ListRepeatableMigrations(migrationsDir string, fsys fs.FS) ([]string, error) {
-	localMigrations, err := fs.ReadDir(fsys, migrationsDir)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.Errorf("failed to read directory: %w", err)
-	}
-	var repeatable []string
-
-	for _, migration := range localMigrations {
-		filename := migration.Name()
-		if strings.HasPrefix(filename, "r_") && strings.HasSuffix(filename, ".sql") {
-			path := filepath.Join(migrationsDir, filename)
-			repeatable = append(repeatable, path)
-		}
-	}
-
-	return repeatable, nil
 }
 
 var initSchemaPattern = regexp.MustCompile(`([0-9]{14})_init\.sql`)

--- a/pkg/migration/list_test.go
+++ b/pkg/migration/list_test.go
@@ -73,6 +73,7 @@ func TestLocalMigrations(t *testing.T) {
 		fsys := fs.MapFS{
 			"20211208000000_init.sql":   &fs.MapFile{},
 			"20211208000001_invalid.ts": &fs.MapFile{},
+			"r_invalid.ts":              &fs.MapFile{},
 		}
 		// Run test
 		versions, err := ListLocalMigrations(".", fsys)
@@ -86,47 +87,6 @@ func TestLocalMigrations(t *testing.T) {
 		fsys := fs.MapFS{"migrations": &fs.MapFile{}}
 		// Run test
 		_, err := ListLocalMigrations("migrations", fsys)
-		// Check error
-		assert.ErrorContains(t, err, "failed to read directory:")
-	})
-}
-
-func TestRepeatableMigrations(t *testing.T) {
-	t.Run("loads repeatable migrations", func(t *testing.T) {
-		// Setup in-memory fs
-		files := []string{
-			"r_test_view.sql",
-			"r_test_function.sql",
-		}
-		fsys := fs.MapFS{}
-		for _, name := range files {
-			fsys[name] = &fs.MapFile{}
-		}
-		// Run test
-		versions, err := ListRepeatableMigrations(".", fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.ElementsMatch(t, files, versions)
-	})
-
-	t.Run("ignores files without 'r_' prefix", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := fs.MapFS{
-			"20211208000000_init.sql": &fs.MapFile{},
-			"r_invalid.ts":            &fs.MapFile{},
-		}
-		// Run test
-		versions, err := ListRepeatableMigrations(".", fsys)
-		// Check error
-		assert.NoError(t, err)
-		assert.Empty(t, versions)
-	})
-
-	t.Run("throws error on open failure", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := fs.MapFS{"migrations": &fs.MapFile{}}
-		// Run test
-		_, err := ListRepeatableMigrations("migrations", fsys)
 		// Check error
 		assert.ErrorContains(t, err, "failed to read directory:")
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Similar to [flyways repeatable migrations](https://documentation.red-gate.com/fd/tutorial-repeatable-migrations-184127625.html) this adds rudimentary functionality for repeatable database migrations to the supabase cli.

- Adds a flag to `supabase migration new` to create a repeatable migration
- Implementation to differentiate between repeatable and common migrations in `supabase migration up`
- Tests

Instead of versioning repeatable migration files they are applied after all pending migrations locally and can then be pushed to remote.

## What is the current behavior?

Currently database objects like views, functions etc. must be duplicated in the migration files when changed. E.g. to change a `view` we create a new versioned migration in which we duplicate the definition of the `view`.

## What is the new behavior?

- `supabase migration new` can now be used to create repeatable migrations
- `supabase migration up` now applies repeatable migrations after all pending migrations

## Additional context

Should close #2784
