### PR TITLE
fix: update gitignore file to exclude dotenvx files

### DIFF
--- a/internal/init/templates/.gitignore
+++ b/internal/init/templates/.gitignore
@@ -1,4 +1,8 @@
 # Supabase
 .branches
 .temp
-.env
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Updated gitignore to follow [dotenv convention](https://github.com/bkeepers/dotenv?tab=readme-ov-file#customizing-rails) more closely.

## Additional context

Add any other context or screenshots.
