### PR TITLE
fix: use direct DbHost from response in `branches get`

### DIFF
--- a/internal/branches/get/get.go
+++ b/internal/branches/get/get.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, branchId string, fsys afero.Fs) error {
 	}
 
 	config := pgconn.Config{
-		Host:     utils.GetSupabaseDbHost(resp.JSON200.DbHost),
+		Host:     resp.JSON200.DbHost,
 		Port:     cast.UIntToUInt16(cast.IntToUint(resp.JSON200.DbPort)),
 		User:     *resp.JSON200.DbUser,
 		Password: *resp.JSON200.DbPass,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a bug fix for the `branches get` command. Currently, it returns an incorrect host in the PostgreSQL URL.

## What is the current behavior?

The PostgreSQL URL contains a redundant db.***.supabase.co.

```sh
> supabase branches get --experimental --output json                                                                                         develop
{
  "POSTGRES_URL": "postgresql://postgres:[password]@db.db.[project-id].supabase.co.supabase.co:5432/?connect_timeout=10"
}
```

## What is the new behavior?

```sh
> go run . branches get --experimental --output json
{
  "POSTGRES_URL": "postgresql://postgres:[password]@db.[project-id].supabase.co:5432/?connect_timeout=10"
}
```
