### PR TITLE
feat(postgrest-config): add delete command to cli for convenience

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/supabase/cli/internal/postgresConfig/delete"
 	"github.com/supabase/cli/internal/postgresConfig/get"
 	"github.com/supabase/cli/internal/postgresConfig/update"
 	"github.com/supabase/cli/internal/utils/flags"
@@ -33,8 +34,18 @@ Custom configuration also overrides the optimizations generated based on the com
 		},
 	}
 
+	postgresConfigDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete specific Postgres database config overrides",
+		Long:  "Delete specific config overrides, reverting them to their default values.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return delete.Run(cmd.Context(), flags.ProjectRef, postgresConfigKeysToDelete, noRestart, afero.NewOsFs())
+		},
+	}
+
 	postgresConfigValues            []string
 	postgresConfigUpdateReplaceMode bool
+	postgresConfigKeysToDelete      []string
 	noRestart                       bool
 )
 
@@ -42,11 +53,16 @@ func init() {
 	postgresCmd.PersistentFlags().StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
 	postgresCmd.AddCommand(postgresConfigGetCmd)
 	postgresCmd.AddCommand(postgresConfigUpdateCmd)
+	postgresCmd.AddCommand(postgresConfigDeleteCmd)
 
 	updateFlags := postgresConfigUpdateCmd.Flags()
 	updateFlags.StringSliceVar(&postgresConfigValues, "config", []string{}, "Config overrides specified as a 'key=value' pair")
 	updateFlags.BoolVar(&postgresConfigUpdateReplaceMode, "replace-existing-overrides", false, "If true, replaces all existing overrides with the ones provided. If false (default), merges existing overrides with the ones provided.")
 	updateFlags.BoolVar(&noRestart, "no-restart", false, "Do not restart the database after updating config.")
+
+	deleteFlags := postgresConfigDeleteCmd.Flags()
+	deleteFlags.StringSliceVar(&postgresConfigKeysToDelete, "config", []string{}, "Config keys to delete (comma-separated)")
+	deleteFlags.BoolVar(&noRestart, "no-restart", false, "Do not restart the database after deleting config.")
 
 	rootCmd.AddCommand(postgresCmd)
 }

--- a/internal/postgresConfig/delete/delete.go
+++ b/internal/postgresConfig/delete/delete.go
@@ -1,0 +1,48 @@
+package delete
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/go-errors/errors"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/postgresConfig/get"
+	"github.com/supabase/cli/internal/utils"
+)
+
+func Run(ctx context.Context, projectRef string, configKeys []string, noRestart bool, fsys afero.Fs) error {
+	// 1. Get current config
+	currentConfig, err := get.GetCurrentPostgresConfig(ctx, projectRef)
+	if err != nil {
+		return err
+	}
+
+	// 2. Remove specified keys
+	for _, key := range configKeys {
+		delete(currentConfig, strings.TrimSpace(key))
+	}
+
+	// 3. Update config with removed keys
+	if noRestart {
+		currentConfig["restart_database"] = false
+	}
+	bts, err := json.Marshal(currentConfig)
+	if err != nil {
+		return errors.Errorf("failed to serialize config overrides: %w", err)
+	}
+
+	resp, err := utils.GetSupabase().V1UpdatePostgresConfigWithBodyWithResponse(ctx, projectRef, "application/json", bytes.NewReader(bts))
+	if err != nil {
+		return errors.Errorf("failed to update config overrides: %w", err)
+	}
+	if resp.JSON200 == nil {
+		if resp.StatusCode() == 400 {
+			return errors.Errorf("failed to update config overrides: %s (%s). This usually indicates that an unsupported or invalid config override was attempted. Please refer to https://supabase.com/docs/guides/platform/custom-postgres-config", resp.Status(), string(resp.Body))
+		}
+		return errors.Errorf("failed to update config overrides: %s (%s)", resp.Status(), string(resp.Body))
+	}
+
+	return get.Run(ctx, projectRef, fsys)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a new `delete` subcommand to `posgres-config` allowing to restore override values back to default ones more easily.

## Usage:

```
# Delete a single configuration parameter
supabase postgres-config delete --config max_connections

# Delete multiple configuration parameters (comma-separated, no spaces)
supabase postgres-config delete --config max_wal_size,effective_cache_size,shared_buffers

# Delete configuration without restarting the database
supabase postgres-config delete --config work_mem,maintenance_work_mem --no-restart
```

Closes DEVW-324