### PR TITLE
fix: ignore envs declared with empty value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -782,7 +782,7 @@ func LoadEnvHook(f reflect.Kind, t reflect.Kind, data interface{}) (interface{},
 	}
 	value := data.(string)
 	if matches := envPattern.FindStringSubmatch(value); len(matches) > 1 {
-		if env, exists := os.LookupEnv(matches[1]); exists {
+		if env := os.Getenv(matches[1]); len(env) > 0 {
 			value = env
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

If user declares an empty value in .env like `MY_SECRET=`, we should treat them as uninitialised like we used to.

## Additional context

Add any other context or screenshots.
