### PR TITLE
fix: Exclude realtime messages publication from publication dropping

### DIFF
--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -81,7 +81,7 @@ begin
     select *
     from pg_publication p
     where
-      p.pubname != 'supabase_realtime'
+      p.pubname not like 'supabase_realtime%'
   loop
     execute format('drop publication if exists %I', rec.pubname);
   end loop;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Exclude realtime messages publication from publication dropping

Requires https://github.com/supabase/realtime/pull/1274 to be merged