### PR TITLE
fix: typo in error message when creating seed table

### DIFF
--- a/pkg/migration/history.go
+++ b/pkg/migration/history.go
@@ -58,7 +58,7 @@ func CreateSeedTable(ctx context.Context, conn *pgx.Conn) error {
 	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_SEED_TABLE, nil, nil, nil, nil)
 	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
-		return errors.Errorf("failed to create schema table: %w", err)
+		return errors.Errorf("failed to create seed table: %w", err)
 	}
 	return nil
 }

--- a/pkg/migration/history.go
+++ b/pkg/migration/history.go
@@ -58,7 +58,7 @@ func CreateSeedTable(ctx context.Context, conn *pgx.Conn) error {
 	batch.ExecParams(CREATE_VERSION_SCHEMA, nil, nil, nil, nil)
 	batch.ExecParams(CREATE_SEED_TABLE, nil, nil, nil, nil)
 	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
-		return errors.Errorf("failed to create migration table: %w", err)
+		return errors.Errorf("failed to create schema table: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo in error message

## What is the current behavior?

says the wrong table name

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
