### PR TITLE
fix: bump edge-runtime to 1.66.6

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20250130-b048539"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.66.5"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.66.6"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.66.6

### Changes

### [1.66.6](https://github.com/supabase/edge-runtime/compare/v1.66.5...v1.66.6) (2025-02-03)

#### Bug Fixes

* **ext/node:** set process.env as own property ([#485](https://github.com/supabase/edge-runtime/issues/485)) ([1b2ab71](https://github.com/supabase/edge-runtime/commit/1b2ab71ad2fc00257d9ab47a5a3edb20eabded2e))
