### PR TITLE
fix: improve function config parse error message

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -426,7 +426,7 @@ func (c *config) loadFromReader(v *viper.Viper, r io.Reader) error {
 		dc.TagName = "toml"
 		dc.Squash = true
 		dc.ZeroFields = true
-		dc.DecodeHook = c.newDecodeHook(LoadEnvHook, ValidateFunctionsHookFunc)
+		dc.DecodeHook = c.newDecodeHook(LoadEnvHook, ValidateFunctionsHook)
 	}); err != nil {
 		return errors.Errorf("failed to parse config: %w", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -479,7 +479,7 @@ func TestLoadFunctionErrorMessageParsing(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot parse 'functions[hello].verify_jwt' as bool: strconv.ParseBool: parsing \"not-a-bool\"")
 	})
-	t.Run("returns error for unkown function fields", func(t *testing.T) {
+	t.Run("returns error for unknown function fields", func(t *testing.T) {
 		config := NewConfig()
 		fsys := fs.MapFS{
 			"supabase/config.toml": &fs.MapFile{Data: []byte(`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -447,7 +447,7 @@ func TestLoadFunctionErrorMessageParsing(t *testing.T) {
 		err := config.Load("", fsys)
 		// Check error contains both decode errors
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Invalid functions config format. Functions should be configured as:\n\n[functions.<function-name>]\nfield = value\n\nExample:\n[functions.hello]\nverify_jwt = true\n")
+		assert.Contains(t, err.Error(), invalidFunctionsConfigFormat)
 	})
 	t.Run("returns error with function slug for invalid non-existent field", func(t *testing.T) {
 		config := NewConfig()
@@ -492,6 +492,6 @@ func TestLoadFunctionErrorMessageParsing(t *testing.T) {
 		// Run test
 		err := config.Load("", fsys)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Invalid functions config format. Functions should be configured as:\n\n[functions.<function-name>]\nfield = value\n\nExample:\n[functions.hello]\nverify_jwt = true\n")
+		assert.Contains(t, err.Error(), invalidFunctionsConfigFormat)
 	})
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -431,3 +431,67 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		assert.Equal(t, "supabase/custom_import_map.json", config.Functions["hello"].ImportMap)
 	})
 }
+
+func TestLoadFunctionErrorMessageParsing(t *testing.T) {
+	t.Run("returns error for array-style function config", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[[functions]]
+			name = "hello"
+			verify_jwt = true
+			`)},
+		}
+		// Run test
+		err := config.Load("", fsys)
+		// Check error contains both decode errors
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid functions config format. Functions should be configured as:\n\n[functions.<function-name>]\nfield = value\n\nExample:\n[functions.hello]\nverify_jwt = true\n")
+	})
+	t.Run("returns error with function slug for invalid non-existent field", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[functions.hello]
+			unknown_field = true
+			`)},
+		}
+		// Run test
+		err := config.Load("", fsys)
+		// Check error contains both decode errors
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "'functions[hello]' has invalid keys: unknown_field")
+	})
+	t.Run("returns error with function slug for invalid field value", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[functions.hello]
+			verify_jwt = "not-a-bool"
+			`)},
+		}
+		// Run test
+		err := config.Load("", fsys)
+		// Check error contains both decode errors
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse 'functions[hello].verify_jwt' as bool: strconv.ParseBool: parsing \"not-a-bool\"")
+	})
+	t.Run("returns error for unkown function fields", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[functions]
+			name = "hello"
+			verify_jwt = true
+			`)},
+		}
+		// Run test
+		err := config.Load("", fsys)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid functions config format. Functions should be configured as:\n\n[functions.<function-name>]\nfield = value\n\nExample:\n[functions.hello]\nverify_jwt = true\n")
+	})
+}

--- a/pkg/config/decode_hooks.go
+++ b/pkg/config/decode_hooks.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+
+	"github.com/go-errors/errors"
+)
+
+var envPattern = regexp.MustCompile(`^env\((.*)\)$`)
+
+// LoadEnvHook is a mapstructure decode hook that loads environment variables
+// from strings formatted as env(VAR_NAME).
+func LoadEnvHook(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
+	if f != reflect.String {
+		return data, nil
+	}
+	value := data.(string)
+	if matches := envPattern.FindStringSubmatch(value); len(matches) > 1 {
+		if env := os.Getenv(matches[1]); len(env) > 0 {
+			value = env
+		}
+	}
+	return value, nil
+}
+
+// ValidateFunctionsHookFunc is a mapstructure decode hook that validates the functions config format.
+func ValidateFunctionsHookFunc(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	// Only handle FunctionConfig type
+	if t != reflect.TypeOf(FunctionConfig{}) {
+		return data, nil
+	}
+
+	// Check if source is not a map
+	if f.Kind() != reflect.Map {
+		return nil, errors.New(`Invalid functions config format. Functions should be configured as:
+
+[functions.<function-name>]
+field = value
+
+Example:
+[functions.hello]
+verify_jwt = true
+`)
+	}
+
+	// Check if any fields are defined directly under [functions] instead of [functions.<name>]
+	if m, ok := data.(map[string]interface{}); ok {
+		for _, value := range m {
+			// Skip nil values and empty function configs as they're valid
+			if value == nil {
+				continue
+			}
+			// If it's already a function type, it's valid
+			if _, isFunction := value.(function); isFunction {
+				continue
+			}
+			// If the value is not a map, it means it's defined directly under [functions]
+			if _, isMap := value.(map[string]interface{}); !isMap {
+				return nil, errors.New(`Invalid functions config format. Functions should be configured as:
+
+[functions.<function-name>]
+field = value
+
+Example:
+[functions.hello]
+verify_jwt = true
+`)
+			}
+		}
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Improve the functions parse config error to give more actionable error message for functions in common case of `Unknown field` or `functions[0] ... expected a map` error.
