### PR TITLE
Fix: Don't overwrite `api.external_url` from config.toml

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -544,16 +544,18 @@ func (c *config) Load(path string, fsys fs.FS) error {
 	if connString, err := fs.ReadFile(fsys, builder.PoolerUrlPath); err == nil && len(connString) > 0 {
 		c.Db.Pooler.ConnectionString = string(connString)
 	}
-	// Update external api url
-	apiUrl := url.URL{Host: net.JoinHostPort(c.Hostname,
-		strconv.FormatUint(uint64(c.Api.Port), 10),
-	)}
-	if c.Api.Tls.Enabled {
-		apiUrl.Scheme = "https"
-	} else {
-		apiUrl.Scheme = "http"
+	if len(c.Api.ExternalUrl) == 0 {
+		// Update external api url
+		apiUrl := url.URL{Host: net.JoinHostPort(c.Hostname,
+			strconv.FormatUint(uint64(c.Api.Port), 10),
+		)}
+		if c.Api.Tls.Enabled {
+			apiUrl.Scheme = "https"
+		} else {
+			apiUrl.Scheme = "http"
+		}
+		c.Api.ExternalUrl = apiUrl.String()
 	}
-	c.Api.ExternalUrl = apiUrl.String()
 	// Update image versions
 	if version, err := fs.ReadFile(fsys, builder.PostgresVersionPath); err == nil {
 		if strings.HasPrefix(string(version), "15.") && semver.Compare(string(version[3:]), "1.0.55") >= 0 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes a bug that prevents users from setting a config value containing the external URL that the Supabase API will be deployed at.

## What is the current behavior?

As stated in #3118, although the `api.external_url` config field exists, its value is always overwritten in pkg/config/config.go. This prevents the user from setting the external URL that is used for things like Supabase Auth generating links.

## What is the new behavior?

Now, if there is a value supplied for `api.external_url`, it will be used as the API's external URL. If there is not a value supplied for `api.external_url`, it will still be set to a value derived from the hardcoded hostname, "127.0.0.1".