### PR TITLE
fix: bump edge-runtime to 1.67.1

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20250113-83c9420"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.67.0"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.67.1"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.67.1

### Changes

### [1.67.1](https://github.com/supabase/edge-runtime/compare/v1.67.0...v1.67.1) (2025-02-12)

#### Bug Fixes
* convert file path with special characters to url correctly ([#490](https://github.com/supabase/edge-runtime/issues/490)) ([3d93fb1](https://github.com/supabase/edge-runtime/commit/3d93fb16c55091d56dee44bb0bc97a888e230a36))

