### PR TITLE
mount correct socket on unix

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -292,13 +292,13 @@ EOF
 			fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "analytics requires docker daemon exposed on tcp://localhost:2375")
 			env = append(env, "DOCKER_HOST="+dindHost.String())
 		case "unix":
-			if parsed, err = client.ParseHostURL(client.DefaultDockerHost); err != nil {
+			if parsed, err = client.ParseHostURL(utils.Docker.DaemonHost()); err != nil {
 				return errors.Errorf("failed to parse default host: %w", err)
 			}
 			if utils.Docker.DaemonHost() != client.DefaultDockerHost {
 				fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "analytics requires mounting default docker socket:", parsed.Host)
 			}
-			binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:ro", parsed.Host))
+			binds = append(binds, fmt.Sprintf("%[1]s:%[2]s:ro", parsed.Host, "/var/run/docker.sock"))
 		}
 		if _, err := utils.DockerStart(
 			ctx,


### PR DESCRIPTION
## What kind of change does this PR introduce?
This should be mounting the correct docker socket on UNIX by using `utils.Docker.DaemonHost()` instead of `client.DefaultDockerHost`. 

Fixes a bug where on rootless docker, it mounts the incorrect path of `/var/run/docker.sock` instead of the correct one `/run/user/1000/docker.sock` or whatever `DOCKER_HOST` 

## What is the current behaviour?
It tries to mount `/var/run/docker.sock`

Please link any relevant issues here.
#3127 

## What is the new behaviour?
Should mount the correct path.

## Additional context
It would be awesome if someone else also tests this functionality as this could introduce bugs on other systems. 

PS - this pr was largely thanks to the help of @PhatDave with testing and debugging.
