### PR TITLE
fix: bump edge-runtime to 1.67.2

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pgmetaImage      = "supabase/postgres-meta:v0.84.2"
 	studioImage      = "supabase/studio:20250113-83c9420"
 	imageProxyImage  = "darthsim/imgproxy:v3.8.0"
-	edgeRuntimeImage = "supabase/edge-runtime:v1.67.1"
+	edgeRuntimeImage = "supabase/edge-runtime:v1.67.2"
 	vectorImage      = "timberio/vector:0.28.1-alpine"
 	supavisorImage   = "supabase/supavisor:1.1.56"
 	gotrueImage      = "supabase/gotrue:v2.167.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.67.2

### Changes

### [1.67.2](https://github.com/supabase/edge-runtime/compare/v1.67.1...v1.67.2) (2025-02-13)

#### Bug Fixes
* unblock `Deno.realPathSync` ([#493](https://github.com/supabase/edge-runtime/issues/493)) ([bbd9dc6](https://github.com/supabase/edge-runtime/commit/bbd9dc61a032ef1ccab8913e82bb3722a20ec717))

