### PR TITLE
fix: handle failure modes when restoring from backup

### DIFF
--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -42,6 +42,7 @@ pg_dump \
 | sed -E "s/^GRANT (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pg_tle").+/\1;/' \
+| sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgsodium").+/\1;/' \
 | sed -E 's/^COMMENT ON EXTENSION (.+)/-- &/' \
 | sed -E 's/^CREATE POLICY "cron_job_/-- &/' \
 | sed -E 's/^ALTER TABLE "cron"/-- &/' \

--- a/internal/db/start/templates/restore.sh
+++ b/internal/db/start/templates/restore.sh
@@ -22,6 +22,7 @@ echo "$0: restoring roles"
 cat "/etc/backup.sql" \
 | grep 'CREATE ROLE' \
 | grep -v 'supabase_admin' \
+| sed -E 's/^(CREATE ROLE postgres);/\1 WITH SUPERUSER;/' \
 | psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin
 
 echo "$0: restoring schema"
@@ -31,6 +32,7 @@ cat "/etc/backup.sql" \
 | sed -E 's/^CREATE TRIGGER /CREATE OR REPLACE TRIGGER /' \
 | sed -E 's/^GRANT ALL ON FUNCTION graphql_public\./-- &/' \
 | sed -E 's/^CREATE ROLE /-- &/' \
+| sed -e '/ALTER ROLE postgres WITH / { h; $p; d; }' -e '$G' \
 | psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin
 
 # run any post migration script to update role passwords

--- a/internal/db/start/templates/schema.sql
+++ b/internal/db/start/templates/schema.sql
@@ -5,6 +5,7 @@
 ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
 ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';
 
+ALTER USER postgres WITH PASSWORD :'pgpass';
 ALTER USER authenticator WITH PASSWORD :'pgpass';
 ALTER USER pgbouncer WITH PASSWORD :'pgpass';
 ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

1. remove hardcoded `pgsodium` schema
2. step down superuser only after restore
3. always assign default postgres password

## Additional context

Add any other context or screenshots.
