### PR TITLE
fix: disable label separation when binding socket

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -274,8 +274,7 @@ EOF
 		}); err != nil {
 			return errors.Errorf("failed to exec template: %w", err)
 		}
-		var binds, env []string
-		var securityOpts []string
+		var binds, env, securityOpts []string
 		// Special case for GitLab pipeline
 		parsed, err := client.ParseHostURL(utils.Docker.DaemonHost())
 		if err != nil {
@@ -297,7 +296,7 @@ EOF
 				return errors.Errorf("failed to parse default host: %w", err)
 			}
 			binds = append(binds, fmt.Sprintf("%s:%s:ro", parsed.Host, dindHost.Host))
-			securityOpts = append(securityOpts, "label=disable")
+			securityOpts = append(securityOpts, "label:disable")
 		}
 		if _, err := utils.DockerStart(
 			ctx,

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -275,6 +275,7 @@ EOF
 			return errors.Errorf("failed to exec template: %w", err)
 		}
 		var binds, env []string
+		var securityOpts []string
 		// Special case for GitLab pipeline
 		parsed, err := client.ParseHostURL(utils.Docker.DaemonHost())
 		if err != nil {
@@ -296,6 +297,7 @@ EOF
 				return errors.Errorf("failed to parse default host: %w", err)
 			}
 			binds = append(binds, fmt.Sprintf("%s:%s:ro", parsed.Host, dindHost.Host))
+			securityOpts = append(securityOpts, "label=disable")
 		}
 		if _, err := utils.DockerStart(
 			ctx,
@@ -318,6 +320,7 @@ EOF
 			container.HostConfig{
 				Binds:         binds,
 				RestartPolicy: container.RestartPolicy{Name: "always"},
+				SecurityOpt:   securityOpts,
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{


### PR DESCRIPTION
This change ensures that when mounting unix sockets for enabling dind access, security opt `label=disable` is set for the container.

Ref: https://docs.podman.io/en/latest/markdown/podman-system-service.1.html#access-the-unix-socket-from-inside-a-container

See-also: https://github.com/supabase/supabase/pull/33603

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

At present when using rootless podman with SELinux enabled, `supbase start` command fails at health check step.

Relates-to: #3099

```console
2025-02-15T15:52:11.439823Z ERROR source{component_kind="source" component_id=docker_host component_type=docker_logs component_name=docker_host}: vector::sources::docker_logs: Listing currently running containers failed. error=error trying to connect: Permission denied (os error 13)
```

## What is the new behavior?

When executing `supabase start` using rootless podman with SELinux enabled, the development environment starts correctly.

## Additional context

```console
2025-02-15T15:52:11.439435Z  INFO vector::topology::running: Running healthchecks.
2025-02-15T15:52:11.439488Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439510Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439519Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439524Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439528Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439536Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439540Z  INFO vector::topology::builder: Healthcheck passed.
2025-02-15T15:52:11.439732Z  INFO vector: Vector has started. debug="false" version="0.28.1" arch="x86_64" revision="ff15924 2023-03-06"
2025-02-15T15:52:11.439823Z ERROR source{component_kind="source" component_id=docker_host component_type=docker_logs component_name=docker_host}: vector::sources::docker_logs: Listing currently running containers failed. error=error trying to connect: Permission denied (os error 13)
2025-02-15T15:52:11.445682Z  INFO vector::internal_events::api: API server running. address=0.0.0.0:9001 playground=http://0.0.0.0:9001/playground
2025-02-15T15:52:11.445706Z  INFO vector::app: All sources have finished.
2025-02-15T15:52:11.445708Z  INFO vector: Vector has stopped.
2025-02-15T15:52:11.446959Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="logflare_rest, logflare_db, logflare_kong, logflare_realtime, logflare_auth, logflare_functions, logflare_storage" time_remaining="59 seconds left"
Stopping containers...
supabase_vector_service-playground container is not ready: starting
Try rerunning the command with --debug to troubleshoot the error.
```
