### PR TITLE
feat: config option for ordering declarative schemas

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -24,7 +24,6 @@ import (
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/gen/keys"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 	"github.com/supabase/cli/pkg/parser"
 )
@@ -33,9 +32,6 @@ type DiffFunc func(context.Context, string, string, []string) (string, error)
 
 func Run(ctx context.Context, schema []string, file string, config pgconn.Config, differ DiffFunc, fsys afero.Fs, options ...func(*pgx.ConnConfig)) (err error) {
 	// Sanity checks.
-	if err := flags.LoadConfig(fsys); err != nil {
-		return err
-	}
 	if utils.IsLocalDatabase(config) {
 		if container, err := createShadowIfNotExists(ctx, fsys); err != nil {
 			return err

--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -88,6 +88,9 @@ func createShadowIfNotExists(ctx context.Context, fsys afero.Fs) (string, error)
 }
 
 func loadDeclaredSchemas(fsys afero.Fs) ([]string, error) {
+	if schemas := utils.Config.Db.Migrations.SchemaPaths; len(schemas) > 0 {
+		return schemas.Files(afero.NewIOFS(fsys))
+	}
 	var declared []string
 	if err := afero.Walk(fsys, utils.SchemasDir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {

--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/helper"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/migration"
 	"github.com/supabase/cli/pkg/pgtest"
@@ -39,9 +40,7 @@ func TestRun(t *testing.T) {
 	t.Run("runs migra diff", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		project := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
+		require.NoError(t, flags.LoadConfig(fsys))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
@@ -85,22 +84,9 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, []byte(diff), contents)
 	})
 
-	t.Run("throws error on malformed config", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
-		// Run test
-		err := Run(context.Background(), []string{"public"}, "", pgconn.Config{}, DiffSchemaMigra, fsys)
-		// Check error
-		assert.ErrorContains(t, err, "toml: expected = after a key, but the document ends there")
-	})
-
 	t.Run("throws error on failure to load user schemas", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		project := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
@@ -115,9 +101,6 @@ func TestRun(t *testing.T) {
 	t.Run("throws error on failure to diff target", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
-		project := apitest.RandomProjectRef()
-		require.NoError(t, afero.WriteFile(fsys, utils.ProjectRefPath, []byte(project), 0644))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/internal/db/diff/pgadmin.go
+++ b/internal/db/diff/pgadmin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/config"
 )
 
@@ -35,13 +34,8 @@ func SaveDiff(out, file string, fsys afero.Fs) error {
 
 func RunPgAdmin(ctx context.Context, schema []string, file string, config pgconn.Config, fsys afero.Fs) error {
 	// Sanity checks.
-	{
-		if err := flags.LoadConfig(fsys); err != nil {
-			return err
-		}
-		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
-			return err
-		}
+	if err := utils.AssertSupabaseDbIsRunning(); err != nil {
+		return err
 	}
 
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {

--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -18,7 +18,6 @@ import (
 	"github.com/supabase/cli/internal/migration/new"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
@@ -35,17 +34,13 @@ var (
 )
 
 func Run(ctx context.Context, schema []string, config pgconn.Config, name string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
-	// 1. Sanity checks.
-	if err := flags.LoadConfig(fsys); err != nil {
-		return err
-	}
-	// 2. Check postgres connection
+	// 1. Check postgres connection
 	conn, err := utils.ConnectByConfig(ctx, config, options...)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(context.Background())
-	// 3. Pull schema
+	// 2. Pull schema
 	timestamp := utils.GetCurrentTimestamp()
 	path := new.GetMigrationPath(timestamp, name)
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
@@ -53,7 +48,7 @@ func Run(ctx context.Context, schema []string, config pgconn.Config, name string
 	}); err != nil {
 		return err
 	}
-	// 4. Insert a row to `schema_migrations`
+	// 3. Insert a row to `schema_migrations`
 	fmt.Fprintln(os.Stderr, "Schema written to "+utils.Bold(path))
 	if shouldUpdate, err := utils.NewConsole().PromptYesNo(ctx, "Update remote migration history table?", true); err != nil {
 		return err

--- a/internal/db/pull/pull_test.go
+++ b/internal/db/pull/pull_test.go
@@ -29,20 +29,9 @@ var dbConfig = pgconn.Config{
 }
 
 func TestPullCommand(t *testing.T) {
-	t.Run("throws error on malformed config", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
-		// Run test
-		err := Run(context.Background(), nil, pgconn.Config{}, "", fsys)
-		// Check error
-		assert.ErrorContains(t, err, "toml: expected = after a key, but the document ends there")
-	})
-
 	t.Run("throws error on connect failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		// Run test
 		err := Run(context.Background(), nil, pgconn.Config{}, "", fsys)
 		// Check error
@@ -53,7 +42,6 @@ func TestPullCommand(t *testing.T) {
 	t.Run("throws error on sync failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)

--- a/internal/db/remote/changes/changes.go
+++ b/internal/db/remote/changes/changes.go
@@ -8,24 +8,17 @@ import (
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/db/diff"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
 var output string
 
 func Run(ctx context.Context, schema []string, config pgconn.Config, fsys afero.Fs) error {
-	// Sanity checks.
-	if err := flags.LoadConfig(fsys); err != nil {
-		return err
-	}
-
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
 		return run(p, ctx, schema, config, fsys)
 	}); err != nil {
 		return err
 	}
-
 	return diff.SaveDiff(output, "", fsys)
 }
 

--- a/internal/db/remote/commit/commit.go
+++ b/internal/db/remote/commit/commit.go
@@ -15,22 +15,15 @@ import (
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
 func Run(ctx context.Context, schema []string, config pgconn.Config, fsys afero.Fs) error {
-	// Sanity checks.
-	if err := flags.LoadConfig(fsys); err != nil {
-		return err
-	}
-
 	if err := utils.RunProgram(ctx, func(p utils.Program, ctx context.Context) error {
 		return run(p, ctx, schema, config, fsys)
 	}); err != nil {
 		return err
 	}
-
 	fmt.Println("Finished " + utils.Aqua("supabase db remote commit") + ".")
 	return nil
 }

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -20,7 +20,6 @@ import (
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/utils"
-	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
@@ -34,9 +33,6 @@ func Run(ctx context.Context, version string, config pgconn.Config, fsys afero.F
 		if _, err := repair.GetMigrationFile(version, fsys); err != nil {
 			return err
 		}
-	}
-	if err := flags.LoadConfig(fsys); err != nil {
-		return err
 	}
 	// 1. Squash local migrations
 	if err := squashToVersion(ctx, version, fsys, options...); err != nil {

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/helper"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 	"github.com/supabase/cli/pkg/pgtest"
 )
@@ -43,7 +44,7 @@ func TestSquashCommand(t *testing.T) {
 	t.Run("squashes local migrations", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
+		require.NoError(t, flags.LoadConfig(fsys))
 		paths := []string{
 			filepath.Join(utils.MigrationsDir, "0_init.sql"),
 			filepath.Join(utils.MigrationsDir, "1_target.sql"),
@@ -108,7 +109,6 @@ func TestSquashCommand(t *testing.T) {
 	t.Run("baselines migration history", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, utils.WriteConfig(fsys, false))
 		path := filepath.Join(utils.MigrationsDir, "0_init.sql")
 		sql := "create schema test"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(sql), 0644))
@@ -138,7 +138,7 @@ func TestSquashCommand(t *testing.T) {
 		assert.ErrorIs(t, err, repair.ErrInvalidVersion)
 	})
 
-	t.Run("throws error on missing config", func(t *testing.T) {
+	t.Run("throws error on missing migration", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
@@ -241,6 +241,7 @@ func TestSquashMigrations(t *testing.T) {
 	t.Run("throws error on shadow migrate failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		require.NoError(t, flags.LoadConfig(fsys))
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -229,11 +229,11 @@ type (
 	FunctionConfig map[string]function
 
 	function struct {
-		Enabled     bool     `toml:"enabled" json:"-"`
-		VerifyJWT   bool     `toml:"verify_jwt" json:"verifyJWT"`
-		ImportMap   string   `toml:"import_map" json:"importMapPath,omitempty"`
-		Entrypoint  string   `toml:"entrypoint" json:"entrypointPath,omitempty"`
-		StaticFiles []string `toml:"static_files" json:"staticFiles,omitempty"`
+		Enabled     bool   `toml:"enabled" json:"-"`
+		VerifyJWT   bool   `toml:"verify_jwt" json:"verifyJWT"`
+		ImportMap   string `toml:"import_map" json:"importMapPath,omitempty"`
+		Entrypoint  string `toml:"entrypoint" json:"entrypointPath,omitempty"`
+		StaticFiles Glob   `toml:"static_files" json:"staticFiles,omitempty"`
 	}
 
 	analytics struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -677,6 +677,11 @@ func (c *baseConfig) resolve(builder pathBuilder, fsys fs.FS) error {
 			}
 		}
 	}
+	for i, pattern := range c.Db.Migrations.SchemaPaths {
+		if len(pattern) > 0 && !filepath.IsAbs(pattern) {
+			c.Db.Migrations.SchemaPaths[i] = path.Join(builder.SupabaseDirPath, pattern)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -81,9 +81,8 @@ type (
 	}
 
 	seed struct {
-		Enabled      bool     `toml:"enabled"`
-		GlobPatterns []string `toml:"sql_paths"`
-		SqlPaths     []string `toml:"-"`
+		Enabled  bool `toml:"enabled"`
+		SqlPaths Glob `toml:"sql_paths"`
 	}
 
 	pooler struct {

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -75,9 +75,14 @@ type (
 		Password     string            `toml:"-"`
 		RootKey      string            `toml:"-" mapstructure:"root_key"`
 		Pooler       pooler            `toml:"pooler"`
+		Migrations   migrations        `toml:"migrations"`
 		Seed         seed              `toml:"seed"`
 		Settings     settings          `toml:"settings"`
 		Vault        map[string]Secret `toml:"vault"`
+	}
+
+	migrations struct {
+		SchemaPaths Glob `toml:"schema_paths"`
 	}
 
 	seed struct {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -45,6 +45,11 @@ max_client_conn = 100
 # [db.vault]
 # secret_key = "env(SECRET_VALUE)"
 
+[db.migrations]
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
 [db.seed]
 # If enabled, seeds the database after migrations during a db reset.
 enabled = true

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -30,6 +30,11 @@ shadow_port = 54320
 # server_version;` on the remote database to check.
 major_version = 15
 
+[db.migrations]
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = ["./schemas/*.sql"]
+
 [db.pooler]
 enabled = true
 # Port to use for the local connection pooler.

--- a/pkg/migration/seed.go
+++ b/pkg/migration/seed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v4"
+	"github.com/supabase/cli/pkg/config"
 )
 
 func getRemoteSeeds(ctx context.Context, conn *pgx.Conn) (map[string]string, error) {
@@ -30,7 +31,11 @@ func getRemoteSeeds(ctx context.Context, conn *pgx.Conn) (map[string]string, err
 	return applied, nil
 }
 
-func GetPendingSeeds(ctx context.Context, locals []string, conn *pgx.Conn, fsys fs.FS) ([]SeedFile, error) {
+func GetPendingSeeds(ctx context.Context, locals config.Glob, conn *pgx.Conn, fsys fs.FS) ([]SeedFile, error) {
+	locals, err := locals.Files(fsys)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "WARN:", err)
+	}
 	if len(locals) == 0 {
 		return nil, nil
 	}

--- a/pkg/migration/seed_test.go
+++ b/pkg/migration/seed_test.go
@@ -77,18 +77,13 @@ func TestPendingSeeds(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("throws error on missing file", func(t *testing.T) {
-		// Setup mock postgres
-		conn := pgtest.NewConn()
-		defer conn.Close(t)
-		conn.Query(SELECT_SEED_TABLE).
-			Reply("SELECT 0")
+	t.Run("ignores missing seed file", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := fs.MapFS{}
 		// Run test
-		_, err := GetPendingSeeds(context.Background(), pending, conn.MockClient(t), fsys)
+		_, err := GetPendingSeeds(context.Background(), pending, nil, fsys)
 		// Check error
-		assert.ErrorIs(t, err, os.ErrNotExist)
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Adds config option for ordering declarative schemas.

```toml
[db.migrations]
schema_paths = ["./schemas/*.sql"]
```

## Additional context

Add any other context or screenshots.
