### PR TITLE
feat: optionally pin service versions

### DIFF
--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -3,6 +3,8 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "{{ .ProjectId }}"
+# If enabled, CLI will only use the pinned service images for local development.
+pin_service_versions = false
 
 [api]
 enabled = true

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -3,6 +3,8 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "test"
+# If enabled, CLI will only use the pinned service images for local development.
+pin_service_versions = false
 
 [api]
 enabled = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/2435

## What is the new behavior?

By setting `pin_service_versions = true` in config.toml, users can choose not to use service versions that match their remote project. This can be useful in CI environments where things shouldn't break.

## Additional context

Another alternative is to add a flag to `supabase link --skip-version-update`
