### PR TITLE
fix: skip realtime publications on schema dump

### DIFF
--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -32,7 +32,7 @@ pg_dump \
 | sed -E 's/^CREATE VIEW "/CREATE OR REPLACE VIEW "/' \
 | sed -E 's/^CREATE FUNCTION "/CREATE OR REPLACE FUNCTION "/' \
 | sed -E 's/^CREATE TRIGGER "/CREATE OR REPLACE TRIGGER "/' \
-| sed -E 's/^CREATE PUBLICATION "supabase_realtime"/-- &/' \
+| sed -E 's/^CREATE PUBLICATION "supabase_realtime/-- &/' \
 | sed -E 's/^CREATE EVENT TRIGGER /-- &/' \
 | sed -E 's/^         WHEN TAG IN /-- &/' \
 | sed -E 's/^   EXECUTE FUNCTION /-- &/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3071#issuecomment-2673190191

## What is the new behavior?

Also ignore `supabase_realtime_messages_publication` when running db dump.

## Additional context

Add any other context or screenshots.
