### PR TITLE
fix: load edge runtime version if exists

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -609,6 +609,9 @@ func (c *config) Load(path string, fsys fs.FS) error {
 			c.Auth.Image = replaceImageTag(Images.Gotrue, string(version))
 		}
 	}
+	if version, err := fs.ReadFile(fsys, builder.FunctionVersionPath); err == nil && len(version) > 0 {
+		c.EdgeRuntime.Image = replaceImageTag(Images.EdgeRuntime, string(version))
+	}
 	if version, err := fs.ReadFile(fsys, builder.PoolerVersionPath); err == nil && len(version) > 0 {
 		c.Db.Pooler.Image = replaceImageTag(Images.Supavisor, string(version))
 	}

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -25,6 +25,7 @@ type pathBuilder struct {
 	PgmetaVersionPath     string
 	PoolerVersionPath     string
 	RealtimeVersionPath   string
+	FunctionVersionPath   string
 	CliVersionPath        string
 	CurrBranchPath        string
 	SchemasDir            string
@@ -54,6 +55,7 @@ func NewPathBuilder(configPath string) pathBuilder {
 		GotrueVersionPath:     filepath.Join(base, ".temp", "gotrue-version"),
 		RestVersionPath:       filepath.Join(base, ".temp", "rest-version"),
 		StorageVersionPath:    filepath.Join(base, ".temp", "storage-version"),
+		FunctionVersionPath:   filepath.Join(base, ".temp", "function-version"),
 		StudioVersionPath:     filepath.Join(base, ".temp", "studio-version"),
 		PgmetaVersionPath:     filepath.Join(base, ".temp", "pgmeta-version"),
 		PoolerVersionPath:     filepath.Join(base, ".temp", "pooler-version"),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Support customising edge runtime version, ie.

```bash
echo "v1.68.0-develop.1" > supabase/.temp/function-version
```

## Additional context

Add any other context or screenshots.
