### PR TITLE
fix: skip altering supabase managed publication

### DIFF
--- a/internal/db/dump/templates/dump_schema.sh
+++ b/internal/db/dump/templates/dump_schema.sh
@@ -37,8 +37,8 @@ pg_dump \
 | sed -E 's/^         WHEN TAG IN /-- &/' \
 | sed -E 's/^   EXECUTE FUNCTION /-- &/' \
 | sed -E 's/^ALTER EVENT TRIGGER /-- &/' \
+| sed -E 's/^ALTER PUBLICATION "supabase_realtime_/-- &/' \
 | sed -E 's/^ALTER FOREIGN DATA WRAPPER (.+) OWNER TO /-- &/' \
-| sed -E 's/^ALTER PUBLICATION (.+) OWNER TO "supabase_admin"/-- &/' \
 | sed -E 's/^ALTER DEFAULT PRIVILEGES FOR ROLE "supabase_admin"/-- &/' \
 | sed -E "s/^GRANT (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/cli/pull/3190

## What is the new behavior?

Alter publication is forbidden because `postgres` role is not the owner of `supabase_realtime_messages_publication`.

## Additional context

Add any other context or screenshots.
