### PR TITLE
fix: rename the override file to edge-runtime-version

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -609,7 +609,7 @@ func (c *config) Load(path string, fsys fs.FS) error {
 			c.Auth.Image = replaceImageTag(Images.Gotrue, string(version))
 		}
 	}
-	if version, err := fs.ReadFile(fsys, builder.FunctionVersionPath); err == nil && len(version) > 0 {
+	if version, err := fs.ReadFile(fsys, builder.EdgeRuntimeVersionPath); err == nil && len(version) > 0 {
 		c.EdgeRuntime.Image = replaceImageTag(Images.EdgeRuntime, string(version))
 	}
 	if version, err := fs.ReadFile(fsys, builder.PoolerVersionPath); err == nil && len(version) > 0 {

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -10,31 +10,31 @@ import (
 )
 
 type pathBuilder struct {
-	SupabaseDirPath       string
-	ConfigPath            string
-	GitIgnorePath         string
-	TempDir               string
-	ImportMapsDir         string
-	ProjectRefPath        string
-	PoolerUrlPath         string
-	PostgresVersionPath   string
-	GotrueVersionPath     string
-	RestVersionPath       string
-	StorageVersionPath    string
-	StudioVersionPath     string
-	PgmetaVersionPath     string
-	PoolerVersionPath     string
-	RealtimeVersionPath   string
-	FunctionVersionPath   string
-	CliVersionPath        string
-	CurrBranchPath        string
-	SchemasDir            string
-	MigrationsDir         string
-	FunctionsDir          string
-	FallbackImportMapPath string
-	FallbackEnvFilePath   string
-	DbTestsDir            string
-	CustomRolesPath       string
+	SupabaseDirPath        string
+	ConfigPath             string
+	GitIgnorePath          string
+	TempDir                string
+	ImportMapsDir          string
+	ProjectRefPath         string
+	PoolerUrlPath          string
+	PostgresVersionPath    string
+	GotrueVersionPath      string
+	RestVersionPath        string
+	StorageVersionPath     string
+	StudioVersionPath      string
+	PgmetaVersionPath      string
+	PoolerVersionPath      string
+	RealtimeVersionPath    string
+	EdgeRuntimeVersionPath string
+	CliVersionPath         string
+	CurrBranchPath         string
+	SchemasDir             string
+	MigrationsDir          string
+	FunctionsDir           string
+	FallbackImportMapPath  string
+	FallbackEnvFilePath    string
+	DbTestsDir             string
+	CustomRolesPath        string
 }
 
 func NewPathBuilder(configPath string) pathBuilder {
@@ -44,31 +44,31 @@ func NewPathBuilder(configPath string) pathBuilder {
 	// TODO: make base path configurable from toml
 	base := filepath.Dir(configPath)
 	return pathBuilder{
-		SupabaseDirPath:       base,
-		ConfigPath:            configPath,
-		GitIgnorePath:         filepath.Join(base, ".gitignore"),
-		TempDir:               filepath.Join(base, ".temp"),
-		ImportMapsDir:         filepath.Join(base, ".temp", "import_maps"),
-		ProjectRefPath:        filepath.Join(base, ".temp", "project-ref"),
-		PoolerUrlPath:         filepath.Join(base, ".temp", "pooler-url"),
-		PostgresVersionPath:   filepath.Join(base, ".temp", "postgres-version"),
-		GotrueVersionPath:     filepath.Join(base, ".temp", "gotrue-version"),
-		RestVersionPath:       filepath.Join(base, ".temp", "rest-version"),
-		StorageVersionPath:    filepath.Join(base, ".temp", "storage-version"),
-		FunctionVersionPath:   filepath.Join(base, ".temp", "function-version"),
-		StudioVersionPath:     filepath.Join(base, ".temp", "studio-version"),
-		PgmetaVersionPath:     filepath.Join(base, ".temp", "pgmeta-version"),
-		PoolerVersionPath:     filepath.Join(base, ".temp", "pooler-version"),
-		RealtimeVersionPath:   filepath.Join(base, ".temp", "realtime-version"),
-		CliVersionPath:        filepath.Join(base, ".temp", "cli-latest"),
-		CurrBranchPath:        filepath.Join(base, ".branches", "_current_branch"),
-		SchemasDir:            filepath.Join(base, "schemas"),
-		MigrationsDir:         filepath.Join(base, "migrations"),
-		FunctionsDir:          filepath.Join(base, "functions"),
-		FallbackImportMapPath: filepath.Join(base, "functions", "import_map.json"),
-		FallbackEnvFilePath:   filepath.Join(base, "functions", ".env"),
-		DbTestsDir:            filepath.Join(base, "tests"),
-		CustomRolesPath:       filepath.Join(base, "roles.sql"),
+		SupabaseDirPath:        base,
+		ConfigPath:             configPath,
+		GitIgnorePath:          filepath.Join(base, ".gitignore"),
+		TempDir:                filepath.Join(base, ".temp"),
+		ImportMapsDir:          filepath.Join(base, ".temp", "import_maps"),
+		ProjectRefPath:         filepath.Join(base, ".temp", "project-ref"),
+		PoolerUrlPath:          filepath.Join(base, ".temp", "pooler-url"),
+		PostgresVersionPath:    filepath.Join(base, ".temp", "postgres-version"),
+		GotrueVersionPath:      filepath.Join(base, ".temp", "gotrue-version"),
+		RestVersionPath:        filepath.Join(base, ".temp", "rest-version"),
+		StorageVersionPath:     filepath.Join(base, ".temp", "storage-version"),
+		EdgeRuntimeVersionPath: filepath.Join(base, ".temp", "edge-runtime-version"),
+		StudioVersionPath:      filepath.Join(base, ".temp", "studio-version"),
+		PgmetaVersionPath:      filepath.Join(base, ".temp", "pgmeta-version"),
+		PoolerVersionPath:      filepath.Join(base, ".temp", "pooler-version"),
+		RealtimeVersionPath:    filepath.Join(base, ".temp", "realtime-version"),
+		CliVersionPath:         filepath.Join(base, ".temp", "cli-latest"),
+		CurrBranchPath:         filepath.Join(base, ".branches", "_current_branch"),
+		SchemasDir:             filepath.Join(base, "schemas"),
+		MigrationsDir:          filepath.Join(base, "migrations"),
+		FunctionsDir:           filepath.Join(base, "functions"),
+		FallbackImportMapPath:  filepath.Join(base, "functions", "import_map.json"),
+		FallbackEnvFilePath:    filepath.Join(base, "functions", ".env"),
+		DbTestsDir:             filepath.Join(base, "tests"),
+		CustomRolesPath:        filepath.Join(base, "roles.sql"),
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change the name of override file from `function-version` to `edge-runtime-version` to make it match with Docker image name.
