### PR TITLE
fix: log url only for debugging http requests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -15,6 +16,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/debug"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
 	"golang.org/x/mod/semver"
@@ -114,7 +116,7 @@ var (
 			}
 			// Prepare context
 			if viper.GetBool("DEBUG") {
-				ctx = utils.WithTraceContext(ctx)
+				http.DefaultTransport = debug.NewTransport()
 				fmt.Fprintln(os.Stderr, cmd.Root().Short)
 			}
 			cmd.SetContext(ctx)

--- a/internal/debug/http.go
+++ b/internal/debug/http.go
@@ -1,0 +1,24 @@
+package debug
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+type debugTransport struct {
+	http.RoundTripper
+	logger *log.Logger
+}
+
+func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.logger.Printf("%s: %s\n", req.Method, req.URL)
+	return t.RoundTripper.RoundTrip(req)
+}
+
+func NewTransport() http.RoundTripper {
+	return &debugTransport{
+		http.DefaultTransport,
+		log.New(os.Stderr, "HTTP ", log.LstdFlags|log.Lmsgprefix),
+	}
+}

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -2,14 +2,11 @@ package utils
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"net/http/httptrace"
-	"net/textproto"
 	"sync"
 
 	"github.com/go-errors/errors"
@@ -77,59 +74,6 @@ func ResolveCNAME(ctx context.Context, host string) (string, error) {
 		return "", errors.Errorf("failed to locate appropriate CNAME record for %s; resolves to %+v", host, data.Answer)
 	}
 	return "", errors.Errorf("failed to locate appropriate CNAME record for %s; resolves to %+v", host, serialized)
-}
-
-func WithTraceContext(ctx context.Context) context.Context {
-	trace := &httptrace.ClientTrace{
-		DNSStart: func(info httptrace.DNSStartInfo) {
-			log.Printf("DNS Start: %+v\n", info)
-		},
-		DNSDone: func(info httptrace.DNSDoneInfo) {
-			if info.Err != nil {
-				log.Println("DNS Error:", info.Err)
-			} else {
-				log.Printf("DNS Done: %+v\n", info)
-			}
-		},
-		ConnectStart: func(network, addr string) {
-			log.Println("Connect Start:", network, addr)
-		},
-		ConnectDone: func(network, addr string, err error) {
-			if err != nil {
-				log.Println("Connect Error:", network, addr, err)
-			} else {
-				log.Println("Connect Done:", network, addr)
-			}
-		},
-		TLSHandshakeStart: func() {
-			log.Println("TLS Start")
-		},
-		TLSHandshakeDone: func(cs tls.ConnectionState, err error) {
-			if err != nil {
-				log.Println("TLS Error:", err)
-			} else {
-				log.Printf("TLS Done: %+v\n", cs)
-			}
-		},
-		WroteHeaderField: func(key string, value []string) {
-			log.Println("Sent Header:", key, value)
-		},
-		WroteRequest: func(wr httptrace.WroteRequestInfo) {
-			if wr.Err != nil {
-				log.Println("Send Error:", wr.Err)
-			} else {
-				log.Println("Send Done")
-			}
-		},
-		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
-			log.Println("Recv 1xx:", code, header)
-			return nil
-		},
-		GotFirstResponseByte: func() {
-			log.Println("Recv First Byte")
-		},
-	}
-	return httptrace.WithClientTrace(ctx, trace)
 }
 
 type DialContextFunc func(context.Context, string, string) (net.Conn, error)


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Replaces trace context with simplified debug output.

```bash
$ supabase start --debug
...
2025/02/24 14:33:21 HTTP HEAD: https://127.0.0.1:54321/rest-admin/v1/ready
2025/02/24 14:33:21 HTTP HEAD: https://127.0.0.1:54321/functions/v1/_internal/health
Started supabase local development setup.
```

## Additional context

TODO:
- [ ] also replace transport for docker api
