### PR TITLE
fix: support main.ts as an entrypoint

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -104,7 +104,7 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 			} else if _, err := fsys.Stat(mainEntrypoint); err == nil {
 				function.Entrypoint = mainEntrypoint
 			} else {
-				return nil, errors.Errorf("Cannot find a valid entrypoint file (index.ts or main.ts) for the function. Set the custom entrypoint path in config.toml")
+				return nil, errors.Errorf("Cannot find a valid entrypoint file (index.ts or main.ts) for the '%s' function. Set the custom entrypoint path in config.toml", name)
 			}
 		}
 		if len(importMapPath) > 0 {

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -289,6 +289,10 @@ verify_jwt = false
 `)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
+
+		// Setup function entrypoint
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, slug, "index.ts"), []byte{}, 0644))
+
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)
 		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
@@ -332,6 +336,10 @@ verify_jwt = false
 `)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
+
+		// Setup function entrypoint
+		require.NoError(t, afero.WriteFile(fsys, filepath.Join(utils.FunctionsDir, slug, "index.ts"), []byte{}, 0644))
+
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)
 		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -654,7 +654,13 @@ func (c *baseConfig) resolve(builder pathBuilder, fsys fs.FS) error {
 	// Resolve functions config
 	for slug, function := range c.Functions {
 		if len(function.Entrypoint) == 0 {
-			function.Entrypoint = filepath.Join(builder.FunctionsDir, slug, "index.ts")
+			indexEntrypoint := filepath.Join(builder.FunctionsDir, slug, "index.ts")
+			mainEntrypoint := filepath.Join(builder.FunctionsDir, slug, "main.ts")
+			if _, err := fs.Stat(fsys, indexEntrypoint); err == nil {
+				function.Entrypoint = indexEntrypoint
+			} else if _, err := fs.Stat(fsys, mainEntrypoint); err == nil {
+				function.Entrypoint = mainEntrypoint
+			}
 		} else if !filepath.IsAbs(function.Entrypoint) {
 			// Append supabase/ because paths in configs are specified relative to config.toml
 			function.Entrypoint = filepath.Join(builder.SupabaseDirPath, function.Entrypoint)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for `main.ts` to be treated as a valid entrypoint along with `index.ts`. This allows functions generated with `deno init` to work without having to change the filename.