### PR TITLE
feat: prompt to configure functions when serving locally

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -231,8 +231,8 @@ type (
 	function struct {
 		Enabled     bool   `toml:"enabled" json:"-"`
 		VerifyJWT   bool   `toml:"verify_jwt" json:"verifyJWT"`
-		ImportMap   string `toml:"import_map" json:"importMapPath,omitempty"`
-		Entrypoint  string `toml:"entrypoint" json:"entrypointPath,omitempty"`
+		ImportMap   string `toml:"import_map,omitempty" json:"importMapPath,omitempty"`
+		Entrypoint  string `toml:"entrypoint,omitempty" json:"entrypointPath,omitempty"`
 		StaticFiles Glob   `toml:"static_files" json:"staticFiles,omitempty"`
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/pull/3201

## What is the new behavior?

`supabase functions serve` now prompts to declare entrypoints in config.toml.

## Additional context

Still exploring if this is the best approach.
