### PR TITLE
feat: output standard env vars from branches get

### DIFF
--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -157,8 +157,6 @@ func init() {
 	createFlags.Var(&branchRegion, "region", "Select a region to deploy the branch database.")
 	createFlags.Var(&size, "size", "Select a desired instance size for the branch database.")
 	createFlags.BoolVar(&persistent, "persistent", false, "Whether to create a persistent branch.")
-	getFlags := branchGetCmd.Flags()
-	getFlags.VarP(&utils.OutputFormat, "output", "o", "Output format of branch details.")
 	branchesCmd.AddCommand(branchCreateCmd)
 	branchesCmd.AddCommand(branchListCmd)
 	branchesCmd.AddCommand(branchGetCmd)

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -21,16 +21,7 @@ var (
 		Short:   "Run code generation tools",
 	}
 
-	keyNames  keys.CustomName
-	keyOutput = utils.EnumFlag{
-		Allowed: []string{
-			utils.OutputEnv,
-			utils.OutputJson,
-			utils.OutputToml,
-			utils.OutputYaml,
-		},
-		Value: utils.OutputEnv,
-	}
+	keyNames keys.CustomName
 
 	genKeysCmd = &cobra.Command{
 		Use:   "keys",
@@ -47,7 +38,11 @@ var (
 			return cmd.Root().PersistentPreRunE(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return keys.Run(cmd.Context(), flags.ProjectRef, keyOutput.Value, keyNames, afero.NewOsFs())
+			format := utils.OutputFormat.Value
+			if format == utils.OutputPretty {
+				format = utils.OutputEnv
+			}
+			return keys.Run(cmd.Context(), flags.ProjectRef, format, keyNames, afero.NewOsFs())
 		},
 	}
 
@@ -114,7 +109,6 @@ func init() {
 	genCmd.AddCommand(genTypesCmd)
 	keyFlags := genKeysCmd.Flags()
 	keyFlags.StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
-	keyFlags.VarP(&keyOutput, "output", "o", "Output format of key variables.")
 	keyFlags.StringSliceVar(&override, "override-name", []string{}, "Override specific variable names.")
 	genCmd.AddCommand(genKeysCmd)
 	rootCmd.AddCommand(genCmd)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -14,10 +14,6 @@ import (
 var (
 	override []string
 	names    status.CustomName
-	output   = utils.EnumFlag{
-		Allowed: append([]string{utils.OutputEnv}, utils.OutputDefaultAllowed...),
-		Value:   utils.OutputPretty,
-	}
 
 	statusCmd = &cobra.Command{
 		GroupID: groupLocalDev,
@@ -32,7 +28,7 @@ var (
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return status.Run(ctx, names, output.Value, afero.NewOsFs())
+			return status.Run(ctx, names, utils.OutputFormat.Value, afero.NewOsFs())
 		},
 		Example: `  supabase status -o env --override-name api.url=NEXT_PUBLIC_SUPABASE_URL
   supabase status -o json`,
@@ -41,7 +37,6 @@ var (
 
 func init() {
 	flags := statusCmd.Flags()
-	flags.VarP(&output, "output", "o", "Output format of status variables.")
 	flags.StringSliceVar(&override, "override-name", []string{}, "Override specific variable names.")
 	rootCmd.AddCommand(statusCmd)
 }

--- a/internal/branches/get/get.go
+++ b/internal/branches/get/get.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
@@ -102,15 +101,9 @@ func toStandardEnvs(detail api.BranchDetailResponse, pooler api.SupavisorConfigR
 	} else {
 		config.Password = direct.Password
 	}
-	envs := map[string]string{
-		"POSTGRES_URL":             utils.ToPostgresURL(*config),
-		"POSTGRES_URL_NON_POOLING": utils.ToPostgresURL(direct),
-		"SUPABASE_URL":             "https://" + utils.GetSupabaseHost(detail.Ref),
-	}
-	for _, entry := range keys {
-		name := strings.ToUpper(entry.Name)
-		key := fmt.Sprintf("SUPABASE_%s_KEY", name)
-		envs[key] = entry.ApiKey
-	}
+	envs := apiKeys.ToEnv(keys)
+	envs["POSTGRES_URL"] = utils.ToPostgresURL(*config)
+	envs["POSTGRES_URL_NON_POOLING"] = utils.ToPostgresURL(direct)
+	envs["SUPABASE_URL"] = "https://" + utils.GetSupabaseHost(detail.Ref)
 	return envs
 }

--- a/internal/branches/get/get.go
+++ b/internal/branches/get/get.go
@@ -4,24 +4,61 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/migration/list"
+	"github.com/supabase/cli/internal/projects/apiKeys"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/pkg/cast"
 )
 
 func Run(ctx context.Context, branchId string, fsys afero.Fs) error {
-	resp, err := utils.GetSupabase().V1GetABranchConfigWithResponse(ctx, branchId)
+	detail, err := getBranchDetail(ctx, branchId)
 	if err != nil {
-		return errors.Errorf("failed to retrieve preview branch: %w", err)
-	}
-	if resp.JSON200 == nil {
-		return errors.New("Unexpected error retrieving preview branch: " + string(resp.Body))
+		return err
 	}
 
+	if utils.OutputFormat.Value != utils.OutputPretty {
+		keys, err := apiKeys.RunGetApiKeys(ctx, detail.Ref)
+		if err != nil {
+			return err
+		}
+		pooler, err := getPoolerConfig(ctx, detail.Ref)
+		if err != nil {
+			return err
+		}
+		envs := toStandardEnvs(detail, pooler, keys)
+		return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, envs)
+	}
+
+	table := `|HOST|PORT|USER|PASSWORD|JWT SECRET|POSTGRES VERSION|STATUS|
+|-|-|-|-|-|-|-|
+` + fmt.Sprintf(
+		"|`%s`|`%d`|`%s`|`%s`|`%s`|`%s`|`%s`|\n",
+		detail.DbHost,
+		detail.DbPort,
+		*detail.DbUser,
+		*detail.DbPass,
+		*detail.JwtSecret,
+		detail.PostgresVersion,
+		detail.Status,
+	)
+
+	return list.RenderTable(table)
+}
+
+func getBranchDetail(ctx context.Context, branchId string) (api.BranchDetailResponse, error) {
+	var result api.BranchDetailResponse
+	resp, err := utils.GetSupabase().V1GetABranchConfigWithResponse(ctx, branchId)
+	if err != nil {
+		return result, errors.Errorf("failed to get branch: %w", err)
+	} else if resp.JSON200 == nil {
+		return result, errors.Errorf("unexpected get branch status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
 	masked := "******"
 	if resp.JSON200.DbUser == nil {
 		resp.JSON200.DbUser = &masked
@@ -32,35 +69,48 @@ func Run(ctx context.Context, branchId string, fsys afero.Fs) error {
 	if resp.JSON200.JwtSecret == nil {
 		resp.JSON200.JwtSecret = &masked
 	}
+	return *resp.JSON200, nil
+}
 
-	config := pgconn.Config{
-		Host:     resp.JSON200.DbHost,
-		Port:     cast.UIntToUInt16(cast.IntToUint(resp.JSON200.DbPort)),
-		User:     *resp.JSON200.DbUser,
-		Password: *resp.JSON200.DbPass,
+func getPoolerConfig(ctx context.Context, ref string) (api.SupavisorConfigResponse, error) {
+	var result api.SupavisorConfigResponse
+	resp, err := utils.GetSupabase().V1GetSupavisorConfigWithResponse(ctx, ref)
+	if err != nil {
+		return result, errors.Errorf("failed to get pooler: %w", err)
+	} else if resp.JSON200 == nil {
+		return result, errors.Errorf("unexpected get pooler status %d: %s", resp.StatusCode(), string(resp.Body))
 	}
-
-	postgresConnectionString := utils.ToPostgresURL(config)
-	if utils.OutputFormat.Value != utils.OutputPretty {
-		envs := map[string]string{
-			"POSTGRES_URL": postgresConnectionString,
+	for _, config := range *resp.JSON200 {
+		if config.DatabaseType == api.PRIMARY {
+			return config, nil
 		}
-		return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, envs)
 	}
+	return result, errors.Errorf("primary database not found: %s", ref)
+}
 
-	table := `|HOST|PORT|USER|PASSWORD|JWT SECRET|POSTGRES VERSION|STATUS|POSTGRES URL|
-|-|-|-|-|-|-|-|-|
-` + fmt.Sprintf(
-		"|`%s`|`%d`|`%s`|`%s`|`%s`|`%s`|`%s`|`%s`|\n",
-		resp.JSON200.DbHost,
-		resp.JSON200.DbPort,
-		*resp.JSON200.DbUser,
-		*resp.JSON200.DbPass,
-		*resp.JSON200.JwtSecret,
-		resp.JSON200.PostgresVersion,
-		resp.JSON200.Status,
-		postgresConnectionString,
-	)
-
-	return list.RenderTable(table)
+func toStandardEnvs(detail api.BranchDetailResponse, pooler api.SupavisorConfigResponse, keys []api.ApiKeyResponse) map[string]string {
+	direct := pgconn.Config{
+		Host:     detail.DbHost,
+		Port:     cast.UIntToUInt16(cast.IntToUint(detail.DbPort)),
+		User:     *detail.DbUser,
+		Password: *detail.DbPass,
+	}
+	config, err := utils.ParsePoolerURL(pooler.ConnectionString)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), err)
+		config = &direct
+	} else {
+		config.Password = direct.Password
+	}
+	envs := map[string]string{
+		"POSTGRES_URL":             utils.ToPostgresURL(*config),
+		"POSTGRES_URL_NON_POOLING": utils.ToPostgresURL(direct),
+		"SUPABASE_URL":             "https://" + utils.GetSupabaseHost(detail.Ref),
+	}
+	for _, entry := range keys {
+		name := strings.ToUpper(entry.Name)
+		key := fmt.Sprintf("SUPABASE_%s_KEY", name)
+		envs[key] = entry.ApiKey
+	}
+	return envs
 }

--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -10,22 +10,19 @@ import (
 	"github.com/supabase/cli/internal/migration/list"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
+	"github.com/supabase/cli/pkg/api"
 )
 
 func Run(ctx context.Context, fsys afero.Fs) error {
-	resp, err := utils.GetSupabase().V1ListAllBranchesWithResponse(ctx, flags.ProjectRef)
+	branches, err := ListBranch(ctx, flags.ProjectRef)
 	if err != nil {
-		return errors.Errorf("failed to list preview branches: %w", err)
-	}
-
-	if resp.JSON200 == nil {
-		return errors.New("Unexpected error listing preview branches: " + string(resp.Body))
+		return err
 	}
 
 	table := `|ID|NAME|DEFAULT|GIT BRANCH|STATUS|CREATED AT (UTC)|UPDATED AT (UTC)|
 |-|-|-|-|-|-|-|
 `
-	for _, branch := range *resp.JSON200 {
+	for _, branch := range branches {
 		gitBranch := " "
 		if branch.GitBranch != nil {
 			gitBranch = *branch.GitBranch
@@ -43,4 +40,32 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	}
 
 	return list.RenderTable(table)
+}
+
+type BranchFilter func(api.BranchResponse) bool
+
+func ListBranch(ctx context.Context, ref string, filter ...BranchFilter) ([]api.BranchResponse, error) {
+	resp, err := utils.GetSupabase().V1ListAllBranchesWithResponse(ctx, ref)
+	if err != nil {
+		return nil, errors.Errorf("failed to list branch: %w", err)
+	} else if resp.JSON200 == nil {
+		return nil, errors.Errorf("unexpected list branch status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	var result []api.BranchResponse
+OUTER:
+	for _, branch := range *resp.JSON200 {
+		for _, keep := range filter {
+			if !keep(branch) {
+				continue OUTER
+			}
+		}
+		result = append(result, branch)
+	}
+	return result, nil
+}
+
+func FilterByName(branchName string) BranchFilter {
+	return func(br api.BranchResponse) bool {
+		return br.Name == branchName
+	}
 }

--- a/internal/projects/apiKeys/api_keys.go
+++ b/internal/projects/apiKeys/api_keys.go
@@ -19,7 +19,8 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 		return err
 	}
 
-	if utils.OutputFormat.Value == utils.OutputPretty {
+	switch utils.OutputFormat.Value {
+	case utils.OutputPretty:
 		table := `|NAME|KEY VALUE|
 |-|-|
 `
@@ -28,6 +29,8 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs) error {
 		}
 
 		return list.RenderTable(table)
+	case utils.OutputToml, utils.OutputEnv:
+		return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, ToEnv(keys))
 	}
 
 	return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, keys)
@@ -41,4 +44,14 @@ func RunGetApiKeys(ctx context.Context, projectRef string) ([]api.ApiKeyResponse
 		return nil, errors.Errorf("unexpected get api keys status %d: %s", resp.StatusCode(), string(resp.Body))
 	}
 	return *resp.JSON200, nil
+}
+
+func ToEnv(keys []api.ApiKeyResponse) map[string]string {
+	envs := make(map[string]string, len(keys))
+	for _, entry := range keys {
+		name := strings.ToUpper(entry.Name)
+		key := fmt.Sprintf("SUPABASE_%s_KEY", name)
+		envs[key] = entry.ApiKey
+	}
+	return envs
 }

--- a/internal/projects/apiKeys/api_keys.go
+++ b/internal/projects/apiKeys/api_keys.go
@@ -37,9 +37,8 @@ func RunGetApiKeys(ctx context.Context, projectRef string) ([]api.ApiKeyResponse
 	resp, err := utils.GetSupabase().V1GetProjectApiKeysWithResponse(ctx, projectRef, &api.V1GetProjectApiKeysParams{})
 	if err != nil {
 		return nil, errors.Errorf("failed to get api keys: %w", err)
-	}
-	if resp.JSON200 == nil {
-		return nil, errors.New("Unexpected error retrieving project api-keys: " + string(resp.Body))
+	} else if resp.JSON200 == nil {
+		return nil, errors.Errorf("unexpected get api keys status %d: %s", resp.StatusCode(), string(resp.Body))
 	}
 	return *resp.JSON200, nil
 }

--- a/internal/projects/apiKeys/api_keys_test.go
+++ b/internal/projects/apiKeys/api_keys_test.go
@@ -3,6 +3,7 @@ package apiKeys
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/h2non/gock"
@@ -14,14 +15,15 @@ import (
 )
 
 func TestProjectApiKeysCommand(t *testing.T) {
+	// Setup valid project ref
+	project := apitest.RandomProjectRef()
+	// Setup valid access token
+	token := apitest.RandomAccessToken(t)
+	t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
 	t.Run("lists all api-keys", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -38,23 +40,9 @@ func TestProjectApiKeysCommand(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
-	t.Run("throws error on missing access token", func(t *testing.T) {
-		// Setup in-memory fs
-		fsys := afero.NewMemMapFs()
-		// Run test
-		err := Run(context.Background(), "", fsys)
-		// Check error
-		assert.ErrorContains(t, err, "Unexpected error retrieving project api-keys")
-	})
-
 	t.Run("throws error on network error", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		// Setup valid project ref
-		project := apitest.RandomProjectRef()
-		// Setup valid access token
-		token := apitest.RandomAccessToken(t)
-		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
 		// Flush pending mocks after test execution
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
@@ -65,5 +53,19 @@ func TestProjectApiKeysCommand(t *testing.T) {
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on service unavailable", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + project + "/api-keys").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := Run(context.Background(), project, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "unexpected get api keys status 503:")
 	})
 }

--- a/internal/projects/create/create.go
+++ b/internal/projects/create/create.go
@@ -36,7 +36,8 @@ func Run(ctx context.Context, params api.V1CreateProjectBodyDto, fsys afero.Fs) 
 
 	projectUrl := fmt.Sprintf("%s/project/%s", utils.GetSupabaseDashboardURL(), resp.JSON201.Id)
 	fmt.Fprintf(os.Stderr, "Created a new project %s at %s\n", utils.Aqua(resp.JSON201.Name), utils.Bold(projectUrl))
-	if utils.OutputFormat.Value == utils.OutputPretty {
+	switch utils.OutputFormat.Value {
+	case utils.OutputPretty, utils.OutputEnv:
 		return nil
 	}
 

--- a/internal/projects/list/list.go
+++ b/internal/projects/list/list.go
@@ -41,7 +41,8 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 		})
 	}
 
-	if utils.OutputFormat.Value == utils.OutputPretty {
+	switch utils.OutputFormat.Value {
+	case utils.OutputPretty:
 		table := `LINKED|ORG ID|REFERENCE ID|NAME|REGION|CREATED AT (UTC)
 |-|-|-|-|-|-|
 `
@@ -57,12 +58,14 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 			)
 		}
 		return list.RenderTable(table)
-	} else if utils.OutputFormat.Value == utils.OutputToml {
+	case utils.OutputToml:
 		return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, struct {
 			Projects []linkedProject `toml:"projects"`
 		}{
 			Projects: projects,
 		})
+	case utils.OutputEnv:
+		return errors.Errorf("--output env flag is not supported")
 	}
 
 	return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, projects)

--- a/internal/sso/create/create.go
+++ b/internal/sso/create/create.go
@@ -83,7 +83,8 @@ func Run(ctx context.Context, params RunParams) error {
 			CreatedAt: resp.JSON201.CreatedAt,
 			UpdatedAt: resp.JSON201.UpdatedAt,
 		})
-
+	case utils.OutputEnv:
+		return nil
 	default:
 		return utils.EncodeOutput(params.Format, os.Stdout, resp.JSON201)
 	}

--- a/internal/sso/get/get.go
+++ b/internal/sso/get/get.go
@@ -30,7 +30,6 @@ func Run(ctx context.Context, ref, providerId, format string) error {
 	case utils.OutputMetadata:
 		_, err := fmt.Println(*resp.JSON200.Saml.MetadataXml)
 		return err
-
 	case utils.OutputPretty:
 		return render.SingleMarkdown(api.Provider{
 			Id:        resp.JSON200.Id,
@@ -39,7 +38,8 @@ func Run(ctx context.Context, ref, providerId, format string) error {
 			CreatedAt: resp.JSON200.CreatedAt,
 			UpdatedAt: resp.JSON200.UpdatedAt,
 		})
-
+	case utils.OutputEnv:
+		return errors.Errorf("--output env flag is not supported")
 	default:
 		return utils.EncodeOutput(format, os.Stdout, resp.JSON200)
 	}

--- a/internal/sso/info/info.go
+++ b/internal/sso/info/info.go
@@ -13,9 +13,8 @@ func Run(ctx context.Context, ref string, format string) error {
 	switch format {
 	case utils.OutputPretty:
 		return render.InfoMarkdown(ref)
-
 	default:
-		return utils.EncodeOutput(format, os.Stdout, map[string]interface{}{
+		return utils.EncodeOutput(format, os.Stdout, map[string]string{
 			"acs_url":     fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/acs", ref),
 			"entity_id":   fmt.Sprintf("https://%s.supabase.co/auth/v1/sso/saml/metadata", ref),
 			"relay_state": fmt.Sprintf("https://%s.supabase.co", ref),

--- a/internal/sso/remove/remove.go
+++ b/internal/sso/remove/remove.go
@@ -34,7 +34,8 @@ func Run(ctx context.Context, ref, providerId, format string) error {
 			CreatedAt: resp.JSON200.CreatedAt,
 			UpdatedAt: resp.JSON200.UpdatedAt,
 		})
-
+	case utils.OutputEnv:
+		return nil
 	default:
 		return utils.EncodeOutput(format, os.Stdout, resp.JSON200)
 	}

--- a/internal/sso/update/update.go
+++ b/internal/sso/update/update.go
@@ -119,7 +119,8 @@ func Run(ctx context.Context, params RunParams) error {
 			CreatedAt: putResp.JSON200.CreatedAt,
 			UpdatedAt: putResp.JSON200.UpdatedAt,
 		})
-
+	case utils.OutputEnv:
+		return nil
 	default:
 		return utils.EncodeOutput(params.Format, os.Stdout, putResp.JSON200)
 	}

--- a/internal/utils/output.go
+++ b/internal/utils/output.go
@@ -22,19 +22,16 @@ const (
 	OutputMetadata = "metadata"
 )
 
-var (
-	OutputDefaultAllowed = []string{
+var OutputFormat = EnumFlag{
+	Allowed: []string{
+		OutputEnv,
 		OutputPretty,
 		OutputJson,
 		OutputToml,
 		OutputYaml,
-	}
-
-	OutputFormat = EnumFlag{
-		Allowed: OutputDefaultAllowed,
-		Value:   OutputPretty,
-	}
-)
+	},
+	Value: OutputPretty,
+}
 
 func EncodeOutput(format string, w io.Writer, value any) error {
 	switch format {

--- a/pkg/function/batch.go
+++ b/pkg/function/batch.go
@@ -34,6 +34,7 @@ func (s *EdgeRuntimeAPI) UpsertFunctions(ctx context.Context, functionConfig con
 	for _, f := range result {
 		exists[f.Slug] = struct{}{}
 	}
+OUTER:
 	for slug, function := range functionConfig {
 		if !function.Enabled {
 			fmt.Fprintln(os.Stderr, "Skipped deploying Function:", slug)
@@ -41,7 +42,7 @@ func (s *EdgeRuntimeAPI) UpsertFunctions(ctx context.Context, functionConfig con
 		}
 		for _, keep := range filter {
 			if !keep(slug) {
-				continue
+				continue OUTER
 			}
 		}
 		var body bytes.Buffer

--- a/pkg/migration/list.go
+++ b/pkg/migration/list.go
@@ -39,6 +39,7 @@ func ListLocalMigrations(migrationsDir string, fsys fs.FS, filter ...func(string
 		filter = append(filter, func(string) bool { return true })
 	}
 	var clean []string
+OUTER:
 	for i, migration := range localMigrations {
 		filename := migration.Name()
 		if i == 0 && shouldSkip(filename) {
@@ -52,10 +53,11 @@ func ListLocalMigrations(migrationsDir string, fsys fs.FS, filter ...func(string
 		}
 		path := filepath.Join(migrationsDir, filename)
 		for _, keep := range filter {
-			if version := matches[1]; keep(version) {
-				clean = append(clean, path)
+			if version := matches[1]; !keep(version) {
+				continue OUTER
 			}
 		}
+		clean = append(clean, path)
 	}
 	return clean, nil
 }

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -22,12 +22,13 @@ func (s *StorageAPI) UpsertBuckets(ctx context.Context, bucketConfig config.Buck
 	for _, b := range buckets {
 		exists[b.Name] = b.Id
 	}
+OUTER:
 	for name, bucket := range bucketConfig {
 		// Update bucket properties if already exists
 		if bucketId, ok := exists[name]; ok {
 			for _, keep := range filter {
 				if !keep(bucketId) {
-					continue
+					continue OUTER
 				}
 			}
 			fmt.Fprintln(os.Stderr, "Updating Storage bucket:", bucketId)


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

```
$ supabase --experimental branches get --output json
Selected branch ID: 709a7cc3-2cfd-417d-8828-76c8bbc58a1e
{
  "POSTGRES_URL": "postgresql://...@aws-0-ap-southeast-1.pooler.supabase.com:6543/postgres?connect_timeout=10",
  "POSTGRES_URL_NON_POOLING": "postgresql://...@db.kpojrjxbvujjhamjpcux.supabase.co:5432/?connect_timeout=10",
  "SUPABASE_ANON_KEY": "...",
  "SUPABASE_SERVICE_ROLE_KEY": "...",
  "SUPABASE_URL": "https://kpojrjxbvujjhamjpcux.supabase.co"
}
```

## Additional context

Add any other context or screenshots.
