### PR TITLE
fix: drop public views explicitly

### DIFF
--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -20,6 +20,17 @@ begin
     execute format('drop routine if exists %I.%I(%s) cascade', rec.pronamespace::regnamespace::name, rec.proname, pg_catalog.pg_get_function_identity_arguments(rec.oid));
   end loop;
 
+  -- views (necessary for views targeting supabase specific schemas objects)
+  for rec in
+    select *
+    from pg_class c
+    where
+      c.relnamespace::regnamespace::name = 'public'
+      and c.relkind = 'v'
+  loop
+    execute format('drop view if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
+  end loop;
+
   -- tables (cascade to views)
   for rec in
     select *


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/orgs/supabase/discussions/18937#discussioncomment-11823004

## What is the current behavior?

View in the `public` schema depending on a supabase specific schema like `storage` aren't dropped as part of the `DropUserSchemas` function, which makes the whole `drop.sql` fails as we then attempt to drop all the user-defined types in `public`. A view being represented by a composite type internally in Postgres, we hit the error `ERROR: cannot drop type objects because view objects requires it (SQLSTATE 2BP01)`.

## What is the new behavior?

I added an explicit step to drop all the views in `public` before dropping the tables.