### PR TITLE
feat: support setting function secrets from config

### DIFF
--- a/internal/functions/new/new.go
+++ b/internal/functions/new/new.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, slug string, fsys afero.Fs) error {
 	}
 	// Load config if available
 	if err := flags.LoadConfig(fsys); err != nil {
-		utils.CmdSuggestion = ""
+		fmt.Fprintln(utils.GetDebugLogger(), err)
 	}
 	if err := createEntrypointFile(slug, fsys); err != nil {
 		return err

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -97,15 +96,7 @@ func Run(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPa
 }
 
 func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, dbUrl string, runtimeOption RuntimeOption, fsys afero.Fs) error {
-	// 1. Load default values
-	if envFilePath == "" {
-		if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
-			envFilePath = utils.FallbackEnvFilePath
-		}
-	} else if !filepath.IsAbs(envFilePath) {
-		envFilePath = filepath.Join(utils.CurrentDirAbs, envFilePath)
-	}
-	// 2. Parse user defined env
+	// 1. Parse custom env file
 	env, err := parseEnvFile(envFilePath, fsys)
 	if err != nil {
 		return err
@@ -124,7 +115,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	if runtimeOption.InspectMode != nil {
 		env = append(env, "SUPABASE_INTERNAL_WALLCLOCK_LIMIT_SEC=0")
 	}
-	// 3. Parse custom import map
+	// 2. Parse custom import map
 	cwd, err := os.Getwd()
 	if err != nil {
 		return errors.Errorf("failed to get working directory: %w", err)
@@ -134,7 +125,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		return err
 	}
 	env = append(env, "SUPABASE_INTERNAL_FUNCTIONS_CONFIG="+functionsConfigString)
-	// 4. Parse entrypoint script
+	// 3. Parse entrypoint script
 	cmd := append([]string{
 		"edge-runtime",
 		"start",
@@ -150,7 +141,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 ` + mainFuncEmbed + `
 EOF
 `}
-	// 5. Parse exposed ports
+	// 4. Parse exposed ports
 	dockerRuntimePort := nat.Port(fmt.Sprintf("%d/tcp", dockerRuntimeServerPort))
 	exposedPorts := nat.PortSet{dockerRuntimePort: struct{}{}}
 	portBindings := nat.PortMap{}
@@ -161,7 +152,7 @@ EOF
 			HostPort: strconv.FormatUint(uint64(utils.Config.EdgeRuntime.InspectorPort), 10),
 		}}
 	}
-	// 6. Start container
+	// 5. Start container
 	_, err = utils.DockerStart(
 		ctx,
 		container.Config{
@@ -189,22 +180,17 @@ EOF
 }
 
 func parseEnvFile(envFilePath string, fsys afero.Fs) ([]string, error) {
-	env := []string{}
-	if len(envFilePath) == 0 {
-		return env, nil
-	}
-	envMap, err := set.ParseEnvFile(envFilePath, fsys)
-	if err != nil {
-		return env, err
-	}
-	for name, value := range envMap {
-		if strings.HasPrefix(name, "SUPABASE_") {
-			fmt.Fprintln(os.Stderr, "Env name cannot start with SUPABASE_, skipping: "+name)
-			continue
+	if envFilePath == "" {
+		if f, err := fsys.Stat(utils.FallbackEnvFilePath); err == nil && !f.IsDir() {
+			envFilePath = utils.FallbackEnvFilePath
 		}
-		env = append(env, name+"="+value)
 	}
-	return env, nil
+	env := []string{}
+	secrets, err := set.ListSecrets(envFilePath, fsys)
+	for _, v := range secrets {
+		env = append(env, fmt.Sprintf("%s=%s", v.Name, v.Value))
+	}
+	return env, err
 }
 
 func populatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fsys afero.Fs) ([]string, string, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,13 +220,14 @@ type (
 	}
 
 	edgeRuntime struct {
-		Enabled       bool              `toml:"enabled"`
-		Image         string            `toml:"-"`
-		Policy        RequestPolicy     `toml:"policy"`
-		InspectorPort uint16            `toml:"inspector_port"`
-		Secrets       map[string]Secret `toml:"secrets"`
+		Enabled       bool          `toml:"enabled"`
+		Image         string        `toml:"-"`
+		Policy        RequestPolicy `toml:"policy"`
+		InspectorPort uint16        `toml:"inspector_port"`
+		Secrets       SecretsConfig `toml:"secrets"`
 	}
 
+	SecretsConfig  map[string]Secret
 	FunctionConfig map[string]function
 
 	function struct {
@@ -509,6 +510,12 @@ func (c *config) loadFromReader(v *viper.Viper, r io.Reader) error {
 	}); err != nil {
 		return errors.Errorf("failed to parse config: %w", err)
 	}
+	// Convert keys to upper case: https://github.com/spf13/viper/issues/1014
+	secrets := make(SecretsConfig, len(c.EdgeRuntime.Secrets))
+	for k, v := range c.EdgeRuntime.Secrets {
+		secrets[strings.ToUpper(k)] = v
+	}
+	c.EdgeRuntime.Secrets = secrets
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,10 +220,11 @@ type (
 	}
 
 	edgeRuntime struct {
-		Enabled       bool          `toml:"enabled"`
-		Image         string        `toml:"-"`
-		Policy        RequestPolicy `toml:"policy"`
-		InspectorPort uint16        `toml:"inspector_port"`
+		Enabled       bool              `toml:"enabled"`
+		Image         string            `toml:"-"`
+		Policy        RequestPolicy     `toml:"policy"`
+		InspectorPort uint16            `toml:"inspector_port"`
+		Secrets       map[string]Secret `toml:"secrets"`
 	}
 
 	FunctionConfig map[string]function
@@ -312,7 +313,9 @@ func (s *storage) Clone() storage {
 
 func (c *baseConfig) Clone() baseConfig {
 	copy := *c
+	copy.Db.Vault = maps.Clone(c.Db.Vault)
 	copy.Storage = c.Storage.Clone()
+	copy.EdgeRuntime.Secrets = maps.Clone(c.EdgeRuntime.Secrets)
 	copy.Functions = maps.Clone(c.Functions)
 	copy.Auth = c.Auth.Clone()
 	if c.Experimental.Webhooks != nil {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -278,6 +278,9 @@ policy = "oneshot"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
 [analytics]
 enabled = true
 port = 54327

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -260,6 +260,9 @@ enabled = true
 policy = "per_worker"
 inspector_port = 8083
 
+[edge_runtime.secrets]
+test_key = "test_value"
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature https://github.com/orgs/supabase/discussions/18937#discussioncomment-12342719

## What is the new behavior?

```toml
[edge_runtime.secrets]
MY_SECRET = "env(some_key)"
```

## Additional context

TODO:
- [x] find an alternative to preserve case sensitivity
