### PR TITLE
feat: add clerk third-party auth config

### DIFF
--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -106,6 +106,7 @@ type (
 		Firebase tpaFirebase `toml:"firebase"`
 		Auth0    tpaAuth0    `toml:"auth0"`
 		Cognito  tpaCognito  `toml:"aws_cognito"`
+		Clerk    tpaClerk    `toml:"clerk"`
 	}
 
 	rateLimit struct {
@@ -135,6 +136,12 @@ type (
 
 		UserPoolID     string `toml:"user_pool_id"`
 		UserPoolRegion string `toml:"user_pool_region"`
+	}
+
+	tpaClerk struct {
+		Enabled bool `toml:"enabled"`
+
+		Domain string `toml:"domain"`
 	}
 
 	email struct {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -270,6 +270,11 @@ enabled = false
 # user_pool_id = "my-user-pool-id"
 # user_pool_region = "us-east-1"
 
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# domain = "example.clerk.accounts.dev" or "clerk.example.com"
+
 [edge_runtime]
 enabled = true
 # Configure one of the supported request policies: `oneshot`, `per_worker`.

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -273,7 +273,7 @@ enabled = false
 # Use Clerk as a third-party provider alongside Supabase Auth.
 [auth.third_party.clerk]
 enabled = false
-# domain = "example.clerk.accounts.dev" or "clerk.example.com"
+# domain = "example.clerk.accounts.dev"
 
 [edge_runtime]
 enabled = true


### PR DESCRIPTION
Adds Clerk as an officially supported Third-Party Auth provider in the CLI.