### PR TITLE
fix: clerk tpa domain pattern works for non-production mode domains

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1209,7 +1209,7 @@ func (c *tpaCognito) validate() (err error) {
 	return nil
 }
 
-var clerkDomainPattern = regexp.MustCompile("^(clerk([.][a-z0-9-]+){2,}|([a-z0-9-][.])+clerk[.]accounts[.]dev)$")
+var clerkDomainPattern = regexp.MustCompile("^(clerk([.][a-z0-9-]+){2,}|([a-z0-9-]+[.])+clerk[.]accounts[.]dev)$")
 
 func (c *tpaClerk) issuerURL() string {
 	return fmt.Sprintf("https://%s", c.Domain)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1223,7 +1223,7 @@ func (c *tpaClerk) validate() (err error) {
 	}
 
 	if !clerkDomainPattern.MatchString(c.Domain) {
-		return errors.New("Invalid config: auth.third_party.clerk has invalid domain, it usually is like clerk.example.com or example.clerk.accounts.dev")
+		return errors.New("Invalid config: auth.third_party.clerk has invalid domain, it usually is like clerk.example.com or example.clerk.accounts.dev. Check https://clerk.com/setup/supabase on how to find the correct value.")
 	}
 
 	return nil

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -273,7 +273,7 @@ enabled = false
 # Use Clerk as a third-party provider alongside Supabase Auth.
 [auth.third_party.clerk]
 enabled = false
-# domain = "example.clerk.accounts.dev"
+# domain = "example.clerk.accounts.dev" obtain from https://clerk.com/setup/supabase
 
 [edge_runtime]
 enabled = true

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -273,7 +273,8 @@ enabled = false
 # Use Clerk as a third-party provider alongside Supabase Auth.
 [auth.third_party.clerk]
 enabled = false
-# domain = "example.clerk.accounts.dev" obtain from https://clerk.com/setup/supabase
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
 
 [edge_runtime]
 enabled = true


### PR DESCRIPTION
Missing `+` wasn't caught.