### PR TITLE
feat: allow deno version in config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -225,6 +225,7 @@ type (
 		Policy        RequestPolicy `toml:"policy"`
 		InspectorPort uint16        `toml:"inspector_port"`
 		Secrets       SecretsConfig `toml:"secrets"`
+		DenoVersion   uint          `toml:"deno_version"`
 	}
 
 	SecretsConfig  map[string]Secret
@@ -826,6 +827,16 @@ func (c *config) Validate(fsys fs.FS) error {
 		if err := ValidateFunctionSlug(name); err != nil {
 			return err
 		}
+	}
+	switch c.EdgeRuntime.DenoVersion {
+	case 0:
+		return errors.New("Missing required field in config: edge_runtime.deno_version")
+	case 1:
+		break
+	case 2:
+		c.EdgeRuntime.Image = deno2
+	default:
+		return errors.Errorf("Failed reading config: Invalid %s: %v.", "edge_runtime.deno_version", c.EdgeRuntime.DenoVersion)
 	}
 	// Validate logflare config
 	if c.Analytics.Enabled {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	pg13 = "supabase/postgres:13.3.0"
-	pg14 = "supabase/postgres:14.1.0.89"
+	pg13  = "supabase/postgres:13.3.0"
+	pg14  = "supabase/postgres:14.1.0.89"
+	deno2 = "supabase/edge-runtime:v1.68.0-develop.8"
 )
 
 type images struct {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -141,7 +141,6 @@ sign_in_sign_ups = 30
 # Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
 token_verifications = 30
 
-
 # Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
 # [auth.captcha]
 # enabled = true
@@ -283,6 +282,8 @@ enabled = true
 policy = "oneshot"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
+# The Deno major version to use.
+deno_version = 1
 
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -259,6 +259,7 @@ enabled = true
 # Use `oneshot` for hot reload, or `per_worker` for load testing.
 policy = "per_worker"
 inspector_port = 8083
+deno_version = 2
 
 [edge_runtime.secrets]
 test_key = "test_value"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Allows users to switch to deno 2 for experimentation.

## Additional context

Add any other context or screenshots.
