### PR TITLE
fix: return deploy metadata from bundle

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -25,9 +25,8 @@ func NewDockerBundler(fsys afero.Fs) function.EszipBundler {
 	return &dockerBundler{fsys: fsys}
 }
 
-func (b *dockerBundler) Bundle(ctx context.Context, entrypoint string, importMap string, staticFiles []string, output io.Writer) error {
+func (b *dockerBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error {
 	// Create temp directory to store generated eszip
-	slug := filepath.Base(filepath.Dir(entrypoint))
 	fmt.Fprintln(os.Stderr, "Bundling Function:", utils.Bold(slug))
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/functions/deploy/bundle_test.go
+++ b/internal/functions/deploy/bundle_test.go
@@ -4,7 +4,10 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/h2non/gock"
@@ -13,16 +16,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestDockerBundle(t *testing.T) {
 	imageUrl := utils.GetRegistryImageUrl(utils.Config.EdgeRuntime.Image)
 	utils.EdgeRuntimeId = "test-edge-runtime"
 	const containerId = "test-container"
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
 
 	t.Run("throws error on bundle failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
+		absImportMap := filepath.Join(cwd, "hello", "deno.json")
+		require.NoError(t, utils.WriteFile(absImportMap, []byte("{}"), fsys))
 		// Setup deno error
 		t.Setenv("TEST_DENO_ERROR", "bundle failed")
 		var body bytes.Buffer
@@ -42,10 +50,51 @@ func TestDockerBundle(t *testing.T) {
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogsExitCode(utils.Docker, containerId, 1))
+		// Setup mock bundler
+		bundler := NewDockerBundler(fsys)
 		// Run test
-		err = NewDockerBundler(fsys).Bundle(context.Background(), "", "", "", []string{}, &body)
+		meta, err := bundler.Bundle(
+			context.Background(),
+			"hello",
+			filepath.Join("hello", "index.ts"),
+			filepath.Join("hello", "deno.json"),
+			[]string{filepath.Join("hello", "data.pdf")},
+			&body,
+		)
 		// Check error
 		assert.ErrorContains(t, err, "error running container: exit 1")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
+		assert.Equal(t, cast.Ptr("hello"), meta.Name)
+		entrypoint := fmt.Sprintf("file://%s/hello/index.ts", filepath.ToSlash(cwd))
+		assert.Equal(t, entrypoint, meta.EntrypointPath)
+		importMap := fmt.Sprintf("file://%s/hello/deno.json", filepath.ToSlash(cwd))
+		assert.Equal(t, &importMap, meta.ImportMapPath)
+		staticFile := fmt.Sprintf("file://%s/hello/data.pdf", filepath.ToSlash(cwd))
+		assert.Equal(t, cast.Ptr([]string{staticFile}), meta.StaticPatterns)
+		assert.Nil(t, meta.VerifyJwt)
+	})
+
+	t.Run("throws error on permission denied", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		// Setup mock bundler
+		bundler := NewDockerBundler(fsys)
+		// Run test
+		meta, err := bundler.Bundle(
+			context.Background(),
+			"hello",
+			"hello/index.ts",
+			"",
+			nil,
+			nil,
+		)
+		// Check error
+		assert.ErrorIs(t, err, os.ErrPermission)
+		assert.Equal(t, cast.Ptr("hello"), meta.Name)
+		entrypoint := fmt.Sprintf("file://%s/hello/index.ts", filepath.ToSlash(cwd))
+		assert.Equal(t, entrypoint, meta.EntrypointPath)
+		assert.Nil(t, meta.ImportMapPath)
+		assert.NotNil(t, meta.StaticPatterns)
+		assert.Nil(t, meta.VerifyJwt)
 	})
 }

--- a/internal/functions/deploy/bundle_test.go
+++ b/internal/functions/deploy/bundle_test.go
@@ -43,7 +43,7 @@ func TestDockerBundle(t *testing.T) {
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogsExitCode(utils.Docker, containerId, 1))
 		// Run test
-		err = NewDockerBundler(fsys).Bundle(context.Background(), "", "", []string{}, &body)
+		err = NewDockerBundler(fsys).Bundle(context.Background(), "", "", "", []string{}, &body)
 		// Check error
 		assert.ErrorContains(t, err, "error running container: exit 1")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/pkg/function/api.go
+++ b/pkg/function/api.go
@@ -15,7 +15,7 @@ type EdgeRuntimeAPI struct {
 }
 
 type EszipBundler interface {
-	Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error
+	Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) (api.FunctionDeployMetadata, error)
 }
 
 func NewEdgeRuntimeAPI(project string, client api.ClientWithResponses, opts ...withOption) EdgeRuntimeAPI {

--- a/pkg/function/api.go
+++ b/pkg/function/api.go
@@ -15,7 +15,7 @@ type EdgeRuntimeAPI struct {
 }
 
 type EszipBundler interface {
-	Bundle(ctx context.Context, entrypoint string, importMap string, staticFiles []string, output io.Writer) error
+	Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error
 }
 
 func NewEdgeRuntimeAPI(project string, client api.ClientWithResponses, opts ...withOption) EdgeRuntimeAPI {

--- a/pkg/function/batch.go
+++ b/pkg/function/batch.go
@@ -47,7 +47,7 @@ OUTER:
 			}
 		}
 		var body bytes.Buffer
-		if err := s.eszip.Bundle(ctx, function.Entrypoint, function.ImportMap, function.StaticFiles, &body); err != nil {
+		if err := s.eszip.Bundle(ctx, slug, function.Entrypoint, function.ImportMap, function.StaticFiles, &body); err != nil {
 			return err
 		}
 		// Update if function already exists

--- a/pkg/function/batch_test.go
+++ b/pkg/function/batch_test.go
@@ -17,7 +17,7 @@ import (
 type MockBundler struct {
 }
 
-func (b *MockBundler) Bundle(ctx context.Context, entrypoint string, importMap string, staticFiles []string, output io.Writer) error {
+func (b *MockBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error {
 	return nil
 }
 

--- a/pkg/function/batch_test.go
+++ b/pkg/function/batch_test.go
@@ -17,8 +17,16 @@ import (
 type MockBundler struct {
 }
 
-func (b *MockBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error {
-	return nil
+func (b *MockBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) (api.FunctionDeployMetadata, error) {
+	if staticFiles == nil {
+		staticFiles = []string{}
+	}
+	return api.FunctionDeployMetadata{
+		Name:           &slug,
+		EntrypointPath: entrypoint,
+		ImportMapPath:  &importMap,
+		StaticPatterns: &staticFiles,
+	}, nil
 }
 
 const (
@@ -54,7 +62,7 @@ func TestUpsertFunctions(t *testing.T) {
 		// Run test
 		err := client.UpsertFunctions(context.Background(), nil)
 		// Check error
-		assert.ErrorContains(t, err, "unexpected status 503:")
+		assert.ErrorContains(t, err, "unexpected list functions status 503:")
 	})
 
 	t.Run("retries on create failure", func(t *testing.T) {

--- a/pkg/function/bundle.go
+++ b/pkg/function/bundle.go
@@ -28,8 +28,7 @@ func NewNativeBundler(tempDir string, fsys fs.FS) EszipBundler {
 // Use a package private variable to allow testing without gosec complaining about G204
 var edgeRuntimeBin = "edge-runtime"
 
-func (b *nativeBundler) Bundle(ctx context.Context, entrypoint string, importMap string, staticFiles []string, output io.Writer) error {
-	slug := filepath.Base(filepath.Dir(entrypoint))
+func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error {
 	outputPath := filepath.Join(b.tempDir, slug+".eszip")
 	// TODO: make edge runtime write to stdout
 	args := []string{"bundle", "--entrypoint", entrypoint, "--output", outputPath}

--- a/pkg/function/bundle.go
+++ b/pkg/function/bundle.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/andybalholm/brotli"
 	"github.com/go-errors/errors"
+	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 type nativeBundler struct {
@@ -28,7 +32,8 @@ func NewNativeBundler(tempDir string, fsys fs.FS) EszipBundler {
 // Use a package private variable to allow testing without gosec complaining about G204
 var edgeRuntimeBin = "edge-runtime"
 
-func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) error {
+func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap string, staticFiles []string, output io.Writer) (api.FunctionDeployMetadata, error) {
+	meta := NewMetadata(slug, entrypoint, importMap, staticFiles)
 	outputPath := filepath.Join(b.tempDir, slug+".eszip")
 	// TODO: make edge runtime write to stdout
 	args := []string{"bundle", "--entrypoint", entrypoint, "--output", outputPath}
@@ -42,16 +47,16 @@ func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
-		return errors.Errorf("failed to bundle function: %w", err)
+		return meta, errors.Errorf("failed to bundle function: %w", err)
 	}
 	defer os.Remove(outputPath)
 	// Compress the output
 	eszipBytes, err := b.fsys.Open(outputPath)
 	if err != nil {
-		return errors.Errorf("failed to open eszip: %w", err)
+		return meta, errors.Errorf("failed to open eszip: %w", err)
 	}
 	defer eszipBytes.Close()
-	return Compress(eszipBytes, output)
+	return meta, Compress(eszipBytes, output)
 }
 
 const compressedEszipMagicID = "EZBR"
@@ -66,4 +71,37 @@ func Compress(r io.Reader, w io.Writer) error {
 		return errors.Errorf("failed to compress eszip: %w", err)
 	}
 	return nil
+}
+
+func NewMetadata(slug, entrypoint, importMap string, staticFiles []string) api.FunctionDeployMetadata {
+	meta := api.FunctionDeployMetadata{
+		Name:           &slug,
+		EntrypointPath: toFileURL(entrypoint),
+	}
+	if len(importMap) > 0 {
+		meta.ImportMapPath = cast.Ptr(toFileURL(importMap))
+	}
+	files := make([]string, len(staticFiles))
+	for i, sf := range staticFiles {
+		files[i] = toFileURL(sf)
+	}
+	meta.StaticPatterns = &files
+	return meta
+}
+
+func toFileURL(hostPath string) string {
+	absHostPath, err := filepath.Abs(hostPath)
+	if err != nil {
+		return hostPath
+	}
+	// Convert to unix path because edge runtime only supports linux
+	unixPath := toUnixPath(absHostPath)
+	parsed := url.URL{Scheme: "file", Path: unixPath}
+	return parsed.String()
+}
+
+func toUnixPath(absHostPath string) string {
+	prefix := filepath.VolumeName(absHostPath)
+	unixPath := filepath.ToSlash(absHostPath)
+	return strings.TrimPrefix(unixPath, prefix)
 }

--- a/pkg/function/bundle_test.go
+++ b/pkg/function/bundle_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	fs "testing/fstest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/pkg/cast"
 )
 
 func TestMain(m *testing.M) {
@@ -25,7 +28,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestBundleFunction(t *testing.T) {
-	edgeRuntimeBin, _ = os.Executable()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	edgeRuntimeBin, err = os.Executable()
+	require.NoError(t, err)
 
 	t.Run("creates eszip bundle", func(t *testing.T) {
 		var body bytes.Buffer
@@ -36,9 +42,52 @@ func TestBundleFunction(t *testing.T) {
 		// Setup mock bundler
 		bundler := nativeBundler{fsys: fsys}
 		// Run test
-		err := bundler.Bundle(context.Background(), "hello", "hello/index.ts", "", nil, &body)
+		meta, err := bundler.Bundle(
+			context.Background(),
+			"hello",
+			"hello/index.ts",
+			"hello/deno.json",
+			[]string{"hello/data.pdf"},
+			&body,
+		)
 		// Check error
 		assert.NoError(t, err)
 		assert.Equal(t, compressedEszipMagicID+";", body.String())
+		assert.Equal(t, cast.Ptr("hello"), meta.Name)
+		entrypoint := fmt.Sprintf("file://%s/hello/index.ts", filepath.ToSlash(cwd))
+		assert.Equal(t, entrypoint, meta.EntrypointPath)
+		importMap := fmt.Sprintf("file://%s/hello/deno.json", filepath.ToSlash(cwd))
+		assert.Equal(t, &importMap, meta.ImportMapPath)
+		staticFile := fmt.Sprintf("file://%s/hello/data.pdf", filepath.ToSlash(cwd))
+		assert.Equal(t, cast.Ptr([]string{staticFile}), meta.StaticPatterns)
+		assert.Nil(t, meta.VerifyJwt)
+	})
+
+	t.Run("ignores empty value", func(t *testing.T) {
+		var body bytes.Buffer
+		// Setup in-memory fs
+		fsys := fs.MapFS{
+			"hello.eszip": &fs.MapFile{},
+		}
+		// Setup mock bundler
+		bundler := nativeBundler{fsys: fsys}
+		// Run test
+		meta, err := bundler.Bundle(
+			context.Background(),
+			"hello",
+			"hello/index.ts",
+			"",
+			nil,
+			&body,
+		)
+		// Check error
+		assert.NoError(t, err)
+		assert.Equal(t, compressedEszipMagicID+";", body.String())
+		assert.Equal(t, cast.Ptr("hello"), meta.Name)
+		entrypoint := fmt.Sprintf("file://%s/hello/index.ts", filepath.ToSlash(cwd))
+		assert.Equal(t, entrypoint, meta.EntrypointPath)
+		assert.Nil(t, meta.ImportMapPath)
+		assert.NotNil(t, meta.StaticPatterns)
+		assert.Nil(t, meta.VerifyJwt)
 	})
 }

--- a/pkg/function/bundle_test.go
+++ b/pkg/function/bundle_test.go
@@ -36,7 +36,7 @@ func TestBundleFunction(t *testing.T) {
 		// Setup mock bundler
 		bundler := nativeBundler{fsys: fsys}
 		// Run test
-		err := bundler.Bundle(context.Background(), "hello/index.ts", "", nil, &body)
+		err := bundler.Bundle(context.Background(), "hello", "hello/index.ts", "", nil, &body)
 		// Check error
 		assert.NoError(t, err)
 		assert.Equal(t, compressedEszipMagicID+";", body.String())

--- a/pkg/migration/list.go
+++ b/pkg/migration/list.go
@@ -35,9 +35,6 @@ func ListLocalMigrations(migrationsDir string, fsys fs.FS, filter ...func(string
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, errors.Errorf("failed to read directory: %w", err)
 	}
-	if len(filter) == 0 {
-		filter = append(filter, func(string) bool { return true })
-	}
 	var clean []string
 OUTER:
 	for i, migration := range localMigrations {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Returns deploy metadata from docker and native bundle.

## Additional context

Add any other context or screenshots.
