### PR TITLE
fix: update docker id before db pull

### DIFF
--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -50,7 +50,7 @@ func ParseDatabaseConfig(flagSet *pflag.FlagSet, fsys afero.Fs) error {
 	// Update connection config
 	switch connType {
 	case direct:
-		if err := utils.Config.Load("", utils.NewRootFS(fsys)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := LoadConfig(fsys); err != nil {
 			return err
 		}
 		if flag := flagSet.Lookup("db-url"); flag != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3306

## What is the new behavior?

When parsing `--db-url` flag, docker id should be loaded with config file.

## Additional context

Add any other context or screenshots.
