### PR TITLE
chore(docs): Remove v1 from title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Supabase CLI (v1)
+# Supabase CLI
 
 [![Coverage Status](https://coveralls.io/repos/github/supabase/cli/badge.svg?branch=main)](https://coveralls.io/github/supabase/cli?branch=main) [![Bitbucket Pipelines](https://img.shields.io/bitbucket/pipelines/supabase-cli/setup-cli/master?style=flat-square&label=Bitbucket%20Canary)](https://bitbucket.org/supabase-cli/setup-cli/pipelines) [![Gitlab Pipeline Status](https://img.shields.io/gitlab/pipeline-status/sweatybridge%2Fsetup-cli?label=Gitlab%20Canary)
 ](https://gitlab.com/sweatybridge/setup-cli/-/pipelines)


### PR DESCRIPTION
It says v1, but the latest releases are v2. It's confusing to find on npm with the wrong major version number.