### PR TITLE
fix: add created by column to migrations

### DIFF
--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -421,7 +421,8 @@ func TestLinkDatabase(t *testing.T) {
 			Query(migration.CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(migration.ADD_STATEMENTS_COLUMN).
-			Query(migration.ADD_NAME_COLUMN)
+			Query(migration.ADD_NAME_COLUMN).
+			Query(migration.ADD_CREATED_BY_COLUMN)
 		// Run test
 		err := linkDatabase(context.Background(), dbConfig, conn.Intercept)
 		// Check error

--- a/internal/testing/helper/history.go
+++ b/internal/testing/helper/history.go
@@ -14,6 +14,8 @@ func MockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(migration.ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(migration.ADD_NAME_COLUMN).
+		Reply("ALTER TABLE").
+		Query(migration.ADD_CREATED_BY_COLUMN).
 		Reply("ALTER TABLE")
 	return conn
 }

--- a/pkg/migration/apply_test.go
+++ b/pkg/migration/apply_test.go
@@ -130,7 +130,8 @@ func TestApplyMigrations(t *testing.T) {
 			Query(CREATE_VERSION_TABLE).
 			ReplyError(pgerrcode.InsufficientPrivilege, "permission denied for relation supabase_migrations").
 			Query(ADD_STATEMENTS_COLUMN).
-			Query(ADD_NAME_COLUMN)
+			Query(ADD_NAME_COLUMN).
+			Query(ADD_CREATED_BY_COLUMN)
 		// Run test
 		err := ApplyMigrations(context.Background(), pending, conn.MockClient(t), fsys)
 		// Check error
@@ -175,6 +176,8 @@ func mockMigrationHistory(conn *pgtest.MockConn) *pgtest.MockConn {
 		Query(ADD_STATEMENTS_COLUMN).
 		Reply("ALTER TABLE").
 		Query(ADD_NAME_COLUMN).
+		Reply("ALTER TABLE").
+		Query(ADD_CREATED_BY_COLUMN).
 		Reply("ALTER TABLE")
 	return conn
 }

--- a/pkg/migration/history.go
+++ b/pkg/migration/history.go
@@ -15,6 +15,7 @@ const (
 	CREATE_VERSION_TABLE     = "CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (version text NOT NULL PRIMARY KEY)"
 	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
 	ADD_NAME_COLUMN          = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS name text"
+	ADD_CREATED_BY_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS created_by text"
 	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES($1, $2, $3)"
 	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = ANY($1)"
 	DELETE_MIGRATION_BEFORE  = "DELETE FROM supabase_migrations.schema_migrations WHERE version <= $1"
@@ -36,6 +37,7 @@ func CreateMigrationTable(ctx context.Context, conn *pgx.Conn) error {
 	batch.ExecParams(CREATE_VERSION_TABLE, nil, nil, nil, nil)
 	batch.ExecParams(ADD_STATEMENTS_COLUMN, nil, nil, nil, nil)
 	batch.ExecParams(ADD_NAME_COLUMN, nil, nil, nil, nil)
+	batch.ExecParams(ADD_CREATED_BY_COLUMN, nil, nil, nil, nil)
 	if _, err := conn.PgConn().ExecBatch(ctx, &batch).ReadAll(); err != nil {
 		return errors.Errorf("failed to create migration table: %w", err)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Adds `created_by` column to be consistent with api.

## Additional context

TODO:
- [ ] update MigrationFile struct to include this field
