### PR TITLE
fix(config): rate limit emails only if custom smtp enabled

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -511,11 +511,11 @@ EOF
 			fmt.Sprintf("GOTRUE_RATE_LIMIT_OTP=%v", utils.Config.Auth.RateLimit.SignInSignUps),
 			fmt.Sprintf("GOTRUE_RATE_LIMIT_VERIFY=%v", utils.Config.Auth.RateLimit.TokenVerifications),
 			fmt.Sprintf("GOTRUE_RATE_LIMIT_SMS_SENT=%v", utils.Config.Auth.RateLimit.SmsSent),
-			fmt.Sprintf("GOTRUE_RATE_LIMIT_EMAIL_SENT=%v", utils.Config.Auth.RateLimit.EmailSent),
 		}
 
 		if utils.Config.Auth.Email.Smtp != nil && utils.Config.Auth.Email.Smtp.Enabled {
 			env = append(env,
+				fmt.Sprintf("GOTRUE_RATE_LIMIT_EMAIL_SENT=%v", utils.Config.Auth.RateLimit.EmailSent),
 				fmt.Sprintf("GOTRUE_SMTP_HOST=%s", utils.Config.Auth.Email.Smtp.Host),
 				fmt.Sprintf("GOTRUE_SMTP_PORT=%d", utils.Config.Auth.Email.Smtp.Port),
 				fmt.Sprintf("GOTRUE_SMTP_USER=%s", utils.Config.Auth.Email.Smtp.User),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is to fix the email rate limit issue on local development.

## What is the current behavior?

Emails are being rate limited even without `auth.email.smtp` being enabled.

## What is the new behavior?

Emails are only rate limited if `auth.email.smtp` is enabled.

## Additional context

Related to https://github.com/supabase/cli/issues/3353
