### PR TITLE
fix: bump deno2 to 1.68.0-develop.13

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -11,7 +11,7 @@ import (
 const (
 	pg13  = "supabase/postgres:13.3.0"
 	pg14  = "supabase/postgres:14.1.0.89"
-	deno2 = "supabase/edge-runtime:v1.68.0-develop.12"
+	deno2 = "supabase/edge-runtime:v1.68.0-develop.13"
 )
 
 type images struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump deno2 to 1.68.0-develop.13