### PR TITLE
fix: resolve legacy import map

### DIFF
--- a/pkg/function/testdata/nested/deno.json
+++ b/pkg/function/testdata/nested/deno.json
@@ -1,1 +1,5 @@
-{}
+{
+  "imports": {
+    "module": "jsr:@supabase/functions-js/edge-runtime.d.ts"
+  }
+}

--- a/pkg/function/testdata/nested/index.ts
+++ b/pkg/function/testdata/nested/index.ts
@@ -1,0 +1,1 @@
+import "module";

--- a/pkg/function/testdata/writes_import_map.form
+++ b/pkg/function/testdata/writes_import_map.form
@@ -7,7 +7,11 @@ Content-Disposition: form-data; name="metadata"
 Content-Disposition: form-data; name="file"; filename="testdata/nested/deno.json"
 Content-Type: application/octet-stream
 
-{}
+{
+  "imports": {
+    "module": "jsr:@supabase/functions-js/edge-runtime.d.ts"
+  }
+}
 
 --test
 Content-Disposition: form-data; name="file"; filename="testdata/geometries/Geometries.js"
@@ -18,3 +22,4 @@ Content-Type: application/octet-stream
 Content-Disposition: form-data; name="file"; filename="testdata/nested/index.ts"
 Content-Type: application/octet-stream
 
+import "module";


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Import maps must be resolved relative to `deno.json` file.

## Additional context

Add any other context or screenshots.
