### PR TITLE
fix: convert all paths to relative for deploy

### DIFF
--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -73,12 +73,12 @@ func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []api.Function
 	jq := queue.NewJobQueue(s.maxJobs)
 	toUpdate := make([]api.BulkUpdateFunctionBody, len(toDeploy))
 	for i, meta := range toDeploy {
-		fmt.Fprintln(os.Stderr, "Deploying Function:", *meta.Name)
 		param := api.V1DeployAFunctionParams{
 			Slug:       meta.Name,
 			BundleOnly: cast.Ptr(true),
 		}
 		bundle := func() error {
+			fmt.Fprintln(os.Stderr, "Deploying Function:", *meta.Name)
 			resp, err := s.upload(ctx, param, meta, fsys)
 			if err != nil {
 				return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

```
failed to load import map: readfile /Users/qiao/work/cli/supabase/functions/deno.json: invalid argument
```

## What is the new behavior?

```
supabase functions deploy test --import-map supabase/functions/deno.json --use-api
```

## Additional context

Add any other context or screenshots.
