### PR TITLE
fix: outside import with relative module graph

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -149,6 +149,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImpo
 		modules := importMap.BindHostModules()
 		dockerImportMapPath := utils.ToDockerPath(hostImportMapPath)
 		modules = append(modules, hostImportMapPath+":"+dockerImportMapPath+":ro")
+
 		// Remove any duplicate mount points
 		for _, mod := range modules {
 			hostPath := strings.Split(mod, ":")[0]

--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -164,8 +164,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImpo
 				return errors.New("file path is a directory: " + srcPath)
 			}
 
-			r := io.TeeReader(f, w)
-			_, err = io.Copy(io.Discard, r) // Discard the read data after writing to w
+			_, err = io.Copy(w, f) // Discard the read data after writing to w
 			if err != nil {
 				return errors.Errorf("failed to copy file content: %w", err)
 			}

--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -148,7 +148,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImpo
 			return nil, err
 		}
 
-		modules := importMap.BindHostModules()
+		modules := utils.BindHostModules(importMap)
 		dockerImportMapPath := utils.ToDockerPath(hostImportMapPath)
 		modules = append(modules, hostImportMapPath+":"+dockerImportMapPath+":ro")
 

--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -122,7 +122,7 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImpo
 			binds = append(binds, hostOutputDir+":"+dockerOutputDir+":rw")
 		}
 	}
-	// Imports outside of ./supabase/functions will be bound by absolute path
+	// Imports outside of ./supabase/functions will be bound by walking the entrypoint
 	modules, err := utils.BindHostModules(cwd, hostEntrypointPath, hostImportMapPath, fsys)
 	if err != nil {
 		return nil, err

--- a/internal/functions/deploy/bundle_test.go
+++ b/internal/functions/deploy/bundle_test.go
@@ -29,7 +29,7 @@ func TestDockerBundle(t *testing.T) {
 	t.Run("throws error on bundle failure", func(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
-		absImportMap := filepath.Join(cwd, "hello", "deno.json")
+		absImportMap := filepath.Join("hello", "deno.json")
 		require.NoError(t, utils.WriteFile(absImportMap, []byte("{}"), fsys))
 		// Setup deno error
 		t.Setenv("TEST_DENO_ERROR", "bundle failed")

--- a/internal/functions/deploy/deploy_test.go
+++ b/internal/functions/deploy/deploy_test.go
@@ -84,8 +84,7 @@ import_map = "./import_map.json"
 `)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
-		importMapPath, err := filepath.Abs(filepath.Join(utils.SupabaseDirPath, "import_map.json"))
-		require.NoError(t, err)
+		importMapPath := filepath.Join(utils.SupabaseDirPath, "import_map.json")
 		require.NoError(t, afero.WriteFile(fsys, importMapPath, []byte("{}"), 0644))
 		// Setup function entrypoint
 		entrypointPath := filepath.Join(utils.FunctionsDir, slug, "index.ts")

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -119,6 +119,14 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 	if err != nil {
 		return errors.Errorf("failed to get working directory: %w", err)
 	}
+	if len(importMapPath) > 0 {
+		if !filepath.IsAbs(importMapPath) {
+			importMapPath = filepath.Join(utils.CurrentDirAbs, importMapPath)
+		}
+		if importMapPath, err = filepath.Rel(cwd, importMapPath); err != nil {
+			return errors.Errorf("failed to resolve relative path: %w", err)
+		}
+	}
 	binds, functionsConfigString, err := populatePerFunctionConfigs(cwd, importMapPath, noVerifyJWT, fsys)
 	if err != nil {
 		return err

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -213,7 +213,6 @@ func populatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fs
 		if err != nil {
 			return nil, "", err
 		}
-
 		binds = append(binds, modules...)
 		fc.ImportMap = utils.ToDockerPath(fc.ImportMap)
 		fc.Entrypoint = utils.ToDockerPath(fc.Entrypoint)

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -64,10 +64,8 @@ const (
 	dockerRuntimeInspectorPort = 8083
 )
 
-var (
-	//go:embed templates/main.ts
-	mainFuncEmbed string
-)
+//go:embed templates/main.ts
+var mainFuncEmbed string
 
 func Run(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, runtimeOption RuntimeOption, fsys afero.Fs) error {
 	// 1. Sanity checks.
@@ -215,6 +213,7 @@ func populatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fs
 		if err != nil {
 			return nil, "", err
 		}
+
 		binds = append(binds, modules...)
 		fc.ImportMap = utils.ToDockerPath(fc.ImportMap)
 		fc.Entrypoint = utils.ToDockerPath(fc.Entrypoint)

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -88,6 +88,7 @@ func TestServeCommand(t *testing.T) {
 	})
 
 	t.Run("throws error on missing import map", func(t *testing.T) {
+		utils.CurrentDirAbs = "/"
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, utils.InitConfig(utils.InitParams{ProjectId: "test"}, fsys))

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -303,6 +303,7 @@ func (m *ImportMap) BindHostModules() []string {
 		dockerPath := ToDockerPath(hostPath)
 		binds = append(binds, hostPath+":"+dockerPath+":ro")
 	}
+
 	for _, mapping := range m.Scopes {
 		for _, hostPath := range mapping {
 			if !filepath.IsAbs(hostPath) || strings.HasPrefix(hostPath, hostFuncDir) {

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -217,12 +217,10 @@ func NewImportMap(absJsonPath string, fsys afero.Fs) (*function.ImportMap, error
 	if err := result.Parse(data); err != nil {
 		return nil, err
 	}
-
 	iofsys := afero.NewIOFS(fsys)
 	if err := result.Resolve(absJsonPath, iofsys); err != nil {
 		return nil, err
 	}
-
 	return &result, nil
 }
 

--- a/internal/utils/deno.go
+++ b/internal/utils/deno.go
@@ -220,7 +220,9 @@ func NewImportMap(absJsonPath string, fsys afero.Fs) (*function.ImportMap, error
 
 	// TODO:(kallebysantos) Find somehow to cast between `afero.Fs` to `io.FS`
 	// in order to use `function.ImportMap.Resolve()`
-	resolve(&result, absJsonPath, fsys)
+	if err := resolve(&result, absJsonPath, fsys); err != nil {
+		return nil, err
+	}
 
 	return &result, nil
 }

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -68,14 +68,13 @@ import "/tmp/index.ts"
 import "../common/index.ts"
 import "../../../supabase/tests/index.ts"
 import "./child/index.ts"`
-		entrypointPath := "/app/supabase/functions/hello/index.ts"
-		require.NoError(t, WriteFile(entrypointPath, []byte(entrypoint), fsys))
+		require.NoError(t, WriteFile("/app/supabase/functions/hello/index.ts", []byte(entrypoint), fsys))
 		require.NoError(t, WriteFile("/tmp/index.ts", []byte{}, fsys))
 		require.NoError(t, WriteFile("/app/supabase/functions/common/index.ts", []byte{}, fsys))
 		require.NoError(t, WriteFile("/app/supabase/tests/index.ts", []byte{}, fsys))
 		require.NoError(t, WriteFile("/app/supabase/functions/hello/child/index.ts", []byte{}, fsys))
 		// Run test
-		mods, err := BindHostModules("/app", entrypointPath, "", fsys)
+		mods, err := BindHostModules("/app", "supabase/functions/hello/index.ts", "", fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, mods, []string{

--- a/internal/utils/deno_test.go
+++ b/internal/utils/deno_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/pkg/function"
 )
 
 func TestResolveImports(t *testing.T) {
@@ -64,7 +65,7 @@ func TestBindModules(t *testing.T) {
 	t.Run("binds docker imports", func(t *testing.T) {
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
-		importMap := ImportMap{
+		importMap := function.ImportMap{
 			Imports: map[string]string{
 				"abs/":   "/tmp/",
 				"root":   cwd + "/common",
@@ -73,7 +74,7 @@ func TestBindModules(t *testing.T) {
 			},
 		}
 		// Run test
-		mods := importMap.BindHostModules()
+		mods := BindHostModules(&importMap)
 		// Check error
 		assert.ElementsMatch(t, mods, []string{
 			"/tmp/:/tmp/:ro",
@@ -83,7 +84,7 @@ func TestBindModules(t *testing.T) {
 	})
 
 	t.Run("binds docker scopes", func(t *testing.T) {
-		importMap := ImportMap{
+		importMap := function.ImportMap{
 			Scopes: map[string]map[string]string{
 				"my-scope": {
 					"my-mod": "https://deno.land",
@@ -91,7 +92,7 @@ func TestBindModules(t *testing.T) {
 			},
 		}
 		// Run test
-		mods := importMap.BindHostModules()
+		mods := BindHostModules(&importMap)
 		// Check error
 		assert.Empty(t, mods)
 	})

--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -218,7 +218,6 @@ func (m *ImportMap) Parse(data []byte) error {
 	return nil
 }
 
-// WARN:(kallebysantos) duplicated code inside `utils.resolve(.., afero.Fs)`
 func (m *ImportMap) Resolve(imPath string, fsys fs.FS) error {
 	// Resolve all paths relative to current file
 	for k, v := range m.Imports {
@@ -232,7 +231,6 @@ func (m *ImportMap) Resolve(imPath string, fsys fs.FS) error {
 	return nil
 }
 
-// WARN:(kallebysantos) duplicated code inside `utils.resolveHostPath(.., afero.Fs)`
 func resolveHostPath(jsonPath, hostPath string, fsys fs.FS) string {
 	// Leave absolute paths unchanged
 	if path.IsAbs(hostPath) {

--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,15 +9,17 @@ import (
 	"io/fs"
 	"mime/multipart"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/go-errors/errors"
-	"github.com/spf13/afero"
-	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/queue"
+	"github.com/tidwall/jsonc"
 )
 
 var ErrNoDeploy = errors.New("All Functions are up to date.")
@@ -163,7 +166,7 @@ func writeForm(form *multipart.Writer, meta api.FunctionDeployMetadata, fsys fs.
 		return nil
 	}
 	// Add import map
-	importMap := utils.ImportMap{}
+	importMap := ImportMap{}
 	if imPath := cast.Val(meta.ImportMapPath, ""); len(imPath) > 0 {
 		data, err := fs.ReadFile(fsys, filepath.FromSlash(imPath))
 		if err != nil {
@@ -173,9 +176,7 @@ func writeForm(form *multipart.Writer, meta api.FunctionDeployMetadata, fsys fs.
 			return err
 		}
 
-		// Casting io.FS to afero.Fs
-		afsys := &afero.FromIOFS{FS: fsys}
-		if err := importMap.Resolve(imPath, afsys); err != nil {
+		if err := importMap.Resolve(imPath, fsys); err != nil {
 			return err
 		}
 
@@ -201,4 +202,128 @@ func writeForm(form *multipart.Writer, meta api.FunctionDeployMetadata, fsys fs.
 		}
 	}
 	return importMap.WalkImportPaths(meta.EntrypointPath, addFile)
+}
+
+type ImportMap struct {
+	Imports map[string]string            `json:"imports"`
+	Scopes  map[string]map[string]string `json:"scopes"`
+}
+
+func (m *ImportMap) Parse(data []byte) error {
+	data = jsonc.ToJSONInPlace(data)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&m); err != nil {
+		return errors.Errorf("failed to parse import map: %w", err)
+	}
+	return nil
+}
+
+// WARN:(kallebysantos) duplicated code inside `utils.resolve(.., afero.Fs)`
+func (m *ImportMap) Resolve(imPath string, fsys fs.FS) error {
+	// Resolve all paths relative to current file
+	for k, v := range m.Imports {
+		m.Imports[k] = resolveHostPath(imPath, v, fsys)
+	}
+	for module, mapping := range m.Scopes {
+		for k, v := range mapping {
+			m.Scopes[module][k] = resolveHostPath(imPath, v, fsys)
+		}
+	}
+	return nil
+}
+
+// WARN:(kallebysantos) duplicated code inside `utils.resolveHostPath(.., afero.Fs)`
+func resolveHostPath(jsonPath, hostPath string, fsys fs.FS) string {
+	// Leave absolute paths unchanged
+	if path.IsAbs(hostPath) {
+		return hostPath
+	}
+	resolved := path.Join(path.Dir(jsonPath), hostPath)
+	if _, err := fs.Stat(fsys, filepath.FromSlash(resolved)); err != nil {
+		// Leave URLs unchanged
+		if err != nil {
+		}
+		return hostPath
+	}
+
+	// Directory imports need to be suffixed with /
+	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
+	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
+		resolved += string(filepath.Separator)
+	}
+
+	// Relative imports must be prefixed with ./ or ../
+	if !path.IsAbs(resolved) {
+		resolved = "./" + resolved
+	}
+	return resolved
+}
+
+// Ref: https://regex101.com/r/DfBdJA/1
+var importPathPattern = regexp.MustCompile(`(?i)(?:import|export)\s+(?:{[^{}]+}|.*?)\s*(?:from)?\s*['"](.*?)['"]|import\(\s*['"](.*?)['"]\)`)
+
+func (importMap *ImportMap) WalkImportPaths(srcPath string, readFile func(curr string, w io.Writer) error) error {
+	seen := map[string]struct{}{}
+	// DFS because it's more efficient to pop from end of array
+	q := make([]string, 1)
+	q[0] = srcPath
+	for len(q) > 0 {
+		curr := q[len(q)-1]
+		q = q[:len(q)-1]
+		// Assume no file is symlinked
+		if _, ok := seen[curr]; ok {
+			continue
+		}
+		seen[curr] = struct{}{}
+		// Read into memory for regex match later
+		var buf bytes.Buffer
+		if err := readFile(curr, &buf); errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintln(os.Stderr, "WARN:", err)
+			continue
+		} else if err != nil {
+			return err
+		}
+		// Traverse all modules imported by the current source file
+		for _, matches := range importPathPattern.FindAllStringSubmatch(buf.String(), -1) {
+			if len(matches) < 3 {
+				continue
+			}
+			// Matches 'from' clause if present, else fallback to 'import'
+			mod := matches[1]
+			if len(mod) == 0 {
+				mod = matches[2]
+			}
+			mod = strings.TrimSpace(mod)
+			// Substitute kv from import map
+			substituted := false
+			for k, v := range importMap.Imports {
+				if strings.HasPrefix(mod, k) {
+					mod = v + mod[len(k):]
+					substituted = true
+				}
+			}
+			// Ignore URLs and directories
+			if len(path.Ext(mod)) == 0 {
+				continue
+			}
+			// Deno import path must begin with one of these prefixes
+			if !isRelPath(mod) && !isAbsPath(mod) {
+				continue
+			}
+			if isRelPath(mod) && !substituted {
+				mod = path.Join(path.Dir(curr), mod)
+			}
+			// Cleans import path to help detect duplicates
+			q = append(q, path.Clean(mod))
+		}
+	}
+	return nil
+}
+
+func isRelPath(mod string) bool {
+	return strings.HasPrefix(mod, "./") || strings.HasPrefix(mod, "../")
+}
+
+func isAbsPath(mod string) bool {
+	return strings.HasPrefix(mod, "/")
 }

--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -241,15 +241,13 @@ func resolveHostPath(jsonPath, hostPath string, fsys fs.FS) string {
 	resolved := path.Join(path.Dir(jsonPath), hostPath)
 	if _, err := fs.Stat(fsys, filepath.FromSlash(resolved)); err != nil {
 		// Leave URLs unchanged
-		if err != nil {
-		}
 		return hostPath
 	}
 
 	// Directory imports need to be suffixed with /
 	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
-	if strings.HasSuffix(hostPath, string(filepath.Separator)) {
-		resolved += string(filepath.Separator)
+	if strings.HasSuffix(hostPath, "/") {
+		resolved += "/"
 	}
 
 	// Relative imports must be prefixed with ./ or ../

--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -175,11 +175,9 @@ func writeForm(form *multipart.Writer, meta api.FunctionDeployMetadata, fsys fs.
 		if err := importMap.Parse(data); err != nil {
 			return err
 		}
-
 		if err := importMap.Resolve(imPath, fsys); err != nil {
 			return err
 		}
-
 		// TODO: replace with addFile once edge runtime supports jsonc
 		fmt.Fprintf(os.Stderr, "Uploading asset (%s): %s\n", *meta.Name, imPath)
 		f, err := form.CreateFormFile("file", imPath)
@@ -241,13 +239,11 @@ func resolveHostPath(jsonPath, hostPath string, fsys fs.FS) string {
 		// Leave URLs unchanged
 		return hostPath
 	}
-
 	// Directory imports need to be suffixed with /
 	// Ref: https://deno.com/manual@v1.33.0/basics/import_maps
 	if strings.HasSuffix(hostPath, "/") {
 		resolved += "/"
 	}
-
 	// Relative imports must be prefixed with ./ or ../
 	if !path.IsAbs(resolved) {
 		resolved = "./" + resolved

--- a/pkg/function/deploy.go
+++ b/pkg/function/deploy.go
@@ -294,7 +294,8 @@ func (importMap *ImportMap) WalkImportPaths(srcPath string, readFile func(curr s
 					substituted = true
 				}
 			}
-			// Ignore URLs and directories
+			// Ignore URLs and directories, assuming no sloppy imports
+			// https://github.com/denoland/deno/issues/2506#issuecomment-2727635545
 			if len(path.Ext(mod)) == 0 {
 				continue
 			}

--- a/pkg/function/deploy_test.go
+++ b/pkg/function/deploy_test.go
@@ -14,11 +14,9 @@ import (
 	fs "testing/fstest"
 
 	"github.com/h2non/gock"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/config"
@@ -51,7 +49,7 @@ func TestImportPaths(t *testing.T) {
 		fsys.On("ReadFile", "testdata/modules/imports.ts").Once()
 		fsys.On("ReadFile", "testdata/geometries/Geometries.js").Once()
 		// Run test
-		im := utils.ImportMap{}
+		im := ImportMap{}
 		err := im.WalkImportPaths("testdata/modules/imports.ts", fsys.ReadFile)
 		// Check error
 		assert.NoError(t, err)
@@ -68,12 +66,10 @@ func TestImportPaths(t *testing.T) {
 		fsys.On("ReadFile", "testdata/shared/mod.ts").Once()
 		fsys.On("ReadFile", "testdata/nested/index.ts").Once()
 		// Setup deno.json
-		im := utils.ImportMap{Imports: map[string]string{
+		im := ImportMap{Imports: map[string]string{
 			"module-name/": "../shared/",
 		}}
-		// Casting io.FS to afero.Fs
-		afsys := &afero.FromIOFS{FS: testImports}
-		assert.NoError(t, im.Resolve("testdata/modules/deno.json", afsys))
+		assert.NoError(t, im.Resolve("testdata/modules/deno.json", testImports))
 		// Run test
 		err := im.WalkImportPaths("testdata/modules/imports.ts", fsys.ReadFile)
 		// Check error
@@ -91,12 +87,10 @@ func TestImportPaths(t *testing.T) {
 		fsys.On("ReadFile", "testdata/shared/mod.ts").Once()
 		fsys.On("ReadFile", "testdata/nested/index.ts").Once()
 		// Setup legacy import map
-		im := utils.ImportMap{Imports: map[string]string{
+		im := ImportMap{Imports: map[string]string{
 			"module-name/": "./shared/",
 		}}
-		// Casting io.FS to afero.Fs
-		afsys := &afero.FromIOFS{FS: testImports}
-		assert.NoError(t, im.Resolve("testdata/import_map.json", afsys))
+		assert.NoError(t, im.Resolve("testdata/import_map.json", testImports))
 		// Run test
 		err := im.WalkImportPaths("testdata/modules/imports.ts", fsys.ReadFile)
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using `outside import` for local development, the bundler does not include relative imports in the Module graph,
Like the following [example](https://github.com/kallebysantos/testing.supabase.outside-imports)

<details>
<summary>Error</summary>

```
worker boot error: failed to create the graph: Module not found "file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/add.ts".
    at file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/index.ts:1:21
worker boot error: failed to create the graph: Module not found "file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/add.ts".
    at file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/index.ts:1:21
InvalidWorkerCreation: worker boot error: failed to create the graph: Module not found "file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/add.ts".
    at file:///Users/kallebysantos/projects/testing/supa/outside-imports/my-lib/index.ts:1:21
    at async UserWorker.create (ext:sb_user_workers/user_workers.js:139:15)
    at async Object.handler (file:///root/index.ts:157:22)
    at async respond (ext:sb_core_main_js/js/http.js:197:14) {
  name: "InvalidWorkerCreation"
}
```
</details>

## What is the new behavior?

This PR applies the same `import resolution` as when deploying from `--use-api`. So it ensures that all files are bundled for local development.

<details>
<summary>Fixed</summary>

![image](https://github.com/user-attachments/assets/d94f5845-4b68-4fb9-99a9-e58234cd635d)

</details>

