### PR TITLE
feat: import map from deno's `importMap` field

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -428,6 +428,26 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		assert.Equal(t, "supabase/functions/hello/deno.json", config.Functions["hello"].ImportMap)
 	})
 
+	t.Run("uses deno.json+importMap field as import map when present", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[functions.hello]
+			`)},
+			"supabase/functions/hello/deno.json": &fs.MapFile{Data: []byte(`
+      {
+        "importMap": "../import_map.json"
+      }`)},
+			"supabase/functions/import_map.json": &fs.MapFile{},
+			"supabase/functions/hello/index.ts":  &fs.MapFile{},
+		}
+		// Run test
+		assert.NoError(t, config.Load("", fsys))
+		// Check that deno.json was set as import map
+		assert.Equal(t, "supabase/functions/import_map.json", config.Functions["hello"].ImportMap)
+	})
+
 	t.Run("uses deno.jsonc as import map when present", func(t *testing.T) {
 		config := NewConfig()
 		fsys := fs.MapFS{
@@ -442,6 +462,26 @@ func TestLoadFunctionImportMap(t *testing.T) {
 		assert.NoError(t, config.Load("", fsys))
 		// Check that deno.jsonc was set as import map
 		assert.Equal(t, "supabase/functions/hello/deno.jsonc", config.Functions["hello"].ImportMap)
+	})
+
+	t.Run("uses deno.jsonc+importMap field as import map when present", func(t *testing.T) {
+		config := NewConfig()
+		fsys := fs.MapFS{
+			"supabase/config.toml": &fs.MapFile{Data: []byte(`
+			project_id = "bvikqvbczudanvggcord"
+			[functions.hello]
+			`)},
+			"supabase/functions/hello/deno.jsonc": &fs.MapFile{Data: []byte(`
+      {
+        "importMap": "../import_map.json"
+      }`)},
+			"supabase/functions/import_map.json": &fs.MapFile{},
+			"supabase/functions/hello/index.ts":  &fs.MapFile{},
+		}
+		// Run test
+		assert.NoError(t, config.Load("", fsys))
+		// Check that deno.json was set as import map
+		assert.Equal(t, "supabase/functions/import_map.json", config.Functions["hello"].ImportMap)
 	})
 
 	t.Run("config.toml takes precedence over deno.json", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature / fix

## What is the current behavior?

Current is not possible to use the [deno's](https://github.com/denoland/deno/blob/7218113d249c45ab139a5c5e9248b7157b542b7e/cli/schemas/config-file.v1.json#L272) `importMap` to specify the target import map.

<details>
<summary>Error</summary>

```
worker boot error: failed to create the graph: Relative import path "@mylib" not prefixed with / or ./ or ../ and not in import map from "file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts"
    at file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts:3:21
worker boot error: failed to create the graph: Relative import path "@mylib" not prefixed with / or ./ or ../ and not in import map from "file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts"
    at file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts:3:21
InvalidWorkerCreation: worker boot error: failed to create the graph: Relative import path "@mylib" not prefixed with / or ./ or ../ and not in import map from "file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts"
    at file:///Users/kallebysantos/projects/community/supabase/supabase-cli/supabase/testing.imports/supabase/functions/hello/index.ts:3:21
    at async UserWorker.create (ext:sb_user_workers/user_workers.js:139:15)
    at async Object.handler (file:///root/index.ts:157:22)
    at async respond (ext:sb_core_main_js/js/http.js:197:14) {
  name: "InvalidWorkerCreation"
}
```
> [Source code](https://github.com/kallebysantos/testing.supabase.outside-imports/commit/774e825a956a2384602d39d254fcf0fce79dc935)

</details>

## What is the new behavior?

This PR add support to load `import_map` path directly from `deno.json(c)` file.

```bash
# Folder structure
supabase/functions/
├── hello
│   ├── deno.json
│   └── index.ts
└── import_map.json
```

```jsonc
// deno.json file
{
  "importMap": "../import_map.json"
}
```