### PR TITLE
fix: move services command to local dev group

### DIFF
--- a/cmd/services.go
+++ b/cmd/services.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	servicesCmd = &cobra.Command{
-		GroupID: groupManagementAPI,
+		GroupID: groupLocalDev,
 		Use:     "services",
 		Short:   "Show versions of all Supabase services",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -19,7 +19,7 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 	if err := flags.LoadProjectRef(fsys); err != nil && !errors.Is(err, utils.ErrNotLinked) {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	if err := utils.Config.Load("", utils.NewRootFS(fsys)); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := flags.LoadConfig(fsys); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 

--- a/internal/utils/access_token.go
+++ b/internal/utils/access_token.go
@@ -20,10 +20,6 @@ var (
 
 const AccessTokenKey = "access-token"
 
-func LoadAccessToken() (string, error) {
-	return LoadAccessTokenFS(afero.NewOsFs())
-}
-
 func LoadAccessTokenFS(fsys afero.Fs) (string, error) {
 	accessToken, err := loadAccessToken(fsys)
 	if err != nil {

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/go-errors/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils/cloudflare"
 	supabase "github.com/supabase/cli/pkg/api"
@@ -116,7 +117,7 @@ func withFallbackDNS(dialContext DialContextFunc) DialContextFunc {
 
 func GetSupabase() *supabase.ClientWithResponses {
 	clientOnce.Do(func() {
-		token, err := LoadAccessToken()
+		token, err := LoadAccessTokenFS(afero.NewOsFs())
 		if err != nil {
 			log.Fatalln(err)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- `supabase services` no longer requires login
- More organized help text.

```
Supabase CLI

Usage:
  supabase [command]

Quick Start:
  bootstrap            Bootstrap a Supabase project from a starter template

Local Development:
  db                   Manage Postgres databases
  gen                  Run code generation tools
  init                 Initialize a local project
  inspect              Tools to inspect your Supabase project
  link                 Link to a Supabase project
  login                Authenticate using an access token
  logout               Log out and delete access tokens locally
  migration            Manage database migration scripts
  seed                 Seed a Supabase project from supabase/config.toml
  services             Show versions of all Supabase services
  start                Start containers for Supabase local development
  status               Show status of local Supabase containers
  stop                 Stop all local Supabase containers
  test                 Run tests on local Supabase containers
  unlink               Unlink a Supabase project

Management APIs:
  branches             Manage Supabase preview branches
  config               Manage Supabase project configurations
  domains              Manage custom domain names for Supabase projects
  encryption           Manage encryption keys of Supabase projects
  functions            Manage Supabase Edge functions
  network-bans         Manage network bans
  network-restrictions Manage network restrictions
  orgs                 Manage Supabase organizations
  postgres-config      Manage Postgres database config
  projects             Manage Supabase projects
  secrets              Manage Supabase secrets
  snippets             Manage Supabase SQL snippets
  ssl-enforcement      Manage SSL enforcement configuration
  sso                  Manage Single Sign-On (SSO) authentication for projects
  storage              Manage Supabase Storage objects
  vanity-subdomains    Manage vanity subdomains for Supabase projects

Additional Commands:
  completion           Generate the autocompletion script for the specified shell
  help                 Help about any command
```

## Additional context

Add any other context or screenshots.
