### PR TITLE
fix: pin storage migration instead of version

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -305,6 +305,7 @@ func initStorageJob(host string) utils.DockerJob {
 		Image: utils.Config.Storage.Image,
 		Env: []string{
 			"DB_INSTALL_ROLES=false",
+			"DB_MIGRATIONS_FREEZE_AT=" + utils.Config.Storage.TargetMigration,
 			"ANON_KEY=" + utils.Config.Auth.AnonKey.Value,
 			"SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey.Value,
 			"PGRST_JWT_SECRET=" + utils.Config.Auth.JwtSecret.Value,

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs, options ...func(
 	// 2. Check database connection
 	config := flags.GetDbConfigOptionalPassword(projectRef)
 	if len(config.Password) > 0 {
-		if err := linkDatabase(ctx, config, options...); err != nil {
+		if err := linkDatabase(ctx, config, fsys, options...); err != nil {
 			return err
 		}
 		// Save database password
@@ -76,7 +76,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs, options ...func(
 func LinkServices(ctx context.Context, projectRef, anonKey string, fsys afero.Fs) {
 	// Ignore non-fatal errors linking services
 	var wg sync.WaitGroup
-	wg.Add(8)
+	wg.Add(7)
 	go func() {
 		defer wg.Done()
 		if err := linkDatabaseSettings(ctx, projectRef); err != nil && viper.GetBool("DEBUG") {
@@ -117,12 +117,6 @@ func LinkServices(ctx context.Context, projectRef, anonKey string, fsys afero.Fs
 	go func() {
 		defer wg.Done()
 		if err := linkGotrueVersion(ctx, api, fsys); err != nil && viper.GetBool("DEBUG") {
-			fmt.Fprintln(os.Stderr, err)
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		if err := linkStorageVersion(ctx, api, fsys); err != nil && viper.GetBool("DEBUG") {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}()
@@ -178,12 +172,14 @@ func linkStorage(ctx context.Context, projectRef string) error {
 	return nil
 }
 
-func linkStorageVersion(ctx context.Context, api tenant.TenantAPI, fsys afero.Fs) error {
-	version, err := api.GetStorageVersion(ctx)
-	if err != nil {
-		return err
+const GET_LATEST_STORAGE_MIGRATION = "SELECT name FROM storage.migrations ORDER BY id DESC LIMIT 1"
+
+func linkStorageVersion(ctx context.Context, conn *pgx.Conn, fsys afero.Fs) error {
+	var name string
+	if err := conn.QueryRow(ctx, GET_LATEST_STORAGE_MIGRATION).Scan(&name); err != nil {
+		return errors.Errorf("failed to fetch storage migration: %w", err)
 	}
-	return utils.WriteFile(utils.StorageVersionPath, []byte(version), fsys)
+	return utils.WriteFile(utils.StorageVersionPath, []byte(name), fsys)
 }
 
 func linkDatabaseSettings(ctx context.Context, projectRef string) error {
@@ -197,13 +193,16 @@ func linkDatabaseSettings(ctx context.Context, projectRef string) error {
 	return nil
 }
 
-func linkDatabase(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) error {
+func linkDatabase(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	conn, err := utils.ConnectByConfig(ctx, config, options...)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(context.Background())
 	updatePostgresConfig(conn)
+	if err := linkStorageVersion(ctx, conn, fsys); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
 	// If `schema_migrations` doesn't exist on the remote database, create it.
 	if err := migration.CreateMigrationTable(ctx, conn); err != nil {
 		return err

--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -119,13 +119,6 @@ services:
           - /storage/v1/
     plugins:
       - name: cors
-{{if StorageVersionBelow "1.10.1" }}
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Forwarded: host={{ .ApiHost }}:{{ .ApiPort }};proto=http"
-{{end}}
   - name: pg-meta
     _comment: "pg-meta: /pg/* -> http://pg-meta:8080/*"
     url: http://{{ .PgmetaId }}:8080/

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -615,11 +615,14 @@ func (c *config) Load(path string, fsys fs.FS) error {
 		if version, err := fs.ReadFile(fsys, builder.RestVersionPath); err == nil && len(version) > 0 {
 			c.Api.Image = replaceImageTag(Images.Postgrest, string(version))
 		}
-		if version, err := fs.ReadFile(fsys, builder.StorageVersionPath); err == nil && len(version) > 0 {
-			c.Storage.Image = replaceImageTag(Images.Storage, string(version))
-		}
 		if version, err := fs.ReadFile(fsys, builder.GotrueVersionPath); err == nil && len(version) > 0 {
 			c.Auth.Image = replaceImageTag(Images.Gotrue, string(version))
+		}
+	}
+	if version, err := fs.ReadFile(fsys, builder.StorageVersionPath); err == nil && len(version) > 0 {
+		// For backwards compatibility, exclude all strings that look like semver
+		if v := strings.TrimSpace(string(version)); !semver.IsValid(v) {
+			c.Storage.TargetMigration = v
 		}
 	}
 	if version, err := fs.ReadFile(fsys, builder.EdgeRuntimeVersionPath); err == nil && len(version) > 0 {

--- a/pkg/config/storage.go
+++ b/pkg/config/storage.go
@@ -10,6 +10,7 @@ type (
 	storage struct {
 		Enabled             bool                 `toml:"enabled"`
 		Image               string               `toml:"-"`
+		TargetMigration     string               `toml:"-"`
 		ImgProxyImage       string               `toml:"-"`
 		FileSizeLimit       sizeInBytes          `toml:"file_size_limit"`
 		ImageTransformation *imageTransformation `toml:"image_transformation"`

--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -12,7 +12,7 @@ FROM timberio/vector:0.28.1-alpine AS vector
 FROM supabase/supavisor:2.5.1 AS supavisor
 FROM supabase/gotrue:v2.171.0 AS gotrue
 FROM supabase/realtime:v2.34.47 AS realtime
-FROM supabase/storage-api:v1.22.3 AS storage
+FROM supabase/storage-api:v1.22.6 AS storage
 FROM supabase/logflare:1.12.0 AS logflare
 # Append to JobImages when adding new dependencies below
 FROM supabase/pgadmin-schema-diff:cli-0.0.5 AS differ


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3425

## What is the new behavior?

Pins storage by migration name instead of image tag.

## Additional context

Add any other context or screenshots.
