### PR TITLE
fix: skip storage version when linking

### DIFF
--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -80,7 +80,7 @@ func listRemoteImages(ctx context.Context, projectRef string) map[string]string 
 		return linked
 	}
 	api := tenant.NewTenantAPI(ctx, projectRef, keys.Anon)
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		if version, err := api.GetGotrueVersion(ctx); err == nil {
@@ -91,12 +91,6 @@ func listRemoteImages(ctx context.Context, projectRef string) map[string]string 
 		defer wg.Done()
 		if version, err := api.GetPostgrestVersion(ctx); err == nil {
 			linked[utils.Config.Api.Image] = version
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		if version, err := api.GetStorageVersion(ctx); err == nil {
-			linked[utils.Config.Storage.Image] = version
 		}
 	}()
 	wg.Wait()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/2473

## What is the new behavior?

No need to show storage version since we are autoupdating MT services.

## Additional context

Add any other context or screenshots.
