### PR TITLE
fix: retry bulk update endpoint on error

### DIFF
--- a/pkg/function/batch_test.go
+++ b/pkg/function/batch_test.go
@@ -42,6 +42,65 @@ func TestUpsertFunctions(t *testing.T) {
 		era.eszip = &MockBundler{}
 	})
 
+	t.Run("deploys with bulk update", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(mockApiHost).
+			Get("/v1/projects/" + mockProject + "/functions").
+			Reply(http.StatusOK).
+			JSON([]api.FunctionResponse{{Slug: "test-a"}})
+		gock.New(mockApiHost).
+			Patch("/v1/projects/" + mockProject + "/functions/test-a").
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Slug: "test-a"})
+		gock.New(mockApiHost).
+			Post("/v1/projects/" + mockProject + "/functions/test-b").
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Slug: "test-b"})
+		gock.New(mockApiHost).
+			Put("/v1/projects/" + mockProject + "/functions").
+			ReplyError(errors.New("network error"))
+		gock.New(mockApiHost).
+			Put("/v1/projects/" + mockProject + "/functions").
+			Reply(http.StatusServiceUnavailable)
+		gock.New(mockApiHost).
+			Put("/v1/projects/" + mockProject + "/functions").
+			Reply(http.StatusOK).
+			JSON(api.V1BulkUpdateFunctionsResponse{})
+		// Run test
+		err := client.UpsertFunctions(context.Background(), config.FunctionConfig{
+			"test-a": {},
+			"test-b": {},
+		})
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("handles concurrent deploy", func(t *testing.T) {
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(mockApiHost).
+			Get("/v1/projects/" + mockProject + "/functions").
+			Reply(http.StatusOK).
+			JSON([]api.FunctionResponse{})
+		gock.New(mockApiHost).
+			Post("/v1/projects/" + mockProject + "/functions").
+			Reply(http.StatusBadRequest).
+			BodyString("Duplicated function slug")
+		gock.New(mockApiHost).
+			Patch("/v1/projects/" + mockProject + "/functions/test").
+			Reply(http.StatusOK).
+			JSON(api.FunctionResponse{Slug: "test"})
+		// Run test
+		err := client.UpsertFunctions(context.Background(), config.FunctionConfig{
+			"test": {},
+		})
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
 	t.Run("retries on network failure", func(t *testing.T) {
 		// Setup mock api
 		defer gock.OffAll()
@@ -84,6 +143,7 @@ func TestUpsertFunctions(t *testing.T) {
 		})
 		// Check error
 		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
 	t.Run("retries on update failure", func(t *testing.T) {
@@ -109,5 +169,6 @@ func TestUpsertFunctions(t *testing.T) {
 		})
 		// Check error
 		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Also retries bulk update endpoint.

## Additional context

Add any other context or screenshots.
