### PR TITLE
fix: use correct env var name to pass auth jwks to storage container

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -833,7 +833,7 @@ EOF
 					"ANON_KEY=" + utils.Config.Auth.AnonKey.Value,
 					"SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey.Value,
 					"AUTH_JWT_SECRET=" + utils.Config.Auth.JwtSecret.Value,
-					fmt.Sprintf("AUTH_JWT_JWKS=%s", jwks),
+					fmt.Sprintf("JWT_JWKS=%s", jwks),
 					fmt.Sprintf("DATABASE_URL=postgresql://supabase_storage_admin:%s@%s:%d/%s", dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database),
 					fmt.Sprintf("FILE_SIZE_LIMIT=%v", utils.Config.Storage.FileSizeLimit),
 					"STORAGE_BACKEND=file",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

JWKs for storage are sent using `AUTH_JWT_JWKS` instead of just `JWT_JWKS` this causes users using 3rd party auth to be unable to upload files locally

## What is the new behavior?

Pass JWKs as `JWT_JWKS` so storage will allow them for verification

Resolves: https://github.com/supabase/cli/issues/3362

