### PR TITLE
fix: apply the decorator flag only if uses deno 1

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -60,7 +60,9 @@ func (b *dockerBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	if viper.GetBool("DEBUG") {
 		cmd = append(cmd, "--verbose")
 	}
-	cmd = append(cmd, function.BundleFlags...)
+	if utils.Config.EdgeRuntime.DenoVersion == 1 {
+		cmd = append(cmd, function.BundleFlags...)
+	}
 
 	env := []string{}
 	if custom_registry := os.Getenv("NPM_CONFIG_REGISTRY"); custom_registry != "" {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Edge runtime (deno 2) no longer accepts that flag, as it is possible to specify the decorator directly in deno.json (the default value is still tc39).
