### PR TITLE
fix: do not restart auth sequence on reset

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -11,7 +11,7 @@ import (
 const (
 	pg13  = "supabase/postgres:13.3.0"
 	pg14  = "supabase/postgres:14.1.0.89"
-	pg15  = "supabase/postgres:15.8.1.069"
+	pg15  = "supabase/postgres:15.8.1.085"
 	deno2 = "supabase/edge-runtime:v1.68.0-develop.14"
 )
 

--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -42,7 +42,7 @@ begin
     execute format('drop materialized view if exists %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
   end loop;
 
-  -- tables (cascade to views)
+  -- tables (cascade to dependent objects)
   for rec in
     select *
     from pg_class c
@@ -65,7 +65,7 @@ begin
       or c.relnamespace::regnamespace::name = 'supabase_migrations')
       and c.relkind = 'r'
   loop
-    execute format('truncate %I.%I restart identity cascade', rec.relnamespace::regnamespace::name, rec.relname);
+    execute format('truncate %I.%I cascade', rec.relnamespace::regnamespace::name, rec.relname);
   end loop;
 
   -- sequences


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3551

## What is the current behavior?

`identity restart` requires privilege to drop sequence, which is no longer granted to the postgres role.

## What is the new behavior?

Most of the time, there's no need to reset any sequences in managed schemas.

## Additional context

Add any other context or screenshots.
