### PR TITLE
fix: do not override collation on pg 15.8

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -24,6 +24,7 @@ import (
 	"github.com/supabase/cli/internal/status"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
+	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/migration"
 	"github.com/supabase/cli/pkg/vault"
 )
@@ -75,7 +76,7 @@ func NewContainerConfig() container.Config {
 			"S3_ACCESS_KEY="+utils.Config.Experimental.S3AccessKey,
 			"S3_SECRET_KEY="+utils.Config.Experimental.S3SecretKey,
 		)
-	} else {
+	} else if config.VersionCompare(utils.Config.Db.Image, "15.8.1.005") < 0 {
 		env = append(env, "POSTGRES_INITDB_ARGS=--lc-collate=C.UTF-8")
 	}
 	config := container.Config{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -615,3 +615,28 @@ func TestLoadEnvIfExists(t *testing.T) {
 		os.Unsetenv("ANOTHER_KEY")
 	})
 }
+
+func TestVersionCompare(t *testing.T) {
+	var testcase = []struct {
+		a string
+		b string
+		r int
+	}{
+		{"15.1.0.55", "15.1.0.55", 0},
+		{"15.8.1.085", "15.1.0.55", 1},
+		{"15.1.0.55", "15.8.1.085", -1},
+		{"15.8.1", "15.8.1", 0},
+		{"17", "15.8", 1},
+		{"14", "15.8", -1},
+		{"oriole-17", "oriole-17", 0},
+		{"17", "oriole-17", 1},
+		{"oriole-17", "17", -1},
+	}
+
+	for _, tt := range testcase {
+		t.Run(fmt.Sprintf("%s vs %s", tt.a, tt.b), func(t *testing.T) {
+			result := VersionCompare(tt.a, tt.b)
+			assert.Equal(t, tt.r, result)
+		})
+	}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Since adopting nix build, our default platform collation is now consistent with our docker image.

## Additional context

Add any other context or screenshots.
