### PR TITLE
fix: early fail on non-exposed docker daemon

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -280,7 +280,7 @@ EOF
 			}
 			env = append(env, "DOCKER_HOST="+dindHost.String())
 		case "npipe":
-			const dockerDaemonNeededErr = "Analytics on windows requires docker daemon exposed on tcp://localhost:2375. See https://supabase.com/docs/guides/local-development/cli/getting-started?queryGroups=platform&platform=windows#running-supabase-locally for more details"
+			const dockerDaemonNeededErr = "Analytics on Windows requires Docker daemon exposed on tcp://localhost:2375.\nSee https://supabase.com/docs/guides/local-development/cli/getting-started?queryGroups=platform&platform=windows#running-supabase-locally for more details."
 			fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), dockerDaemonNeededErr)
 			env = append(env, "DOCKER_HOST="+dindHost.String())
 		case "unix":


### PR DESCRIPTION
## What kind of change does this PR introduce?

When trying to run supabase locally on windows, It checks if the docker daemon is properly exposed on `:2375` instead of printing a warning. 

If it is not running, it directs the user to the relevant documentation and gives a more verbose hint on how to solve the problem

## What is the current behavior?

If it is not exposed, supabase continues trying to start, and crashes with an obscure error message.

Please link any relevant issues here.

https://github.com/supabase/cli/issues/2505

## What is the new behavior?

Performs a get request on the docker daemon, and checks if it is available before running the analytics

## Additional context

![image](https://github.com/user-attachments/assets/df0faeab-2034-4b11-a707-f73bf90c6901)
