### PR TITLE
fix: diff declarative schemas without supabase stop

### DIFF
--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -87,12 +87,15 @@ func squashMigrations(ctx context.Context, migrations []string, fsys afero.Fs, o
 	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
 		return err
 	}
+	if err := start.InitDatabase(ctx, shadow[:12], os.Stderr); err != nil {
+		return err
+	}
 	conn, err := diff.ConnectShadowDatabase(ctx, 10*time.Second, options...)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(context.Background())
-	if err := start.SetupDatabase(ctx, conn, shadow[:12], os.Stderr, fsys); err != nil {
+	if err := start.SetupDatabase(ctx, conn, os.Stderr, fsys); err != nil {
 		return err
 	}
 	// Assuming entities in managed schemas are not altered, we can simply diff the dumps before and after migrations.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Running `supabase db diff` now uses declared schemas if they are defined. To diff the local database instead, users must comment out `[db.migrations] schema_paths` in config.toml.

This is made possible by creating a template database named `_shadow` that contains the initial schema without any user migrations. When diffing, a new database `contrib_regression` is created from template to apply all declarative schemas. A separate container is then created to apply all migrations on the `postgres` database. Finally, a diff is generated between `postgres` and `contrib_regression`.

When diffing linked or remote database, declarative schemas are not used.

## Additional context

Migrations which don't work

- [x] `create extension pg_cron`

```
ERROR: can only create extension in database postgres (SQLSTATE P0001)
Jobs must be scheduled from the database configured in cron.database_name, since the pg_cron background worker reads job descriptions from this database.
```

Possible solution is to remove pg_cron from declared schemas and diff output.