### PR TITLE
fix: unset git branch when name is provided

### DIFF
--- a/internal/branches/create/create.go
+++ b/internal/branches/create/create.go
@@ -22,8 +22,8 @@ func Run(ctx context.Context, body api.CreateBranchBody, fsys afero.Fs) error {
 			return errors.New(context.Canceled)
 		}
 		body.BranchName = gitBranch
+		body.GitBranch = &gitBranch
 	}
-	body.GitBranch = &gitBranch
 
 	resp, err := utils.GetSupabase().V1CreateABranchWithResponse(ctx, flags.ProjectRef, body)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

When branch name is provided, do not set the current git branch.

## Additional context

Add any other context or screenshots.
