### PR TITLE
Update default Mailpit SMTP port to 1025 and pop3 port to 1110 in con…

### DIFF
--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -75,13 +75,13 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
+[mailpit]
 enabled = true
 # Port to use for the email testing server web interface.
 port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
-# smtp_port = 54325
-# pop3_port = 54326
+# smtp_port = 1025
+# pop3_port = 1110
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 


### PR DESCRIPTION
…fig.toml template

## What kind of change does this PR introduce?
default config toml change:
Update default SMTP and pop3 configuration in config.toml template to use Mailpit

## What is the current behavior?
The cli and config.toml file still references Inbucket as the default local email testing server, with the SMTP and pop3 port set to 54324.

## What is the new behavior?

* The default **SMTP port** is updated from `54325` to `1025` and pop3 is updated from `54326` to `1110` to reflect the switch to **Mailpit**, which listens respectively on ports `1025` and `1110` by default.
* All references to **Inbucket** in descriptions or comments are replaced with **Mailpit**.

Feel free to include screenshots if it includes visual changes.

## Additional context

Supabase has recently migrated from **Inbucket** to **Mailpit** as the default local email testing service. Updating the `config.toml` file helps keep the developer documentation consistent and avoids confusion during local setup.
