### PR TITLE
Update mailpit label for supabase status in terminal and other reference to inbucket

### DIFF
--- a/docs/templates/examples.yaml
+++ b/docs/templates/examples.yaml
@@ -79,7 +79,7 @@ supabase-status:
            GraphQL URL: http://127.0.0.1:54321/graphql/v1
                 DB URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
             Studio URL: http://127.0.0.1:54323
-          Inbucket URL: http://127.0.0.1:54324
+          Mailpit URL: http://127.0.0.1:54324
             JWT secret: super-secret-jwt-token-with-at-least-32-characters-long
               anon key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       service_role key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
@@ -91,7 +91,7 @@ supabase-status:
       API_URL="http://127.0.0.1:54321"
       DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
       GRAPHQL_URL="http://127.0.0.1:54321/graphql/v1"
-      INBUCKET_URL="http://127.0.0.1:54324"
+      Mailpit_URL="http://127.0.0.1:54324"
       JWT_SECRET="super-secret-jwt-token-with-at-least-32-characters-long"
       SERVICE_ROLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
       STUDIO_URL="http://127.0.0.1:54323"
@@ -99,7 +99,7 @@ supabase-status:
     name: Customize the names of exported variables
     code: supabase status -o env --override-name auth.anon_key=SUPABASE_ANON_KEY --override-name auth.service_role_key=SUPABASE_SERVICE_KEY
     response: |
-      Stopped services: [supabase_inbucket_cli supabase_rest_cli supabase_studio_cli]
+      Stopped services: [supabase_Mailpit_cli supabase_rest_cli supabase_studio_cli]
       SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
       DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
       GRAPHQL_URL="http://127.0.0.1:54321/graphql/v1"

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -517,12 +517,12 @@ EOF
 				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", utils.Config.Auth.Email.Smtp.AdminEmail),
 				fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", utils.Config.Auth.Email.Smtp.SenderName),
 			)
-		} else if utils.Config.Inbucket.Enabled {
+		} else if utils.Config.Mailpit.Enabled {
 			env = append(env,
-				"GOTRUE_SMTP_HOST="+utils.InbucketId,
+				"GOTRUE_SMTP_HOST="+utils.MailpitId,
 				"GOTRUE_SMTP_PORT=1025",
-				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", utils.Config.Inbucket.AdminEmail),
-				fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", utils.Config.Inbucket.SenderName),
+				fmt.Sprintf("GOTRUE_SMTP_ADMIN_EMAIL=%s", utils.Config.Mailpit.AdminEmail),
+				fmt.Sprintf("GOTRUE_SMTP_SENDER_NAME=%s", utils.Config.Mailpit.SenderName),
 			)
 		}
 
@@ -703,35 +703,35 @@ EOF
 	}
 
 	// Start Mailpit
-	if utils.Config.Inbucket.Enabled && !isContainerExcluded(utils.Config.Inbucket.Image, excluded) {
-		inbucketPortBindings := nat.PortMap{"8025/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Inbucket.Port), 10)}}}
-		if utils.Config.Inbucket.SmtpPort != 0 {
-			inbucketPortBindings["1025/tcp"] = []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Inbucket.SmtpPort), 10)}}
+	if utils.Config.Mailpit.Enabled && !isContainerExcluded(utils.Config.Mailpit.Image, excluded) {
+		mailpitPortBindings := nat.PortMap{"8025/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Mailpit.Port), 10)}}}
+		if utils.Config.Mailpit.SmtpPort != 0 {
+			mailpitPortBindings["1025/tcp"] = []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Mailpit.SmtpPort), 10)}}
 		}
-		if utils.Config.Inbucket.Pop3Port != 0 {
-			inbucketPortBindings["1110/tcp"] = []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Inbucket.Pop3Port), 10)}}
+		if utils.Config.Mailpit.Pop3Port != 0 {
+			mailpitPortBindings["1110/tcp"] = []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Mailpit.Pop3Port), 10)}}
 		}
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{
-				Image: utils.Config.Inbucket.Image,
+				Image: utils.Config.Mailpit.Image,
 			},
 			container.HostConfig{
-				PortBindings:  inbucketPortBindings,
+				PortBindings:  mailpitPortBindings,
 				RestartPolicy: container.RestartPolicy{Name: "always"},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
 					utils.NetId: {
-						Aliases: utils.InbucketAliases,
+						Aliases: utils.MailpitAliases,
 					},
 				},
 			},
-			utils.InbucketId,
+			utils.MailpitId,
 		); err != nil {
 			return err
 		}
-		started = append(started, utils.InbucketId)
+		started = append(started, utils.MailpitId)
 	}
 
 	// Start Realtime.

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -139,8 +139,8 @@ func TestDatabaseStart(t *testing.T) {
 		utils.Config.Auth.Email.DoubleConfirmChanges = true
 		utils.Config.Auth.Email.EnableConfirmations = true
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Auth.Image), utils.GotrueId)
-		utils.InbucketId = "test-inbucket"
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Inbucket.Image), utils.InbucketId)
+		utils.MailpitId = "test-mailpit"
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Mailpit.Image), utils.MailpitId)
 		utils.RealtimeId = "test-realtime"
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Realtime.Image), utils.RealtimeId)
 		utils.RestId = "test-rest"
@@ -164,7 +164,7 @@ func TestDatabaseStart(t *testing.T) {
 		defer conn.Close(t)
 		// Setup health probes
 		started := []string{
-			utils.DbId, utils.KongId, utils.GotrueId, utils.InbucketId, utils.RealtimeId,
+			utils.DbId, utils.KongId, utils.GotrueId, utils.MailpitId, utils.RealtimeId,
 			utils.StorageId, utils.ImgProxyId, utils.EdgeRuntimeId, utils.PgmetaId, utils.StudioId,
 			utils.LogflareId, utils.RestId, utils.VectorId,
 		}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -29,7 +29,7 @@ type CustomName struct {
 	StorageS3URL             string `env:"api.storage_s3_url,default=STORAGE_S3_URL"`
 	DbURL                    string `env:"db.url,default=DB_URL"`
 	StudioURL                string `env:"studio.url,default=STUDIO_URL"`
-	InbucketURL              string `env:"inbucket.url,default=INBUCKET_URL"`
+	MailpitURL              string `env:"mailpit.url,default=MAILPIT_URL"`
 	JWTSecret                string `env:"auth.jwt_secret,default=JWT_SECRET"`
 	AnonKey                  string `env:"auth.anon_key,default=ANON_KEY"`
 	ServiceRoleKey           string `env:"auth.service_role_key,default=SERVICE_ROLE_KEY"`
@@ -54,8 +54,8 @@ func (c *CustomName) toValues(exclude ...string) map[string]string {
 		values[c.AnonKey] = utils.Config.Auth.AnonKey.Value
 		values[c.ServiceRoleKey] = utils.Config.Auth.ServiceRoleKey.Value
 	}
-	if utils.Config.Inbucket.Enabled && !utils.SliceContains(exclude, utils.InbucketId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.Config.Inbucket.Image)) {
-		values[c.InbucketURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Inbucket.Port)
+	if utils.Config.Mailpit.Enabled && !utils.SliceContains(exclude, utils.MailpitId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.Config.Mailpit.Image)) {
+		values[c.MailpitURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Mailpit.Port)
 	}
 	if utils.Config.Storage.Enabled && !utils.SliceContains(exclude, utils.StorageId) && !utils.SliceContains(exclude, utils.ShortContainerImageName(utils.Config.Storage.Image)) {
 		values[c.StorageS3URL] = utils.GetApiUrl("/storage/v1/s3")
@@ -209,7 +209,7 @@ func PrettyPrint(w io.Writer, exclude ...string) {
 		StorageS3URL:             "  " + utils.Aqua("S3 Storage URL"),
 		DbURL:                    "          " + utils.Aqua("DB URL"),
 		StudioURL:                "      " + utils.Aqua("Studio URL"),
-		InbucketURL:              "    " + utils.Aqua("Inbucket URL"),
+		MailpitURL:              "    " + utils.Aqua("Mailpit URL"),
 		JWTSecret:                "      " + utils.Aqua("JWT secret"),
 		AnonKey:                  "        " + utils.Aqua("anon key"),
 		ServiceRoleKey:           "" + utils.Aqua("service_role key"),

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -141,7 +141,7 @@ func TestPrintStatus(t *testing.T) {
 	utils.Config.Realtime.Enabled = false
 	utils.Config.Studio.Enabled = false
 	utils.Config.Analytics.Enabled = false
-	utils.Config.Inbucket.Enabled = false
+	utils.Config.Mailpit.Enabled = false
 
 	t.Run("outputs env var", func(t *testing.T) {
 		utils.Config.Hostname = "127.0.0.1"

--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -194,7 +194,7 @@ func TestStopServices(t *testing.T) {
 		utils.ConfigId = "test-config"
 		utils.StorageId = "test-storage"
 		utils.EdgeRuntimeId = "test-functions"
-		utils.InbucketId = "test-inbucket"
+		utils.MailpitId = "test-mailpit"
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
@@ -211,7 +211,7 @@ func TestStopServices(t *testing.T) {
 		utils.ConfigId = "test-config"
 		utils.StorageId = "test-storage"
 		utils.EdgeRuntimeId = "test-functions"
-		utils.InbucketId = "test-inbucket"
+		utils.MailpitId = "test-mailpit"
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		require.NoError(t, client.WithVersion("1.41")(utils.Docker))

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -20,7 +20,7 @@ var (
 	ConfigId      string
 	KongId        string
 	GotrueId      string
-	InbucketId    string
+	MailpitId     string
 	RealtimeId    string
 	RestId        string
 	StorageId     string
@@ -36,7 +36,7 @@ var (
 	DbAliases          = []string{"db", "db.supabase.internal"}
 	KongAliases        = []string{"kong", "api.supabase.internal"}
 	GotrueAliases      = []string{"auth"}
-	InbucketAliases    = []string{"inbucket"}
+	MailpitAliases    = []string{"mailpit"}
 	RealtimeAliases    = []string{"realtime", Config.Realtime.TenantId}
 	RestAliases        = []string{"rest"}
 	StorageAliases     = []string{"storage"}
@@ -66,7 +66,7 @@ func UpdateDockerIds() {
 	ConfigId = GetId("config")
 	KongId = GetId(KongAliases[0])
 	GotrueId = GetId(GotrueAliases[0])
-	InbucketId = GetId(InbucketAliases[0])
+	MailpitId = GetId(MailpitAliases[0])
 	RealtimeId = GetId(RealtimeAliases[0])
 	RestId = GetId(RestAliases[0])
 	StorageId = GetId(StorageAliases[0])
@@ -84,7 +84,7 @@ func GetDockerIds() []string {
 	return []string{
 		KongId,
 		GotrueId,
-		InbucketId,
+		MailpitId,
 		RealtimeId,
 		RestId,
 		StorageId,

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -33,7 +33,7 @@ func TestUpdateDockerIds(t *testing.T) {
 		assert.Equal(t, "supabase_db_test-project", DbId)
 		assert.Equal(t, "supabase_kong_test-project", KongId)
 		assert.Equal(t, "supabase_auth_test-project", GotrueId)
-		assert.Equal(t, "supabase_inbucket_test-project", InbucketId)
+		assert.Equal(t, "supabase_mailpit_test-project", MailpitId)
 		assert.Equal(t, "supabase_realtime_test-project", RealtimeId)
 		assert.Equal(t, "supabase_rest_test-project", RestId)
 		assert.Equal(t, "supabase_storage_test-project", StorageId)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,7 +166,7 @@ type (
 		Db           db             `toml:"db"`
 		Realtime     realtime       `toml:"realtime"`
 		Studio       studio         `toml:"studio"`
-		Inbucket     inbucket       `toml:"inbucket"`
+		Mailpit      mailpit        `toml:"mailpit"`
 		Storage      storage        `toml:"storage"`
 		Auth         auth           `toml:"auth"`
 		EdgeRuntime  edgeRuntime    `toml:"edge_runtime"`
@@ -199,7 +199,7 @@ type (
 		PgmetaImage  string `toml:"-"`
 	}
 
-	inbucket struct {
+	mailpit struct {
 		Enabled    bool   `toml:"enabled"`
 		Image      string `toml:"-"`
 		Port       uint16 `toml:"port"`
@@ -379,8 +379,8 @@ func NewConfig(editors ...ConfigEditor) config {
 				Value: defaultJwtSecret,
 			},
 		},
-		Inbucket: inbucket{
-			Image:      Images.Inbucket,
+		Mailpit: mailpit{
+			Image:      Images.Mailpit,
 			AdminEmail: "admin@email.com",
 			SenderName: "Admin",
 		},
@@ -792,9 +792,9 @@ func (c *config) Validate(fsys fs.FS) error {
 		}
 	}
 	// Validate smtp config
-	if c.Inbucket.Enabled {
-		if c.Inbucket.Port == 0 {
-			return errors.New("Missing required field in config: inbucket.port")
+	if c.Mailpit.Enabled {
+		if c.Mailpit.Port == 0 {
+			return errors.New("Missing required field in config: mailpit.port")
 		}
 	}
 	// Validate auth config

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -19,7 +19,7 @@ type images struct {
 	Pg string `mapstructure:"pg"`
 	// Append to Services when adding new dependencies below
 	Kong        string `mapstructure:"kong"`
-	Inbucket    string `mapstructure:"mailpit"`
+	Mailpit    string `mapstructure:"mailpit"`
 	Postgrest   string `mapstructure:"postgrest"`
 	Pgmeta      string `mapstructure:"pgmeta"`
 	Studio      string `mapstructure:"studio"`
@@ -64,7 +64,7 @@ func (s images) Services() []string {
 		s.Storage,
 		s.ImgProxy,
 		s.Kong,
-		s.Inbucket,
+		s.Mailpit,
 		s.Postgrest,
 		s.Pgmeta,
 		s.Studio,

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -75,13 +75,13 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
+[mailpit]
 enabled = true
 # Port to use for the email testing server web interface.
 port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
-# smtp_port = 54325
-# pop3_port = 54326
+# smtp_port = 1025
+# pop3_port = 1110
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -75,13 +75,13 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
+[mailpit]
 enabled = true
 # Port to use for the email testing server web interface.
 port = 54324
 # Uncomment to expose additional ports for testing user applications that send emails.
-# smtp_port = 54325
-# pop3_port = 54326
+# smtp_port = 1025
+# pop3_port = 1110
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 


### PR DESCRIPTION

## What kind of change does this PR introduce?
default config toml change:
Update status output to use Mailpit

## What is the current behavior?
The cli status still references Inbucket as the default local email testing server.

## What is the new behavior?

* The status output **inbucket url** is updated from `inbucket` to `mailpit`  to reflect the switch to **Mailpit**.
* All references to **Inbucket** in descriptions or code are replaced with **Mailpit**.
* 
## Additional context

Supabase has recently migrated from **Inbucket** to **Mailpit** as the default local email testing service. Updating the `config.toml` file helps keep the developer documentation consistent and avoids confusion during local setup.
