### PR TITLE
feat: alias migration down command as reset

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -195,7 +195,7 @@ var (
 			if noSeed {
 				utils.Config.Db.Seed.Enabled = false
 			}
-			return reset.Run(cmd.Context(), migrationVersion, flags.DbConfig, afero.NewOsFs())
+			return reset.Run(cmd.Context(), migrationVersion, nLastVersion, flags.DbConfig, afero.NewOsFs())
 		},
 	}
 
@@ -319,6 +319,8 @@ func init() {
 	resetFlags.BoolVar(&noSeed, "no-seed", false, "Skip running the seed script after reset.")
 	dbResetCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
 	resetFlags.StringVar(&migrationVersion, "version", "", "Reset up to the specified version.")
+	resetFlags.UintVar(&nLastVersion, "last", 0, "Reset up to the last n migration versions.")
+	dbResetCmd.MarkFlagsMutuallyExclusive("version", "last")
 	dbCmd.AddCommand(dbResetCmd)
 	// Build lint command
 	lintFlags := dbLintCmd.Flags()

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -96,7 +96,7 @@ func TestResetCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.BucketResponse{})
 		// Run test
-		err := Run(context.Background(), "", dbConfig, fsys, conn.Intercept)
+		err := Run(context.Background(), "", 0, dbConfig, fsys, conn.Intercept)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -106,7 +106,7 @@ func TestResetCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), "", pgconn.Config{Host: "db.supabase.co"}, fsys)
+		err := Run(context.Background(), "", 0, pgconn.Config{Host: "db.supabase.co"}, fsys)
 		// Check error
 		assert.ErrorIs(t, err, context.Canceled)
 	})
@@ -116,7 +116,7 @@ func TestResetCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), "", pgconn.Config{Host: "db.supabase.co"}, fsys)
+		err := Run(context.Background(), "", 0, pgconn.Config{Host: "db.supabase.co"}, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 	})
@@ -131,7 +131,7 @@ func TestResetCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusNotFound)
 		// Run test
-		err := Run(context.Background(), "", dbConfig, fsys)
+		err := Run(context.Background(), "", 0, dbConfig, fsys)
 		// Check error
 		assert.ErrorIs(t, err, utils.ErrNotRunning)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -153,7 +153,7 @@ func TestResetCommand(t *testing.T) {
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := Run(context.Background(), "", dbConfig, fsys)
+		err := Run(context.Background(), "", 0, dbConfig, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())

--- a/internal/migration/down/down.go
+++ b/internal/migration/down/down.go
@@ -1,0 +1,38 @@
+package down
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/afero"
+	"github.com/supabase/cli/internal/db/reset"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/migration"
+)
+
+var errOutOfRange = errors.New("last version must be smaller than total applied migrations")
+
+func Run(ctx context.Context, last int, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+	conn, err := utils.ConnectByConfig(ctx, config, options...)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(context.Background())
+	remoteMigrations, err := migration.ListRemoteMigrations(ctx, conn)
+	if err != nil {
+		return err
+	}
+	version := ""
+	if i := len(remoteMigrations) - last; i > 0 {
+		version = remoteMigrations[i-1]
+	} else {
+		if i == 0 {
+			utils.CmdSuggestion = fmt.Sprintf("Try %s if you want to revert all migrations.", utils.Aqua("supabase db reset"))
+		}
+		return errors.New(errOutOfRange)
+	}
+	return reset.Run(ctx, version, config, fsys)
+}

--- a/internal/migration/down/down_test.go
+++ b/internal/migration/down/down_test.go
@@ -1,0 +1,76 @@
+package down
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/migration"
+	"github.com/supabase/cli/pkg/pgtest"
+)
+
+var dbConfig = pgconn.Config{
+	Host:     "127.0.0.1",
+	Port:     5432,
+	User:     "admin",
+	Password: "password",
+	Database: "postgres",
+}
+
+func TestMigrationsDown(t *testing.T) {
+	t.Run("resets last n migrations", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		files := []string{
+			filepath.Join(utils.MigrationsDir, "20221201000000_test.sql"),
+			filepath.Join(utils.MigrationsDir, "20221201000001_test.sql"),
+			filepath.Join(utils.MigrationsDir, "20221201000002_test.sql"),
+		}
+		for _, path := range files {
+			require.NoError(t, afero.WriteFile(fsys, path, []byte(""), 0644))
+		}
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(migration.LIST_MIGRATION_VERSION).
+			Reply("SELECT 2", []interface{}{"20221201000000"}, []interface{}{"20221201000001"})
+		// Run test
+		err := Run(context.Background(), 1, dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("throws error on out of range", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(migration.LIST_MIGRATION_VERSION).
+			Reply("SELECT 2", []interface{}{"20221201000000"}, []interface{}{"20221201000001"})
+		// Run test
+		err := Run(context.Background(), 2, dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorIs(t, err, errOutOfRange)
+	})
+
+	t.Run("throws error on missing version", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Setup mock postgres
+		conn := pgtest.NewConn()
+		defer conn.Close(t)
+		conn.Query(migration.LIST_MIGRATION_VERSION).
+			Reply("SELECT 2", []interface{}{"20221201000000"}, []interface{}{"20221201000001"})
+		// Run test
+		err := Run(context.Background(), 1, dbConfig, fsys, conn.Intercept)
+		// Check error
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}

--- a/internal/migration/down/down_test.go
+++ b/internal/migration/down/down_test.go
@@ -57,7 +57,7 @@ func TestMigrationsDown(t *testing.T) {
 		// Run test
 		err := Run(context.Background(), 2, dbConfig, fsys, conn.Intercept)
 		// Check error
-		assert.ErrorIs(t, err, errOutOfRange)
+		assert.ErrorContains(t, err, "--last must be smaller than total applied migrations: 2")
 	})
 
 	t.Run("throws error on missing version", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/issues/611

## What is the new behavior?

Adds an alias for `db reset` so that it's easier to revert the last n migrations without inputting the full version string.

```
$ supabase db start
Seeding globals from roles.sql...
Applying migration 20250510162534_table.sql...
Applying migration 20250510162754_index.sql...
NOTICE (42P06): schema "supabase_migrations" already exists, skipping
Seeding data from supabase/seed.sql...
A new version of Supabase CLI is available: v2.23.4 (currently installed v)
We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli
$ supabase migrations down
Connecting to local database...
Resetting local database to version: 20250510162534
Recreating database...
```

## Additional context

https://x.com/nicolaygerold/status/1928396644241879115
