### PR TITLE
fix: expose pointer to config struct

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -317,10 +317,12 @@ func (c *baseConfig) Clone() baseConfig {
 	return copy
 }
 
-type ConfigEditor func(*config)
+type Config *config
+
+type ConfigEditor func(Config)
 
 func WithHostname(hostname string) ConfigEditor {
-	return func(c *config) {
+	return func(c Config) {
 		c.Hostname = hostname
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Allows external packages to hold references to config object but not instantiate.

## Additional context

Add any other context or screenshots.
