### PR TITLE
fix: fallback to deploy with api when docker not found

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -51,7 +51,11 @@ func Run(ctx context.Context, slugs []string, useDocker bool, noVerifyJWT *bool,
 	}
 	opt := function.WithMaxJobs(maxJobs)
 	if useDocker {
-		opt = function.WithBundler(NewDockerBundler(fsys))
+		if utils.IsDockerRunning(ctx) {
+			opt = function.WithBundler(NewDockerBundler(fsys))
+		} else {
+			fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "Docker is not running")
+		}
 	}
 	api := function.NewEdgeRuntimeAPI(flags.ProjectRef, *utils.GetSupabase(), opt)
 	if err := api.Deploy(ctx, functionConfig, afero.NewIOFS(fsys)); errors.Is(err, function.ErrNoDeploy) {

--- a/internal/utils/docker.go
+++ b/internal/utils/docker.go
@@ -460,6 +460,11 @@ func DockerExecOnceWithStream(ctx context.Context, containerId, workdir string, 
 	return err
 }
 
+func IsDockerRunning(ctx context.Context) bool {
+	_, err := Docker.Ping(ctx)
+	return !client.IsErrConnectionFailed(err)
+}
+
 var portErrorPattern = regexp.MustCompile("Bind for (.*) failed: port is already allocated")
 
 func parsePortBindError(err error) string {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

`--use-api` when docker is unavailable

## Additional context

Add any other context or screenshots.
