### PR TITLE
chore(ci): add api-sync codegen automation workflow

### DIFF
--- a/.github/workflows/api-sync.yml
+++ b/.github/workflows/api-sync.yml
@@ -1,0 +1,53 @@
+name: API Sync
+
+on:
+  repository_dispatch:
+    types: [api-sync]
+  workflow_dispatch: # allow manual triggering
+
+# Add explicit permissions
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync API Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run codegen
+        run: go generate
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --ignore-space-at-eol --exit-code --quiet pkg; then
+            echo "No changes detected"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: sync API types from infrastructure"
+          title: "chore: sync API types from infrastructure"
+          body: |
+            This PR was automatically created to sync API types from the infrastructure repository.
+
+            Changes were detected in the generated API code after syncing with the latest spec from infrastructure.
+          branch: sync/api-types
+          base: develop
+          labels: |
+            automated pr
+            api-sync


### PR DESCRIPTION
In the same spirit than dependabot and to have regular based api codegen updates:

- Periodically update and create a PR if there is diff between current API and cli codegen (everyday midnight)
- Can be manually run to create a PR that update the codegen to latest version.