### PR TITLE
chore(ci): use PAT for generated PR

### DIFF
--- a/.github/workflows/api-sync.yml
+++ b/.github/workflows/api-sync.yml
@@ -40,6 +40,7 @@ jobs:
         if: steps.check.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.GH_PAT }}
           commit-message: "chore: sync API types from infrastructure"
           title: "chore: sync API types from infrastructure"
           body: |


### PR DESCRIPTION
Otherwise additional workflows (CI/tests) won't be started over the generated PR and will be kept pending
