### PR TITLE
fix: bump edge-runtime to 1.68.0-develop.18

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pg13  = "supabase/postgres:13.3.0"
 	pg14  = "supabase/postgres:14.1.0.89"
 	pg15  = "supabase/postgres:15.8.1.085"
-	deno2 = "supabase/edge-runtime:v1.68.0-develop.14"
+	deno2 = "supabase/edge-runtime:v1.68.0-develop.18"
 )
 
 type images struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump edge-runtime to 1.68.0-develop.18

### Changes

### [1.68.0-develop.18](https://github.com/supabase/edge-runtime/compare/v1.68.0-develop.14...v1.68.0-develop.18) (2025-06-18)

#### Bug Fixes
* **ci:** do not run CI if PR is marked as draft ([#544](https://github.com/supabase/edge-runtime/issues/544)) ([492db16](https://github.com/supabase/edge-runtime/commit/492db166131661c16aab1626489ed0b6e5d24a89))
* **cli:** ip address parsing to support both ipv4 and ipv6 ([#547](https://github.com/supabase/edge-runtime/issues/547)) ([e126e1f](https://github.com/supabase/edge-runtime/commit/e126e1f73194571a115d5ae9506fcd4992f5d772))

#### Features

* allow enabling the unstable sloppy imports ([#533](https://github.com/supabase/edge-runtime/issues/533)) ([3c38740](https://github.com/supabase/edge-runtime/commit/3c387409c72b0df5b1ef36ac6228254e81b82aa8))
* introduce v8 locker in our codebase ([#549](https://github.com/supabase/edge-runtime/issues/549)) ([c56fc63](https://github.com/supabase/edge-runtime/commit/c56fc637e2fbfbd26c8e6ca82fc907d97bb8693d))