### PR TITLE
fix: handle windows path separator when globbing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,9 +114,10 @@ func (g Glob) Files(fsys fs.FS) ([]string, error) {
 		sort.Strings(matches)
 		// Remove duplicates
 		for _, item := range matches {
-			if _, exists := set[item]; !exists {
-				set[item] = struct{}{}
-				result = append(result, item)
+			fp := filepath.ToSlash(item)
+			if _, exists := set[fp]; !exists {
+				set[fp] = struct{}{}
+				result = append(result, fp)
 			}
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3556#issuecomment-2994470733

## What is the new behavior?

Make sure the glob always returns unix paths.

## Additional context

Add any other context or screenshots.
