### PR TITLE
fix: `bootstrap` command for creation scratch project

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -78,8 +78,10 @@ func Run(ctx context.Context, starter StarterTemplate, fsys afero.Fs, options ..
 	}
 	// 2. Create project
 	params := api.V1CreateProjectBody{
-		Name:        filepath.Base(workdir),
-		TemplateUrl: &starter.Url,
+		Name: filepath.Base(workdir),
+	}
+	if len(starter.Url) > 0 {
+		params.TemplateUrl = &starter.Url
 	}
 	if err := create.Run(ctx, params, fsys); err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When run `supabase bootstrap` for "scratch" project, I met following error.

```
$ npx supabase bootstrap --debug
Supabase CLI 2.24.3
Enter a directory to bootstrap your project (or leave blank to use /Users/yyh-gl/workspaces/temp): debug
2025/06/04 20:53:28 HTTP GET: https://api.github.com/repos/supabase-community/supabase-samples/contents/samples.json?ref=main
Using workdir debug
Generate VS Code settings for Deno? [y/N] y
Generated VS Code settings in .vscode/settings.json. Please install the recommended extension!
Creating project:    debug
2025/06/04 20:53:38 HTTP GET: https://api.supabase.com/v1/organizations
Selected org-id:    <org-id>
Selected region:     ap-southeast-1
Enter your database password (or leave blank to generate one):
2025/06/04 20:53:42 HTTP POST: https://api.supabase.com/v1/projects
Unexpected error creating project: {"message":"template_url: Invalid url"}
```

https://github.com/supabase/cli/issues/3654

## What is the new behavior?

The following error no longer appears when running `supabase bootstrap` for "scratch" project, and we can create scratch project.

`Unexpected error creating project: {"message":"template_url: Invalid url"}`

## Additional context

null

## Others

I’m wondering the following points, I don't know the general solution in this project.

- Create a stub for the user input
  - Specify project creation location (path), etc
- Create a stub for the Supabase login process

So I couldn't add the tests...
If you know the good way, let me know!
