### PR TITLE
fix: delete all buckets with storage rm

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -70,7 +70,6 @@ cp -r ss:///bucket/docs .
 		Example: `rm -r ss:///bucket/docs
 rm ss:///bucket/docs/example.md ss:///bucket/readme.md
 `,
-		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rm.Run(cmd.Context(), args, recursive, afero.NewOsFs())
 		},

--- a/internal/storage/rm/rm.go
+++ b/internal/storage/rm/rm.go
@@ -49,9 +49,22 @@ func Run(ctx context.Context, paths []string, recursive bool, fsys afero.Fs) err
 	if err != nil {
 		return err
 	}
+	if len(groups) == 0 {
+		if !recursive {
+			return errors.New(errMissingFlag)
+		}
+		buckets, err := api.ListBuckets(ctx)
+		if err != nil {
+			return err
+		}
+		for _, b := range buckets {
+			groups[b.Name] = []string{""}
+		}
+	}
+	console := utils.NewConsole()
 	for bucket, prefixes := range groups {
 		confirm := fmt.Sprintf("Confirm deleting files in bucket %v?", utils.Bold(bucket))
-		if shouldDelete, err := utils.NewConsole().PromptYesNo(ctx, confirm, false); err != nil {
+		if shouldDelete, err := console.PromptYesNo(ctx, confirm, false); err != nil {
 			return err
 		} else if !shouldDelete {
 			continue


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3840

## What is the new behavior?

Allow deleting all buckets with `supabase storage rm -r`

## Additional context

Add any other context or screenshots.
