### PR TITLE
fix: handle deno import url separately

### DIFF
--- a/pkg/function/deno_test.go
+++ b/pkg/function/deno_test.go
@@ -58,7 +58,7 @@ func TestImportPaths(t *testing.T) {
 		im := ImportMap{Imports: map[string]string{
 			"module-name/": "../shared/",
 		}}
-		assert.NoError(t, im.Resolve("testdata/modules/deno.json", testImports))
+		assert.NoError(t, im.Resolve("testdata/modules/deno.json"))
 		// Run test
 		err := im.WalkImportPaths("testdata/modules/imports.ts", fsys.ReadFile)
 		// Check error
@@ -79,7 +79,7 @@ func TestImportPaths(t *testing.T) {
 		im := ImportMap{Imports: map[string]string{
 			"module-name/": "./shared/",
 		}}
-		assert.NoError(t, im.Resolve("testdata/import_map.json", testImports))
+		assert.NoError(t, im.Resolve("testdata/import_map.json"))
 		// Run test
 		err := im.WalkImportPaths("testdata/modules/imports.ts", fsys.ReadFile)
 		// Check error
@@ -116,7 +116,7 @@ func TestResolveImports(t *testing.T) {
 		assert.Equal(t, "./common", resolved.Imports["root"])
 		assert.Equal(t, "./supabase/tests", resolved.Imports["parent"])
 		assert.Equal(t, "./supabase/functions/child/", resolved.Imports["child"])
-		assert.Equal(t, "../missing", resolved.Imports["missing"])
+		assert.Equal(t, "./supabase/missing", resolved.Imports["missing"])
 	})
 
 	t.Run("resolves parent scopes", func(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Local file paths should be resolved relatively to deno.json even if they don't exist.

URLs imports are left unchanged.

## Additional context

Add any other context or screenshots.
