### PR TITLE
fix: Update img proxy env to be consistent with prod

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -911,6 +911,8 @@ EOF
 					"IMGPROXY_MAX_SRC_FILE_SIZE=25000000",
 					"IMGPROXY_MAX_ANIMATION_FRAMES=60",
 					"IMGPROXY_ENABLE_WEBP_DETECTION=true",
+					"IMGPROXY_PRESETS=default=width:3000/height:8192",
+					"IMGPROXY_FORMAT_QUALITY=jpeg=80,avif=62,webp=80",
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD", "imgproxy", "health"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A couple environment variables used by imgproxy in prod are not included when running locally. This results in inconsistent behavior when resizing images locally compared to prod

## What is the new behavior?

Include values for `IMGPROXY_PRESETS` and `IMGPROXY_FORMAT_QUALITY` that match the settings used in prod

## Additional context

Specifically, the default behavior for resize when providing only one dimension (height OR width) is to use the resize type of "cover" which will not work if a default preset is not defined. This causes very different behavior than prod which can cause a frustrating experience for users.

This change resolve the issue explained in this discussion: https://github.com/orgs/supabase/discussions/37316
