### PR TITLE
fix: handle new tenant api key

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -176,16 +176,11 @@ var (
 
 func checkHTTPHead(ctx context.Context, path string) error {
 	healthOnce.Do(func() {
-		server := utils.Config.Api.ExternalUrl
-		header := func(req *http.Request) {
-			req.Header.Add("apikey", utils.Config.Auth.AnonKey.Value)
-		}
-		client := NewKongClient()
-		healthClient = fetcher.NewFetcher(
-			server,
-			fetcher.WithHTTPClient(client),
-			fetcher.WithRequestEditor(header),
-			fetcher.WithExpectedStatus(http.StatusOK),
+		healthClient = fetcher.NewServiceGateway(
+			utils.Config.Api.ExternalUrl,
+			utils.Config.Auth.AnonKey.Value,
+			fetcher.WithHTTPClient(NewKongClient()),
+			fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
 		)
 	})
 	// HEAD method does not return response body

--- a/internal/storage/client/api.go
+++ b/internal/storage/client/api.go
@@ -28,21 +28,19 @@ func NewStorageAPI(ctx context.Context, projectRef string) (storage.StorageAPI, 
 }
 
 func newLocalClient() *fetcher.Fetcher {
-	client := status.NewKongClient()
-	return fetcher.NewFetcher(
+	return fetcher.NewServiceGateway(
 		utils.Config.Api.ExternalUrl,
-		fetcher.WithHTTPClient(client),
-		fetcher.WithBearerToken(utils.Config.Auth.ServiceRoleKey.Value),
+		utils.Config.Auth.ServiceRoleKey.Value,
+		fetcher.WithHTTPClient(status.NewKongClient()),
 		fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
-		fetcher.WithExpectedStatus(http.StatusOK),
 	)
 }
 
 func newRemoteClient(projectRef, token string) *fetcher.Fetcher {
-	return fetcher.NewFetcher(
+	return fetcher.NewServiceGateway(
 		"https://"+utils.GetSupabaseHost(projectRef),
-		fetcher.WithBearerToken(token),
+		token,
+		fetcher.WithHTTPClient(http.DefaultClient),
 		fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
-		fetcher.WithExpectedStatus(http.StatusOK),
 	)
 }

--- a/pkg/fetcher/gateway.go
+++ b/pkg/fetcher/gateway.go
@@ -1,0 +1,28 @@
+package fetcher
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+func NewServiceGateway(server, token string, overrides ...FetcherOption) *Fetcher {
+	opts := append([]FetcherOption{
+		WithHTTPClient(&http.Client{
+			Timeout: 10 * time.Second,
+		}),
+		withAuthToken(token),
+		WithExpectedStatus(http.StatusOK),
+	}, overrides...)
+	return NewFetcher(server, opts...)
+}
+
+func withAuthToken(token string) FetcherOption {
+	if strings.HasPrefix(token, "sb_") {
+		header := func(req *http.Request) {
+			req.Header.Add("apikey", token)
+		}
+		return WithRequestEditor(header)
+	}
+	return WithBearerToken(token)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

CLI should prefer new api key over legacy ones.

## Additional context

Add any other context or screenshots.
