### PR TITLE
fix: disable ssl when connecting in debug mode

### DIFF
--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
@@ -113,5 +114,6 @@ func isRequireSSL(ctx context.Context, dbUrl string, options ...func(*pgx.ConnCo
 		}
 		return false, err
 	}
-	return true, conn.Close(ctx)
+	// SSL is not supported in debug mode
+	return !viper.GetBool("DEBUG"), conn.Close(ctx)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3847

## What is the new behavior?

Since our debug proxy cannot negotiate ssl, always disable ssl when connecting in debug mode.

## Additional context

Add any other context or screenshots.
