### PR TITLE
fix: set postgres role for pg_dump

### DIFF
--- a/pkg/migration/scripts/dump_data.sh
+++ b/pkg/migration/scripts/dump_data.sh
@@ -22,6 +22,7 @@ echo "SET session_replication_role = replica;
 pg_dump \
     --data-only \
     --quote-all-identifier \
+    --role "postgres" \
     --exclude-schema "${EXCLUDED_SCHEMAS:-}" \
     --exclude-table "auth.schema_migrations" \
     --exclude-table "storage.migrations" \

--- a/pkg/migration/scripts/dump_role.sh
+++ b/pkg/migration/scripts/dump_role.sh
@@ -19,6 +19,7 @@ export PGDATABASE="$PGDATABASE"
 #   - do not alter membership grants by supabase_admin role
 pg_dumpall \
     --roles-only \
+    --role "postgres" \
     --quote-all-identifier \
     --no-role-passwords \
     --no-comments \

--- a/pkg/migration/scripts/dump_schema.sh
+++ b/pkg/migration/scripts/dump_schema.sh
@@ -25,6 +25,7 @@ export PGDATABASE="$PGDATABASE"
 pg_dump \
     --schema-only \
     --quote-all-identifier \
+    --role "postgres" \
     --exclude-schema "${EXCLUDED_SCHEMAS:-}" \
     ${EXTRA_FLAGS:-} \
 | sed -E 's/^CREATE SCHEMA "/CREATE SCHEMA IF NOT EXISTS "/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/3957

## What is the new behavior?

Temporary role must be stepped up to `postgres` for the necessary privileges to run pg_dump.

## Additional context

Add any other context or screenshots.
