### PR TITLE
fix: use service key for version checks

### DIFF
--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -39,7 +39,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs, options ...func(
 	if err != nil {
 		return err
 	}
-	LinkServices(ctx, projectRef, keys.Anon, fsys)
+	LinkServices(ctx, projectRef, keys.ServiceRole, fsys)
 
 	// 2. Check database connection
 	config := flags.NewDbConfigWithPassword(ctx, projectRef)
@@ -66,7 +66,7 @@ func Run(ctx context.Context, projectRef string, fsys afero.Fs, options ...func(
 	return nil
 }
 
-func LinkServices(ctx context.Context, projectRef, anonKey string, fsys afero.Fs) {
+func LinkServices(ctx context.Context, projectRef, serviceKey string, fsys afero.Fs) {
 	// Ignore non-fatal errors linking services
 	var wg sync.WaitGroup
 	wg.Add(8)
@@ -106,7 +106,7 @@ func LinkServices(ctx context.Context, projectRef, anonKey string, fsys afero.Fs
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}()
-	api := tenant.NewTenantAPI(ctx, projectRef, anonKey)
+	api := tenant.NewTenantAPI(ctx, projectRef, serviceKey)
 	go func() {
 		defer wg.Done()
 		if err := linkPostgrestVersion(ctx, api, fsys); err != nil && viper.GetBool("DEBUG") {

--- a/internal/utils/tenant/client.go
+++ b/internal/utils/tenant/client.go
@@ -88,10 +88,10 @@ type TenantAPI struct {
 	*fetcher.Fetcher
 }
 
-func NewTenantAPI(ctx context.Context, projectRef, anonKey string) TenantAPI {
+func NewTenantAPI(ctx context.Context, projectRef, serviceKey string) TenantAPI {
 	return TenantAPI{Fetcher: fetcher.NewServiceGateway(
 		"https://"+utils.GetSupabaseHost(projectRef),
-		anonKey,
+		serviceKey,
 		fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
 	)}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

New publishable key can't be used to access PostgREST schema.

## Additional context

Add any other context or screenshots.
