### PR TITLE
fix: diff schemas using pgkit migra

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -100,7 +100,7 @@ var (
 			differ := diff.DiffSchemaMigra
 			if usePgSchema {
 				differ = diff.DiffPgSchema
-				fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "--use-pg-schema flag is experimental and may not include all entities, such as RLS policies, enums, and grants.")
+				fmt.Fprintln(os.Stderr, utils.Yellow("WARNING:"), "--use-pg-schema flag is experimental and may not include all entities, such as views and grants.")
 			}
 			return diff.Run(cmd.Context(), schema, file, flags.DbConfig, differ, afero.NewOsFs())
 		},

--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/supabase/cli/internal/testing/helper"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/internal/utils/flags"
-	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/migration"
 	"github.com/supabase/cli/pkg/pgtest"
 )
@@ -64,7 +63,7 @@ func TestRun(t *testing.T) {
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-shadow-storage", ""))
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.Auth.Image), "test-shadow-auth")
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-shadow-auth", ""))
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(config.Images.Migra), "test-migra")
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.EdgeRuntime.Image), "test-migra")
 		diff := "create table test();"
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, "test-migra", diff))
 		// Setup mock postgres
@@ -285,7 +284,7 @@ create schema public`)
 		gock.New(utils.Docker.DaemonHost()).
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/test-shadow-db").
 			Reply(http.StatusOK)
-		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(config.Images.Migra), "test-migra")
+		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.EdgeRuntime.Image), "test-migra")
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/test-migra/logs").
 			ReplyError(errors.New("network error"))

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -20,10 +20,36 @@ var (
 	//go:embed templates/migra.ts
 	diffSchemaTypeScript string
 
-	localSchemas = []string{
+	managedSchemas = []string{
+		// Local development
 		"_analytics",
 		"_realtime",
 		"_supavisor",
+		// Owned by extensions
+		"cron",
+		"graphql",
+		"graphql_public",
+		"net",
+		"pgroonga",
+		"pgtle",
+		"repack",
+		"tiger_data",
+		"vault",
+		// Deprecated extensions
+		"pgsodium",
+		"pgsodium_masks",
+		"timescaledb_experimental",
+		"timescaledb_information",
+		"_timescaledb_cache",
+		"_timescaledb_catalog",
+		"_timescaledb_config",
+		"_timescaledb_debug",
+		"_timescaledb_functions",
+		"_timescaledb_internal",
+		// Managed by Supabase
+		"pgbouncer",
+		"supabase_functions",
+		"supabase_migrations",
 	}
 )
 
@@ -59,7 +85,7 @@ func DiffSchemaMigra(ctx context.Context, source, target string, schema []string
 	if len(schema) > 0 {
 		env = append(env, "INCLUDED_SCHEMAS="+strings.Join(schema, ","))
 	} else {
-		env = append(env, "EXCLUDED_SCHEMAS="+strings.Join(localSchemas, ","))
+		env = append(env, "EXCLUDED_SCHEMAS="+strings.Join(managedSchemas, ","))
 	}
 	cmd := []string{"edge-runtime", "start", "--main-service=."}
 	if viper.GetBool("DEBUG") {

--- a/internal/db/diff/pgschema.go
+++ b/internal/db/diff/pgschema.go
@@ -10,6 +10,42 @@ import (
 	pgschema "github.com/stripe/pg-schema-diff/pkg/diff"
 )
 
+var managedSchemas = append([]string{
+	"pg_catalog",
+	// Owned by extensions
+	"cron",
+	"graphql",
+	"graphql_public",
+	"net",
+	"pgmq",
+	"pgroonga",
+	"pgtle",
+	"repack",
+	"tiger",
+	"tiger_data",
+	"topology",
+	"vault",
+	// Deprecated extensions
+	"pgsodium",
+	"pgsodium_masks",
+	"timescaledb_experimental",
+	"timescaledb_information",
+	"_timescaledb_cache",
+	"_timescaledb_catalog",
+	"_timescaledb_config",
+	"_timescaledb_debug",
+	"_timescaledb_functions",
+	"_timescaledb_internal",
+	// Managed by Supabase
+	"auth",
+	"extensions",
+	"pgbouncer",
+	"realtime",
+	"storage",
+	"supabase_functions",
+	"supabase_migrations",
+}, localSchemas...)
+
 func DiffPgSchema(ctx context.Context, source, target string, schema []string) (string, error) {
 	dbSrc, err := sql.Open("pgx", source)
 	if err != nil {
@@ -22,12 +58,17 @@ func DiffPgSchema(ctx context.Context, source, target string, schema []string) (
 	}
 	defer dbDst.Close()
 	// Generate DDL based on schema plan
+	opts := []pgschema.PlanOpt{pgschema.WithDoNotValidatePlan()}
+	if len(schema) > 0 {
+		opts = append(opts, pgschema.WithIncludeSchemas(schema...))
+	} else {
+		opts = append(opts, pgschema.WithExcludeSchemas(managedSchemas...))
+	}
 	plan, err := pgschema.Generate(
 		ctx,
 		pgschema.DBSchemaSource(dbSrc),
 		pgschema.DBSchemaSource(dbDst),
-		pgschema.WithDoNotValidatePlan(),
-		pgschema.WithIncludeSchemas(schema...),
+		opts...,
 	)
 	if err != nil {
 		return "", errors.Errorf("failed to generate plan: %w", err)

--- a/internal/db/diff/templates/migra.ts
+++ b/internal/db/diff/templates/migra.ts
@@ -1,0 +1,99 @@
+import { createClient } from "npm:@pgkit/client";
+import { Migration } from "npm:@pgkit/migra";
+
+const clientBase = createClient(Deno.env.get("SOURCE"));
+const clientHead = createClient(Deno.env.get("TARGET"));
+const includedSchemas = Deno.env.get("INCLUDED_SCHEMAS");
+
+const managedSchemas = ["auth", "realtime", "storage"];
+const extensionSchemas = [
+  "pg_catalog",
+  "extensions",
+  "pgmq",
+  "tiger",
+  "topology",
+];
+const excludedSchemas = [
+  ...(Deno.env.get("EXCLUDED_SCHEMAS") ?? "").split(","),
+  ...extensionSchemas,
+  ...managedSchemas,
+  // Owned by extensions
+  "cron",
+  "graphql",
+  "graphql_public",
+  "net",
+  "pgroonga",
+  "pgtle",
+  "repack",
+  "tiger_data",
+  "vault",
+  // Deprecated extensions
+  "pgsodium",
+  "pgsodium_masks",
+  "timescaledb_experimental",
+  "timescaledb_information",
+  "_timescaledb_cache",
+  "_timescaledb_catalog",
+  "_timescaledb_config",
+  "_timescaledb_debug",
+  "_timescaledb_functions",
+  "_timescaledb_internal",
+  // Managed by Supabase
+  "pgbouncer",
+  "supabase_functions",
+  "supabase_migrations",
+];
+
+try {
+  let sql = "";
+  if (includedSchemas) {
+    for (const schema of includedSchemas.split(",")) {
+      const m = await Migration.create(clientBase, clientHead, {
+        schema,
+        ignore_extension_versions: true,
+      });
+      m.set_safety(false);
+      m.add_all_changes(true);
+      sql += m.sql;
+    }
+  } else {
+    // Migra does not ignore custom types and triggers created by extensions, so we diff
+    // them separately. This workaround only applies to a known list of managed schemas.
+    for (const schema of extensionSchemas) {
+      const e = await Migration.create(clientBase, clientHead, {
+        schema,
+        ignore_extension_versions: true,
+      });
+      e.set_safety(false);
+      e.add(e.changes.schemas({ creations_only: true }));
+      e.add_extension_changes();
+      sql += e.sql;
+    }
+    // Diff user defined entities in non-managed schemas, including extensions.
+    const m = await Migration.create(clientBase, clientHead, {
+      exclude_schema: excludedSchemas,
+      ignore_extension_versions: true,
+    });
+    m.set_safety(false);
+    m.add_all_changes(true);
+    sql += m.sql;
+    // For managed schemas, we want to include triggers and RLS policies only.
+    for (const schema of managedSchemas) {
+      const s = await Migration.create(clientBase, clientHead, {
+        schema,
+        ignore_extension_versions: true,
+      });
+      s.set_safety(false);
+      s.add(s.changes.triggers({ drops_only: true }));
+      s.add(s.changes.rlspolicies({ drops_only: true }));
+      s.add(s.changes.rlspolicies({ creations_only: true }));
+      s.add(s.changes.triggers({ creations_only: true }));
+      sql += s.sql;
+    }
+  }
+  console.log(sql);
+} catch (e) {
+  console.error(e);
+} finally {
+  await Promise.all([clientHead.end(), clientBase.end()]);
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Using pgkit/migra solves a few issues:
1. Cross schema references now works properly when multiple schemas are excluded
2. Triggers and RLS policies in managed schemas are now captured automatically
3. Extensions in all schemas can be included (previously was just `extensions` schema)

Uses edge runtime to execute migra also reduces the number of container images needed.

## Additional context

closes https://github.com/supabase/cli/issues/3919
closes https://github.com/supabase/cli/issues/3993
closes https://github.com/supabase/cli/issues/3379
closes https://github.com/supabase/cli/issues/3342
closes https://github.com/supabase/cli/issues/3234
closes https://github.com/supabase/cli/issues/1113
closes https://github.com/supabase/cli/issues/1514
closes https://github.com/supabase/cli/issues/2620