### PR TITLE
feat(cli): show branch ref to list command

### DIFF
--- a/internal/branches/list/list.go
+++ b/internal/branches/list/list.go
@@ -22,8 +22,8 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 
 	switch utils.OutputFormat.Value {
 	case utils.OutputPretty:
-		table := `|ID|NAME|DEFAULT|GIT BRANCH|STATUS|CREATED AT (UTC)|UPDATED AT (UTC)|
-|-|-|-|-|-|-|-|
+		table := `|ID|BRANCH PROJECT ID|NAME|DEFAULT|GIT BRANCH|STATUS|CREATED AT (UTC)|UPDATED AT (UTC)|
+|-|-|-|-|-|-|-|-|
 `
 		for _, branch := range branches {
 			gitBranch := " "
@@ -31,8 +31,9 @@ func Run(ctx context.Context, fsys afero.Fs) error {
 				gitBranch = *branch.GitBranch
 			}
 			table += fmt.Sprintf(
-				"|`%s`|`%s`|`%t`|`%s`|`%s`|`%s`|`%s`|\n",
+				"|`%s`|`%s`|`%s`|`%t`|`%s`|`%s`|`%s`|`%s`|\n",
 				branch.Id,
+				branch.ProjectRef,
 				strings.ReplaceAll(branch.Name, "|", "\\|"),
 				branch.IsDefault,
 				strings.ReplaceAll(gitBranch, "|", "\\|"),


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Show the project ref of the branch under `BRANCH PROJECT ID` so it can still be reference as `project_id` under the `config.toml` and we can reference this command as a way to get the branch value to configure the remote section: https://supabase.com/docs/guides/deployment/branching/configuration#remote-specific-configuration
