### PR TITLE
chore: separate coverage reporting step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
           go tool gotestsum -- -race -v -count=1 ./... \
           -coverpkg="./cmd/...,./internal/...,${pkgs}" -coverprofile=coverage.out
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage.out
+
+  coverage:
+    name: Coverage
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report
       - uses: coverallsapp/github-action@v2
         with:
           file: coverage.out


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the new behavior?

Separate coverage reporting since it's unreliable and often blocks CI.

## Additional context

Add any other context or screenshots.
