### PR TITLE
feat(cli): set per_worker as default request policy for functions serve

### DIFF
--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -303,9 +303,10 @@ enabled = false
 
 [edge_runtime]
 enabled = true
-# Configure one of the supported request policies: `oneshot`, `per_worker`.
-# Use `oneshot` for hot reload, or `per_worker` for load testing.
-policy = "oneshot"
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 # The Deno major version to use.


### PR DESCRIPTION
Hot reload is now enabled by default when serving Edge Functions locally. Users experiencing issues with auto-reload (e.g. large repos, symlinked paths, or limited import resolution) can switch back to oneshot mode in config.toml.

## What kind of change does this PR introduce?

As of [CLI v2.27.0](https://github.com/supabase/cli/releases/tag/v2.27.0), `supabase functions serve` now supports **hot reload** when using the `per_worker` request policy.
This means you can get automatic reloads on code changes while still benefiting from the higher throughput of `per_worker` mode.

`per_worker` is now the default policy for new projects.
If you encounter issues with hot reload, you can switch back to `oneshot` mode and [file a bug report](https://github.com/supabase/cli/issues/new/choose).

**Known issues:**

* Large repositories may hit the max recursion depth limit.
* Changes in symlinked directories are not detected.
* Only files reachable through imports from the function’s entrypoint are watched.

**How to switch back to `oneshot` mode:**

1. Open your `supabase/config.toml` file.
2. Find or add the `policy` setting under `[edge_runtime]`.
3. Set it to:

   ```toml
   policy = "oneshot"
   ```
4. Save the file and restart `supabase functions serve`.