### PR TITLE
feat: support oriole 17 experimental image

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -73,7 +73,7 @@ func NewContainerConfig(args ...string) container.Config {
 	}
 	if len(utils.Config.Experimental.OrioleDBVersion) > 0 {
 		env = append(env,
-			"POSTGRES_INITDB_ARGS=--lc-collate=C",
+			"POSTGRES_INITDB_ARGS=--lc-collate=C --lc-ctype=C",
 			fmt.Sprintf("S3_ENABLED=%t", true),
 			"S3_HOST="+utils.Config.Experimental.S3Host,
 			"S3_REGION="+utils.Config.Experimental.S3Region,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -763,11 +763,14 @@ func (c *config) Validate(fsys fs.FS) error {
 		return errors.New("Missing required field in config: db.major_version")
 	case 12:
 		return errors.New("Postgres version 12.x is unsupported. To use the CLI, either start a new project or follow project migration steps here: https://supabase.com/docs/guides/database#migrating-between-projects.")
-	case 13, 14, 17:
-		// TODO: support oriole db 17 eventually
-	case 15:
+	case 13, 14:
+	case 15, 17:
 		if len(c.Experimental.OrioleDBVersion) > 0 {
-			c.Db.Image = "supabase/postgres:orioledb-" + c.Experimental.OrioleDBVersion
+			if VersionCompare(c.Experimental.OrioleDBVersion, "15.1.1.13") > 0 {
+				c.Db.Image = fmt.Sprintf("supabase/postgres:%s-orioledb", c.Experimental.OrioleDBVersion)
+			} else {
+				c.Db.Image = "supabase/postgres:orioledb-" + c.Experimental.OrioleDBVersion
+			}
 			if err := assertEnvLoaded(c.Experimental.S3Host); err != nil {
 				return err
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Support pg17 version of oriole db in local dev.

Tested with the following supabase/config.toml

```toml
[auth]
enabled = false

[realtime]
enabled = false

[experimental]
orioledb_version = "17.5.1.017"
```

## Additional context

TODO:
- [ ] auth migrations crash
- [ ] realtime migrations crash
