### PR TITLE
fix: bump edge-runtime to 1.68.0-develop.39

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pg13  = "supabase/postgres:13.3.0"
 	pg14  = "supabase/postgres:14.1.0.89"
 	pg15  = "supabase/postgres:15.8.1.085"
-	deno2 = "supabase/edge-runtime:v1.68.0-develop.37"
+	deno2 = "supabase/edge-runtime:v1.68.0-develop.39"
 )
 
 type images struct {


### PR DESCRIPTION
https://github.com/supabase/edge-runtime/compare/v1.68.0-develop.37...v1.68.0-develop.39