### PR TITLE
fix: use deno 2.x by default for EdgeRuntime

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -875,9 +875,10 @@ func (c *config) Validate(fsys fs.FS) error {
 	case 0:
 		return errors.New("Missing required field in config: edge_runtime.deno_version")
 	case 1:
+		c.EdgeRuntime.Image = deno1
 		break
 	case 2:
-		c.EdgeRuntime.Image = deno2
+		break
 	default:
 		return errors.Errorf("Failed reading config: Invalid %s: %v.", "edge_runtime.deno_version", c.EdgeRuntime.DenoVersion)
 	}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,7 +12,7 @@ const (
 	pg13  = "supabase/postgres:13.3.0"
 	pg14  = "supabase/postgres:14.1.0.89"
 	pg15  = "supabase/postgres:15.8.1.085"
-	deno2 = "supabase/edge-runtime:v1.68.0-develop.39"
+	deno1 = "supabase/edge-runtime:v1.68.3"
 )
 
 type images struct {

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -310,7 +310,7 @@ policy = "per_worker"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 # The Deno major version to use.
-deno_version = 1
+deno_version = 2
 
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Since hosted environment is fully migrated to Deno 2.1, we can use `deno_version = 2` as the default in CLI. https://github.com/orgs/supabase/discussions/37941
