### PR TITLE
fix: deprecate gen keys command

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -27,8 +27,9 @@ var (
 	keyNames keys.CustomName
 
 	genKeysCmd = &cobra.Command{
-		Use:   "keys",
-		Short: "Generate keys for preview branch",
+		Deprecated: `use "gen signing-key" instead.`,
+		Use:        "keys",
+		Short:      "Generate keys for preview branch",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			es, err := env.EnvironToEnvSet(override)
 			if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Gen keys command was never working as intended.

## Additional context

Add any other context or screenshots.
