### PR TITLE
fix(db): Exclude extensions schema from db pull

### DIFF
--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -28,7 +28,7 @@ var (
 	errMissing     = errors.New("No migrations found")
 	errInSync      = errors.New("No schema changes found")
 	errConflict    = errors.Errorf("The remote database's migration history does not match local files in %s directory.", utils.MigrationsDir)
-	managedSchemas = []string{"auth", "storage", "realtime"}
+	managedSchemas = []string{"auth", "storage", "realtime", "extensions"}
 )
 
 func Run(ctx context.Context, schema []string, config pgconn.Config, name string, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {


### PR DESCRIPTION
When running db pull, the schema diff was incorrectly including functions from the extensions schema, such as grant_pg_cron_access. This would generate a migration file that fails to apply locally due to permission errors, as these functions are owned by system roles. By adding extensions to the list of managed schemas, the CLI's diffing logic now correctly handles these objects, preventing it from generating migrations for platform-level functions. This resolves the local must be owner error.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

 When a user runs supabase db pull, the command generates a migration file that includes CREATE OR REPLACE statements
 for functions within the extensions schema (e.g., grant_pg_cron_access). When the user attempts to apply this migration to their local database (for example, by running supabase db reset), it fails with a permission error: ERROR: must be owner of function... (SQLSTATE 42501). This blocks the user's workflow, forcing them to manually remove these statements from the migration file each time they pull from the remote database (trivial task for fewer migrations but tedious task for bigger ones)

## What is the new behavior?

 With this change, supabase db pull now correctly identifies the extensions schema as a schema managed by Supabase. As a result, it no longer includes platform-level functions from this schema in the user-facing migration file. 
 The db pull command now completes successfully without generating a migration that will fail on local execution.

## Additional context

The fix was implemented by adding "extensions" to the internal list of managedSchemas in internal/db/pull/pull.go. This ensures the CLI's diffing engine treats the extensions schema with the same rules as other Supabase-managed schemas like auth and storage, resolving the root cause of the bug.
