### PR TITLE
fix: consistent exp url as cloud version

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -317,6 +317,7 @@ func initStorageJob(host string) utils.DockerJob {
 			// TODO: https://github.com/supabase/storage-api/issues/55
 			"REGION=stub",
 			"GLOBAL_S3_BUCKET=stub",
+			"SIGNED_UPLOAD_URL_EXPIRATION_TIME=7200",
 		},
 		Cmd: []string{"node", "dist/scripts/migrate-call.js"},
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the new behavior?

Consistent upload expiry URL value with cloud version
