### PR TITLE
fix: reset local JWT secret after stop --no-backup to ensure fresh anon key (#4042)

### DIFF
--- a/internal/stop/stop.go
+++ b/internal/stop/stop.go
@@ -32,6 +32,14 @@ func Run(ctx context.Context, backup bool, projectId string, all bool, fsys afer
 		return err
 	}
 
+	// Remove local JWT secret if --no-backup is used
+	if !backup {
+		configPath := utils.ConfigPath // typically ".supabase/config.json"
+		if err := fsys.Remove(configPath); err != nil && err != afero.ErrFileNotFound {
+			fmt.Printf("Warning: failed to remove JWT secret config: %v\n", err)
+		}
+	}
+
 	fmt.Println("Stopped " + utils.Aqua("supabase") + " local development setup.")
 	if resp, err := utils.Docker.VolumeList(ctx, volume.ListOptions{
 		Filters: utils.CliProjectFilter(searchProjectIdFilter),


### PR DESCRIPTION
- Remove .supabase/config.json after `supabase stop --no-backup` to reset the local JWT secret.
- Add test to verify config removal and JWT secret reset.
- Ensure `supabase start` generates a new anon key after a full reset.
- Fixes issue #4042 (Edge Functions fail with stale anon key after reset).

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Running supabase stop --no-backup only stopped containers and removed Docker volumes.
The local JWT secret in .supabase/config.json was not deleted or reset.
On subsequent supabase start, the CLI reused the old JWT secret, so the anon key stayed the same.
This caused Edge Functions to reject requests with {"msg":"Invalid JWT"} after a full reset refer #4042 

## What is the new behavior?

Running supabase stop --no-backup now also deletes .supabase/config.json, removing the local JWT secret.
On the next supabase start, the CLI generates a new JWT secret and a new anon key.
The anon key is now valid for the local API gateway and Edge Functions after a full reset.
Local development and Edge Functions work reliably after a stop/start cycle.

## Additional context

Added a test case for the jwt secret reset.
