### PR TITLE
fix: Update signed upload url default expiration to match prod

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -883,6 +883,7 @@ EOF
 					"S3_PROTOCOL_PREFIX=/storage/v1",
 					"UPLOAD_FILE_SIZE_LIMIT=52428800000",
 					"UPLOAD_FILE_SIZE_LIMIT_STANDARD=5242880000",
+					"SIGNED_UPLOAD_URL_EXPIRATION_TIME=7200",
 				},
 				Healthcheck: &container.HealthConfig{
 					// For some reason, localhost resolves to IPv6 address on GitPod which breaks healthcheck.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

SIGNED_UPLOAD_URL_EXPIRATION_TIME defaults to 60 seconds, but in production the default is 7200

## What is the new behavior?

set SIGNED_UPLOAD_URL_EXPIRATION_TIME to 7200 to match production environment
