### PR TITLE
fix: generate keys when auth is disabled

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -854,9 +854,6 @@ func (c *config) Validate(fsys fs.FS) error {
 				return errors.Errorf("failed to decode signing keys: %w", err)
 			}
 		}
-		if err := c.Auth.generateAPIKeys(); err != nil {
-			return err
-		}
 		if err := c.Auth.Hook.validate(); err != nil {
 			return err
 		}
@@ -875,6 +872,9 @@ func (c *config) Validate(fsys fs.FS) error {
 		if err := c.Auth.ThirdParty.validate(); err != nil {
 			return err
 		}
+	}
+	if err := c.Auth.generateAPIKeys(); err != nil {
+		return err
 	}
 	// Validate functions config
 	for name := range c.Functions {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/4181

## What is the new behavior?

Use default keys when auth is disabled.

## Additional context

Add any other context or screenshots.
