### PR TITLE
docs: update branch names in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## Release process
 
-We release to stable channel every two weeks.
+We release to stable channel every two weeks via `main` branch.
 
-We release to beta channel on merge to `main` branch.
+We release to beta channel on merge to `develop` branch.
 
 Hotfixes are released manually. Follow these steps:
 


### PR DESCRIPTION
Updates branch names mentioned in `CONTRIBUTING.md` (`develop` for beta channel, `main` for stable channel).