### PR TITLE
feat(auth): add OAuth server configuration support

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -694,6 +694,13 @@ EOF
 		}
 		env = append(env, fmt.Sprintf("GOTRUE_EXTERNAL_WEB3_SOLANA_ENABLED=%v", utils.Config.Auth.Web3.Solana.Enabled))
 
+		// OAuth server configuration
+		if utils.Config.Auth.OAuthServer.Enabled {
+			env = append(env, fmt.Sprintf("GOTRUE_OAUTH_SERVER_ENABLED=%v", utils.Config.Auth.OAuthServer.Enabled))
+			env = append(env, "GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH="+utils.Config.Auth.OAuthServer.AuthorizationPath)
+			env = append(env, fmt.Sprintf("GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION=%v", utils.Config.Auth.OAuthServer.AllowDynamicRegistration))
+		}
+
 		if _, err := utils.DockerStart(
 			ctx,
 			container.Config{

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -698,7 +698,7 @@ EOF
 		if utils.Config.Auth.OAuthServer.Enabled {
 			env = append(env,
 				fmt.Sprintf("GOTRUE_OAUTH_SERVER_ENABLED=%v", utils.Config.Auth.OAuthServer.Enabled),
-				"GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH="+utils.Config.Auth.OAuthServer.AuthorizationPath,
+				"GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH="+utils.Config.Auth.OAuthServer.AuthorizationUrlPath,
 				fmt.Sprintf("GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION=%v", utils.Config.Auth.OAuthServer.AllowDynamicRegistration),
 			)
 		}

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -696,9 +696,11 @@ EOF
 
 		// OAuth server configuration
 		if utils.Config.Auth.OAuthServer.Enabled {
-			env = append(env, fmt.Sprintf("GOTRUE_OAUTH_SERVER_ENABLED=%v", utils.Config.Auth.OAuthServer.Enabled))
-			env = append(env, "GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH="+utils.Config.Auth.OAuthServer.AuthorizationPath)
-			env = append(env, fmt.Sprintf("GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION=%v", utils.Config.Auth.OAuthServer.AllowDynamicRegistration))
+			env = append(env,
+				fmt.Sprintf("GOTRUE_OAUTH_SERVER_ENABLED=%v", utils.Config.Auth.OAuthServer.Enabled),
+				"GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH="+utils.Config.Auth.OAuthServer.AuthorizationPath,
+				fmt.Sprintf("GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION=%v", utils.Config.Auth.OAuthServer.AllowDynamicRegistration),
+			)
 		}
 
 		if _, err := utils.DockerStart(

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -162,15 +162,16 @@ type (
 		SigningKeysPath            string               `toml:"signing_keys_path"`
 		SigningKeys                []JWK                `toml:"-"`
 
-		RateLimit rateLimit `toml:"rate_limit"`
-		Captcha   *captcha  `toml:"captcha"`
-		Hook      hook      `toml:"hook"`
-		MFA       mfa       `toml:"mfa"`
-		Sessions  sessions  `toml:"sessions"`
-		Email     email     `toml:"email"`
-		Sms       sms       `toml:"sms"`
-		External  external  `toml:"external"`
-		Web3      web3      `toml:"web3"`
+		RateLimit   rateLimit   `toml:"rate_limit"`
+		Captcha     *captcha    `toml:"captcha"`
+		Hook        hook        `toml:"hook"`
+		MFA         mfa         `toml:"mfa"`
+		Sessions    sessions    `toml:"sessions"`
+		Email       email       `toml:"email"`
+		Sms         sms         `toml:"sms"`
+		External    external    `toml:"external"`
+		Web3        web3        `toml:"web3"`
+		OAuthServer OAuthServer `toml:"oauth_server"`
 
 		// Custom secrets can be injected from .env file
 		PublishableKey Secret `toml:"publishable_key"`
@@ -368,6 +369,12 @@ type (
 		Solana   solana   `toml:"solana"`
 		Ethereum ethereum `toml:"ethereum"`
 	}
+
+	OAuthServer struct {
+		Enabled                  bool   `toml:"enabled"`
+		AllowDynamicRegistration bool   `toml:"allow_dynamic_registration"`
+		AuthorizationPath        string `toml:"authorization_path"`
+	}
 )
 
 func (a *auth) ToUpdateAuthConfigBody() v1API.UpdateAuthConfigBody {
@@ -399,6 +406,7 @@ func (a *auth) ToUpdateAuthConfigBody() v1API.UpdateAuthConfigBody {
 	a.Sms.toAuthConfigBody(&body)
 	a.External.toAuthConfigBody(&body)
 	a.Web3.toAuthConfigBody(&body)
+	a.OAuthServer.toAuthConfigBody(&body)
 	return body
 }
 
@@ -426,6 +434,7 @@ func (a *auth) FromRemoteAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	a.Sms.fromAuthConfig(remoteConfig)
 	a.External.fromAuthConfig(remoteConfig)
 	a.Web3.fromAuthConfig(remoteConfig)
+	a.OAuthServer.fromAuthConfig(remoteConfig)
 }
 
 func (r rateLimit) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
@@ -1336,6 +1345,18 @@ func (w *web3) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	if value, err := remoteConfig.ExternalWeb3EthereumEnabled.Get(); err == nil {
 		w.Ethereum.Enabled = value
 	}
+}
+
+func (o OAuthServer) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
+	// TODO(cemal) :: implement me
+	// OAuth server configuration is behind a feature flag in the remote API
+	// Will be implemented when the feature reaches GA
+}
+
+func (o *OAuthServer) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
+	// TODO(cemal) :: implement me
+	// OAuth server configuration is behind a feature flag in the remote API
+	// Will be implemented when the feature reaches GA
 }
 
 func (a *auth) DiffWithRemote(remoteConfig v1API.AuthConfigResponse, filter ...func(string) bool) ([]byte, error) {

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -373,7 +373,7 @@ type (
 	OAuthServer struct {
 		Enabled                  bool   `toml:"enabled"`
 		AllowDynamicRegistration bool   `toml:"allow_dynamic_registration"`
-		AuthorizationPath        string `toml:"authorization_url_path"`
+		AuthorizationUrlPath     string `toml:"authorization_url_path"`
 	}
 )
 

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -373,7 +373,7 @@ type (
 	OAuthServer struct {
 		Enabled                  bool   `toml:"enabled"`
 		AllowDynamicRegistration bool   `toml:"allow_dynamic_registration"`
-		AuthorizationPath        string `toml:"authorization_path"`
+		AuthorizationPath        string `toml:"authorization_url_path"`
 	}
 )
 

--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -10,7 +10,7 @@ FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.69.12 AS edgeruntime
 FROM timberio/vector:0.28.1-alpine AS vector
 FROM supabase/supavisor:2.7.0 AS supavisor
-FROM supabase/gotrue:v2.179.0 AS gotrue
+FROM supabase/gotrue:v2.180.0 AS gotrue
 FROM supabase/realtime:v2.51.3 AS realtime
 FROM supabase/storage-api:v1.27.4 AS storage
 FROM supabase/logflare:1.22.3 AS logflare

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -304,6 +304,15 @@ enabled = false
 # Obtain from https://clerk.com/setup/supabase
 # domain = "example.clerk.accounts.dev"
 
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -309,7 +309,7 @@ enabled = false
 # Enable OAuth server functionality
 enabled = false
 # Path for OAuth consent flow UI
-authorization_path = "/oauth/consent"
+authorization_url_path = "/oauth/consent"
 # Allow dynamic client registration
 allow_dynamic_registration = false
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -144,6 +144,15 @@ minimum_password_length = 6
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
 password_requirements = ""
 
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = true
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = true
+
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
 email_sent = 2


### PR DESCRIPTION
## Summary
 Add support for new OAuth server environment variables in local development:
  - GOTRUE_OAUTH_SERVER_ENABLED
  - GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION
  - GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH

The feature isn't in GA yet in the platform, so skipping updating the remote config for now.