### PR TITLE
chore: bump studio image for remote MCP release

### DIFF
--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -5,7 +5,7 @@ FROM library/kong:2.8.1 AS kong
 FROM axllent/mailpit:v1.22.3 AS mailpit
 FROM postgrest/postgrest:v13.0.7 AS postgrest
 FROM supabase/postgres-meta:v0.91.6 AS pgmeta
-FROM supabase/studio:2025.09.29-sha-626eb30 AS studio
+FROM supabase/studio:2025.10.01-sha-8460121 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.69.12 AS edgeruntime
 FROM timberio/vector:0.28.1-alpine AS vector


### PR DESCRIPTION
Bumps studio image (see [action](https://github.com/supabase/supabase/actions/runs/18168161734)) to include changes for remote MCP release:

- https://github.com/supabase/supabase/pull/36867
- https://github.com/supabase/supabase/pull/39022
- https://github.com/supabase/supabase/pull/38981
- Maybe other MCP tweaks I'm forgetting

I tested running `go run . start` and I see the MCP "Connect" tab showing in local studio.

<img width="3596" height="2168" alt="CleanShot 2025-10-01 at 12 55 43@2x" src="https://github.com/user-attachments/assets/2727180b-6e63-4df3-a49e-98ed1795e4d8" />
