### PR TITLE
feat: populate pg-meta crypto key in pg-meta and studio

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1116,6 +1116,7 @@ EOF
 					"PG_META_DB_USER=" + dbConfig.User,
 					fmt.Sprintf("PG_META_DB_PORT=%d", dbConfig.Port),
 					"PG_META_DB_PASSWORD=" + dbConfig.Password,
+					"CRYPTO_KEY=" + utils.Config.Studio.PgmetaCryptoKey,
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD-SHELL", `node --eval="fetch('http://127.0.0.1:8080/health').then((r) => {if (!r.ok) throw new Error(r.status)})"`},
@@ -1168,6 +1169,7 @@ EOF
 					"SUPABASE_SERVICE_KEY=" + utils.Config.Auth.ServiceRoleKey.Value,
 					"LOGFLARE_PRIVATE_ACCESS_TOKEN=" + utils.Config.Analytics.ApiKey,
 					"OPENAI_API_KEY=" + utils.Config.Studio.OpenaiApiKey.Value,
+					"PG_META_CRYPTO_KEY=" + utils.Config.Studio.PgmetaCryptoKey,
 					fmt.Sprintf("LOGFLARE_URL=http://%v:4000", utils.LogflareId),
 					fmt.Sprintf("NEXT_PUBLIC_ENABLE_LOGS=%v", utils.Config.Analytics.Enabled),
 					fmt.Sprintf("NEXT_ANALYTICS_BACKEND_PROVIDER=%v", utils.Config.Analytics.Backend),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,12 +169,13 @@ type (
 	}
 
 	studio struct {
-		Enabled      bool   `toml:"enabled" json:"enabled"`
-		Image        string `toml:"-" json:"-"`
-		Port         uint16 `toml:"port" json:"port"`
-		ApiUrl       string `toml:"api_url" json:"api_url"`
-		OpenaiApiKey Secret `toml:"openai_api_key" json:"openai_api_key"`
-		PgmetaImage  string `toml:"-" json:"-"`
+		Enabled         bool   `toml:"enabled" json:"enabled"`
+		Image           string `toml:"-" json:"-"`
+		Port            uint16 `toml:"port" json:"port"`
+		ApiUrl          string `toml:"api_url" json:"api_url"`
+		OpenaiApiKey    Secret `toml:"openai_api_key" json:"openai_api_key"`
+		PgmetaImage     string `toml:"-" json:"-"`
+		PgmetaCryptoKey string `toml:"-" json:"-"`
 	}
 
 	inbucket struct {
@@ -405,8 +406,9 @@ func NewConfig(editors ...ConfigEditor) config {
 			SenderName: "Admin",
 		},
 		Studio: studio{
-			Image:       Images.Studio,
-			PgmetaImage: Images.Pgmeta,
+			Image:           Images.Studio,
+			PgmetaImage:     Images.Pgmeta,
+			PgmetaCryptoKey: "SAMPLE_KEY",
 		},
 		Analytics: analytics{
 			Image:       Images.Logflare,


### PR DESCRIPTION
Companion to https://github.com/supabase/supabase/pull/39041

- Adds `PgmetaCryptoKey` to the studio config, defaulting to "SAMPLE_KEY" to match the [postgres-meta fallback](https://github.com/supabase/postgres-meta/blob/dcb8e9ba9a70f05aab4865144743233ed285db59/src/server/constants.ts#L9)
- Populates studio's `PG_META_CRYPTO_KEY` and pg-meta's `CRYPTO_KEY` with this

Ref AI-153