### PR TITLE
feat(kong): Add `.well-known/oauth-authorization-server` endpoint

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -45,6 +45,16 @@ services:
           replace:
             headers:
               - "Authorization: {{ .BearerToken }}"
+  - name: well-known-oauth
+    _comment: "GoTrue: /.well-known/oauth-authorization-server -> http://auth:9999/.well-known/oauth-authorization-server"
+    url: http://{{ .GotrueId }}:9999/.well-known/oauth-authorization-server
+    routes:
+      - name: well-known-oauth
+        strip_path: true
+        paths:
+          - /.well-known/oauth-authorization-server
+    plugins:
+      - name: cors
   - name: auth-v1
     _comment: "GoTrue: /auth/v1/* -> http://auth:9999/*"
     url: http://{{ .GotrueId }}:9999/


### PR DESCRIPTION
Routes `/.well-known/oauth-authorization-server` from the base URL to the auth service to support OAuth 2.0 Authorization Server Metadata discovery.