### PR TITLE
fix: pass down apikey as query param to realtime

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -87,6 +87,7 @@ type kongConfig struct {
 	ApiHost       string
 	ApiPort       uint16
 	BearerToken   string
+	QueryToken    string
 }
 
 var (
@@ -357,6 +358,13 @@ EOF
 				// Finally, the apikey header may be set to a legacy JWT. In that case, we want to copy
 				// it to Authorization header for backwards compatibility.
 				`$((function() return (headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or (headers.apikey == '%s' and 'Bearer %s') or (headers.apikey == '%s' and 'Bearer %s') or headers.apikey end)())`,
+				utils.Config.Auth.SecretKey.Value,
+				utils.Config.Auth.ServiceRoleKey.Value,
+				utils.Config.Auth.PublishableKey.Value,
+				utils.Config.Auth.AnonKey.Value,
+			),
+			QueryToken: fmt.Sprintf(
+				`$((function() return (query_params.apikey == '%s' and '%s') or (query_params.apikey == '%s' and '%s') or query_params.apikey end)())`,
 				utils.Config.Auth.SecretKey.Value,
 				utils.Config.Auth.ServiceRoleKey.Value,
 				utils.Config.Auth.PublishableKey.Value,

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -146,7 +146,7 @@ func run(ctx context.Context, fsys afero.Fs, excludedContainers []string, dbConf
 		excluded[name] = true
 	}
 
-	jwks, err := utils.Config.Auth.ResolveJWKS(ctx, fsys)
+	jwks, err := utils.Config.Auth.ResolveJWKS(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -132,9 +132,9 @@ services:
       - name: request-transformer
         config:
           replace:
-            headers:
-              - "Authorization: {{ .BearerToken }}"
-  - name: realtime-v1-longpoll
+            querystring:
+              - "apikey:{{ .QueryToken }}"
+  - name: realtime-v1-longpoll-not-working
     _comment: "Realtime: /realtime/v1/* -> ws://realtime:4000/socket/longpoll"
     url: http://{{ .RealtimeId }}:4000/socket
     protocol: http

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/joho/godotenv"
-	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/pkg/cast"
 	"github.com/supabase/cli/pkg/fetcher"
@@ -1428,7 +1427,7 @@ type (
 // ResolveJWKS creates the JWKS from the JWT secret and Third-Party Auth
 // configs by resolving the JWKS via the OIDC discovery URL.
 // It always returns a JWKS string, except when there's an error fetching.
-func (a *auth) ResolveJWKS(ctx context.Context, fsys afero.Fs) (string, error) {
+func (a *auth) ResolveJWKS(ctx context.Context) (string, error) {
 	var jwks remoteJWKS
 
 	if issuerURL := a.ThirdParty.IssuerURL(); issuerURL != "" {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Translate opaque key to jwt when calling realtime.

## Additional context

Add any other context or screenshots.
