### PR TITLE
fix: set project ref metadata for function logs

### DIFF
--- a/internal/start/templates/vector.yaml
+++ b/internal/start/templates/vector.yaml
@@ -117,6 +117,13 @@ transforms:
           .event_message = parsed.msg
           .metadata.level = parsed.level
       }
+  # Function logs are unstructured messages on stderr
+  functions_logs:
+    type: remap
+    inputs:
+      - router.functions
+    source: |-
+      .metadata.project_ref = del(.project)
   # Storage logs may contain json objects so we parse them for completeness
   storage_logs:
     type: remap
@@ -207,7 +214,7 @@ sinks:
   logflare_functions:
     type: "http"
     inputs:
-      - router.functions
+      - functions_logs
     encoding:
       codec: "json"
     method: "post"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Augment edge runtime container logs with metadata.

## Additional context

Add any other context or screenshots.
