### PR TITLE
fix: exclude directories for local migrations

### DIFF
--- a/pkg/migration/list.go
+++ b/pkg/migration/list.go
@@ -38,6 +38,9 @@ func ListLocalMigrations(migrationsDir string, fsys fs.FS, filter ...func(string
 	var clean []string
 OUTER:
 	for i, migration := range localMigrations {
+		if migration.IsDir() {
+			continue
+		}
 		filename := migration.Name()
 		if i == 0 && shouldSkip(filename) {
 			fmt.Fprintf(os.Stderr, "Skipping migration %s... (replace \"init\" with a different file name to apply this migration)\n", filename)


### PR DESCRIPTION
## What kind of change does this PR introduce?

I use an ORM that generates a `meta` directory in the `migrations` directory. This change should ignore any directories when listing local migrations.

## What is the current behavior?

Currently the CLI outputs the following when a `meta` directory exists in the `migrations` directory:

```
Skipping migration meta... (file name must match pattern "<timestamp>_name.sql")
```

## What is the new behavior?

Directories in the `migrations` directory will be skipped silently.

## Additional context

I want to use the Supabase migrations instead of the built-in ORM migration tool as it integrates more smoothly into my workflow.

I'm not a Go dev and I don't have a dev environment set up but I figured this is a tiny change so it hopefully isn't an issue. I was initially going to create an issue but decided I might as well make it a PR, apologies if I missed anything! I can create an issue if this needs more work.

Thanks!
