### PR TITLE
feat: add command to pull project to local

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/clone"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
+)
+
+var (
+	cloneCmd = &cobra.Command{
+		GroupID: groupQuickStart,
+		Use:     "clone",
+		Short:   "Clones a Supabase project to your local environment",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			if !viper.IsSet("WORKDIR") {
+				title := fmt.Sprintf("Enter a directory to clone your project to (or leave blank to use %s): ", utils.Bold(utils.CurrentDirAbs))
+				if workdir, err := utils.NewConsole().PromptText(ctx, title); err != nil {
+					return err
+				} else {
+					viper.Set("WORKDIR", workdir)
+				}
+			}
+			return clone.Run(ctx, afero.NewOsFs())
+		},
+	}
+)
+
+func init() {
+	cloneFlags := cloneCmd.Flags()
+	cloneFlags.StringVar(&flags.ProjectRef, "project-ref", "", "Project ref of the Supabase project.")
+	rootCmd.AddCommand(cloneCmd)
+}

--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -1,0 +1,106 @@
+package clone
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/db/pull"
+	"github.com/supabase/cli/internal/link"
+	"github.com/supabase/cli/internal/login"
+	"github.com/supabase/cli/internal/projects/apiKeys"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
+	"github.com/supabase/cli/internal/utils/tenant"
+	"github.com/supabase/cli/pkg/api"
+	"golang.org/x/term"
+)
+
+func Run(ctx context.Context, fsys afero.Fs) error {
+	if err := changeWorkDir(ctx, fsys); err != nil {
+		return err
+	}
+	// 1. Login
+	if err := checkLogin(ctx, fsys); err != nil {
+		return err
+	}
+	// 2. Link project
+	if err := linkProject(ctx, fsys); err != nil {
+		return err
+	}
+	// 3. Pull migrations
+	dbConfig := flags.NewDbConfigWithPassword(ctx, flags.ProjectRef)
+	if err := dumpRemoteSchema(ctx, dbConfig, fsys); err != nil {
+		return err
+	}
+	return nil
+}
+
+func changeWorkDir(ctx context.Context, fsys afero.Fs) error {
+	workdir := viper.GetString("WORKDIR")
+	if !filepath.IsAbs(workdir) {
+		workdir = filepath.Join(utils.CurrentDirAbs, workdir)
+	}
+	if err := utils.MkdirIfNotExistFS(fsys, workdir); err != nil {
+		return err
+	}
+	if empty, err := afero.IsEmpty(fsys, workdir); err != nil {
+		return errors.Errorf("failed to read workdir: %w", err)
+	} else if !empty {
+		title := fmt.Sprintf("Do you want to overwrite existing files in %s directory?", utils.Bold(workdir))
+		if shouldOverwrite, err := utils.NewConsole().PromptYesNo(ctx, title, true); err != nil {
+			return err
+		} else if !shouldOverwrite {
+			return errors.New(context.Canceled)
+		}
+	}
+	return utils.ChangeWorkDir(fsys)
+}
+
+func checkLogin(ctx context.Context, fsys afero.Fs) error {
+	if _, err := utils.LoadAccessTokenFS(fsys); !errors.Is(err, utils.ErrMissingToken) {
+		return err
+	}
+	params := login.RunParams{
+		OpenBrowser: term.IsTerminal(int(os.Stdin.Fd())),
+		Fsys:        fsys,
+	}
+	return login.Run(ctx, os.Stdout, params)
+}
+
+func linkProject(ctx context.Context, fsys afero.Fs) error {
+	// Use an empty fs to skip loading from file
+	if err := flags.ParseProjectRef(ctx, afero.NewMemMapFs()); err != nil {
+		return err
+	}
+	policy := utils.NewBackoffPolicy(ctx)
+	keys, err := backoff.RetryNotifyWithData(func() ([]api.ApiKeyResponse, error) {
+		fmt.Fprintln(os.Stderr, "Linking project...")
+		return apiKeys.RunGetApiKeys(ctx, flags.ProjectRef)
+	}, policy, utils.NewErrorCallback())
+	if err != nil {
+		return err
+	}
+	// Load default config to update docker id
+	if err := flags.LoadConfig(fsys); err != nil {
+		return err
+	}
+	link.LinkServices(ctx, flags.ProjectRef, tenant.NewApiKey(keys).ServiceRole, false, fsys)
+	return utils.WriteFile(utils.ProjectRefPath, []byte(flags.ProjectRef), fsys)
+}
+
+func dumpRemoteSchema(ctx context.Context, config pgconn.Config, fsys afero.Fs) error {
+	schemaPath := filepath.Join(utils.SchemasDir, "remote.sql")
+	utils.Config.Db.Migrations.SchemaPaths = append(utils.Config.Db.Migrations.SchemaPaths, filepath.ToSlash(schemaPath))
+	if err := pull.CloneRemoteSchema(ctx, schemaPath, config, fsys); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Schema written to "+utils.Bold(schemaPath))
+	return nil
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Add `supabase clone` to setup a local project from an existing hosted project.

## Additional context

The vision here is that each command should follow the unix philosophy of building small single task programs that are composable. Unfortunately, this introduces a lot of fragmentation that affects the overall UX.

Hence, we are adding new commands to `quick start` section which is a composable stack of other sipmle commands.
