### PR TITLE
fix: include shadow port in local database check

### DIFF
--- a/internal/utils/connect.go
+++ b/internal/utils/connect.go
@@ -182,5 +182,5 @@ func ConnectByConfig(ctx context.Context, config pgconn.Config, options ...func(
 }
 
 func IsLocalDatabase(config pgconn.Config) bool {
-	return config.Host == Config.Hostname && config.Port == Config.Db.Port
+	return config.Host == Config.Hostname && (config.Port == Config.Db.Port || config.Port == Config.Db.ShadowPort)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Treat shadow database the same way as connecting to local.

## Additional context

This was causing errors when diffing schemas because TLS was attempted on a local port.
