### PR TITLE
fix(functions): prevent redundant bind mounts on windows

### DIFF
--- a/internal/functions/deploy/bundle.go
+++ b/internal/functions/deploy/bundle.go
@@ -130,6 +130,9 @@ func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImpo
 	// Remove any duplicate mount points
 	for _, mod := range modules {
 		hostPath := strings.Split(mod, ":")[0]
+		if volName := filepath.VolumeName(mod); len(volName) > 0 {
+			hostPath = volName + strings.Split(strings.TrimPrefix(mod, volName), ":")[0]
+		}
 		if !strings.HasPrefix(hostPath, hostFuncDir) &&
 			(len(hostOutputDir) == 0 || !strings.HasPrefix(hostPath, hostOutputDir)) {
 			binds = append(binds, mod)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #4290

## What is the new behavior?

Correctly split paths on windows. Didn't use `ToDockerPath` as it uses `filepath.ToSlash` internally

<img width="1224" height="162" alt="image" src="https://github.com/user-attachments/assets/04b63737-6014-4b0e-9cb8-076c30f609cc" />

