### PR TITLE
fix: return immediately on canceling login

### DIFF
--- a/internal/utils/flags/db_url.go
+++ b/internal/utils/flags/db_url.go
@@ -124,6 +124,8 @@ func NewDbConfigWithPassword(ctx context.Context, projectRef string) pgconn.Conf
 	loginRole, err := initLoginRole(ctx, projectRef, config)
 	if err == nil {
 		return loginRole
+	} else if errors.Is(err, context.Canceled) {
+		return config
 	}
 	// Proceed with password prompt
 	fmt.Fprintln(utils.GetDebugLogger(), err)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/4302

## What is the new behavior?

Cancellation error should exit immediately.

## Additional context

Add any other context or screenshots.
