### PR TITLE
fix: link both storage version and migration

### DIFF
--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -69,6 +69,7 @@ var (
 	GotrueVersionPath     = filepath.Join(TempDir, "gotrue-version")
 	RestVersionPath       = filepath.Join(TempDir, "rest-version")
 	StorageVersionPath    = filepath.Join(TempDir, "storage-version")
+	StorageMigrationPath  = filepath.Join(TempDir, "storage-migration")
 	StudioVersionPath     = filepath.Join(TempDir, "studio-version")
 	PgmetaVersionPath     = filepath.Join(TempDir, "pgmeta-version")
 	PoolerVersionPath     = filepath.Join(TempDir, "pooler-version")

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -21,6 +21,7 @@ type pathBuilder struct {
 	GotrueVersionPath      string
 	RestVersionPath        string
 	StorageVersionPath     string
+	StorageMigrationPath   string
 	StudioVersionPath      string
 	PgmetaVersionPath      string
 	PoolerVersionPath      string
@@ -55,6 +56,7 @@ func NewPathBuilder(configPath string) pathBuilder {
 		GotrueVersionPath:      filepath.Join(base, ".temp", "gotrue-version"),
 		RestVersionPath:        filepath.Join(base, ".temp", "rest-version"),
 		StorageVersionPath:     filepath.Join(base, ".temp", "storage-version"),
+		StorageMigrationPath:   filepath.Join(base, ".temp", "storage-migration"),
 		EdgeRuntimeVersionPath: filepath.Join(base, ".temp", "edge-runtime-version"),
 		StudioVersionPath:      filepath.Join(base, ".temp", "studio-version"),
 		PgmetaVersionPath:      filepath.Join(base, ".temp", "pgmeta-version"),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Link storage version to avoid migration not found errors on new platform releases.

Also uses JobQueue to enforce max concurrent http requests.

## Additional context

Add any other context or screenshots.
