### PR TITLE
show api keys with deprecated flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,11 +145,11 @@ func Execute() {
 	if err != nil {
 		fmt.Fprintln(utils.GetDebugLogger(), err)
 	}
-	if semver.Compare(version, "v"+utils.Version) > 0 {
-		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
-	}
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
+	}
+	if semver.Compare(version, "v"+utils.Version) > 0 {
+		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -67,13 +67,9 @@ func (c *CustomName) toValues(exclude ...string) map[string]string {
 	if authEnabled {
 		values[c.PublishableKey] = utils.Config.Auth.PublishableKey.Value
 		values[c.SecretKey] = utils.Config.Auth.SecretKey.Value
-		values[c.JWTSecret] = utils.Config.Auth.JwtSecret.Value
-		values[c.AnonKey] = utils.Config.Auth.AnonKey.Value
-		values[c.ServiceRoleKey] = utils.Config.Auth.ServiceRoleKey.Value
 	}
 	if inbucketEnabled {
 		values[c.MailpitURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Inbucket.Port)
-		values[c.InbucketURL] = fmt.Sprintf("http://%s:%d", utils.Config.Hostname, utils.Config.Inbucket.Port)
 	}
 	if storageEnabled {
 		values[c.StorageS3URL] = utils.GetApiUrl("/storage/v1/s3")
@@ -220,13 +216,9 @@ func PrettyPrint(w io.Writer, exclude ...string) {
 		McpURL:                   "         " + utils.Aqua("MCP URL"),
 		DbURL:                    "    " + utils.Aqua("Database URL"),
 		StudioURL:                "      " + utils.Aqua("Studio URL"),
-		InbucketURL:              "    " + utils.Aqua("Inbucket URL"),
 		MailpitURL:               "     " + utils.Aqua("Mailpit URL"),
 		PublishableKey:           " " + utils.Aqua("Publishable key"),
 		SecretKey:                "      " + utils.Aqua("Secret key"),
-		JWTSecret:                "      " + utils.Aqua("JWT secret"),
-		AnonKey:                  "        " + utils.Aqua("anon key"),
-		ServiceRoleKey:           "" + utils.Aqua("service_role key"),
 		StorageS3AccessKeyId:     "   " + utils.Aqua("S3 Access Key"),
 		StorageS3SecretAccessKey: "   " + utils.Aqua("S3 Secret Key"),
 		StorageS3Region:          "       " + utils.Aqua("S3 Region"),

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -234,11 +234,14 @@ func PrettyPrint(w io.Writer, exclude ...string) {
 	val := reflect.ValueOf(names)
 	for i := 0; i < val.NumField(); i++ {
 		k := val.Field(i).String()
-		if tag := t.Field(i).Tag.Get("env"); isDeprecated(tag) {
-			continue
-		}
+		tag := t.Field(i).Tag.Get("env")
+		deprecated := isDeprecated(tag)
 		if v, ok := values[k]; ok {
-			fmt.Fprintf(w, "%s: %s\n", k, v)
+			if deprecated {
+				fmt.Fprintf(w, "%s: %s %s\n", k, v, utils.Yellow("(deprecating soon)"))
+			} else {
+				fmt.Fprintf(w, "%s: %s\n", k, v)
+			}
 		}
 	}
 }

--- a/internal/utils/colors.go
+++ b/internal/utils/colors.go
@@ -13,6 +13,10 @@ func Yellow(str string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render(str)
 }
 
+func Orange(str string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render(str)
+}
+
 // For errors.
 func Red(str string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(str)


### PR DESCRIPTION
## What kind of change does this PR introduce?

A lot of users still use Anon and Service Role key, they find it difficult to get those while developing with the CLI as they expect to see them in the `supabase status` command.

e.g [2231](https://github.com/orgs/supabase/discussions/2231), [4211](https://github.com/supabase/cli/issues/4211)

## What is the current behavior?

The CLI skips the deprecated fields instead of showing a tag.
<img width="695" height="241" alt="Screenshot 2025-10-16 at 18 48 21" src="https://github.com/user-attachments/assets/d1283df1-3557-4a17-82ce-a1d9217a6ceb" />

## What is the new behavior?

The CLI shows the keys with a `soon deprecating` tag.
<img width="1282" height="348" alt="Screenshot 2025-10-16 at 19 00 21" src="https://github.com/user-attachments/assets/750d20f7-e9f4-48f0-8274-7a7f7bd3807e" />

