### PR TITLE
feat: handle oauth-protected-resource for edge functions

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -404,7 +404,7 @@ EOF
 					"KONG_DATABASE=off",
 					"KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml",
 					"KONG_DNS_ORDER=LAST,A,CNAME", // https://github.com/supabase/cli/issues/14
-					"KONG_PLUGINS=request-transformer,cors",
+					"KONG_PLUGINS=request-transformer,cors,pre-function",
 					fmt.Sprintf("KONG_PORT_MAPS=%d:8000", utils.Config.Api.Port),
 					// Need to increase the nginx buffers in kong to avoid it rejecting the rather
 					// sizeable response headers azure can generate

--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -225,6 +225,28 @@ services:
           - /pooler/v2/
     plugins:
       - name: cors
+      - name: request-transformer
+        config:
+          replace:
+            headers:
+              - "Authorization: {{ .BearerToken }}"
+  - name: oauth-protected-resource
+    _comment: "OAuth Protected Resource: /.well-known/oauth-protected-resource/functions/v1/<whatever> -> /functions/v1/<whatever>/.well-known/oauth-protected-resource"
+    url: http://{{ .EdgeRuntimeId }}:8081/
+    routes:
+      - name: oauth-protected-resource
+        strip_path: false
+        paths:
+          - /.well-known/oauth-protected-resource/functions/v1/
+    plugins:
+      - name: cors
+      - name: pre-function
+        config:
+          access:
+            - |
+              local uri = kong.request.get_path()
+              local new_uri = uri:gsub("^/.well%-known/oauth%-protected%-resource/functions/v1", "") .. "/.well-known/oauth-protected-resource"
+              kong.service.request.set_path(new_uri)
   - name: mcp
     _comment: "MCP: /mcp -> http://studio:3000/api/mcp"
     url: http://{{ .StudioId }}:3000/api/mcp


### PR DESCRIPTION
rewriting `/.well-known/oauth-protected-resource/functions/v1/<whatever>` -> `/functions/v1/<whatever>/.well-known/oauth-protected-resource`

just for poc for now