### PR TITLE
fix: enable snapchat provider automatically for selected profile

### DIFF
--- a/internal/utils/flags/config_path.go
+++ b/internal/utils/flags/config_path.go
@@ -1,6 +1,8 @@
 package flags
 
 import (
+	"strings"
+
 	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/utils"
 )
@@ -11,5 +13,14 @@ func LoadConfig(fsys afero.Fs) error {
 		return err
 	}
 	utils.UpdateDockerIds()
+	// Apply profile specific overrides
+	if strings.EqualFold(utils.CurrentProfile.Name, "snap") {
+		ext := utils.Config.Auth.External["snapchat"]
+		ext.Enabled = true
+		ext.ClientId = utils.CurrentProfile.AuthClientID
+		// Any dummy value should work for local dev
+		ext.Secret.Value = utils.CurrentProfile.AuthClientID
+		utils.Config.Auth.External["snapchat"] = ext
+	}
 	return nil
 }

--- a/internal/utils/profile.go
+++ b/internal/utils/profile.go
@@ -15,9 +15,10 @@ type Profile struct {
 	Name         string `mapstructure:"name" validate:"required"`
 	APIURL       string `mapstructure:"api_url" validate:"required,http_url"`
 	DashboardURL string `mapstructure:"dashboard_url" validate:"required,http_url"`
+	DocsURL      string `mapstructure:"docs_url" validate:"omitempty,http_url"`
 	ProjectHost  string `mapstructure:"project_host" validate:"required,hostname_rfc1123"`
 	PoolerHost   string `mapstructure:"pooler_host" validate:"omitempty,hostname_rfc1123"`
-	DocsURL      string `mapstructure:"docs_url" validate:"omitempty,http_url"`
+	AuthClientID string `mapstructure:"client_id" validate:"omitempty,uuid4"`
 	StudioImage  string `mapstructure:"studio_image"`
 }
 
@@ -48,6 +49,7 @@ var allProfiles = []Profile{{
 	DocsURL:      "https://cloud.snap.com/docs",
 	ProjectHost:  "snapcloud.dev",
 	PoolerHost:   "snapcloud.co",
+	AuthClientID: "f7573b20-df47-48f1-b606-e8db4ec16252",
 }}
 
 var CurrentProfile Profile


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Current workaround is to manually edit config.toml

```toml
[auth.external.snapchat]
enabled = true
client_id = "f7573b20-df47-48f1-b606-e8db4ec16252"
secret = "any_random_string_here"
```

## What is the new behavior?

Provision it by default since that's the only auth provider supported on snap profile.

## Additional context

Add any other context or screenshots.
