### PR TITLE
fix: reset config url when skipping pooler

### DIFF
--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -69,6 +69,7 @@ func LinkServices(ctx context.Context, projectRef, serviceKey string, skipPooler
 		func() error { return linkStorage(ctx, projectRef) },
 		func() error {
 			if skipPooler {
+				utils.Config.Db.Pooler.ConnectionString = ""
 				return fsys.RemoveAll(utils.PoolerUrlPath)
 			}
 			return linkPooler(ctx, projectRef, fsys)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Config may contain pooler url from previously cached value. Zero it out if `--skip-pooler` flag is specified.

## Additional context

Add any other context or screenshots.
