### PR TITLE
fix: drop schema specifier when enabling pgmq

### DIFF
--- a/pkg/migration/scripts/dump_schema.sh
+++ b/pkg/migration/scripts/dump_schema.sh
@@ -48,6 +48,7 @@ pg_dump \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pg_tle").+/\1;/' \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgsodium").+/\1;/' \
+| sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgmq").+/\1;/' \
 | sed -E 's/^COMMENT ON EXTENSION (.+)/-- &/' \
 | sed -E 's/^CREATE POLICY "cron_job_/-- &/' \
 | sed -E 's/^ALTER TABLE "cron"/-- &/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

When running db dump, the `pgmq` schema is excluded because it's managed by extension.

Dropping the specifier allows pgmq extension to be created without running into missing schema error.

## Additional context

Add any other context or screenshots.
