### PR TITLE
Update studio image supabase/studio:2025.10.31-sha-d66307f

### DIFF
--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -5,7 +5,7 @@ FROM library/kong:2.8.1 AS kong
 FROM axllent/mailpit:v1.22.3 AS mailpit
 FROM postgrest/postgrest:v13.0.7 AS postgrest
 FROM supabase/postgres-meta:v0.93.1 AS pgmeta
-FROM supabase/studio:2025.10.27-sha-85b84e0 AS studio
+FROM supabase/studio:2025.10.31-sha-d66307f AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.69.17 AS edgeruntime
 FROM timberio/vector:0.28.1-alpine AS vector


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update Studio docker image to `supabase/studio:2025.10.31-sha-d66307f` with mcp-server version v0.5.8
