### PR TITLE
fix: variable check for _timeout made explicit to exclude checkpoint timeout

### DIFF
--- a/internal/postgresConfig/update/update.go
+++ b/internal/postgresConfig/update/update.go
@@ -56,7 +56,7 @@ func Run(ctx context.Context, projectRef string, values []string, replaceOverrid
 		}
 		// statement_timeout and wal_sender_timeout must be typed as string
 		for k, v := range finalOverrides {
-			if _, ok := v.(string); strings.HasSuffix(k, "_timeout") && !ok {
+			if _, ok := v.(string); strings.HasSuffix(k, "statement_timeout") || strings.HasSuffix(k, "wal_sender_timeout") && !ok {
 				finalOverrides[k] = fmt.Sprintf("%v", v)
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Curren behaviour was using a general check fir `_timeout` to convert to string. With the addition of `checkpoint_timeout`, this was causing failures.

## What is the new behavior?

Made timeout check explicit for `statment_timeout` and `wal_sender_timeout` so type failures do not occur

## Additional context

Add any other context or screenshots.
