### PR TITLE
fix: update storage API version in Dockerfile

### DIFF
--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -12,7 +12,7 @@ FROM timberio/vector:0.28.1-alpine AS vector
 FROM supabase/supavisor:2.7.4 AS supavisor
 FROM supabase/gotrue:v2.182.1 AS gotrue
 FROM supabase/realtime:v2.63.3 AS realtime
-FROM supabase/storage-api:v1.30.0 AS storage
+FROM supabase/storage-api:v1.31.0 AS storage
 FROM supabase/logflare:1.26.4 AS logflare
 # Append to JobImages when adding new dependencies below
 FROM supabase/pgadmin-schema-diff:cli-0.0.5 AS differ


### PR DESCRIPTION
## What kind of change does this PR introduce?

Storage Version update

## What is the new behavior?

Storage version update to 1.31.0
