### PR TITLE
fix: set Pooler RLIMIT_NOFILE to empty

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1113,6 +1113,7 @@ EOF
 					"API_JWT_SECRET=" + utils.Config.Auth.JwtSecret.Value,
 					"METRICS_JWT_SECRET=" + utils.Config.Auth.JwtSecret.Value,
 					"REGION=local",
+					"RLIMIT_NOFILE=",
 					"RUN_JANITOR=true",
 					"ERL_AFLAGS=-proto_dist inet_tcp",
 				},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Starting Supabase with the pooler active occasionally causes the following error:

```
Starting database...
Initialising schema...
Seeding globals from roles.sql...
Seeding data from supabase/seed.sql...
Starting containers...
Waiting for health checks...
supabase_pooler_myproject container logs:
Setting RLIMIT_NOFILE to 100000
/app/limits.sh: line 6: ulimit: open files: cannot modify limit: Operation not permitted
Setting RLIMIT_NOFILE to 100000
/app/limits.sh: line 6: ulimit: open files: cannot modify limit: Operation not permitted
```

For me, this fixes https://github.com/supabase/cli/issues/4443, but I was encountering this issue much earlier (October 19th), so it's possible that the issue is a separate bug.

I'm guessing that not many people have encountered this issue, since you need to manually enable the pooler in your `supabase/config.toml` file with:

```toml
[db.pooler]
enabled = true
```

## What is the new behavior?

`npx supabase start` works when the pooler is enabled.

## Additional context

We already set the Realtime `RLIMIT_NOFILE` to empty, we should do the same with the pooler to avoid similar `NOFILE` issues with Docker. I've basically copied the approach of this previous commit.

See: ba4f37ecdd6561c8d8d9913954f1e94698b9062e
