### PR TITLE
fix: use upsert when repairing history table

### DIFF
--- a/internal/migration/repair/repair.go
+++ b/internal/migration/repair/repair.go
@@ -71,7 +71,7 @@ func UpdateMigrationTable(ctx context.Context, conn *pgx.Conn, version []string,
 			if err != nil {
 				return err
 			}
-			batch.Queue(migration.INSERT_MIGRATION_VERSION, f.Version, f.Name, f.Statements)
+			batch.Queue(migration.UPSERT_MIGRATION_VERSION, f.Version, f.Name, f.Statements)
 		}
 	case Reverted:
 		if !repairAll {

--- a/pkg/migration/history.go
+++ b/pkg/migration/history.go
@@ -16,6 +16,7 @@ const (
 	ADD_STATEMENTS_COLUMN    = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS statements text[]"
 	ADD_NAME_COLUMN          = "ALTER TABLE supabase_migrations.schema_migrations ADD COLUMN IF NOT EXISTS name text"
 	INSERT_MIGRATION_VERSION = "INSERT INTO supabase_migrations.schema_migrations(version, name, statements) VALUES($1, $2, $3)"
+	UPSERT_MIGRATION_VERSION = INSERT_MIGRATION_VERSION + " ON CONFLICT (version) DO UPDATE SET name = EXCLUDED.name, statements = EXCLUDED.statements"
 	DELETE_MIGRATION_VERSION = "DELETE FROM supabase_migrations.schema_migrations WHERE version = ANY($1)"
 	DELETE_MIGRATION_BEFORE  = "DELETE FROM supabase_migrations.schema_migrations WHERE version <= $1"
 	TRUNCATE_VERSION_TABLE   = "TRUNCATE supabase_migrations.schema_migrations"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Use upsert when repairing migration history.

## Additional context

Add any other context or screenshots.
