### PR TITLE
fix: use schema qualified references

### DIFF
--- a/internal/inspect/calls/calls.sql
+++ b/internal/inspect/calls/calls.sql
@@ -21,6 +21,6 @@ SELECT
       )
     )
   )::text AS sync_io_time
-FROM pg_stat_statements s
+FROM extensions.pg_stat_statements s
 ORDER BY calls DESC
 LIMIT 10

--- a/internal/inspect/db_stats/db_stats.sql
+++ b/internal/inspect/db_stats/db_stats.sql
@@ -52,7 +52,7 @@ SELECT
   COALESCE((SELECT size FROM total_objects WHERE relkind = 'i'), '0 bytes') AS total_index_size,
   COALESCE((SELECT size FROM total_objects WHERE relkind = 'r'), '0 bytes') AS total_table_size,
   COALESCE((SELECT size FROM total_objects WHERE relkind = 't'), '0 bytes') AS total_toast_size,
-  COALESCE((SELECT (now() - stats_reset)::text FROM pg_stat_statements_info), 'N/A') AS time_since_stats_reset,
+  COALESCE((SELECT (now() - stats_reset)::text FROM extensions.pg_stat_statements_info), 'N/A') AS time_since_stats_reset,
   (SELECT COALESCE(ratio::text, 'N/A') FROM cache_hit WHERE relkind = 'i') AS index_hit_rate,
   (SELECT COALESCE(ratio::text, 'N/A') FROM cache_hit WHERE relkind = 't') AS table_hit_rate,
   COALESCE((SELECT pg_size_pretty(SUM(size)) FROM pg_ls_waldir()), '0 bytes') AS wal_size

--- a/internal/inspect/outliers/outliers.sql
+++ b/internal/inspect/outliers/outliers.sql
@@ -21,6 +21,6 @@ SELECT
     )
   )::text AS sync_io_time,
   query
-FROM pg_stat_statements s WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+FROM extensions.pg_stat_statements s WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY total_exec_time DESC
 LIMIT 10


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Inspection queries must use schema qualified references, ie. `extensions.pg_stat_statements`, so it works with temp login role.

## Additional context

Add any other context or screenshots.
