### PR TITLE
fix: add id-token permission for npm oidc

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  # Required for npm OIDC
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix


## Additional context

Trusted publishers are only supported from npm 11.5.1 and up
