### PR TITLE
feat: deprecate beta channel on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,18 +60,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-  publish:
-    name: Publish NPM
-    needs:
-      - fast-forward
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/tag-npm.yml
-    with:
-      release: ${{ needs.fast-forward.outputs.release_tag }}
-    secrets: inherit
-
   compose:
     name: Bump self-hosted versions
     needs:
@@ -100,7 +88,6 @@ jobs:
     needs:
       - fast-forward
       - commit
-      - publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "develop",
-        "channel": "beta"
+        "channel": "latest"
       }
     ],
     "plugins": [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Remove `beta` channel since `npm dist-tag` is not supported by trusted publishing.

https://github.com/npm/cli/issues/8547

## Additional context

Add any other context or screenshots.
