### PR TITLE
fix: add GOTRUE_EXTERNAL_WEB3_ETHEREUM_ENABLED to auth env

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -793,7 +793,10 @@ EOF
 				env = append(env, fmt.Sprintf("GOTRUE_EXTERNAL_%s_URL=%s", strings.ToUpper(name), config.Url))
 			}
 		}
-		env = append(env, fmt.Sprintf("GOTRUE_EXTERNAL_WEB3_SOLANA_ENABLED=%v", utils.Config.Auth.Web3.Solana.Enabled))
+		env = append(env,
+			fmt.Sprintf("GOTRUE_EXTERNAL_WEB3_SOLANA_ENABLED=%v", utils.Config.Auth.Web3.Solana.Enabled),
+			fmt.Sprintf("GOTRUE_EXTERNAL_WEB3_ETHEREUM_ENABLED=%v", utils.Config.Auth.Web3.Ethereum.Enabled),
+		)
 
 		// OAuth server configuration
 		if utils.Config.Auth.OAuthServer.Enabled {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #4551 

## What is the new behavior?

`GOTRUE_EXTERNAL_WEB3_ETHEREUM_ENABLED` env var is passed to auth container
