### PR TITLE
Update docs: mention Docker requirement for db pull

### DIFF
--- a/docs/supabase/db/pull.md
+++ b/docs/supabase/db/pull.md
@@ -4,8 +4,7 @@ Pulls schema changes from a remote database. A new migration file will be create
 
 Requires your local project to be linked to a remote database by running `supabase link`. For self-hosted databases, you can pass in the connection parameters using `--db-url` flag.
 
-> **Note**  
-> This command requires Docker Desktop (or a running Docker daemon), as it starts a local Postgres container to diff your remote schema.
+> Note this command requires Docker Desktop (or a running Docker daemon), as it starts a local Postgres container to diff your remote schema.
 
 Optionally, a new row can be inserted into the migration history table to reflect the current state of the remote database.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update for db pull--add Docker requirement.


## What is the current behavior?

The `supabase db pull` command can fail with:

> Cannot connect to the Docker daemon at unix:///.../docker.sock. Is the docker daemon running?

when Docker Desktop (or another Docker engine) is not running, but this requirement is not mentioned in the docs.

Related issue: #4507


## What is the new behavior?

The `supabase db pull` docs now include a short note:

> This command requires Docker Desktop (or a running Docker daemon), as it starts a local Postgres container to diff your remote schema.

This should make it clearer for new users that `db pull` depends on a running Docker daemon.

This is how it would be rendered: 
<img width="1013" height="410" alt="Screenshot 2025-11-30 at 19 32 47" src="https://github.com/user-attachments/assets/224a4063-1212-49e7-81a9-21a3765b2222" />


## Additional context

From my understanding, several other `supabase db` subcommands (e.g. `db start`, `db dump`) also rely on Docker to run Postgres or `pg_dump` in a container.

To keep this PR small and focused, I only updated the `db pull` docs. I’m happy to:

- add a more general note under the top-level `supabase db` section, and/or  
- update the docs for the other `db` subcommands in a follow-up PR,

if you think that would be helpful. 