### PR TITLE
chore: remove beta installation instructions from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
 npm i supabase --save-dev
 ```
 
-To install the beta release channel:
-
-```bash
-npm i supabase@beta --save-dev
-```
-
 When installing with yarn 4, you need to disable experimental fetch with the following nodejs config.
 
 ```


### PR DESCRIPTION
Removed instructions for installing the beta release of supabase.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
