### PR TITLE
fix: ensure conf.d directory exists for postgres 17 compatibility

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -89,6 +89,7 @@ func NewContainerConfig(args ...string) container.Config {
 			Retries:  3,
 		},
 		Entrypoint: []string{"sh", "-c", `
+mkdir -p /etc/postgresql-custom/conf.d && \
 cat <<'EOF' > /etc/postgresql.schema.sql && \
 cat <<'EOF' > /etc/postgresql-custom/pgsodium_root.key && \
 cat <<'EOF' >> /etc/postgresql/postgresql.conf && \
@@ -143,6 +144,7 @@ func StartDatabase(ctx context.Context, fromBackup string, fsys afero.Fs, w io.W
 	}
 	if len(fromBackup) > 0 {
 		config.Entrypoint = []string{"sh", "-c", `
+mkdir -p /etc/postgresql-custom/conf.d && \
 cat <<'EOF' > /etc/postgresql.schema.sql && \
 cat <<'EOF' > /docker-entrypoint-initdb.d/migrate.sh && \
 cat <<'EOF' > /etc/postgresql-custom/pgsodium_root.key && \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for backwards compatibility with existing config volumes after CLI upgrade.

## What is the current behavior?

After upgrading to CLI v2.65.2 (which uses postgres image 17.6.1.058), `supabase start` fails with:
```
could not open configuration directory "/etc/postgresql-custom/conf.d": No such file or directory FATAL: configuration file "/etc/postgresql/postgresql.conf" contains error
```
## What is the new behavior?

The CLI now creates the `conf.d` directory before starting postgres, ensuring backwards compatibility with existing volumes.

## Root cause

The new postgres image includes `include_dir = '/etc/postgresql-custom/conf.d'` in postgresql.conf. When an existing config volume (from older CLI versions) is mounted, Docker does not copy image contents to the volume, so the `conf.d` directory is missing.

## Fix

Added `mkdir -p /etc/postgresql-custom/conf.d` to the entrypoint script before postgres starts. This is idempotent and safe for both new and existing volumes.

Closes supabase/cli#4571