### PR TITLE
fix: remove config volume mount from db container

### DIFF
--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -38,7 +38,6 @@ func TestResetCommand(t *testing.T) {
 
 	t.Run("seeds storage after reset", func(t *testing.T) {
 		utils.DbId = "test-reset"
-		utils.ConfigId = "test-config"
 		utils.Config.Db.MajorVersion = 15
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -122,7 +122,6 @@ func NewHostConfig() container.HostConfig {
 		RestartPolicy: container.RestartPolicy{Name: "always"},
 		Binds: []string{
 			utils.DbId + ":/var/lib/postgresql/data",
-			utils.ConfigId + ":/etc/postgresql-custom",
 		},
 	}
 	if utils.Config.Db.MajorVersion <= 14 {

--- a/internal/db/start/start_test.go
+++ b/internal/db/start/start_test.go
@@ -55,7 +55,6 @@ func TestStartDatabase(t *testing.T) {
 	t.Run("initialize main branch", func(t *testing.T) {
 		utils.Config.Db.MajorVersion = 15
 		utils.DbId = "supabase_db_test"
-		utils.ConfigId = "supabase_config_test"
 		utils.Config.Db.Port = 5432
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -103,7 +102,6 @@ func TestStartDatabase(t *testing.T) {
 	t.Run("recover from backup volume", func(t *testing.T) {
 		utils.Config.Db.MajorVersion = 14
 		utils.DbId = "supabase_db_test"
-		utils.ConfigId = "supabase_config_test"
 		utils.Config.Db.Port = 5432
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
@@ -316,7 +314,6 @@ func TestStartDatabaseWithCustomSettings(t *testing.T) {
 		// Setup
 		utils.Config.Db.MajorVersion = 15
 		utils.DbId = "supabase_db_test"
-		utils.ConfigId = "supabase_config_test"
 		utils.Config.Db.Port = 5432
 		utils.Config.Db.Settings.MaxConnections = cast.Ptr(uint(50))
 

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -120,7 +120,6 @@ func TestDatabaseStart(t *testing.T) {
 		}
 		// Start postgres
 		utils.DbId = "test-postgres"
-		utils.ConfigId = "test-config"
 		utils.Config.Db.Port = 54322
 		utils.Config.Db.MajorVersion = 15
 		gock.New(utils.Docker.DaemonHost()).
@@ -230,7 +229,6 @@ func TestDatabaseStart(t *testing.T) {
 			JSON(image.InspectResponse{})
 		// Start postgres
 		utils.DbId = "test-postgres"
-		utils.ConfigId = "test-config"
 		utils.Config.Db.Port = 54322
 		utils.Config.Db.MajorVersion = 15
 		gock.New(utils.Docker.DaemonHost()).

--- a/internal/stop/stop_test.go
+++ b/internal/stop/stop_test.go
@@ -191,7 +191,6 @@ func TestStopServices(t *testing.T) {
 
 	t.Run("removes data volumes", func(t *testing.T) {
 		utils.DbId = "test-db"
-		utils.ConfigId = "test-config"
 		utils.StorageId = "test-storage"
 		utils.EdgeRuntimeId = "test-functions"
 		utils.InbucketId = "test-inbucket"
@@ -208,7 +207,6 @@ func TestStopServices(t *testing.T) {
 
 	t.Run("skips all filter when removing data volumes with Docker version pre-v1.42", func(t *testing.T) {
 		utils.DbId = "test-db"
-		utils.ConfigId = "test-config"
 		utils.StorageId = "test-storage"
 		utils.EdgeRuntimeId = "test-functions"
 		utils.InbucketId = "test-inbucket"

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -18,7 +18,6 @@ import (
 var (
 	NetId         string
 	DbId          string
-	ConfigId      string
 	KongId        string
 	GotrueId      string
 	InbucketId    string
@@ -64,7 +63,6 @@ func UpdateDockerIds() {
 		NetId = GetId("network")
 	}
 	DbId = GetId(DbAliases[0])
-	ConfigId = GetId("config")
 	KongId = GetId(KongAliases[0])
 	GotrueId = GetId(GotrueAliases[0])
 	InbucketId = GetId(InbucketAliases[0])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/4571

## What is the new behavior?

Since we started injecting pgsodium root key via container entrypoint, there's no need to volume mount the `/etc/postgresql-custom` directory.

This resolves the problem where new directories are added to this path from upstream postgres image, hence breaking local upgrades.

## Additional context

relates to https://github.com/supabase/cli/pull/1212
supersedes https://github.com/supabase/cli/pull/4570
