### PR TITLE
fix: use double width emoji as icons

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -228,7 +228,7 @@ func PrettyPrint(w io.Writer, exclude ...string) {
 
 	groups := []OutputGroup{
 		{
-			Name: "🛠️  Development Tools",
+			Name: "🔧 Development Tools",
 			Items: []OutputItem{
 				{Label: "Studio", Value: values[names.StudioURL], Type: Link},
 				{Label: "Mailpit", Value: values[names.MailpitURL], Type: Link},
@@ -245,7 +245,7 @@ func PrettyPrint(w io.Writer, exclude ...string) {
 			},
 		},
 		{
-			Name: "🗄️  Database",
+			Name: "⛁ Database",
 			Items: []OutputItem{
 				{Label: "URL", Value: values[names.DbURL], Type: Link},
 			},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

<img width="570" height="499" alt="Screenshot 2025-12-04 at 5 04 43 PM" src="https://github.com/user-attachments/assets/790df602-78c1-4af4-8410-d6718a18ba67" />

## Additional context

Add any other context or screenshots.
