### PR TITLE
fix(db diff): filter inherited constraints for partitioned tables

### DIFF
--- a/internal/db/diff/pgadmin.go
+++ b/internal/db/diff/pgadmin.go
@@ -44,7 +44,7 @@ func RunPgAdmin(ctx context.Context, schema []string, file string, config pgconn
 		return err
 	}
 
-	return SaveDiff(output, file, fsys)
+	return SaveDiff(filterInheritedConstraints(output), file, fsys)
 }
 
 var output string


### PR DESCRIPTION
## summary

this pr fixes an issue where `supabase db diff` generates incorrect migrations for partitioned tables. when a foreign key references a partitioned table, postgresql automatically creates inherited constraints with numeric suffixes (fkey1, fkey2, etc.) for each partition. migra sees these as separate constraints and generates drop/add statements that fail with:

`error: cannot drop inherited constraint table_name_fkey1 of relation table_name`

## problem

when using declarative schemas with partitioned tables:
1. postgresql creates inherited fk constraints for each partition (users_photo_fkey1, users_photo_fkey2, etc.)
2. migra treats these as independent constraints
3. the generated migration tries to drop inherited constraints (which postgresql forbids)
4. users gets duplicate constraint operations

## solution

added a filter that removes alter table statements operating on constraints matching the pattern `fkey` followed by digits. this pattern is exclusively used by postgresql for auto-generated inherited constraints. legitimate user-defined constraints (like `users_id_fkey` without numeric suffix) are preserved.

the fix is applied to both the migra and pgadmin diff paths.

## testing

added 7 test cases covering:
- filtering inherited fkey constraints
- preserving non-inherited constraints  
- empty input handling
- mixed statements with partitioned table constraints
- exact bug report pattern matching

closes #4562