### PR TITLE
fix: change restart policy to unless stopped

### DIFF
--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -119,7 +119,7 @@ func NewHostConfig() container.HostConfig {
 	hostPort := strconv.FormatUint(uint64(utils.Config.Db.Port), 10)
 	hostConfig := container.HostConfig{
 		PortBindings:  nat.PortMap{"5432/tcp": []nat.PortBinding{{HostPort: hostPort}}},
-		RestartPolicy: container.RestartPolicy{Name: "always"},
+		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 		Binds: []string{
 			utils.DbId + ":/var/lib/postgresql/data",
 		},

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -318,7 +318,7 @@ EOF
 			container.HostConfig{
 				Binds:         bind,
 				PortBindings:  nat.PortMap{"4000/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Analytics.Port), 10)}}},
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -401,7 +401,7 @@ EOF
 			},
 			container.HostConfig{
 				Binds:         binds,
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 				SecurityOpt:   securityOpts,
 			},
 			network.NetworkingConfig{
@@ -526,7 +526,7 @@ EOF
 				PortBindings: nat.PortMap{nat.Port(fmt.Sprintf("%d/tcp", dockerPort)): []nat.PortBinding{{
 					HostPort: strconv.FormatUint(uint64(utils.Config.Api.Port), 10)},
 				}},
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -824,7 +824,7 @@ EOF
 				},
 			},
 			container.HostConfig{
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -868,7 +868,7 @@ EOF
 			},
 			container.HostConfig{
 				PortBindings:  inbucketPortBindings,
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -924,7 +924,7 @@ EOF
 				},
 			},
 			container.HostConfig{
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -958,7 +958,7 @@ EOF
 				// PostgREST does not expose a shell for health check
 			},
 			container.HostConfig{
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -1017,7 +1017,7 @@ EOF
 				},
 			},
 			container.HostConfig{
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 				Binds:         []string{utils.StorageId + ":" + dockerStoragePath},
 			},
 			network.NetworkingConfig{
@@ -1060,7 +1060,7 @@ EOF
 			},
 			container.HostConfig{
 				VolumesFrom:   []string{utils.StorageId},
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -1107,7 +1107,7 @@ EOF
 				},
 			},
 			container.HostConfig{
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -1155,7 +1155,7 @@ EOF
 			},
 			container.HostConfig{
 				PortBindings:  nat.PortMap{"3000/tcp": []nat.PortBinding{{HostPort: strconv.FormatUint(uint64(utils.Config.Studio.Port), 10)}}},
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
@@ -1232,7 +1232,7 @@ EOF
 				PortBindings: nat.PortMap{nat.Port(fmt.Sprintf("%d/tcp", dockerPort)): []nat.PortBinding{{
 					HostPort: strconv.FormatUint(uint64(utils.Config.Db.Pooler.Port), 10)},
 				}},
-				RestartPolicy: container.RestartPolicy{Name: "always"},
+				RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			},
 			network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/cli/issues/4586

## What is the new behavior?

Use `unless-stopped` restart policy so that containers can be manually stopped from docker.

## Additional context

Add any other context or screenshots.
