### PR TITLE
fix: enable s3 locally by default

### DIFF
--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -112,9 +112,9 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
-# Uncomment to allow connections via S3 compatible clients
-# [storage.s3_protocol]
-# enabled = true
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
 
 # Image transformation API is available to Supabase Pro plan.
 # [storage.image_transformation]

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -112,7 +112,7 @@ file_size_limit = "50MiB"
 allowed_mime_types = ["image/png", "image/jpeg"]
 objects_path = "./images"
 
-# Uncomment to allow connections via S3 compatible clients
+# Allow connections via S3 compatible clients
 [storage.s3_protocol]
 enabled = true
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/cli/pull/4545

## What is the new behavior?

Enable s3 by default as many folks are relying on it.

## Additional context

Add any other context or screenshots.
