### PR TITLE
feat(typegen): add python type generator

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -60,6 +60,7 @@ var (
 			types.LangTypescript,
 			types.LangGo,
 			types.LangSwift,
+			types.LangPython,
 		},
 		Value: types.LangTypescript,
 	}

--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -23,6 +23,7 @@ const (
 	LangTypescript = "typescript"
 	LangGo         = "go"
 	LangSwift      = "swift"
+	LangPython     = "python"
 )
 
 const (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add python type generation

Example

```sh
supabase gen types --lang=python --local --schema public
```

## What is the current behavior?

No Python type generation

## What is the new behavior?

Python type generation

## Additional context

Add any other context or screenshots.
