### PR TITLE
feat(db): support edge function names in webhook triggers

### DIFF
--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -28,6 +28,7 @@ import (
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/seed/buckets"
 	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/migration"
 )
 
@@ -251,7 +252,7 @@ func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys
 		return err
 	}
 	defer conn.Close(context.Background())
-	return down.ResetAll(ctx, version, conn, fsys)
+	return down.ResetAll(ctx, version, flags.ProjectRef, false, conn, fsys)
 }
 
 func LikeEscapeSchema(schemas []string) (result []string) {

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/fstest"
+	"github.com/supabase/cli/internal/testing/helper"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/pgtest"
 	"github.com/supabase/cli/pkg/storage"
@@ -28,7 +29,7 @@ func TestResetCommand(t *testing.T) {
 	utils.Config.Hostname = "127.0.0.1"
 	utils.Config.Db.Port = 5432
 
-	var dbConfig = pgconn.Config{
+	dbConfig := pgconn.Config{
 		Host:     utils.Config.Hostname,
 		Port:     utils.Config.Db.Port,
 		User:     "admin",
@@ -39,6 +40,9 @@ func TestResetCommand(t *testing.T) {
 	t.Run("seeds storage after reset", func(t *testing.T) {
 		utils.DbId = "test-reset"
 		utils.Config.Db.MajorVersion = 15
+		origServiceRoleKey := utils.Config.Auth.ServiceRoleKey.Value
+		utils.Config.Auth.ServiceRoleKey.Value = ""
+		t.Cleanup(func() { utils.Config.Auth.ServiceRoleKey.Value = origServiceRoleKey })
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock docker
@@ -67,6 +71,7 @@ func TestResetCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		helper.MockVaultSetup(conn, "")
 		// Restarts services
 		utils.StorageId = "test-storage"
 		utils.GotrueId = "test-auth"

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -34,7 +34,7 @@ var (
 	//go:embed templates/schema.sql
 	initialSchema string
 	//go:embed templates/webhook.sql
-	webhookSchema string
+	WebhookSchema string
 	//go:embed templates/_supabase.sql
 	_supabaseSchema string
 	//go:embed templates/restore.sh
@@ -94,7 +94,7 @@ cat <<'EOF' > /etc/postgresql-custom/pgsodium_root.key && \
 cat <<'EOF' >> /etc/postgresql/postgresql.conf && \
 docker-entrypoint.sh postgres -D /etc/postgresql ` + strings.Join(args, " ") + `
 ` + initialSchema + `
-` + webhookSchema + `
+` + WebhookSchema + `
 ` + _supabaseSchema + `
 EOF
 ` + utils.Config.Db.RootKey.Value + `
@@ -248,7 +248,15 @@ func initSchema(ctx context.Context, conn *pgx.Conn, host string, w io.Writer) e
 		} else if err := file.ExecBatch(ctx, conn); err != nil {
 			return err
 		}
-		return InitSchema14(ctx, conn)
+		if err := InitSchema14(ctx, conn); err != nil {
+			return err
+		}
+		if file, err := migration.NewMigrationFromReader(strings.NewReader(WebhookSchema)); err != nil {
+			return err
+		} else if err := file.ExecBatch(ctx, conn); err != nil {
+			return err
+		}
+		return nil
 	}
 	return initSchema15(ctx, host)
 }
@@ -372,8 +380,9 @@ func SetupDatabase(ctx context.Context, conn *pgx.Conn, host string, w io.Writer
 	if err := initSchema(ctx, conn, host, w); err != nil {
 		return err
 	}
+	secrets := vault.WithEdgeFunctionSecrets(utils.Config.Db.Vault, "", utils.Config.Auth.ServiceRoleKey.Value)
 	// Create vault secrets first so roles.sql can reference them
-	if err := vault.UpsertVaultSecrets(ctx, utils.Config.Db.Vault, conn); err != nil {
+	if err := vault.UpsertVaultSecrets(ctx, secrets, conn); err != nil {
 		return err
 	}
 	err := migration.SeedGlobals(ctx, []string{utils.CustomRolesPath}, conn, afero.NewIOFS(fsys))

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -46,6 +46,9 @@ func TestSquashCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, flags.LoadConfig(fsys))
+		origServiceRoleKey := utils.Config.Auth.ServiceRoleKey.Value
+		utils.Config.Auth.ServiceRoleKey.Value = ""
+		t.Cleanup(func() { utils.Config.Auth.ServiceRoleKey.Value = origServiceRoleKey })
 		paths := []string{
 			filepath.Join(utils.MigrationsDir, "0_init.sql"),
 			filepath.Join(utils.MigrationsDir, "1_target.sql"),
@@ -84,6 +87,7 @@ func TestSquashCommand(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		helper.MockVaultSetup(conn, "")
 		helper.MockMigrationHistory(conn).
 			Query("RESET ALL").
 			Reply("RESET").
@@ -282,6 +286,9 @@ func TestSquashMigrations(t *testing.T) {
 		path := filepath.Join(utils.MigrationsDir, "0_init.sql")
 		sql := "create schema test"
 		require.NoError(t, afero.WriteFile(fsys, path, []byte(sql), 0644))
+		origServiceRoleKey := utils.Config.Auth.ServiceRoleKey.Value
+		utils.Config.Auth.ServiceRoleKey.Value = ""
+		t.Cleanup(func() { utils.Config.Auth.ServiceRoleKey.Value = origServiceRoleKey })
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()
@@ -311,6 +318,7 @@ func TestSquashMigrations(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		helper.MockVaultSetup(conn, "")
 		helper.MockMigrationHistory(conn).
 			Query("RESET ALL").
 			Reply("RESET").

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/testing/helper"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/config"
 	"github.com/supabase/cli/pkg/pgtest"
@@ -93,6 +94,9 @@ func TestStartCommand(t *testing.T) {
 
 func TestDatabaseStart(t *testing.T) {
 	t.Run("starts database locally", func(t *testing.T) {
+		origServiceRoleKey := utils.Config.Auth.ServiceRoleKey.Value
+		utils.Config.Auth.ServiceRoleKey.Value = ""
+		t.Cleanup(func() { utils.Config.Auth.ServiceRoleKey.Value = origServiceRoleKey })
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock docker
@@ -164,6 +168,7 @@ func TestDatabaseStart(t *testing.T) {
 		// Setup mock postgres
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
+		helper.MockVaultSetup(conn, "")
 		// Setup health probes
 		started := []string{
 			utils.DbId, utils.KongId, utils.GotrueId, utils.InbucketId, utils.RealtimeId,

--- a/internal/testing/helper/vault.go
+++ b/internal/testing/helper/vault.go
@@ -1,0 +1,25 @@
+package helper
+
+import (
+	"fmt"
+
+	"github.com/supabase/cli/pkg/pgtest"
+	"github.com/supabase/cli/pkg/vault"
+)
+
+func MockVaultSetup(conn *pgtest.MockConn, projectRef string) *pgtest.MockConn {
+	var url string
+	if len(projectRef) == 0 {
+		url = "http://kong:8000/functions/v1"
+	} else {
+		url = fmt.Sprintf("https://%s.supabase.co/functions/v1", projectRef)
+	}
+	// Mock vault existence check
+	conn.Query(vault.CHECK_VAULT).
+		Reply("SELECT 1", []interface{}{1}).
+		Query(vault.READ_VAULT_KV, []string{vault.SecretFunctionsUrl}).
+		Reply("SELECT 0").
+		Query(vault.CREATE_VAULT_KV, url, vault.SecretFunctionsUrl).
+		Reply("SELECT 1")
+	return conn
+}

--- a/pkg/vault/batch_test.go
+++ b/pkg/vault/batch_test.go
@@ -1,0 +1,123 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supabase/cli/pkg/config"
+)
+
+func TestWithEdgeFunctionSecrets(t *testing.T) {
+	t.Run("adds local defaults when projectRef is empty", func(t *testing.T) {
+		secrets := map[string]config.Secret{}
+		serviceRoleKey := "test-service-role-key"
+
+		result := WithEdgeFunctionSecrets(secrets, "", serviceRoleKey)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, "http://kong:8000/functions/v1", result[SecretFunctionsUrl].Value)
+		assert.Equal(t, serviceRoleKey, result[SecretServiceRoleKey].Value)
+	})
+
+	t.Run("adds production URL when projectRef is provided", func(t *testing.T) {
+		secrets := map[string]config.Secret{}
+		serviceRoleKey := "test-service-role-key"
+		projectRef := "abcdefghijklmnop"
+
+		result := WithEdgeFunctionSecrets(secrets, projectRef, serviceRoleKey)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, "https://abcdefghijklmnop.supabase.co/functions/v1", result[SecretFunctionsUrl].Value)
+		assert.NotContains(t, result, SecretServiceRoleKey)
+	})
+
+	t.Run("preserves user-defined secrets", func(t *testing.T) {
+		userUrl := "https://custom.example.com/functions/v1"
+		userKey := "custom-service-key"
+		secrets := map[string]config.Secret{
+			SecretFunctionsUrl:   {Value: userUrl, SHA256: "custom-hash"},
+			SecretServiceRoleKey: {Value: userKey, SHA256: "custom-hash"},
+		}
+
+		result := WithEdgeFunctionSecrets(secrets, "some-project", "ignored-key")
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, userUrl, result[SecretFunctionsUrl].Value)
+		assert.Equal(t, "custom-hash", result[SecretFunctionsUrl].SHA256)
+		assert.Equal(t, userKey, result[SecretServiceRoleKey].Value)
+		assert.Equal(t, "custom-hash", result[SecretServiceRoleKey].SHA256)
+	})
+
+	t.Run("skips service role key when empty", func(t *testing.T) {
+		secrets := map[string]config.Secret{}
+
+		result := WithEdgeFunctionSecrets(secrets, "", "")
+
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, SecretFunctionsUrl)
+		assert.NotContains(t, result, SecretServiceRoleKey)
+	})
+
+	t.Run("preserves existing secrets in input", func(t *testing.T) {
+		existingSecret := config.Secret{Value: "existing-value", SHA256: "existing-hash"}
+		secrets := map[string]config.Secret{
+			"custom_secret": existingSecret,
+		}
+
+		result := WithEdgeFunctionSecrets(secrets, "", "service-key")
+
+		assert.Len(t, result, 3)
+		assert.Equal(t, existingSecret, result["custom_secret"])
+		assert.Contains(t, result, SecretFunctionsUrl)
+		assert.Contains(t, result, SecretServiceRoleKey)
+	})
+
+	t.Run("does not modify original map", func(t *testing.T) {
+		secrets := map[string]config.Secret{
+			"existing": {Value: "value", SHA256: "hash"},
+		}
+
+		result := WithEdgeFunctionSecrets(secrets, "", "service-key")
+
+		assert.Len(t, secrets, 1)
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("handles nil input map", func(t *testing.T) {
+		result := WithEdgeFunctionSecrets(nil, "", "service-key")
+
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, SecretFunctionsUrl)
+		assert.Contains(t, result, SecretServiceRoleKey)
+	})
+
+	t.Run("partial override - only URL defined by user for remote", func(t *testing.T) {
+		secrets := map[string]config.Secret{
+			SecretFunctionsUrl: {Value: "https://custom.example.com/functions/v1", SHA256: "custom"},
+		}
+		result := WithEdgeFunctionSecrets(secrets, "project-ref", "auto-service-key")
+		assert.Len(t, result, 1)
+		assert.Equal(t, "https://custom.example.com/functions/v1", result[SecretFunctionsUrl].Value)
+		assert.NotContains(t, result, SecretServiceRoleKey)
+	})
+
+	t.Run("partial override - only URL defined by user for local", func(t *testing.T) {
+		secrets := map[string]config.Secret{
+			SecretFunctionsUrl: {Value: "http://custom:8000/functions/v1", SHA256: "custom"},
+		}
+		result := WithEdgeFunctionSecrets(secrets, "", "auto-service-key")
+		assert.Len(t, result, 2)
+		assert.Equal(t, "http://custom:8000/functions/v1", result[SecretFunctionsUrl].Value)
+		assert.Equal(t, "auto-service-key", result[SecretServiceRoleKey].Value)
+	})
+
+	t.Run("partial override - only service key defined by user", func(t *testing.T) {
+		secrets := map[string]config.Secret{
+			SecretServiceRoleKey: {Value: "user-defined-key", SHA256: "custom"},
+		}
+		result := WithEdgeFunctionSecrets(secrets, "my-project", "ignored-key")
+		assert.Len(t, result, 2)
+		assert.Equal(t, "https://my-project.supabase.co/functions/v1", result[SecretFunctionsUrl].Value)
+		assert.Equal(t, "user-defined-key", result[SecretServiceRoleKey].Value)
+	})
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Refs: #1705, supabase/supabase#34139

Webhooks require full URLs, breaking when migrating between environments.

## What is the new behavior?

- `supabase_functions.http_request()` auto-detects slugs vs URLs, reads secrets from vault, injects Authorization header
-  Vault secrets synced in `start`, `db push`, `db reset`, `migration up/down`
-  Works for PG14 and PG15+ stacks
