### PR TITLE
chore: update studio image for `@supabase/mcp-server-supabase` v0.5.10

### DIFF
--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -5,7 +5,7 @@ FROM library/kong:2.8.1 AS kong
 FROM axllent/mailpit:v1.22.3 AS mailpit
 FROM postgrest/postgrest:v14.1 AS postgrest
 FROM supabase/postgres-meta:v0.95.1 AS pgmeta
-FROM supabase/studio:2025.12.15-sha-e98ba37 AS studio
+FROM supabase/studio:2025.12.17-sha-43f4f7f AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.69.28 AS edgeruntime
 FROM timberio/vector:0.28.1-alpine AS vector


### PR DESCRIPTION
Published in https://github.com/supabase/supabase/actions/runs/20314495737

Part of `@supabase/mcp-server-supabase` v0.5.10 release process. 

Ref [AI-316](https://linear.app/supabase/issue/AI-316/mcp-release-v0510)
