### PR TITLE
feat(config): support env() references in auth hook URI fields

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1249,6 +1249,13 @@ func (h *hookConfig) validate(hookType string) (err error) {
 	if h.URI == "" {
 		return errors.Errorf("Missing required field in config: auth.hook.%s.uri", hookType)
 	}
+	// Skip validation if URI contains unresolved env() reference
+	// This allows users to use env(SUPABASE_PROJECT_URL)/functions/v1/...
+	// which will be resolved at deploy time by the platform
+	if strings.Contains(h.URI, "env(") {
+		fmt.Fprintf(os.Stderr, "WARN: auth.hook.%s.uri contains env() reference, skipping local validation\n", hookType)
+		return nil
+	}
 	parsed, err := url.Parse(h.URI)
 	if err != nil {
 		return errors.Errorf("failed to parse template url: %w", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -319,6 +319,13 @@ func TestValidateHookURI(t *testing.T) {
 			},
 			errorMsg: "Invalid hook config: auth.hook.valid pg-functions URI with unsupported secrets.secrets is unsupported for pg-functions URI",
 		},
+		{
+			name: "URI with env() reference skips validation",
+			hookConfig: hookConfig{
+				Enabled: true,
+				URI:     "env(SUPABASE_PROJECT_URL)/functions/v1/send-email",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

This PR enables `env()` variable references in auth hook URI fields, solving the configuration problem for preview branches where the project URL is dynamic.

## Problem

When using Supabase branching, each preview branch gets a unique URL (e.g., `https://<random-id>.supabase.co`). Users configuring HTTP auth hooks face a problem:
```toml
[auth.hook.send_email]
enabled = true
uri = "https://???.supabase.co/functions/v1/send-email"  # What goes here?
secrets = "env(SEND_EMAIL_HOOK_SECRET)"  # This works!
```

- **Local dev**: needs `http://host.docker.internal:54321/functions/v1/send_email`
- **Production**: needs `https://myproject.supabase.co/functions/v1/send-email`
- **Preview branches**: needs `https://<dynamic-id>.supabase.co/functions/v1/send-email`

The `secrets` field supports `env()` references, but `uri` did not. When users tried:
```toml
uri = "env(SUPABASE_PROJECT_URL)/functions/v1/send-email"
```

The CLI rejected it because validation tried to parse the unresolved string as a URL and failed on the scheme check.

## Solution

Skip URI validation when the field contains an `env()` reference, allowing the platform to resolve it at deploy time. This follows the same pattern used for other config fields (like `auth.site_url`, `auth.external.*.redirect_uri`, etc.) which already support `env()` references.

### Changes

- **`pkg/config/config.go`**: Added check in `hookConfig.validate()` to skip validation when URI contains `env(` pattern, with a warning message
- **`pkg/config/config_test.go`**: Added test case for `env()` URI references

## Usage

Users can now write:
```toml
[auth.hook.send_email]
enabled = true
uri = "env(SUPABASE_PROJECT_URL)/functions/v1/send-email"
secrets = "env(SEND_EMAIL_HOOK_SECRET)"
```

And set the environment variable appropriately per environment:
- CI/CD can inject the correct URL for each preview branch
- Local `.env` can use `host.docker.internal`
- Production can use the fixed project URL

## Testing
```bash
go test ./config/... -v -run "TestValidateHookURI"
```

All existing tests pass, plus new test case:
- `URI_with_env()_reference_skips_validation` ✅

## Future Considerations

For a more seamless experience, the platform could automatically inject a `SUPABASE_PROJECT_URL` environment variable when deploying preview branches. This would pair well with this CLI change to provide zero-config preview branch support for auth hooks.

## Related Issues

- Fixes https://github.com/supabase/supabase/issues/41088
- Related discussion: https://github.com/orgs/supabase/discussions/18937

cc @kallebysantos