### PR TITLE
fix: ncalls to handle > billion calls formating

### DIFF
--- a/internal/inspect/calls/calls.sql
+++ b/internal/inspect/calls/calls.sql
@@ -2,7 +2,7 @@ SELECT
   query,
   (interval '1 millisecond' * total_exec_time)::text AS total_exec_time,
   to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-  to_char(calls, 'FM999G999G990') AS ncalls,
+  to_char(calls, 'FM999G999G999G999G990') AS ncalls,
   /*
     Handle column names for 15 and 17
   */


### PR DESCRIPTION
## What kind of change does this PR introduce?

It fixes a "bug" when users have now `ncalls` that are higher than the billion..

## What is the current behavior?

 It shows data like `###,###,###` instead, of let's say `1,123,456,789`, so adding

<img width="679" height="246" alt="Capture d’écran 2025-12-23 à 09 18 33" src="https://github.com/user-attachments/assets/264fe2df-ccd7-435a-bc00-51bc460402ea" />

## What is the new behavior?

It shows fixed values because the formating as gone from 
`   to_char(calls, 'FM999G999G990') AS ncalls,`
to 
`   to_char(calls, 'FM999G999G999G999G990') AS ncalls,`
in the source query `internal/inspect/calls/calls.sql`
Feel free to include screenshots if it includes visual changes.

After the patch (and some time ofc: live database), one can see the ncalls with > 1 billion calls..

<img width="481" height="247" alt="Capture d’écran 2025-12-23 à 10 59 32" src="https://github.com/user-attachments/assets/d395ed9d-99cb-49d8-a082-c026d45022a0" />

## Additional context

N/A