### PR TITLE
fix: remove fdw grant option from schema dump

### DIFF
--- a/pkg/migration/scripts/dump_schema.sh
+++ b/pkg/migration/scripts/dump_schema.sh
@@ -44,6 +44,7 @@ pg_dump \
 | sed -E 's/^ALTER PUBLICATION "supabase_realtime_/-- &/' \
 | sed -E 's/^ALTER FOREIGN DATA WRAPPER (.+) OWNER TO /-- &/' \
 | sed -E 's/^ALTER DEFAULT PRIVILEGES FOR ROLE "supabase_admin"/-- &/' \
+| sed -E 's/^GRANT ALL ON FOREIGN DATA WRAPPER (.+) TO "postgres" WITH GRANT OPTION/-- &/' \
 | sed -E "s/^GRANT (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pg_tle").+/\1;/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

```bash
ERROR: grant options cannot be granted back to your own grantor (SQLSTATE 0LP01)
At statement: 1843
GRANT ALL ON FOREIGN DATA WRAPPER "postgres_fdw" TO "postgres" WITH GRANT OPTION
```

## Additional context

Add any other context or screenshots.
