### PR TITLE
fix(db): execute seed sql for modified seed files

### DIFF
--- a/pkg/migration/file.go
+++ b/pkg/migration/file.go
@@ -177,10 +177,8 @@ func (m *SeedFile) ExecBatchWithCache(ctx context.Context, conn *pgx.Conn, fsys 
 	}
 	// Data statements don't mutate schemas, safe to use statement cache
 	batch := pgx.Batch{}
-	if !m.Dirty {
-		for _, line := range lines {
-			batch.Queue(line)
-		}
+	for _, line := range lines {
+		batch.Queue(line)
 	}
 	batch.Queue(UPSERT_SEED_FILE, m.Path, m.Hash)
 	// No need to track version here because there are no schema changes

--- a/pkg/migration/seed_test.go
+++ b/pkg/migration/seed_test.go
@@ -98,10 +98,12 @@ func TestSeedData(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		mockSeedHistory(conn).
-			Query(UPSERT_SEED_FILE, seed.Path, seed.Hash).
+			Query(testSeed+`;INSERT INTO supabase_migrations.seed_files(path, hash) VALUES( 'testdata/seed.sql' ,  '61868484fc0ddca2a2022217629a9fd9a4cf1ca479432046290797d6d40ffcc3' ) ON CONFLICT (path) DO UPDATE SET hash = EXCLUDED.hash`).
 			Reply("INSERT 0 1")
 		// Run test
-		err := SeedData(context.Background(), []SeedFile{seed}, conn.MockClient(t), testMigrations)
+		err := SeedData(context.Background(), []SeedFile{seed}, conn.MockClient(t, func(cc *pgx.ConnConfig) {
+			cc.PreferSimpleProtocol = true
+		}), testMigrations)
 		// Check error
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
when running `supabase db push --include-seed`, modified seed files were detected and their hashes updated, but the actual seed sql was not executed. this happened because `ExecBatchWithCache` only queued sql statements when `Dirty` was false, but modified seeds have `Dirty` set to true.

closes https://github.com/supabase/cli/issues/4670
