### PR TITLE
feat(seed): Add new flag option for setting custom seed file path

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -193,8 +193,9 @@ var (
 		},
 	}
 
-	noSeed      bool
-	lastVersion uint
+	noSeed           bool
+	lastVersion      uint
+	overrideSeedFile string
 
 	dbResetCmd = &cobra.Command{
 		Use:   "reset",
@@ -202,6 +203,8 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if noSeed {
 				utils.Config.Db.Seed.Enabled = false
+			} else if len(overrideSeedFile) > 0 {
+				utils.Config.Db.Seed.SqlPaths = []string{overrideSeedFile}
 			}
 			return reset.Run(cmd.Context(), migrationVersion, lastVersion, flags.DbConfig, afero.NewOsFs())
 		},
@@ -325,7 +328,9 @@ func init() {
 	resetFlags.Bool("linked", false, "Resets the linked project with local migrations.")
 	resetFlags.Bool("local", true, "Resets the local database with local migrations.")
 	resetFlags.BoolVar(&noSeed, "no-seed", false, "Skip running the seed script after reset.")
+	resetFlags.StringVar(&overrideSeedFile, "override-seed-file", "", "Path to a custom seed SQL file to use instead of the default.")
 	dbResetCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
+	dbResetCmd.MarkFlagsMutuallyExclusive("no-seed", "override-seed-file")
 	resetFlags.StringVar(&migrationVersion, "version", "", "Reset up to the specified version.")
 	resetFlags.UintVar(&lastVersion, "last", 0, "Reset up to the last n migration versions.")
 	dbResetCmd.MarkFlagsMutuallyExclusive("version", "last")

--- a/docs/supabase/db/reset.md
+++ b/docs/supabase/db/reset.md
@@ -6,4 +6,6 @@ Requires the local development stack to be started by running `supabase start`.
 
 Recreates the local Postgres container and applies all local migrations found in `supabase/migrations` directory. If test data is defined in `supabase/seed.sql`, it will be seeded after the migrations are run. Any other data or schema changes made during local development will be discarded.
 
+Use the `--no-seed` flag to skip seeding entirely. Alternatively, use the `--override-seed-file` flag to specify a custom seed file path instead of the default `supabase/seed.sql`. This is useful when you want to reset with different initial data, such as an empty state with minimal setup.
+
 When running db reset with `--linked` or `--db-url` flag, a SQL script is executed to identify and drop all user created entities in the remote database. Since Postgres roles are cluster level entities, any custom roles created through the dashboard or `supabase/roles.sql` will not be deleted by remote reset.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature

## What is the current behavior?
Currently, [supabase db reset](vscode-file://vscode-app/c:/Users/alber/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) only supports two seed behaviors:

Run the default seed file(s) defined in config (e.g. `supabase/seed.sql`)
Skip seeding entirely with `--no-seed`
There is no way to specify an alternative seed file at runtime. Users who want to reset their database with different initial data (e.g., an empty state with minimal setup vs. a full product example) must either:

Manually swap seed files before running reset
Skip seeding and manually run the desired seed file afterward

## What is the new behavior?
Added a new `--override-seed-file` flag to `supabase db reset` that allows specifying a custom seed SQL file path:

The `--override-seed-file` and `--no-seed`  flags are mutually exclusive since using both doesn't make sense.

## Additional context

Add any other context or screenshots.
