### PR TITLE
feat: add -f/--foreground flag to supabase start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -40,6 +40,7 @@ var (
 	excludedContainers []string
 	ignoreHealthCheck  bool
 	preview            bool
+	foreground         bool
 
 	startCmd = &cobra.Command{
 		GroupID: groupLocalDev,
@@ -47,7 +48,7 @@ var (
 		Short:   "Start containers for Supabase local development",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validateExcludedContainers(excludedContainers)
-			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers, ignoreHealthCheck)
+			return start.Run(cmd.Context(), afero.NewOsFs(), excludedContainers, ignoreHealthCheck, foreground)
 		},
 	}
 )
@@ -58,6 +59,7 @@ func init() {
 	flags.StringSliceVarP(&excludedContainers, "exclude", "x", []string{}, "Names of containers to not start. ["+names+"]")
 	flags.BoolVar(&ignoreHealthCheck, "ignore-health-check", false, "Ignore unhealthy services and exit 0")
 	flags.BoolVar(&preview, "preview", false, "Connect to feature preview branch")
+	flags.BoolVarP(&foreground, "foreground", "f", false, "Run in foreground and stop services on exit")
 	cobra.CheckErr(flags.MarkHidden("preview"))
 	rootCmd.AddCommand(startCmd)
 }

--- a/docs/supabase/start.md
+++ b/docs/supabase/start.md
@@ -9,3 +9,5 @@ All service containers are started by default. You can exclude those not needed 
 > It is recommended to have at least 7GB of RAM to start all services.
 
 Health checks are automatically added to verify the started containers. Use `--ignore-health-check` flag to ignore these errors.
+
+By default, `supabase start` starts the services and exits. Use `-f` or `--foreground` flag to run in foreground mode, which keeps the command running and automatically stops services when the terminal is closed or interrupted.

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -31,7 +31,7 @@ func TestStartCommand(t *testing.T) {
 		fsys := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fsys, utils.ConfigPath, []byte("malformed"), 0644))
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false)
+		err := Run(context.Background(), fsys, []string{}, false, false)
 		// Check error
 		assert.ErrorContains(t, err, "toml: expected = after a key, but the document ends there")
 	})
@@ -47,7 +47,7 @@ func TestStartCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			ReplyError(errors.New("network error"))
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false)
+		err := Run(context.Background(), fsys, []string{}, false, false)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -84,7 +84,7 @@ func TestStartCommand(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(running)
 		// Run test
-		err := Run(context.Background(), fsys, []string{}, false)
+		err := Run(context.Background(), fsys, []string{}, false, false)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())


### PR DESCRIPTION
## What kind of change does this PR introduce?

### Feature

Add foreground mode to supabase start command that keeps the process
running and automatically stops services when the terminal exits.


## What is the current behavior?

supabase start : 

- Starts all Supabase services and exits immediately
- Services continue running in background
- User must manually run 'supabase stop' to clean up

Closes #4681 

## What is the new behavior?

supabase start -f : 

- Starts all Supabase services
- Stays running in foreground 
- Automatically stops services when terminal exits (Ctrl+C, close window, etc.)
- Same graceful shutdown as manual 'supabase stop'
