### PR TITLE
fix: use static list of project regions

### DIFF
--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -28,8 +28,10 @@ var (
 	projectName string
 	orgId       string
 	dbPassword  string
-	region      utils.EnumFlag
-	size        = utils.EnumFlag{
+	region      = utils.EnumFlag{
+		Allowed: utils.AwsRegions(),
+	}
+	size = utils.EnumFlag{
 		Allowed: []string{
 			string(api.V1CreateProjectBodyDesiredInstanceSizeLarge),
 			string(api.V1CreateProjectBodyDesiredInstanceSizeMedium),

--- a/internal/utils/profile.go
+++ b/internal/utils/profile.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -127,4 +128,13 @@ func getProfileName(fsys afero.Fs) string {
 		fmt.Fprintln(debuglogger, err)
 		return prof
 	}
+}
+
+func AwsRegions() []string {
+	result := make([]string, len(allProfiles[0].ProjectRegions))
+	for i, region := range allProfiles[0].ProjectRegions {
+		result[i] = string(region)
+	}
+	sort.Strings(result)
+	return result
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #4689

## What is the new behavior?

LoadProfile is called before awsRegions are loaded.

## Additional context

`region` var is initialized at package scope in projects.go. As regions are scoped to profile now (https://github.com/supabase/cli/pull/4596), at this point the current profile isn't loaded yet so the `region.Allowed` is set to empty slice. `LoadProfile` is called inside `rootCmd.PersistentPreRunE` which runs after flag parsing and flag validation.


Marking this as a draft for now to get early feedback from maintainers. Happy to adjust the approach if there's a preferred pattern here.