### PR TITLE
feat: allow configuring local health check timeout

### DIFF
--- a/internal/db/diff/diff.go
+++ b/internal/db/diff/diff.go
@@ -143,7 +143,7 @@ func DiffDatabase(ctx context.Context, schema []string, config pgconn.Config, w 
 		return "", err
 	}
 	defer utils.DockerRemove(shadow)
-	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+	if err := start.WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, shadow); err != nil {
 		return "", err
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys, options...); err != nil {

--- a/internal/db/diff/diff_test.go
+++ b/internal/db/diff/diff_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/testing/helper"
@@ -212,7 +211,7 @@ func TestDiffDatabase(t *testing.T) {
 	})
 
 	t.Run("throws error on health check failure", func(t *testing.T) {
-		start.HealthTimeout = time.Millisecond
+		utils.Config.Db.HealthTimeout = time.Millisecond
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock docker

--- a/internal/db/diff/pgadmin.go
+++ b/internal/db/diff/pgadmin.go
@@ -58,7 +58,7 @@ func run(p utils.Program, ctx context.Context, schema []string, config pgconn.Co
 		return err
 	}
 	defer utils.DockerRemove(shadow)
-	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+	if err := start.WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, shadow); err != nil {
 		return err
 	}
 	if err := MigrateShadowDatabase(ctx, shadow, fsys); err != nil {

--- a/internal/db/reset/reset.go
+++ b/internal/db/reset/reset.go
@@ -131,7 +131,7 @@ func resetDatabase15(ctx context.Context, version string, fsys afero.Fs, options
 	if _, err := utils.DockerStart(ctx, config, hostConfig, networkingConfig, utils.DbId); err != nil {
 		return err
 	}
-	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, utils.DbId); err != nil {
+	if err := start.WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, utils.DbId); err != nil {
 		return err
 	}
 	if err := start.SetupLocalDatabase(ctx, version, fsys, os.Stderr, options...); err != nil {
@@ -215,7 +215,7 @@ func RestartDatabase(ctx context.Context, w io.Writer) error {
 	if err := utils.Docker.ContainerRestart(ctx, utils.DbId, container.StopOptions{}); err != nil {
 		return errors.Errorf("failed to restart container: %w", err)
 	}
-	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, utils.DbId); err != nil {
+	if err := start.WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, utils.DbId); err != nil {
 		return err
 	}
 	return restartServices(ctx)

--- a/internal/db/reset/reset_test.go
+++ b/internal/db/reset/reset_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -16,7 +15,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/utils"
@@ -376,7 +374,6 @@ func TestRestartDatabase(t *testing.T) {
 
 	t.Run("throws error on health check timeout", func(t *testing.T) {
 		utils.DbId = "test-reset"
-		start.HealthTimeout = 0 * time.Second
 		// Setup mock docker
 		require.NoError(t, apitest.MockDocker(utils.Docker))
 		defer gock.OffAll()

--- a/internal/db/start/start.go
+++ b/internal/db/start/start.go
@@ -30,7 +30,6 @@ import (
 )
 
 var (
-	HealthTimeout = 120 * time.Second
 	//go:embed templates/schema.sql
 	initialSchema string
 	//go:embed templates/webhook.sql
@@ -177,7 +176,7 @@ EOF`}
 		return err
 	}
 	// Ignore health check because restoring a large backup may take longer than 2 minutes
-	if err := WaitForHealthyService(ctx, HealthTimeout, utils.DbId); err != nil && len(fromBackup) == 0 {
+	if err := WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, utils.DbId); err != nil && len(fromBackup) == 0 {
 		return err
 	}
 	// Initialize if we are on PG14 and there's no existing db volume

--- a/internal/migration/squash/squash.go
+++ b/internal/migration/squash/squash.go
@@ -85,7 +85,7 @@ func squashMigrations(ctx context.Context, migrations []string, fsys afero.Fs, o
 		return err
 	}
 	defer utils.DockerRemove(shadow)
-	if err := start.WaitForHealthyService(ctx, start.HealthTimeout, shadow); err != nil {
+	if err := start.WaitForHealthyService(ctx, utils.Config.Db.HealthTimeout, shadow); err != nil {
 		return err
 	}
 	conn, err := diff.ConnectShadowDatabase(ctx, 10*time.Second, options...)

--- a/internal/migration/squash/squash_test.go
+++ b/internal/migration/squash/squash_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/db/start"
 	"github.com/supabase/cli/internal/migration/repair"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/fstest"
@@ -214,7 +213,7 @@ func TestSquashMigrations(t *testing.T) {
 	})
 
 	t.Run("throws error on health check failure", func(t *testing.T) {
-		start.HealthTimeout = time.Millisecond
+		utils.Config.Db.HealthTimeout = time.Millisecond
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Setup mock docker

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"slices"
+	"time"
 
 	"github.com/go-errors/errors"
 	v1API "github.com/supabase/cli/pkg/api"
@@ -78,6 +79,7 @@ type (
 		Image               string              `toml:"-"`
 		Port                uint16              `toml:"port"`
 		ShadowPort          uint16              `toml:"shadow_port"`
+		HealthTimeout       time.Duration       `toml:"health_timeout"`
 		MajorVersion        uint                `toml:"major_version"`
 		Password            string              `toml:"-"`
 		RootKey             Secret              `toml:"root_key"`

--- a/pkg/config/templates/config.toml
+++ b/pkg/config/templates/config.toml
@@ -29,6 +29,8 @@ enabled = false
 port = 54322
 # Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 17

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -29,6 +29,8 @@ key_path = "../certs/my-key.pem"
 port = 54322
 # Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 17


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes https://github.com/supabase/cli/issues/1894

## What is the new behavior?

Allow users to configure database health check timeout via config.toml.

## Additional context

Add any other context or screenshots.
