### PR TITLE
fix: setup cancellation context for all commands

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -28,7 +26,7 @@ var (
 		Short:   "Bootstrap a Supabase project from a starter template",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			ctx := cmd.Context()
 			if !viper.IsSet("WORKDIR") {
 				title := fmt.Sprintf("Enter a directory to bootstrap your project (or leave blank to use %s): ", utils.Bold(utils.CurrentDirAbs))
 				if workdir, err := utils.NewConsole().PromptText(ctx, title); err != nil {

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
 
 	"github.com/spf13/afero"
@@ -31,11 +30,6 @@ var (
 		GroupID: groupLocalDev,
 		Use:     "db",
 		Short:   "Manage Postgres databases",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			cmd.SetContext(ctx)
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
 	}
 
 	dbBranchCmd = &cobra.Command{

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"os"
-	"os/signal"
 	"strings"
 	"time"
 
@@ -88,7 +87,7 @@ var (
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			ctx := cmd.Context()
 			if flags.DbConfig.Host == "" {
 				// If no flag is specified, prompt for project id.
 				if err := flags.ParseProjectRef(ctx, afero.NewMemMapFs()); errors.Is(err, utils.ErrNotLinked) {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/inspect"
@@ -33,11 +30,6 @@ var (
 	inspectDBCmd = &cobra.Command{
 		Use:   "db",
 		Short: "Tools to inspect your Supabase database",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			cmd.SetContext(ctx)
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
 	}
 
 	inspectDBStatsCmd = &cobra.Command{

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -28,7 +27,7 @@ var (
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			ctx := cmd.Context()
 			// Use an empty fs to skip loading from file
 			if err := flags.ParseProjectRef(ctx, afero.NewMemMapFs()); err != nil {
 				return err

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -25,11 +24,6 @@ var (
 		Use:     "migration",
 		Aliases: []string{"migrations"},
 		Short:   "Manage database migration scripts",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			cmd.SetContext(ctx)
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
 	}
 
 	migrationListCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ var (
 			}
 			cmd.SilenceUsage = true
 			// Load profile before changing workdir
-			ctx := cmd.Context()
+			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			fsys := afero.NewOsFs()
 			if err := utils.LoadProfile(ctx, fsys); err != nil {
 				return err
@@ -106,7 +106,6 @@ var (
 				if err := promptLogin(fsys); err != nil {
 					return err
 				}
-				ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 				if cmd.Flags().Lookup("project-ref") != nil {
 					if err := flags.ParseProjectRef(ctx, fsys); err != nil {
 						return err

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/seed/buckets"
@@ -16,11 +13,6 @@ var (
 		GroupID: groupLocalDev,
 		Use:     "seed",
 		Short:   "Seed a Supabase project from " + utils.ConfigPath,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			cmd.SetContext(ctx)
-			return cmd.Root().PersistentPreRunE(cmd, args)
-		},
 	}
 
 	bucketsCmd = &cobra.Command{

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	env "github.com/Netflix/go-env"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -27,8 +24,7 @@ var (
 			return env.Unmarshal(es, &names)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return status.Run(ctx, names, utils.OutputFormat.Value, afero.NewOsFs())
+			return status.Run(cmd.Context(), names, utils.OutputFormat.Value, afero.NewOsFs())
 		},
 		Example: `  supabase status -o env --override-name api.url=NEXT_PUBLIC_SUPABASE_URL
   supabase status -o json`,

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/stop"
@@ -19,8 +16,7 @@ var (
 		Use:     "stop",
 		Short:   "Stop all local Supabase containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return stop.Run(ctx, !noBackup, projectId, all, afero.NewOsFs())
+			return stop.Run(cmd.Context(), !noBackup, projectId, all, afero.NewOsFs())
 		},
 	}
 )

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/test/new"
@@ -33,8 +30,7 @@ var (
 		Short: "Create a new test file",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return new.Run(ctx, args[0], template.Value, afero.NewOsFs())
+			return new.Run(cmd.Context(), args[0], template.Value, afero.NewOsFs())
 		},
 	}
 )

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/supabase/cli/internal/unlink"
@@ -15,8 +12,7 @@ var (
 		Use:     "unlink",
 		Short:   "Unlink a Supabase project",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt)
-			return unlink.Run(ctx, afero.NewOsFs())
+			return unlink.Run(cmd.Context(), afero.NewOsFs())
 		},
 	}
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Since we no longer rely on bubbletea for signal handling, we can propagate context cancellation to all commands.

This fixes an issue where containers are not cleaned up properly after cancelling supabase start.

## Additional context

Add any other context or screenshots.
