### PR TITLE
feat(functions): implement serve individual functions

### DIFF
--- a/docs/supabase/functions/serve.md
+++ b/docs/supabase/functions/serve.md
@@ -1,6 +1,8 @@
 ## supabase-functions-serve
 
-Serve all Functions locally.
+Serve Functions locally.
+
+When no function names are provided, all functions in config.toml file plus those in the `supabase/functions` directory are served. When one or more function names are specified, only those functions will be served.
 
 `supabase functions serve` command includes additional flags to assist developers in debugging Edge Functions via the v8 inspector protocol, allowing for debugging via Chrome DevTools, VS Code, and IntelliJ IDEA for example. Refer to the [docs guide](/docs/guides/functions/debugging-tools) for setup instructions.
 

--- a/internal/functions/serve/testdata/config.toml
+++ b/internal/functions/serve/testdata/config.toml
@@ -6,3 +6,7 @@ static_files = ["image.png"]
 [functions.world]
 enabled = false
 verify_jwt = false
+
+[functions.good]
+
+[functions.bye]

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1094,7 +1094,7 @@ EOF
 	// Start all functions.
 	if utils.Config.EdgeRuntime.Enabled && !isContainerExcluded(utils.Config.EdgeRuntime.Image, excluded) {
 		dbUrl := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Port, dbConfig.Database)
-		if err := serve.ServeFunctions(ctx, "", nil, "", dbUrl, serve.RuntimeOption{}, fsys); err != nil {
+		if err := serve.ServeFunctions(ctx, nil, "", nil, "", dbUrl, serve.RuntimeOption{}, fsys); err != nil {
 			return err
 		}
 		started = append(started, utils.EdgeRuntimeId)
@@ -1140,7 +1140,7 @@ EOF
 
 	// Start Studio.
 	if utils.Config.Studio.Enabled && !isContainerExcluded(utils.Config.Studio.Image, excluded) {
-		binds, _, err := serve.PopulatePerFunctionConfigs(workdir, "", nil, fsys)
+		binds, _, err := serve.PopulatePerFunctionConfigs(nil, workdir, "", nil, fsys)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make it possible to serve individual functios

## What is the current behavior?

`supabase functions serve hello-world` is serving all functions

## What is the new behavior?

`supabase functions serve hello-world` now serves individual functions

## Additional context

the `supabase functions serve` command is ignoring function name arguments and always serves all functions.

I think the expected behaviour is for it to accept function names as arguments (similar to `deploy`).  I’ve collected a few places where the example `supabase functions serve hello-world` is used throughout the docs:
https://supabase.com/docs/guides/functions/development-tips#skipping-authorization-checks
https://supabase.com/docs/guides/functions/function-configuration#skipping-authorization-checks
https://supabase.com/docs/guides/functions/quickstart-dashboard#cli
https://supabase.com/docs/guides/functions/quickstart#step-3-test-your-function-locally
https://supabase.com/docs/guides/functions/secrets#local-secrets

with the changes in this PR, it would be now possible to do: 
`supabase functions serve hello-world`
`supabase functions serve fun1 fun2 fun3` etc…

It also, addresses this issue: https://github.com/supabase/cli/issues/4395

and adds tests.
It might look some tests are redundant, but I thought it would be better to cover these different cases, because we are going from ignored to any amount of functions.  and, about this `—all` hidden flag implementation, I added a comment about that, because it currently has no effect.

I also added slug validation to the `serve` command for the case where the function is not mentioned in the 'config.toml' file, this might allow to catch invalid slugs earlier in the development.  

did many tests by hand, testing different combinations of functions and calling all function endpoints to check which of them are listening, like: 

running:
<img width="905" height="149" alt="Screenshot 2026-01-09 at 19 46 43" src="https://github.com/user-attachments/assets/6f97e88f-fbee-44f6-ac24-3cc2fce35abc" />

checking:
<img width="438" height="162" alt="Screenshot 2026-01-09 at 19 45 06" src="https://github.com/user-attachments/assets/36dd53a7-08f0-41a3-81ae-cdb6126a59b0" />


I did not touch the file watcher, it keeps watching all functions, regardless of which ones are being served. I can implement that in a subsequent PR if you guys find it relevant. Although I think it might not be too relevant.

Lastly, there is kind of a bug (not introduced by this PR), where we are allowing "non existent functions" to be served (which naturally results in `BOOT_ERROR ` of the deno worker as it doesn't find the file when it comes the time to get it, when the function is called). I was fixing that putting a check inside the "PopulatePerFunctionConfigs" function, but then the refactor of tests (mocking the existence of function files) was ocupying the most part of changes, so I reverted. I would like to know what are your thoughts on that, if that is relevant of course.
