### PR TITLE
fix(db): set working directory for SQL relative imports

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -44,7 +44,10 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		cmd = append(cmd, dockerPath)
 		binds[i] = fmt.Sprintf("%s:%s:ro", fp, dockerPath)
 		if workingDir == "" {
-			workingDir = filepath.Dir(dockerPath)
+			workingDir = dockerPath
+			if path.Ext(dockerPath) != "" {
+				workingDir = path.Dir(dockerPath)
+			}
 		}
 	}
 	if viper.GetBool("DEBUG") {

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types/container"

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -35,6 +35,7 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 	}
 	binds := make([]string, len(testFiles))
 	cmd := []string{"pg_prove", "--ext", ".pg", "--ext", ".sql", "-r"}
+	var workingDir string
 	for i, fp := range testFiles {
 		if !filepath.IsAbs(fp) {
 			fp = filepath.Join(utils.CurrentDirAbs, fp)
@@ -42,6 +43,9 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		dockerPath := utils.ToDockerPath(fp)
 		cmd = append(cmd, dockerPath)
 		binds[i] = fmt.Sprintf("%s:%s:ro", fp, dockerPath)
+		if workingDir == "" {
+			workingDir = filepath.Dir(dockerPath)
+		}
 	}
 	if viper.GetBool("DEBUG") {
 		cmd = append(cmd, "--verbose")
@@ -89,7 +93,8 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 				"PGPASSWORD=" + config.Password,
 				"PGDATABASE=" + config.Database,
 			},
-			Cmd: cmd,
+			Cmd:        cmd,
+			WorkingDir: workingDir,
 		},
 		hostConfig,
 		network.NetworkingConfig{},


### PR DESCRIPTION
## Summary
Fixes SQL relative imports in test files by setting the container working directory.

## Problem
SQL files using `\i` fail with "No such file or directory" because the container has no working directory set.

## Solution
Set `WorkingDir` to the parent directory of the test file, allowing psql to resolve relative imports correctly.

## Related
- Extends https://github.com/supabase/cli/pull/4590  
- Closes https://github.com/supabase/cli/issues/4734
