### PR TITLE
fix: write interactive prompts to stderr when stdout is redirected

### DIFF
--- a/internal/utils/flags/project_ref.go
+++ b/internal/utils/flags/project_ref.go
@@ -22,9 +22,7 @@ func ParseProjectRef(ctx context.Context, fsys afero.Fs) error {
 	}
 	// Prompt as the last resort
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		// Interactive prompts should always be written to stderr
-		opts := []tea.ProgramOption{tea.WithOutput(os.Stderr)}
-		return PromptProjectRef(ctx, "Select a project:", opts...)
+		return PromptProjectRef(ctx, "Select a project:")
 	}
 	return errors.New(utils.ErrNotLinked)
 }

--- a/internal/utils/prompt.go
+++ b/internal/utils/prompt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -123,6 +124,8 @@ func PromptChoice(ctx context.Context, title string, items []PromptItem, opts ..
 	// Create our model
 	ctx, cancel := context.WithCancel(ctx)
 	initial := model{cancel: cancel, list: l}
+	// Interactive prompts should always be written to stderr
+	opts = append(opts, tea.WithOutput(os.Stderr))
 	prog := tea.NewProgram(initial, opts...)
 	state, err := prog.Run()
 	if err != nil {


### PR DESCRIPTION
## Summary
Fixes interactive prompts being written to output files when using stdout redirection with `supabase gen types`.

## Problem
When running `supabase gen types > types.ts`, the interactive project reference prompt was being written to the output file instead of the terminal. This corrupted the generated TypeScript file with prompt text.

## Solution
Interactive prompts now always write to stderr by passing `tea.WithOutput(os.Stderr)` to the Bubble Tea program in `project_ref.go`. This ensures prompts remain visible in the terminal while keeping stdout clean for piped output.

## Related
- Closes https://github.com/supabase/cli/issues/4742
