### PR TITLE
fix: use fixed expiry for asymmetric JWT generation

### DIFF
--- a/pkg/config/apikeys.go
+++ b/pkg/config/apikeys.go
@@ -75,7 +75,7 @@ func (a *auth) generateAPIKeys() error {
 func (a auth) generateJWT(role string) (string, error) {
 	claims := CustomClaims{Issuer: "supabase-demo", Role: role}
 	if len(a.SigningKeys) > 0 {
-		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour * 24 * 365 * 10)) // 10 years
+		claims.ExpiresAt = jwt.NewNumericDate(time.Unix(defaultJwtExpiry, 0))
 		return GenerateAsymmetricJWT(a.SigningKeys[0], claims)
 	}
 	// Fallback to generating symmetric keys


### PR DESCRIPTION

## Summary

Running `supabase status -o env` multiple times produces different `SERVICE_ROLE_KEY` values on each invocation when using asymmetric signing keys. 
This breaks workflows where the service role key needs to be stored in a vault or used consistently across multiple command runs.

## Problem

When `LoadConfig()` is called (which happens on every `supabase status` run), it regenerates JWT keys. 
For asymmetric keys, the expiry was set using `time.Now().Add(10 years)`, 
causing the JWT payload to have a different expiry timestamp on each generation:

- Run 1: `exp: 2036-01-23 19:37:15`
- Run 2: `exp: 2036-01-23 19:37:16` (1 second later)

Different expiry → Different `JWT` payload → Different `SERVICE_ROLE_KEY`

## Solution

Use the same fixed expiry constant (`defaultJwtExpiry = 1983812996`, expires Nov 2032) that symmetric keys already use. 
This ensures the JWT payload remains identical across multiple generations.
This aligns asymmetric key behavior with symmetric keys (line 35)

## Related 
- Closes #4751


