### PR TITLE
fix: enable gotrue template reloading

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -580,6 +580,7 @@ EOF
 			fmt.Sprintf("GOTRUE_MAILER_AUTOCONFIRM=%v", !utils.Config.Auth.Email.EnableConfirmations),
 			fmt.Sprintf("GOTRUE_MAILER_OTP_LENGTH=%v", utils.Config.Auth.Email.OtpLength),
 			fmt.Sprintf("GOTRUE_MAILER_OTP_EXP=%v", utils.Config.Auth.Email.OtpExpiry),
+			"GOTRUE_MAILER_TEMPLATE_RELOADING_ENABLED=true",
 
 			fmt.Sprintf("GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=%v", utils.Config.Auth.EnableAnonymousSignIns),
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #4668 

## What is the new behavior?

enable template reloading to handle template loading failures when kong is not ready to serve requests. Default retry time is 10s which should be sufficient for kong to become available during startup. Also default template stale time is 10m so it should prevent unnecessary reloads.

https://github.com/supabase/auth/blob/1ae3a3dcad766a3989f86a37c347b9e3806c14dc/internal/conf/configuration.go#L533-L546
