### PR TITLE
fix: remove dots from allowed project_id characters to prevent Vector container crashes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -435,7 +435,7 @@ var (
 	initConfigEmbed    string
 	initConfigTemplate = template.Must(template.New("initConfig").Parse(initConfigEmbed))
 
-	invalidProjectId = regexp.MustCompile("[^a-zA-Z0-9_.-]+")
+	invalidProjectId = regexp.MustCompile("[^a-zA-Z0-9_-]+")
 	refPattern       = regexp.MustCompile(`^[a-z]{20}$`)
 )
 
@@ -975,10 +975,10 @@ func truncateText(text string, maxLen int) string {
 const maxProjectIdLength = 40
 
 func sanitizeProjectId(src string) string {
-	// A valid project ID must only contain alphanumeric and special characters _.-
+	// A valid project ID must only contain alphanumeric and special characters _-
 	sanitized := invalidProjectId.ReplaceAllString(src, "_")
 	// It must also start with an alphanumeric character
-	sanitized = strings.TrimLeft(sanitized, "_.-")
+	sanitized = strings.TrimLeft(sanitized, "_-")
 	// Truncate sanitized ID to 40 characters since docker hostnames cannot exceed
 	// 63 characters, and we need to save space for padding supabase_*_edge_runtime.
 	return truncateText(sanitized, maxProjectIdLength)


### PR DESCRIPTION
### Summary
Dots in `project_id` cause Vector analytics container to crash with `invalid authority: InvalidIpv4Address` panic,
 preventing Supabase from starting.

### Problem
Many  users where facing an issue that when `project_id` contains dots (e.g., `myapp-2.0`),  the value is used to construct Docker hostnames like `http://myapp-2.0:port`.
 Vector's URI parser interprets `2.0` as an incomplete IPv4 address,  causing a panic and crash loop. The existing regex allowed dots as valid characters.

### Solution
Remove `.` from the regex pattern. Now dots are automatically replaced with underscores during sanitization,
with a warning message to inform users. 

### Related

- closes https://github.com/supabase/cli/issues/4767
