### PR TITLE
fix: defaults to legacy anon key

### DIFF
--- a/pkg/config/apikeys.go
+++ b/pkg/config/apikeys.go
@@ -74,7 +74,7 @@ func (a *auth) generateAPIKeys() error {
 
 func (a auth) generateJWT(role string) (string, error) {
 	claims := CustomClaims{Issuer: "supabase-demo", Role: role}
-	if len(a.SigningKeys) > 0 {
+	if len(a.SigningKeysPath) > 0 {
 		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour * 24 * 365 * 10)) // 10 years
 		return GenerateAsymmetricJWT(a.SigningKeys[0], claims)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/cli/issues/4751
follow up https://github.com/supabase/cli/pull/4688

## What is the new behavior?

Keep legacy anon and service_role keys around unless user explicitly enables custom signing key.

## Additional context

supersedes https://github.com/supabase/cli/pull/4752
