### PR TITLE
fix: set correct valid methods env var

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -627,7 +627,7 @@ EOF
 		if keys, err := json.Marshal(utils.Config.Auth.SigningKeys); err == nil {
 			env = append(env, "GOTRUE_JWT_KEYS="+string(keys))
 			// TODO: deprecate HS256 when it's no longer supported
-			env = append(env, "GOTRUE_JWT_VALID_METHODS=HS256,RS256,ES256")
+			env = append(env, "GOTRUE_JWT_VALIDMETHODS=HS256,RS256,ES256")
 		}
 
 		if utils.Config.Auth.Email.Smtp != nil && utils.Config.Auth.Email.Smtp.Enabled {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Use the currently accepted env var for auth.

## Additional context

relates to https://github.com/supabase/auth/pull/2334
