### PR TITLE
fix: prevent panic when signing keys

### DIFF
--- a/pkg/config/apikeys.go
+++ b/pkg/config/apikeys.go
@@ -74,7 +74,7 @@ func (a *auth) generateAPIKeys() error {
 
 func (a auth) generateJWT(role string) (string, error) {
 	claims := CustomClaims{Issuer: "supabase-demo", Role: role}
-	if len(a.SigningKeysPath) > 0 {
+	if len(a.SigningKeysPath) > 0 && len(a.SigningKeys) > 0 {
 		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour * 24 * 365 * 10)) // 10 years
 		return GenerateAsymmetricJWT(a.SigningKeys[0], claims)
 	}


### PR DESCRIPTION
## Problem

running `supabase gen signing-key` with an empty `signing_keys.json`  with only `[]` file causes a panic:

```
runtime error: index out of range [0] with length 0
```
## Solution

Add length check for `SigningKeys` array before accessing the first element. 



## Related

- Closes #4804
- Extends #4778
