### PR TITLE
fix(studio): use postgres user for read write operations

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1173,6 +1173,7 @@ EOF
 					"SNIPPETS_MANAGEMENT_FOLDER=" + containerSnippetsPath,
 					// Ref: https://github.com/vercel/next.js/issues/51684#issuecomment-1612834913
 					"HOSTNAME=0.0.0.0",
+					"POSTGRES_USER_READ_WRITE=postgres",
 				},
 				Healthcheck: &container.HealthConfig{
 					Test:     []string{"CMD-SHELL", `node --eval="fetch('http://127.0.0.1:3000/api/platform/profile').then((r) => {if (!r.ok) throw new Error(r.status)})"`},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

studio sends its own connection string to pgmeta for executing queries via studio sql-editor. It defaults to `supabase_admin` user. https://github.com/supabase/supabase/blob/18cc6f8fe9654e0b682d4f6564adc838977d197e/apps/studio/lib/api/self-hosted/constants.ts#L8

## What is the new behavior?

Use `postgres` user for studio read write operations
