### PR TITLE
Fix pgTAP single-file working dir

### DIFF
--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 	bindsSet := map[string]struct{}{}
 	cmd := []string{"pg_prove", "--ext", ".pg", "--ext", ".sql", "-r"}
 	var workingDir string
-	for i, fp := range testFiles {
+	for _, fp := range testFiles {
 		if !filepath.IsAbs(fp) {
 			fp = filepath.Join(utils.CurrentDirAbs, fp)
 		}

--- a/internal/db/test/test.go
+++ b/internal/db/test/test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -34,7 +35,7 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		}
 		testFiles = append(testFiles, absTestsDir)
 	}
-	binds := make([]string, len(testFiles))
+	bindsSet := map[string]struct{}{}
 	cmd := []string{"pg_prove", "--ext", ".pg", "--ext", ".sql", "-r"}
 	var workingDir string
 	for i, fp := range testFiles {
@@ -43,14 +44,24 @@ func Run(ctx context.Context, testFiles []string, config pgconn.Config, fsys afe
 		}
 		dockerPath := utils.ToDockerPath(fp)
 		cmd = append(cmd, dockerPath)
-		binds[i] = fmt.Sprintf("%s:%s:ro", fp, dockerPath)
+
+		hostDir := fp
+		dockerDir := dockerPath
+		if path.Ext(dockerPath) != "" {
+			hostDir = filepath.Dir(fp)
+			dockerDir = path.Dir(dockerPath)
+		}
+		bindsSet[fmt.Sprintf("%s:%s:ro", hostDir, dockerDir)] = struct{}{}
+
 		if workingDir == "" {
-			workingDir = dockerPath
-			if path.Ext(dockerPath) != "" {
-				workingDir = path.Dir(dockerPath)
-			}
+			workingDir = dockerDir
 		}
 	}
+	binds := make([]string, 0, len(bindsSet))
+	for b := range bindsSet {
+		binds = append(binds, b)
+	}
+	sort.Strings(binds)
 	if viper.GetBool("DEBUG") {
 		cmd = append(cmd, "--verbose")
 	}


### PR DESCRIPTION
Fixes supabase/cli#4850

When running a single pgTAP test file, pg_prove was invoked with only the file bind-mounted.
This meant psql \ir includes (relative to the file) failed because the directory wasn’t mounted
and working dir didn’t resolve correctly.

Change:
- Mount the test file’s directory (or the test directory itself) into the container
- Set WorkingDir to that directory
- De-duplicate/sort binds
