### PR TITLE
Fix MCP OAuth route matching in local Kong

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -236,5 +236,6 @@ services:
         strip_path: true
         paths:
           - /mcp
+          - /mcp/
     plugins:
       - name: cors


### PR DESCRIPTION
Fixes #4811

MCP auth requests hit /mcp/oauth/*, but the current Kong route only matches /mcp. This can cause no Route matched and break OAuth in CLI v2.75.x. Add /mcp/ to the route paths so subpaths match consistently.

Changes

Add /mcp/ to MCP route paths in [kong.yml](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/bbook/.vscode/extensions/openai.chatgpt-0.5.72-win32-x64/webview/#) to allow subpath matching.
Notes

No behavior change for /mcp root.
Should resolve 404s for MCP OAuth endpoints.