### PR TITLE
Honor sslmode=disable for db connections (fix TLS regression)

### DIFF
--- a/pkg/pgxv5/connect.go
+++ b/pkg/pgxv5/connect.go
@@ -18,6 +18,9 @@ func Connect(ctx context.Context, connString string, options ...func(*pgx.ConnCo
 	if err != nil {
 		return nil, errors.Errorf("failed to parse connection string: %w", err)
 	}
+	if strings.EqualFold(config.RuntimeParams["sslmode"], "disable") {
+		config.TLSConfig = nil
+	}
 	config.OnNotice = func(pc *pgconn.PgConn, n *pgconn.Notice) {
 		if !shouldIgnore(n.Message) {
 			fmt.Fprintf(os.Stderr, "%s (%s): %s\n", n.Severity, n.Code, n.Message)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

CLI 2.75.x attempts a TLS connection even when `sslmode=disable` is set in `--db-url`, causing `tls error (server refused TLS connection)`. The same command succeeds with `--debug` because TLS is disabled there.  
Issue: #4839 (regression of #4288)

## What is the new behavior?

When `sslmode=disable` is present in the connection string, the CLI explicitly disables TLS, so non‑TLS self‑hosted databases connect successfully without needing `--debug`.

## Additional context

This aligns normal behavior with the `--debug` path, which already disables TLS. No user‑visible changes beyond respecting `sslmode=disable`.
