### PR TITLE
fix: only upload functions declared in config.toml

### DIFF
--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -110,7 +110,7 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 	for _, name := range slugs {
 		function, ok := utils.Config.Functions[name]
 		if !ok {
-			function.Enabled = true
+			function.Enabled = false
 			function.VerifyJWT = true
 		}
 		// Precedence order: flag > config > fallback

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -22,6 +22,7 @@ func Run(ctx context.Context, slugs []string, useDocker bool, noVerifyJWT *bool,
 	if err := flags.LoadConfig(fsys); err != nil {
 		return err
 	} else if len(slugs) > 0 {
+		slugs = utils.RemoveDuplicates(slugs)
 		for _, s := range slugs {
 			if err := utils.ValidateFunctionSlug(s); err != nil {
 				return err

--- a/internal/functions/deploy/deploy.go
+++ b/internal/functions/deploy/deploy.go
@@ -67,7 +67,13 @@ func Run(ctx context.Context, slugs []string, useDocker bool, noVerifyJWT *bool,
 	} else if err != nil {
 		return err
 	}
-	fmt.Printf("Deployed Functions on project %s: %s\n", utils.Aqua(flags.ProjectRef), strings.Join(slugs, ", "))
+	deployed := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		if functionConfig[slug].Enabled {
+			deployed = append(deployed, slug)
+		}
+	}
+	fmt.Printf("Deployed Functions on project %s: %s\n", utils.Aqua(flags.ProjectRef), strings.Join(deployed, ", "))
 	url := fmt.Sprintf("%s/project/%v/functions", utils.GetSupabaseDashboardURL(), flags.ProjectRef)
 	fmt.Println("You can inspect your deployment in the Dashboard: " + url)
 	if !prune {
@@ -92,7 +98,7 @@ func GetFunctionSlugs(fsys afero.Fs) (slugs []string, err error) {
 	for slug := range utils.Config.Functions {
 		slugs = append(slugs, slug)
 	}
-	return slugs, nil
+	return utils.RemoveDuplicates(slugs), nil
 }
 
 func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, fsys afero.Fs) (config.FunctionConfig, error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1. If a function dir with index.ts is present on disk but not defined in config.toml, it is still deployed. I assume this isn't expected behavior.
  	To Reproduce:
  	- run: `supabase functions new should-not-upload`
  	- comment out/remove this function's config from config.toml
  	- run: `supabase functions deploy --use-api`
  	- function is still deployed.
 
	<img width="1537" height="471" alt="image" src="https://github.com/user-attachments/assets/110c29c3-9aad-4779-982d-9b906ebd5fbc" />
	
	<img width="1747" height="277" alt="Screenshot from 2026-02-12 03-07-38-final" src="https://github.com/user-attachments/assets/4399443d-3329-4c01-be28-9504dbb84b57" />

 
2. deploy success msg is shown for all function slugs, even the ones which aren't deployed. Also the slugs slice contains duplicates, so does the msg derived from slugs slice
  
	  `should-not-upload` is disabled `functions.should-not-upload.enabled=false` but the deploy success msg still prints this slug and msg contains duplicates.
	  	<img width="1602" height="241" alt="Screenshot from 2026-02-12 01-07-17-final" src="https://github.com/user-attachments/assets/a76a3d85-158d-41e8-9880-966da09984ef" />


## What is the new behavior?

- dont upload functions if not defined in config.toml. `<function>.enabled` behavior remains same.
- dedup slugs returned from `GetFunctionSlugs` and only print deploy success msg for functions actually deployed.
