### PR TITLE
fix: kong stops responding

### DIFF
--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -526,7 +526,6 @@ vector --config /etc/vector/vector.yaml
 					// Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126
 					"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
 					"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
-					"KONG_NGINX_WORKER_PROCESSES=1",
 					// Use modern TLS certificate
 					"KONG_SSL_CERT=/home/kong/localhost.crt",
 					"KONG_SSL_CERT_KEY=/home/kong/localhost.key",


### PR DESCRIPTION
kong easily gets overwhelmed when receiving many requests, resulting in an error complaining about not having enough workers. This was due to KONG_NGINX_WORKER_PROCESSES=1 being set. Kong automatically determines the right number of worker processes (1 per allocated CPU) when this is not specified, which resolves the issue.

## What kind of change does this PR introduce?

Bug fix (removing a bad env var for the Kong container).

## What is the current behavior?

If many parallel requests are made to the Storage API, Kong will quickly stop responding and start terminating socket connections.

## What is the new behavior?

Kong is able to handle many parallel connections without choking.