### PR TITLE
fix(ci): only fail lint on issues in changed code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           args: --timeout 3m --verbose
           version: latest
+          only-new-issues: true
 
   start:
     name: Start


### PR DESCRIPTION
## Summary
Fix go-linter causing issue with warning / error on untouched part of the code.