### PR TITLE
fix(auth): pass GOTRUE_JWT_VALID_METHODS env var for GoTrue compat

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -627,7 +627,9 @@ EOF
 		if keys, err := json.Marshal(utils.Config.Auth.SigningKeys); err == nil {
 			env = append(env, "GOTRUE_JWT_KEYS="+string(keys))
 			// TODO: deprecate HS256 when it's no longer supported
+			// TODO: remove VALIDMETHODS after a while to avoid breaking changes
 			env = append(env, "GOTRUE_JWT_VALIDMETHODS=HS256,RS256,ES256")
+			env = append(env, "GOTRUE_JWT_VALID_METHODS=HS256,RS256,ES256")
 		}
 
 		if utils.Config.Auth.Email.Smtp != nil && utils.Config.Auth.Email.Smtp.Enabled {


### PR DESCRIPTION
the envvar name is updated to be consistent with the rest. (https://github.com/supabase/auth/pull/2334)
for now keeping the deprecated GOTRUE_JWT_VALIDMETHODS for backward compatibility, we can remove it in near future.