### PR TITLE
fix(pull): attempt to fix unkown authority error for db pull

### DIFF
--- a/internal/gen/types/types.go
+++ b/internal/gen/types/types.go
@@ -138,6 +138,8 @@ func isRequireSSL(ctx context.Context, dbUrl string, options ...func(*pgx.ConnCo
 	if os.Getenv("SUPABASE_CA_SKIP_VERIFY") == "true" {
 		opts = append(opts, func(cc *pgx.ConnConfig) {
 			if cc.TLSConfig != nil {
+				// #nosec G402 -- Intentionally skipped for this TLS capability probe only.
+				// Downstream migra/pgdelta flows still validate certificates using GetRootCA.
 				cc.TLSConfig.InsecureSkipVerify = true
 			}
 		})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Attempt to fix the `failed to write startup message (x509: certificate signed by unknown authority)` error on `db pull`.

Underneath error seems to comes from slight differences about how the certificat verify is done.
The certificat validation should be delegated, while it seems to be checked at the point where we check if the connection require ssl or not.