### PR TITLE
fix(updater): network restrictions not enabled

### DIFF
--- a/pkg/config/updater.go
+++ b/pkg/config/updater.go
@@ -107,6 +107,9 @@ func (u *ConfigUpdater) UpdateDbConfig(ctx context.Context, projectRef string, c
 }
 
 func (u *ConfigUpdater) UpdateDbNetworkRestrictionsConfig(ctx context.Context, projectRef string, n networkRestrictions, filter ...func(string) bool) error {
+	if !n.Enabled {
+		return nil
+	}
 	networkRestrictionsConfig, err := u.client.V1GetNetworkRestrictionsWithResponse(ctx, projectRef)
 	if err != nil {
 		return errors.Errorf("failed to read network restrictions config: %w", err)

--- a/pkg/config/updater_test.go
+++ b/pkg/config/updater_test.go
@@ -119,6 +119,41 @@ func TestUpdateDbConfig(t *testing.T) {
 	})
 }
 
+func TestUpdateDbNetworkRestrictionsConfig(t *testing.T) {
+	server := "http://localhost"
+	client, err := v1API.NewClientWithResponses(server)
+	require.NoError(t, err)
+
+	t.Run("skips update if disabled locally", func(t *testing.T) {
+		updater := NewConfigUpdater(*client)
+		// Run test
+		err := updater.UpdateDbNetworkRestrictionsConfig(context.Background(), "test-project", networkRestrictions{})
+		// Check result
+		assert.NoError(t, err)
+		assert.False(t, gock.HasUnmatchedRequest())
+	})
+
+	t.Run("returns error on 400 when enabled locally", func(t *testing.T) {
+		updater := NewConfigUpdater(*client)
+		// Setup mock server
+		defer gock.Off()
+		gock.New(server).
+			Get("/v1/projects/test-project/network-restrictions").
+			Reply(http.StatusBadRequest).
+			JSON(map[string]any{
+				"message": "project not allowed to set up network restrictions",
+			})
+		// Run test
+		err := updater.UpdateDbNetworkRestrictionsConfig(context.Background(), "test-project", networkRestrictions{
+			Enabled: true,
+		})
+		// Check result
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status 400")
+		assert.True(t, gock.IsDone())
+	})
+}
+
 func TestUpdateExperimentalConfig(t *testing.T) {
 	server := "http://localhost"
 	client, err := v1API.NewClientWithResponses(server)


### PR DESCRIPTION
## Summary

Mitigates workflow failures caused by `400` responses from network restrictions endpoints when projects are not entitled to manage restrictions and local config has `db.network_restrictions.enabled = false` or not set.

The fix ensures we only read/update network restrictions when local config explicitly enables the feature, while preserving strict failure behavior when it is enabled.
