### PR TITLE
fix(test): remove orphaned gock mock in TestUpdateRemoteConfig

### DIFF
--- a/pkg/config/updater_test.go
+++ b/pkg/config/updater_test.go
@@ -331,11 +331,6 @@ func TestUpdateRemoteConfig(t *testing.T) {
 			JSON(v1API.PostgresConfigResponse{
 				MaxConnections: cast.Ptr(cast.UintToInt(100)),
 			})
-		// Network config
-		gock.New(server).
-			Get("/v1/projects/test-project/network-restrictions").
-			Reply(http.StatusOK).
-			JSON(v1API.V1GetNetworkRestrictionsResponse{})
 		// Auth config
 		gock.New(server).
 			Get("/v1/projects/test-project/config/auth").


### PR DESCRIPTION
## Summary

`TestUpdateRemoteConfig/updates_all_configs` fails because `gock.IsDone()` returns `false` — a registered mock for `GET /v1/projects/test-project/network-restrictions` is never consumed.

## Root Cause

This is a regression introduced by the interaction of two commits:

1. **`69937e09`** (Dec 2025, PR #4545 — S3 protocol support): Added a gock mock for the network-restrictions endpoint to the "updates all configs" integration test. At the time, `UpdateDbNetworkRestrictionsConfig` made the API call unconditionally, so the mock was always consumed.

2. **`2f6e0c32`** (Feb 2026, PR #4887 — network restrictions safety fix): Added an early-return guard to `UpdateDbNetworkRestrictionsConfig`:
   ```go
   if !n.Enabled {
       return nil
   }
   ```
   This correctly prevents 400 errors on projects without network restrictions entitlements. However, the "updates all configs" test was not updated to account for this new guard. Since the test config does not set `NetworkRestrictions.Enabled = true`, the function now returns early, the HTTP call is never made, and the gock mock is left unconsumed.

## Fix

Remove the orphaned gock mock (5 lines). The test intentionally leaves `NetworkRestrictions.Enabled` at its zero value (`false`), consistent with Auth/Storage/Experimental which are each explicitly set to `Enabled: true` when the test intends to exercise their update paths.

The dedicated `TestUpdateDbNetworkRestrictionsConfig` (also added in PR #4887) already covers both the disabled-skip and enabled-error paths.

## Test plan

- [x] `go test ./config/... -run TestUpdateRemoteConfig -count=1` passes
- [x] Verified the same `TestAuthDiff` failures exist on upstream `develop` (pre-existing, unrelated)