### PR TITLE
fix(functions): forward NPM_AUTH_TOKEN to deploy bundler container

### DIFF
--- a/apps/cli-go/internal/functions/deploy/bundle.go
+++ b/apps/cli-go/internal/functions/deploy/bundle.go
@@ -65,9 +65,7 @@ func (b *dockerBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	if !function.ShouldUsePackageJsonDiscovery(entrypoint, importMap, afero.NewIOFS(b.fsys)) {
 		env = append(env, "DENO_NO_PACKAGE_JSON=1")
 	}
-	if custom_registry := os.Getenv("NPM_CONFIG_REGISTRY"); custom_registry != "" {
-		env = append(env, "NPM_CONFIG_REGISTRY="+custom_registry)
-	}
+	env = append(env, getNpmEnv()...)
 	// Run bundle
 	if err := utils.DockerRunOnceWithConfig(
 		ctx,
@@ -94,6 +92,16 @@ func (b *dockerBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	}
 	defer eszipBytes.Close()
 	return meta, function.Compress(eszipBytes, output)
+}
+
+func getNpmEnv() []string {
+	env := []string{}
+	for _, name := range []string{"NPM_CONFIG_REGISTRY", "NPM_AUTH_TOKEN"} {
+		if value := os.Getenv(name); value != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
 }
 
 func GetBindMounts(cwd, hostFuncDir, hostOutputDir, hostEntrypointPath, hostImportMapPath string, fsys afero.Fs) ([]string, error) {

--- a/apps/cli-go/internal/functions/deploy/bundle_test.go
+++ b/apps/cli-go/internal/functions/deploy/bundle_test.go
@@ -98,3 +98,22 @@ func TestDockerBundle(t *testing.T) {
 		assert.Nil(t, meta.VerifyJwt)
 	})
 }
+
+func TestGetNpmEnv(t *testing.T) {
+	t.Run("forwards configured npm environment", func(t *testing.T) {
+		t.Setenv("NPM_CONFIG_REGISTRY", "https://npm.pkg.github.com")
+		t.Setenv("NPM_AUTH_TOKEN", "test-token")
+
+		assert.Equal(t, []string{
+			"NPM_CONFIG_REGISTRY=https://npm.pkg.github.com",
+			"NPM_AUTH_TOKEN=test-token",
+		}, getNpmEnv())
+	})
+
+	t.Run("skips unset npm environment", func(t *testing.T) {
+		t.Setenv("NPM_CONFIG_REGISTRY", "")
+		t.Setenv("NPM_AUTH_TOKEN", "")
+
+		assert.Empty(t, getNpmEnv())
+	})
+}


### PR DESCRIPTION
## Summary

The Docker bundler for `functions deploy` forwards `NPM_CONFIG_REGISTRY` from the host environment into the container. When `.npmrc` uses `${NPM_AUTH_TOKEN}` for private registry authentication, the token also needs to be available inside that bundler container.

This PR forwards `NPM_AUTH_TOKEN` from the host environment alongside `NPM_CONFIG_REGISTRY`.

Addresses the CI/CD host environment case in #4927.

## Reproduction

| # | Method | Result | Error |
|---|--------|--------|-------|
| 1 | `supabase functions deploy hello` (`.npmrc` with `${NPM_AUTH_TOKEN}`) | **Fail** | `401 unauthenticated` |
| 2 | `NPM_AUTH_TOKEN=xxx supabase functions deploy hello` | **Fail** | `401 unauthenticated` (env not forwarded to container) |
| 3 | `.npmrc` with hardcoded token | **Pass** | - |
| 4 | `NPM_AUTH_TOKEN=xxx` with patched CLI | **Pass** | - |

Tested with a private package (`@addniner/test-private-pkg`) on GitHub Packages, with Docker cache cleared between attempts.

## Testing

- `go test ./internal/functions/deploy`