### PR TITLE
fix(branching): ensure pgmq extension creation syntax is dumped on branch operations

### DIFF
--- a/pkg/migration/drop.go
+++ b/pkg/migration/drop.go
@@ -23,7 +23,6 @@ var (
 		`\_realtime`,
 		`\_supavisor`,
 		"pgbouncer",
-		"pgmq",
 		"pgsodium",
 		"pgtle",
 		`supabase\_migrations`,

--- a/pkg/migration/queries/drop.sql
+++ b/pkg/migration/queries/drop.sql
@@ -7,7 +7,7 @@ begin
     from pg_namespace pn
     left join pg_depend pd on pd.objid = pn.oid
     where pd.deptype is null
-      and not pn.nspname like any(array['information\_schema', 'pg\_%', '\_analytics', '\_realtime', '\_supavisor', 'pgbouncer', 'pgmq', 'pgsodium', 'pgtle', 'supabase\_migrations', 'vault', 'extensions', 'public'])
+      and not pn.nspname like any(array['information\_schema', 'pg\_%', '\_analytics', '\_realtime', '\_supavisor', 'pgbouncer', 'pgsodium', 'pgtle', 'supabase\_migrations', 'vault', 'extensions', 'public'])
       and pn.nspowner::regrole::text != 'supabase_admin'
   loop
     -- If an extension uses a schema it doesn't create, dropping the schema will cascade to also

--- a/pkg/migration/scripts/dump_schema.sh
+++ b/pkg/migration/scripts/dump_schema.sh
@@ -49,7 +49,7 @@ pg_dump \
 | sed -E "s/^REVOKE (.+) ON (.+) \"(${EXCLUDED_SCHEMAS:-})\"/-- &/" \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pg_tle").+/\1;/' \
 | sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgsodium").+/\1;/' \
-| sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgmq").+/\1;/' \
+| sed -E 's/^(CREATE EXTENSION IF NOT EXISTS "pgmq").+/CREATE SCHEMA IF NOT EXISTS "pgmq"; \1 WITH SCHEMA "pgmq";/' \
 | sed -E 's/^COMMENT ON EXTENSION (.+)/-- &/' \
 | sed -E 's/^CREATE POLICY "cron_job_/-- &/' \
 | sed -E 's/^ALTER TABLE "cron"/-- &/' \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #40666 #4492

## What is the current behavior?

1. Currently, `pgmq` queues fail to create during Supabase Branch Resets (producing `schema pgmq does not exist` or `sequence already exists` errors).
2. This is because `pg_dump --schema-only` originally produced a segmentation fault with older versions of `pgmq` (fixed in `tembo-io/pgmq` 1.5.0), leading to it being deliberately excluded in `dump.go` via \#3043.
3. To bypass the fact that `CREATE SCHEMA pgmq` is not emitted due to this exclusion, `dump_schema.sh` attempts to strip the schema requirement from `CREATE EXTENSION IF NOT EXISTS pgmq WITH SCHEMA pgmq`.
4. Without the explict `WITH SCHEMA` definition, the pgmq extension inappropriately initializes into `public` on Branch copies instead of its own schema. This breaks downstream logic, leaving orphaned tables on the branch.
5. Furthermore, `pgmq` is explicitly ignored in `drop.go` / `drop.sql`, resulting in queue tables never actually being wiped when a Branch is Reset.

## What is the new behavior?

1. Modified the sed replacement for `pgmq` inside `dump_schema.sh`. Instead of stripping the schema, it now prepends `CREATE SCHEMA IF NOT EXISTS "pgmq";` and preserves `WITH SCHEMA "pgmq"`. This ensures pgmq is consistently installed in its correct schema during branch creations.
2. Removed `pgmq` from `ManagedSchemas` in `drop.go` and the exclusion array in `drop.sql`. This allows `supabase db reset` and Branch Reset operations to accurately drop and rebuild the `pgmq` schema, clearing the orphaned queue tables and sequences, preventing "already exists" failures during migrations.