### PR TITLE
feat: add SUPABASE_HOSTNAME env var to override local service host

### DIFF
--- a/docs/supabase/start.md
+++ b/docs/supabase/start.md
@@ -9,3 +9,5 @@ All service containers are started by default. You can exclude those not needed 
 > It is recommended to have at least 7GB of RAM to start all services.
 
 Health checks are automatically added to verify the started containers. Use `--ignore-health-check` flag to ignore these errors.
+
+> If the CLI is running inside a dev container with the Docker socket bind-mounted, set the `SUPABASE_SERVICES_HOSTNAME` environment variable to the hostname reachable from inside that container, such as `host.docker.internal`.

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -256,6 +256,12 @@ func ValidateFunctionSlug(slug string) error {
 }
 
 func GetHostname() string {
+	// Overrides the host for local service connections. Useful when
+	// running inside a dev container when the Docker host is not
+	// 127.0.0.1 (container's own loopback).
+	if h := os.Getenv("SUPABASE_SERVICES_HOSTNAME"); h != "" {
+		return h
+	}
 	host := Docker.DaemonHost()
 	if parsed, err := client.ParseHostURL(host); err == nil && parsed.Scheme == "tcp" {
 		if host, _, err := net.SplitHostPort(parsed.Host); err == nil {

--- a/internal/utils/misc_test.go
+++ b/internal/utils/misc_test.go
@@ -157,6 +157,18 @@ func TestAssertProjectRefIsValid(t *testing.T) {
 	})
 }
 
+func TestGetHostname(t *testing.T) {
+	t.Run("returns SUPABASE_SERVICES_HOSTNAME when set", func(t *testing.T) {
+		t.Setenv("SUPABASE_SERVICES_HOSTNAME", "host.docker.internal")
+		assert.Equal(t, "host.docker.internal", GetHostname())
+	})
+
+	t.Run("returns 127.0.0.1 when SUPABASE_SERVICES_HOSTNAME is not set", func(t *testing.T) {
+		t.Setenv("SUPABASE_SERVICES_HOSTNAME", "")
+		assert.Equal(t, "127.0.0.1", GetHostname())
+	})
+}
+
 func TestWriteFile(t *testing.T) {
 	t.Run("writes file with directories", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()


### PR DESCRIPTION
Allows the CLI to work correctly when run inside a dev container with the Docker socket bind-mounted. In that context 127.0.0.1 is the container's own loopback, not the Docker host.

Set `SUPABASE_HOSTNAME=host.docker.internal` to reach sibling containers via Docker Desktop's host gateway without proxying the Docker socket.

---

AI assistance: Claude Sonnet 4.6 in Pi Agent
- Used to find root cause, propose fix options, draft code/test/docs.
- I ran supabase start inside the dev container, confirmed all services healthy, reviewed/edited all code changes/text.

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

If `supbase start` is run from a sibling container (e.g. with /var/run/docker.sock mounted from the host), the command is unable to connect to the those containers after starting them in order to do health checks:
```
$ cli/supabase start
supabase_rest_mal container logs:
10/Mar/2026:16:01:56 +0000: Starting PostgREST 14.5...
10/Mar/2026:16:01:56 +0000: Admin server listening on 0.0.0.0:3001
...
Stopping containers...
failed to execute http request: Head "http://127.0.0.1:54321/rest-admin/v1/ready": dial tcp 127.0.0.1:54321: connect: connection refused
failed to execute http request: Head "http://127.0.0.1:54321/functions/v1/_internal/health": dial tcp 127.0.0.1:54321: connect: connection refused
```

## What is the new behavior?

```
$ SUPABASE_HOSTNAME=host.docker.internal cli/supabase start
Starting containers...
Started supabase local development setup.
...
```
