### PR TITLE
fix: add StartPeriod to storage container health check

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1029,9 +1029,10 @@ EOF
 						"CMD", "wget", "--no-verbose", "--tries=1", "--spider",
 						"http://127.0.0.1:5000/status",
 					},
-					Interval: 10 * time.Second,
-					Timeout:  2 * time.Second,
-					Retries:  3,
+					Interval:    10 * time.Second,
+					Timeout:     2 * time.Second,
+					Retries:     3,
+					StartPeriod: 10 * time.Second,
 				},
 			},
 			container.HostConfig{


### PR DESCRIPTION
## Summary

Fixes #4941

- Adds `StartPeriod: 10 * time.Second` to the storage container's Docker health check config

## Why

Storage-api v1.41.8 (bumped in #4935) added a DB connection pool monitor (`startMonitor`) that can delay readiness on startup. Without a `StartPeriod`, Docker begins counting health check failures immediately from container start. With 10s intervals and 3 retries, the container can be marked `unhealthy` within ~30s — before the pool monitor finishes initializing. This causes ~50% failure rate on ARM CI runners.

## How

`StartPeriod` tells Docker to ignore health check failures during the initial grace window. This is the same pattern already used by Logflare and Mailpit containers in this codebase. During the 10s start period, failed health checks don't count toward the retry limit, giving storage time to fully initialize before Docker starts tracking failures.