### PR TITLE
fix: suggestion to use signing_keys.json

### DIFF
--- a/internal/gen/signingkeys/signingkeys.go
+++ b/internal/gen/signingkeys/signingkeys.go
@@ -120,8 +120,8 @@ To enable JWT signing keys in your local project:
 2. Update your %s with the new keys path
 
 [auth]
-signing_keys_path = "./signing_key.json"
-`, utils.Bold(filepath.Join(utils.SupabaseDirPath, "signing_key.json")), utils.Bold(utils.ConfigPath))
+signing_keys_path = "./signing_keys.json"
+`, utils.Bold(filepath.Join(utils.SupabaseDirPath, "signing_keys.json")), utils.Bold(utils.ConfigPath))
 		return nil
 	}
 


### PR DESCRIPTION
Fixes `gen signing-key` output to suggest `signing_keys.json` (plural) so it matches [`config.toml`](https://github.com/supabase/cli/blob/a743a01cfb7c028105bfb2304cf33d352d876b5a/pkg/config/templates/config.toml#L162)
