### PR TITLE
feat(functions): exposing JWKs as non internal env

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -133,7 +133,7 @@ func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, 
 		"SUPABASE_SERVICE_ROLE_KEY="+utils.Config.Auth.ServiceRoleKey.Value,
 		"SUPABASE_DB_URL="+dbUrl,
 		"SUPABASE_INTERNAL_JWT_SECRET="+utils.Config.Auth.JwtSecret.Value,
-		"SUPABASE_INTERNAL_JWKS="+jwks,
+		"SUPABASE_JWKS="+jwks,
 		fmt.Sprintf("SUPABASE_INTERNAL_HOST_PORT=%d", utils.Config.Api.Port),
 	)
 	if viper.GetBool("DEBUG") {

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -122,7 +122,7 @@ async function isValidLegacyJWT(jwtSecret: string, jwt: string): Promise<boolean
 let jwks = (() => {
   try {
     // using injected JWKS from cli
-    return jose.createLocalJWKSet(JSON.parse(Deno.env.get('SUPABASE_INTERNAL_JWKS')));
+    return jose.createLocalJWKSet(JSON.parse(Deno.env.get('SUPABASE_JWKS')));
   } catch (error) {
     return null
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Previous PR I choose to expose JWKs as `SUPABASE_INTERNAL` prefix

## What is the new behavior?

Better exposing it as non `SUPABASE_INTERNAL`, so it matches the same version as platform, as well makes it available from `UserWorker` environment