### PR TITLE
fix(docker): bump vector from 0.28.1 to 0.53.0 for ARM page size support

### DIFF
--- a/internal/start/templates/vector.yaml
+++ b/internal/start/templates/vector.yaml
@@ -49,10 +49,13 @@ transforms:
           .metadata.request.headers.referer = req.referer
           .metadata.request.headers.user_agent = req.agent
           .metadata.request.headers.cf_connecting_ip = req.client
-          .metadata.request.method = req.method
-          .metadata.request.path = req.path
-          .metadata.request.protocol = req.protocol
           .metadata.response.status_code = req.status
+          url, split_err = split(req.request, " ")
+          if split_err == null {
+              .metadata.request.method = url[0]
+              .metadata.request.path = url[1]
+              .metadata.request.protocol = url[2]
+          }
       }
       if err != null {
         abort
@@ -101,7 +104,7 @@ transforms:
       parsed, err = parse_regex(.event_message, r'^(?P<time>.*): (?P<msg>.*)$')
       if err == null {
           .event_message = parsed.msg
-          .timestamp = to_timestamp!(parsed.time)
+          .timestamp = parse_timestamp!(value: parsed.time, format: "%d/%b/%Y:%H:%M:%S %z")
           .metadata.host = .project
       }
   # Realtime logs are structured so we parse the severity level using regex (ignore time because it has no date)

--- a/pkg/config/templates/Dockerfile
+++ b/pkg/config/templates/Dockerfile
@@ -8,7 +8,7 @@ FROM supabase/postgres-meta:v0.96.1 AS pgmeta
 FROM supabase/studio:2026.03.23-sha-b7847b7 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.73.0 AS edgeruntime
-FROM timberio/vector:0.28.1-alpine AS vector
+FROM timberio/vector:0.53.0-alpine AS vector
 FROM supabase/supavisor:2.7.4 AS supavisor
 FROM supabase/gotrue:v2.188.1 AS gotrue
 FROM supabase/realtime:v2.78.18 AS realtime


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Vector 0.28.1 crashes on ARM Linux systems with non-4KB page sizes (Asahi Linux, CentOS/aarch64, Oracle ARM) due to jemalloc being compiled with a hardcoded 4KB max page size. The container aborts immediately with `Unsupported system page size` before processing any logs.

Closes #4779

## What is the new behavior?

Vector 0.53.0 includes the upstream fix (vectordotdev/vector#18481) which compiles jemalloc with support for pages up to 64KB, covering all common ARM configurations. Two VRL breaking changes in the vector.yaml config are also updated:
- `parse_nginx_log` no longer returns `method`/`path`/`protocol` as separate fields; split `req.request` instead
- `to_timestamp!` removed; replaced with `parse_timestamp!` using explicit format

Changes match the self-hosted fix in supabase/supabase#42525.

## Additional context

Requires running the **Mirror Dependencies** workflow to publish `timberio/vector:0.53.0-alpine` to `public.ecr.aws/supabase` before merging.
