### PR TITLE
fix(analytics): wait for logflare before starting vector

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -392,9 +392,11 @@ EOF
 			container.Config{
 				Image: utils.Config.Analytics.VectorImage,
 				Env:   env,
-				Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /etc/vector/vector.yaml && vector --config /etc/vector/vector.yaml
+				Entrypoint: []string{"sh", "-c", `cat <<'EOF' > /etc/vector/vector.yaml
 ` + vectorConfigBuf.String() + `
 EOF
+until wget --no-verbose --tries=1 --spider http://` + utils.LogflareId + `:4000/health 2>/dev/null; do sleep 2; done
+vector --config /etc/vector/vector.yaml
 `},
 				Healthcheck: &container.HealthConfig{
 					Test: []string{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Vector starts before Logflare is ready to accept requests. During startup, Logflare returns 401 Unauthorized while its auth is still initializing. Vector treats 401 as a non-retriable client error (hardcoded in Vector's HTTP retry logic — only 408, 429, and 5xx are retried) and permanently drops those log batches. This results in missing startup logs in Studio and noisy error output in Vector's container logs.

## What is the new behavior?

Vector's entrypoint now polls Logflare's health endpoint (`/health`) every 2 seconds before starting. Vector only launches once Logflare is confirmed ready, eliminating the 401 errors and ensuring all logs are delivered from the moment Vector starts collecting.

Tested locally — before: 37 x 401 errors, after: 0.

## Additional context

Vector's HTTP sink retry logic is hardcoded and not configurable — 401 will never be retried regardless of `retry_max_duration_secs`. The wait loop uses `wget` which is already available in the Vector Alpine image (used by its own healthcheck).
