### PR TITLE
fix(functions): reload kong after edge runtime restart

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -117,7 +117,14 @@ func restartEdgeRuntime(ctx context.Context, envFilePath string, noVerifyJWT *bo
 	dbUrl := fmt.Sprintf("postgresql://postgres:postgres@%s:5432/postgres", utils.DbAliases[0])
 	// 3. Serve and log to console
 	fmt.Fprintln(os.Stderr, "Setting up Edge Functions runtime...")
-	return ServeFunctions(ctx, envFilePath, noVerifyJWT, importMapPath, dbUrl, runtimeOption, fsys)
+	if err := ServeFunctions(ctx, envFilePath, noVerifyJWT, importMapPath, dbUrl, runtimeOption, fsys); err != nil {
+		return err
+	}
+	// 4. Reload Kong to refresh DNS cache for the new Edge Runtime container IP.
+	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload"}, os.Stderr, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "Warning: failed to reload Kong:", err)
+	}
+	return nil
 }
 
 func ServeFunctions(ctx context.Context, envFilePath string, noVerifyJWT *bool, importMapPath string, dbUrl string, runtimeOption RuntimeOption, fsys afero.Fs) error {

--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -45,6 +45,18 @@ func TestServeCommand(t *testing.T) {
 			Reply(http.StatusOK)
 		apitest.MockDockerStart(utils.Docker, utils.GetRegistryImageUrl(utils.Config.EdgeRuntime.Image), containerId)
 		require.NoError(t, apitest.MockDockerLogsStream(utils.Docker, containerId, 1, strings.NewReader("failed")))
+		// Mock kong reload after edge runtime restart
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/supabase_kong_test/exec").
+			Reply(http.StatusOK).
+			JSON(container.ExecCreateResponse{ID: "kong-reload"})
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/exec/kong-reload/start").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/exec/kong-reload/json").
+			Reply(http.StatusOK).
+			JSON(container.ExecInspect{ExitCode: 0})
 		// Run test with timeout context
 		err := Run(context.Background(), "", nil, "", RuntimeOption{}, fsys)
 		// Check error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After `supabase functions serve` restarts the Edge Runtime container (on file change or initial serve), Kong's DNS cache still points to the old container IP, causing 502 errors on `/functions/v1/*` endpoints.

closes #4757

## What is the new behavior?

Runs `kong reload` after each Edge Runtime restart to flush DNS cache and resolve the new container IP.

## Additional context

The reload is non-disruptive. Kong flushes DNS without dropping in-flight connections. If the reload fails, a warning is printed to stderr and execution continues.

