### PR TITLE
fix(functions): support `--all` flag to download all functions

### DIFF
--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -53,7 +53,7 @@ var (
 				useDocker = false
 			}
 			slug := ""
-			if len(args) > 0 {
+			if len(args) > 0 && !downloadAll {
 				slug = args[0]
 			}
 			return download.Run(cmd.Context(), slug, flags.ProjectRef, useLegacyBundle, useDocker, afero.NewOsFs())

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -46,19 +46,15 @@ var (
 	functionsDownloadCmd = &cobra.Command{
 		Use:   "download [Function name]",
 		Short: "Download a Function from Supabase",
-		Long:  "Download the source code for a Function from the linked Supabase project. Use --all to download all functions at once.",
+		Long:  "Download the source code for a Function from the linked Supabase project. If no function name is provided, or if --all is used, downloads all functions.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if useApi {
 				useDocker = false
 			}
 			slug := ""
-			if downloadAll {
-				slug = ""
-			} else if len(args) > 0 {
+			if len(args) > 0 {
 				slug = args[0]
-			} else {
-				return errors.New("Function name is required. Use --all to download all functions.")
 			}
 			return download.Run(cmd.Context(), slug, flags.ProjectRef, useLegacyBundle, useDocker, afero.NewOsFs())
 		},

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -46,15 +46,19 @@ var (
 	functionsDownloadCmd = &cobra.Command{
 		Use:   "download [Function name]",
 		Short: "Download a Function from Supabase",
-		Long:  "Download the source code for a Function from the linked Supabase project. If no function name is provided, downloads all functions.",
+		Long:  "Download the source code for a Function from the linked Supabase project. Use --all to download all functions at once.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if useApi {
 				useDocker = false
 			}
 			slug := ""
-			if len(args) > 0 {
+			if downloadAll {
+				slug = ""
+			} else if len(args) > 0 {
 				slug = args[0]
+			} else {
+				return errors.New("Function name is required. Use --all to download all functions.")
 			}
 			return download.Run(cmd.Context(), slug, flags.ProjectRef, useLegacyBundle, useDocker, afero.NewOsFs())
 		},
@@ -63,6 +67,7 @@ var (
 	useApi          bool
 	useDocker       bool
 	useLegacyBundle bool
+	downloadAll     bool
 	noVerifyJWT     = new(bool)
 	importMapPath   string
 	prune           bool


### PR DESCRIPTION
Previously, the command `supabase functions download --all` won't work, most of cli tools use the `--all` flag to do all, so I added it
Closes #5004 