### PR TITLE
feat: add request-transformer plugin to modify Host header

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -238,3 +238,11 @@ services:
           - /mcp
     plugins:
       - name: cors
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Host: localhost"
+          replace:
+            headers:
+              - "Host: localhost"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, When using Repairkong to proxy /api/mcp, NextJS cannot access domains containing only underscores.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
