### PR TITLE
fix(diff): migra js OOM error

### DIFF
--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -23,10 +23,6 @@ var (
 	//go:embed templates/migra.ts
 	diffSchemaTypeScript string
 
-	// Allow a larger V8 heap for large schema diffs executed inside edge-runtime.
-	// The default heap has proven too small for some user projects.
-	migraV8Flags = "--max-old-space-size=4096"
-
 	managedSchemas = []string{
 		// Local development
 		"_analytics",
@@ -114,7 +110,6 @@ func DiffSchemaMigra(ctx context.Context, source, target pgconn.Config, schema [
 	env := []string{
 		"SOURCE=" + utils.ToPostgresURL(source),
 		"TARGET=" + utils.ToPostgresURL(target),
-		"V8_FLAGS=" + migraV8Flags,
 	}
 	debugf := func(string, ...any) {}
 	if types.IsSSLDebugEnabled() {

--- a/internal/db/diff/migra.go
+++ b/internal/db/diff/migra.go
@@ -23,6 +23,10 @@ var (
 	//go:embed templates/migra.ts
 	diffSchemaTypeScript string
 
+	// Allow a larger V8 heap for large schema diffs executed inside edge-runtime.
+	// The default heap has proven too small for some user projects.
+	migraV8Flags = "--max-old-space-size=4096"
+
 	managedSchemas = []string{
 		// Local development
 		"_analytics",
@@ -110,6 +114,7 @@ func DiffSchemaMigra(ctx context.Context, source, target pgconn.Config, schema [
 	env := []string{
 		"SOURCE=" + utils.ToPostgresURL(source),
 		"TARGET=" + utils.ToPostgresURL(target),
+		"V8_FLAGS=" + migraV8Flags,
 	}
 	debugf := func(string, ...any) {}
 	if types.IsSSLDebugEnabled() {
@@ -143,7 +148,20 @@ func DiffSchemaMigra(ctx context.Context, source, target pgconn.Config, schema [
 	binds := []string{utils.EdgeRuntimeId + ":/root/.cache/deno:rw"}
 	var stdout, stderr bytes.Buffer
 	if err := utils.RunEdgeRuntimeScript(ctx, env, diffSchemaTypeScript, binds, "error diffing schema", &stdout, &stderr); err != nil {
+		if shouldFallbackToLegacyMigra(err) {
+			debugf("DiffSchemaMigra falling back to legacy migra after edge-runtime OOM")
+			return DiffSchemaMigraBash(ctx, source, target, schema, options...)
+		}
 		return "", err
 	}
 	return stdout.String(), nil
+}
+
+func shouldFallbackToLegacyMigra(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "Fatal JavaScript out of memory") ||
+		strings.Contains(message, "Ineffective mark-compacts near heap limit")
 }

--- a/internal/utils/edgeruntime.go
+++ b/internal/utils/edgeruntime.go
@@ -38,7 +38,7 @@ EOF
 		"",
 		stdout,
 		stderr,
-	); err != nil && !strings.HasPrefix(stderr.String(), "main worker has been destroyed") {
+	); err != nil && !strings.Contains(stderr.String(), "main worker has been destroyed") {
 		return errors.Errorf("%s: %w:\n%s", errPrefix, err, stderr.String())
 	}
 	return nil


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes a regression we had since `2.52.5` when migrating to pgkit/edge-runtime diff for larges database schemas. It caused OOM error with migra:

```
error diffing schema: error running container: exit 133:                                                                                                                                                   
                                                                                                                                                                                                           
<--- Last few GCs --->                                                                                                                                                                                     
                                                                                                                                                                                                           
[8:0xffff7cde0000]     9024 ms: Mark-Compact 1400.7 (1404.7) -> 1399.4 (1405.4) MB, pooled: 0 MB, 458.71 / 0.00 ms  (average mu = 0.057, current mu = 0.004) allocation failure; scavenge might not succeed
                                                                                                                                                                                                           
                                                                                                                                                                                                           
<--- JS stacktrace --->                                                                                                                                                                                    
                                                                                                                                                                                                           
                                                                                                                                                                                                           
                                                                                                                                                                                                           
#                                                                                                                                                                                                          
# Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit                                                                                                                                
#                                                                                                                                                                                                          
==== C stack trace ===============================                                                                                                                                                         
                                                                                                                                                                                                           
    edge-runtime(+0x3ef4710) [0xaaaad8bc4710]                                                                                                                                                              
    edge-runtime(+0x35a235c) [0xaaaad827235c]                                                                                                                                                              
    edge-runtime(+0x359f6c4) [0xaaaad826f6c4]                                                                                                                                                              
    edge-runtime(+0x35d306c) [0xaaaad82a306c]                                                                                                                                                              
    edge-runtime(+0x36e3e90) [0xaaaad83b3e90]                                                                                                                                                              
    edge-runtime(+0x36f52b0) [0xaaaad83c52b0]                                                                                                                                                              
    edge-runtime(+0x36f4ae0) [0xaaaad83c4ae0]                                                                                                                                                              
    edge-runtime(+0x3b89ea8) [0xaaaad8859ea8]                                                                                                                                                              
Trace/breakpoint trap
```



To mitigate this issue, I added a fallback to use the Bash/python approach if this OOM error occurs with the JS wrapper.