### PR TITLE
feat(telemetry): stitch CLI identity from API response header

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,6 +140,15 @@ var (
 			} else {
 				ctx = telemetry.WithService(ctx, service)
 			}
+			if service != nil {
+				utils.OnGotrueID = func(gotrueID string) {
+					if service.NeedsIdentityStitch() {
+						if err := service.StitchLogin(gotrueID); err != nil {
+							fmt.Fprintln(utils.GetDebugLogger(), err)
+						}
+					}
+				}
+			}
 			ctx = telemetry.WithCommandContext(ctx, commandAnalyticsContext(cmd))
 			cmd.SetContext(ctx)
 			// Setup sentry last to ignore errors from parsing cli flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -141,11 +142,14 @@ var (
 				ctx = telemetry.WithService(ctx, service)
 			}
 			if service != nil {
+				var stitchOnce sync.Once
 				utils.OnGotrueID = func(gotrueID string) {
 					if service.NeedsIdentityStitch() {
-						if err := service.StitchLogin(gotrueID); err != nil {
-							fmt.Fprintln(utils.GetDebugLogger(), err)
-						}
+						stitchOnce.Do(func() {
+							if err := service.StitchLogin(gotrueID); err != nil {
+								fmt.Fprintln(utils.GetDebugLogger(), err)
+							}
+						})
 					}
 				}
 			}

--- a/internal/telemetry/service.go
+++ b/internal/telemetry/service.go
@@ -153,6 +153,10 @@ func (s *Service) ClearDistinctID() error {
 	return SaveState(s.state, s.fsys)
 }
 
+func (s *Service) NeedsIdentityStitch() bool {
+	return s != nil && s.state.DistinctID == "" && s.canSend()
+}
+
 func (s *Service) GroupIdentify(groupType string, groupKey string, properties map[string]any) error {
 	if !s.canSend() {
 		return nil

--- a/internal/telemetry/service_test.go
+++ b/internal/telemetry/service_test.go
@@ -213,6 +213,28 @@ func TestServiceCaptureIncludesLinkedProjectGroups(t *testing.T) {
 	}, analytics.captures[0].groups)
 }
 
+func TestServiceNeedsIdentityStitch(t *testing.T) {
+	now := time.Date(2026, time.April, 1, 12, 0, 0, 0, time.UTC)
+	t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
+	fsys := afero.NewMemMapFs()
+	analytics := &fakeAnalytics{enabled: true}
+
+	service, err := NewService(fsys, Options{
+		Analytics: analytics,
+		Now:       func() time.Time { return now },
+	})
+	require.NoError(t, err)
+
+	t.Run("true when DistinctID is empty", func(t *testing.T) {
+		assert.True(t, service.NeedsIdentityStitch())
+	})
+
+	t.Run("false after StitchLogin", func(t *testing.T) {
+		require.NoError(t, service.StitchLogin("user-123"))
+		assert.False(t, service.NeedsIdentityStitch())
+	})
+}
+
 func TestServiceCaptureHonorsConsentAndEnvOptOut(t *testing.T) {
 	now := time.Date(2026, time.April, 1, 12, 0, 0, 0, time.UTC)
 

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -21,6 +21,8 @@ const (
 	DNS_OVER_HTTPS = "https"
 )
 
+var OnGotrueID func(string)
+
 var (
 	clientOnce sync.Once
 	apiClient  *supabase.ClientWithResponses
@@ -123,8 +125,13 @@ func GetSupabase() *supabase.ClientWithResponses {
 		if t, ok := http.DefaultTransport.(*http.Transport); ok {
 			t.DialContext = withFallbackDNS(t.DialContext)
 		}
+		transport := &identityTransport{
+			RoundTripper: http.DefaultTransport,
+			onGotrueID:   OnGotrueID,
+		}
 		apiClient, err = supabase.NewClientWithResponses(
 			GetSupabaseAPIHost(),
+			supabase.WithHTTPClient(&http.Client{Transport: transport}),
 			supabase.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 				req.Header.Set("Authorization", "Bearer "+token)
 				req.Header.Set("User-Agent", "SupabaseCLI/"+Version)

--- a/internal/utils/api.go
+++ b/internal/utils/api.go
@@ -127,7 +127,7 @@ func GetSupabase() *supabase.ClientWithResponses {
 		}
 		transport := &identityTransport{
 			RoundTripper: http.DefaultTransport,
-			onGotrueID:   OnGotrueID,
+			onGotrueID:   &OnGotrueID,
 		}
 		apiClient, err = supabase.NewClientWithResponses(
 			GetSupabaseAPIHost(),

--- a/internal/utils/identity_transport.go
+++ b/internal/utils/identity_transport.go
@@ -6,7 +6,7 @@ const HeaderGotrueID = "X-Gotrue-Id"
 
 type identityTransport struct {
 	http.RoundTripper
-	onGotrueID func(string)
+	onGotrueID *func(string)
 }
 
 func (t *identityTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -14,8 +14,8 @@ func (t *identityTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	if err != nil {
 		return resp, err
 	}
-	if id := resp.Header.Get(HeaderGotrueID); id != "" && t.onGotrueID != nil {
-		t.onGotrueID(id)
+	if id := resp.Header.Get(HeaderGotrueID); id != "" && t.onGotrueID != nil && *t.onGotrueID != nil {
+		(*t.onGotrueID)(id)
 	}
 	return resp, err
 }

--- a/internal/utils/identity_transport.go
+++ b/internal/utils/identity_transport.go
@@ -1,0 +1,21 @@
+package utils
+
+import "net/http"
+
+const HeaderGotrueId = "X-Gotrue-Id"
+
+type identityTransport struct {
+	http.RoundTripper
+	onGotrueID func(string)
+}
+
+func (t *identityTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if id := resp.Header.Get(HeaderGotrueId); id != "" && t.onGotrueID != nil {
+		t.onGotrueID(id)
+	}
+	return resp, err
+}

--- a/internal/utils/identity_transport.go
+++ b/internal/utils/identity_transport.go
@@ -2,7 +2,7 @@ package utils
 
 import "net/http"
 
-const HeaderGotrueId = "X-Gotrue-Id"
+const HeaderGotrueID = "X-Gotrue-Id"
 
 type identityTransport struct {
 	http.RoundTripper
@@ -14,7 +14,7 @@ func (t *identityTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	if err != nil {
 		return resp, err
 	}
-	if id := resp.Header.Get(HeaderGotrueId); id != "" && t.onGotrueID != nil {
+	if id := resp.Header.Get(HeaderGotrueID); id != "" && t.onGotrueID != nil {
 		t.onGotrueID(id)
 	}
 	return resp, err

--- a/internal/utils/identity_transport_test.go
+++ b/internal/utils/identity_transport_test.go
@@ -42,6 +42,37 @@ func TestIdentityTransport_IgnoresWhenHeaderMissing(t *testing.T) {
 	assert.Empty(t, captured)
 }
 
+func TestIdentityTransport_NilCallbackDoesNotPanic(t *testing.T) {
+	transport := &identityTransport{
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Gotrue-Id": []string{"user-abc-123"}},
+			}, nil
+		}),
+		onGotrueID: nil,
+	}
+	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestIdentityTransport_InnerTransportError(t *testing.T) {
+	var captured string
+	transport := &identityTransport{
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, assert.AnError
+		}),
+		onGotrueID: func(id string) { captured = id },
+	}
+	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
+	resp, err := transport.RoundTrip(req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Empty(t, captured)
+}
+
 // roundTripFunc is a test helper to create inline RoundTrippers.
 type roundTripFunc func(*http.Request) (*http.Response, error)
 

--- a/internal/utils/identity_transport_test.go
+++ b/internal/utils/identity_transport_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestIdentityTransport_CapturesGotrueIdHeader(t *testing.T) {
 	var captured string
+	cb := func(id string) { captured = id }
 	transport := &identityTransport{
 		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -16,7 +17,7 @@ func TestIdentityTransport_CapturesGotrueIdHeader(t *testing.T) {
 				Header:     http.Header{"X-Gotrue-Id": []string{"user-abc-123"}},
 			}, nil
 		}),
-		onGotrueID: func(id string) { captured = id },
+		onGotrueID: &cb,
 	}
 	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
 	resp, err := transport.RoundTrip(req)
@@ -27,6 +28,7 @@ func TestIdentityTransport_CapturesGotrueIdHeader(t *testing.T) {
 
 func TestIdentityTransport_IgnoresWhenHeaderMissing(t *testing.T) {
 	var captured string
+	cb := func(id string) { captured = id }
 	transport := &identityTransport{
 		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -34,7 +36,7 @@ func TestIdentityTransport_IgnoresWhenHeaderMissing(t *testing.T) {
 				Header:     http.Header{},
 			}, nil
 		}),
-		onGotrueID: func(id string) { captured = id },
+		onGotrueID: &cb,
 	}
 	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
 	_, err := transport.RoundTrip(req)
@@ -58,13 +60,31 @@ func TestIdentityTransport_NilCallbackDoesNotPanic(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 }
 
+func TestIdentityTransport_NilFuncBehindPointerDoesNotPanic(t *testing.T) {
+	var cb func(string) // nil func
+	transport := &identityTransport{
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Gotrue-Id": []string{"user-abc-123"}},
+			}, nil
+		}),
+		onGotrueID: &cb,
+	}
+	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
 func TestIdentityTransport_InnerTransportError(t *testing.T) {
 	var captured string
+	cb := func(id string) { captured = id }
 	transport := &identityTransport{
 		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return nil, assert.AnError
 		}),
-		onGotrueID: func(id string) { captured = id },
+		onGotrueID: &cb,
 	}
 	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
 	resp, err := transport.RoundTrip(req)

--- a/internal/utils/identity_transport_test.go
+++ b/internal/utils/identity_transport_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentityTransport_CapturesGotrueIdHeader(t *testing.T) {
+	var captured string
+	transport := &identityTransport{
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"X-Gotrue-Id": []string{"user-abc-123"}},
+			}, nil
+		}),
+		onGotrueID: func(id string) { captured = id },
+	}
+	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "user-abc-123", captured)
+}
+
+func TestIdentityTransport_IgnoresWhenHeaderMissing(t *testing.T) {
+	var captured string
+	transport := &identityTransport{
+		RoundTripper: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+			}, nil
+		}),
+		onGotrueID: func(id string) { captured = id },
+	}
+	req, _ := http.NewRequest("GET", "https://api.supabase.io/v1/projects", nil)
+	_, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Empty(t, captured)
+}
+
+// roundTripFunc is a test helper to create inline RoundTrippers.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary

- Adds an `identityTransport` RoundTripper that reads `X-Gotrue-Id` from management API response headers
- When the header is present and the device hasn't been identified yet, calls existing `StitchLogin()` to link `device_id` → `gotrue_id` in PostHog
- One-time per device, cached in `telemetry.json` after first stitch

**Companion PR:** supabase/platform#31378 — platform-side interceptor that sets the `X-Gotrue-Id` response header. Safe to merge in either order; without the header, this change is a transparent no-op.

**Context:** [GROWTH-756](https://linear.app/supabase/issue/GROWTH-756/cli-telemetry-send-dollaridentify-with-gotrue-id-for-token-based-auth) — ~89% of CLI devices are anonymous. CLI tokens are opaque (`sbp_*`), so `gotrue_id` can't be extracted locally. This piggybacks on existing API calls to passively resolve identity, taking coverage from 11% → ~85%.

## Test plan

- [ ] `go test ./internal/utils/ -run TestIdentityTransport -v` — transport captures header when present, ignores when absent
- [ ] `go test ./internal/telemetry/ -run TestServiceNeedsIdentityStitch -v` — returns true when DistinctID empty, false after stitch
- [ ] `go test ./...` — no regressions
- [ ] Manual: run any authenticated command with `DEBUG=true` — confirms no errors (header not present yet, so no stitch attempt)