### PR TITLE
fix(docker): force client.DefaultDockerHost for supabase start when using colima

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -382,7 +382,7 @@ EOF
 			} else if strings.HasSuffix(parsed.Host, "/.docker/run/docker.sock") ||
 				strings.HasSuffix(parsed.Host, "/.docker/desktop/docker.sock") ||
 				strings.Contains(parsed.Host, "/.colima/") {
-				// Docker will not mount rootless socket directly;
+				// Docker Desktop and Colima will not mount rootless socket directly;
 				// instead, specify root socket to have it handled under the hood
 				binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:ro", dindHost.Host))
 			} else {

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -381,7 +381,8 @@ EOF
 				return errors.Errorf("failed to parse default host: %w", err)
 			} else if strings.HasSuffix(parsed.Host, "/.docker/run/docker.sock") ||
 				strings.HasSuffix(parsed.Host, "/.docker/desktop/docker.sock") ||
-				strings.Contains(parsed.Host, "/.colima/") {
+				strings.HasSuffix(parsed.Host, "/.colima/default/docker.sock") ||
+				strings.HasSuffix(parsed.Host, "/.colima/docker.sock") {
 				// Docker Desktop and Colima will not mount rootless socket directly;
 				// instead, specify root socket to have it handled under the hood
 				binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:ro", dindHost.Host))

--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -380,7 +380,8 @@ EOF
 			if dindHost, err = client.ParseHostURL(client.DefaultDockerHost); err != nil {
 				return errors.Errorf("failed to parse default host: %w", err)
 			} else if strings.HasSuffix(parsed.Host, "/.docker/run/docker.sock") ||
-				strings.HasSuffix(parsed.Host, "/.docker/desktop/docker.sock") {
+				strings.HasSuffix(parsed.Host, "/.docker/desktop/docker.sock") ||
+				strings.Contains(parsed.Host, "/.colima/") {
 				// Docker will not mount rootless socket directly;
 				// instead, specify root socket to have it handled under the hood
 				binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:ro", dindHost.Host))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

#5073

## What is the new behavior?

Force the use of client.DefaultDockerHost when running supabase start with colima
