### PR TITLE
feat(telemetry): attach org/project groups to all CLI events

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,6 +173,7 @@ func Execute() {
 	executedCmd, err := rootCmd.ExecuteC()
 	if executedCmd != nil {
 		if service := telemetry.FromContext(executedCmd.Context()); service != nil {
+			telemetry.EnsureProjectGroupsCached(executedCmd.Context(), flags.ProjectRef, afero.NewOsFs())
 			_ = service.Capture(executedCmd.Context(), telemetry.EventCommandExecuted, map[string]any{
 				telemetry.PropExitCode:   exitCode(err),
 				telemetry.PropDurationMs: time.Since(startedAt).Milliseconds(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,7 @@ func Execute() {
 	executedCmd, err := rootCmd.ExecuteC()
 	if executedCmd != nil {
 		if service := telemetry.FromContext(executedCmd.Context()); service != nil {
-			telemetry.EnsureProjectGroupsCached(executedCmd.Context(), flags.ProjectRef, afero.NewOsFs())
+			ensureProjectGroupsCached(executedCmd.Context(), service)
 			_ = service.Capture(executedCmd.Context(), telemetry.EventCommandExecuted, map[string]any{
 				telemetry.PropExitCode:   exitCode(err),
 				telemetry.PropDurationMs: time.Since(startedAt).Milliseconds(),
@@ -199,6 +199,35 @@ func Execute() {
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
 	}
+}
+
+// ensureProjectGroupsCached populates the telemetry linked-project cache when
+// a project ref is available but no cache exists. This ensures org/project
+// PostHog groups are attached to all CLI events, not just those after `supabase link`.
+//
+// Does not overwrite an existing cache — `supabase link` is the authoritative source.
+// Checks auth before calling the API to avoid the log.Fatalln in GetSupabase().
+func ensureProjectGroupsCached(ctx context.Context, service *telemetry.Service) {
+	ref := flags.ProjectRef
+	if ref == "" {
+		return
+	}
+	fsys := afero.NewOsFs()
+	if telemetry.HasLinkedProject(fsys) {
+		return
+	}
+	if _, err := utils.LoadAccessTokenFS(fsys); err != nil {
+		return
+	}
+	resp, err := utils.GetSupabase().V1GetProjectWithResponse(ctx, ref)
+	if err != nil {
+		fmt.Fprintln(utils.GetDebugLogger(), err)
+		return
+	}
+	if resp.JSON200 == nil {
+		return
+	}
+	telemetry.CacheProjectAndIdentifyGroups(*resp.JSON200, service, fsys)
 }
 
 func exitCode(err error) int {

--- a/internal/telemetry/project.go
+++ b/internal/telemetry/project.go
@@ -1,7 +1,9 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -46,6 +48,33 @@ func LoadLinkedProject(fsys afero.Fs) (LinkedProject, error) {
 		return LinkedProject{}, errors.Errorf("failed to parse linked project: %w", err)
 	}
 	return linked, nil
+}
+
+// EnsureProjectGroupsCached fetches project metadata from the API and caches it
+// in linked-project.json when a project ref is available but no matching cache
+// exists. This ensures linkedProjectGroups returns org/project groups for all
+// events, not just those fired after `supabase link`.
+//
+// Best-effort: silently returns on any error so telemetry never breaks commands.
+func EnsureProjectGroupsCached(ctx context.Context, projectRef string, fsys afero.Fs) {
+	if projectRef == "" {
+		return
+	}
+	// Already cached and matches current ref? Nothing to do.
+	if existing, err := LoadLinkedProject(fsys); err == nil && existing.Ref == projectRef {
+		return
+	}
+	resp, err := utils.GetSupabase().V1GetProjectWithResponse(ctx, projectRef)
+	if err != nil {
+		fmt.Fprintln(utils.GetDebugLogger(), err)
+		return
+	}
+	if resp.JSON200 == nil {
+		return
+	}
+	if err := SaveLinkedProject(*resp.JSON200, fsys); err != nil {
+		fmt.Fprintln(utils.GetDebugLogger(), err)
+	}
 }
 
 func linkedProjectGroups(fsys afero.Fs) map[string]string {

--- a/internal/telemetry/project.go
+++ b/internal/telemetry/project.go
@@ -1,7 +1,6 @@
 package telemetry
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -50,30 +49,41 @@ func LoadLinkedProject(fsys afero.Fs) (LinkedProject, error) {
 	return linked, nil
 }
 
-// EnsureProjectGroupsCached fetches project metadata from the API and caches it
-// in linked-project.json when a project ref is available but no matching cache
-// exists. This ensures linkedProjectGroups returns org/project groups for all
-// events, not just those fired after `supabase link`.
+// HasLinkedProject reports whether a cached linked-project.json exists.
+func HasLinkedProject(fsys afero.Fs) bool {
+	_, err := LoadLinkedProject(fsys)
+	return err == nil
+}
+
+// CacheProjectAndIdentifyGroups writes project metadata to linked-project.json
+// and fires GroupIdentify for the org and project so PostHog has group metadata.
+// This matches the behavior of the `supabase link` flow.
 //
-// Best-effort: silently returns on any error so telemetry never breaks commands.
-func EnsureProjectGroupsCached(ctx context.Context, projectRef string, fsys afero.Fs) {
-	if projectRef == "" {
-		return
-	}
-	// Already cached and matches current ref? Nothing to do.
-	if existing, err := LoadLinkedProject(fsys); err == nil && existing.Ref == projectRef {
-		return
-	}
-	resp, err := utils.GetSupabase().V1GetProjectWithResponse(ctx, projectRef)
-	if err != nil {
+// The caller is responsible for fetching the project from the API and checking
+// auth — this function only handles caching and PostHog group identification.
+//
+// Best-effort: logs errors to debug output, never returns them.
+func CacheProjectAndIdentifyGroups(project api.V1ProjectWithDatabaseResponse, service *Service, fsys afero.Fs) {
+	if err := SaveLinkedProject(project, fsys); err != nil {
 		fmt.Fprintln(utils.GetDebugLogger(), err)
+	}
+	if service == nil {
 		return
 	}
-	if resp.JSON200 == nil {
-		return
+	if project.OrganizationId != "" {
+		if err := service.GroupIdentify(GroupOrganization, project.OrganizationId, map[string]any{
+			"organization_slug": project.OrganizationSlug,
+		}); err != nil {
+			fmt.Fprintln(utils.GetDebugLogger(), err)
+		}
 	}
-	if err := SaveLinkedProject(*resp.JSON200, fsys); err != nil {
-		fmt.Fprintln(utils.GetDebugLogger(), err)
+	if project.Ref != "" {
+		if err := service.GroupIdentify(GroupProject, project.Ref, map[string]any{
+			"name":              project.Name,
+			"organization_slug": project.OrganizationSlug,
+		}); err != nil {
+			fmt.Fprintln(utils.GetDebugLogger(), err)
+		}
 	}
 }
 

--- a/internal/telemetry/project_test.go
+++ b/internal/telemetry/project_test.go
@@ -1,128 +1,107 @@
 package telemetry
 
 import (
-	"context"
-	"net/http"
 	"testing"
+	"time"
 
-	"github.com/h2non/gock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/supabase/cli/internal/testing/apitest"
-	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
 
-func TestEnsureProjectGroupsCached(t *testing.T) {
+var testProject = api.V1ProjectWithDatabaseResponse{
+	Ref:              "proj_abc",
+	Name:             "My Project",
+	OrganizationId:   "org_123",
+	OrganizationSlug: "acme",
+}
+
+func newTestService(t *testing.T, fsys afero.Fs, analytics *fakeAnalytics) *Service {
+	t.Helper()
+	service, err := NewService(fsys, Options{
+		Analytics: analytics,
+		Now:       func() time.Time { return time.Date(2026, time.April, 15, 12, 0, 0, 0, time.UTC) },
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func TestHasLinkedProject(t *testing.T) {
 	t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
 
-	projectJSON := map[string]interface{}{
-		"ref":               "proj_abc",
-		"organization_id":   "org_123",
-		"organization_slug": "acme",
-		"name":              "My Project",
-		"region":            "us-east-1",
-		"created_at":        "2024-01-01T00:00:00Z",
-		"status":            "ACTIVE_HEALTHY",
-		"database":          map[string]interface{}{"host": "db.example.supabase.co", "version": "15.1.0.117"},
-	}
-
-	t.Run("skips when project ref is empty", func(t *testing.T) {
+	t.Run("false when no cache", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		EnsureProjectGroupsCached(context.Background(), "", fsys)
-		_, err := LoadLinkedProject(fsys)
-		assert.Error(t, err)
+		assert.False(t, HasLinkedProject(fsys))
 	})
 
-	t.Run("skips when cache already matches", func(t *testing.T) {
+	t.Run("true when cache exists", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
-			Ref:              "proj_abc",
-			Name:             "My Project",
-			OrganizationId:   "org_123",
-			OrganizationSlug: "acme",
-		}, fsys))
-		// No gock mocks — any API call would panic
-		EnsureProjectGroupsCached(context.Background(), "proj_abc", fsys)
-		linked, err := LoadLinkedProject(fsys)
-		require.NoError(t, err)
-		assert.Equal(t, "org_123", linked.OrganizationID)
+		require.NoError(t, SaveLinkedProject(testProject, fsys))
+		assert.True(t, HasLinkedProject(fsys))
 	})
+}
 
-	t.Run("fetches and caches when no cache exists", func(t *testing.T) {
-		t.Cleanup(apitest.MockPlatformAPI(t))
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects/proj_abc").
-			Reply(http.StatusOK).
-			JSON(projectJSON)
+func TestCacheProjectAndIdentifyGroups(t *testing.T) {
+	t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
 
+	t.Run("writes cache file", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		EnsureProjectGroupsCached(context.Background(), "proj_abc", fsys)
+		CacheProjectAndIdentifyGroups(testProject, nil, fsys)
 
 		linked, err := LoadLinkedProject(fsys)
 		require.NoError(t, err)
 		assert.Equal(t, "proj_abc", linked.Ref)
 		assert.Equal(t, "org_123", linked.OrganizationID)
 		assert.Equal(t, "acme", linked.OrganizationSlug)
+		assert.Equal(t, "My Project", linked.Name)
 	})
 
-	t.Run("updates cache when ref differs", func(t *testing.T) {
-		t.Cleanup(apitest.MockPlatformAPI(t))
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects/proj_xyz").
-			Reply(http.StatusOK).
-			JSON(map[string]interface{}{
-				"ref":               "proj_xyz",
-				"organization_id":   "org_456",
-				"organization_slug": "other",
-				"name":              "Other Project",
-				"region":            "eu-west-1",
-				"created_at":        "2024-06-01T00:00:00Z",
-				"status":            "ACTIVE_HEALTHY",
-				"database":          map[string]interface{}{"host": "db.other.supabase.co", "version": "15.1.0.117"},
-			})
-
+	t.Run("fires GroupIdentify for org and project", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
-			Ref:              "proj_abc",
-			Name:             "My Project",
-			OrganizationId:   "org_123",
-			OrganizationSlug: "acme",
-		}, fsys))
+		analytics := &fakeAnalytics{enabled: true}
+		service := newTestService(t, fsys, analytics)
 
-		EnsureProjectGroupsCached(context.Background(), "proj_xyz", fsys)
+		CacheProjectAndIdentifyGroups(testProject, service, fsys)
 
+		require.Len(t, analytics.groupIdentifies, 2)
+
+		orgCall := analytics.groupIdentifies[0]
+		assert.Equal(t, GroupOrganization, orgCall.groupType)
+		assert.Equal(t, "org_123", orgCall.groupKey)
+		assert.Equal(t, "acme", orgCall.properties["organization_slug"])
+
+		projCall := analytics.groupIdentifies[1]
+		assert.Equal(t, GroupProject, projCall.groupType)
+		assert.Equal(t, "proj_abc", projCall.groupKey)
+		assert.Equal(t, "My Project", projCall.properties["name"])
+		assert.Equal(t, "acme", projCall.properties["organization_slug"])
+	})
+
+	t.Run("skips GroupIdentify when service is nil", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		CacheProjectAndIdentifyGroups(testProject, nil, fsys)
+
+		// Cache should still be written
 		linked, err := LoadLinkedProject(fsys)
 		require.NoError(t, err)
-		assert.Equal(t, "proj_xyz", linked.Ref)
-		assert.Equal(t, "org_456", linked.OrganizationID)
+		assert.Equal(t, "proj_abc", linked.Ref)
 	})
 
-	t.Run("no-ops on API error", func(t *testing.T) {
-		t.Cleanup(apitest.MockPlatformAPI(t))
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects/proj_bad").
-			ReplyError(assert.AnError)
-
+	t.Run("skips GroupIdentify for empty org ID", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		EnsureProjectGroupsCached(context.Background(), "proj_bad", fsys)
+		analytics := &fakeAnalytics{enabled: true}
+		service := newTestService(t, fsys, analytics)
 
-		_, err := LoadLinkedProject(fsys)
-		assert.Error(t, err) // no cache written
-	})
+		noOrgProject := api.V1ProjectWithDatabaseResponse{
+			Ref:  "proj_abc",
+			Name: "My Project",
+		}
+		CacheProjectAndIdentifyGroups(noOrgProject, service, fsys)
 
-	t.Run("no-ops on 404", func(t *testing.T) {
-		t.Cleanup(apitest.MockPlatformAPI(t))
-		gock.New(utils.DefaultApiHost).
-			Get("/v1/projects/proj_missing").
-			Reply(http.StatusNotFound)
-
-		fsys := afero.NewMemMapFs()
-		EnsureProjectGroupsCached(context.Background(), "proj_missing", fsys)
-
-		_, err := LoadLinkedProject(fsys)
-		assert.Error(t, err) // no cache written
+		// Only project GroupIdentify, no org
+		require.Len(t, analytics.groupIdentifies, 1)
+		assert.Equal(t, GroupProject, analytics.groupIdentifies[0].groupType)
 	})
 }
 
@@ -137,12 +116,7 @@ func TestLinkedProjectGroups(t *testing.T) {
 
 	t.Run("returns groups from cache", func(t *testing.T) {
 		fsys := afero.NewMemMapFs()
-		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
-			Ref:              "proj_abc",
-			Name:             "My Project",
-			OrganizationId:   "org_123",
-			OrganizationSlug: "acme",
-		}, fsys))
+		require.NoError(t, SaveLinkedProject(testProject, fsys))
 		groups := linkedProjectGroups(fsys)
 		assert.Equal(t, map[string]string{
 			GroupOrganization: "org_123",

--- a/internal/telemetry/project_test.go
+++ b/internal/telemetry/project_test.go
@@ -1,0 +1,152 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/utils"
+	"github.com/supabase/cli/pkg/api"
+)
+
+func TestEnsureProjectGroupsCached(t *testing.T) {
+	t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
+
+	projectJSON := map[string]interface{}{
+		"ref":               "proj_abc",
+		"organization_id":   "org_123",
+		"organization_slug": "acme",
+		"name":              "My Project",
+		"region":            "us-east-1",
+		"created_at":        "2024-01-01T00:00:00Z",
+		"status":            "ACTIVE_HEALTHY",
+		"database":          map[string]interface{}{"host": "db.example.supabase.co", "version": "15.1.0.117"},
+	}
+
+	t.Run("skips when project ref is empty", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		EnsureProjectGroupsCached(context.Background(), "", fsys)
+		_, err := LoadLinkedProject(fsys)
+		assert.Error(t, err)
+	})
+
+	t.Run("skips when cache already matches", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
+			Ref:              "proj_abc",
+			Name:             "My Project",
+			OrganizationId:   "org_123",
+			OrganizationSlug: "acme",
+		}, fsys))
+		// No gock mocks — any API call would panic
+		EnsureProjectGroupsCached(context.Background(), "proj_abc", fsys)
+		linked, err := LoadLinkedProject(fsys)
+		require.NoError(t, err)
+		assert.Equal(t, "org_123", linked.OrganizationID)
+	})
+
+	t.Run("fetches and caches when no cache exists", func(t *testing.T) {
+		t.Cleanup(apitest.MockPlatformAPI(t))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/proj_abc").
+			Reply(http.StatusOK).
+			JSON(projectJSON)
+
+		fsys := afero.NewMemMapFs()
+		EnsureProjectGroupsCached(context.Background(), "proj_abc", fsys)
+
+		linked, err := LoadLinkedProject(fsys)
+		require.NoError(t, err)
+		assert.Equal(t, "proj_abc", linked.Ref)
+		assert.Equal(t, "org_123", linked.OrganizationID)
+		assert.Equal(t, "acme", linked.OrganizationSlug)
+	})
+
+	t.Run("updates cache when ref differs", func(t *testing.T) {
+		t.Cleanup(apitest.MockPlatformAPI(t))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/proj_xyz").
+			Reply(http.StatusOK).
+			JSON(map[string]interface{}{
+				"ref":               "proj_xyz",
+				"organization_id":   "org_456",
+				"organization_slug": "other",
+				"name":              "Other Project",
+				"region":            "eu-west-1",
+				"created_at":        "2024-06-01T00:00:00Z",
+				"status":            "ACTIVE_HEALTHY",
+				"database":          map[string]interface{}{"host": "db.other.supabase.co", "version": "15.1.0.117"},
+			})
+
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
+			Ref:              "proj_abc",
+			Name:             "My Project",
+			OrganizationId:   "org_123",
+			OrganizationSlug: "acme",
+		}, fsys))
+
+		EnsureProjectGroupsCached(context.Background(), "proj_xyz", fsys)
+
+		linked, err := LoadLinkedProject(fsys)
+		require.NoError(t, err)
+		assert.Equal(t, "proj_xyz", linked.Ref)
+		assert.Equal(t, "org_456", linked.OrganizationID)
+	})
+
+	t.Run("no-ops on API error", func(t *testing.T) {
+		t.Cleanup(apitest.MockPlatformAPI(t))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/proj_bad").
+			ReplyError(assert.AnError)
+
+		fsys := afero.NewMemMapFs()
+		EnsureProjectGroupsCached(context.Background(), "proj_bad", fsys)
+
+		_, err := LoadLinkedProject(fsys)
+		assert.Error(t, err) // no cache written
+	})
+
+	t.Run("no-ops on 404", func(t *testing.T) {
+		t.Cleanup(apitest.MockPlatformAPI(t))
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/proj_missing").
+			Reply(http.StatusNotFound)
+
+		fsys := afero.NewMemMapFs()
+		EnsureProjectGroupsCached(context.Background(), "proj_missing", fsys)
+
+		_, err := LoadLinkedProject(fsys)
+		assert.Error(t, err) // no cache written
+	})
+}
+
+func TestLinkedProjectGroups(t *testing.T) {
+	t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
+
+	t.Run("returns nil when no cache", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		groups := linkedProjectGroups(fsys)
+		assert.Nil(t, groups)
+	})
+
+	t.Run("returns groups from cache", func(t *testing.T) {
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, SaveLinkedProject(api.V1ProjectWithDatabaseResponse{
+			Ref:              "proj_abc",
+			Name:             "My Project",
+			OrganizationId:   "org_123",
+			OrganizationSlug: "acme",
+		}, fsys))
+		groups := linkedProjectGroups(fsys)
+		assert.Equal(t, map[string]string{
+			GroupOrganization: "org_123",
+			GroupProject:      "proj_abc",
+		}, groups)
+	})
+}


### PR DESCRIPTION
## Problem

Only ~19% of CLI events have PostHog group properties set (`$group_0` for org, `$group_1` for project). Groups are only written during `supabase link`, so any command using `--project-ref` without linking first sends events that are invisible to PostHog group analytics. This means we can't filter or aggregate ~80% of CLI activity by org or project.

Back in early April when CLI telemetry shipped, the plumbing for groups was built out (the `CommandContext.Groups` field, `mergeGroups()` layering, `linkedProjectGroups()` reader) but only the link flow actually populates the cache.

## Changes

- Add `EnsureProjectGroupsCached()` in `internal/telemetry/project.go` — when a project ref is available but no matching `linked-project.json` exists, fetches the project from the management API and caches it. Subsequent commands with the same ref skip the API call entirely.
- Call it from `Execute()` in `cmd/root.go` right before firing `cli_command_executed`, so the existing `linkedProjectGroups()` reader picks up the cached data.
- Best-effort throughout — errors log to debug and never break commands.
- New test file with 8 cases covering cache hit, cache miss, ref change, API errors, and 404s.

## Testing

- All 25 telemetry tests pass (`go test ./internal/telemetry/... -v`)
- Full build passes (`go build ./...`)
- Verified the API response type (`V1ProjectWithDatabaseResponse`) matches what `SaveLinkedProject` expects

Closes GROWTH-761