### PR TITLE
chore: Add additional path to auth-v1-open-callback

### DIFF
--- a/internal/start/templates/kong.yml
+++ b/internal/start/templates/kong.yml
@@ -19,6 +19,7 @@ services:
         strip_path: true
         paths:
           - /auth/v1/callback
+          - /callback
     plugins:
       - name: cors
   - name: auth-v1-open-authorize


### PR DESCRIPTION
## What kind of change does this PR introduce?

- bug fix for: https://github.com/supabase/auth/issues/2477
- prefer over: https://github.com/supabase/auth/pull/2478 (see https://github.com/supabase/auth/issues/2477#issuecomment-4229286176)

## What is the current behavior?

In the new custom OIDC/OAuth provider, it hard-codes the redirect URI to {{KONG-GATEWAY}} `/callback`. Since Auth/GoTrue  can be self-hosted, and not necessarily behind Kong, at `/auth/v1`, it seems like the callback cannot be modified in Auth/GoTrue (instead, in Kong, (see https://github.com/supabase/auth/issues/2477#issuecomment-4229286176)).

## What is the new behavior?

The new behavior properly proxies `/callback` and `/auth/v1/callback` to GoTrue.

## Additional context

See the issue linked above (https://github.com/supabase/auth/issues/2477)

Basically, the below line of code cannot change:

https://github.com/supabase/auth/blob/2d8f2b6168cfc753f55c7bd157bfda6ef05af007/internal/api/external.go#L682

Instead, Kong needs to properly proxy `/callback` in the same way that it ports `/auth/v1/callback`
