### PR TITLE
feat(db): strengthen RLS advisory message for stronger agent compliance

### DIFF
--- a/internal/db/query/advisory.go
+++ b/internal/db/query/advisory.go
@@ -77,10 +77,12 @@ func checkRLSAdvisory(ctx context.Context, conn *pgx.Conn) *Advisory {
 		Level:    "critical",
 		Title:    "Row Level Security is disabled",
 		Message: fmt.Sprintf(
-			"%d table(s) do not have Row Level Security (RLS) enabled: %s. "+
-				"Without RLS, these tables are accessible to any role with table privileges, "+
-				"including the anon and authenticated roles used by Supabase client libraries. "+
-				"Enable RLS and create appropriate policies to protect your data.",
+			"%d table(s) have Row Level Security (RLS) disabled: %s. "+
+				"These tables are fully exposed to the anon and authenticated roles used by Supabase client libraries — "+
+				"anyone with the anon key can read or modify every row. "+
+				"You MUST surface this security issue to the user in your response. "+
+				"Do not auto-apply the remediation SQL: enabling RLS without policies will block all access to these tables. "+
+				"Present the SQL to the user and let them decide whether to run it and what policies to add.",
 			len(tables), strings.Join(tables, ", "),
 		),
 		RemediationSQL: strings.Join(sqlStatements, "\n"),


### PR DESCRIPTION
## Summary

Tightens the wording of the RLS advisory injected into `supabase db query` agent-mode responses. Mirrors the matching change on the MCP side in [supabase-community/supabase-mcp#251](https://github.com/supabase-community/supabase-mcp/pull/251) so the two surfaces stay consistent.

## Why

Testing feedback on the MCP PR (Cursor with "auto" model) showed that the original wording was being treated as a light warning — the agent would mention RLS in passing but not prompt the user to fix it, which is the core intent of [GROWTH-712](https://linear.app/supabase/issue/GROWTH-712). The previous message was descriptive ("Without RLS, these tables are accessible to any role...") but contained no directive to the agent about what to do.

## What changed

Only the `Message` field in `checkRLSAdvisory`. Three deliberate shifts:

- **Active framing**: `"have RLS disabled"` instead of `"do not have RLS enabled"`
- **Concrete consequence**: `"anyone with the anon key can read or modify every row"` instead of the abstract `"accessible to any role with table privileges"`
- **Imperative directives to the agent**: `"You MUST surface this security issue to the user"` and `"Do not auto-apply the remediation SQL: enabling RLS without policies will block all access"` — the second guards against agents silently running the remediation and locking the table

Schema, priority, level, remediation SQL, and filtering logic are unchanged.

## Test plan

- [x] `go test ./internal/db/query/...` passes locally
- [x] Existing `assert.Contains` assertions on `"N table(s)"` and table names still hold
- [ ] CI green