### PR TITLE
chore(workflows): enable install scripts for supabase package in Yarn

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -82,7 +82,13 @@ jobs:
       - run: yarn set version berry
       # - run: yarn config set nodeLinker node-modules
       - run: yarn init -y
+      # Yarn Berry 4.14+ disables install scripts by default (yarnpkg/berry#7089).
+      # The supabase package relies on a postinstall script to fetch its binary,
+      # so we opt in via YARN_ENABLE_SCRIPTS just for this install step (the
+      # Yarn analog to pnpm's --allow-build=supabase).
       - run: yarn add -D ./supabase-1.28.0.tgz
+        env:
+          YARN_ENABLE_SCRIPTS: "true"
       - if: ${{ matrix.os != 'windows-latest' }}
         run: yarn supabase --version
       # Workaround for running extensionless executable on windows


### PR DESCRIPTION
… Berry setup

This change sets the YARN_ENABLE_SCRIPTS environment variable to true during the installation of the supabase package, allowing its postinstall script to run as required by Yarn Berry 4.14+. This adjustment ensures the necessary binary is fetched correctly.