### PR TITLE
feat: --diff-engine flag on db pull

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -80,15 +80,19 @@ var (
 		},
 	}
 
-	useMigra    bool
-	usePgAdmin  bool
-	usePgSchema bool
-	usePgDelta  bool
-	diffFrom    string
-	diffTo      string
-	outputPath  string
-	schema      []string
-	file        string
+	useMigra       bool
+	usePgAdmin     bool
+	usePgSchema    bool
+	usePgDelta     bool
+	pullDiffEngine = utils.EnumFlag{
+		Allowed: []string{"migra", "pg-delta"},
+		Value:   "migra",
+	}
+	diffFrom   string
+	diffTo     string
+	outputPath string
+	schema     []string
+	file       string
 
 	dbDiffCmd = &cobra.Command{
 		Use:   "diff",
@@ -172,8 +176,13 @@ var (
 			if len(args) > 0 {
 				name = args[0]
 			}
-			useDelta := shouldUsePgDelta()
-			return pull.Run(cmd.Context(), schema, flags.DbConfig, name, useDelta, afero.NewOsFs())
+			pullDiffer := diff.DiffSchemaMigra
+			usePgDeltaDiff := pullDiffEngine.Value == "pg-delta"
+			if usePgDeltaDiff {
+				pullDiffer = diff.DiffPgDelta
+			}
+			useDeclarativePgDelta := shouldUsePgDelta()
+			return pull.Run(cmd.Context(), schema, flags.DbConfig, name, useDeclarativePgDelta, usePgDeltaDiff, pullDiffer, afero.NewOsFs())
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Finished " + utils.Aqua("supabase db pull") + ".")
@@ -202,7 +211,7 @@ var (
 		Short:      "Commit remote changes as a new migration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			useDelta := shouldUsePgDelta()
-			return pull.Run(cmd.Context(), schema, flags.DbConfig, "remote_commit", useDelta, afero.NewOsFs())
+			return pull.Run(cmd.Context(), schema, flags.DbConfig, "remote_commit", useDelta, false, diff.DiffSchemaMigra, afero.NewOsFs())
 		},
 	}
 
@@ -411,11 +420,13 @@ func init() {
 	// This flag activates declarative pull output through pg-delta instead of the
 	// legacy migration SQL pull path.
 	pullFlags.BoolVar(&usePgDelta, "use-pg-delta", false, "Use pg-delta to pull declarative schema.")
+	pullFlags.Var(&pullDiffEngine, "diff-engine", "Diff engine to use for migration-style db pull.")
 	pullFlags.StringSliceVarP(&schema, "schema", "s", []string{}, "Comma separated list of schema to include.")
 	pullFlags.String("db-url", "", "Pulls from the database specified by the connection string (must be percent-encoded).")
 	pullFlags.Bool("linked", true, "Pulls from the linked project.")
 	pullFlags.Bool("local", false, "Pulls from the local database.")
 	dbPullCmd.MarkFlagsMutuallyExclusive("db-url", "linked", "local")
+	dbPullCmd.MarkFlagsMutuallyExclusive("use-pg-delta", "diff-engine")
 	pullFlags.StringVarP(&dbPassword, "password", "p", "", "Password to your remote Postgres database.")
 	cobra.CheckErr(viper.BindPFlag("DB_PASSWORD", pullFlags.Lookup("password")))
 	dbCmd.AddCommand(dbPullCmd)

--- a/docs/supabase/db/pull.md
+++ b/docs/supabase/db/pull.md
@@ -9,3 +9,5 @@ Requires your local project to be linked to a remote database by running `supaba
 Optionally, a new row can be inserted into the migration history table to reflect the current state of the remote database.
 
 If no entries exist in the migration history table, `pg_dump` will be used to capture all contents of the remote schemas you have created. Otherwise, this command will only diff schema changes against the remote database, similar to running `db diff --linked`.
+
+Pass `--diff-engine pg-delta` to keep the migration-file `db pull` workflow while using pg-delta for the shadow diff step. Pass `--use-pg-delta` to switch to the declarative pg-delta export workflow instead.

--- a/internal/db/pull/pull.go
+++ b/internal/db/pull/pull.go
@@ -34,7 +34,7 @@ var (
 	errConflict = errors.Errorf("The remote database's migration history does not match local files in %s directory.", utils.MigrationsDir)
 )
 
-func Run(ctx context.Context, schema []string, config pgconn.Config, name string, usePgDelta bool, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, schema []string, config pgconn.Config, name string, usePgDelta bool, usePgDeltaDiff bool, differ diff.DiffFunc, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
 	// 1. Check postgres connection
 	conn, err := utils.ConnectByConfig(ctx, config, options...)
 	if err != nil {
@@ -60,7 +60,7 @@ func Run(ctx context.Context, schema []string, config pgconn.Config, name string
 	// 2. Pull schema
 	timestamp := utils.GetCurrentTimestamp()
 	path := new.GetMigrationPath(timestamp, name)
-	if err := run(ctx, schema, path, conn, fsys); err != nil {
+	if err := run(ctx, schema, path, conn, usePgDeltaDiff, differ, fsys); err != nil {
 		return err
 	}
 	// 3. Insert a row to `schema_migrations`
@@ -110,7 +110,7 @@ func pullDeclarativePgDelta(ctx context.Context, schema []string, config pgconn.
 	return nil
 }
 
-func run(ctx context.Context, schema []string, path string, conn *pgx.Conn, fsys afero.Fs) error {
+func run(ctx context.Context, schema []string, path string, conn *pgx.Conn, usePgDeltaDiff bool, differ diff.DiffFunc, fsys afero.Fs) error {
 	config := conn.Config().Config
 	// 1. Assert `supabase/migrations` and `schema_migrations` are in sync.
 	if err := assertRemoteInSync(ctx, conn, fsys); errors.Is(err, errMissing) {
@@ -119,7 +119,7 @@ func run(ctx context.Context, schema []string, path string, conn *pgx.Conn, fsys
 			return err
 		}
 		// Run a second pass to pull in changes from default privileges and managed schemas
-		if err = diffRemoteSchema(ctx, nil, path, config, fsys); errors.Is(err, errInSync) {
+		if err = diffRemoteSchema(ctx, nil, path, config, usePgDeltaDiff, differ, fsys); errors.Is(err, errInSync) {
 			err = nil
 		}
 		return err
@@ -127,7 +127,7 @@ func run(ctx context.Context, schema []string, path string, conn *pgx.Conn, fsys
 		return err
 	}
 	// 2. Fetch remote schema changes
-	return diffRemoteSchema(ctx, schema, path, config, fsys)
+	return diffRemoteSchema(ctx, schema, path, config, usePgDeltaDiff, differ, fsys)
 }
 
 func dumpRemoteSchema(ctx context.Context, path string, config pgconn.Config, fsys afero.Fs) error {
@@ -144,9 +144,9 @@ func dumpRemoteSchema(ctx context.Context, path string, config pgconn.Config, fs
 	return migration.DumpSchema(ctx, config, f, dump.DockerExec)
 }
 
-func diffRemoteSchema(ctx context.Context, schema []string, path string, config pgconn.Config, fsys afero.Fs) error {
+func diffRemoteSchema(ctx context.Context, schema []string, path string, config pgconn.Config, usePgDeltaDiff bool, differ diff.DiffFunc, fsys afero.Fs) error {
 	// Diff remote db (source) & shadow db (target) and write it as a new migration.
-	output, err := diff.DiffDatabase(ctx, schema, config, os.Stderr, fsys, diff.DiffSchemaMigra, false)
+	output, err := diff.DiffDatabase(ctx, schema, config, os.Stderr, fsys, differ, usePgDeltaDiff)
 	if err != nil {
 		return err
 	}

--- a/internal/db/pull/pull_test.go
+++ b/internal/db/pull/pull_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/db/diff"
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/utils"
@@ -33,7 +34,7 @@ func TestPullCommand(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), nil, pgconn.Config{}, "", false, fsys)
+		err := Run(context.Background(), nil, pgconn.Config{}, "", false, false, diff.DiffSchemaMigra, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "invalid port (outside range)")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -48,7 +49,7 @@ func TestPullCommand(t *testing.T) {
 		conn.Query(migration.LIST_MIGRATION_VERSION).
 			ReplyError(pgerrcode.InvalidCatalogName, `database "postgres" does not exist`)
 		// Run test
-		err := Run(context.Background(), nil, dbConfig, "", false, fsys, conn.Intercept)
+		err := Run(context.Background(), nil, dbConfig, "", false, false, diff.DiffSchemaMigra, fsys, conn.Intercept)
 		// Check error
 		assert.ErrorContains(t, err, `ERROR: database "postgres" does not exist (SQLSTATE 3D000)`)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -74,7 +75,7 @@ func TestPullSchema(t *testing.T) {
 		conn.Query(migration.LIST_MIGRATION_VERSION).
 			Reply("SELECT 0")
 		// Run test
-		err := run(context.Background(), nil, "0_test.sql", conn.MockClient(t), fsys)
+		err := run(context.Background(), nil, "0_test.sql", conn.MockClient(t), false, diff.DiffSchemaMigra, fsys)
 		// Check error
 		assert.ErrorIs(t, err, errNetwork)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -100,7 +101,7 @@ func TestPullSchema(t *testing.T) {
 		conn.Query(migration.LIST_MIGRATION_VERSION).
 			Reply("SELECT 1", []any{"0"})
 		// Run test
-		err := run(context.Background(), []string{"public"}, "", conn.MockClient(t), fsys)
+		err := run(context.Background(), []string{"public"}, "", conn.MockClient(t), false, diff.DiffSchemaMigra, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "network error")
 		assert.Empty(t, apitest.ListUnmatchedRequests())


### PR DESCRIPTION
**Summary**

This PR adds a `--diff-engine` flag to `supabase db pull` so users can keep the existing migration-file workflow while choosing which diff engine is used for the shadow diff step.

This is primarily meant to address cases where `db pull`’s migration-style flow appends Supabase-managed objects that should be filtered by a different diff engine. In particular, it lets users opt into `pg-delta` for the diff phase without switching `db pull` into declarative export mode.

**What changed**

- Added `--diff-engine` to `supabase db pull`
- Supported values:
  - `migra` (default)
  - `pg-delta`
- Kept `--use-pg-delta` unchanged for declarative `db pull` behavior
- Made `--use-pg-delta` and `--diff-engine` mutually exclusive
- Threaded the selected diff engine through the migration-style `db pull` path
- Updated `db pull` docs accordingly

**Examples**

Migration-style `db pull` with the default engine:

```bash
supabase db pull
```

Migration-style `db pull` using pg-delta for the diff step:

```bash
supabase db pull --diff-engine pg-delta
```

Declarative pg-delta export mode remains:

```bash
supabase db pull --use-pg-delta
```

**Why**

`db pull` currently has two distinct behaviors:

- Migration-style pull:
  - creates or updates a migration file
  - builds a shadow database
  - replays local migrations
  - diffs remote against shadow
- Declarative pg-delta pull:
  - exports declarative schema files

Before this change, the migration-style path was effectively tied to migra. That made it difficult to recover from cases where the diff step emitted managed Supabase objects that a different engine, such as pg-delta, would filter more appropriately.

This PR separates:
- “which pull mode is being used”
from
- “which diff engine is used in migration-style pull”

**Behavioral notes**

- No behavior change for existing `supabase db pull` usage
- No behavior change for existing `supabase db pull --use-pg-delta`
- The new behavior is opt-in via `--diff-engine pg-delta`