### PR TITLE
fix: remove version comparison check for storage image updates

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -660,10 +660,7 @@ func (c *config) Load(path string, fsys fs.FS, overrides ...ConfigEditor) error 
 		}
 	}
 	if version, err := fs.ReadFile(fsys, builder.StorageVersionPath); err == nil && len(version) > 0 {
-		// Only replace image if local storage version is newer
-		if i := strings.IndexByte(Images.Storage, ':'); semver.Compare(strings.TrimSpace(string(version)), Images.Storage[i+1:]) > 0 {
-			c.Storage.Image = replaceImageTag(Images.Storage, string(version))
-		}
+		c.Storage.Image = replaceImageTag(Images.Storage, string(version))
 	}
 	if version, err := fs.ReadFile(fsys, builder.StorageMigrationPath); err == nil && len(version) > 0 {
 		c.Storage.TargetMigration = strings.TrimSpace(string(version))


### PR DESCRIPTION
## Summary
Simplified the storage image update logic by removing the semantic version comparison check that previously only allowed updates when the local storage version was newer than the current image tag.

## Changes
- Removed the `semver.Compare()` check that gated storage image updates
- Now unconditionally update the storage image tag when a local storage version file is present
- This allows the storage image to be updated regardless of version ordering

## Implementation Details
The previous logic only replaced the storage image tag if the local version was semantically newer than the currently configured image tag. This change removes that constraint, enabling storage image updates in all cases where a version file exists, which provides more flexibility in version management and configuration updates.

https://claude.ai/code/session_01BkwrNKzkRwUvYZhjCdJwqK

Closes: CLI-1393