### PR TITLE
fix(start): guard db_logs vector transform against null regex capture

### DIFF
--- a/internal/start/templates/vector.yaml
+++ b/internal/start/templates/vector.yaml
@@ -154,11 +154,10 @@ transforms:
 
       parsed, err = parse_regex(.event_message, r'.*(?P<level>INFO|NOTICE|WARNING|ERROR|LOG|FATAL|PANIC?):.*', numeric_groups: true)
 
-      if err != null || parsed == null {
+      if err != null || parsed == null || parsed.level == null {
         .metadata.parsed.error_severity = "info"
-      }
-      if parsed != null {
-       .metadata.parsed.error_severity = parsed.level
+      } else {
+        .metadata.parsed.error_severity = parsed.level
       }
       if .metadata.parsed.error_severity == "info" {
           .metadata.parsed.error_severity = "log"


### PR DESCRIPTION
## What

In the `db_logs` transform of the Vector config, `upcase!()` aborts
with `expected string, got null` when `parse_regex` matches an event
message but the `level` named group resolves to null. The existing
fallback branch only covers regex failure
(`err != null || parsed == null`), so a third path (match succeeded,
capture null) overwrites the `"info"` fallback with null and crashes
on upcase.

## Why

Running a Next.js dev server against the local Supabase stack with
routine service-role Postgres queries produces 3,000+ aborted
`db_logs` transforms in ~2 minutes. Vector retries the failures,
Logflare's ingest queue backs up (`ErlSysMon` warnings for
`:long_message_queue` and `:long_schedule` at 746ms), and the
analytics container sustains 100% CPU. On a resource-constrained
host (laptop, Docker at 8 GB) this cascades into swap thrashing and
host unresponsiveness.

## How

Extend the fallback condition to also fire when `parsed.level` is
null, and guard the match-path assignment symmetrically, so
`error_severity` always holds a non-null string before `upcase!()`.

## Verification

Before: thousands of `function call error for "upcase" at (476:516):
expected string, got null` errors from `db_logs` in the Vector
container logs during dev activity.

After: zero transform failures under the same workload.