### PR TITLE
fix(windows): json unmarshal errors in telemetry and pg-delta declarative sync

### DIFF
--- a/internal/db/diff/pgdelta.go
+++ b/internal/db/diff/pgdelta.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -47,12 +48,14 @@ func isPostgresURL(ref string) bool {
 
 // containerRef translates a host-relative catalog file path into the absolute
 // path where it appears inside the edge runtime container (CWD mounted at
-// /workspace). Postgres URLs and empty strings pass through unchanged.
+// /workspace). Postgres URLs and empty strings pass through unchanged. Path
+// separators are normalised to forward slashes so Windows paths (with `\`)
+// resolve correctly inside the Linux container.
 func containerRef(ref string) string {
 	if ref == "" || isPostgresURL(ref) {
 		return ref
 	}
-	return "/workspace/" + ref
+	return "/workspace/" + filepath.ToSlash(ref)
 }
 
 // pgDeltaFormatOptions returns the experimental.pgdelta.format_options config for
@@ -143,6 +146,9 @@ func DeclarativeExportPgDeltaRef(ctx context.Context, sourceRef, targetRef strin
 	if err := utils.RunEdgeRuntimeScript(ctx, env, pgDeltaDeclarativeExportScript, binds, "error exporting declarative schema", &stdout, &stderr); err != nil {
 		return DeclarativeOutput{}, err
 	}
+	if stdout.Len() == 0 {
+		return DeclarativeOutput{}, errors.Errorf("error exporting declarative schema: edge-runtime script produced no output:\n%s", stderr.String())
+	}
 	var result DeclarativeOutput
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		return DeclarativeOutput{}, errors.Errorf("failed to parse declarative export output: %w", err)
@@ -176,5 +182,9 @@ func ExportCatalogPgDelta(ctx context.Context, targetRef, role string, options .
 	if err := utils.RunEdgeRuntimeScript(ctx, env, pgDeltaCatalogExportScript, binds, "error exporting pg-delta catalog", &stdout, &stderr); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	snapshot := strings.TrimSpace(stdout.String())
+	if len(snapshot) == 0 {
+		return "", errors.Errorf("error exporting pg-delta catalog: edge-runtime script produced no output:\n%s", stderr.String())
+	}
+	return snapshot, nil
 }

--- a/internal/db/diff/pgdelta_test.go
+++ b/internal/db/diff/pgdelta_test.go
@@ -1,0 +1,30 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerRef(t *testing.T) {
+	t.Run("passes empty string through", func(t *testing.T) {
+		assert.Equal(t, "", containerRef(""))
+	})
+
+	t.Run("passes postgres URLs through", func(t *testing.T) {
+		assert.Equal(t, "postgresql://user@host:5432/db", containerRef("postgresql://user@host:5432/db"))
+		assert.Equal(t, "postgres://user@host:5432/db", containerRef("postgres://user@host:5432/db"))
+	})
+
+	t.Run("normalises Windows path separators", func(t *testing.T) {
+		// On Windows, filepath.Join produces backslashes which the Linux
+		// container cannot read; containerRef must convert them.
+		ref := `supabase\.temp\pgdelta\catalog-baseline-17.6.1.106.json`
+		assert.Equal(t, "/workspace/supabase/.temp/pgdelta/catalog-baseline-17.6.1.106.json", containerRef(ref))
+	})
+
+	t.Run("leaves unix paths untouched", func(t *testing.T) {
+		ref := "supabase/.temp/pgdelta/catalog-baseline-17.6.1.106.json"
+		assert.Equal(t, "/workspace/supabase/.temp/pgdelta/catalog-baseline-17.6.1.106.json", containerRef(ref))
+	})
+}

--- a/internal/db/diff/pgdelta_test.go
+++ b/internal/db/diff/pgdelta_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,9 @@ func TestContainerRef(t *testing.T) {
 	})
 
 	t.Run("normalises Windows path separators", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("path separator behaviour is Windows-only")
+		}
 		// On Windows, filepath.Join produces backslashes which the Linux
 		// container cannot read; containerRef must convert them.
 		ref := `supabase\.temp\pgdelta\catalog-baseline-17.6.1.106.json`

--- a/internal/db/pgcache/cache.go
+++ b/internal/db/pgcache/cache.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-errors/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/spf13/afero"
@@ -255,5 +256,9 @@ func exportCatalog(ctx context.Context, targetRef string, options ...func(*pgx.C
 	if err := utils.RunEdgeRuntimeScript(ctx, env, pgDeltaCatalogExportTS, binds, "error exporting pg-delta catalog", &stdout, &stderr); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	snapshot := strings.TrimSpace(stdout.String())
+	if len(snapshot) == 0 {
+		return "", errors.Errorf("error exporting pg-delta catalog: edge-runtime script produced no output:\n%s", stderr.String())
+	}
+	return snapshot, nil
 }

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -17,6 +17,12 @@ const SchemaVersion = 1
 
 const sessionRotationThreshold = 30 * time.Minute
 
+// errMalformedState marks any read where the file existed but couldn't be
+// decoded into a State — covers JSON syntax errors, unexpected types
+// (e.g. session_last_active stored as a number), and field-level unmarshal
+// failures from time.Time / uuid. Used to trigger fresh-state creation.
+var errMalformedState = errors.New("malformed telemetry state")
+
 type State struct {
 	Enabled           bool      `json:"enabled"`
 	DeviceID          string    `json:"device_id"`
@@ -48,7 +54,7 @@ func LoadState(fsys afero.Fs) (State, error) {
 	}
 	var state State
 	if err := json.Unmarshal(contents, &state); err != nil {
-		return State{}, errors.Errorf("failed to parse telemetry file: %w", err)
+		return State{}, errors.Errorf("%w: %v", errMalformedState, err)
 	}
 	return state, nil
 }
@@ -74,7 +80,11 @@ func LoadOrCreateState(fsys afero.Fs, now time.Time) (State, bool, error) {
 		state.SessionLastActive = now.UTC()
 		return state, false, SaveState(state, fsys)
 	}
-	if !errors.Is(err, os.ErrNotExist) {
+	// Treat a missing file OR an unparseable file as "no existing state" and
+	// recreate. Identity fields (device_id, session_id) are not worth
+	// surfacing an error for — losing them is harmless. We only propagate
+	// genuine I/O errors (permissions, disk full) so the user can act.
+	if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errMalformedState) {
 		return State{}, false, err
 	}
 	state = State{

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -82,8 +82,8 @@ func TestLoadOrCreateState(t *testing.T) {
 	t.Run("recovers from corrupted state file", func(t *testing.T) {
 		// Each entry simulates a real-world corruption shape we've observed.
 		corruptions := map[string][]byte{
-			"empty file":             []byte{},
-			"truncated json":         []byte(`{"enabled":tru`),
+			"empty file":     {},
+			"truncated json": []byte(`{"enabled":tru`),
 			"session_last_active is a number (not a string)": []byte(`{"enabled":true,"device_id":"d","session_id":"s","session_last_active":1776770348993,"schema_version":1}`),
 			"session_last_active is a malformed string":      []byte(`{"enabled":true,"device_id":"d","session_id":"s","session_last_active":"not-a-time","schema_version":1}`),
 		}

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -79,6 +79,38 @@ func TestLoadOrCreateState(t *testing.T) {
 		assert.Equal(t, now, state.SessionLastActive)
 	})
 
+	t.Run("recovers from corrupted state file", func(t *testing.T) {
+		// Each entry simulates a real-world corruption shape we've observed.
+		corruptions := map[string][]byte{
+			"empty file":             []byte{},
+			"truncated json":         []byte(`{"enabled":tru`),
+			"session_last_active is a number (not a string)": []byte(`{"enabled":true,"device_id":"d","session_id":"s","session_last_active":1776770348993,"schema_version":1}`),
+			"session_last_active is a malformed string":      []byte(`{"enabled":true,"device_id":"d","session_id":"s","session_last_active":"not-a-time","schema_version":1}`),
+		}
+		for label, contents := range corruptions {
+			t.Run(label, func(t *testing.T) {
+				t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
+				fsys := afero.NewMemMapFs()
+				path, err := telemetryPath()
+				require.NoError(t, err)
+				require.NoError(t, fsys.MkdirAll("/tmp/supabase-home", 0755))
+				require.NoError(t, afero.WriteFile(fsys, path, contents, 0644))
+
+				state, created, err := LoadOrCreateState(fsys, now)
+
+				require.NoError(t, err)
+				assert.True(t, created)
+				assert.True(t, state.Enabled)
+				assert.Equal(t, SchemaVersion, state.SchemaVersion)
+				assert.NoError(t, uuid.Validate(state.DeviceID))
+				assert.NoError(t, uuid.Validate(state.SessionID))
+				saved, err := LoadState(fsys)
+				require.NoError(t, err)
+				assert.Equal(t, state, saved)
+			})
+		}
+	})
+
 	t.Run("rotates stale session after inactivity threshold", func(t *testing.T) {
 		t.Setenv("SUPABASE_HOME", "/tmp/supabase-home")
 		fsys := afero.NewMemMapFs()


### PR DESCRIPTION
## Summary

Three Windows-only failures, all surfacing as JSON parse errors. None reproduce on macOS or Linux.

## Reported errors

### 1. `supabase telemetry disable`

```
failed to parse telemetry file: Time.UnmarshalJSON: input is not a JSON string
```

The on-disk `~/.supabase/telemetry.json` had `session_last_active` stored as a number (epoch millis) instead of an RFC3339 string — `time.Time.UnmarshalJSON` rejects numbers. `LoadOrCreateState` only handled `os.ErrNotExist`, so the parse error propagated and the command crashed.

### 2. `supabase db schema declarative sync --experimental` (export step)

```
error exporting declarative schema: edge-runtime script produced no output:
NotFound: No such file or directory (os error 2): readfile
  '/workspace/supabase\.temp\pgdelta\catalog-baseline-17.6.1.106.json'
```

The catalog file path was constructed on Windows with `filepath.Join`, which produces `\` separators. `containerRef` prefixed it with `/workspace/` and passed it to the Linux edge-runtime container, which cannot read backslash paths. Before this PR the subprocess crashed silently and the user only saw the much less helpful `unexpected end of JSON input` from `json.Unmarshal` on empty stdout — surfacing stderr is what made the underlying path bug visible in the first place.

### 3. `supabase db schema declarative sync --experimental` (diff step)

```
error diffing schema: edge-runtime script produced no output:
main worker has been destroyed
```

For the export and catalog scripts, empty stdout means the subprocess crashed. For the diff script, empty stdout means there are simply no schema changes. The empty-stdout guard therefore lives in the export and catalog callers (which require non-empty output), and the diff caller correctly accepts empty stdout as "no changes".

## Fixes

- **`internal/telemetry/state.go`**: sentinel `errMalformedState` so any unmarshal failure (`*json.SyntaxError`, `*json.UnmarshalTypeError`, `time.Time.UnmarshalJSON`, …) recreates state. Identity fields are not worth surfacing an error for; losing them is harmless.
- **`internal/db/diff/pgdelta.go`**: `containerRef` runs `filepath.ToSlash` so Windows paths normalise before being passed into the Linux container. `DeclarativeExportPgDeltaRef` and `ExportCatalogPgDelta` now error with stderr when stdout is empty, instead of failing later with `unexpected end of JSON input`.
- **`internal/db/pgcache/cache.go`**: same empty-stdout guard on `exportCatalog`.

## Test plan

- [x] `go build ./...`
- [x] `TestLoadOrCreateState/recovers_from_corrupted_state_file` — table covering empty file, truncated JSON, `session_last_active` as number, `session_last_active` as malformed string
- [x] `TestContainerRef` — Windows path with `\` separators, Unix path passthrough, postgres URL passthrough
- [x] Manual on Windows 11: `go run . telemetry disable` against the actually-corrupted file → succeeds, file rewritten with valid JSON
- [x] Manual on Windows 11: `go run . db schema declarative sync --experimental --yes` → `No schema changes found` (previously crashed with `unexpected end of JSON input`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)