### PR TITLE
WIP: isolate secrets set inputs

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -245,7 +245,7 @@ func parseEnvFile(envFilePath string, fsys afero.Fs) ([]string, error) {
 		envFilePath = filepath.Join(utils.CurrentDirAbs, envFilePath)
 	}
 	env := []string{}
-	secrets, err := set.ListSecrets(envFilePath, fsys)
+	secrets, err := set.ListSecretsWithConfig(envFilePath, fsys)
 	for _, v := range secrets {
 		env = append(env, fmt.Sprintf("%s=%s", v.Name, v.Value))
 	}

--- a/internal/secrets/set/set.go
+++ b/internal/secrets/set/set.go
@@ -44,12 +44,20 @@ func Run(ctx context.Context, projectRef, envFilePath string, args []string, fsy
 }
 
 func ListSecrets(envFilePath string, fsys afero.Fs, envArgs ...string) (api.CreateSecretBody, error) {
+	return parseSecrets(map[string]string{}, envFilePath, fsys, envArgs...)
+}
+
+func ListSecretsWithConfig(envFilePath string, fsys afero.Fs, envArgs ...string) (api.CreateSecretBody, error) {
 	envMap := map[string]string{}
 	for name, secret := range utils.Config.EdgeRuntime.Secrets {
 		if len(secret.SHA256) > 0 {
 			envMap[name] = secret.Value
 		}
 	}
+	return parseSecrets(envMap, envFilePath, fsys, envArgs...)
+}
+
+func parseSecrets(envMap map[string]string, envFilePath string, fsys afero.Fs, envArgs ...string) (api.CreateSecretBody, error) {
 	if len(envFilePath) > 0 {
 		parsed, err := parseEnvFile(envFilePath, fsys)
 		if err != nil {

--- a/internal/secrets/set/set_test.go
+++ b/internal/secrets/set/set_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/config"
 )
 
 func TestSecretSetCommand(t *testing.T) {
@@ -63,6 +64,21 @@ func TestSecretSetCommand(t *testing.T) {
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("Ignores edge runtime config secrets", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		secrets := utils.Config.EdgeRuntime.Secrets
+		t.Cleanup(func() { utils.Config.EdgeRuntime.Secrets = secrets })
+		utils.Config.EdgeRuntime.Secrets = config.SecretsConfig{
+			"FOO": {Value: "foo", SHA256: "hash"},
+		}
+		// Run test
+		result, err := ListSecrets("", fsys, "BAR=bar")
+		// Check error
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, api.CreateSecretBody{{Name: "BAR", Value: "bar"}}, result)
 	})
 
 	t.Run("throws error on empty secret", func(t *testing.T) {


### PR DESCRIPTION
## TL;DR

`supabase secrets set` was mixing explicit secrets with edge runtime secrets from config

somewhat command like `supabase secrets set BAR=bar` could unexpectedly send both `BAR` and secrets from `[edge_runtime.secrets]`

## prob

`secrets set` was using `[edge_runtime.secrets]` when building the payload for the bulk create secrets endpoint

That made explicit inputs like args behave unexpectedly because local edge runtime config secrets were included in the same request

### sol

Keep `secrets set` limited to explicit args and `--env-file`
& edrt config secrets on the existing `functions serve` 

<details>
<summary>alt approach</summary>

I also considered keeping config secrets only for noarg `secrets set`

That would preserve the old  behavior while still avoiding mixed payloads when args or `--env-file` are used

I kept the other version because `functions serve` already handles edge runtime config secrets and 
remote uploads should be explicit IMO
wdyt?

</details>

### ref:

- closes https://github.com/supabase/supabase/issues/45242
