### PR TITLE
Introduce --no-clobber/-n flag to cp command to avoid skip existing

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -34,8 +34,9 @@ var (
 		},
 	}
 
-	options storage.FileOptions
-	maxJobs uint
+	options   storage.FileOptions
+	maxJobs   uint
+	noClobber bool
 
 	cpCmd = &cobra.Command{
 		Use: "cp <src> <dst>",
@@ -50,7 +51,7 @@ cp -r ss:///bucket/docs .
 				fo.CacheControl = options.CacheControl
 				fo.ContentType = options.ContentType
 			}
-			return cp.Run(cmd.Context(), args[0], args[1], recursive, maxJobs, afero.NewOsFs(), opts)
+			return cp.Run(cmd.Context(), args[0], args[1], recursive, maxJobs, noClobber, afero.NewOsFs(), opts)
 		},
 	}
 
@@ -89,6 +90,7 @@ func init() {
 	cpFlags.StringVar(&options.ContentType, "content-type", "", "Custom Content-Type header for HTTP upload.")
 	cpFlags.Lookup("content-type").DefValue = "auto-detect"
 	cpFlags.UintVarP(&maxJobs, "jobs", "j", 1, "Maximum number of parallel jobs.")
+	cpFlags.BoolVarP(&noClobber, "no-clobber", "n", false, "Do not overwrite an existing file.")
 	storageCmd.AddCommand(cpCmd)
 	rmCmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Recursively remove a directory.")
 	storageCmd.AddCommand(rmCmd)

--- a/internal/storage/cp/cp.go
+++ b/internal/storage/cp/cp.go
@@ -22,7 +22,7 @@ import (
 
 var errUnsupportedOperation = errors.New("Unsupported operation")
 
-func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, fsys afero.Fs, opts ...func(*storage.FileOptions)) error {
+func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, noClobber bool, fsys afero.Fs, opts ...func(*storage.FileOptions)) error {
 	srcParsed, err := url.Parse(src)
 	if err != nil {
 		return errors.Errorf("failed to parse src url: %w", err)
@@ -41,7 +41,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, fsy
 			localPath = filepath.Join(utils.CurrentDirAbs, dst)
 		}
 		if recursive {
-			return DownloadStorageObjectAll(ctx, api, srcParsed.Path, localPath, maxJobs, fsys)
+			return DownloadStorageObjectAll(ctx, api, srcParsed.Path, localPath, maxJobs, noClobber, fsys)
 		}
 		return api.DownloadObject(ctx, srcParsed.Path, localPath, fsys)
 	} else if srcParsed.Scheme == "" && strings.EqualFold(dstParsed.Scheme, client.STORAGE_SCHEME) {
@@ -50,7 +50,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, fsy
 			localPath = filepath.Join(utils.CurrentDirAbs, localPath)
 		}
 		if recursive {
-			return UploadStorageObjectAll(ctx, api, dstParsed.Path, localPath, maxJobs, fsys, opts...)
+			return UploadStorageObjectAll(ctx, api, dstParsed.Path, localPath, maxJobs, noClobber, fsys, opts...)
 		}
 		return api.UploadObject(ctx, dstParsed.Path, src, utils.NewRootFS(fsys), opts...)
 	} else if strings.EqualFold(srcParsed.Scheme, client.STORAGE_SCHEME) && strings.EqualFold(dstParsed.Scheme, client.STORAGE_SCHEME) {
@@ -60,7 +60,7 @@ func Run(ctx context.Context, src, dst string, recursive bool, maxJobs uint, fsy
 	return errors.New(errUnsupportedOperation)
 }
 
-func DownloadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remotePath, localPath string, maxJobs uint, fsys afero.Fs) error {
+func DownloadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remotePath, localPath string, maxJobs uint, noClobber bool, fsys afero.Fs) error {
 	// Prepare local directory for download
 	if fi, err := fsys.Stat(localPath); err == nil && fi.IsDir() {
 		localPath = filepath.Join(localPath, path.Base(remotePath))
@@ -71,7 +71,6 @@ func DownloadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remot
 	err := ls.IterateStoragePathsAll(ctx, api, remotePath, func(objectPath string) error {
 		relPath := strings.TrimPrefix(objectPath, remotePath)
 		dstPath := filepath.Join(localPath, filepath.FromSlash(relPath))
-		fmt.Fprintln(os.Stderr, "Downloading:", objectPath, "=>", dstPath)
 		count++
 		job := func() error {
 			if strings.HasSuffix(objectPath, "/") {
@@ -81,9 +80,21 @@ func DownloadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remot
 				return err
 			}
 			// Overwrites existing file when using --recursive flag
-			f, err := fsys.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			var f afero.File
+			var err error
+			if noClobber {
+				f, err = fsys.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+			} else {
+				f, err = fsys.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			}
 			if err != nil {
+				if errors.Is(err, afero.ErrFileExists) {
+					fmt.Fprintln(os.Stderr, "Skipped (already exists):", objectPath, "=>", dstPath)
+					return nil
+				}
 				return errors.Errorf("failed to create file: %w", err)
+			} else {
+				fmt.Fprintln(os.Stderr, "Downloading:", objectPath, "=>", dstPath)
 			}
 			defer f.Close()
 			return api.DownloadObjectStream(ctx, objectPath, f)
@@ -96,7 +107,7 @@ func DownloadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remot
 	return errors.Join(err, jq.Collect())
 }
 
-func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remotePath, localPath string, maxJobs uint, fsys afero.Fs, opts ...func(*storage.FileOptions)) error {
+func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remotePath, localPath string, maxJobs uint, noClobber bool, fsys afero.Fs, opts ...func(*storage.FileOptions)) error {
 	noSlash := strings.TrimSuffix(remotePath, "/")
 	// Check if directory exists on remote
 	dirExists := false
@@ -115,9 +126,9 @@ func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remoteP
 			return err
 		}
 	}
-	// Overwrites existing object when using --recursive flag
+	// Overwrites existing object when using --recursive flag except when using --no-clobber (shorthand -n) flag
 	opts = append(opts, func(fo *storage.FileOptions) {
-		fo.Overwrite = true
+		fo.Overwrite = !noClobber
 	})
 	baseName := filepath.Base(localPath)
 	jq := queue.NewJobQueue(maxJobs)
@@ -145,6 +156,15 @@ func UploadStorageObjectAll(ctx context.Context, api storage.StorageAPI, remoteP
 				dstPath = path.Join(dstPath, baseName)
 			}
 			dstPath = path.Join(dstPath, relPath)
+		}
+		if noClobber {
+			bucket, prefix := client.SplitBucketPrefix(dstPath)
+			objects, err := api.ListObjects(ctx, bucket, prefix, 0)
+			fileExists := err == nil && len(objects) == 1 && objects[0].Id != nil
+			if fileExists {
+				fmt.Fprintln(os.Stderr, "Skipped (already exists):", filePath, "=>", dstPath)
+				return nil
+			}
 		}
 		fmt.Fprintln(os.Stderr, "Uploading:", filePath, "=>", dstPath)
 		job := func() error {

--- a/internal/storage/cp/cp_test.go
+++ b/internal/storage/cp/cp_test.go
@@ -65,7 +65,7 @@ func TestStorageCP(t *testing.T) {
 			Post("/storage/v1/object/private/file").
 			Reply(http.StatusOK)
 		// Run test
-		err := Run(context.Background(), "/tmp/file", "ss:///private/file", false, 1, fsys)
+		err := Run(context.Background(), "/tmp/file", "ss:///private/file", false, 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -85,7 +85,7 @@ func TestStorageCP(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.BucketResponse{})
 		// Run test
-		err := Run(context.Background(), "abstract.pdf", "ss:///private", true, 1, fsys)
+		err := Run(context.Background(), "abstract.pdf", "ss:///private", true, 1, false, fsys)
 		// Check error
 		assert.ErrorIs(t, err, fs.ErrNotExist)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -104,7 +104,7 @@ func TestStorageCP(t *testing.T) {
 			Get("/storage/v1/object/private/file").
 			Reply(http.StatusOK)
 		// Run test
-		err := Run(context.Background(), "ss:///private/file", "abstract.pdf", false, 1, fsys)
+		err := Run(context.Background(), "ss:///private/file", "abstract.pdf", false, 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -127,7 +127,7 @@ func TestStorageCP(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.BucketResponse{})
 		// Run test
-		err := Run(context.Background(), "ss:///private", ".", true, 1, fsys)
+		err := Run(context.Background(), "ss:///private", ".", true, 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Object not found: /private")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -137,7 +137,7 @@ func TestStorageCP(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), ":", ".", false, 1, fsys)
+		err := Run(context.Background(), ":", ".", false, 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "missing protocol scheme")
 	})
@@ -146,7 +146,7 @@ func TestStorageCP(t *testing.T) {
 		// Setup in-memory fs
 		fsys := afero.NewMemMapFs()
 		// Run test
-		err := Run(context.Background(), ".", ":", false, 1, fsys)
+		err := Run(context.Background(), ".", ":", false, 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "missing protocol scheme")
 	})
@@ -161,7 +161,7 @@ func TestStorageCP(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON(apiKeys)
 		// Run test
-		err := Run(context.Background(), ".", ".", false, 1, fsys)
+		err := Run(context.Background(), ".", ".", false, 1, false, fsys)
 		// Check error
 		assert.ErrorIs(t, err, errUnsupportedOperation)
 	})
@@ -190,7 +190,7 @@ func TestUploadAll(t *testing.T) {
 			Post("/storage/v1/object/tmp/readme.md").
 			Reply(http.StatusOK)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "", "/tmp", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "", "/tmp", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -214,7 +214,7 @@ func TestUploadAll(t *testing.T) {
 			Post("/storage/v1/bucket").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "", "/tmp", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "", "/tmp", 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Error status 503:")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -240,7 +240,7 @@ func TestUploadAll(t *testing.T) {
 			Post("/storage/v1/object/private/dir/tmp/docs/api.md").
 			Reply(http.StatusOK)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "/private/dir/", "/tmp", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "/private/dir/", "/tmp", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -265,7 +265,7 @@ func TestUploadAll(t *testing.T) {
 			Post("/storage/v1/object/private/readme.md").
 			Reply(http.StatusOK)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "private", "/tmp/readme.md", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "private", "/tmp/readme.md", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -287,7 +287,7 @@ func TestUploadAll(t *testing.T) {
 			Post("/storage/v1/object/private/file").
 			Reply(http.StatusOK)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "private/file", "/tmp/readme.md", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "private/file", "/tmp/readme.md", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -302,7 +302,7 @@ func TestUploadAll(t *testing.T) {
 			Get("/storage/v1/bucket").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		err := UploadStorageObjectAll(context.Background(), mockApi, "missing", ".", 1, fsys)
+		err := UploadStorageObjectAll(context.Background(), mockApi, "missing", ".", 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Error status 503:")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -339,7 +339,7 @@ func TestDownloadAll(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.ObjectResponse{})
 		// Run test
-		err := DownloadStorageObjectAll(context.Background(), mockApi, "", "/", 1, fsys)
+		err := DownloadStorageObjectAll(context.Background(), mockApi, "", "/", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -374,7 +374,7 @@ func TestDownloadAll(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.ObjectResponse{})
 		// Run test
-		err := DownloadStorageObjectAll(context.Background(), mockApi, "/private", "/tmp", 1, fsys)
+		err := DownloadStorageObjectAll(context.Background(), mockApi, "/private", "/tmp", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -396,7 +396,7 @@ func TestDownloadAll(t *testing.T) {
 			Reply(http.StatusOK).
 			JSON([]storage.ObjectResponse{})
 		// Run test
-		err := DownloadStorageObjectAll(context.Background(), mockApi, "private/dir/", "/", 1, fsys)
+		err := DownloadStorageObjectAll(context.Background(), mockApi, "private/dir/", "/", 1, false, fsys)
 		// Check error
 		assert.ErrorContains(t, err, "Object not found: private/dir/")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -443,7 +443,7 @@ func TestDownloadAll(t *testing.T) {
 			Get("/storage/v1/object/private/tmp/docs/readme.md").
 			Reply(http.StatusOK)
 		// Run test
-		err := DownloadStorageObjectAll(context.Background(), mockApi, "private/tmp/", "/", 1, fsys)
+		err := DownloadStorageObjectAll(context.Background(), mockApi, "private/tmp/", "/", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -468,7 +468,7 @@ func TestDownloadAll(t *testing.T) {
 			Get("/storage/v1/object/private/abstract.pdf").
 			Reply(http.StatusOK)
 		// Run test
-		err := DownloadStorageObjectAll(context.Background(), mockApi, "/private/abstract.pdf", "/tmp/file", 1, fsys)
+		err := DownloadStorageObjectAll(context.Background(), mockApi, "/private/abstract.pdf", "/tmp/file", 1, false, fsys)
 		// Check error
 		assert.NoError(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())


### PR DESCRIPTION
## What kind of change does this PR introduce?

It introduces an new feature. Specifically the --no-clobber/-n flag for the storage cp command.

## What is the current behavior?
There is no way to skip files that already exist at the destination. This is really frustrating when you're copying tens of thousands of files to get a bad gateway error halfway through the transfer and have to start over.

Closes issue #5149.

## What is the new behavior?
When --no-clobber/-n is passed to the storage cp command files that already exist at the destination path are skipped.