### PR TITLE
fix(functions): set nofile ulimit for Edge Runtime container

### DIFF
--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -224,6 +224,7 @@ EOF
 			Binds:        binds,
 			PortBindings: portBindings,
 			Resources: container.Resources{
+                                  // Raise nofile to accommodate FD usage from many concurrent Deno isolates (see #5151).
 				Ulimits: []*container.Ulimit{
 					{
 						Name: "nofile",

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -223,6 +223,15 @@ EOF
 		container.HostConfig{
 			Binds:        binds,
 			PortBindings: portBindings,
+			Resources: container.Resources{
+				Ulimits: []*container.Ulimit{
+					{
+						Name: "nofile",
+						Soft: 65536,
+						Hard: 65536,
+					},
+				},
+			},
 		},
 		network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -224,7 +224,7 @@ EOF
 			Binds:        binds,
 			PortBindings: portBindings,
 			Resources: container.Resources{
-                // Raise nofile to accommodate FD usage from many concurrent Deno isolates (see #5151).
+				// Raise nofile to accommodate FD usage from many concurrent Deno isolates (see #5151).
 				Ulimits: []*container.Ulimit{
 					{
 						Name: "nofile",

--- a/internal/functions/serve/serve.go
+++ b/internal/functions/serve/serve.go
@@ -224,7 +224,7 @@ EOF
 			Binds:        binds,
 			PortBindings: portBindings,
 			Resources: container.Resources{
-                                  // Raise nofile to accommodate FD usage from many concurrent Deno isolates (see #5151).
+                // Raise nofile to accommodate FD usage from many concurrent Deno isolates (see #5151).
 				Ulimits: []*container.Ulimit{
 					{
 						Name: "nofile",


### PR DESCRIPTION
Fixes #5151

## What type of PR is this?

- bug

## What this PR does / why it is needed:

The Edge Runtime container was started with Docker's default `nofile` ulimit (1024 soft limit). For projects with many Edge Functions (200+) and long-running local dev sessions, the per-isolate file descriptor usage accumulates until new isolates fail to boot with:

```
worker boot error: failed to bootstrap runtime: Reading /root/.cache/deno/npm/...: Too many open files (os error 24)
```

This PR sets the `nofile` ulimit to 65536 (both soft and hard) for the Edge Runtime container, allowing sufficient file descriptors for Deno isolates handling many concurrent functions.

## Changes:

- Add `Resources.Ulimits` to the `container.HostConfig` in `ServeFunctions`, setting `nofile` to 65536

## Reproduction:

1. Project with ~200 Edge Functions
2. `supabase start`
3. Let it run several hours; alphabetically late functions start returning HTTP 503 BOOT-FEHLER
4. After this fix, the container starts with 65536 file descriptors, preventing the issue
