### PR TITLE
feat: emit Claude Code plugin hint from CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,6 +196,9 @@ func Execute() {
 	if semver.Compare(version, "v"+utils.Version) > 0 {
 		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
 	}
+	if hint := utils.SuggestClaudePlugin(); hint != "" {
+		fmt.Fprintln(os.Stderr, hint)
+	}
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -193,11 +193,11 @@ func Execute() {
 	if err != nil {
 		fmt.Fprintln(utils.GetDebugLogger(), err)
 	}
-	if semver.Compare(version, "v"+utils.Version) > 0 {
-		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
-	}
 	if hint := utils.SuggestClaudePlugin(); hint != "" {
 		fmt.Fprintln(os.Stderr, hint)
+	}
+	if semver.Compare(version, "v"+utils.Version) > 0 {
+		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
 	}
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -172,6 +172,9 @@ func Run(ctx context.Context, stdout io.Writer, params RunParams) error {
 		}
 		handleTelemetryAfterLogin(ctx, params)
 		fmt.Println(loggedInMsg)
+		if hint := utils.SuggestClaudePlugin(); hint != "" {
+			fmt.Fprintln(os.Stderr, hint)
+		}
 		return nil
 	}
 
@@ -223,6 +226,9 @@ func Run(ctx context.Context, stdout io.Writer, params RunParams) error {
 
 	fmt.Fprintf(stdout, "Token %s created successfully.\n\n", utils.Bold(params.TokenName))
 	fmt.Fprintln(stdout, loggedInMsg)
+	if hint := utils.SuggestClaudePlugin(); hint != "" {
+		fmt.Fprintln(os.Stderr, hint)
+	}
 
 	return nil
 }

--- a/internal/utils/agent/agent.go
+++ b/internal/utils/agent/agent.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// IsClaudeCode reports whether the CLI is running inside Claude Code.
+func IsClaudeCode() bool {
+	return os.Getenv("CLAUDECODE") != "" || os.Getenv("CLAUDE_CODE") != ""
+}
+
 // IsAgent checks environment variables to detect if the CLI is being invoked
 // by an AI coding agent. Based on the detection logic from Vercel's
 // @vercel/functions/ai package.
@@ -37,7 +42,7 @@ func IsAgent() bool {
 		return true
 	}
 	// Claude Code
-	if os.Getenv("CLAUDECODE") != "" || os.Getenv("CLAUDE_CODE") != "" {
+	if IsClaudeCode() {
 		return true
 	}
 	// Replit

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -38,6 +38,15 @@ func ShortContainerImageName(imageName string) string {
 
 const SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot the error."
 
+const claudeCodeHint = `<claude-code-hint v="1" type="plugin" value="supabase@claude-plugins-official" />`
+
+func SuggestClaudePlugin() string {
+	if os.Getenv("CLAUDECODE") != "" {
+		return claudeCodeHint
+	}
+	return ""
+}
+
 var (
 	CmdSuggestion string
 	CurrentDirAbs string

--- a/internal/utils/misc.go
+++ b/internal/utils/misc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"github.com/supabase/cli/internal/utils/agent"
 	"github.com/supabase/cli/pkg/migration"
 )
 
@@ -41,7 +42,7 @@ const SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot
 const claudeCodeHint = `<claude-code-hint v="1" type="plugin" value="supabase@claude-plugins-official" />`
 
 func SuggestClaudePlugin() string {
-	if os.Getenv("CLAUDECODE") != "" {
+	if agent.IsClaudeCode() {
 		return claudeCodeHint
 	}
 	return ""


### PR DESCRIPTION
## Summary

- Adds `SuggestClaudePlugin()` to `internal/utils/misc.go` that returns the `<claude-code-hint />` tag when the `CLAUDECODE` env var is set (no-op otherwise)
- Calls it in `Execute()` (`cmd/root.go`) so every `supabase` invocation can trigger the hint
- Calls it after login success in `internal/login/login.go` (both token and browser paths) to catch users in a setup flow

Claude Code deduplicates by plugin per session, so emitting broadly is safe. The tag is stripped from output before it reaches the model and never counts toward token usage.

Closes [AI-689](https://linear.app/supabase/issue/AI-689/investigate-claude-code-plugin-hints)

<img width="451" height="480" alt="image" src="https://github.com/user-attachments/assets/30ff3498-219b-45e1-80c9-0c9e579455fb" />


## References

- Protocol docs: https://code.claude.com/docs/en/plugin-hints
- Plugin source: https://github.com/Rodriguespn/claude-plugins-official