### PR TITLE
fix: skip bucket seeding

### DIFF
--- a/internal/seed/buckets/buckets.go
+++ b/internal/seed/buckets/buckets.go
@@ -11,6 +11,9 @@ import (
 )
 
 func Run(ctx context.Context, projectRef string, interactive bool, fsys afero.Fs) error {
+	if len(projectRef) == 0 && len(utils.Config.Storage.Buckets) == 0 {
+		return nil
+	}
 	api, err := client.NewStorageAPI(ctx, projectRef)
 	if err != nil {
 		return err

--- a/internal/seed/buckets/buckets_test.go
+++ b/internal/seed/buckets/buckets_test.go
@@ -54,16 +54,24 @@ public = false`
 	})
 
 	t.Run("ignores unconfigured buckets", func(t *testing.T) {
-		// Setup mock api
-		defer gock.OffAll()
+		t.Cleanup(func() {
+			utils.Config.Storage.TargetMigration = ""
+			gock.OffAll()
+		})
+		utils.Config.Storage.TargetMigration = "custom-metadata"
 		gock.New(utils.Config.Api.ExternalUrl).
 			Get("/storage/v1/bucket").
-			Reply(http.StatusOK).
-			JSON([]storage.BucketResponse{})
+			Reply(http.StatusBadRequest).
+			JSON(map[string]string{
+				"statusCode": "403",
+				"error":      "Unauthorized",
+				"message":    "new row violates row-level security policy",
+			})
 		// Run test
 		err := Run(context.Background(), "", false, afero.NewMemMapFs())
 		// Check error
 		assert.NoError(t, err)
+		assert.Len(t, gock.Pending(), 1)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }


### PR DESCRIPTION
## TL;DR

skip local storage bucket seeding when no buckets are configured. 
the unnecessary `GET /storage/v1/bucket` call was causing `supabase start` to fail with 
`Error status 400: {"statusCode":"403","error":"Unauthorized","message":"new row violates row-level security policy"}`

## sol:

`buckets.Run` now returns early for local runs when `[storage.buckets]` is empty, configured local buckets and linked project bucket seeding still use the existing path unchanged

added a test aswell

## ref:

- Closes https://github.com/supabase/cli/issues/5157
- Closes https://github.com/supabase/cli/issues/4866
