### PR TITLE
fix: prepend mailer_urlpaths with JwtIssuer

### DIFF
--- a/internal/start/start.go
+++ b/internal/start/start.go
@@ -1315,10 +1315,10 @@ func buildGotrueEnv(dbConfig pgconn.Config) []string {
 
 		fmt.Sprintf("GOTRUE_SMTP_MAX_FREQUENCY=%v", utils.Config.Auth.Email.MaxFrequency),
 
-		"GOTRUE_MAILER_URLPATHS_INVITE=/verify",
-		"GOTRUE_MAILER_URLPATHS_CONFIRMATION=/verify",
-		"GOTRUE_MAILER_URLPATHS_RECOVERY=/verify",
-		"GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=/verify",
+		fmt.Sprintf("GOTRUE_MAILER_URLPATHS_INVITE=%s/verify", utils.Config.Auth.JwtIssuer),
+		fmt.Sprintf("GOTRUE_MAILER_URLPATHS_CONFIRMATION=%s/verify", utils.Config.Auth.JwtIssuer),
+		fmt.Sprintf("GOTRUE_MAILER_URLPATHS_RECOVERY=%s/verify", utils.Config.Auth.JwtIssuer),
+		fmt.Sprintf("GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=%s/verify", utils.Config.Auth.JwtIssuer),
 		"GOTRUE_RATE_LIMIT_EMAIL_SENT=360000",
 
 		fmt.Sprintf("GOTRUE_EXTERNAL_PHONE_ENABLED=%v", utils.Config.Auth.Sms.EnableSignup),

--- a/internal/start/start_test.go
+++ b/internal/start/start_test.go
@@ -307,7 +307,7 @@ func TestBuildGotrueEnv(t *testing.T) {
 		utils.Config = original
 	})
 
-	t.Run("uses auth scoped external url and relative mailer paths", func(t *testing.T) {
+	t.Run("uses auth scoped external url and absolute mailer urls", func(t *testing.T) {
 		utils.Config = config.NewConfig()
 		utils.Config.Api.ExternalUrl = "http://127.0.0.1:54321"
 		utils.Config.Auth.ExternalUrl = "http://127.0.0.1:54321/auth/v1"
@@ -328,10 +328,10 @@ func TestBuildGotrueEnv(t *testing.T) {
 
 		assert.Equal(t, "http://127.0.0.1:54321/auth/v1", env["API_EXTERNAL_URL"])
 		assert.Equal(t, "http://127.0.0.1:54321/auth/v1", env["GOTRUE_JWT_ISSUER"])
-		assert.Equal(t, "/verify", env["GOTRUE_MAILER_URLPATHS_INVITE"])
-		assert.Equal(t, "/verify", env["GOTRUE_MAILER_URLPATHS_CONFIRMATION"])
-		assert.Equal(t, "/verify", env["GOTRUE_MAILER_URLPATHS_RECOVERY"])
-		assert.Equal(t, "/verify", env["GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE"])
+		assert.Equal(t, "http://127.0.0.1:54321/auth/v1/verify", env["GOTRUE_MAILER_URLPATHS_INVITE"])
+		assert.Equal(t, "http://127.0.0.1:54321/auth/v1/verify", env["GOTRUE_MAILER_URLPATHS_CONFIRMATION"])
+		assert.Equal(t, "http://127.0.0.1:54321/auth/v1/verify", env["GOTRUE_MAILER_URLPATHS_RECOVERY"])
+		assert.Equal(t, "http://127.0.0.1:54321/auth/v1/verify", env["GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE"])
 		assert.NotContains(t, env, "GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI")
 	})
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #5163

## What is the new behavior?

prepend `GOTRUE_MAILER_URLPATHS_<flow>` env with `Auth.JwtIssuer` url. Safe to use full url in path env as supabase auth constructs the final email link using `externalURL.ResolveReference(path).String()` for all mailer paths https://github.com/supabase/auth/blob/be317c1a37aba9bc7d0c6664f476f446bfecb942/internal/mailer/templatemailer/templatemailer.go#L365

