### PR TITLE
fix(functions): edge-runtime template offline bootstrap (#45570)

### DIFF
--- a/internal/functions/serve/serve_test.go
+++ b/internal/functions/serve/serve_test.go
@@ -128,6 +128,22 @@ func TestServeCommand(t *testing.T) {
 	})
 }
 
+func TestMainTemplateNoRemoteImports(t *testing.T) {
+	// Regression pin for supabase/supabase#45570: the embedded edge-runtime
+	// entrypoint must not re-introduce remote imports, otherwise `supabase
+	// start` cannot bootstrap the worker container offline.
+	for _, scheme := range []string{
+		"https://deno.land/",
+		"http://deno.land/",
+		"https://esm.sh/",
+		"https://cdn.jsdelivr.net/",
+		"https://unpkg.com/",
+	} {
+		assert.NotContains(t, mainFuncEmbed, scheme,
+			"templates/main.ts must not import from %s (offline boot regression)", scheme)
+	}
+}
+
 func TestServeFunctions(t *testing.T) {
 	require.NoError(t, utils.Config.Load("testdata/config.toml", testdata))
 	utils.UpdateDockerIds()

--- a/internal/functions/serve/templates/main.ts
+++ b/internal/functions/serve/templates/main.ts
@@ -1,7 +1,80 @@
-import { STATUS_CODE, STATUS_TEXT } from "https://deno.land/std/http/status.ts";
-import * as posix from "https://deno.land/std/path/posix/mod.ts";
-
 import * as jose from "jsr:@panva/jose@6";
+
+// Inlined from std/http/status to avoid remote-import resolution at boot,
+// which fails when `supabase start` runs offline (no network reachable from
+// the edge-runtime container). Only the values referenced below are kept.
+// Ref: supabase/supabase#45570
+const STATUS_CODE = {
+  OK: 200,
+  Unauthorized: 401,
+  NotFound: 404,
+  InternalServerError: 500,
+  ServiceUnavailable: 503,
+} as const;
+
+const STATUS_TEXT: Record<number, string> = {
+  [STATUS_CODE.OK]: "OK",
+  [STATUS_CODE.Unauthorized]: "Unauthorized",
+  [STATUS_CODE.NotFound]: "Not Found",
+  [STATUS_CODE.InternalServerError]: "Internal Server Error",
+  [STATUS_CODE.ServiceUnavailable]: "Service Unavailable",
+};
+
+// Inlined from std/path/posix. Same offline-boot reason as above.
+// Only the three helpers used by this file are reproduced.
+const posix = {
+  dirname(path: string): string {
+    if (path.length === 0) return ".";
+    let end = -1;
+    let matched = false;
+    for (let i = path.length - 1; i >= 1; --i) {
+      if (path.charCodeAt(i) === 0x2f /* / */) {
+        if (matched) {
+          end = i;
+          break;
+        }
+      } else {
+        matched = true;
+      }
+    }
+    if (end === -1) return path.charCodeAt(0) === 0x2f ? "/" : ".";
+    if (end === 0 && path.charCodeAt(0) === 0x2f) return "/";
+    return path.slice(0, end);
+  },
+  join(...segments: string[]): string {
+    if (segments.length === 0) return ".";
+    let joined = "";
+    for (const segment of segments) {
+      if (segment.length > 0) {
+        joined = joined.length === 0 ? segment : `${joined}/${segment}`;
+      }
+    }
+    if (joined.length === 0) return ".";
+    // Normalize duplicate slashes and `.`/`..` segments while keeping a leading slash.
+    const isAbsolute = joined.charCodeAt(0) === 0x2f;
+    const parts: string[] = [];
+    for (const part of joined.split("/")) {
+      if (part === "" || part === ".") continue;
+      if (part === "..") {
+        if (parts.length > 0 && parts[parts.length - 1] !== "..") parts.pop();
+        else if (!isAbsolute) parts.push("..");
+        continue;
+      }
+      parts.push(part);
+    }
+    let result = parts.join("/");
+    if (isAbsolute) result = "/" + result;
+    return result.length === 0 ? (isAbsolute ? "/" : ".") : result;
+  },
+  toFileUrl(path: string): URL {
+    if (path.charCodeAt(0) !== 0x2f) {
+      throw new TypeError(`Path must be absolute: received "${path}"`);
+    }
+    const url = new URL("file:///");
+    url.pathname = encodeURI(path).replace(/[?#]/g, encodeURIComponent);
+    return url;
+  },
+};
 
 const SB_SPECIFIC_ERROR_CODE = {
   BootError:


### PR DESCRIPTION
## What

The edge-runtime entrypoint that `supabase start` writes into `/root/index.ts` (embedded from `internal/functions/serve/templates/main.ts`) starts with two remote imports:

```ts
import { STATUS_CODE, STATUS_TEXT } from "https://deno.land/std/http/status.ts";
import * as posix from "https://deno.land/std/path/posix/mod.ts";
```

Deno's graph builder resolves these every time the worker boots, so the runtime container fails to come up when the host has no network access.

Reported in supabase/supabase#45570:

> ```
> error: TypeError: error sending request from 127.0.0.1:50932 for https://deno.land/std/http/status.ts (resolved to 2606:50c0:8000::153:443): client error (Connect): tcp connect error: Network is unreachable (os error 101): Network is unreachable (os error 101)
>     at file:///root/index.ts:1:42
> ```

## Why this happens

The image is `supabase/edge-runtime:vX.Y.Z` (pulled, not built here), and `index.ts` is materialised on each container start via the embedded template — there is no build-time `deno cache` step we can hook into to pre-warm the module graph for these URLs. Pinning to JSR hits the same wall: `jsr:` specifiers also require a registry round-trip on first use unless previously cached.

## Fix

Inline the very small std surface this template actually depends on and drop the remote imports. Concretely:

| Was | Now |
| --- | --- |
| `STATUS_CODE.{OK,Unauthorized,NotFound,InternalServerError,ServiceUnavailable}` from `https://deno.land/std/http/status.ts` | local `STATUS_CODE` const with the same five numeric values |
| `STATUS_TEXT[STATUS_CODE.InternalServerError]` from the same module | local `STATUS_TEXT` record with the same five reason phrases |
| `posix.{dirname,join,toFileUrl}` from `https://deno.land/std/path/posix/mod.ts` | local `posix` object with the same three helpers |

The posix shim's outputs were cross-checked against `node:path.posix` for the path shapes this template constructs (`/supabase/functions/<name>/index.ts`, package-json discovery joins, absolute-to-`file://` conversion). `STATUS_TEXT` reason phrases match RFC 9110.

This is the smallest viable diff that makes offline boot work — no Dockerfile changes, no new `//go:embed` plumbing, no surrounding refactor.

The `jsr:@panva/jose@6` import on line 1 is unaffected: edge-runtime images already ship that module pre-cached (it has been in this template since #4721), which is why JWT verification works offline today and the std imports are the only blocker.

## Regression test

Added `TestMainTemplateNoRemoteImports` in `internal/functions/serve/serve_test.go`. It scans the embedded template for `https://deno.land/`, `http://deno.land/`, `https://esm.sh/`, `https://cdn.jsdelivr.net/`, and `https://unpkg.com/` and fails if any reappear. If anyone re-introduces a bare URL import here, the test catches it before the next offline-start regression.

## Verification

- `go build ./...` clean
- `go test ./internal/functions/...` all pass (incl. existing `TestServeCommand`, `TestServeFunctions`, and the new pin)
- `go vet ./...` clean

Closes supabase/supabase#45570