### PR TITLE
fix(ci): grant contents: write + id-token: write to release.yml caller jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.review.state == 'approved'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -157,6 +159,9 @@ jobs:
     name: Release
     needs: plan
     if: needs.plan.outputs.should_release == 'true'
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/release-shared.yml
     with:
       version: ${{ needs.plan.outputs.version }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Following the merge of #5181, `release.yml` cannot dispatch into `release-shared.yml`. GitHub Actions caps a called workflow at the caller job's permission set. `release.yml`'s top-level grant was `contents: read` only, so the call is rejected:

> Error calling workflow `'supabase/cli/.github/workflows/release-shared.yml@b28104f951cf960777c11d1a769ddf9d9cf54a57'`. The nested job `'publish'` is requesting `'contents: write, id-token: write'`, but is only allowed `'contents: read, id-token: none'`.

## What is the new behavior?

Set per-job permissions on the two jobs that need elevated scope, instead of bumping the workflow-wide grant:

- `fast-forward` job: `contents: write` (so the App-token-authed `git push origin main` succeeds).
- `release` job (the one with `uses: ./.github/workflows/release-shared.yml`): `contents: write` + `id-token: write`, so the called workflow's `publish`, GH-release, and OIDC-trusted-publishing steps can claim what they need.

`plan` stays on the workflow-default `contents: read`.