### PR TITLE
fix(ci): use App token for semantic-release dry-run push verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+      # semantic-release runs `git push --dry-run HEAD:<branch>` as part of
+      # verifyAuth even in `dry_run: true` mode, so the token must have push
+      # access to the protected `develop`/`main` branches. The default
+      # GITHUB_TOKEN doesn't, so we mint an App-installation token from the
+      # same App used for fast-forward + brew/scoop pushes.
+      - id: app-token
+        if: github.event_name == 'push'
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - id: semantic-release
         if: github.event_name == 'push'
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
@@ -82,7 +93,7 @@ jobs:
           working_directory: apps/cli
           dry_run: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - id: compute
         env:
           EVENT: ${{ github.event_name }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `plan` job in `release.yml` fails on every push to develop. Run [25432641784](https://github.com/supabase/cli/actions/runs/25432641784/job/74602494867):

> `[semantic-release] › ✘  The command "git push --dry-run --no-verify https://x-access-token:[secure]@github.com/supabase/cli HEAD:develop" failed with the error message remote: Permission to supabase/cli.git denied to github-actions[bot].`
>
> `fatal: unable to access 'https://github.com/supabase/cli/': The requested URL returned error: 403.`
>
> `[semantic-release] › ✘  EGITNOPERMISSION Cannot push to the Git repository.`

`cycjimmy/semantic-release-action` runs `git push --dry-run HEAD:<branch>` as part of `verifyAuth` **even with `dry_run: true`**. The default `GITHUB_TOKEN` (`github-actions[bot]`) has no push access to the protected `develop` / `main` branches, so the dry-push 403s and the whole job aborts before computing a version.

## What is the new behavior?

Mint a GitHub App installation token in the `plan` job — same App that already powers the `fast-forward` and brew/scoop jobs — and pass it as `GITHUB_TOKEN` to the semantic-release step. The App has `contents: write` on the repo and bypasses branch protection, so the dry-push succeeds and version computation proceeds.

The token is only generated for `push` events (semantic-release doesn't run on `workflow_dispatch`), so manual dispatches don't burn an App token mint.