### PR TITLE
fix: nullable in openapi codegen

### DIFF
--- a/packages/api/scripts/generate.ts
+++ b/packages/api/scripts/generate.ts
@@ -262,6 +262,49 @@ function replaceBinarySchemaCode(code: string): string {
   return code.replace(/Schema\.String\.annotate\(\{\s*"format":\s*"binary"\s*\}\)/g, "BinaryInput");
 }
 
+function normalizeJsonSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeJsonSchemaValue);
+  }
+  return isRecord(value) ? normalizeNullableJsonSchema(value) : value;
+}
+
+function normalizeNullableJsonSchema(schema: JsonSchema.JsonSchema): JsonSchema.JsonSchema {
+  const normalized: JsonSchema.JsonSchema = {};
+  for (const [key, value] of Object.entries(schema)) {
+    normalized[key] = normalizeJsonSchemaValue(value);
+  }
+
+  const type = normalized.type;
+  if (!Array.isArray(type) || !type.includes("null")) {
+    return normalized;
+  }
+
+  if (Array.isArray(normalized.enum) && normalized.enum.includes(null)) {
+    return normalized;
+  }
+
+  const nonNullTypes = type.filter((entry) => entry !== "null");
+  if (nonNullTypes.length === 0) {
+    return { type: "null" };
+  }
+  if (!nonNullTypes.includes("object") && !nonNullTypes.includes("array")) {
+    return normalized;
+  }
+
+  const nonNullSchema = { ...normalized };
+  delete nonNullSchema.type;
+  return {
+    anyOf: [
+      {
+        ...nonNullSchema,
+        type: nonNullTypes.length === 1 ? nonNullTypes[0] : nonNullTypes,
+      },
+      { type: "null" },
+    ],
+  };
+}
+
 function resolveSchema(document: OpenApiDocument, schema: OpenApiSchema): OpenApiSchema {
   if (schema.$ref) {
     const prefix = "#/components/schemas/";
@@ -531,13 +574,15 @@ function renderSchemaSource(
   const definitions = Object.fromEntries(
     Object.entries(document.components?.schemas ?? {}).map(([name, schema]) => [
       name,
-      JsonSchema.fromSchemaOpenApi3_0(sanitizeOpenApiSchema(schema)).schema,
+      normalizeNullableJsonSchema(
+        JsonSchema.fromSchemaOpenApi3_0(sanitizeOpenApiSchema(schema)).schema,
+      ),
     ]),
   );
 
   const nameMap = schemaEntries.map((entry) => entry.name);
-  const schemas = schemaEntries.map(
-    (entry) => JsonSchema.fromSchemaOpenApi3_0(entry.schema).schema,
+  const schemas = schemaEntries.map((entry) =>
+    normalizeNullableJsonSchema(JsonSchema.fromSchemaOpenApi3_0(entry.schema).schema),
   );
 
   if (!Arr.isArrayNonEmpty(schemas)) {

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -108,7 +108,9 @@ export const ApiKeyResponse = Schema.Struct({
   name: Schema.String,
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   hash: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
   inserted_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
   updated_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
 });
@@ -830,7 +832,9 @@ export const V1CreateProjectApiKeyInput = Schema.Struct({
     .check(Schema.isMaxLength(64))
     .check(Schema.isPattern(new RegExp("^[a-z_][a-z0-9_]+$"))),
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
 });
 export const V1CreateProjectApiKeyOutput = Schema.Struct({
   api_key: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
@@ -845,7 +849,9 @@ export const V1CreateProjectApiKeyOutput = Schema.Struct({
   name: Schema.String,
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   hash: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
   inserted_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
   updated_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
 });
@@ -1114,7 +1120,9 @@ export const V1DeleteProjectApiKeyOutput = Schema.Struct({
   name: Schema.String,
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   hash: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
   inserted_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
   updated_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
 });
@@ -2547,6 +2555,7 @@ export const V1GetPostgresUpgradeStatusOutput = Schema.Struct({
       ),
       status: Schema.Number.check(Schema.isFinite()),
     }),
+    Schema.Null,
   ]),
 });
 export const V1GetPostgrestServiceConfigInput = Schema.Struct({
@@ -2633,7 +2642,9 @@ export const V1GetProjectApiKeyOutput = Schema.Struct({
   name: Schema.String,
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   hash: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
   inserted_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
   updated_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
 });
@@ -5111,7 +5122,9 @@ export const V1UpdateProjectApiKeyInput = Schema.Struct({
       .check(Schema.isPattern(new RegExp("^[a-z_][a-z0-9_]+$"))),
   ),
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
 });
 export const V1UpdateProjectApiKeyOutput = Schema.Struct({
   api_key: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
@@ -5126,7 +5139,9 @@ export const V1UpdateProjectApiKeyOutput = Schema.Struct({
   name: Schema.String,
   description: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   hash: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  secret_jwt_template: Schema.optionalKey(Schema.Union([Schema.Struct({})])),
+  secret_jwt_template: Schema.optionalKey(
+    Schema.Union([Schema.Record(Schema.String, Schema.Unknown), Schema.Null]),
+  ),
   inserted_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
   updated_at: Schema.optionalKey(Schema.Union([Schema.String.annotate({ format: "date-time" })])),
 });

--- a/packages/api/src/internal/client.unit.test.ts
+++ b/packages/api/src/internal/client.unit.test.ts
@@ -335,6 +335,57 @@ describe("makeSupabaseApiClient", () => {
     expect(result.database.host).toBe("db.supabase.internal");
   });
 
+  test("decodes nullable JWT templates in API key responses", async () => {
+    const result = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.flatMap((client) =>
+          client.execute<"v1GetProjectApiKeys">(operationDefinitions.v1GetProjectApiKeys, {
+            ref: "abcdefghijklmnopqrst",
+            reveal: true,
+          }),
+        ),
+        Effect.provide(
+          httpClientLayer((request) => {
+            const url = requestUrl(request);
+            expect(url.pathname).toBe("/v1/projects/abcdefghijklmnopqrst/api-keys");
+            expect(requestUrlParam(request, "reveal")).toBe("true");
+            return Effect.succeed(
+              jsonResponse(request, 200, [
+                {
+                  name: "anon",
+                  type: "legacy",
+                  api_key: "anon-key",
+                  secret_jwt_template: null,
+                },
+                {
+                  name: "service_role",
+                  type: "secret",
+                  api_key: "service-role-key",
+                  secret_jwt_template: { role: "service_role" },
+                },
+              ]),
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(result).toEqual([
+      {
+        name: "anon",
+        type: "legacy",
+        api_key: "anon-key",
+        secret_jwt_template: null,
+      },
+      {
+        name: "service_role",
+        type: "secret",
+        api_key: "service-role-key",
+        secret_jwt_template: { role: "service_role" },
+      },
+    ]);
+  });
+
   test("does not retry 5xx responses for POST requests", async () => {
     let attempts = 0;
 


### PR DESCRIPTION
# Fix nullable schemas in OpenAPI codegen

## Summary

Fixes OpenAPI code generation for nullable object and array schemas so generated Effect schemas correctly accept `null` where the Management API spec allows it.

This fixes cases like nullable API key JWT templates and nullable object responses that were previously generated too narrowly.

## What Changed

- Adds a normalization pass after converting OpenAPI schemas to JSON Schema.
- Rewrites schemas with `type` arrays containing `"null"` for nullable objects/arrays into `anyOf` forms that Effect schema generation handles correctly.
- Preserves enum schemas that explicitly include `null`.
- Regenerates API contracts with the corrected nullable shapes.
- Updates generated API key contracts so `secret_jwt_template` accepts either an object record or `null`.
- Updates generated Postgres upgrade status output so nullable object responses include `Schema.Null`.
- Adds a client unit test that decodes API key responses containing both `secret_jwt_template: null` and object JWT templates.

