### PR TITLE
feat: add `supabase functions list`

### DIFF
--- a/apps/cli/src/next/commands/functions/functions.command.ts
+++ b/apps/cli/src/next/commands/functions/functions.command.ts
@@ -1,8 +1,9 @@
 import { Command } from "effect/unstable/cli";
+import { functionsListCommand } from "./list/list.command.ts";
 import { functionsNewCommand } from "./new/new.command.ts";
 
 export const functionsCommand = Command.make("functions").pipe(
   Command.withDescription("Manage Supabase Edge Functions."),
   Command.withShortDescription("Manage Supabase Edge Functions"),
-  Command.withSubcommands([functionsNewCommand]),
+  Command.withSubcommands([functionsNewCommand, functionsListCommand]),
 );

--- a/apps/cli/src/next/commands/functions/list/list.command.ts
+++ b/apps/cli/src/next/commands/functions/list/list.command.ts
@@ -1,0 +1,37 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { Command } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+import { credentialsLayer } from "../../../auth/credentials.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { functionsList } from "./list.handler.ts";
+
+const functionsListRuntimeLayer = Layer.mergeAll(
+  BunServices.layer,
+  FetchHttpClient.layer,
+  credentialsLayer,
+  commandRuntimeLayer(["functions", "list"]),
+);
+
+export const functionsListCommand = Command.make("list").pipe(
+  Command.withDescription(
+    "List Edge Functions from the local project inventory and enrich with linked remote deployment data when available.",
+  ),
+  Command.withShortDescription("List Edge Functions"),
+  Command.withExamples([
+    {
+      command: "supabase functions list",
+      description: "List local Edge Functions and linked remote deployment status",
+    },
+    {
+      command: "supabase functions list --output-format json",
+      description: "Emit the merged functions inventory as JSON",
+    },
+  ]),
+  Command.withHandler(() =>
+    functionsList().pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(functionsListRuntimeLayer),
+);

--- a/apps/cli/src/next/commands/functions/list/list.handler.ts
+++ b/apps/cli/src/next/commands/functions/list/list.handler.ts
@@ -113,9 +113,7 @@ const loadRemoteInventory = Effect.fnUntraced(function* () {
   const credentials = yield* Credentials;
   const commandRuntime = yield* CommandRuntime;
 
-  const maybeLinkState = yield* projectLinkState.load.pipe(
-    Effect.catch(() => Effect.succeed(Option.none())),
-  );
+  const maybeLinkState = yield* projectLinkState.load;
   if (Option.isNone(maybeLinkState)) {
     return {
       source: { checked: false, reason: "not_linked" },

--- a/apps/cli/src/next/commands/functions/list/list.handler.ts
+++ b/apps/cli/src/next/commands/functions/list/list.handler.ts
@@ -1,0 +1,224 @@
+import { inferFunctionsManifest, type ResolvedFunctionConfig } from "@supabase/config";
+import { makeApiClient } from "@supabase/api/effect";
+import { Effect, Option, Redacted } from "effect";
+import { CommandRuntime } from "../../../../shared/runtime/command-runtime.service.ts";
+import { Credentials } from "../../../auth/credentials.service.ts";
+import { CliConfig } from "../../../config/cli-config.service.ts";
+import { ProjectLinkState } from "../../../config/project-link-state.service.ts";
+import { RuntimeInfo } from "../../../../shared/runtime/runtime-info.service.ts";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { outputTable } from "../../../../shared/output/table.ts";
+
+type RemoteReason = "not_linked" | "not_authenticated" | "request_failed";
+
+interface RemoteFunction {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly status: "ACTIVE" | "REMOVED" | "THROTTLED";
+  readonly version: number;
+  readonly created_at: number;
+  readonly updated_at: number;
+  readonly verify_jwt?: boolean;
+  readonly import_map?: boolean;
+  readonly entrypoint_path?: string;
+  readonly import_map_path?: string;
+  readonly ezbr_sha256?: string;
+}
+
+interface RemoteSource {
+  readonly checked: boolean;
+  readonly project_ref?: string;
+  readonly reason?: RemoteReason;
+}
+
+interface RemoteInventory {
+  readonly source: RemoteSource;
+  readonly functions: Readonly<Record<string, RemoteFunction>>;
+}
+
+interface FunctionInventoryItem {
+  readonly slug: string;
+  readonly local: ResolvedFunctionConfig | null;
+  readonly remote: RemoteFunction | null;
+}
+
+interface RemoteTextMessage {
+  readonly level: "info" | "warn";
+  readonly message: string;
+}
+
+function formatUtcTimestamp(timestamp: number | undefined): string {
+  if (timestamp === undefined) {
+    return "-";
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return "Invalid date";
+  }
+
+  return date.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function remoteTextMessage(source: RemoteSource): RemoteTextMessage | undefined {
+  switch (source.reason) {
+    case "not_linked":
+      return {
+        level: "info",
+        message: "Showing local functions only. Link a project to include deployed functions.",
+      };
+    case "not_authenticated":
+      return {
+        level: "info",
+        message:
+          "Showing local functions only. Log in to include deployed functions from the linked project.",
+      };
+    case "request_failed":
+      return {
+        level: "warn",
+        message: "Remote deployments could not be fetched; showing local inventory only.",
+      };
+    case undefined:
+      return undefined;
+  }
+}
+
+function localStatus(config: ResolvedFunctionConfig | null): string {
+  if (config === null) {
+    return "-";
+  }
+
+  return config.enabled ? "enabled" : "disabled";
+}
+
+function entrypointFor(item: FunctionInventoryItem): string {
+  return item.local?.entrypoint ?? item.remote?.entrypoint_path ?? "-";
+}
+
+function toRecord<T extends { readonly slug: string }>(items: ReadonlyArray<T>): Record<string, T> {
+  return Object.fromEntries(items.map((item) => [item.slug, item]));
+}
+
+function resolveToken(
+  configuredToken: Option.Option<Redacted.Redacted<string>>,
+  storedToken: Option.Option<Redacted.Redacted<string>>,
+): Option.Option<Redacted.Redacted<string>> {
+  return Option.isSome(configuredToken) ? configuredToken : storedToken;
+}
+
+const loadRemoteInventory = Effect.fnUntraced(function* () {
+  const projectLinkState = yield* ProjectLinkState;
+  const cliConfig = yield* CliConfig;
+  const credentials = yield* Credentials;
+  const commandRuntime = yield* CommandRuntime;
+
+  const maybeLinkState = yield* projectLinkState.load.pipe(
+    Effect.catch(() => Effect.succeed(Option.none())),
+  );
+  if (Option.isNone(maybeLinkState)) {
+    return {
+      source: { checked: false, reason: "not_linked" },
+      functions: {},
+    } satisfies RemoteInventory;
+  }
+
+  const projectRef = maybeLinkState.value.project.ref;
+  const storedToken = yield* credentials.getAccessToken;
+  const token = resolveToken(cliConfig.accessToken, storedToken);
+  if (Option.isNone(token)) {
+    return {
+      source: { checked: false, project_ref: projectRef, reason: "not_authenticated" },
+      functions: {},
+    } satisfies RemoteInventory;
+  }
+
+  const api = yield* makeApiClient({
+    baseUrl: cliConfig.apiUrl,
+    accessToken: token.value,
+    userAgent: "@supabase/cli",
+    headers: {
+      "X-Supabase-Command": commandRuntime.commandPath.join(" "),
+      "X-Supabase-Command-Run-ID": commandRuntime.commandRunId,
+    },
+  });
+
+  return yield* api.v1.listAllFunctions({ ref: projectRef }).pipe(
+    Effect.match({
+      onFailure: () =>
+        ({
+          source: { checked: false, project_ref: projectRef, reason: "request_failed" },
+          functions: {},
+        }) satisfies RemoteInventory,
+      onSuccess: (functions) =>
+        ({
+          source: { checked: true, project_ref: projectRef },
+          functions: toRecord(functions),
+        }) satisfies RemoteInventory,
+    }),
+  );
+});
+
+function mergeInventory(
+  local: Readonly<Record<string, ResolvedFunctionConfig>>,
+  remote: Readonly<Record<string, RemoteFunction>>,
+): ReadonlyArray<FunctionInventoryItem> {
+  return [...new Set([...Object.keys(local), ...Object.keys(remote)])]
+    .sort((left, right) => left.localeCompare(right))
+    .map((slug) => ({
+      slug,
+      local: local[slug] ?? null,
+      remote: remote[slug] ?? null,
+    }));
+}
+
+export const functionsList = Effect.fnUntraced(function* () {
+  const output = yield* Output;
+  const runtimeInfo = yield* RuntimeInfo;
+
+  yield* output.intro("List Edge Functions");
+
+  const local = yield* inferFunctionsManifest({ cwd: runtimeInfo.cwd });
+  const remote = yield* loadRemoteInventory();
+  const functions = mergeInventory(local, remote.functions);
+  const sources = {
+    local: { checked: true },
+    remote: remote.source,
+  };
+
+  if (output.format !== "text") {
+    yield* output.success("Edge Functions inventory.", { functions, sources });
+    return;
+  }
+
+  if (functions.length === 0) {
+    yield* output.outro("No Edge Functions found.");
+    const remoteMessage = remoteTextMessage(remote.source);
+    if (remoteMessage !== undefined) {
+      yield* output[remoteMessage.level](remoteMessage.message);
+    }
+    return;
+  }
+
+  yield* outputTable(
+    ["SLUG", "LOCAL", "REMOTE", "VERSION", "UPDATED_AT (UTC)", "ENTRYPOINT"],
+    functions,
+    (item) => [
+      item.slug,
+      localStatus(item.local),
+      item.remote?.status ?? "-",
+      item.remote?.version === undefined ? "-" : String(item.remote.version),
+      formatUtcTimestamp(item.remote?.updated_at),
+      entrypointFor(item),
+    ],
+  );
+
+  const remoteMessage = remoteTextMessage(remote.source);
+  if (remoteMessage !== undefined) {
+    yield* output[remoteMessage.level](remoteMessage.message);
+  }
+
+  yield* output.outro(
+    `Found ${functions.length} Edge Function${functions.length === 1 ? "" : "s"}.`,
+  );
+});

--- a/apps/cli/src/next/commands/functions/list/list.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/list/list.integration.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from "@effect/vitest";
+import { FunctionResponse } from "@supabase/api/effect";
+import { BunServices } from "@effect/platform-bun";
+import { mkdtempSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer, Option, Stdio } from "effect";
+import { Command } from "effect/unstable/cli";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { CliConfig } from "../../../config/cli-config.service.ts";
+import type { ProjectLinkStateValue } from "../../../config/project-link-state.service.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import {
+  mockAnalytics,
+  mockCredentials,
+  mockOutput,
+  mockProcessControl,
+  mockProjectLinkState,
+  mockRuntimeInfo,
+} from "../../../../../tests/helpers/mocks.ts";
+import { functionsCommand } from "../functions.command.ts";
+import { functionsList } from "./list.handler.ts";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+
+const LINK_STATE: ProjectLinkStateValue = {
+  project: {
+    ref: PROJECT_REF,
+    name: "Linked Project",
+    organization_id: "org-id",
+    organization_slug: "org-slug",
+  },
+  active_branch: {
+    ref: PROJECT_REF,
+    name: "main",
+    is_default: true,
+  },
+  fetchedAt: "2026-01-01T00:00:00.000Z",
+  versions: {},
+};
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "supabase-functions-list-"));
+}
+
+function makeFunction(
+  overrides: Partial<typeof FunctionResponse.Type> = {},
+): typeof FunctionResponse.Type {
+  return {
+    id: "function-id",
+    slug: "hello-world",
+    name: "Hello World",
+    status: "ACTIVE",
+    version: 2,
+    created_at: 1_687_423_025_152,
+    updated_at: 1_687_423_025_152,
+    verify_jwt: true,
+    import_map: true,
+    entrypoint_path: "functions/hello-world/index.ts",
+    import_map_path: "functions/hello-world/deno.json",
+    ...overrides,
+  };
+}
+
+function cliConfigLayer() {
+  return Layer.succeed(
+    CliConfig,
+    CliConfig.of({
+      apiUrl: "https://api.supabase.com",
+      dashboardUrl: "https://supabase.com/dashboard",
+      projectHost: "supabase.co",
+      telemetryPosthogHost: "https://us.i.posthog.com",
+      telemetryPosthogKey: "phc_test_key",
+      accessToken: Option.none(),
+      noKeyring: Option.none(),
+      supabaseHome: "/tmp/supabase-cli-test-home",
+      debug: Option.none(),
+      telemetryDebug: Option.none(),
+      telemetryDisabled: Option.none(),
+      doNotTrack: Option.none(),
+    }),
+  );
+}
+
+function jsonResponse(
+  request: HttpClientRequest.HttpClientRequest,
+  status: number,
+  body: unknown,
+): HttpClientResponse.HttpClientResponse {
+  return HttpClientResponse.fromWeb(
+    request,
+    new Response(JSON.stringify(body), {
+      status,
+      headers: {
+        "content-type": "application/json",
+      },
+    }),
+  );
+}
+
+function mockFunctionsApi(
+  functions: ReadonlyArray<typeof FunctionResponse.Type>,
+  opts: { status?: number } = {},
+) {
+  const requests: Array<{
+    url: string;
+    headers: Readonly<Record<string, string | undefined>>;
+  }> = [];
+
+  const http = Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.sync(() => {
+        requests.push({
+          url: request.url,
+          headers: request.headers,
+        });
+        return jsonResponse(request, opts.status ?? 200, functions);
+      }),
+    ),
+  );
+
+  return {
+    layer: http,
+    get requests() {
+      return requests;
+    },
+  };
+}
+
+async function writeLocalFunction(cwd: string, slug: string, opts: { denoJson?: boolean } = {}) {
+  const functionDir = join(cwd, "supabase", "functions", slug);
+  await mkdir(functionDir, { recursive: true });
+  await writeFile(join(functionDir, "index.ts"), "Deno.serve(() => new Response())\n");
+  if (opts.denoJson ?? true) {
+    await writeFile(join(functionDir, "deno.json"), '{"imports":{}}\n');
+  }
+}
+
+function setup(opts: {
+  cwd: string;
+  linked?: boolean;
+  accessToken?: string;
+  remoteFunctions?: ReadonlyArray<typeof FunctionResponse.Type>;
+  remoteStatus?: number;
+  format?: "text" | "json" | "stream-json";
+}) {
+  const out = mockOutput({ format: opts.format ?? "text", interactive: false });
+  const credentials =
+    opts.accessToken === undefined
+      ? mockCredentials()
+      : mockCredentials({ existingToken: opts.accessToken });
+  const api = mockFunctionsApi(opts.remoteFunctions ?? [], { status: opts.remoteStatus });
+  const layer = Layer.mergeAll(
+    BunServices.layer,
+    out.layer,
+    mockRuntimeInfo({ cwd: opts.cwd }),
+    cliConfigLayer(),
+    mockProjectLinkState(opts.linked ? LINK_STATE : undefined),
+    credentials.layer,
+    commandRuntimeLayer(["functions", "list"]),
+    api.layer,
+  );
+
+  return { out, layer, api };
+}
+
+describe("functions list", () => {
+  it.live("lists local functions when the project is not linked and does not call the API", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const { out, layer, api } = setup({ cwd: tempDir, linked: false });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      expect(api.requests).toHaveLength(0);
+      const info = out.messages.filter((message) => message.type === "info").map((m) => m.message);
+      expect(info.some((message) => message.includes("hello-world"))).toBe(true);
+      expect(info.some((message) => message.includes("enabled"))).toBe(true);
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({
+          type: "info",
+          message: "Showing local functions only. Link a project to include deployed functions.",
+        }),
+      );
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("merges local and remote functions by slug in JSON mode", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const { out, layer, api } = setup({
+        cwd: tempDir,
+        linked: true,
+        accessToken: "test-token",
+        format: "json",
+        remoteFunctions: [
+          makeFunction(),
+          makeFunction({
+            id: "remote-only-id",
+            slug: "remote-only",
+            name: "Remote Only",
+            entrypoint_path: "functions/remote-only/index.ts",
+            import_map_path: "functions/remote-only/deno.json",
+          }),
+        ],
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      expect(api.requests).toHaveLength(1);
+      expect(api.requests[0]?.url).toBe(
+        "https://api.supabase.com/v1/projects/abcdefghijklmnopqrst/functions",
+      );
+      expect(api.requests[0]?.headers["x-supabase-command"]).toBe("functions list");
+      const success = out.messages.find((message) => message.type === "success");
+      const data = success?.data as {
+        functions: Array<{
+          slug: string;
+          local: unknown | null;
+          remote: { slug: string } | null;
+        }>;
+        sources: { remote: { checked: boolean; project_ref?: string } };
+      };
+
+      expect(data.sources.remote).toEqual({ checked: true, project_ref: PROJECT_REF });
+      expect(data.functions).toHaveLength(2);
+      expect(data.functions.find((item) => item.slug === "hello-world")).toMatchObject({
+        local: expect.objectContaining({ entrypoint: "./functions/hello-world/index.ts" }),
+        remote: expect.objectContaining({ slug: "hello-world" }),
+      });
+      expect(data.functions.find((item) => item.slug === "remote-only")).toMatchObject({
+        local: null,
+        remote: expect.objectContaining({ slug: "remote-only" }),
+      });
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("keeps local-only functions when remote enrichment succeeds", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "local-only"));
+      const { out, layer } = setup({
+        cwd: tempDir,
+        linked: true,
+        accessToken: "test-token",
+        format: "json",
+        remoteFunctions: [],
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      const data = success?.data as {
+        functions: Array<{ slug: string; local: unknown | null; remote: unknown | null }>;
+      };
+      expect(data.functions).toEqual([
+        expect.objectContaining({
+          slug: "local-only",
+          local: expect.objectContaining({ entrypoint: "./functions/local-only/index.ts" }),
+          remote: null,
+        }),
+      ]);
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("reports not_authenticated while keeping local inventory", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const { out, layer, api } = setup({
+        cwd: tempDir,
+        linked: true,
+        format: "json",
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      expect(api.requests).toHaveLength(0);
+      const success = out.messages.find((message) => message.type === "success");
+      const data = success?.data as {
+        sources: { remote: { checked: boolean; project_ref?: string; reason?: string } };
+        functions: Array<{ slug: string }>;
+      };
+      expect(data.sources.remote).toEqual({
+        checked: false,
+        project_ref: PROJECT_REF,
+        reason: "not_authenticated",
+      });
+      expect(data.functions).toHaveLength(1);
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("reports request_failed while keeping local inventory", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const { out, layer } = setup({
+        cwd: tempDir,
+        linked: true,
+        accessToken: "test-token",
+        format: "json",
+        remoteStatus: 503,
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      const data = success?.data as {
+        sources: { remote: { checked: boolean; project_ref?: string; reason?: string } };
+        functions: Array<{ slug: string }>;
+      };
+      expect(data.sources.remote).toEqual({
+        checked: false,
+        project_ref: PROJECT_REF,
+        reason: "request_failed",
+      });
+      expect(data.functions).toHaveLength(1);
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("prints an empty state when no local or remote functions exist", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      const { out, layer } = setup({
+        cwd: tempDir,
+        linked: true,
+        accessToken: "test-token",
+        remoteFunctions: [],
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({ type: "outro", message: "No Edge Functions found." }),
+      );
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("registers the command under functions list", () => {
+    const tempDir = makeTempDir();
+    const out = mockOutput({ format: "text", interactive: false });
+    const analytics = mockAnalytics();
+    const processControl = mockProcessControl();
+    const api = mockFunctionsApi([]);
+    const layer = Layer.mergeAll(
+      BunServices.layer,
+      out.layer,
+      analytics.layer,
+      processControl.layer,
+      mockRuntimeInfo({ cwd: tempDir }),
+      cliConfigLayer(),
+      mockProjectLinkState(),
+      mockCredentials().layer,
+      api.layer,
+      Stdio.layerTest({
+        args: Effect.succeed(["functions", "list"]),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      yield* Command.runWith(functionsCommand, { version: "0.1.0" })(["list"]).pipe(
+        Effect.provide(layer),
+      );
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({ type: "outro", message: "No Edge Functions found." }),
+      );
+      expect(analytics.captured).toContainEqual(
+        expect.objectContaining({
+          event: "cli_command_executed",
+          properties: expect.objectContaining({ exit_code: 0 }),
+        }),
+      );
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+});

--- a/apps/cli/src/next/commands/functions/list/list.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/list/list.integration.test.ts
@@ -11,7 +11,11 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import { CliConfig } from "../../../config/cli-config.service.ts";
-import type { ProjectLinkStateValue } from "../../../config/project-link-state.service.ts";
+import {
+  InvalidProjectLinkStateError,
+  ProjectLinkState,
+  type ProjectLinkStateValue,
+} from "../../../config/project-link-state.service.ts";
 import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
 import {
   mockAnalytics,
@@ -129,6 +133,24 @@ function mockFunctionsApi(
       return requests;
     },
   };
+}
+
+function mockInvalidProjectLinkState() {
+  const error = new InvalidProjectLinkStateError({
+    detail: "The linked project state file is invalid or unreadable.",
+    suggestion: "Fix or remove project.json, then retry the command.",
+  });
+
+  return Layer.succeed(
+    ProjectLinkState,
+    ProjectLinkState.of({
+      load: Effect.fail(error),
+      save: () => Effect.void,
+      clear: Effect.void,
+      getActiveBranch: Effect.fail(error),
+      setActiveBranch: () => Effect.fail(error),
+    }),
+  );
 }
 
 async function writeLocalFunction(cwd: string, slug: string, opts: { denoJson?: boolean } = {}) {
@@ -273,6 +295,33 @@ describe("functions list", () => {
           remote: null,
         }),
       ]);
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("fails when the linked project state is invalid", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const out = mockOutput({ format: "text", interactive: false });
+      const api = mockFunctionsApi([]);
+      const layer = Layer.mergeAll(
+        BunServices.layer,
+        out.layer,
+        mockRuntimeInfo({ cwd: tempDir }),
+        cliConfigLayer(),
+        mockInvalidProjectLinkState(),
+        mockCredentials({ existingToken: "test-token" }).layer,
+        commandRuntimeLayer(["functions", "list"]),
+        api.layer,
+      );
+
+      const error = yield* functionsList().pipe(Effect.provide(layer), Effect.flip);
+
+      expect(error).toBeInstanceOf(InvalidProjectLinkStateError);
+      expect(api.requests).toHaveLength(0);
     }).pipe(
       Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
     );

--- a/apps/cli/src/next/commands/functions/new/new.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/new/new.integration.test.ts
@@ -8,10 +8,13 @@ import { Cause, Effect, Exit, Layer, Option, Stdio } from "effect";
 import { Command } from "effect/unstable/cli";
 import {
   mockAnalytics,
+  mockCredentials,
   mockOutput,
   mockProcessControl,
+  mockProjectLinkState,
   mockRuntimeInfo,
 } from "../../../../../tests/helpers/mocks.ts";
+import { CliConfig } from "../../../config/cli-config.service.ts";
 import { functionsCommand } from "../functions.command.ts";
 import { functionsNew } from "./new.handler.ts";
 
@@ -26,6 +29,26 @@ function buildLayer(cwd: string) {
     out,
     layer: Layer.mergeAll(out.layer, mockRuntimeInfo({ cwd }), BunServices.layer),
   };
+}
+
+function cliConfigLayer() {
+  return Layer.succeed(
+    CliConfig,
+    CliConfig.of({
+      apiUrl: "https://api.supabase.com",
+      dashboardUrl: "https://supabase.com/dashboard",
+      projectHost: "supabase.co",
+      telemetryPosthogHost: "https://us.i.posthog.com",
+      telemetryPosthogKey: "phc_test_key",
+      accessToken: Option.none(),
+      noKeyring: Option.none(),
+      supabaseHome: "/tmp/supabase-cli-test-home",
+      debug: Option.none(),
+      telemetryDebug: Option.none(),
+      telemetryDisabled: Option.none(),
+      doNotTrack: Option.none(),
+    }),
+  );
 }
 
 function expectFailureTag(exit: Exit.Exit<unknown, unknown>, tag: string) {
@@ -225,6 +248,9 @@ describe("functions new", () => {
       processControl.layer,
       mockRuntimeInfo({ cwd: tempDir }),
       BunServices.layer,
+      cliConfigLayer(),
+      mockProjectLinkState(),
+      mockCredentials().layer,
       Stdio.layerTest({
         args: Effect.succeed(["functions", "new", "hello-world"]),
       }),


### PR DESCRIPTION
# Add `supabase functions list`

## Summary

Adds the next CLI `supabase functions list` command.

The command builds a local Edge Functions inventory from the project config/filesystem and, when the project is linked and authenticated, enriches that inventory with remote deployment data from the Supabase Management API.

## What Changed

- Registers `supabase functions list` under the next CLI functions command tree.
- Infers local Edge Functions with `@supabase/config`, including functions declared in `supabase/config.toml`.
- Fetches deployed functions from the linked project when credentials are available.
- Merges local and remote functions by slug so users can see both local presence and remote deployment status in one view.
- Adds text output with local status, remote status, version, updated timestamp, and entrypoint.
- Adds JSON output for agents and automation.
- Handles common partial-data cases gracefully:
  - unlinked project
  - linked project without credentials
  - remote API request failure
  - empty local/remote inventory
- Adds integration coverage for the command behavior.
