### PR TITLE
fix(ci): disable persist-credentials on release plan checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,6 @@ jobs:
       publish_brew_scoop: ${{ steps.compute.outputs.publish_brew_scoop }}
       dry_run: ${{ steps.compute.outputs.dry_run }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
       # semantic-release runs `git push --dry-run HEAD:<branch>` as part of
       # verifyAuth even in `dry_run: true` mode, so the token must have push
       # access to the protected `develop`/`main` branches. The default
@@ -86,6 +83,15 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      # `persist-credentials: false` is required: otherwise checkout caches the
+      # default GITHUB_TOKEN as an `http.extraheader` in git config, and that
+      # Authorization header overrides the App token semantic-release puts in
+      # the push URL — making the dry-push identify as `github-actions[bot]`
+      # and get rejected by branch protection.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - id: semantic-release
         if: github.event_name == 'push'
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0


### PR DESCRIPTION
## Current Behavior

The `plan` job in `release.yml` fails on push to `develop`:

```
remote: Permission to supabase/cli.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/supabase/cli/': The requested URL returned error: 403.
[semantic-release] ✘ EGITNOPERMISSION Cannot push to the Git repository.
```

`actions/checkout` runs before the App token is minted (and without a token override), so it persists the default `GITHUB_TOKEN` (`github-actions[bot]`) as an `http.<url>.extraheader` in the local git config. When `semantic-release` later runs `git push --dry-run https://x-access-token:<APP_TOKEN>@github.com/...` as part of `verifyAuth` (it does this even with `dry_run: true`), git also sends the cached `Authorization` header — which takes precedence over the URL credentials. GitHub identifies the caller as `github-actions[bot]`, who can't push to the protected `develop` branch, so the dry-push 403s and the workflow aborts before computing a version.

The previous fix (#5183) added App-token minting and passed it via `GITHUB_TOKEN` env, but the persisted checkout credential silently overrode it.

## Expected Behavior

The `plan` job successfully runs `semantic-release --dry-run` on push to `develop`/`main`, computes the next version, and the downstream `release` job fires when appropriate.

## What Changed

- Moved the `app-token` step before `actions/checkout` so the App token is available when checkout runs.
- Added `persist-credentials: false` to `actions/checkout` in the `plan` job, so it does not cache the default `GITHUB_TOKEN` as an extraheader. semantic-release's URL-embedded App token then becomes the only auth git sends, and the dry-push succeeds.

## Test plan

- [ ] Workflow runs to completion on next push to `develop`
- [ ] `plan` job emits `should_release` and a computed `version`
- [ ] Downstream `release` job is dispatched as expected