### PR TITLE
fix(ci): force-overwrite pre-existing yarn shim on Windows corepack install

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Enable Corepack
       shell: bash
-      run: npm install --global corepack && corepack enable
+      run: npm install --global --force corepack && corepack enable
 
     - name: Configure dependency cache
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
## Summary
- Windows smoke-test failed during the shared setup action with `npm error code EEXIST` / `File exists: C:\npm\prefix\yarn.cmd` (see [run 25442623088, job 74641222877](https://github.com/supabase/cli/actions/runs/25442623088/job/74641222877)).
- The `windows-2025-vs2026` runner image already provides a `yarn.cmd` shim at `C:\npm\prefix`, so `npm install --global corepack` aborts before it can write its own yarn shim.
- Pass `--force` to npm so it overwrites the pre-existing shim with corepack's. No-op on Linux/macOS where the conflict doesn't exist.

## Test plan
- [ ] Re-run the Release / smoke-test (windows-latest) job and confirm the Enable Corepack step succeeds and the rest of the pipeline (pnpm cache + install) follows through.
- [ ] Sanity-check macOS/Ubuntu smoke-test jobs still pass (no behavior change expected on those runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)