### PR TITLE
test(stack): make edge-runtime image assertion registry-agnostic

### DIFF
--- a/packages/stack/tests/createStack-docker.e2e.test.ts
+++ b/packages/stack/tests/createStack-docker.e2e.test.ts
@@ -96,7 +96,7 @@ dockerDescribe("createStack e2e (docker mode)", () => {
         fetch(`${stack.url}/functions/v1/test`),
       ]);
 
-      expect(runningImages).toContain("public.ecr.aws/supabase/edge-runtime");
+      expect(runningImages).toContain("supabase/edge-runtime");
       expect(states).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: "edge-runtime", status: "Healthy" }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update test assertion to avoid flawkyness: https://github.com/supabase/cli/actions/runs/25448285603/job/74658295314

## What is the current behavior?

The docker e2e suite asserted on the full ECR prefix (`public.ecr.aws/supabase/edge-runtime`), but the prefetch system in `StackPreparation.pullImage` intentionally falls back to Docker Hub and GHCR candidates when the ECR pull fails or when a different candidate is already cached locally. When that fallback triggered on CI, the running image became `supabase/edge-runtime:<tag>` and the assertion failed even though the service was healthy and serving traffic.

## What is the new behavior?
Drop the registry prefix so the assertion matches any of the three candidate registries, mirroring the pattern already used for postgres / postgrest / gotrue earlier in the same file. The co-located `states` and `/functions/v1/test` assertions still verify that the correct service is running.

## Additional context

Add any other context or screenshots.
