### PR TITLE
fix(cli): restore bare-semver `--version` output

### DIFF
--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -6,6 +6,7 @@ import { CliOutput, Command } from "effect/unstable/cli";
 import { CLI_VERSION } from "./version.ts";
 import { Credentials } from "../../next/auth/credentials.service.ts";
 import { jsonCliOutputFormatter } from "../output/json-formatter.ts";
+import { textCliOutputFormatter } from "../output/text-formatter.ts";
 import { outputLayerFor } from "../output/output.layer.ts";
 import { normalizeCause } from "../output/normalize-error.ts";
 import type { OutputFormat } from "../output/types.ts";
@@ -41,7 +42,7 @@ function formatterLayerFor(args: ReadonlyArray<string>) {
   const format = outputFormatFor(args);
   return format === "json" || format === "stream-json"
     ? CliOutput.layer(jsonCliOutputFormatter())
-    : Layer.empty;
+    : CliOutput.layer(textCliOutputFormatter());
 }
 
 function projectContextLayerFor(runtimeLayer: Layer.Layer<never>) {

--- a/apps/cli/src/shared/cli/version.integration.test.ts
+++ b/apps/cli/src/shared/cli/version.integration.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "@effect/vitest";
+import { BunServices } from "@effect/platform-bun";
+import { Effect, Layer } from "effect";
+import { CliOutput, Command } from "effect/unstable/cli";
+import { vi } from "vitest";
+import { legacyRoot } from "../../legacy/cli/root.ts";
+import { nextRoot } from "../../next/cli/root.ts";
+import { textCliOutputFormatter } from "../output/text-formatter.ts";
+
+describe("CLI --version (text)", () => {
+  const versionLayer = Layer.mergeAll(CliOutput.layer(textCliOutputFormatter()), BunServices.layer);
+
+  test("legacy shell prints bare semver on stdout", async () => {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((first?: unknown, ...rest: unknown[]) => {
+        const line =
+          rest.length === 0
+            ? first === undefined
+              ? ""
+              : String(first)
+            : [first, ...rest].map(String).join(" ");
+        logs.push(line);
+      });
+    try {
+      // `Command.runWith` keeps handler/global-flag services in its env type even when
+      // `--version` exits early; only BunServices + CliOutput are needed at runtime here.
+      await Effect.runPromise(
+        Command.runWith(legacyRoot, { version: "2.99.0-beta.1" })(["--version"]).pipe(
+          Effect.provide(versionLayer),
+        ) as Effect.Effect<void>,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs[0]).toMatch(/^\d+\.\d+\.\d+/);
+    expect(logs[0]).not.toMatch(/supabase\s+v/i);
+  });
+
+  test("next shell prints bare semver on stdout", async () => {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((first?: unknown, ...rest: unknown[]) => {
+        const line =
+          rest.length === 0
+            ? first === undefined
+              ? ""
+              : String(first)
+            : [first, ...rest].map(String).join(" ");
+        logs.push(line);
+      });
+    try {
+      await Effect.runPromise(
+        Command.runWith(nextRoot, { version: "2.99.0-beta.1" })(["--version"]).pipe(
+          Effect.provide(versionLayer),
+        ) as Effect.Effect<void>,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs[0]).toMatch(/^\d+\.\d+\.\d+/);
+    expect(logs[0]).not.toMatch(/supabase\s+v/i);
+  });
+});

--- a/apps/cli/src/shared/output/text-formatter.ts
+++ b/apps/cli/src/shared/output/text-formatter.ts
@@ -1,0 +1,9 @@
+import { CliOutput } from "effect/unstable/cli";
+
+export function textCliOutputFormatter(): CliOutput.Formatter {
+  const base = CliOutput.defaultFormatter({ colors: false });
+  return {
+    ...base,
+    formatVersion: (_name, version) => version,
+  };
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Effect CLI's default formatter prints `${name} v${version}` on `--version`, which broke release smoke tests and any external script parsing the version. Override `formatVersion` for text mode in `formatterLayerFor` and lock the contract with an integration test covering both shells.
