### PR TITLE
chore(ci): add linting workflow for pull requests

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -1,0 +1,35 @@
+name: Lint Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
+    branches:
+      - main
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
+    name: Lint Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event_name == 'pull_request_target'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: github.event_name == 'merge_group'
+        run: echo "Merge queue entry does not have a pull request payload; reporting success for the required lint check."


### PR DESCRIPTION
Will avoid in the future a PR getting merged with invalid semantic release name, causing it to be dismissed from deployment:

https://github.com/supabase/cli/pull/5176

https://github.com/supabase/cli/actions/runs/25422547737/job/74567952624

https://github.com/supabase/cli/pull/5063