### PR TITLE
fix(ci): publish via pnpm so catalog: deps survive packing

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -6,7 +6,7 @@
     "supabase": "dist/supabase.js"
   },
   "files": [
-    "dist/"
+    "dist/supabase.js"
   ],
   "type": "module",
   "publishConfig": {

--- a/apps/cli/scripts/publish.ts
+++ b/apps/cli/scripts/publish.ts
@@ -41,6 +41,7 @@ const umbrellaName: string = cliPkgJson.name;
 const dryRunFlag = dryRun ? ["--dry-run"] : [];
 const tagFlag = ["--tag", tag];
 const provenanceFlag = ["--provenance"];
+const noGitChecksFlag = ["--no-git-checks"];
 
 console.log(
   dryRun
@@ -54,7 +55,9 @@ await Promise.all(
   PLATFORM_PACKAGES.map(async (pkg) => {
     const pkgDir = path.join(root, "packages", pkg);
     console.log(`  Publishing @supabase/${pkg}...`);
-    await $`bun publish --access public ${provenanceFlag} ${tagFlag} ${dryRunFlag}`.cwd(pkgDir);
+    await $`pnpm publish --access public ${provenanceFlag} ${tagFlag} ${noGitChecksFlag} ${dryRunFlag}`.cwd(
+      pkgDir,
+    );
     console.log(`  @supabase/${pkg} published.`);
   }),
 );
@@ -64,7 +67,7 @@ console.log("\nBuilding umbrella package shim...");
 await $`pnpm build:shim`.cwd(cliDir);
 
 console.log(`Publishing umbrella package ${umbrellaName}...`);
-await $`bun publish ${provenanceFlag} ${tagFlag} ${dryRunFlag}`.cwd(cliDir);
+await $`pnpm publish ${provenanceFlag} ${tagFlag} ${noGitChecksFlag} ${dryRunFlag}`.cwd(cliDir);
 console.log(`${umbrellaName} published.`);
 
 console.log("\nAll packages published successfully.");

--- a/apps/cli/scripts/sync-versions.ts
+++ b/apps/cli/scripts/sync-versions.ts
@@ -15,7 +15,6 @@ const PACKAGE_PATHS = {
 } as const;
 
 const ALL_PACKAGES = Object.keys(PACKAGE_PATHS) as Array<keyof typeof PACKAGE_PATHS>;
-const PLATFORM_PACKAGES = ALL_PACKAGES.filter((pkg) => pkg !== "cli");
 
 const { values } = parseArgs({
   options: {
@@ -36,16 +35,6 @@ for (const pkg of ALL_PACKAGES) {
   const pkgJson = await Bun.file(pkgJsonPath).json();
 
   pkgJson.version = version;
-
-  // Replace workspace:* references with explicit versions for publishing
-  if (pkg === "cli" && pkgJson.optionalDependencies) {
-    for (const platformPkg of PLATFORM_PACKAGES) {
-      const depName = `@supabase/${platformPkg}`;
-      if (depName in pkgJson.optionalDependencies) {
-        pkgJson.optionalDependencies[depName] = version;
-      }
-    }
-  }
 
   await Bun.write(pkgJsonPath, `${JSON.stringify(pkgJson, null, "\t")}\n`);
   console.log(`Updated ${pkg} to v${version}`);

--- a/apps/cli/tests/helpers/npm-registry.ts
+++ b/apps/cli/tests/helpers/npm-registry.ts
@@ -76,8 +76,6 @@ export async function runNpmTest(
   version: string,
   tag: "latest" | "alpha" | "beta" = "latest",
 ): Promise<boolean> {
-  const publishEnv = { ...process.env, NPM_CONFIG_TOKEN: "dummy" };
-
   await using _pkgJsons = await savePackageJsons();
   await using tmp = await createTmpDir("npm-smoke-");
 
@@ -101,6 +99,14 @@ listen: 0.0.0.0:${PORT}
 `,
   );
 
+  // pnpm publish delegates to npm internals, which only honor per-registry auth
+  // configured in an .npmrc — `NPM_CONFIG_TOKEN` is not consulted. Write a temp
+  // .npmrc with `_authToken` for the verdaccio host and point npm at it via
+  // `npm_config_userconfig` so every publish call sees credentials.
+  const publishNpmrc = path.join(tmp.path, "publish.npmrc");
+  await writeFile(publishNpmrc, `//localhost:${PORT}/:_authToken=dummy\n`);
+  const publishEnv = { ...process.env, npm_config_userconfig: publishNpmrc };
+
   // Sync versions across all packages
   console.log(`Syncing versions to ${version}...`);
   await $`pnpm exec bun apps/cli/scripts/sync-versions.ts --version ${version}`.cwd(root).quiet();
@@ -115,7 +121,9 @@ listen: 0.0.0.0:${PORT}
   await Promise.all(
     platformPackages.map(async (pkg) => {
       const pkgDir = path.join(root, "packages", pkg);
-      await $`bun publish --registry ${registry.url} --tag ${tag}`.cwd(pkgDir).env(publishEnv);
+      await $`pnpm publish --registry ${registry.url} --tag ${tag} --no-git-checks`
+        .cwd(pkgDir)
+        .env(publishEnv);
       console.log(`  @supabase/${pkg}`);
     }),
   );
@@ -129,7 +137,9 @@ listen: 0.0.0.0:${PORT}
   const umbrellaName: string = cliPkgJson.name;
 
   console.log("Publishing umbrella package...");
-  await $`bun publish --registry ${registry.url} --tag ${tag}`.cwd(cliDir).env(publishEnv);
+  await $`pnpm publish --registry ${registry.url} --tag ${tag} --no-git-checks`
+    .cwd(cliDir)
+    .env(publishEnv);
   console.log(`  ${umbrellaName}\n`);
 
   // Create test project

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@supabase/config",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Switch the npm publisher from `bun publish` to `pnpm publish` in both [`apps/cli/scripts/publish.ts`](apps/cli/scripts/publish.ts) (real release) and [`apps/cli/tests/helpers/npm-registry.ts`](apps/cli/tests/helpers/npm-registry.ts) (verdaccio smoke). pnpm owns the `catalog:` and `workspace:*` protocols and rewrites both into concrete versions in the published `package.json` at pack time — `bun publish` only resolves `catalog:` from a `bun.lock`, which this monorepo doesn't have.
- Drop the now-redundant `workspace:*` rewriting from [`apps/cli/scripts/sync-versions.ts`](apps/cli/scripts/sync-versions.ts).
- Narrow [`apps/cli`](apps/cli/package.json) `files` to `dist/supabase.js` so the dev-only `dist/main-legacy.js` (264K) and `dist/main-next.js` (281K) stop shipping in the npm tarball — they're only consumed by [`packages/cli-test-helpers/src/harness.ts`](packages/cli-test-helpers/src/harness.ts) inside the workspace.
- Add a `version` to [`packages/config/package.json`](packages/config/package.json) — `pnpm publish` strips workspace devDependencies from the tarball but resolves them at pack time and refuses if the workspace package has no version field. Every other workspace package already has one; this aligns the odd-one-out.
- Replace the no-op `NPM_CONFIG_TOKEN` env var in the smoke harness with a temp `.npmrc` referenced via `npm_config_userconfig`, the documented pattern for per-registry auth that npm/pnpm honor.

## What is the current behavior?

The release smoke matrix on every push to `develop` fails the npm Verdaccio step on macOS-15-intel and ubuntu-latest with:

```
bun publish v1.3.13
error: Failed to resolve catalog version for "@effect/atom-react" in `dependencies` (catalogs require a lockfile).
```

Most recent run: https://github.com/supabase/cli/actions/runs/25481778896/job/74768309391. The same `bun publish` is used by the real release at [`apps/cli/scripts/publish.ts`](apps/cli/scripts/publish.ts), so this is a production blocker, not just a smoke-test bug — every umbrella publish that has `catalog:` deps in `dependencies` would abort the same way.

## Why pnpm publish?

`pnpm publish`:

- Is the publisher that owns the `catalog:` and `workspace:*` protocols and rewrites both into concrete versions in the published tarball at pack time. No custom tooling, no parsing of `pnpm-workspace.yaml`, no second source of truth.
- Removes machinery rather than adding it: the `workspace:*` rewriting in `sync-versions.ts` is now unnecessary and is deleted.
- Future-proofs the migration. When the umbrella shim absorbs the Go binary's responsibilities and `effect`, `@effect/atom-react`, `ink`, `react`, etc. become real runtime deps for the npm consumer, those `catalog:` references keep working — they get resolved correctly at every publish without anyone touching the tooling.
- Is consistent across all 9 published packages, so the next package that adopts a catalog dep doesn't reintroduce the bug.
- Supports `--tag`, `--registry`, `--dry-run`, `--provenance`, and `--no-git-checks` — covering both the real release and the verdaccio smoke run.

## Verification

Local smoke run end-to-end:

```sh
pnpm --filter supabase test:smoke -- --version 2.99.0-beta.1 --tag beta
```

The npm Verdaccio step now PASSes; the published umbrella tarball is exactly:

```
package/dist/supabase.js
package/package.json
package/README.md
```

(3 files, 10.3 kB unpacked — down from the previous tarball that also shipped `main-legacy.js` and `main-next.js`).

The published `package.json` contains only concrete versions:

- `effect: "^4.0.0-beta.43"` (from `catalog:`)
- `@effect/atom-react: "4.0.0-beta.54"` (from `catalog:`)
- `@effect/platform-bun: "^4.0.0-beta.43"` (from `catalog:`)
- All 8 `optionalDependencies` rewritten from `workspace:*` to the concrete platform-package version.
- `@supabase/{api,config,stack}` (devDependencies) resolved to `0.1.0` from `workspace:*`.

Dry-run of the real release script also exits 0:

```sh
pnpm exec bun apps/cli/scripts/publish.ts --tag beta --dry-run
```

## Test plan

- [ ] CI Release / smoke-test matrix is green across `ubuntu-latest`, `macos-latest`, `macos-15-intel`, `windows-latest`.
- [ ] CI Release / publish (when run on a real release tag) succeeds with `pnpm publish --provenance` against the production npm registry via OIDC trust.
- [ ] Inspect the next published `supabase` umbrella tarball on npm and confirm it contains only `dist/supabase.js`, `package.json`, `README.md`, and that `dependencies` / `optionalDependencies` are concrete versions.