### PR TITLE
fix(cli): copy Go binary for musl builds from glibc package

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "apps/cli"
   },
   "bin": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,6 +2,17 @@
   "name": "supabase",
   "version": "0.0.0-automated",
   "private": false,
+  "description": "Supabase CLI",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "apps/cli"
+  },
   "bin": {
     "supabase": "dist/supabase.js"
   },

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
@@ -152,6 +152,23 @@ async function buildMuslBinaries() {
       const outfile = path.join(binDir, "supabase");
       console.log(`[${target.pkg}] Compiling Bun CLI (musl)...`);
       await $`bun build ${entrypoint} --compile --minify --target=${target.bunTarget} --define=process.env.SUPABASE_CLI_VERSION=${JSON.stringify(version)} --outfile=${outfile}`;
+
+      if (shell === "legacy") {
+        // Go binary is CGO_ENABLED=0 (fully static), so the glibc Linux build works on
+        // musl too. Copy it from the matching glibc package so the published musl npm
+        // package contains the supabase-go binary that LegacyGoProxy resolves to.
+        const glibcTarget = TARGETS.find(
+          (candidate) => "nfpmArch" in candidate && candidate.nfpmArch === target.nfpmArch,
+        );
+        if (!glibcTarget) {
+          throw new Error(`No glibc Linux target found for musl arch ${target.nfpmArch}`);
+        }
+        const src = path.join(root, "packages", glibcTarget.pkg, "bin", "supabase-go");
+        const dst = path.join(binDir, "supabase-go");
+        console.log(`[${target.pkg}] Copying Go binary from ${glibcTarget.pkg}...`);
+        await copyFile(src, dst);
+      }
+
       console.log(`[${target.pkg}] Done.`);
     }),
   );

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-darwin-arm64"
   },
   "os": ["darwin"],

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (darwin-arm64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-darwin-arm64"
+  },
   "os": ["darwin"],
   "cpu": ["arm64"],
   "preferUnplugged": true,

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-darwin-x64"
   },
   "os": ["darwin"],

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (darwin-x64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-darwin-x64"
+  },
   "os": ["darwin"],
   "cpu": ["x64"],
   "preferUnplugged": true,

--- a/packages/cli-linux-arm64-musl/package.json
+++ b/packages/cli-linux-arm64-musl/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-linux-arm64-musl"
   },
   "os": ["linux"],

--- a/packages/cli-linux-arm64-musl/package.json
+++ b/packages/cli-linux-arm64-musl/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (linux-arm64-musl)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-linux-arm64-musl"
+  },
   "os": ["linux"],
   "cpu": ["arm64"],
   "libc": ["musl"],

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-linux-arm64"
   },
   "os": ["linux"],

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (linux-arm64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-linux-arm64"
+  },
   "os": ["linux"],
   "cpu": ["arm64"],
   "libc": ["glibc"],

--- a/packages/cli-linux-x64-musl/package.json
+++ b/packages/cli-linux-x64-musl/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (linux-x64-musl)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-linux-x64-musl"
+  },
   "os": ["linux"],
   "cpu": ["x64"],
   "libc": ["musl"],

--- a/packages/cli-linux-x64-musl/package.json
+++ b/packages/cli-linux-x64-musl/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-linux-x64-musl"
   },
   "os": ["linux"],

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-linux-x64"
   },
   "os": ["linux"],

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (linux-x64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-linux-x64"
+  },
   "os": ["linux"],
   "cpu": ["x64"],
   "libc": ["glibc"],

--- a/packages/cli-windows-arm64/package.json
+++ b/packages/cli-windows-arm64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (windows-arm64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-windows-arm64"
+  },
   "os": ["win32"],
   "cpu": ["arm64"],
   "preferUnplugged": true,

--- a/packages/cli-windows-arm64/package.json
+++ b/packages/cli-windows-arm64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-windows-arm64"
   },
   "os": ["win32"],

--- a/packages/cli-windows-x64/package.json
+++ b/packages/cli-windows-x64/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/supabase/cli.git",
+    "url": "https://github.com/supabase/cli.git",
     "directory": "packages/cli-windows-x64"
   },
   "os": ["win32"],

--- a/packages/cli-windows-x64/package.json
+++ b/packages/cli-windows-x64/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "description": "Supabase CLI binary (windows-x64)",
   "license": "MIT",
+  "homepage": "https://github.com/supabase/cli#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/supabase/cli.git",
+    "directory": "packages/cli-windows-x64"
+  },
   "os": ["win32"],
   "cpu": ["x64"],
   "preferUnplugged": true,


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix and metadata polish.

- **Bug fix:** Ensures **Linux musl** optional binary packages built with **legacy shell** include `supabase-go` by copying the matching **static glibc** Go binary into the musl package output during `apps/cli/scripts/build.ts`.
- **Feature / packaging:** Adds standard **npm `package.json` fields** (`homepage`, `bugs`, `repository`, plus main-package `description` / `license` where applicable) on `supabase` and the `@supabase/cli-*` platform packages.

## What is the current behavior?

- Musl builds compile the Bun CLI but, in legacy mode, may **omit** `supabase-go` even though **LegacyGoProxy** expects to resolve it—breaking Go-backed flows on musl installs.
- Published packages lack **homepage / bugs / repository** links that npm and tooling often surface.

## What is the new behavior?

- For **`shell === "legacy"`** musl targets, after the Bun compile step the script finds the **glibc** target with the same **`nfpmArch`**, copies `packages/<glibc-pkg>/bin/supabase-go` to `packages/<musl-pkg>/bin/supabase-go`, and logs the copy—so **published musl tarballs match what LegacyGoProxy resolves**.
- **npm metadata** is consistent across the main CLI and optional architecture packages (repo URL + per-package `directory`, issues URL, homepage).

_No UI changes; screenshots not applicable._

## Additional context

- The inline rationale in `build.ts`: Go is built with **CGO disabled** (static), so the **glibc-labeled** Linux binary is appropriate to reuse on **musl** for the same CPU arch.
- Files touched besides `build.ts`: `apps/cli/package.json` and each `packages/cli-*/package.json` that gained metadata.
