### PR TITLE
chore(ci): add Go setup and module pre-download step in release workflow

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -49,6 +49,17 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: apps/cli-go/go.mod
+          cache: true
+          cache-dependency-path: apps/cli-go/go.sum
+
+      - name: Pre-download Go modules
+        working-directory: apps/cli-go
+        run: go mod download -x
+
       - name: Install nfpm
         run: |
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list


### PR DESCRIPTION
- Introduced a new step to set up Go using actions/setup-go, specifying the Go version from the go.mod file.
- Added a step to pre-download Go modules in the apps/cli-go directory to ensure dependencies are available before the build process.