### PR TITLE
fix(cli): smoke test now actually verifies our local build

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -1,0 +1,36 @@
+name: Smoke Test (PR)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    branches:
+      - develop
+    paths:
+      - "apps/cli/**"
+      - ".github/workflows/release-shared.yml"
+      - ".github/workflows/smoke-test-pr.yml"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/release-shared.yml
+    with:
+      # PR-scoped version so concurrent PRs don't collide on the build artifact
+      # name (release-shared.yml uploads `cli-build-${shell}-${version}`).
+      version: 0.0.0-pr-${{ github.event.pull_request.number }}
+      shell: legacy
+      npm_tag: latest
+      prerelease: true
+      dry_run: true

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -15,7 +15,16 @@ on:
       - ".github/workflows/smoke-test-pr.yml"
 
 permissions:
-  contents: read
+  # release-shared.yml's `publish` job declares `contents: write` and
+  # `id-token: write`. Even though that job is gated by `!inputs.dry_run`
+  # and never runs here, GitHub validates nested-workflow permissions at
+  # startup and rejects the run if the caller grants less than any
+  # nested job requests. Granting the superset here is safe because (a)
+  # `dry_run: true` short-circuits the privileged jobs at runtime and
+  # (b) for fork PRs GitHub still issues a read-only GITHUB_TOKEN
+  # regardless of the declared scope.
+  contents: write
+  id-token: write
   actions: read
 
 concurrency:

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -34,3 +34,9 @@ jobs:
       npm_tag: latest
       prerelease: true
       dry_run: true
+    # release-shared.yml's publish/homebrew/scoop jobs reference
+    # `secrets.APP_ID` and `secrets.GH_APP_PRIVATE_KEY`. They are gated by
+    # `!inputs.dry_run` and never execute here, but GitHub validates secret
+    # references at startup, so the called workflow needs the secrets bag
+    # propagated even when the jobs that use them are skipped.
+    secrets: inherit

--- a/apps/cli/tests/helpers/npm-registry.ts
+++ b/apps/cli/tests/helpers/npm-registry.ts
@@ -1,9 +1,19 @@
 import { $ } from "bun";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { verifyExpectedShell } from "./release-shell.ts";
+import { runCli, verifyExpectedShell } from "./release-shell.ts";
 
 const root = path.resolve(import.meta.dir, "../../../..");
 
@@ -72,6 +82,131 @@ async function savePackageJsons() {
   };
 }
 
+function modeOctal(mode: number): string {
+  return `0${(mode & 0o777).toString(8).padStart(3, "0")}`;
+}
+
+async function describePath(p: string): Promise<string> {
+  try {
+    const ls = await lstat(p);
+    if (ls.isSymbolicLink()) {
+      const target = await readlink(p);
+      try {
+        const st = await stat(p);
+        return `symlink ${modeOctal(ls.mode)} -> ${target} (target ${modeOctal(st.mode)} ${st.size}B)`;
+      } catch (e) {
+        return `symlink ${modeOctal(ls.mode)} -> ${target} (target unreadable: ${e})`;
+      }
+    }
+    return `file ${modeOctal(ls.mode)} ${ls.size}B`;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return "MISSING";
+    return `unstattable: ${e}`;
+  }
+}
+
+async function dumpInstalledTree(testDir: string, ext: string): Promise<void> {
+  console.log("\nInstalled tree state:");
+  const interesting = [
+    path.join(testDir, "node_modules", ".bin", `supabase${ext}`),
+    path.join(testDir, "node_modules", "supabase", "package.json"),
+    path.join(testDir, "node_modules", "supabase", "dist", "supabase.js"),
+  ];
+  for (const p of interesting) {
+    console.log(`  ${path.relative(testDir, p)}: ${await describePath(p)}`);
+  }
+
+  const supabaseScope = path.join(testDir, "node_modules", "@supabase");
+  let scopeEntries: string[] = [];
+  try {
+    scopeEntries = await readdir(supabaseScope);
+  } catch {
+    console.log(`  node_modules/@supabase: MISSING`);
+    return;
+  }
+  for (const entry of scopeEntries.sort()) {
+    const pkgDir = path.join(supabaseScope, entry);
+    const pkgJsonPath = path.join(pkgDir, "package.json");
+    try {
+      const pkgJson = JSON.parse(await readFile(pkgJsonPath, "utf-8"));
+      console.log(`  node_modules/@supabase/${entry}: ${pkgJson.name}@${pkgJson.version}`);
+    } catch {
+      console.log(`  node_modules/@supabase/${entry}: <unreadable package.json>`);
+    }
+    const binDir = path.join(pkgDir, "bin");
+    try {
+      const binEntries = await readdir(binDir);
+      for (const b of binEntries.sort()) {
+        const bp = path.join(binDir, b);
+        console.log(`    bin/${b}: ${await describePath(bp)}`);
+      }
+    } catch {
+      // no bin/
+    }
+  }
+}
+
+async function findPlatformBinary(testDir: string, ext: string): Promise<string | null> {
+  const supabaseScope = path.join(testDir, "node_modules", "@supabase");
+  let entries: string[] = [];
+  try {
+    entries = await readdir(supabaseScope);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(supabaseScope, entry, "bin", `supabase${ext}`);
+    try {
+      await stat(candidate);
+      return candidate;
+    } catch {
+      // not this one
+    }
+  }
+  return null;
+}
+
+async function inspectVerdaccioTarball(storageDir: string, pkg: string): Promise<void> {
+  const pkgStorage = path.join(storageDir, "@supabase", pkg);
+  let files: string[] = [];
+  try {
+    files = await readdir(pkgStorage);
+  } catch {
+    console.log(`  @supabase/${pkg}: <no tarball in verdaccio storage>`);
+    return;
+  }
+  const tarball = files.find((f) => f.endsWith(".tgz"));
+  if (!tarball) {
+    console.log(`  @supabase/${pkg}: <no .tgz under ${pkgStorage}>`);
+    return;
+  }
+  const tarballPath = path.join(pkgStorage, tarball);
+  const listing = await $`tar -tvf ${tarballPath}`.text();
+  // Surface only the bin entries — full listings drown the log.
+  const binLines = listing
+    .split("\n")
+    .filter((line) => line.includes("/bin/"))
+    .map((line) => `    ${line.trim()}`);
+  if (binLines.length === 0) {
+    console.log(`  @supabase/${pkg} (${tarball}): <no bin/ entries>`);
+    return;
+  }
+  console.log(`  @supabase/${pkg} (${tarball}):`);
+  for (const line of binLines) console.log(line);
+}
+
+export function describeError(e: unknown): string {
+  if (e instanceof Error) {
+    const parts = [e.stack ?? `${e.name}: ${e.message}`];
+    const stdout = (e as { stdout?: unknown }).stdout;
+    const stderr = (e as { stderr?: unknown }).stderr;
+    if (stdout != null) parts.push(`stdout: ${String(stdout).trim()}`);
+    if (stderr != null) parts.push(`stderr: ${String(stderr).trim()}`);
+    return parts.join("\n");
+  }
+  return String(e);
+}
+
 export async function runNpmTest(
   version: string,
   tag: "latest" | "alpha" | "beta" = "latest",
@@ -81,19 +216,36 @@ export async function runNpmTest(
 
   const PORT = 4873;
   const configPath = path.join(tmp.path, "config.yaml");
+  const storageDir = path.join(tmp.path, "storage");
 
+  // Verdaccio config: store our published tarballs locally, but proxy *anything
+  // else* to the public npm registry. The umbrella's package.json declares
+  // bundled-in runtime deps (effect, ink, react, …) — those are inlined in
+  // dist/supabase.js but still resolved at install time by npm, so without
+  // an uplink the install 404s on the first transitive dep. Our own packages
+  // are pinned to Verdaccio (no proxy) so we cannot accidentally fall through
+  // to the public registry's `supabase` or `@supabase/cli-*`.
   await writeFile(
     configPath,
-    `storage: ${path.join(tmp.path, "storage")}
+    `storage: ${storageDir}
 auth:
   htpasswd:
     file: ${path.join(tmp.path, "htpasswd")}
     max_users: 100
-uplinks: {}
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
 packages:
+  "supabase":
+    access: $all
+    publish: $all
+  "@supabase/*":
+    access: $all
+    publish: $all
   "**":
     access: $all
     publish: $all
+    proxy: npmjs
 max_body_size: 200mb
 listen: 0.0.0.0:${PORT}
 `,
@@ -128,6 +280,13 @@ listen: 0.0.0.0:${PORT}
     }),
   );
 
+  // Inspect what Verdaccio actually received — directly answers whether
+  // `publishConfig.executableFiles` is being applied to the published tarball.
+  console.log("\nVerdaccio tarball contents (bin entries only):");
+  for (const pkg of platformPackages) {
+    await inspectVerdaccioTarball(storageDir, pkg);
+  }
+
   // Build and publish umbrella package
   const cliDir = path.join(root, "apps", "cli");
   console.log("\nBuilding umbrella package shim...");
@@ -142,6 +301,23 @@ listen: 0.0.0.0:${PORT}
     .env(publishEnv);
   console.log(`  ${umbrellaName}\n`);
 
+  console.log("Verdaccio umbrella tarball contents:");
+  const umbrellaStorage = path.join(storageDir, umbrellaName);
+  try {
+    const files = await readdir(umbrellaStorage);
+    const tarball = files.find((f) => f.endsWith(".tgz"));
+    if (tarball) {
+      const listing = await $`tar -tvf ${path.join(umbrellaStorage, tarball)}`.text();
+      for (const line of listing.split("\n").filter(Boolean)) {
+        console.log(`    ${line.trim()}`);
+      }
+    } else {
+      console.log(`  <no .tgz under ${umbrellaStorage}>`);
+    }
+  } catch {
+    console.log(`  <no umbrella tarball storage at ${umbrellaStorage}>`);
+  }
+
   // Create test project
   const testDir = path.join(tmp.path, "test-project");
   await mkdir(testDir);
@@ -154,21 +330,53 @@ listen: 0.0.0.0:${PORT}
     `registry=${registry.url}\n//localhost:${PORT}/:_authToken=dummy\n`,
   );
 
-  // Install
+  // Install. Pass --registry explicitly: in some environments (notably ones
+  // where pnpm has set `npm_config_*` env vars) those override the project
+  // .npmrc, and `npm install supabase` silently fetches from registry.npmjs.org
+  // instead — the test then accidentally exercises the published 2.x CLI rather
+  // than the umbrella we just packed. The CLI flag wins over both env vars and
+  // .npmrc, so it is the only resolution path that is actually safe here.
   const installSpec = tag === "latest" ? umbrellaName : `${umbrellaName}@${tag}`;
-  console.log(`Installing ${installSpec}...`);
-  await $`npm install ${installSpec}`.cwd(testDir);
+  console.log(`\nInstalling ${installSpec}...`);
+  await $`npm install --registry ${registry.url} ${installSpec}`.cwd(testDir);
 
   // Verify
   console.log("\nVerifying...");
   const ext = process.platform === "win32" ? ".cmd" : "";
   const binPath = path.join(testDir, "node_modules", ".bin", `supabase${ext}`);
-  const versionOutput = (await $`${binPath} --version`.text()).trim();
-  const hasValidVersion = /^\d+\.\d+\.\d+/.test(versionOutput);
+
+  await dumpInstalledTree(testDir, ext);
+
+  const versionResult = await runCli(binPath, ["--version"]);
+  const hasValidVersion =
+    versionResult.exitCode === 0 && /^\d+\.\d+\.\d+/.test(versionResult.stdout);
+
+  if (!hasValidVersion) {
+    console.log(`\n[verify] supabase --version FAILED:`);
+    console.log(`  exit=${versionResult.exitCode}`);
+    console.log(`  stdout=${JSON.stringify(versionResult.stdout)}`);
+    console.log(`  stderr=${JSON.stringify(versionResult.stderr)}`);
+
+    // Isolate "shim broken" vs "platform binary broken" by trying the
+    // platform binary directly.
+    const platformBin = await findPlatformBinary(testDir, ext);
+    if (platformBin) {
+      console.log(`\n[verify] retrying via platform binary: ${platformBin}`);
+      const direct = await runCli(platformBin, ["--version"]);
+      console.log(`  exit=${direct.exitCode}`);
+      console.log(`  stdout=${JSON.stringify(direct.stdout)}`);
+      console.log(`  stderr=${JSON.stringify(direct.stderr)}`);
+    } else {
+      console.log(`\n[verify] no platform binary found under node_modules/@supabase/*/bin/`);
+    }
+  }
+
   const shellCheck = await verifyExpectedShell(binPath);
   const passed = hasValidVersion && shellCheck.passed;
 
-  console.log(`\n${passed ? "PASS" : "FAIL"} — supabase --version: ${versionOutput}`);
+  console.log(
+    `\n${passed ? "PASS" : "FAIL"} — supabase --version exit=${versionResult.exitCode} stdout=${JSON.stringify(versionResult.stdout)}`,
+  );
   console.log(shellCheck.detail);
 
   return passed;

--- a/apps/cli/tests/helpers/release-shell.ts
+++ b/apps/cli/tests/helpers/release-shell.ts
@@ -3,7 +3,13 @@ type ShellCheckResult = {
   readonly detail: string;
 };
 
-async function runCli(binPath: string, args: Array<string>) {
+export interface CliRunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+export async function runCli(binPath: string, args: Array<string>): Promise<CliRunResult> {
   const proc = Bun.spawn([binPath, ...args], {
     stdout: "pipe",
     stderr: "pipe",
@@ -30,6 +36,6 @@ export async function verifyExpectedShell(binPath: string): Promise<ShellCheckRe
     passed,
     detail: passed
       ? 'dispatch ok: "init --help" succeeded'
-      : `expected dispatch via "init --help", got exit=${result.exitCode}, stdout="${result.stdout}", stderr="${result.stderr}"`,
+      : `expected dispatch via "init --help", got exit=${result.exitCode}, stdout=${JSON.stringify(result.stdout)}, stderr=${JSON.stringify(result.stderr)}`,
   };
 }

--- a/apps/cli/tests/smoke-test-linux.ts
+++ b/apps/cli/tests/smoke-test-linux.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
-import { runNpmTest } from "./helpers/npm-registry.ts";
+import { describeError, runNpmTest } from "./helpers/npm-registry.ts";
 import { verifyExpectedShell } from "./helpers/release-shell.ts";
 
 const { values } = parseArgs({
@@ -51,7 +51,7 @@ console.log("=".repeat(60));
     console.log(`[${name}] ${shellCheck.detail}`);
     results.push({ name, status: passed ? "pass" : "fail" });
   } catch (e) {
-    console.log(`[${name}] FAIL — ${e}`);
+    console.log(`[${name}] FAIL —\n${describeError(e)}`);
     results.push({ name, status: "fail" });
   }
 }
@@ -156,7 +156,7 @@ try {
   const npmPassed = await runNpmTest(version, tag);
   results.push({ name: "npm", status: npmPassed ? "pass" : "fail" });
 } catch (e) {
-  console.error(`[npm] Error: ${e}`);
+  console.error(`[npm] Error:\n${describeError(e)}`);
   results.push({ name: "npm", status: "fail" });
 }
 

--- a/apps/cli/tests/smoke-test-macos.ts
+++ b/apps/cli/tests/smoke-test-macos.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
-import { createTmpDir, runNpmTest } from "./helpers/npm-registry.ts";
+import { createTmpDir, describeError, runNpmTest } from "./helpers/npm-registry.ts";
 import { verifyExpectedShell } from "./helpers/release-shell.ts";
 
 const { values } = parseArgs({
@@ -49,7 +49,7 @@ console.log("=".repeat(60));
     console.log(`[${name}] ${shellCheck.detail}`);
     results.push({ name, status: passed ? "pass" : "fail" });
   } catch (e) {
-    console.log(`[${name}] FAIL — ${e}`);
+    console.log(`[${name}] FAIL —\n${describeError(e)}`);
     results.push({ name, status: "fail" });
   }
 }
@@ -64,7 +64,7 @@ try {
   const npmPassed = await runNpmTest(version, tag);
   results.push({ name: "npm", status: npmPassed ? "pass" : "fail" });
 } catch (e) {
-  console.error(`[npm] Error: ${e}`);
+  console.error(`[npm] Error:\n${describeError(e)}`);
   results.push({ name: "npm", status: "fail" });
 }
 
@@ -114,7 +114,7 @@ if (!hasBrew) {
       await $`brew untap supabase/test-tap`.nothrow();
     }
   } catch (e) {
-    console.error(`[brew] Error: ${e}`);
+    console.error(`[brew] Error:\n${describeError(e)}`);
     results.push({ name: "brew", status: "fail" });
   }
 }


### PR DESCRIPTION
## Current Behavior

The release-CI smoke test for the npm/Verdaccio sub-test reports `[npm] Error: ShellError: Failed with exit code 1` on linux + macos with no further detail. The `await $` invocation in `apps/cli/tests/helpers/npm-registry.ts` swallows stderr on non-zero exit, so the actual cause is invisible.

Worse: even when the test passes, it has been doing so for a false reason. With the diagnostics added in this PR, two regressions surface that have been masked for some time:

1. `npm install` ignores the test project's `.npmrc` in environments where pnpm has set `npm_config_*` env vars. The install silently resolves `supabase` against `registry.npmjs.org` instead of the local Verdaccio, fetching the public 2.x CLI (76 transitive deps). The version regex `/^\d+\.\d+\.\d+/` matches whatever that package prints, so the smoke test reports PASS while exercising none of our build artifacts. The recent CI failure is the public package's postinstall now failing on the runners — the symptom, not the cause.
2. Verdaccio is configured with `uplinks: {}`, so even when the local registry is hit, transitive deps from the umbrella's runtime `dependencies` (`@clack/prompts`, `effect`, `ink`, `react`, …) 404. Those deps are bundled into `dist/supabase.js` at build time but `npm install` still resolves them.

`b2b397af`'s `publishConfig.executableFiles` fix was correct — diagnostics confirm tarball entries land at mode `0755`. The smoke test just never reached them.

Smoke tests also currently only run post-merge in `release-shared.yml`. Packaging regressions therefore slip through PR review and only surface when a release is cut — 2.99.0-beta.1 being the most recent example.

## New Behavior

**Diagnostics (`2beff61a`)**

- Capture stdout / stderr / exit-code on the verify spawn instead of letting Bun's `\$` collapse them into an opaque \`ShellError\`.
- After publish, \`tar -tvf\` each platform tarball from Verdaccio storage and log the \`bin/\` mode bits — directly answers whether \`executableFiles\` is being honoured.
- After install, dump the resolved tree: \`.bin/supabase\`'s symlink target + mode, the umbrella shim's mode, every unpacked \`@supabase/cli-*/bin/\` entry, and each platform package's \`name@version\`.
- On verify failure, retry against the platform binary directly to isolate "shim broken" vs "binary broken".
- \`runCli\` (already in \`release-shell.ts\`) is now the single spawn primitive for both checks; \`verifyExpectedShell\`'s failure detail includes captured stderr.
- Smoke-test runners log \`e.stack\` + \`e.stdout\` / \`e.stderr\` instead of \`\${e}\` on every catch.

**Fix (`2beff61a`)**

- Pass \`--registry \${verdaccio_url}\` explicitly to \`npm install\`. The CLI flag wins over env vars and \`.npmrc\`, so the install can no longer fall through to the public registry.
- Pin \`supabase\` and \`@supabase/*\` to local-only resolution in Verdaccio's \`packages\` config; configure an \`npmjs\` uplink for everything else so the umbrella's bundled-in runtime deps still resolve. Mirrors what a real \`npm install supabase\` does today.

**PR-CI smoke job (`2b9e2bee`)**

\`.github/workflows/smoke-test-pr.yml\` is a thin caller that reuses \`release-shared.yml\` with \`dry_run: true\`. The shared workflow already gates publish jobs on \`!inputs.dry_run\`, so only \`build\` + \`smoke-test\` actually run.

- Triggers on \`pull_request\` events with paths under \`apps/cli/**\`, plus the workflow files themselves so changes to the workflow re-trigger on the PR that introduced them.
- Synthesises a PR-scoped version (\`0.0.0-pr-\${PR_NUMBER}\`) so concurrent PRs do not collide on the build artifact name.
- Skips drafts and cancels superseded runs.

## Test plan

- [x] \`nx run supabase:check:all\` (types/lint/fmt/knip).
- [x] Local smoke run with stub binaries: \`0.0.1-smoke\` resolves to the local umbrella (not the public 2.x CLI), platform binary mode is \`0755\`, \`supabase --version\` returns \`0.0.1-smoke\`.
- [ ] Release-CI \`smoke-test\` matrix passes on this branch's run.
- [ ] On this PR, the new \`Smoke Test (PR) / smoke / build\` and four \`Smoke Test (PR) / smoke / smoke-test (...)\` jobs appear and pass.
- [ ] Confirm \`publish\` / \`publish-homebrew\` / \`publish-scoop\` jobs from the called workflow report skipped on this PR.

## Related Issue(s)

Follow-up to #5199, #5200, #5201.