### PR TITLE
chore(ci): update smoke test workflow to trigger on additional paths

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -14,7 +14,6 @@ on:
     # `release-shared.yml`'s build/smoke jobs need to re-validate.
     paths:
       - "apps/cli/scripts/build.ts"
-      - "apps/cli/scripts/checksums.ts"
       - "apps/cli/scripts/sync-versions.ts"
       - "apps/cli/src/**"
       - "apps/cli/package.json"

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -9,10 +9,21 @@ on:
       - ready_for_review
     branches:
       - develop
+    # Trigger on any change that could affect the build phase or how the
+    # built artifacts behave at runtime. Anything in this list is something
+    # `release-shared.yml`'s build/smoke jobs need to re-validate.
     paths:
-      - "apps/cli/**"
-      - ".github/workflows/release-shared.yml"
-      - ".github/workflows/smoke-test-pr.yml"
+      - "apps/cli/scripts/build.ts"
+      - "apps/cli/scripts/checksums.ts"
+      - "apps/cli/scripts/sync-versions.ts"
+      - "apps/cli/src/**"
+      - "apps/cli/package.json"
+      - "apps/cli-go/**"
+      - "packages/cli-*/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/actions/setup/**"
 
 permissions:
   # release-shared.yml's `publish` job declares `contents: write` and


### PR DESCRIPTION
- Expanded the paths that trigger the smoke test workflow to include specific scripts and configuration files in the apps/cli and packages directories.
- Added comments to clarify the purpose of the path triggers, ensuring that any changes affecting the build phase or runtime behavior will re-validate the smoke tests.