### PR TITLE
fix(ci): make release re-cut reliable after stale-bytes runs

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -152,6 +152,26 @@ jobs:
       - name: Publish to npm
         run: pnpm exec bun apps/cli/scripts/publish.ts --tag ${{ inputs.npm_tag }}
 
+      # Push the version tag to origin as soon as npm has the bytes, before any
+      # downstream step that can fail. Without this, a failure in the GH-release
+      # step (or anything after) leaves origin with no tag for the version that
+      # is now live on npm — and `semantic-release --dry-run` on the next push
+      # will keep recomputing the same version, causing the publish job to no-op
+      # against stale bytes. Idempotent: skips push if the tag is already on
+      # origin (e.g. a re-run of a job that previously got past this step).
+      - name: Push version tag
+        run: |
+          set -euo pipefail
+          tag="v${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
+            echo "Tag ${tag} already on origin; skipping push."
+          else
+            git tag -a "${tag}" -m "Release ${tag}"
+            git push origin "${tag}"
+          fi
+
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,14 @@ on:
         description: npm package version to publish (must be unique on npm; pick the next unused version)
         required: true
         type: string
+      # Defaults to `true` so a stray "Run workflow" click can't accidentally
+      # publish — operators recovering from a stale-bytes run must consciously
+      # untick this when dispatching.
       dry_run:
         description: Dry run (skip actual publishing)
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
       - main
   pull_request_review:
     types: [submitted]
+  # workflow_dispatch is the manual re-cut path. Use it when:
+  #   - a previous release published stale bytes under a version that
+  #     semantic-release keeps re-computing (cut a fresh version forward), or
+  #   - a downstream step (GH release, brew, scoop) failed after npm published
+  #     and you need to rerun the whole pipeline against an explicit version.
   workflow_dispatch:
     inputs:
       channel:
@@ -18,14 +23,14 @@ on:
           - beta
           - stable
       version:
-        description: npm package version to publish
+        description: npm package version to publish (must be unique on npm; pick the next unused version)
         required: true
         type: string
       dry_run:
         description: Dry run (skip actual publishing)
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read

--- a/apps/cli/scripts/publish.ts
+++ b/apps/cli/scripts/publish.ts
@@ -62,21 +62,23 @@ async function isAlreadyPublished(name: string, version: string): Promise<boolea
   throw new Error(`npm registry probe for ${name}@${version} returned HTTP ${res.status}`);
 }
 
+type PublishResult = "published" | "skipped";
+
 // Publishes one workspace package idempotently. If the version is already
 // on the registry — either before we start or after a publish-time conflict
-// — we skip and return. Any other failure propagates.
+// — we skip and return "skipped". Any other failure propagates.
 async function publishPackage(opts: {
   name: string;
   version: string;
   cwd: string;
   extraFlags?: string[];
-}): Promise<void> {
+}): Promise<PublishResult> {
   const { name, version, cwd, extraFlags = [] } = opts;
   const label = `${name}@${version}`;
 
   if (await isAlreadyPublished(name, version)) {
     console.log(`  [skip] ${label} already published.`);
-    return;
+    return "skipped";
   }
 
   console.log(`  Publishing ${label}...`);
@@ -85,12 +87,13 @@ async function publishPackage(opts: {
       cwd,
     );
     console.log(`  ${label} published.`);
+    return "published";
   } catch (error) {
     if (await isAlreadyPublished(name, version)) {
       console.log(
         `  [skip] ${label} reported a conflict but is now present on the registry; treating as success.`,
       );
-      return;
+      return "skipped";
     }
     throw error;
   }
@@ -118,7 +121,7 @@ for (const pkg of PLATFORM_PACKAGES) {
 
 // Publish all platform packages in parallel
 console.log("Publishing platform packages...");
-await Promise.all(
+const platformResults = await Promise.all(
   PLATFORM_PACKAGES.map((pkg) =>
     publishPackage({
       name: `@supabase/${pkg}`,
@@ -134,10 +137,30 @@ console.log("\nBuilding umbrella package shim...");
 await $`pnpm build:shim`.cwd(cliDir);
 
 console.log(`Publishing umbrella package ${umbrellaName}...`);
-await publishPackage({
+const umbrellaResult = await publishPackage({
   name: umbrellaName,
   version: umbrellaVersion,
   cwd: cliDir,
 });
+
+const results = [...platformResults, umbrellaResult];
+const publishedCount = results.filter((r) => r === "published").length;
+const skippedCount = results.filter((r) => r === "skipped").length;
+
+console.log(`\nPublished: ${publishedCount}, Skipped: ${skippedCount}.`);
+
+// All-skipped is ambiguous: it can mean "recovering from a downstream-only
+// failure (GH release / brew / scoop) — bytes already on npm, just continue"
+// OR "semantic-release re-computed a version whose bytes are already live, so
+// today's commits silently did not ship". Since we cannot tell those apart
+// here, log a loud warning so the human reviewing the workflow run can decide
+// whether to re-cut as a fresh version via `workflow_dispatch`.
+if (publishedCount === 0) {
+  console.warn(
+    `\n[warn] No packages were published — every package was already on the registry at ${umbrellaVersion}.\n` +
+      `       If today's commits were expected to ship, the version did not advance.\n` +
+      `       Re-cut as a fresh version via the Release workflow (workflow_dispatch).`,
+  );
+}
 
 console.log("\nAll packages published successfully.");


### PR DESCRIPTION
## Current Behavior

Follow-up to #5207. The post-merge run on develop (workflow run [25501868685](https://github.com/supabase/cli/actions/runs/25501868685)) reproduced the failure mode @avallete flagged in [the original review](https://github.com/supabase/cli/pull/5207#discussion_r3201887720):

- `supabase@2.99.0-beta.1` was published earlier the same day from `62509de5` (the musl-glibc fix).
- After merging #5205 and #5207, the next push to develop ran `semantic-release --dry-run` again. With only `@semantic-release/commit-analyzer` configured and dry-run mode never registering the prior release, semantic-release found `v2.98.2` as the last release on develop and recomputed the same `2.99.0-beta.1` from the 110 commits since.
- All 9 packages probed `200 OK` on npm and the new idempotent script logged `[skip] @supabase/...@2.99.0-beta.1 already published.` × 9 → exit 0.
- Net result: today's fixes (#5205, #5207 itself) silently did **not** ship under any version, and the workflow reported green.

The original PR's idempotent-skip semantics is correct for partial-failure recovery (5/8 published mid-run, retry publishes the remaining 3) — but it is also correct in the stale-bytes case where you don't actually want to skip. The two scenarios are indistinguishable inside `publish.ts` alone.

Push events on develop alone can't escape this state, because `dry_run: true` semantic-release will keep emitting the same beta version until the prior tag is in a form it recognises. The fix is to make the manual re-cut path (workflow_dispatch with an explicit version) reliable and obvious, and to make the silent-no-op visible.

## Expected Behavior

- Operators recovering from a stale-bytes run can dispatch the Release workflow with `version=<next-unused>` and have it actually publish (no need to remember to untick dry-run).
- The version git tag lands on origin as soon as bytes are on npm, even if a downstream step (GitHub release / brew / scoop) fails.
- An all-skipped publish run prints a loud warning advising re-cut, instead of looking identical to a clean success.

## Summary

- `release.yml` — flip `workflow_dispatch.dry_run` default from `true` to `false`. Document workflow_dispatch as the manual re-cut path with a top-of-trigger comment. The `version` input description now explicitly says it must be unique on npm.
- `release-shared.yml` — explicit `Push version tag` step in the publish job, after `pnpm publish` and before `softprops/action-gh-release`. Idempotent: skips push if the tag is already on origin (e.g. previous-run replay). Without this, any failure between npm and softprops leaves origin without the tag for a version that's already live on npm.
- `publish.ts` — `publishPackage` now returns `"published" | "skipped"`; the script prints `Published: N, Skipped: M.` and, when `published === 0`, a multi-line `[warn]` that names the version and tells the operator to re-cut via workflow_dispatch. We can't auto-detect stale-bytes vs downstream-failure recovery here, but the warning is enough signal for a human reviewing the run to decide.

Out of scope: replacing `dry_run: true` semantic-release with a real release pipeline (so push events advance prerelease versions automatically). The current minimal `release` config (only `commit-analyzer`) is part of the same root cause but reshaping it touches branch-protection, the GH-App push token, and how main → develop fast-forwards interact with channel tracking — separate change.

## Test Plan

- [x] `cd apps/cli && pnpm check:all` (types, lint, fmt, knip) passes.
- [x] `bun build apps/cli/scripts/publish.ts` parses cleanly.
- [x] `bunx js-yaml` round-trips both modified workflow files.
- [ ] Manual smoke (after merge): trigger Release workflow_dispatch with `channel=beta`, `version=2.99.0-beta.2`, `dry_run` left at the new default (`false`). Confirm: 9 packages publish, `v2.99.0-beta.2` lands on origin, GH release + brew + scoop converge, `Published: 9, Skipped: 0` summary line in publish-job logs.
- [ ] Manual no-op smoke (optional): dispatch the same `2.99.0-beta.2` a second time. Confirm: 9 packages skip, the `[warn] No packages were published` block fires, tag-push step skips (already on origin), GH release / brew / scoop are idempotent.

Fixes the failure mode in workflow run [25501868685](https://github.com/supabase/cli/actions/runs/25501868685).