### PR TITLE
fix(cli): drop full-request timeout from service gateway uploads

### DIFF
--- a/.github/workflows/cli-go-ci.yml
+++ b/.github/workflows/cli-go-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report
-          path: coverage.out
+          path: apps/cli-go/coverage.out
 
   coverage:
     name: Coverage
@@ -71,6 +71,7 @@ jobs:
           args: --timeout 5m --verbose
           version: latest
           only-new-issues: true
+          working-directory: apps/cli-go
 
   start:
     name: Start

--- a/apps/cli-go/internal/status/status.go
+++ b/apps/cli-go/internal/status/status.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/Netflix/go-env"
 	"github.com/docker/docker/api/types"
@@ -161,10 +162,10 @@ func IsServiceReady(ctx context.Context, container string) error {
 }
 
 // NewKongClient returns an HTTP client configured for the local Kong gateway.
-// It deliberately omits http.Client.Timeout because the same client is reused
-// for streaming storage uploads where a full-request deadline would truncate
-// large transfers under load; callers should pass per-call deadlines via the
-// request context instead.
+// It deliberately omits http.Client.Timeout: this client is shared with
+// streaming storage uploads, where a full-request deadline would truncate
+// large transfers under load. Short-lived callers (e.g. health probes) should
+// bound themselves with a per-call context deadline instead.
 //
 // To regenerate local certificate pair:
 //
@@ -197,6 +198,10 @@ var (
 	healthOnce   sync.Once
 )
 
+// healthProbeTimeout caps a single readiness probe so a hung response cannot
+// stall the surrounding retry loop in WaitForHealthyService.
+const healthProbeTimeout = 10 * time.Second
+
 func checkHTTPHead(ctx context.Context, path string) error {
 	healthOnce.Do(func() {
 		healthClient = fetcher.NewServiceGateway(
@@ -206,6 +211,8 @@ func checkHTTPHead(ctx context.Context, path string) error {
 			fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
 		)
 	})
+	ctx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
+	defer cancel()
 	// HEAD method does not return response body
 	resp, err := healthClient.Send(ctx, http.MethodHead, path, nil)
 	if err != nil {

--- a/apps/cli-go/internal/status/status.go
+++ b/apps/cli-go/internal/status/status.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/Netflix/go-env"
 	"github.com/docker/docker/api/types"
@@ -161,15 +160,19 @@ func IsServiceReady(ctx context.Context, container string) error {
 	return assertContainerHealthy(ctx, container)
 }
 
+// NewKongClient returns an HTTP client configured for the local Kong gateway.
+// It deliberately omits http.Client.Timeout because the same client is reused
+// for streaming storage uploads where a full-request deadline would truncate
+// large transfers under load; callers should pass per-call deadlines via the
+// request context instead.
+//
 // To regenerate local certificate pair:
 //
 //	openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
 //	  -nodes -keyout kong.local.key -out kong.local.crt -subj "/CN=localhost" \
 //	  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 func NewKongClient() *http.Client {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
+	client := &http.Client{}
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		pool, err := x509.SystemCertPool()
 		if err != nil {

--- a/apps/cli-go/pkg/fetcher/gateway.go
+++ b/apps/cli-go/pkg/fetcher/gateway.go
@@ -3,14 +3,16 @@ package fetcher
 import (
 	"net/http"
 	"strings"
-	"time"
 )
 
+// NewServiceGateway returns a Fetcher for Supabase service-gateway calls (Kong,
+// Storage, Auth, etc.). It deliberately omits http.Client.Timeout so streaming
+// operations such as storage uploads are not capped under load. Connection
+// setup is still bounded by the default transport's dial and TLS-handshake
+// timeouts, and per-call deadlines should flow through the request context.
 func NewServiceGateway(server, token string, overrides ...FetcherOption) *Fetcher {
 	opts := append([]FetcherOption{
-		WithHTTPClient(&http.Client{
-			Timeout: 10 * time.Second,
-		}),
+		WithHTTPClient(&http.Client{}),
 		withAuthToken(token),
 		WithExpectedStatus(http.StatusOK),
 	}, overrides...)


### PR DESCRIPTION
## Summary

- Removes the 10s `http.Client.Timeout` from `NewServiceGateway` and `NewKongClient` so streaming storage uploads no longer fail with `Client.Timeout exceeded while awaiting headers` under load.
- The cap was inherited from the tenant-API health-check client when `NewServiceGateway` was extracted in #3929; it was never chosen for storage uploads. The active client for local seed (`newLocalClient` → `NewKongClient`) carries the same anti-pattern, so both are addressed.
- Connection setup is still bounded by the default transport's dial / TLS-handshake timeouts, and per-call deadlines continue to flow through the request `Context`.

Fixes [CLI-1441](https://linear.app/supabase/issue/CLI-1441/storage-uploads-can-time-out-after-10-seconds).

## Why

`http.Client.Timeout` covers dial + send + waiting for response, so a single small upload taking >10s for the server to ack would surface as a hard failure. `supabase seed buckets --linked` already worked because `newRemoteClient` overrides the gateway client with `http.DefaultClient` (no timeout); the local path through Kong did not.

## Test plan

- [x] `go test ./internal/utils/tenant/ ./internal/storage/client/ ./internal/status/` (all pass)
- [x] `go vet` clean for both touched packages
- [ ] Manual repro: re-run the proxy-delay scenario from the issue and confirm the upload completes instead of timing out at 10s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFScBK1kF6twDYjraZ2hQm)_