### PR TITLE
fix(cli): suppress Claude Code hint when stderr is not a terminal

### DIFF
--- a/apps/cli-go/internal/utils/misc.go
+++ b/apps/cli-go/internal/utils/misc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils/agent"
 	"github.com/supabase/cli/pkg/migration"
+	"golang.org/x/term"
 )
 
 // Assigned using `-ldflags` https://stackoverflow.com/q/11354518
@@ -42,10 +43,16 @@ const SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot
 const claudeCodeHint = `<claude-code-hint v="1" type="plugin" value="supabase@claude-plugins-official" />`
 
 func SuggestClaudePlugin() string {
-	if agent.IsClaudeCode() {
-		return claudeCodeHint
+	if !agent.IsClaudeCode() {
+		return ""
 	}
-	return ""
+	// Suppress the hint when stderr is not a terminal. This avoids contaminating
+	// captured or redirected output (for example `supabase gen types > out.ts 2>&1`,
+	// or any tool runner that pipes both streams to a file). See #5212.
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return ""
+	}
+	return claudeCodeHint
 }
 
 var (

--- a/apps/cli-go/internal/utils/misc_test.go
+++ b/apps/cli-go/internal/utils/misc_test.go
@@ -215,3 +215,21 @@ func TestGetDeclarativeDir(t *testing.T) {
 		assert.Equal(t, DeclarativeDir, GetDeclarativeDir())
 	})
 }
+
+func TestSuggestClaudePlugin(t *testing.T) {
+	t.Run("returns empty when not running inside Claude Code", func(t *testing.T) {
+		t.Setenv("CLAUDECODE", "")
+		t.Setenv("CLAUDE_CODE", "")
+
+		assert.Empty(t, SuggestClaudePlugin())
+	})
+
+	t.Run("returns empty when stderr is not a terminal", func(t *testing.T) {
+		// Tests run with a piped stderr, so this exercises the suppression
+		// path that prevents the trailer from contaminating redirected
+		// output (see #5212).
+		t.Setenv("CLAUDECODE", "1")
+
+		assert.Empty(t, SuggestClaudePlugin())
+	})
+}


### PR DESCRIPTION
Fixes #5212.

`SuggestClaudePlugin()` now skips the hint when stderr is not a terminal, so it can no longer contaminate redirected output such as `supabase gen types > out.ts 2>&1`. Verified inside a Claude Code session and added a unit test.