### PR TITLE
fix(cli): skip Claude Code plugin hint when stdout is non-TTY (#5212)

### DIFF
--- a/apps/cli-e2e/src/tests/gen.e2e.test.ts
+++ b/apps/cli-e2e/src/tests/gen.e2e.test.ts
@@ -12,10 +12,16 @@ describe("gen", () => {
     testBehaviour.skipIf(isRecording)(
       "generates typescript types from project",
       async ({ run, projectRef }) => {
-        const result = await run(["gen", "types", "--project-id", projectRef]);
+        // #5212 — with CLAUDECODE=1, piped/redirected output must not include the
+        // plugin hint (would break `gen types > file.ts` and similar captures).
+        const result = await run(["gen", "types", "--project-id", projectRef], {
+          env: { CLAUDECODE: "1" },
+        });
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("export type Json");
         expect(result.stdout).toContain("export type Database");
+        expect(result.stdout).not.toMatch(/claude-code-hint/);
+        expect(result.stderr).not.toMatch(/claude-code-hint/);
       },
     );
 

--- a/apps/cli-e2e/src/tests/test-context.ts
+++ b/apps/cli-e2e/src/tests/test-context.ts
@@ -21,11 +21,13 @@ function scenarioSlug(task: { name: string; suite?: { name: string } | null }): 
   return prefix + slugify(task.name);
 }
 
+type ExecOptions = NonNullable<Parameters<typeof exec>[2]>;
+
 interface BehaviourFixtures {
   projectRef: string;
   orgId: string;
   workspace: TempDir;
-  run: (cmd: string[]) => Promise<CLIResult>;
+  run: (cmd: string[], execOpts?: ExecOptions) => Promise<CLIResult>;
   runNoProjectId: (cmd: string[]) => Promise<CLIResult>;
   apiUrl: string;
   storageBucket: string;
@@ -38,7 +40,8 @@ interface BehaviourFixtures {
  *  - `projectRef` — a real project ref (record mode) or the replay default
  *  - `orgId` — a real org slug (record mode) or the replay default
  *  - `workspace` — fresh temp dir, auto-disposed after the test
- *  - `run` — pre-configured `exec()` for the current TARGET
+ *  - `run` — pre-configured `exec()` for the current TARGET (optional second
+ *    argument forwarded as `exec` options, e.g. extra `env` entries)
  *  - `apiUrl` — the replay server base URL (for setting up error overrides)
  *
  *  Auto-wires a named scenario for the test before running it, so the replay
@@ -90,7 +93,7 @@ export const testBehaviour = test.extend<BehaviourFixtures>({
       cwd: workspace.path,
       projectId: inject("projectRef") as string,
     });
-    await use((cmd) => exec(harness, cmd));
+    await use((cmd, execOpts) => exec(harness, cmd, execOpts));
   },
 
   runNoProjectId: async ({ workspace }, use) => {

--- a/apps/cli-go/internal/utils/misc.go
+++ b/apps/cli-go/internal/utils/misc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/supabase/cli/internal/utils/agent"
 	"github.com/supabase/cli/pkg/migration"
+	"golang.org/x/term"
 )
 
 // Assigned using `-ldflags` https://stackoverflow.com/q/11354518
@@ -42,10 +43,17 @@ const SuggestDebugFlag = "Try rerunning the command with --debug to troubleshoot
 const claudeCodeHint = `<claude-code-hint v="1" type="plugin" value="supabase@claude-plugins-official" />`
 
 func SuggestClaudePlugin() string {
-	if agent.IsClaudeCode() {
-		return claudeCodeHint
+	if !agent.IsClaudeCode() {
+		return ""
 	}
-	return ""
+	// Suppress the hint when stdout is non-interactive (redirected to a file
+	// or piped). Without this guard, captured output could be contaminated by
+	// the trailer if anything ever leaks the tag onto stdout, and the
+	// install-prompt UX is only meaningful in an interactive shell anyway.
+	if !term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: stdout fd is a small int on supported platforms
+		return ""
+	}
+	return claudeCodeHint
 }
 
 var (

--- a/apps/cli-go/internal/utils/misc_test.go
+++ b/apps/cli-go/internal/utils/misc_test.go
@@ -215,22 +215,3 @@ func TestGetDeclarativeDir(t *testing.T) {
 		assert.Equal(t, DeclarativeDir, GetDeclarativeDir())
 	})
 }
-
-func TestSuggestClaudePlugin(t *testing.T) {
-	// In `go test`, os.Stdout is a pipe (not a TTY), so this exercises the
-	// non-interactive guard that prevents the hint from ever reaching
-	// captured/redirected output.
-	t.Run("suppresses hint when stdout is non-tty", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "1")
-		t.Setenv("CLAUDE_CODE", "")
-
-		assert.Equal(t, "", SuggestClaudePlugin())
-	})
-
-	t.Run("returns empty string when not running in claude code", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "")
-		t.Setenv("CLAUDE_CODE", "")
-
-		assert.Equal(t, "", SuggestClaudePlugin())
-	})
-}

--- a/apps/cli-go/internal/utils/misc_test.go
+++ b/apps/cli-go/internal/utils/misc_test.go
@@ -215,3 +215,22 @@ func TestGetDeclarativeDir(t *testing.T) {
 		assert.Equal(t, DeclarativeDir, GetDeclarativeDir())
 	})
 }
+
+func TestSuggestClaudePlugin(t *testing.T) {
+	// In `go test`, os.Stdout is a pipe (not a TTY), so this exercises the
+	// non-interactive guard that prevents the hint from ever reaching
+	// captured/redirected output.
+	t.Run("suppresses hint when stdout is non-tty", func(t *testing.T) {
+		t.Setenv("CLAUDECODE", "1")
+		t.Setenv("CLAUDE_CODE", "")
+
+		assert.Equal(t, "", SuggestClaudePlugin())
+	})
+
+	t.Run("returns empty string when not running in claude code", func(t *testing.T) {
+		t.Setenv("CLAUDECODE", "")
+		t.Setenv("CLAUDE_CODE", "")
+
+		assert.Equal(t, "", SuggestClaudePlugin())
+	})
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix (plus e2e regression coverage).

### What is the current behavior?

When `CLAUDECODE=1` (e.g. Claude Code / agent harness), the CLI can emit a `<claude-code-hint … />` trailer intended for the Claude Code UI. That is inappropriate when the user is capturing primary output (redirects, pipes, or tools that merge streams), because it can end up in generated files or other machine-readable output and break consumers such as TypeScript parsing.

Tracked in [#5212](https://github.com/supabase/cli/issues/5212).

### What is the new behavior?

`SuggestClaudePlugin()` only returns the hint when running inside Claude Code **and** standard output is a terminal (interactive). If stdout is redirected or piped, the hint is not suggested, so it is not printed after commands and captured output stays clean.

An e2e case exercises `gen types` with `CLAUDECODE=1` and asserts neither captured stdout nor stderr contains `claude-code-hint`. The `testBehaviour` `run` helper accepts optional `exec` options so tests can set extra env vars without duplicating harness setup.

No user-facing visual changes.

### Additional context

- The regression test lives in `apps/cli-e2e` and reuses the existing gen-types scenario (same test title → same fixture slug).
- Run the focused suite with  
  `SUPABASE_GO_BINARY="$PWD/apps/cli-go/supabase-go" pnpm nx run @supabase/cli-e2e:test:go -- src/tests/gen.e2e.test.ts`  
  (and `test:legacy` if you want parity on the legacy harness).

## Testing method

Use RED/GREEN testing with the e2e test to ensure this properly fix an existing regression.