### PR TITLE
poc(cli): node SEA binary build pipeline (failover reference)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,6 +49,7 @@
     "react": "^19.2.5"
   },
   "devDependencies": {
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@supabase/api": "workspace:*",
     "@supabase/config": "workspace:*",
@@ -58,10 +59,12 @@
     "@types/react": "^19.2.14",
     "@typescript/native-preview": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
+    "esbuild": "^0.28.0",
     "knip": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
+    "postject": "1.0.0-alpha.6",
     "react-devtools-core": "^7.0.1",
     "vitest": "catalog:"
   },

--- a/apps/cli/scripts/build-sea.ts
+++ b/apps/cli/scripts/build-sea.ts
@@ -1,0 +1,89 @@
+/**
+ * Node Single Executable Application (SEA) PoC build script.
+ *
+ * Pipeline:
+ *   1. esbuild bundles `sea-poc-entry.ts` into a single CJS file (SEA does not support ESM).
+ *   2. Node generates a SEA blob from the bundle via `--experimental-sea-config`.
+ *   3. The host `node` binary is copied to `dist/sea/supabase-sea`.
+ *   4. `postject` injects the blob into the copy under the `NODE_SEA_BLOB` resource.
+ *
+ * Run with:  pnpm exec bun apps/cli/scripts/build-sea.ts
+ *
+ * Limitations (intentional for the PoC):
+ *   - Linux/macOS only here; Windows would also need `signtool` removal and the
+ *     `Mach-O` arg for postject is omitted (would be `--macho-segment-name NODE_SEA`).
+ *   - Native modules (e.g. `@napi-rs/keyring`) are NOT packed; the bundle would
+ *     `require()` them at runtime and fail. The current entry deliberately avoids them.
+ */
+import { $ } from "bun";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = path.resolve(import.meta.dir, "../../..");
+const outDir = path.join(root, "apps/cli/dist/sea");
+const entry = path.join(root, "apps/cli/scripts/sea-poc-entry.ts");
+const esbuildBin = path.join(root, "apps/cli/node_modules/.bin/esbuild");
+const postjectBin = path.join(root, "apps/cli/node_modules/.bin/postject");
+const bundle = path.join(outDir, "sea-poc.cjs");
+const seaConfig = path.join(outDir, "sea-config.json");
+const seaBlob = path.join(outDir, "sea-poc.blob");
+const ext = process.platform === "win32" ? ".exe" : "";
+const binary = path.join(outDir, `supabase-sea${ext}`);
+
+const SENTINEL = "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2";
+
+// process.execPath under Bun points to the Bun binary — we need the host Node
+// binary (which contains the SEA fuse sentinel postject must find).
+const nodeBin = Bun.which("node");
+if (!nodeBin) throw new Error("`node` not found on PATH — required as the SEA host binary.");
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+
+console.log("[1/4] esbuild bundle -> CJS");
+await $`${esbuildBin} ${entry} --bundle --platform=node --target=node22 --format=cjs --minify --outfile=${bundle}`.cwd(root);
+
+const bundleSize = (await stat(bundle)).size;
+console.log(`       bundle: ${(bundleSize / 1024).toFixed(1)} KiB`);
+
+console.log("[2/4] sea config + blob");
+await writeFile(
+  seaConfig,
+  JSON.stringify(
+    {
+      main: bundle,
+      output: seaBlob,
+      disableExperimentalSEAWarning: true,
+      useSnapshot: false,
+      useCodeCache: true,
+    },
+    null,
+    2,
+  ),
+);
+await $`node --experimental-sea-config ${seaConfig}`;
+
+const blobSize = (await stat(seaBlob)).size;
+console.log(`       blob: ${(blobSize / 1024).toFixed(1)} KiB`);
+
+console.log(`[3/4] copy host node binary (${nodeBin})`);
+const cpResult = Bun.spawnSync(["/bin/cp", nodeBin, binary]);
+if (cpResult.exitCode !== 0) throw new Error(`cp failed: ${cpResult.exitCode}`);
+await $`chmod +w ${binary}`;
+
+console.log("[4/4] postject inject");
+const postjectArgs = [
+  binary,
+  "NODE_SEA_BLOB",
+  seaBlob,
+  "--sentinel-fuse",
+  SENTINEL,
+];
+if (process.platform === "darwin") postjectArgs.push("--macho-segment-name", "NODE_SEA");
+await $`${postjectBin} ${postjectArgs}`.cwd(root);
+
+const binarySize = (await stat(binary)).size;
+console.log(`\nbinary: ${binary}`);
+console.log(`size:   ${(binarySize / (1024 * 1024)).toFixed(2)} MiB`);
+console.log(`run:    ${binary} hello sea\n`);

--- a/apps/cli/scripts/sea-poc-entry.ts
+++ b/apps/cli/scripts/sea-poc-entry.ts
@@ -1,0 +1,30 @@
+/**
+ * PoC entrypoint for Node SEA experiment.
+ *
+ * Mirrors the shape of `apps/cli/src/shared/cli/run.ts` (Stdio.args + FileSystem),
+ * but uses `@effect/platform-node`'s `NodeServices.layer` instead of `BunServices.layer`.
+ *
+ * The goal is to prove an Effect program — using the same primitives the CLI uses —
+ * can be bundled and packaged as a Node Single Executable Application.
+ */
+import { NodeServices } from "@effect/platform-node";
+import { Effect, FileSystem, Stdio } from "effect";
+
+const program = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio;
+  const fs = yield* FileSystem.FileSystem;
+
+  const args = yield* stdio.args;
+  yield* Effect.log(`sea-poc args: ${JSON.stringify(args)}`);
+
+  const cwd = process.cwd();
+  const entries = yield* fs.readDirectory(cwd);
+  yield* Effect.log(`cwd has ${entries.length} entries (first 3: ${entries.slice(0, 3).join(", ")})`);
+
+  yield* Effect.log("sea-poc ok");
+});
+
+// Wrapped in an IIFE because SEA requires CJS output, which forbids top-level await.
+void (async () => {
+  await Effect.runPromise(program.pipe(Effect.provide(NodeServices.layer)));
+})();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5
     devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.43(effect@4.0.0-beta.43)(ioredis@5.10.1)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.43(effect@4.0.0-beta.43)(vitest@4.1.5)
@@ -138,6 +141,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       knip:
         specifier: 'catalog:'
         version: 6.6.1
@@ -150,12 +156,15 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.21.1
+      postject:
+        specifier: 1.0.0-alpha.6
+        version: 1.0.0-alpha.6
       react-devtools-core:
         specifier: ^7.0.1
         version: 7.0.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
     optionalDependencies:
       '@supabase/cli-darwin-arm64':
         specifier: workspace:*
@@ -3116,6 +3125,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -4646,6 +4659,11 @@ packages:
       rxjs:
         optional: true
 
+  postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   pretty-format@30.3.0:
     resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -5671,7 +5689,7 @@ snapshots:
   '@effect/vitest@4.0.0-beta.43(effect@4.0.0-beta.43)(vitest@4.1.5)':
     dependencies:
       effect: 4.0.0-beta.43
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -7340,7 +7358,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -7361,13 +7379,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.5(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -7702,6 +7720,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@9.5.0: {}
 
   compressible@2.0.18:
     dependencies:
@@ -9688,6 +9708,10 @@ snapshots:
     dependencies:
       '@posthog/core': 1.25.3
 
+  postject@1.0.0-alpha.6:
+    dependencies:
+      commander: 9.5.0
+
   pretty-format@30.3.0:
     dependencies:
       '@jest/schemas': 30.0.5
@@ -10553,7 +10577,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10562,7 +10586,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      esbuild: 0.27.4
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
@@ -10598,10 +10622,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -10618,7 +10642,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0


### PR DESCRIPTION
## Summary

**Reference PoC — not for merge.** Linked from a Linear RFC capturing the Bun → Node SEA failover plan discussed in the team meeting.

Proves the toolchain end-to-end on Linux: an Effect program using `NodeServices.layer` (the same `Stdio` + `FileSystem` services the CLI consumes today via `BunServices`), bundled with `esbuild` to CJS, packed into a Node SEA blob, and injected into a copy of the host `node` binary with `postject`.

## What's here

- `apps/cli/scripts/sea-poc-entry.ts` — minimal Node-only Effect entry, mirrors the `Stdio.args` + `FileSystem` shape used in `apps/cli/src/shared/cli/run.ts`.
- `apps/cli/scripts/build-sea.ts` — esbuild → SEA blob → postject pipeline.
- `apps/cli/package.json` — adds `@effect/platform-node` (catalog), `esbuild`, `postject`.

## Result

```
$ apps/cli/dist/sea/supabase-sea hello sea
[INFO] sea-poc args: ["hello","sea"]
[INFO] cwd has 22 entries (first 3: .git, .github, .gitignore)
[INFO] sea-poc ok
```

| | Size |
|---|---|
| esbuild CJS bundle | 644 KiB |
| SEA blob (`useCodeCache: true`) | 893 KiB |
| Final SEA binary | **120 MiB** |
| Bun `--compile --minify` (today) | 55–90 MiB |

## Gotchas surfaced

1. SEA requires CJS — top-level `await` must be wrapped.
2. Under Bun, `process.execPath` is the Bun binary; resolve `node` via `Bun.which("node")`.
3. No cross-compile: one CI job per target downloads the matching `node-vX.Y.Z-<os>-<arch>` and injects locally. musl needs unofficial Node builds.
4. Native modules (`@napi-rs/keyring`) can't live inside the blob. Either ship `.node` side-cars or use SEA assets with extract-to-disk.
5. macOS / Windows need `codesign --remove-signature` (resp. `signtool`) before postject and a re-sign after.
6. The real CLI port still needs `BunServices.layer` → `NodeServices.layer` at 11 source sites (mechanical, identical service shape).
7. Repo-local bug worth keeping in mind: `node:fs/promises.cp`, Bun's shell `cp` builtin, and `node:child_process.spawnSync` under Bun all truncate the Node binary copy. Only `Bun.spawnSync(["/bin/cp", …])` is reliable.

See the linked Linear RFC for the full ADR and decision criteria.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T27mu6CHG6WesHHa6Lnfod)_