### PR TITLE
fix(ci): pin Bun and add cache + retried fallback installer

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,10 +5,38 @@ description: Perform standard setup and install dependencies using pnpm
 runs:
   using: "composite"
   steps:
-    - name: Install Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+    - name: Resolve Bun version
+      shell: bash
+      run: echo "BUN_VERSION=1.3.13" >> "$GITHUB_ENV"
+
+    - name: Restore Bun toolchain cache
+      id: bun-toolchain-cache
+      uses: actions/cache@v4
       with:
-        bun-version: latest
+        path: /opt/hostedtoolcache/bun
+        key: bun-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}
+
+    - name: Install Bun
+      id: install-bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      continue-on-error: true
+      with:
+        bun-version: ${{ env.BUN_VERSION }}
+
+    - name: Install Bun (fallback with retries)
+      if: steps.install-bun.outcome == 'failure'
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 3
+        max_attempts: 5
+        retry_wait_seconds: 30
+        command: |
+          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+    - name: Verify Bun
+      shell: bash
+      run: bun --version
 
     - name: Install Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
## Summary
Enhanced the Bun setup action to improve installation reliability by adding toolchain caching, pinning to a specific version, implementing a fallback installation mechanism with retries, and adding version verification.

## Key Changes
- **Pin Bun version**: Changed from `latest` to a specific version (`1.3.13`) for reproducible builds
- **Add toolchain caching**: Implemented caching of the Bun toolchain to `/opt/hostedtoolcache/bun` to speed up subsequent workflow runs
- **Implement fallback installation**: Added a retry-based fallback mechanism using `nick-fields/retry@v3` that directly downloads and installs Bun via curl if the primary setup action fails
- **Add version verification**: Added a verification step to confirm Bun is properly installed by running `bun --version`
- **Improve error handling**: Made the primary installation step non-blocking with `continue-on-error: true` to allow the fallback mechanism to execute

## Implementation Details
- The fallback installation uses curl to download from `https://bun.sh/install` with up to 5 retry attempts and 30-second wait intervals between retries
- The Bun binary path is explicitly added to `$GITHUB_PATH` in the fallback step to ensure it's available for subsequent steps
- All steps use the pinned `BUN_VERSION` environment variable for consistency across the workflow

https://claude.ai/code/session_01KYCuKb2pWDBjsAZ2DagygF