### PR TITLE
docs(branches): clarify main branch credential field behavior in get help

### DIFF
--- a/apps/cli-go/cmd/branches.go
+++ b/apps/cli-go/cmd/branches.go
@@ -80,7 +80,7 @@ var (
 		Short: "Retrieve details of a preview branch",
 		Long: "Retrieve details of the specified preview branch.\n\n" +
 			"Note: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.",
-		Args:  cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			fsys := afero.NewOsFs()

--- a/apps/cli-go/cmd/branches.go
+++ b/apps/cli-go/cmd/branches.go
@@ -78,7 +78,8 @@ var (
 	branchGetCmd = &cobra.Command{
 		Use:   "get [name]",
 		Short: "Retrieve details of a preview branch",
-		Long:  "Retrieve details of the specified preview branch.",
+		Long: "Retrieve details of the specified preview branch.\n\n" +
+			"Note: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/apps/cli/src/legacy/commands/branches/get/get.command.ts
+++ b/apps/cli/src/legacy/commands/branches/get/get.command.ts
@@ -16,7 +16,10 @@ const config = {
 export type LegacyBranchesGetFlags = CliCommand.Command.Config.Infer<typeof config>;
 
 export const legacyBranchesGetCommand = Command.make("get", config).pipe(
-  Command.withDescription("Retrieve details of the specified preview branch."),
+  Command.withDescription(
+    "Retrieve details of the specified preview branch.\n\n" +
+      "Note: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.",
+  ),
   Command.withShortDescription("Retrieve details of a preview branch"),
   Command.withHandler((flags) => legacyBranchesGet(flags)),
 );


### PR DESCRIPTION
## Summary
Updated the help documentation for the `branches get` command in both the TypeScript CLI and Go CLI to clarify behavior regarding password-dependent fields when retrieving the main branch details.

## Key Changes
- **TypeScript CLI** (`apps/cli/src/legacy/commands/branches/get/get.command.ts`): Extended the command description to include a note explaining that password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated for the main branch because production database credentials are not retrievable via API.
- **Go CLI** (`apps/cli-go/cmd/branches.go`): Added the same clarification note to the `Long` help text of the `branchGetCmd` command.

## Implementation Details
- The note is appended to the existing command descriptions with proper formatting (double newline for separation)
- The documentation change applies consistently across both CLI implementations to ensure users get the same information regardless of which CLI they use
- This helps prevent confusion when users query the main branch and don't see expected database credential fields in the response

https://claude.ai/code/session_019SsgQZhkBLT6xWJRcm68Ef