### PR TITLE
ci(cli-go-api-sync): improve PR approval and automerge reliability

### DIFF
--- a/.github/workflows/cli-go-api-sync.yml
+++ b/.github/workflows/cli-go-api-sync.yml
@@ -58,16 +58,17 @@ jobs:
           base: develop
 
       - name: Approve a PR
-        if: steps.check.outputs.has_changes == 'true'
-        run: gh pr review --approve "${{ steps.cpr.outputs.pull-request-number }}"
+        if: steps.check.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-operation == 'created'
+        continue-on-error: true
+        run: gh pr review --approve --repo "${{ github.repository }}" "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Pull Request Automerge
         if: steps.check.outputs.has_changes == 'true'
-        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
+        run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 defaults:
   run:
     working-directory: apps/cli-go


### PR DESCRIPTION
Improves the reliability of the CLI Go API sync workflow's PR approval and automerge steps.

**Changes:**
- Only approve newly created PRs (skip approval for updated PRs) by adding `steps.cpr.outputs.pull-request-operation == 'created'` condition
- Add `continue-on-error: true` to the approval step to prevent workflow failure if approval fails
- Add explicit `--repo` flag to both `gh pr review` and `gh pr merge` commands for clarity and robustness
- Switch from `GITHUB_TOKEN` to `GH_TOKEN` environment variable for better GitHub CLI compatibility

These changes make the workflow more resilient to transient GitHub API issues and prevent unnecessary approval attempts on PR updates.

https://claude.ai/code/session_01VqwcMnADHsysHpgwZaErny