### PR TITLE
feat(cli): add org creation survey prompts

### DIFF
--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -62,14 +62,14 @@ func buildOnboardingSurveyRequest(ctx context.Context, slug string) (onboardingS
 		return body, nil
 	}
 
-	fmt.Fprintln(os.Stderr, "Optional: help us improve Supabase by answering two quick questions.")
-	heardFrom, err := console.PromptText(ctx, "Where did you hear about us? (optional) ")
+	fmt.Fprintln(os.Stderr, "Answer two optional questions so we can improve your Supabase experience. Press Enter to skip.")
+	heardFrom, err := console.PromptText(ctx, "1/2 Where did you hear about us? ")
 	if err != nil {
 		return body, err
 	}
 	body.HeardFrom = strings.TrimSpace(heardFrom)
 
-	building, err := console.PromptText(ctx, "What are you building? (optional) ")
+	building, err := console.PromptText(ctx, "2/2 What are you building? ")
 	if err != nil {
 		return body, err
 	}

--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -1,9 +1,12 @@
 package create
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/supabase/cli/internal/orgs/list"
@@ -11,8 +14,24 @@ import (
 	"github.com/supabase/cli/pkg/api"
 )
 
+type createOrganizationRequest struct {
+	Name      string `json:"name"`
+	HeardFrom string `json:"heard_from,omitempty"`
+	Building  string `json:"building,omitempty"`
+}
+
+var newConsole = utils.NewConsole
+
 func Run(ctx context.Context, name string) error {
-	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithResponse(ctx, api.V1CreateAnOrganizationJSONRequestBody{Name: name})
+	body, err := buildCreateOrganizationRequest(ctx, name)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return errors.Errorf("failed to encode organization request: %w", err)
+	}
+	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
 	if err != nil {
 		return errors.Errorf("failed to create organization: %w", err)
 	} else if resp.JSON201 == nil {
@@ -25,4 +44,26 @@ func Run(ctx context.Context, name string) error {
 		return utils.RenderTable(table)
 	}
 	return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, *resp.JSON201)
+}
+
+func buildCreateOrganizationRequest(ctx context.Context, name string) (createOrganizationRequest, error) {
+	body := createOrganizationRequest{Name: name}
+	console := newConsole()
+	if utils.OutputFormat.Value != utils.OutputPretty || !console.IsTTY {
+		return body, nil
+	}
+
+	heardFrom, err := console.PromptText(ctx, "Where did you hear about us? ")
+	if err != nil {
+		return body, err
+	}
+	body.HeardFrom = strings.TrimSpace(heardFrom)
+
+	building, err := console.PromptText(ctx, "What are you building? ")
+	if err != nil {
+		return body, err
+	}
+	body.Building = strings.TrimSpace(building)
+
+	return body, nil
 }

--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -15,12 +15,6 @@ import (
 	"github.com/supabase/cli/pkg/fetcher"
 )
 
-type createOrganizationInput struct {
-	Name      string
-	HeardFrom string
-	Building  string
-}
-
 type onboardingSurveyRequest struct {
 	Slug      string `json:"slug"`
 	HeardFrom string `json:"heard_from,omitempty"`
@@ -31,15 +25,11 @@ var newConsole = utils.NewConsole
 var submitSurvey = submitOnboardingSurvey
 
 func Run(ctx context.Context, name string) error {
-	input, err := buildCreateOrganizationInput(ctx, name)
-	if err != nil {
-		return err
-	}
 	if utils.OutputFormat.Value == utils.OutputPretty {
 		fmt.Fprintln(os.Stderr, "Creating organization...")
 	}
 	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithResponse(ctx, api.V1CreateAnOrganizationJSONRequestBody{
-		Name: input.Name,
+		Name: name,
 	})
 	if err != nil {
 		return errors.Errorf("failed to create organization: %w", err)
@@ -47,30 +37,32 @@ func Run(ctx context.Context, name string) error {
 		return errors.Errorf("unexpected create organization status %d: %s", resp.StatusCode(), string(resp.Body))
 	}
 
-	survey := onboardingSurveyRequest{
-		Slug:      organizationSlug(*resp.JSON201),
-		HeardFrom: input.HeardFrom,
-		Building:  input.Building,
-	}
-	if err := submitSurvey(ctx, survey); err != nil && utils.OutputFormat.Value == utils.OutputPretty {
-		fmt.Fprintln(os.Stderr, "WARN: failed to submit organization survey:", err)
-	}
-
 	fmt.Println("Created organization:", resp.JSON201.Id)
 	if utils.OutputFormat.Value == utils.OutputPretty {
 		table := list.ToMarkdown([]api.OrganizationResponseV1{*resp.JSON201})
-		return utils.RenderTable(table)
+		if err := utils.RenderTable(table); err != nil {
+			return err
+		}
+		survey, err := buildOnboardingSurveyRequest(ctx, organizationSlug(*resp.JSON201))
+		if err != nil {
+			return err
+		}
+		if err := submitSurvey(ctx, survey); err != nil {
+			fmt.Fprintln(os.Stderr, "WARN: failed to submit organization survey:", err)
+		}
+		return nil
 	}
 	return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, *resp.JSON201)
 }
 
-func buildCreateOrganizationInput(ctx context.Context, name string) (createOrganizationInput, error) {
-	body := createOrganizationInput{Name: name}
+func buildOnboardingSurveyRequest(ctx context.Context, slug string) (onboardingSurveyRequest, error) {
+	body := onboardingSurveyRequest{Slug: slug}
 	console := newConsole()
-	if utils.OutputFormat.Value != utils.OutputPretty || !console.IsTTY {
+	if !console.IsTTY {
 		return body, nil
 	}
 
+	fmt.Fprintln(os.Stderr, "Optional: help us improve Supabase by answering two quick questions.")
 	heardFrom, err := console.PromptText(ctx, "Where did you hear about us? (optional) ")
 	if err != nil {
 		return body, err

--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -31,6 +31,9 @@ func Run(ctx context.Context, name string) error {
 	if err != nil {
 		return errors.Errorf("failed to encode organization request: %w", err)
 	}
+	if utils.OutputFormat.Value == utils.OutputPretty {
+		fmt.Fprintln(os.Stderr, "Creating organization...")
+	}
 	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
 	if err != nil {
 		return errors.Errorf("failed to create organization: %w", err)
@@ -53,13 +56,13 @@ func buildCreateOrganizationRequest(ctx context.Context, name string) (createOrg
 		return body, nil
 	}
 
-	heardFrom, err := console.PromptText(ctx, "Where did you hear about us? ")
+	heardFrom, err := console.PromptText(ctx, "Where did you hear about us? (optional) ")
 	if err != nil {
 		return body, err
 	}
 	body.HeardFrom = strings.TrimSpace(heardFrom)
 
-	building, err := console.PromptText(ctx, "What are you building? ")
+	building, err := console.PromptText(ctx, "What are you building? (optional) ")
 	if err != nil {
 		return body, err
 	}

--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -1,44 +1,59 @@
 package create
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/go-errors/errors"
+	"github.com/spf13/afero"
 	"github.com/supabase/cli/internal/orgs/list"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
+	"github.com/supabase/cli/pkg/fetcher"
 )
 
-type createOrganizationRequest struct {
-	Name      string `json:"name"`
+type createOrganizationInput struct {
+	Name      string
+	HeardFrom string
+	Building  string
+}
+
+type onboardingSurveyRequest struct {
+	Slug      string `json:"slug"`
 	HeardFrom string `json:"heard_from,omitempty"`
 	Building  string `json:"building,omitempty"`
 }
 
 var newConsole = utils.NewConsole
+var submitSurvey = submitOnboardingSurvey
 
 func Run(ctx context.Context, name string) error {
-	body, err := buildCreateOrganizationRequest(ctx, name)
+	input, err := buildCreateOrganizationInput(ctx, name)
 	if err != nil {
 		return err
-	}
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return errors.Errorf("failed to encode organization request: %w", err)
 	}
 	if utils.OutputFormat.Value == utils.OutputPretty {
 		fmt.Fprintln(os.Stderr, "Creating organization...")
 	}
-	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
+	resp, err := utils.GetSupabase().V1CreateAnOrganizationWithResponse(ctx, api.V1CreateAnOrganizationJSONRequestBody{
+		Name: input.Name,
+	})
 	if err != nil {
 		return errors.Errorf("failed to create organization: %w", err)
 	} else if resp.JSON201 == nil {
 		return errors.Errorf("unexpected create organization status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	survey := onboardingSurveyRequest{
+		Slug:      organizationSlug(*resp.JSON201),
+		HeardFrom: input.HeardFrom,
+		Building:  input.Building,
+	}
+	if err := submitSurvey(ctx, survey); err != nil && utils.OutputFormat.Value == utils.OutputPretty {
+		fmt.Fprintln(os.Stderr, "WARN: failed to submit organization survey:", err)
 	}
 
 	fmt.Println("Created organization:", resp.JSON201.Id)
@@ -49,8 +64,8 @@ func Run(ctx context.Context, name string) error {
 	return utils.EncodeOutput(utils.OutputFormat.Value, os.Stdout, *resp.JSON201)
 }
 
-func buildCreateOrganizationRequest(ctx context.Context, name string) (createOrganizationRequest, error) {
-	body := createOrganizationRequest{Name: name}
+func buildCreateOrganizationInput(ctx context.Context, name string) (createOrganizationInput, error) {
+	body := createOrganizationInput{Name: name}
 	console := newConsole()
 	if utils.OutputFormat.Value != utils.OutputPretty || !console.IsTTY {
 		return body, nil
@@ -69,4 +84,32 @@ func buildCreateOrganizationRequest(ctx context.Context, name string) (createOrg
 	body.Building = strings.TrimSpace(building)
 
 	return body, nil
+}
+
+func organizationSlug(org api.OrganizationResponseV1) string {
+	if org.Slug != "" {
+		return org.Slug
+	}
+	return org.Id
+}
+
+func submitOnboardingSurvey(ctx context.Context, body onboardingSurveyRequest) error {
+	if body.HeardFrom == "" && body.Building == "" {
+		return nil
+	}
+	token, err := utils.LoadAccessTokenFS(afero.NewOsFs())
+	if err != nil {
+		return err
+	}
+	client := fetcher.NewFetcher(
+		utils.GetSupabaseAPIHost(),
+		fetcher.WithBearerToken(token),
+		fetcher.WithUserAgent("SupabaseCLI/"+utils.Version),
+		fetcher.WithExpectedStatus(http.StatusNoContent),
+	)
+	resp, err := client.Send(ctx, http.MethodPost, "/platform/organizations/onboarding-survey", body)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
 }

--- a/apps/cli-go/internal/orgs/create/create.go
+++ b/apps/cli-go/internal/orgs/create/create.go
@@ -62,14 +62,15 @@ func buildOnboardingSurveyRequest(ctx context.Context, slug string) (onboardingS
 		return body, nil
 	}
 
-	fmt.Fprintln(os.Stderr, "Answer two optional questions so we can improve your Supabase experience. Press Enter to skip.")
-	heardFrom, err := console.PromptText(ctx, "1/2 Where did you hear about us? ")
+	fmt.Fprintln(os.Stderr, "Answer two optional questions to help us improve Supabase. Press Enter to skip.")
+	fmt.Fprintln(os.Stderr)
+	heardFrom, err := console.PromptText(ctx, "1/2: Where did you hear about us? ")
 	if err != nil {
 		return body, err
 	}
 	body.HeardFrom = strings.TrimSpace(heardFrom)
 
-	building, err := console.PromptText(ctx, "2/2 What are you building? ")
+	building, err := console.PromptText(ctx, "2/2: What are you building? ")
 	if err != nil {
 		return body, err
 	}

--- a/apps/cli-go/internal/orgs/create/create_test.go
+++ b/apps/cli-go/internal/orgs/create/create_test.go
@@ -19,6 +19,7 @@ func TestOrganizationCreateCommand(t *testing.T) {
 
 	t.Cleanup(func() {
 		newConsole = utils.NewConsole
+		submitSurvey = submitOnboardingSurvey
 		utils.OutputFormat.Value = utils.OutputPretty
 	})
 
@@ -31,7 +32,7 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{Name: orgName}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			Reply(http.StatusCreated).
 			JSON(api.OrganizationResponseV1{
 				Id:   "combined-fuchsia-lion",
@@ -61,16 +62,22 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{
-				Name:      orgName,
-				HeardFrom: "GitHub",
-				Building:  "AI coding assistant",
-			}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			Reply(http.StatusCreated).
 			JSON(api.OrganizationResponseV1{
 				Id:   "combined-fuchsia-lion",
 				Name: orgName,
+				Slug: "combined-fuchsia-lion",
 			})
+		gock.New(utils.DefaultApiHost).
+			Post("/platform/organizations/onboarding-survey").
+			MatchType("json").
+			JSON(onboardingSurveyRequest{
+				Slug:      "combined-fuchsia-lion",
+				HeardFrom: "GitHub",
+				Building:  "AI coding assistant",
+			}).
+			Reply(http.StatusNoContent)
 		// Run test
 		assert.NoError(t, Run(context.Background(), orgName))
 		// Validate api
@@ -95,7 +102,7 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{Name: orgName}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			Reply(http.StatusCreated).
 			JSON(api.OrganizationResponseV1{
 				Id:   "combined-fuchsia-lion",
@@ -129,12 +136,53 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{Name: orgName}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			Reply(http.StatusCreated).
 			JSON(api.OrganizationResponseV1{
 				Id:   "combined-fuchsia-lion",
 				Name: orgName,
 			})
+		// Run test
+		assert.NoError(t, Run(context.Background(), orgName))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("does not fail organization creation when survey submit fails", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		t.Cleanup(fstest.MockStdin(t, "GitHub\nAI coding assistant\n"))
+		newConsole = func() *utils.Console {
+			console := utils.NewConsole()
+			console.IsTTY = true
+			return console
+		}
+		t.Cleanup(func() {
+			newConsole = utils.NewConsole
+		})
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/organizations").
+			MatchType("json").
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
+			Reply(http.StatusCreated).
+			JSON(api.OrganizationResponseV1{
+				Id:   "combined-fuchsia-lion",
+				Name: orgName,
+				Slug: "combined-fuchsia-lion",
+			})
+		gock.New(utils.DefaultApiHost).
+			Post("/platform/organizations/onboarding-survey").
+			MatchType("json").
+			JSON(onboardingSurveyRequest{
+				Slug:      "combined-fuchsia-lion",
+				HeardFrom: "GitHub",
+				Building:  "AI coding assistant",
+			}).
+			Reply(http.StatusServiceUnavailable).
+			JSON(map[string]string{"message": "unavailable"})
 		// Run test
 		assert.NoError(t, Run(context.Background(), orgName))
 		// Validate api
@@ -150,7 +198,7 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{Name: orgName}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			ReplyError(errors.New("network error"))
 		// Run test
 		assert.Error(t, Run(context.Background(), orgName))
@@ -167,7 +215,7 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
 			MatchType("json").
-			JSON(createOrganizationRequest{Name: orgName}).
+			JSON(api.V1CreateAnOrganizationJSONRequestBody{Name: orgName}).
 			Reply(http.StatusServiceUnavailable).
 			JSON(map[string]string{"message": "unavailable"})
 		// Run test

--- a/apps/cli-go/internal/orgs/create/create_test.go
+++ b/apps/cli-go/internal/orgs/create/create_test.go
@@ -9,12 +9,18 @@ import (
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/supabase/cli/internal/testing/apitest"
+	"github.com/supabase/cli/internal/testing/fstest"
 	"github.com/supabase/cli/internal/utils"
 	"github.com/supabase/cli/pkg/api"
 )
 
 func TestOrganizationCreateCommand(t *testing.T) {
 	orgName := "Test Organization"
+
+	t.Cleanup(func() {
+		newConsole = utils.NewConsole
+		utils.OutputFormat.Value = utils.OutputPretty
+	})
 
 	t.Run("create an organization", func(t *testing.T) {
 		// Setup valid access token
@@ -24,6 +30,106 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{Name: orgName}).
+			Reply(http.StatusCreated).
+			JSON(api.OrganizationResponseV1{
+				Id:   "combined-fuchsia-lion",
+				Name: orgName,
+			})
+		// Run test
+		assert.NoError(t, Run(context.Background(), orgName))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("sends optional survey fields from interactive prompts", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		t.Cleanup(fstest.MockStdin(t, "GitHub\nAI coding assistant\n"))
+		newConsole = func() *utils.Console {
+			console := utils.NewConsole()
+			console.IsTTY = true
+			return console
+		}
+		t.Cleanup(func() {
+			newConsole = utils.NewConsole
+		})
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{
+				Name:      orgName,
+				HeardFrom: "GitHub",
+				Building:  "AI coding assistant",
+			}).
+			Reply(http.StatusCreated).
+			JSON(api.OrganizationResponseV1{
+				Id:   "combined-fuchsia-lion",
+				Name: orgName,
+			})
+		// Run test
+		assert.NoError(t, Run(context.Background(), orgName))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("omits blank survey prompt answers", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		t.Cleanup(fstest.MockStdin(t, "\n\n"))
+		newConsole = func() *utils.Console {
+			console := utils.NewConsole()
+			console.IsTTY = true
+			return console
+		}
+		t.Cleanup(func() {
+			newConsole = utils.NewConsole
+		})
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{Name: orgName}).
+			Reply(http.StatusCreated).
+			JSON(api.OrganizationResponseV1{
+				Id:   "combined-fuchsia-lion",
+				Name: orgName,
+			})
+		// Run test
+		assert.NoError(t, Run(context.Background(), orgName))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("skips survey prompts for structured output", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+		utils.OutputFormat.Value = utils.OutputJson
+		t.Cleanup(func() {
+			utils.OutputFormat.Value = utils.OutputPretty
+		})
+		t.Cleanup(fstest.MockStdin(t, "GitHub\nAI coding assistant\n"))
+		newConsole = func() *utils.Console {
+			console := utils.NewConsole()
+			console.IsTTY = true
+			return console
+		}
+		t.Cleanup(func() {
+			newConsole = utils.NewConsole
+		})
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+		gock.New(utils.DefaultApiHost).
+			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{Name: orgName}).
 			Reply(http.StatusCreated).
 			JSON(api.OrganizationResponseV1{
 				Id:   "combined-fuchsia-lion",
@@ -43,6 +149,8 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{Name: orgName}).
 			ReplyError(errors.New("network error"))
 		// Run test
 		assert.Error(t, Run(context.Background(), orgName))
@@ -58,6 +166,8 @@ func TestOrganizationCreateCommand(t *testing.T) {
 		defer gock.OffAll()
 		gock.New(utils.DefaultApiHost).
 			Post("/v1/organizations").
+			MatchType("json").
+			JSON(createOrganizationRequest{Name: orgName}).
 			Reply(http.StatusServiceUnavailable).
 			JSON(map[string]string{"message": "unavailable"})
 		// Run test


### PR DESCRIPTION
Adds optional survey capture to the Go-backed `supabase orgs create` flow. Resolves GROWTH-772.

The command now creates the organization first, then asks interactive, pretty-output users where they heard about Supabase and what they are building as an optional follow-up. Org creation still sends only the required org name, and non-empty survey answers are submitted separately to the onboarding survey endpoint with the created org slug. Non-interactive and structured-output runs continue to send only the required org name so scripts and agents are not blocked by prompts.