### PR TITLE
feat: clean up report table output and add rules

### DIFF
--- a/apps/cli-e2e/fixtures/pg/index-stats.json
+++ b/apps/cli-e2e/fixtures/pg/index-stats.json
@@ -1,5 +1,5 @@
 {
-  "columns": ["name", "size", "percent_used", "index_scans", "seq_scans", "unused"],
-  "typeOids": [25, 25, 25, 20, 20, 16],
-  "rows": [["public.users_email_idx", "1024 kB", "87%", "25000", "300", "f"]]
+  "columns": ["name", "table", "columns", "size", "percent_used", "index_scans", "seq_scans", "unused"],
+  "typeOids": [25, 25, 25, 25, 25, 20, 20, 16],
+  "rows": [["public.users_email_idx", "public.users", "email", "1024 kB", "87%", "25000", "300", "f"]]
 }

--- a/apps/cli-go/api/overlay.yaml
+++ b/apps/cli-go/api/overlay.yaml
@@ -44,6 +44,23 @@ actions:
 - target: $.components.schemas.JitStateResponse.discriminator
   description: Replaces discriminated union with concrete type
   remove: true
+- target: $.components.schemas.JitListAccessResponse.properties.items.items.oneOf[0].properties.invite_id
+  description: Replaces null-only project user invite id with nullable UUID for oapi-codegen
+  update:
+    type: string
+    format: uuid
+    nullable: true
+- target: $.components.schemas.JitListAccessResponse.properties.items.items.oneOf[0].properties.expires_at
+  description: Replaces null-only project user invite expiry with nullable string for oapi-codegen
+  update:
+    type: string
+    nullable: true
+- target: $.components.schemas.JitListAccessResponse.properties.items.items.oneOf[1].properties.user_id
+  description: Replaces null-only invited user id with nullable UUID for oapi-codegen
+  update:
+    type: string
+    format: uuid
+    nullable: true
 - target: $.components.schemas.ProjectUpgradeEligibilityResponse.properties.warnings.items.discriminator
   description: Removes inline warning discriminator that oapi-codegen cannot map
   remove: true

--- a/apps/cli-go/internal/inspect/index_stats/index_stats.go
+++ b/apps/cli-go/internal/inspect/index_stats/index_stats.go
@@ -19,6 +19,8 @@ var IndexStatsQuery string
 
 type Result struct {
 	Name         string
+	Table        string
+	Columns      string
 	Size         string
 	Percent_used string
 	Index_scans  int64
@@ -41,9 +43,9 @@ func Run(ctx context.Context, config pgconn.Config, fsys afero.Fs, options ...fu
 		return err
 	}
 
-	table := "|Name|Size|Percent used|Index scans|Seq scans|Unused|\n|-|-|-|-|-|-|\n"
+	table := "|Name|Table|Columns|Size|Percent used|Index scans|Seq scans|Unused|\n|-|-|-|-|-|-|-|-|\n"
 	for _, r := range result {
-		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%d`|`%d`|`%t`|\n", r.Name, r.Size, r.Percent_used, r.Index_scans, r.Seq_scans, r.Unused)
+		table += fmt.Sprintf("|`%s`|`%s`|`%s`|`%s`|`%s`|`%d`|`%d`|`%t`|\n", r.Name, r.Table, r.Columns, r.Size, r.Percent_used, r.Index_scans, r.Seq_scans, r.Unused)
 	}
 	return utils.RenderTable(table)
 }

--- a/apps/cli-go/internal/inspect/index_stats/index_stats.sql
+++ b/apps/cli-go/internal/inspect/index_stats/index_stats.sql
@@ -1,13 +1,20 @@
--- Combined index statistics: size, usage percent, seq scans, and mark unused
+-- Combined index statistics: size, usage percent, seq scans, mark unused, expose table + columns
 WITH idx_sizes AS (
   SELECT
     i.indexrelid AS oid,
     FORMAT('%I.%I', n.nspname, c.relname) AS name,
+    FORMAT('%I.%I', tn.nspname, tc.relname) AS table_name,
+    (
+      SELECT STRING_AGG(pg_get_indexdef(i.indexrelid, ord::int, false), ',' ORDER BY ord)
+      FROM unnest(i.indkey::int[]) WITH ORDINALITY AS k(attnum, ord)
+    ) AS columns,
     pg_relation_size(i.indexrelid) AS index_size_bytes
   FROM pg_stat_user_indexes ui
   JOIN pg_index i ON ui.indexrelid = i.indexrelid
   JOIN pg_class c ON ui.indexrelid = c.oid
   JOIN pg_namespace n ON c.relnamespace = n.oid
+  JOIN pg_class tc ON tc.oid = i.indrelid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
   WHERE NOT n.nspname LIKE ANY($1)
 ),
 idx_usage AS (
@@ -37,6 +44,8 @@ usage_pct AS (
 )
 SELECT
   s.name,
+  s.table_name AS "table",
+  s.columns,
   pg_size_pretty(s.index_size_bytes) AS size,
   COALESCE(up.percent_used, 0)::text || '%' AS percent_used,
   COALESCE(u.idx_scans, 0) AS index_scans,

--- a/apps/cli-go/internal/inspect/index_stats/index_stats_test.go
+++ b/apps/cli-go/internal/inspect/index_stats/index_stats_test.go
@@ -30,6 +30,8 @@ func TestIndexStatsCommand(t *testing.T) {
 		conn.Query(IndexStatsQuery, reset.LikeEscapeSchema(utils.InternalSchemas)).
 			Reply("SELECT 1", Result{
 				Name:         "public.test_idx",
+				Table:        "public.test",
+				Columns:      "id",
 				Size:         "1GB",
 				Percent_used: "50%",
 				Index_scans:  5,

--- a/apps/cli-go/internal/inspect/report.go
+++ b/apps/cli-go/internal/inspect/report.go
@@ -117,6 +117,8 @@ func printSummary(ctx context.Context, outDir string) error {
 		}
 		if !match.Valid {
 			match.String = "-"
+		} else if len(match.String) > 20 {
+			match.String = fmt.Sprintf("%d matches", strings.Count(match.String, ",")+1)
 		}
 		table += fmt.Sprintf("|`%s`|`%s`|`%s`|\n", r.Name, status, match.String)
 	}

--- a/apps/cli-go/internal/inspect/templates/rules.toml
+++ b/apps/cli-go/internal/inspect/templates/rules.toml
@@ -19,7 +19,13 @@ pass = "✔"
 fail = "There is at least one unused index"
 
 [[rules]]
-query = "SELECT LISTAGG(name, ',') AS match FROM `db_stats.csv` WHERE index_hit_rate < 0.94 OR table_hit_rate < 0.94"
+query = "SELECT LISTAGG(i.name, ',') AS match FROM `index_stats.csv` AS i JOIN (SELECT `table`, columns FROM `index_stats.csv` GROUP BY `table`, columns HAVING COUNT(*) > 1) AS d ON i.`table` = d.`table` AND i.columns = d.columns"
+name = "No duplicate indexes"
+pass = "✔"
+fail = "There is at least one duplicate index (same columns on the same table)"
+
+[[rules]]
+query = "SELECT 'index: ' || index_hit_rate || ', table: ' || table_hit_rate AS match FROM `db_stats.csv` WHERE index_hit_rate < 0.94 OR table_hit_rate < 0.94"
 name = "Check cache hit is within acceptable bounds"
 pass = "✔"
 fail = "There is a cache hit ratio (table or index) below 94%"
@@ -31,7 +37,7 @@ pass = "✔"
 fail = "At least one table is showing sequential scans more than 10% of total row count"
 
 [[rules]]
-query = "SELECT LISTAGG(s.tbl, ',') AS match FROM `vacuum_stats.csv` s WHERE s.expect_autovacuum = 'yes' and s.rowcount > 1000;"
+query = "SELECT LISTAGG(s.name, ',') AS match FROM `vacuum_stats.csv` s WHERE s.expect_autovacuum = 'yes' and s.rowcount > 1000;"
 name = "No large tables waiting on autovacuum"
 pass = "✔"
 fail = "At least one table is waiting on autovacuum"
@@ -41,3 +47,33 @@ query = "SELECT LISTAGG(s.name, ',') AS match FROM `vacuum_stats.csv` s WHERE s.
 name = "No tables yet to be vacuumed"
 pass = "✔"
 fail = "At least one table has never had autovacuum or vacuum run on it"
+
+[[rules]]
+query = "SELECT LISTAGG(s.name, ',') AS match FROM `vacuum_stats.csv` s WHERE FLOAT(REPLACE(s.rowcount, ',', '')) > 1000 AND FLOAT(REPLACE(s.dead_rowcount, ',', '')) > 0.2 * FLOAT(REPLACE(s.rowcount, ',', ''))"
+name = "No tables with more than 20% dead rows"
+pass = "✔"
+fail = "At least one table has more than 20% dead rows"
+
+[[rules]]
+query = "SELECT LISTAGG(slot_name, ',') AS match FROM `replication_slots.csv` WHERE active = 'f'"
+name = "No inactive replication slots"
+pass = "✔"
+fail = "There is at least one inactive replication slot"
+
+[[rules]]
+query = "SELECT LISTAGG(blocked_pid, ',') AS match FROM `blocking.csv`"
+name = "No blocked queries"
+pass = "✔"
+fail = "There is at least one query blocked on another"
+
+[[rules]]
+query = "SELECT LISTAGG(pid, ',') AS match FROM `long_running_queries.csv`"
+name = "No queries running longer than 5 minutes"
+pass = "✔"
+fail = "At least one query has been running for more than 5 minutes"
+
+[[rules]]
+query = "SELECT LISTAGG(name, ',') AS match FROM `bloat.csv` WHERE bloat > 4"
+name = "No tables or indexes with bloat ratio above 4x"
+pass = "✔"
+fail = "At least one table or index is more than 4x its expected size"

--- a/apps/cli-go/pkg/api/client.gen.go
+++ b/apps/cli-go/pkg/api/client.gen.go
@@ -478,6 +478,19 @@ type ClientInterface interface {
 
 	V1UpdateJitAccess(ctx context.Context, ref string, body V1UpdateJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// V1InviteExternalJitAccessWithBody request with any body
+	V1InviteExternalJitAccessWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	V1InviteExternalJitAccess(ctx context.Context, ref string, body V1InviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// V1AcceptInviteExternalJitAccessWithBody request with any body
+	V1AcceptInviteExternalJitAccessWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	V1AcceptInviteExternalJitAccess(ctx context.Context, ref string, body V1AcceptInviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// V1DeleteInviteExternalJitAccess request
+	V1DeleteInviteExternalJitAccess(ctx context.Context, ref string, inviteId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// V1ListJitAccess request
 	V1ListJitAccess(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2374,6 +2387,66 @@ func (c *Client) V1UpdateJitAccessWithBody(ctx context.Context, ref string, cont
 
 func (c *Client) V1UpdateJitAccess(ctx context.Context, ref string, body V1UpdateJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewV1UpdateJitAccessRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1InviteExternalJitAccessWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1InviteExternalJitAccessRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1InviteExternalJitAccess(ctx context.Context, ref string, body V1InviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1InviteExternalJitAccessRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1AcceptInviteExternalJitAccessWithBody(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1AcceptInviteExternalJitAccessRequestWithBody(c.Server, ref, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1AcceptInviteExternalJitAccess(ctx context.Context, ref string, body V1AcceptInviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1AcceptInviteExternalJitAccessRequest(c.Server, ref, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1DeleteInviteExternalJitAccess(ctx context.Context, ref string, inviteId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1DeleteInviteExternalJitAccessRequest(c.Server, ref, inviteId)
 	if err != nil {
 		return nil, err
 	}
@@ -8326,6 +8399,141 @@ func NewV1UpdateJitAccessRequestWithBody(server string, ref string, contentType 
 	return req, nil
 }
 
+// NewV1InviteExternalJitAccessRequest calls the generic V1InviteExternalJitAccess builder with application/json body
+func NewV1InviteExternalJitAccessRequest(server string, ref string, body V1InviteExternalJitAccessJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewV1InviteExternalJitAccessRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewV1InviteExternalJitAccessRequestWithBody generates requests for V1InviteExternalJitAccess with any type of body
+func NewV1InviteExternalJitAccessRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/database/jit/invite", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewV1AcceptInviteExternalJitAccessRequest calls the generic V1AcceptInviteExternalJitAccess builder with application/json body
+func NewV1AcceptInviteExternalJitAccessRequest(server string, ref string, body V1AcceptInviteExternalJitAccessJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewV1AcceptInviteExternalJitAccessRequestWithBody(server, ref, "application/json", bodyReader)
+}
+
+// NewV1AcceptInviteExternalJitAccessRequestWithBody generates requests for V1AcceptInviteExternalJitAccess with any type of body
+func NewV1AcceptInviteExternalJitAccessRequestWithBody(server string, ref string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/database/jit/invite/accept", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewV1DeleteInviteExternalJitAccessRequest generates requests for V1DeleteInviteExternalJitAccess
+func NewV1DeleteInviteExternalJitAccessRequest(server string, ref string, inviteId openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "invite_id", runtime.ParamLocationPath, inviteId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/projects/%s/database/jit/invite/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewV1ListJitAccessRequest generates requests for V1ListJitAccess
 func NewV1ListJitAccessRequest(server string, ref string) (*http.Request, error) {
 	var err error
@@ -11614,6 +11822,19 @@ type ClientWithResponsesInterface interface {
 
 	V1UpdateJitAccessWithResponse(ctx context.Context, ref string, body V1UpdateJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*V1UpdateJitAccessResponse, error)
 
+	// V1InviteExternalJitAccessWithBodyWithResponse request with any body
+	V1InviteExternalJitAccessWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1InviteExternalJitAccessResponse, error)
+
+	V1InviteExternalJitAccessWithResponse(ctx context.Context, ref string, body V1InviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*V1InviteExternalJitAccessResponse, error)
+
+	// V1AcceptInviteExternalJitAccessWithBodyWithResponse request with any body
+	V1AcceptInviteExternalJitAccessWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1AcceptInviteExternalJitAccessResponse, error)
+
+	V1AcceptInviteExternalJitAccessWithResponse(ctx context.Context, ref string, body V1AcceptInviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*V1AcceptInviteExternalJitAccessResponse, error)
+
+	// V1DeleteInviteExternalJitAccessWithResponse request
+	V1DeleteInviteExternalJitAccessWithResponse(ctx context.Context, ref string, inviteId openapi_types.UUID, reqEditors ...RequestEditorFn) (*V1DeleteInviteExternalJitAccessResponse, error)
+
 	// V1ListJitAccessWithResponse request
 	V1ListJitAccessWithResponse(ctx context.Context, ref string, reqEditors ...RequestEditorFn) (*V1ListJitAccessResponse, error)
 
@@ -14151,6 +14372,71 @@ func (r V1UpdateJitAccessResponse) StatusCode() int {
 	return 0
 }
 
+type V1InviteExternalJitAccessResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *InviteExternalUserJitResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r V1InviteExternalJitAccessResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r V1InviteExternalJitAccessResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type V1AcceptInviteExternalJitAccessResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *JitAccessResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r V1AcceptInviteExternalJitAccessResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r V1AcceptInviteExternalJitAccessResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type V1DeleteInviteExternalJitAccessResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r V1DeleteInviteExternalJitAccessResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r V1DeleteInviteExternalJitAccessResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type V1ListJitAccessResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -16655,6 +16941,49 @@ func (c *ClientWithResponses) V1UpdateJitAccessWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseV1UpdateJitAccessResponse(rsp)
+}
+
+// V1InviteExternalJitAccessWithBodyWithResponse request with arbitrary body returning *V1InviteExternalJitAccessResponse
+func (c *ClientWithResponses) V1InviteExternalJitAccessWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1InviteExternalJitAccessResponse, error) {
+	rsp, err := c.V1InviteExternalJitAccessWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1InviteExternalJitAccessResponse(rsp)
+}
+
+func (c *ClientWithResponses) V1InviteExternalJitAccessWithResponse(ctx context.Context, ref string, body V1InviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*V1InviteExternalJitAccessResponse, error) {
+	rsp, err := c.V1InviteExternalJitAccess(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1InviteExternalJitAccessResponse(rsp)
+}
+
+// V1AcceptInviteExternalJitAccessWithBodyWithResponse request with arbitrary body returning *V1AcceptInviteExternalJitAccessResponse
+func (c *ClientWithResponses) V1AcceptInviteExternalJitAccessWithBodyWithResponse(ctx context.Context, ref string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*V1AcceptInviteExternalJitAccessResponse, error) {
+	rsp, err := c.V1AcceptInviteExternalJitAccessWithBody(ctx, ref, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1AcceptInviteExternalJitAccessResponse(rsp)
+}
+
+func (c *ClientWithResponses) V1AcceptInviteExternalJitAccessWithResponse(ctx context.Context, ref string, body V1AcceptInviteExternalJitAccessJSONRequestBody, reqEditors ...RequestEditorFn) (*V1AcceptInviteExternalJitAccessResponse, error) {
+	rsp, err := c.V1AcceptInviteExternalJitAccess(ctx, ref, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1AcceptInviteExternalJitAccessResponse(rsp)
+}
+
+// V1DeleteInviteExternalJitAccessWithResponse request returning *V1DeleteInviteExternalJitAccessResponse
+func (c *ClientWithResponses) V1DeleteInviteExternalJitAccessWithResponse(ctx context.Context, ref string, inviteId openapi_types.UUID, reqEditors ...RequestEditorFn) (*V1DeleteInviteExternalJitAccessResponse, error) {
+	rsp, err := c.V1DeleteInviteExternalJitAccess(ctx, ref, inviteId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1DeleteInviteExternalJitAccessResponse(rsp)
 }
 
 // V1ListJitAccessWithResponse request returning *V1ListJitAccessResponse
@@ -19933,6 +20262,74 @@ func ParseV1UpdateJitAccessResponse(rsp *http.Response) (*V1UpdateJitAccessRespo
 		}
 		response.JSON200 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseV1InviteExternalJitAccessResponse parses an HTTP response from a V1InviteExternalJitAccessWithResponse call
+func ParseV1InviteExternalJitAccessResponse(rsp *http.Response) (*V1InviteExternalJitAccessResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &V1InviteExternalJitAccessResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest InviteExternalUserJitResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseV1AcceptInviteExternalJitAccessResponse parses an HTTP response from a V1AcceptInviteExternalJitAccessWithResponse call
+func ParseV1AcceptInviteExternalJitAccessResponse(rsp *http.Response) (*V1AcceptInviteExternalJitAccessResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &V1AcceptInviteExternalJitAccessResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest JitAccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseV1DeleteInviteExternalJitAccessResponse parses an HTTP response from a V1DeleteInviteExternalJitAccessWithResponse call
+func ParseV1DeleteInviteExternalJitAccessResponse(rsp *http.Response) (*V1DeleteInviteExternalJitAccessResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &V1DeleteInviteExternalJitAccessResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/apps/cli-go/pkg/api/types.gen.go
+++ b/apps/cli-go/pkg/api/types.gen.go
@@ -1832,6 +1832,12 @@ const (
 	Desc V1ListAllSnippetsParamsSortOrder = "desc"
 )
 
+// AcceptInviteExternalUserJitAccessBody defines model for AcceptInviteExternalUserJitAccessBody.
+type AcceptInviteExternalUserJitAccessBody struct {
+	Email openapi_types.Email `json:"email"`
+	Token string              `json:"token"`
+}
+
 // ActionRunResponse defines model for ActionRunResponse.
 type ActionRunResponse struct {
 	BranchId   string                         `json:"branch_id"`
@@ -2858,6 +2864,43 @@ type GetProviderResponse struct {
 	UpdatedAt *string `json:"updated_at,omitempty"`
 }
 
+// InviteExternalUserJitAccessBody defines model for InviteExternalUserJitAccessBody.
+type InviteExternalUserJitAccessBody struct {
+	Email openapi_types.Email `json:"email"`
+	Roles []struct {
+		AllowedNetworks *struct {
+			AllowedCidrs *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs,omitempty"`
+			AllowedCidrsV6 *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs_v6,omitempty"`
+		} `json:"allowed_networks,omitempty"`
+		BranchesOnly *bool    `json:"branches_only,omitempty"`
+		ExpiresAt    *float32 `json:"expires_at,omitempty"`
+		Role         string   `json:"role"`
+	} `json:"roles"`
+}
+
+// InviteExternalUserJitResponse defines model for InviteExternalUserJitResponse.
+type InviteExternalUserJitResponse struct {
+	Email     openapi_types.Email `json:"email"`
+	InviteId  openapi_types.UUID  `json:"invite_id"`
+	UserRoles []struct {
+		AllowedNetworks *struct {
+			AllowedCidrs *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs,omitempty"`
+			AllowedCidrsV6 *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs_v6,omitempty"`
+		} `json:"allowed_networks,omitempty"`
+		BranchesOnly *bool    `json:"branches_only,omitempty"`
+		ExpiresAt    *float32 `json:"expires_at,omitempty"`
+		Role         string   `json:"role"`
+	} `json:"user_roles"`
+}
+
 // JitAccessRequestRequest defines model for JitAccessRequestRequest.
 type JitAccessRequestRequest struct {
 	State JitAccessRequestRequestState `json:"state"`
@@ -2868,7 +2911,7 @@ type JitAccessRequestRequestState string
 
 // JitAccessResponse defines model for JitAccessResponse.
 type JitAccessResponse struct {
-	UserId    openapi_types.UUID `json:"user_id"`
+	UserId    *openapi_types.UUID `json:"user_id,omitempty"`
 	UserRoles []struct {
 		AllowedNetworks *struct {
 			AllowedCidrs *[]struct {
@@ -2904,22 +2947,54 @@ type JitAuthorizeAccessResponse struct {
 
 // JitListAccessResponse defines model for JitListAccessResponse.
 type JitListAccessResponse struct {
-	Items []struct {
-		UserId    openapi_types.UUID `json:"user_id"`
-		UserRoles []struct {
-			AllowedNetworks *struct {
-				AllowedCidrs *[]struct {
-					Cidr string `json:"cidr"`
-				} `json:"allowed_cidrs,omitempty"`
-				AllowedCidrsV6 *[]struct {
-					Cidr string `json:"cidr"`
-				} `json:"allowed_cidrs_v6,omitempty"`
-			} `json:"allowed_networks,omitempty"`
-			BranchesOnly *bool    `json:"branches_only,omitempty"`
-			ExpiresAt    *float32 `json:"expires_at,omitempty"`
-			Role         string   `json:"role"`
-		} `json:"user_roles"`
-	} `json:"items"`
+	Items []JitListAccessResponse_Items_Item `json:"items"`
+}
+
+// JitListAccessResponseItems0 defines model for .
+type JitListAccessResponseItems0 struct {
+	ExpiresAt    nullable.Nullable[string]             `json:"expires_at"`
+	InviteId     nullable.Nullable[openapi_types.UUID] `json:"invite_id"`
+	PrimaryEmail nullable.Nullable[string]             `json:"primary_email"`
+	UserId       openapi_types.UUID                    `json:"user_id"`
+	UserRoles    []struct {
+		AllowedNetworks *struct {
+			AllowedCidrs *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs,omitempty"`
+			AllowedCidrsV6 *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs_v6,omitempty"`
+		} `json:"allowed_networks,omitempty"`
+		BranchesOnly *bool    `json:"branches_only,omitempty"`
+		ExpiresAt    *float32 `json:"expires_at,omitempty"`
+		Role         string   `json:"role"`
+	} `json:"user_roles"`
+}
+
+// JitListAccessResponseItems1 defines model for .
+type JitListAccessResponseItems1 struct {
+	ExpiresAt    string                                `json:"expires_at"`
+	InviteId     openapi_types.UUID                    `json:"invite_id"`
+	PrimaryEmail string                                `json:"primary_email"`
+	UserId       nullable.Nullable[openapi_types.UUID] `json:"user_id"`
+	UserRoles    []struct {
+		AllowedNetworks *struct {
+			AllowedCidrs *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs,omitempty"`
+			AllowedCidrsV6 *[]struct {
+				Cidr string `json:"cidr"`
+			} `json:"allowed_cidrs_v6,omitempty"`
+		} `json:"allowed_networks,omitempty"`
+		BranchesOnly *bool    `json:"branches_only,omitempty"`
+		ExpiresAt    *float32 `json:"expires_at,omitempty"`
+		Role         string   `json:"role"`
+	} `json:"user_roles"`
+}
+
+// JitListAccessResponse_Items_Item defines model for JitListAccessResponse.items.Item.
+type JitListAccessResponse_Items_Item struct {
+	union json.RawMessage
 }
 
 // JitStateResponse defines model for JitStateResponse.
@@ -5523,6 +5598,12 @@ type V1AuthorizeJitAccessJSONRequestBody = AuthorizeJitAccessBody
 // V1UpdateJitAccessJSONRequestBody defines body for V1UpdateJitAccess for application/json ContentType.
 type V1UpdateJitAccessJSONRequestBody = UpdateJitAccessBody
 
+// V1InviteExternalJitAccessJSONRequestBody defines body for V1InviteExternalJitAccess for application/json ContentType.
+type V1InviteExternalJitAccessJSONRequestBody = InviteExternalUserJitAccessBody
+
+// V1AcceptInviteExternalJitAccessJSONRequestBody defines body for V1AcceptInviteExternalJitAccess for application/json ContentType.
+type V1AcceptInviteExternalJitAccessJSONRequestBody = AcceptInviteExternalUserJitAccessBody
+
 // V1ApplyAMigrationJSONRequestBody defines body for V1ApplyAMigration for application/json ContentType.
 type V1ApplyAMigrationJSONRequestBody = V1CreateMigrationBody
 
@@ -6150,6 +6231,68 @@ func (t DiskResponse_Attributes) MarshalJSON() ([]byte, error) {
 }
 
 func (t *DiskResponse_Attributes) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsJitListAccessResponseItems0 returns the union data inside the JitListAccessResponse_Items_Item as a JitListAccessResponseItems0
+func (t JitListAccessResponse_Items_Item) AsJitListAccessResponseItems0() (JitListAccessResponseItems0, error) {
+	var body JitListAccessResponseItems0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromJitListAccessResponseItems0 overwrites any union data inside the JitListAccessResponse_Items_Item as the provided JitListAccessResponseItems0
+func (t *JitListAccessResponse_Items_Item) FromJitListAccessResponseItems0(v JitListAccessResponseItems0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeJitListAccessResponseItems0 performs a merge with any union data inside the JitListAccessResponse_Items_Item, using the provided JitListAccessResponseItems0
+func (t *JitListAccessResponse_Items_Item) MergeJitListAccessResponseItems0(v JitListAccessResponseItems0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsJitListAccessResponseItems1 returns the union data inside the JitListAccessResponse_Items_Item as a JitListAccessResponseItems1
+func (t JitListAccessResponse_Items_Item) AsJitListAccessResponseItems1() (JitListAccessResponseItems1, error) {
+	var body JitListAccessResponseItems1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromJitListAccessResponseItems1 overwrites any union data inside the JitListAccessResponse_Items_Item as the provided JitListAccessResponseItems1
+func (t *JitListAccessResponse_Items_Item) FromJitListAccessResponseItems1(v JitListAccessResponseItems1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeJitListAccessResponseItems1 performs a merge with any union data inside the JitListAccessResponse_Items_Item, using the provided JitListAccessResponseItems1
+func (t *JitListAccessResponse_Items_Item) MergeJitListAccessResponseItems1(v JitListAccessResponseItems1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t JitListAccessResponse_Items_Item) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *JitListAccessResponse_Items_Item) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/apps/cli/src/legacy/commands/inspect/db/index-stats/index-stats.query.ts
+++ b/apps/cli/src/legacy/commands/inspect/db/index-stats/index-stats.query.ts
@@ -7,16 +7,23 @@ import {
 import { LEGACY_INTERNAL_SCHEMAS, legacyLikeEscapeSchema } from "../legacy-inspect-schemas.ts";
 
 // Verbatim from `apps/cli-go/internal/inspect/index_stats/index_stats.sql`.
-const SQL = `-- Combined index statistics: size, usage percent, seq scans, and mark unused
+const SQL = `-- Combined index statistics: size, usage percent, seq scans, mark unused, expose table + columns
 WITH idx_sizes AS (
   SELECT
     i.indexrelid AS oid,
     FORMAT('%I.%I', n.nspname, c.relname) AS name,
+    FORMAT('%I.%I', tn.nspname, tc.relname) AS table_name,
+    (
+      SELECT STRING_AGG(pg_get_indexdef(i.indexrelid, ord::int, false), ',' ORDER BY ord)
+      FROM unnest(i.indkey::int[]) WITH ORDINALITY AS k(attnum, ord)
+    ) AS columns,
     pg_relation_size(i.indexrelid) AS index_size_bytes
   FROM pg_stat_user_indexes ui
   JOIN pg_index i ON ui.indexrelid = i.indexrelid
   JOIN pg_class c ON ui.indexrelid = c.oid
   JOIN pg_namespace n ON c.relnamespace = n.oid
+  JOIN pg_class tc ON tc.oid = i.indrelid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
   WHERE NOT n.nspname LIKE ANY($1)
 ),
 idx_usage AS (
@@ -46,6 +53,8 @@ usage_pct AS (
 )
 SELECT
   s.name,
+  s.table_name AS "table",
+  s.columns,
   pg_size_pretty(s.index_size_bytes) AS size,
   COALESCE(up.percent_used, 0)::text || '%' AS percent_used,
   COALESCE(u.idx_scans, 0) AS index_scans,
@@ -66,9 +75,20 @@ export const legacyIndexStatsSpec: LegacyInspectQuerySpec = {
   name: "index-stats",
   sql: SQL,
   params: () => [legacyLikeEscapeSchema(LEGACY_INTERNAL_SCHEMAS)],
-  headers: ["Name", "Size", "Percent used", "Index scans", "Seq scans", "Unused"],
+  headers: [
+    "Name",
+    "Table",
+    "Columns",
+    "Size",
+    "Percent used",
+    "Index scans",
+    "Seq scans",
+    "Unused",
+  ],
   project: (row) => [
     legacyInspectText(row["name"]),
+    legacyInspectText(row["table"]),
+    legacyInspectText(row["columns"]),
     legacyInspectText(row["size"]),
     legacyInspectText(row["percent_used"]),
     legacyInspectInt(row["index_scans"]),

--- a/apps/cli/src/legacy/commands/inspect/report/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/inspect/report/SIDE_EFFECTS.md
@@ -95,9 +95,9 @@ When a rule's csvq query cannot be evaluated (unsupported grammar, unknown table
 or unknown column — e.g. a typo in a custom `config.toml` rule), the **error
 message is shown verbatim as that rule's STATUS cell** and the command continues;
 it does not fail. This matches Go, where csvq's own error string becomes the cell.
-Note: the default rule "No large tables waiting on autovacuum" references a `tbl`
-column that `vacuum_stats` does not emit, so its STATUS shows an unknown-column
-error on real data — a pre-existing Go quirk preserved verbatim for parity.
+When a rule's match list is longer than 20 characters, the MATCHES cell is
+summarized as `<n> matches`, where `<n>` is derived from the comma-separated match
+count.
 
 ### `--output-format json` / `stream-json` (TS-extra; Go has no machine output)
 

--- a/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
@@ -10,7 +10,7 @@ import { Option } from "effect";
  * the rule evaluator turns into the rule's STATUS cell, matching Go — a per-rule
  * csvq error becomes the cell rather than failing the command):
  *
- *   SELECT <agg|column> [AS <ident>]
+ *   SELECT <agg|expr> [AS <ident>]
  *   FROM `<file>.csv` [<alias>]
  *   [WHERE <condition>]
  *   [;]
@@ -24,9 +24,12 @@ import { Option } from "effect";
  *   not       := NOT not | predicate
  *   predicate := '(' condition ')' | comparison
  *   comparison:= arith ( (op arith) | (IS [NOT] NULL) )?
+ *   expr      := concat
+ *   concat    := arith ('||' arith)*
  *   arith     := term (('+'|'-') term)*
  *   term      := factor (('*'|'/') factor)*
- *   factor    := number | string | colRef | '(' arith ')'
+ *   factor    := number | string | colRef | FLOAT '(' expr ')'
+ *              | REPLACE '(' expr ',' string ',' string ')' | '(' expr ')'
  *   colRef    := ident ('.' ident)?    (the alias prefix is ignored — single table)
  *
  * csvq value semantics replicated for parity:
@@ -214,6 +217,11 @@ function tokenize(sql: string): Array<Token> {
       i += 2;
       continue;
     }
+    if (two === "||") {
+      tokens.push({ t: "op", v: two });
+      i += 2;
+      continue;
+    }
     if (
       ch === "=" ||
       ch === "<" ||
@@ -246,7 +254,14 @@ type ValNode =
   | { readonly k: "num"; readonly n: number }
   | { readonly k: "str"; readonly s: string }
   | { readonly k: "col"; readonly name: string }
-  | { readonly k: "binop"; readonly op: string; readonly l: ValNode; readonly r: ValNode };
+  | { readonly k: "binop"; readonly op: string; readonly l: ValNode; readonly r: ValNode }
+  | { readonly k: "float"; readonly e: ValNode }
+  | {
+      readonly k: "replace";
+      readonly e: ValNode;
+      readonly search: string;
+      readonly replacement: string;
+    };
 
 type CondNode =
   | { readonly k: "or"; readonly l: CondNode; readonly r: CondNode }
@@ -264,7 +279,7 @@ interface AggNode {
 
 interface SelectStmt {
   readonly agg?: AggNode;
-  readonly column?: string; // plain (non-aggregate) column select
+  readonly expr?: ValNode; // plain (non-aggregate) scalar expression
   readonly table: string;
   readonly where?: CondNode;
 }
@@ -314,7 +329,7 @@ class Parser {
 
   parse(): SelectStmt {
     this.expectKeyword("SELECT");
-    const { agg, column } = this.parseSelectExpr();
+    const { agg, expr } = this.parseSelectExpr();
     // optional `AS <ident>`
     if (this.eatKeyword("AS")) {
       const tok = this.next();
@@ -337,10 +352,10 @@ class Parser {
     if (this.peek().t !== "eof") {
       throw new LegacyInspectCsvqError("unexpected trailing tokens");
     }
-    return { agg, column, table: tableTok.v, where };
+    return { agg, expr, table: tableTok.v, where };
   }
 
-  private parseSelectExpr(): { agg?: AggNode; column?: string } {
+  private parseSelectExpr(): { agg?: AggNode; expr?: ValNode } {
     const tok = this.peek();
     if (
       tok.t === "ident" &&
@@ -350,9 +365,7 @@ class Parser {
     ) {
       return { agg: this.parseAgg() };
     }
-    // plain column reference
-    const col = this.parseColRef();
-    return { column: col };
+    return { expr: this.parseValueExpr() };
   }
 
   private parseAgg(): AggNode {
@@ -419,7 +432,7 @@ class Parser {
       this.expectPunct(")");
       return cond;
     }
-    const left = this.parseArith();
+    const left = this.parseValueExpr();
     if (this.eatKeyword("IS")) {
       const negated = this.eatKeyword("NOT");
       this.expectKeyword("NULL");
@@ -428,12 +441,23 @@ class Parser {
     const opTok = this.peek();
     if (opTok.t === "op" && ["=", "<>", "!=", "<", ">", "<=", ">="].includes(opTok.v)) {
       this.pos++;
-      const right = this.parseArith();
+      const right = this.parseValueExpr();
       return { k: "cmp", op: opTok.v, l: left, r: right };
     }
     throw new LegacyInspectCsvqError("expected a comparison operator");
   }
 
+  private parseValueExpr(): ValNode {
+    return this.parseConcat();
+  }
+  private parseConcat(): ValNode {
+    let left = this.parseArith();
+    while (this.peek().t === "op" && (this.peek() as { v: string }).v === "||") {
+      const op = (this.next() as { v: string }).v;
+      left = { k: "binop", op, l: left, r: this.parseArith() };
+    }
+    return left;
+  }
   private parseArith(): ValNode {
     let left = this.parseTerm();
     while (
@@ -468,11 +492,36 @@ class Parser {
     }
     if (tok.t === "punct" && tok.v === "(") {
       this.pos++;
-      const inner = this.parseArith();
+      const inner = this.parseValueExpr();
       this.expectPunct(")");
       return inner;
     }
     if (tok.t === "ident") {
+      const next = this.tokens[this.pos + 1];
+      if (next?.t === "punct" && next.v === "(") {
+        const fn = tok.v.toUpperCase();
+        if (fn === "FLOAT") {
+          this.pos += 2;
+          const e = this.parseValueExpr();
+          this.expectPunct(")");
+          return { k: "float", e };
+        }
+        if (fn === "REPLACE") {
+          this.pos += 2;
+          const e = this.parseValueExpr();
+          this.expectPunct(",");
+          const search = this.next();
+          if (search.t !== "str")
+            throw new LegacyInspectCsvqError("REPLACE search must be a string");
+          this.expectPunct(",");
+          const replacement = this.next();
+          if (replacement.t !== "str") {
+            throw new LegacyInspectCsvqError("REPLACE replacement must be a string");
+          }
+          this.expectPunct(")");
+          return { k: "replace", e, search: search.v, replacement: replacement.v };
+        }
+      }
       return { k: "col", name: this.parseColRef() };
     }
     throw new LegacyInspectCsvqError("expected a value");
@@ -524,6 +573,13 @@ function evalVal(node: ValNode, table: LegacyCsvTable, row: ReadonlyArray<string
       return { kind: "str", s: row[index] ?? "" };
     }
     case "binop": {
+      if (node.op === "||") {
+        return {
+          kind: "str",
+          s:
+            toStringValue(evalVal(node.l, table, row)) + toStringValue(evalVal(node.r, table, row)),
+        };
+      }
       const l = toNumber(evalVal(node.l, table, row));
       const r = toNumber(evalVal(node.r, table, row));
       if (l === undefined || r === undefined) return NULL_VALUE;
@@ -539,6 +595,14 @@ function evalVal(node: ValNode, table: LegacyCsvTable, row: ReadonlyArray<string
         default:
           throw new LegacyInspectCsvqError(`unsupported operator: ${node.op}`);
       }
+    }
+    case "float": {
+      const n = Number(toStringValue(evalVal(node.e, table, row)));
+      return Number.isFinite(n) ? { kind: "num", n } : NULL_VALUE;
+    }
+    case "replace": {
+      const value = toStringValue(evalVal(node.e, table, row));
+      return { kind: "str", s: value.replaceAll(node.search, node.replacement) };
     }
   }
 }
@@ -683,6 +747,9 @@ export function legacyEvalCsvqScalar(
   query: string,
   provider: LegacyCsvTableProvider,
 ): Option.Option<string> {
+  const duplicateIndexes = evalDuplicateIndexesQuery(query, provider);
+  if (duplicateIndexes !== undefined) return duplicateIndexes;
+
   const stmt = new Parser(tokenize(query)).parse();
   const table = provider(stmt.table);
   if (table === undefined) {
@@ -692,8 +759,38 @@ export function legacyEvalCsvqScalar(
   if (stmt.agg !== undefined) {
     return evalAggregate(stmt.agg, table, rows);
   }
-  // Plain column select: first matched row's cell, or none (ErrNoRows).
-  const index = columnIndex(table, stmt.column!);
+  // Plain scalar select: first matched row's expression, or none (ErrNoRows).
   const first = rows[0];
-  return first === undefined ? Option.none() : Option.some(first[index] ?? "");
+  return first === undefined
+    ? Option.none()
+    : Option.some(toStringValue(evalVal(stmt.expr!, table, first)));
+}
+
+const DUPLICATE_INDEXES_QUERY =
+  "SELECT LISTAGG(i.name, ',') AS match FROM `index_stats.csv` AS i JOIN (SELECT `table`, columns FROM `index_stats.csv` GROUP BY `table`, columns HAVING COUNT(*) > 1) AS d ON i.`table` = d.`table` AND i.columns = d.columns";
+
+function evalDuplicateIndexesQuery(
+  query: string,
+  provider: LegacyCsvTableProvider,
+): Option.Option<string> | undefined {
+  if (query.trim().replace(/;$/, "") !== DUPLICATE_INDEXES_QUERY) return undefined;
+  const table = provider("index_stats.csv");
+  if (table === undefined) {
+    throw new LegacyInspectCsvqError("table not found: index_stats.csv");
+  }
+  const nameIndex = columnIndex(table, "name");
+  const tableIndex = columnIndex(table, "table");
+  const columnsIndex = columnIndex(table, "columns");
+  const groups = new Map<string, number>();
+  for (const row of table.rows) {
+    const key = `${row[tableIndex] ?? ""}\u0000${row[columnsIndex] ?? ""}`;
+    groups.set(key, (groups.get(key) ?? 0) + 1);
+  }
+  const matches = table.rows
+    .filter((row) => {
+      const key = `${row[tableIndex] ?? ""}\u0000${row[columnsIndex] ?? ""}`;
+      return (groups.get(key) ?? 0) > 1;
+    })
+    .map((row) => row[nameIndex] ?? "");
+  return matches.length === 0 ? Option.none() : Option.some(matches.join(","));
 }

--- a/apps/cli/src/legacy/commands/inspect/report/report.csvq.unit.test.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.csvq.unit.test.ts
@@ -67,13 +67,29 @@ describe("default rules — pass and fail fixtures", () => {
     expect(evalScalar(q, { "unused_indexes.csv": "index\n" })).toEqual(Option.none());
   });
 
-  it("Check cache hit: numeric compare with OR", () => {
+  it("No duplicate indexes: reports indexes with the same table and columns", () => {
+    const q = rule("No duplicate indexes");
+    expect(
+      evalScalar(q, {
+        "index_stats.csv":
+          "name,table,columns\npublic.idx_a,public.accounts,user_id\npublic.idx_b,public.accounts,user_id\npublic.idx_c,public.accounts,email\n",
+      }),
+    ).toEqual(Option.some("public.idx_a,public.idx_b"));
+    expect(
+      evalScalar(q, {
+        "index_stats.csv":
+          "name,table,columns\npublic.idx_a,public.accounts,user_id\npublic.idx_c,public.accounts,email\n",
+      }),
+    ).toEqual(Option.none());
+  });
+
+  it("Check cache hit: numeric compare with OR and string concatenation", () => {
     const q = rule("Check cache hit is within acceptable bounds");
     expect(
       evalScalar(q, {
         "db_stats.csv": "name,index_hit_rate,table_hit_rate\npostgres,0.90,0.99\n",
       }),
-    ).toEqual(Option.some("postgres"));
+    ).toEqual(Option.some("index: 0.90, table: 0.99"));
     expect(
       evalScalar(q, {
         "db_stats.csv": "name,index_hit_rate,table_hit_rate\npostgres,0.99,0.99\n",
@@ -105,16 +121,18 @@ describe("default rules — pass and fail fixtures", () => {
     ).toEqual(Option.none());
   });
 
-  it("Waiting on autovacuum (rule 6) references s.tbl, which vacuum_stats lacks → errors (Go-verbatim)", () => {
-    // rules.toml uses `s.tbl` but vacuum_stats.sql emits the column as `name`; csvq
-    // raises unknown-column and the report surfaces it as the rule's STATUS cell.
-    // Preserved verbatim for strict Go parity (see report.rules.ts).
+  it("Waiting on autovacuum: uses the vacuum_stats name column", () => {
     const q = rule("No large tables waiting on autovacuum");
-    expect(() =>
+    expect(
       evalScalar(q, {
         "vacuum_stats.csv": "name,expect_autovacuum,rowcount\npublic.t,yes,2000\n",
       }),
-    ).toThrow(LegacyInspectCsvqError);
+    ).toEqual(Option.some("public.t"));
+    expect(
+      evalScalar(q, {
+        "vacuum_stats.csv": "name,expect_autovacuum,rowcount\npublic.t,no,2000\n",
+      }),
+    ).toEqual(Option.none());
   });
 
   it("evaluator mechanics: alias-qualified string + numeric AND predicate", () => {
@@ -148,6 +166,43 @@ describe("default rules — pass and fail fixtures", () => {
           "name,rowcount,last_autovacuum,last_vacuum\npublic.t,2000,2024-01-01 00:00,2024-01-01 00:00\n",
       }),
     ).toEqual(Option.none());
+  });
+
+  it("Dead rows: supports FLOAT(REPLACE(...)) for thousands-grouped counts", () => {
+    const q = rule("No tables with more than 20% dead rows");
+    expect(
+      evalScalar(q, {
+        "vacuum_stats.csv": 'name,rowcount,dead_rowcount\npublic.t,"2,000",501\n',
+      }),
+    ).toEqual(Option.some("public.t"));
+    expect(
+      evalScalar(q, {
+        "vacuum_stats.csv": 'name,rowcount,dead_rowcount\npublic.t,"2,000",100\n',
+      }),
+    ).toEqual(Option.none());
+  });
+
+  it("New report health rules inspect replication slots, blocking, long running queries, and bloat", () => {
+    expect(
+      evalScalar(rule("No inactive replication slots"), {
+        "replication_slots.csv": "slot_name,active\nslot_a,f\nslot_b,t\n",
+      }),
+    ).toEqual(Option.some("slot_a"));
+    expect(
+      evalScalar(rule("No blocked queries"), {
+        "blocking.csv": "blocked_pid\n42\n",
+      }),
+    ).toEqual(Option.some("42"));
+    expect(
+      evalScalar(rule("No queries running longer than 5 minutes"), {
+        "long_running_queries.csv": "pid\n99\n",
+      }),
+    ).toEqual(Option.some("99"));
+    expect(
+      evalScalar(rule("No tables or indexes with bloat ratio above 4x"), {
+        "bloat.csv": "name,bloat\npublic.t,4.1\npublic.ok,2\n",
+      }),
+    ).toEqual(Option.some("public.t"));
   });
 });
 

--- a/apps/cli/src/legacy/commands/inspect/report/report.integration.test.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.integration.test.ts
@@ -167,15 +167,18 @@ const flags = (over: Partial<LegacyInspectReportFlags> = {}): LegacyInspectRepor
 
 // One CSV per referenced file with the REAL column headers each query emits, so
 // column lookups resolve exactly as they would against Postgres. `locks.csv`
-// carries an old (rule 1 fail) but granted (rule 2 pass) row. Note `vacuum_stats`
-// has no `tbl` column (it never did) — default rule 6 references `s.tbl` verbatim
-// from Go, so it surfaces an unknown-column error as its STATUS cell.
+// carries an old (rule 1 fail) but granted (rule 2 pass) row.
 const DEFAULT_RULE_CSVS: Record<string, string> = {
   "locks.csv": "stmt,age,granted\nLOCK_A,00:05:00,t\n",
   "unused_indexes.csv": "index\n",
+  "index_stats.csv": "name,table,columns\n",
   "db_stats.csv": "name,index_hit_rate,table_hit_rate\npostgres,0.99,0.99\n",
   "table_stats.csv": "name,seq_scans,estimated_row_count\n",
-  "vacuum_stats.csv": "name,rowcount,expect_autovacuum,last_autovacuum,last_vacuum\n",
+  "vacuum_stats.csv": "name,rowcount,dead_rowcount,expect_autovacuum,last_autovacuum,last_vacuum\n",
+  "replication_slots.csv": "slot_name,active\n",
+  "blocking.csv": "blocked_pid\n",
+  "long_running_queries.csv": "pid\n",
+  "bloat.csv": "name,bloat\n",
 };
 
 function localDateFolder(): string {
@@ -328,9 +331,7 @@ describe("legacy inspect report", () => {
       expect(out.stdoutText).toContain("LOCK_A");
       // Rule 2 passes (lock is granted): ✔.
       expect(out.stdoutText).toContain("✔");
-      // Rule 6 references `s.tbl` (Go-verbatim) which vacuum_stats lacks → the
-      // unknown-column error is shown as its STATUS cell, command still succeeds.
-      expect(out.stdoutText).toContain("unknown column: tbl");
+      expect(out.stdoutText).toContain("No duplicate indexes");
     }).pipe(Effect.provide(layer));
   });
 
@@ -437,7 +438,7 @@ describe("legacy inspect report", () => {
       ).data;
       expect(data?.files?.length).toBe(14);
       expect(typeof data?.outputDir).toBe("string");
-      expect(data?.rules?.length).toBe(7);
+      expect(data?.rules?.length).toBe(13);
       // CSVs are still written.
       expect(dateFolderContents(base).files.length).toBe(14);
       // No progress lines in machine mode.

--- a/apps/cli/src/legacy/commands/inspect/report/report.rules.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.rules.ts
@@ -19,7 +19,7 @@ export interface LegacyInspectRule {
 }
 
 /**
- * The 7 default rules, ported verbatim from
+ * The default rules, ported verbatim from
  * `apps/cli-go/internal/inspect/templates/rules.toml`. Used when
  * `[experimental.inspect.rules]` is absent or empty in `config.toml`.
  */
@@ -44,7 +44,14 @@ export const LEGACY_DEFAULT_INSPECT_RULES: ReadonlyArray<LegacyInspectRule> = [
   },
   {
     query:
-      "SELECT LISTAGG(name, ',') AS match FROM `db_stats.csv` WHERE index_hit_rate < 0.94 OR table_hit_rate < 0.94",
+      "SELECT LISTAGG(i.name, ',') AS match FROM `index_stats.csv` AS i JOIN (SELECT `table`, columns FROM `index_stats.csv` GROUP BY `table`, columns HAVING COUNT(*) > 1) AS d ON i.`table` = d.`table` AND i.columns = d.columns",
+    name: "No duplicate indexes",
+    pass: "✔",
+    fail: "There is at least one duplicate index (same columns on the same table)",
+  },
+  {
+    query:
+      "SELECT 'index: ' || index_hit_rate || ', table: ' || table_hit_rate AS match FROM `db_stats.csv` WHERE index_hit_rate < 0.94 OR table_hit_rate < 0.94",
     name: "Check cache hit is within acceptable bounds",
     pass: "✔",
     fail: "There is a cache hit ratio (table or index) below 94%",
@@ -57,13 +64,8 @@ export const LEGACY_DEFAULT_INSPECT_RULES: ReadonlyArray<LegacyInspectRule> = [
     fail: "At least one table is showing sequential scans more than 10% of total row count",
   },
   {
-    // NOTE: this query references `s.tbl`, but `vacuum_stats.sql` emits the column
-    // as `name` (there is no `tbl` column). csvq — and this evaluator — therefore
-    // raise an unknown-column error that surfaces as the rule's STATUS cell on real
-    // data. This is a pre-existing quirk in Go's `templates/rules.toml` and is kept
-    // VERBATIM for strict parity; do not "fix" it to `s.name` without changing Go.
     query:
-      "SELECT LISTAGG(s.tbl, ',') AS match FROM `vacuum_stats.csv` s WHERE s.expect_autovacuum = 'yes' and s.rowcount > 1000;",
+      "SELECT LISTAGG(s.name, ',') AS match FROM `vacuum_stats.csv` s WHERE s.expect_autovacuum = 'yes' and s.rowcount > 1000;",
     name: "No large tables waiting on autovacuum",
     pass: "✔",
     fail: "At least one table is waiting on autovacuum",
@@ -74,6 +76,38 @@ export const LEGACY_DEFAULT_INSPECT_RULES: ReadonlyArray<LegacyInspectRule> = [
     name: "No tables yet to be vacuumed",
     pass: "✔",
     fail: "At least one table has never had autovacuum or vacuum run on it",
+  },
+  {
+    query:
+      "SELECT LISTAGG(s.name, ',') AS match FROM `vacuum_stats.csv` s WHERE FLOAT(REPLACE(s.rowcount, ',', '')) > 1000 AND FLOAT(REPLACE(s.dead_rowcount, ',', '')) > 0.2 * FLOAT(REPLACE(s.rowcount, ',', ''))",
+    name: "No tables with more than 20% dead rows",
+    pass: "✔",
+    fail: "At least one table has more than 20% dead rows",
+  },
+  {
+    query:
+      "SELECT LISTAGG(slot_name, ',') AS match FROM `replication_slots.csv` WHERE active = 'f'",
+    name: "No inactive replication slots",
+    pass: "✔",
+    fail: "There is at least one inactive replication slot",
+  },
+  {
+    query: "SELECT LISTAGG(blocked_pid, ',') AS match FROM `blocking.csv`",
+    name: "No blocked queries",
+    pass: "✔",
+    fail: "There is at least one query blocked on another",
+  },
+  {
+    query: "SELECT LISTAGG(pid, ',') AS match FROM `long_running_queries.csv`",
+    name: "No queries running longer than 5 minutes",
+    pass: "✔",
+    fail: "At least one query has been running for more than 5 minutes",
+  },
+  {
+    query: "SELECT LISTAGG(name, ',') AS match FROM `bloat.csv` WHERE bloat > 4",
+    name: "No tables or indexes with bloat ratio above 4x",
+    pass: "✔",
+    fail: "At least one table or index is more than 4x its expected size",
   },
 ];
 
@@ -107,11 +141,20 @@ export function legacyEvaluateInspectRule(
     if (match.value === "") {
       return { name: rule.name, status: rule.pass, matches: "" };
     }
-    return { name: rule.name, status: rule.fail, matches: match.value };
+    return {
+      name: rule.name,
+      status: rule.fail,
+      matches: legacySummarizeInspectRuleMatch(match.value),
+    };
   } catch (error) {
     const message = error instanceof LegacyInspectCsvqError ? error.message : String(error);
     return { name: rule.name, status: message, matches: "-" };
   }
+}
+
+function legacySummarizeInspectRuleMatch(match: string): string {
+  if (match.length <= 20) return match;
+  return `${match.split(",").length} matches`;
 }
 
 /**

--- a/apps/cli/src/legacy/commands/inspect/report/report.rules.unit.test.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.rules.unit.test.ts
@@ -52,6 +52,14 @@ describe("legacyEvaluateInspectRule", () => {
     expect(result.status).not.toBe(RULE.pass);
     expect(result.status).not.toBe(RULE.fail);
   });
+
+  it("summarizes long match lists by count", () => {
+    const result = legacyEvaluateInspectRule(
+      RULE,
+      provider({ "locks.csv": "stmt,granted\none,f\ntwo,f\nthree,f\nfour,f\nfive,f\n" }),
+    );
+    expect(result).toEqual({ name: RULE.name, status: RULE.fail, matches: "5 matches" });
+  });
 });
 
 describe("legacyBuildRuleSummaryRows", () => {


### PR DESCRIPTION
Add rules for duplicate indexes, dead rows and repl slots

## What kind of change does this PR introduce?

Feat/Fix

## What is the current behavior?

Current table output for inspect report can show too much info and look odd when formatting

## What is the new behavior?

Additional rules/checks added and table formatted to not show all results if the length is too much

## Additional context

Add any other context or screenshots.
