### PR TITLE
fix(cli): restore --auth flag on legacy functions new proxy

### DIFF
--- a/apps/cli/src/legacy/commands/functions/new/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/functions/new/SIDE_EFFECTS.md
@@ -8,9 +8,9 @@
 
 ## Files Written
 
-| Path                                           | Format     | When                               |
-| ---------------------------------------------- | ---------- | ---------------------------------- |
-| `<workdir>/supabase/functions/<name>/index.ts` | TypeScript | always (creates function scaffold) |
+| Path                                           | Format     | When                                                             |
+| ---------------------------------------------- | ---------- | ---------------------------------------------------------------- |
+| `<workdir>/supabase/functions/<name>/index.ts` | TypeScript | always (creates function scaffold, template depends on `--auth`) |
 
 ## API Routes
 
@@ -50,4 +50,5 @@ Not applicable (proxied to Go binary).
 
 - Creates a new Edge Function scaffold locally.
 - Requires exactly one argument: the function name.
+- `--auth` selects the auth-mode template (`none` | `apikey` | `user`, default: `apikey`).
 - Phase 0 proxy: all invocations are forwarded to the bundled Go binary.

--- a/apps/cli/src/legacy/commands/functions/new/new.command.ts
+++ b/apps/cli/src/legacy/commands/functions/new/new.command.ts
@@ -1,10 +1,16 @@
-import { Argument, Command } from "effect/unstable/cli";
+import { Argument, Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { legacyFunctionsNew } from "./new.handler.ts";
+
+const AUTH_MODE_VALUES = ["none", "apikey", "user"] as const;
 
 const config = {
   functionName: Argument.string("Function name").pipe(
     Argument.withDescription("Name of the Function to create."),
+  ),
+  auth: Flag.choice("auth", AUTH_MODE_VALUES).pipe(
+    Flag.withDescription("use a specific auth mode"),
+    Flag.optional,
   ),
 } as const;
 

--- a/apps/cli/src/legacy/commands/functions/new/new.handler.ts
+++ b/apps/cli/src/legacy/commands/functions/new/new.handler.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
 import type { LegacyFunctionsNewFlags } from "./new.command.ts";
 
@@ -7,5 +7,6 @@ export const legacyFunctionsNew = Effect.fn("legacy.functions.new")(function* (
 ) {
   const proxy = yield* LegacyGoProxy;
   const args: string[] = ["functions", "new", flags.functionName];
+  if (Option.isSome(flags.auth)) args.push("--auth", flags.auth.value);
   yield* proxy.exec(args);
 });


### PR DESCRIPTION
The Go CLI exposes `--auth` (`none` | `apikey` | `user`, default `apikey`) on `supabase functions new` to select the auth-mode template, but the legacy TS shim did not declare it, so the flag was silently dropped before reaching the Go binary.

Add the flag to the command definition and forward it through the proxy handler when present.

Resolves [CLI-1474](https://linear.app/supabase/issue/CLI-1474/restore-auth-flag-on-legacy-functions-new-proxy).