### PR TITLE
fix(cli): publish root README to npm umbrella package

### DIFF
--- a/apps/cli/scripts/publish.ts
+++ b/apps/cli/scripts/publish.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { copyFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
@@ -135,6 +136,13 @@ const platformResults = await Promise.all(
 // Build the umbrella package bin shim, then publish
 console.log("\nBuilding umbrella package shim...");
 await $`pnpm build:shim`.cwd(cliDir);
+
+// npm renders the README from the package directory on the package page.
+// The workspace-internal apps/cli/README.md documents the source layout for
+// contributors, which is not what we want users to see on npmjs.com. Copy
+// the repo root README — the user-facing one — over it just before publish.
+console.log("\nStaging root README for umbrella package...");
+await copyFile(path.join(root, "README.md"), path.join(cliDir, "README.md"));
 
 console.log(`Publishing umbrella package ${umbrellaName}...`);
 const umbrellaResult = await publishPackage({


### PR DESCRIPTION
## Summary

The umbrella `supabase` package was shipping `apps/cli/README.md` — workspace-layout documentation for contributors — as its npm README, so the npmjs.com package page rendered repo-internal notes instead of the user-facing project README.

`apps/cli/scripts/publish.ts` now copies the repository's root `README.md` over `apps/cli/README.md` immediately before `pnpm publish` runs for the umbrella package. The workspace-internal README stays in place for repo readers, and the user-facing README is what gets published to npm.

The `homepage` field (`https://github.com/supabase/cli#readme`) already points to the root README on GitHub, so it is unchanged.

Fixes [CLI-1479](https://linear.app/supabase/issue/CLI-1479/fix-incorrect-readme-shown-on-npm-page).

https://claude.ai/code/session_01LzrhvRuUEjjEKRToDATaVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzrhvRuUEjjEKRToDATaVc)_