### PR TITLE
fix(cli): restore --jobs flag on legacy functions deploy proxy

### DIFF
--- a/apps/cli/src/legacy/commands/functions/deploy/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/functions/deploy/SIDE_EFFECTS.md
@@ -58,4 +58,5 @@ Not applicable (proxied to Go binary).
 - Requires a linked project (`--project-ref` or linked project config).
 - Uses Docker by default to bundle functions; `--use-api` switches to server-side bundling.
 - `--prune` deletes functions that exist in the Supabase project but not locally.
+- `--jobs` (`-j`) sets the maximum number of parallel deploys; must be combined with `--use-api`.
 - Phase 0 proxy: all invocations are forwarded to the bundled Go binary.

--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.command.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.command.ts
@@ -23,6 +23,11 @@ const config = {
   prune: Flag.boolean("prune").pipe(
     Flag.withDescription("Delete Functions that exist in Supabase project but not locally."),
   ),
+  jobs: Flag.integer("jobs").pipe(
+    Flag.withAlias("j"),
+    Flag.withDescription("Maximum number of parallel jobs."),
+    Flag.optional,
+  ),
 } as const;
 
 export const legacyFunctionsDeployCommand = Command.make("deploy", config).pipe(
@@ -36,6 +41,7 @@ export const legacyFunctionsDeployCommand = Command.make("deploy", config).pipe(
       useApi: flags.useApi,
       importMap: flags.importMap,
       prune: flags.prune,
+      jobs: flags.jobs,
     }),
   ),
 );

--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.handler.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.handler.ts
@@ -8,6 +8,7 @@ interface LegacyFunctionsDeployFlags {
   readonly useApi: boolean;
   readonly importMap: Option.Option<string>;
   readonly prune: boolean;
+  readonly jobs: Option.Option<number>;
 }
 
 export const legacyFunctionsDeploy = Effect.fn("legacy.functions.deploy")(function* (
@@ -21,5 +22,6 @@ export const legacyFunctionsDeploy = Effect.fn("legacy.functions.deploy")(functi
   if (flags.useApi) args.push("--use-api");
   if (Option.isSome(flags.importMap)) args.push("--import-map", flags.importMap.value);
   if (flags.prune) args.push("--prune");
+  if (Option.isSome(flags.jobs)) args.push("--jobs", String(flags.jobs.value));
   yield* proxy.exec(args);
 });


### PR DESCRIPTION
The Go CLI exposes --jobs (-j, default 1) on supabase functions deploy
to control parallel deploys when combined with --use-api, but the legacy
TS shim did not declare it, so the flag was rejected at the shim's
arg-parsing layer before reaching the Go binary.

Add the flag to the command definition and forward it through the proxy
handler when present.

Fixes #5263