### PR TITLE
fix(cli): scope hidden flags per-command instead of globally

### DIFF
--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.command.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.command.ts
@@ -1,5 +1,5 @@
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { withHidden } from "../../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../../shared/cli/hidden-flag.ts";
 import { legacyFunctionsDeploy } from "./deploy.handler.ts";
 
 const config = {
@@ -42,6 +42,7 @@ const config = {
 export const legacyFunctionsDeployCommand = Command.make("deploy", config).pipe(
   Command.withDescription("Deploy a Function to the linked Supabase project."),
   Command.withShortDescription("Deploy a Function to Supabase"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) =>
     legacyFunctionsDeploy({
       functionNames: flags.functionNames.map(String),

--- a/apps/cli/src/legacy/commands/functions/download/download.command.ts
+++ b/apps/cli/src/legacy/commands/functions/download/download.command.ts
@@ -1,6 +1,6 @@
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
-import { withHidden } from "../../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../../shared/cli/hidden-flag.ts";
 import { legacyFunctionsDownload } from "./download.handler.ts";
 
 const config = {
@@ -32,5 +32,6 @@ export const legacyFunctionsDownloadCommand = Command.make("download", config).p
     "Download the source code for a Function from the linked Supabase project. If no function name is provided, downloads all functions.",
   ),
   Command.withShortDescription("Download a Function from Supabase"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyFunctionsDownload(flags)),
 );

--- a/apps/cli/src/legacy/commands/functions/serve/serve.command.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.command.ts
@@ -1,6 +1,6 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
-import { withHidden } from "../../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../../shared/cli/hidden-flag.ts";
 import { legacyFunctionsServe } from "./serve.handler.ts";
 
 const INSPECT_MODES = ["run", "brk", "wait"] as const;
@@ -35,5 +35,6 @@ export type LegacyFunctionsServeFlags = CliCommand.Command.Config.Infer<typeof c
 export const legacyFunctionsServeCommand = Command.make("serve", config).pipe(
   Command.withDescription("Serve all Functions locally."),
   Command.withShortDescription("Serve all Functions locally"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyFunctionsServe(flags)),
 );

--- a/apps/cli/src/legacy/commands/init/init.command.ts
+++ b/apps/cli/src/legacy/commands/init/init.command.ts
@@ -1,6 +1,6 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
-import { withHidden } from "../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../shared/cli/hidden-flag.ts";
 import { legacyInit } from "./init.handler.ts";
 
 const config = {
@@ -34,5 +34,6 @@ export type LegacyInitFlags = CliCommand.Command.Config.Infer<typeof config>;
 export const legacyInitCommand = Command.make("init", config).pipe(
   Command.withDescription("Initialize a local project."),
   Command.withShortDescription("Initialize a local project"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyInit(flags)),
 );

--- a/apps/cli/src/legacy/commands/projects/create/create.command.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.command.ts
@@ -1,6 +1,6 @@
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
-import { withHidden } from "../../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../../shared/cli/hidden-flag.ts";
 import { legacyProjectsCreate } from "./create.handler.ts";
 
 const AWS_REGIONS = [
@@ -93,5 +93,6 @@ export const legacyProjectsCreateCommand = Command.make("create", config).pipe(
       description: "Create a new project",
     },
   ]),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyProjectsCreate(flags)),
 );

--- a/apps/cli/src/legacy/commands/start/start.command.ts
+++ b/apps/cli/src/legacy/commands/start/start.command.ts
@@ -1,6 +1,6 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
-import { withHidden } from "../../../shared/cli/hidden-flag.ts";
+import { withHidden, withHiddenFromConfig } from "../../../shared/cli/hidden-flag.ts";
 import { legacyStart } from "./start.handler.ts";
 
 const config = {
@@ -25,5 +25,6 @@ export type LegacyStartFlags = CliCommand.Command.Config.Infer<typeof config>;
 export const legacyStartCommand = Command.make("start", config).pipe(
   Command.withDescription("Start containers for Supabase local development."),
   Command.withShortDescription("Start local Supabase stack"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyStart(flags)),
 );

--- a/apps/cli/src/legacy/commands/stop/stop.command.ts
+++ b/apps/cli/src/legacy/commands/stop/stop.command.ts
@@ -1,11 +1,20 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
+import { withHidden, withHiddenFromConfig } from "../../../shared/cli/hidden-flag.ts";
 import { legacyStop } from "./stop.handler.ts";
 
 const config = {
   projectId: Flag.string("project-id").pipe(
     Flag.withDescription("Local project ID to stop."),
     Flag.optional,
+  ),
+  // Hidden boolean kept for Go CLI parity: `--backup=false` is the historical
+  // way to skip the backup and is functionally identical to `--no-backup`.
+  backup: withHidden(
+    Flag.boolean("backup").pipe(
+      Flag.withDescription("Backs up the current database before stopping."),
+      Flag.withDefault(true),
+    ),
   ),
   noBackup: Flag.boolean("no-backup").pipe(
     Flag.withDescription("Deletes all data volumes after stopping."),
@@ -20,5 +29,6 @@ export type LegacyStopFlags = CliCommand.Command.Config.Infer<typeof config>;
 export const legacyStopCommand = Command.make("stop", config).pipe(
   Command.withDescription("Stop all local Supabase containers."),
   Command.withShortDescription("Stop all local Supabase containers"),
+  withHiddenFromConfig(config),
   Command.withHandler((flags) => legacyStop(flags)),
 );

--- a/apps/cli/src/legacy/commands/stop/stop.handler.ts
+++ b/apps/cli/src/legacy/commands/stop/stop.handler.ts
@@ -6,6 +6,9 @@ export const legacyStop = Effect.fn("legacy.stop")(function* (flags: LegacyStopF
   const proxy = yield* LegacyGoProxy;
   const args: string[] = ["stop"];
   if (Option.isSome(flags.projectId)) args.push("--project-id", flags.projectId.value);
+  // `--backup` defaults to true; only forward when explicitly disabled, which
+  // matches the Go CLI semantics (`!noBackup` && `--backup=false`).
+  if (!flags.backup) args.push("--backup=false");
   if (flags.noBackup) args.push("--no-backup");
   if (flags.all) args.push("--all");
   yield* proxy.exec(args);

--- a/apps/cli/src/legacy/commands/stop/stop.integration.test.ts
+++ b/apps/cli/src/legacy/commands/stop/stop.integration.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { legacyStop } from "./stop.handler.ts";
+import type { LegacyStopFlags } from "./stop.command.ts";
+
+function setupLegacyStop() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+  });
+  return { layer, calls };
+}
+
+const baseFlags: LegacyStopFlags = {
+  projectId: Option.none(),
+  backup: true,
+  noBackup: false,
+  all: false,
+};
+
+describe("legacy stop", () => {
+  it.live("forwards no extra flags when defaults are used", () => {
+    const { layer, calls } = setupLegacyStop();
+    return Effect.gen(function* () {
+      yield* legacyStop(baseFlags);
+      expect(calls).toEqual([["stop"]]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards --backup=false when the hidden --backup flag is disabled", () => {
+    const { layer, calls } = setupLegacyStop();
+    return Effect.gen(function* () {
+      yield* legacyStop({ ...baseFlags, backup: false });
+      expect(calls).toEqual([["stop", "--backup=false"]]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards --no-backup, --project-id and --all", () => {
+    const { layer, calls } = setupLegacyStop();
+    return Effect.gen(function* () {
+      yield* legacyStop({
+        projectId: Option.some("abc"),
+        backup: true,
+        noBackup: true,
+        all: true,
+      });
+      expect(calls).toEqual([["stop", "--project-id", "abc", "--no-backup", "--all"]]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/cli/src/shared/cli/hidden-flag.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.ts
@@ -1,7 +1,19 @@
-import type { Flag, HelpDoc } from "effect/unstable/cli";
-import type * as Param from "effect/unstable/cli/Param";
+import { Context } from "effect";
+import { Command, type Flag, type HelpDoc } from "effect/unstable/cli";
+import * as Param from "effect/unstable/cli/Param";
 
-const hiddenFlagNames = new Set<string>();
+/**
+ * Per-command set of hidden flag names. Attached to a `Command` via
+ * `Command.annotate` so each command carries its own list, then read off
+ * `HelpDoc.annotations` by `stripHiddenFlagsFromHelpDoc`.
+ */
+export const LegacyHiddenFlags: Context.Reference<ReadonlySet<string>> = Context.Reference<
+  ReadonlySet<string>
+>("supabase/legacy/LegacyHiddenFlags", {
+  defaultValue: () => new Set<string>(),
+});
+
+const hiddenFlagNames = new WeakMap<object, ReadonlyArray<string>>();
 
 const collectSingleNames = (param: Param.Param<Param.ParamKind, unknown>): Array<string> => {
   const node = param as
@@ -25,17 +37,44 @@ const collectSingleNames = (param: Param.Param<Param.ParamKind, unknown>): Array
  * Marks a flag as hidden so that it is parsed normally but omitted from
  * `--help` output. This mirrors Cobra's `MarkHidden` from the Go CLI, which
  * the upstream Effect CLI does not yet expose natively.
+ *
+ * The flag reference is recorded in a module-local `WeakMap`; the
+ * per-command list is materialised by `withHiddenFromConfig` so flags with
+ * the same name in unrelated commands do not collide.
  */
 export const withHidden = <A>(flag: Flag.Flag<A>): Flag.Flag<A> => {
-  for (const name of collectSingleNames(flag)) {
-    hiddenFlagNames.add(name);
-  }
+  hiddenFlagNames.set(flag, collectSingleNames(flag));
   return flag;
 };
 
+/**
+ * Pipe step for a `Command` that walks the command's flag config, finds
+ * every flag previously wrapped with `withHidden`, and attaches the
+ * resulting set of hidden flag names to the command via `Command.annotate`.
+ * Apply directly after `Command.make(name, config)` so the same `config`
+ * object is in scope.
+ */
+export const withHiddenFromConfig =
+  (config: Record<string, unknown>) =>
+  <Name extends string, Input, ContextInput, E, R>(
+    cmd: Command.Command<Name, Input, ContextInput, E, R>,
+  ): Command.Command<Name, Input, ContextInput, E, R> => {
+    const hidden = new Set<string>();
+    for (const value of Object.values(config)) {
+      if (value === null || typeof value !== "object") continue;
+      const names = hiddenFlagNames.get(value);
+      if (names === undefined) continue;
+      for (const name of names) hidden.add(name);
+    }
+    if (hidden.size === 0) return cmd;
+    return Command.annotate(cmd, LegacyHiddenFlags, hidden);
+  };
+
 export const stripHiddenFlagsFromHelpDoc = (doc: HelpDoc.HelpDoc): HelpDoc.HelpDoc => {
-  const filteredFlags = doc.flags.filter((flag) => !hiddenFlagNames.has(flag.name));
-  const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hiddenFlagNames.has(flag.name));
+  const hidden = Context.get(doc.annotations, LegacyHiddenFlags);
+  if (hidden.size === 0) return doc;
+  const filteredFlags = doc.flags.filter((flag) => !hidden.has(flag.name));
+  const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hidden.has(flag.name));
   return {
     ...doc,
     flags: filteredFlags,

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -1,7 +1,12 @@
 import { Context, Option } from "effect";
-import { Flag, type HelpDoc } from "effect/unstable/cli";
+import { Command, Flag, type HelpDoc } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
-import { stripHiddenFlagsFromHelpDoc, withHidden } from "./hidden-flag.ts";
+import {
+  LegacyHiddenFlags,
+  stripHiddenFlagsFromHelpDoc,
+  withHidden,
+  withHiddenFromConfig,
+} from "./hidden-flag.ts";
 
 const flagDoc = (name: string): HelpDoc.FlagDoc => ({
   name,
@@ -19,34 +24,114 @@ const helpDoc = (overrides: Partial<HelpDoc.HelpDoc>): HelpDoc.HelpDoc => ({
   ...overrides,
 });
 
+const helpDocWithHidden = (
+  hidden: ReadonlyArray<string>,
+  overrides: Partial<HelpDoc.HelpDoc>,
+): HelpDoc.HelpDoc =>
+  helpDoc({
+    ...overrides,
+    annotations: Context.make(LegacyHiddenFlags, new Set(hidden)),
+  });
+
+// Reach into the internal command shape to obtain the help doc the formatter
+// would render. Effect builds this from `Command.annotations`, which is the
+// contract `withHiddenFromConfig` relies on.
+interface CommandImpl {
+  readonly buildHelpDoc: (path: ReadonlyArray<string>) => HelpDoc.HelpDoc;
+}
+const buildHelpDoc = <Name extends string, Input, ContextInput, E, R>(
+  cmd: Command.Command<Name, Input, ContextInput, E, R>,
+): HelpDoc.HelpDoc => (cmd as unknown as CommandImpl).buildHelpDoc([]);
+
 describe("withHidden", () => {
   it("returns the same flag instance", () => {
     const flag = Flag.boolean("legacy-bundle");
     expect(withHidden(flag)).toBe(flag);
   });
 
-  it("registers the underlying single name even when wrapped with combinators", () => {
-    const flag = Flag.string("plan").pipe(Flag.optional);
-    withHidden(flag);
+  it("does not register flag names globally — only commands wired via withHiddenFromConfig hide them", () => {
+    withHidden(Flag.boolean("stray"));
 
-    const stripped = stripHiddenFlagsFromHelpDoc(
-      helpDoc({ flags: [flagDoc("plan"), flagDoc("visible")] }),
-    );
-    expect(stripped.flags.map((f) => f.name)).toEqual(["visible"]);
+    const stripped = stripHiddenFlagsFromHelpDoc(helpDoc({ flags: [flagDoc("stray")] }));
+    expect(stripped.flags.map((f) => f.name)).toEqual(["stray"]);
+  });
+});
+
+describe("withHiddenFromConfig", () => {
+  it("strips wrapped flags from the command's help doc", () => {
+    const config = {
+      plan: withHidden(Flag.string("plan").pipe(Flag.optional)),
+      visible: Flag.boolean("visible"),
+    } as const;
+
+    const cmd = Command.make("demo", config).pipe(withHiddenFromConfig(config));
+    const doc = stripHiddenFlagsFromHelpDoc(buildHelpDoc(cmd));
+
+    expect(doc.flags.map((f) => f.name)).toEqual(["visible"]);
   });
 
-  it("filters hidden flags from globalFlags as well", () => {
-    withHidden(Flag.boolean("preview"));
+  it("scopes hidden-ness to the wrapping command — same flag name in another command stays visible", () => {
+    const hiddenConfig = {
+      interactive: withHidden(Flag.boolean("interactive")),
+    } as const;
+    const visibleConfig = {
+      interactive: Flag.boolean("interactive"),
+    } as const;
 
-    const stripped = stripHiddenFlagsFromHelpDoc(
-      helpDoc({ globalFlags: [flagDoc("preview"), flagDoc("verbose")] }),
+    const hiddenCmd = Command.make("create", hiddenConfig).pipe(withHiddenFromConfig(hiddenConfig));
+    const visibleCmd = Command.make("init", visibleConfig).pipe(
+      withHiddenFromConfig(visibleConfig),
     );
+
+    expect(stripHiddenFlagsFromHelpDoc(buildHelpDoc(hiddenCmd)).flags.map((f) => f.name)).toEqual(
+      [],
+    );
+    expect(stripHiddenFlagsFromHelpDoc(buildHelpDoc(visibleCmd)).flags.map((f) => f.name)).toEqual([
+      "interactive",
+    ]);
+  });
+
+  it("is a no-op when the config contains no hidden flags", () => {
+    const config = { visible: Flag.boolean("visible") } as const;
+    const cmd = Command.make("demo", config);
+    const piped = cmd.pipe(withHiddenFromConfig(config));
+
+    expect(piped).toBe(cmd);
+  });
+
+  it("collects names through Flag combinators like optional", () => {
+    const config = {
+      plan: withHidden(Flag.string("plan").pipe(Flag.optional)),
+    } as const;
+    const cmd = Command.make("demo", config).pipe(withHiddenFromConfig(config));
+    const annotated = Context.get(buildHelpDoc(cmd).annotations, LegacyHiddenFlags);
+
+    expect([...annotated]).toEqual(["plan"]);
+  });
+});
+
+describe("stripHiddenFlagsFromHelpDoc", () => {
+  it("returns the doc unchanged when annotations are empty", () => {
+    const doc = helpDoc({ flags: [flagDoc("foo")] });
+    expect(stripHiddenFlagsFromHelpDoc(doc)).toBe(doc);
+  });
+
+  it("filters both flags and globalFlags by the doc's annotation", () => {
+    const doc = helpDocWithHidden(["preview", "plan"], {
+      flags: [flagDoc("plan"), flagDoc("visible")],
+      globalFlags: [flagDoc("preview"), flagDoc("verbose")],
+    });
+
+    const stripped = stripHiddenFlagsFromHelpDoc(doc);
+    expect(stripped.flags.map((f) => f.name)).toEqual(["visible"]);
     expect(stripped.globalFlags?.map((f) => f.name)).toEqual(["verbose"]);
   });
 
-  it("leaves docs without globalFlags untouched", () => {
-    const stripped = stripHiddenFlagsFromHelpDoc(helpDoc({ flags: [flagDoc("foo")] }));
+  it("leaves docs without globalFlags untouched in that field", () => {
+    const doc = helpDocWithHidden(["foo"], { flags: [flagDoc("foo"), flagDoc("bar")] });
+    const stripped = stripHiddenFlagsFromHelpDoc(doc);
+
     expect(stripped.globalFlags).toBeUndefined();
-    expect(stripped.flags.map((f) => f.name)).toEqual(["foo"]);
+    expect(stripped.flags.map((f) => f.name)).toEqual(["bar"]);
   });
 });


### PR DESCRIPTION
Refactor the hidden flag system to scope flag visibility per-command rather than maintaining a global registry. This prevents flag name collisions when the same flag name appears in different commands with different visibility requirements.

## Changes

- **Replaced global hidden flag registry with per-command annotations**: Changed from a module-level `Set<string>` to a `Context.Reference` (`LegacyHiddenFlags`) that attaches hidden flag metadata directly to each `Command` via `Command.annotate`.

- **Introduced `withHiddenFromConfig` helper**: New pipe step that walks a command's flag config, collects all flags wrapped with `withHidden`, and attaches the resulting set to the command. This materializes the per-command list at command construction time, scoping visibility to that specific command.

- **Updated `withHidden` to use WeakMap tracking**: Changed from adding to a global set to recording flag references in a module-local `WeakMap`, allowing `withHiddenFromConfig` to look up which flags were marked hidden without polluting global state.

- **Updated `stripHiddenFlagsFromHelpDoc` to read from annotations**: Now reads the hidden flag set from the help doc's `LegacyHiddenFlags` annotation instead of checking a global registry, enabling per-command filtering.

- **Applied `withHiddenFromConfig` to all legacy commands**: Updated `stop`, `start`, `init`, `functions deploy`, `functions download`, and `functions serve` commands to wire their configs through `withHiddenFromConfig`.

- **Added `--backup` hidden flag to stop command**: Restored the historical `--backup` flag (hidden by default) for Go CLI parity, with handler logic to forward `--backup=false` when explicitly disabled.

- **Added integration test for stop command**: New test file validates that the `--backup` flag is correctly forwarded to the Go proxy.

## Implementation Details

The refactor maintains backward compatibility with the existing `withHidden` API while fixing the architectural issue where flags with the same name in different commands would interfere with each other. The `Context.Reference` pattern ensures each command carries its own isolated set of hidden flag names, read during help doc rendering.

Related: CLI-1483

https://claude.ai/code/session_01EB93upyjdFDB3czXheQknG