### PR TITLE
fix(cli): fix smoke test shell and npm tag quoting in release workflow

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -134,6 +134,10 @@ jobs:
         run: chmod +x packages/cli-*/bin/supabase || true
 
       - name: Run smoke tests
+        # Force bash so ${VERSION}/${NPM_TAG} expand identically across the
+        # ubuntu/macos/windows matrix — windows-latest defaults to pwsh, which
+        # treats those as empty PowerShell variables (env vars are `$env:VAR`).
+        shell: bash
         run: pnpm run test:smoke -- --version "${VERSION}" --tag "${NPM_TAG}"
         working-directory: apps/cli
 
@@ -164,7 +168,7 @@ jobs:
         run: pnpm exec bun apps/cli/scripts/sync-versions.ts --version "${VERSION}"
 
       - name: Publish to npm
-        run: pnpm exec bun apps/cli/scripts/publish.ts --tag ""${NPM_TAG}""
+        run: pnpm exec bun apps/cli/scripts/publish.ts --tag "${NPM_TAG}"
 
       # Push the version tag to origin as soon as npm has the bytes, before any
       # downstream step that can fail. Without this, a failure in the GH-release


### PR DESCRIPTION
Fixes two issues in the release workflow that affect cross-platform compatibility and npm publishing:

- **Smoke test shell**: Added explicit `shell: bash` to the smoke test step. The Windows runner defaults to PowerShell, which treats `${VERSION}` and `${NPM_TAG}` as empty variables (PowerShell uses `$env:VAR` syntax). This ensures consistent variable expansion across the ubuntu/macos/windows matrix.

- **NPM tag quoting**: Removed unnecessary double-quoting of the `${NPM_TAG}` variable in the publish step (`""${NPM_TAG}""` → `"${NPM_TAG}"`). The extra quotes were being passed literally to the script, causing incorrect tag values.

https://claude.ai/code/session_018LbJcjCcwYkz86cN5Qw19s