### PR TITLE
fix: hide legacy hidden subcommands

### DIFF
--- a/apps/cli/src/legacy/commands/branches/branches.command.ts
+++ b/apps/cli/src/legacy/commands/branches/branches.command.ts
@@ -1,4 +1,5 @@
 import { Command } from "effect/unstable/cli";
+import { withHiddenSubcommands } from "../../../shared/cli/hidden-flag.ts";
 import { legacyBranchesListCommand } from "./list/list.command.ts";
 import { legacyBranchesCreateCommand } from "./create/create.command.ts";
 import { legacyBranchesGetCommand } from "./get/get.command.ts";
@@ -11,6 +12,7 @@ import { legacyBranchesDisableCommand } from "./disable/disable.command.ts";
 export const legacyBranchesCommand = Command.make("branches").pipe(
   Command.withDescription("Manage Supabase preview branches."),
   Command.withShortDescription("Manage preview branches"),
+  withHiddenSubcommands(["disable"]),
   Command.withSubcommands([
     legacyBranchesListCommand,
     legacyBranchesCreateCommand,

--- a/apps/cli/src/legacy/commands/db/db.command.ts
+++ b/apps/cli/src/legacy/commands/db/db.command.ts
@@ -1,4 +1,5 @@
 import { Command } from "effect/unstable/cli";
+import { withHiddenSubcommands } from "../../../shared/cli/hidden-flag.ts";
 import { legacyDbDiffCommand } from "./diff/diff.command.ts";
 import { legacyDbDumpCommand } from "./dump/dump.command.ts";
 import { legacyDbPushCommand } from "./push/push.command.ts";
@@ -16,6 +17,7 @@ import { legacyDbSchemaCommand } from "./schema/schema.command.ts";
 export const legacyDbCommand = Command.make("db").pipe(
   Command.withDescription("Manage Postgres databases."),
   Command.withShortDescription("Manage databases"),
+  withHiddenSubcommands(["branch", "remote", "test"]),
   Command.withSubcommands([
     legacyDbDiffCommand,
     legacyDbDumpCommand,

--- a/apps/cli/src/shared/cli/hidden-flag.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.ts
@@ -13,6 +13,12 @@ export const LegacyHiddenFlags: Context.Reference<ReadonlySet<string>> = Context
   defaultValue: () => new Set<string>(),
 });
 
+export const LegacyHiddenSubcommands: Context.Reference<ReadonlySet<string>> = Context.Reference<
+  ReadonlySet<string>
+>("supabase/legacy/LegacyHiddenSubcommands", {
+  defaultValue: () => new Set<string>(),
+});
+
 const hiddenFlagNames = new WeakMap<object, ReadonlyArray<string>>();
 
 const collectSingleNames = (param: Param.Param<Param.ParamKind, unknown>): Array<string> => {
@@ -70,14 +76,29 @@ export const withHiddenFromConfig =
     return Command.annotate(cmd, LegacyHiddenFlags, hidden);
   };
 
+export const withHiddenSubcommands =
+  (names: ReadonlyArray<string>) =>
+  <Name extends string, Input, ContextInput, E, R>(
+    cmd: Command.Command<Name, Input, ContextInput, E, R>,
+  ): Command.Command<Name, Input, ContextInput, E, R> =>
+    Command.annotate(cmd, LegacyHiddenSubcommands, new Set(names));
+
 export const stripHiddenFlagsFromHelpDoc = (doc: HelpDoc.HelpDoc): HelpDoc.HelpDoc => {
-  const hidden = Context.get(doc.annotations, LegacyHiddenFlags);
-  if (hidden.size === 0) return doc;
-  const filteredFlags = doc.flags.filter((flag) => !hidden.has(flag.name));
-  const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hidden.has(flag.name));
+  const hiddenFlags = Context.get(doc.annotations, LegacyHiddenFlags);
+  const hiddenSubcommands = Context.get(doc.annotations, LegacyHiddenSubcommands);
+  if (hiddenFlags.size === 0 && hiddenSubcommands.size === 0) return doc;
+  const filteredFlags = doc.flags.filter((flag) => !hiddenFlags.has(flag.name));
+  const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hiddenFlags.has(flag.name));
+  const filteredSubcommands = doc.subcommands
+    ?.map((group) => ({
+      ...group,
+      commands: group.commands.filter((command) => !hiddenSubcommands.has(command.name)),
+    }))
+    .filter((group) => group.commands.length > 0);
   return {
     ...doc,
     flags: filteredFlags,
+    ...(filteredSubcommands !== undefined && { subcommands: filteredSubcommands }),
     ...(filteredGlobalFlags !== undefined && { globalFlags: filteredGlobalFlags }),
   };
 };

--- a/apps/cli/src/shared/cli/hidden-flag.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.ts
@@ -89,12 +89,19 @@ export const stripHiddenFlagsFromHelpDoc = (doc: HelpDoc.HelpDoc): HelpDoc.HelpD
   if (hiddenFlags.size === 0 && hiddenSubcommands.size === 0) return doc;
   const filteredFlags = doc.flags.filter((flag) => !hiddenFlags.has(flag.name));
   const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hiddenFlags.has(flag.name));
-  const filteredSubcommands = doc.subcommands
-    ?.map((group) => ({
-      ...group,
-      commands: group.commands.filter((command) => !hiddenSubcommands.has(command.name)),
-    }))
-    .filter((group) => group.commands.length > 0);
+  const filteredSubcommands = doc.subcommands?.flatMap((group) => {
+    const commands = group.commands.filter((command) => !hiddenSubcommands.has(command.name));
+    if (commands.length === 0) return [];
+    return [
+      {
+        ...group,
+        commands: commands as unknown as readonly [
+          HelpDoc.SubcommandDoc,
+          ...Array<HelpDoc.SubcommandDoc>,
+        ],
+      },
+    ];
+  });
   return {
     ...doc,
     flags: filteredFlags,

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -159,9 +159,15 @@ describe("stripHiddenFlagsFromHelpDoc", () => {
     const doc = helpDocWithHiddenSubcommands(["legacy"], {
       subcommands: [
         {
+          group: undefined,
           commands: [
-            { name: "visible", shortDescription: "visible", description: "visible" },
-            { name: "legacy", shortDescription: "legacy", description: "legacy" },
+            {
+              name: "visible",
+              alias: undefined,
+              shortDescription: "visible",
+              description: "visible",
+            },
+            { name: "legacy", alias: undefined, shortDescription: "legacy", description: "legacy" },
           ],
         },
       ],

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -3,9 +3,11 @@ import { Command, Flag, type HelpDoc } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 import {
   LegacyHiddenFlags,
+  LegacyHiddenSubcommands,
   stripHiddenFlagsFromHelpDoc,
   withHidden,
   withHiddenFromConfig,
+  withHiddenSubcommands,
 } from "./hidden-flag.ts";
 
 const flagDoc = (name: string): HelpDoc.FlagDoc => ({
@@ -31,6 +33,15 @@ const helpDocWithHidden = (
   helpDoc({
     ...overrides,
     annotations: Context.make(LegacyHiddenFlags, new Set(hidden)),
+  });
+
+const helpDocWithHiddenSubcommands = (
+  hidden: ReadonlyArray<string>,
+  overrides: Partial<HelpDoc.HelpDoc>,
+): HelpDoc.HelpDoc =>
+  helpDoc({
+    ...overrides,
+    annotations: Context.make(LegacyHiddenSubcommands, new Set(hidden)),
   });
 
 // Reach into the internal command shape to obtain the help doc the formatter
@@ -110,6 +121,15 @@ describe("withHiddenFromConfig", () => {
   });
 });
 
+describe("withHiddenSubcommands", () => {
+  it("adds hidden subcommand annotations to the command help doc", () => {
+    const cmd = Command.make("demo").pipe(withHiddenSubcommands(["legacy"]));
+    const annotated = Context.get(buildHelpDoc(cmd).annotations, LegacyHiddenSubcommands);
+
+    expect([...annotated]).toEqual(["legacy"]);
+  });
+});
+
 describe("stripHiddenFlagsFromHelpDoc", () => {
   it("returns the doc unchanged when annotations are empty", () => {
     const doc = helpDoc({ flags: [flagDoc("foo")] });
@@ -133,5 +153,21 @@ describe("stripHiddenFlagsFromHelpDoc", () => {
 
     expect(stripped.globalFlags).toBeUndefined();
     expect(stripped.flags.map((f) => f.name)).toEqual(["bar"]);
+  });
+
+  it("filters hidden subcommands by the doc's annotation", () => {
+    const doc = helpDocWithHiddenSubcommands(["legacy"], {
+      subcommands: [
+        {
+          commands: [
+            { name: "visible", shortDescription: "visible", description: "visible" },
+            { name: "legacy", shortDescription: "legacy", description: "legacy" },
+          ],
+        },
+      ],
+    });
+
+    const stripped = stripHiddenFlagsFromHelpDoc(doc);
+    expect(stripped.subcommands?.[0]?.commands.map((command) => command.name)).toEqual(["visible"]);
   });
 });


### PR DESCRIPTION
## TL;DR

hide legacy subcommands from help output when the go cli marks them hidden, while keeping them callable

## prob

the legacy ts cli still showed a few subcommands in `--help` that the go cli explicitly marks as hidden:

- `branches disable`
- `db branch`
- `db remote`
- `db test`

this happened because the existing hidden help mechanism only covered flags, not subcommands

change extends the same pattern to hidden subcommands and 
annotates the affected parent commands accordingly

execution is unchanged, so the subcommands remain callable directly

## ref: 

- extends https://github.com/supabase/cli/pull/5278
