### PR TITLE
ci: migrate CI and release workflows to Blacksmith runners

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Restore Bun toolchain cache
       id: bun-toolchain-cache
-      uses: useblacksmith/cache@v5
+      uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6 # v5
       with:
         path: /opt/hostedtoolcache/bun
         key: bun-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}
@@ -39,7 +39,7 @@ runs:
       run: bun --version
 
     - name: Install Node.js
-      uses: useblacksmith/setup-node@v5
+      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5
       with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -49,7 +49,7 @@ runs:
       run: npm install --global --force corepack && corepack enable
 
     - name: Configure dependency cache
-      uses: useblacksmith/setup-node@v5
+      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5
       with:
         cache: pnpm
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Restore Bun toolchain cache
       id: bun-toolchain-cache
-      uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6 # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: /opt/hostedtoolcache/bun
         key: bun-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}
@@ -39,7 +39,7 @@ runs:
       run: bun --version
 
     - name: Install Node.js
-      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -49,7 +49,7 @@ runs:
       run: npm install --global --force corepack && corepack enable
 
     - name: Configure dependency cache
-      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         cache: pnpm
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Restore Bun toolchain cache
       id: bun-toolchain-cache
-      uses: actions/cache@v4
+      uses: useblacksmith/cache@v5
       with:
         path: /opt/hostedtoolcache/bun
         key: bun-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}
@@ -39,7 +39,7 @@ runs:
       run: bun --version
 
     - name: Install Node.js
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      uses: useblacksmith/setup-node@v5
       with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -49,7 +49,7 @@ runs:
       run: npm install --global --force corepack && corepack enable
 
     - name: Configure dependency cache
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      uses: useblacksmith/setup-node@v5
       with:
         cache: pnpm
 

--- a/.github/workflows/cli-go-api-sync.yml
+++ b/.github/workflows/cli-go-api-sync.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   sync:
     name: Sync API Types
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/cli-go-ci.yml
+++ b/.github/workflows/cli-go-ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@v5
+      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@v5
+      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           # Linter requires no cache
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: useblacksmith/setup-go@v5
+      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: useblacksmith/setup-go@v5
+      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@v5
+      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true

--- a/.github/workflows/cli-go-ci.yml
+++ b/.github/workflows/cli-go-ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/cli-go-ci.yml
+++ b/.github/workflows/cli-go-ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           # Linter requires no cache
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true

--- a/.github/workflows/cli-go-ci.yml
+++ b/.github/workflows/cli-go-ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           # Linter requires no cache
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true

--- a/.github/workflows/cli-go-codeql.yml
+++ b/.github/workflows/cli-go-codeql.yml
@@ -32,7 +32,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       # required for all workflows

--- a/.github/workflows/cli-go-mirror.yml
+++ b/.github/workflows/cli-go-mirror.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       tags: ${{ steps.list.outputs.tags }}
       curr: ${{ steps.curr.outputs.tags }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -98,6 +98,11 @@ jobs:
 
   smoke-test:
     needs: build
+    # macos-15-intel is the slowest smoke leg and the only one not on
+    # Blacksmith (Blacksmith macOS is ARM-only). Skip it on prereleases
+    # (PR smoke + develop -> beta) so beta wall-clock isn't gated by it;
+    # stable releases on main still run the full matrix.
+    if: ${{ !(matrix.runner == 'macos-15-intel' && inputs.prerelease) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Setup Go
-        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true
@@ -149,7 +149,7 @@ jobs:
   publish:
     needs: smoke-test
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       CHANNEL: ${{ inputs.channel }}
       NPM_TAG: ${{ inputs.npm_tag }}
@@ -271,7 +271,7 @@ jobs:
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       BREW_NAME: ${{ inputs.brew_name }}
       VERSION: ${{ inputs.version }}
@@ -313,7 +313,7 @@ jobs:
   publish-scoop:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       SCOOP_NAME: ${{ inputs.scoop_name }}
       VERSION: ${{ inputs.version }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [blacksmith-8vcpu-ubuntu-2404, macos-latest, macos-15-intel, windows-latest]
+        runner: [blacksmith-8vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, macos-15-intel, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.runner }}
     env:
       NPM_TAG: ${{ inputs.npm_tag }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+        runner: [blacksmith-8vcpu-ubuntu-2404, macos-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.runner }}
     env:
       NPM_TAG: ${{ inputs.npm_tag }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   build:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     env:
       BUN_SHELL: ${{ inputs.shell }}
       VERSION: ${{ inputs.version }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Setup Go
-        uses: useblacksmith/setup-go@v5
+        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -97,7 +97,7 @@ jobs:
       # Authorization header overrides the App token semantic-release puts in
       # the push URL — making the dry-push identify as `github-actions[bot]`
       # and get rejected by branch protection.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -97,7 +97,7 @@ jobs:
       # Authorization header overrides the App token semantic-release puts in
       # the push URL — making the dry-push identify as `github-actions[bot]`
       # and get rejected by branch protection.
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -57,7 +57,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -114,7 +114,7 @@ jobs:
       - name: Cache Go CLI binary
         if: steps.detect.outputs.cli_e2e == 'true'
         id: cache-go-binary
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: apps/cli-go/supabase-go
           key: go-cli-${{ runner.os }}-${{ hashFiles('apps/cli-go/**/*.go',
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         if: steps.detect.outputs.cli_e2e == 'true' &&
           steps.cache-go-binary.outputs.cache-hit != 'true'
-        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: useblacksmith/setup-go@v5
+        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -57,7 +57,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: useblacksmith/setup-go@v5
+        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -80,7 +80,7 @@ jobs:
         shard: [ 1, 2, 3 ]
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 0
 
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         if: steps.detect.outputs.cli_e2e == 'true' &&
           steps.cache-go-binary.outputs.cache-hit != 'true'
-        uses: useblacksmith/setup-go@v5
+        uses: useblacksmith/setup-go@f12a3dabb4171193018e496855e47349b360c056 # v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   check:
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     name: Check code quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -49,7 +49,7 @@ jobs:
   test-core:
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     name: Run unit and integration tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -73,7 +73,7 @@ jobs:
   test-e2e:
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     name: Run end-to-end tests (shard ${{ matrix.shard }}/3)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -57,7 +57,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum
@@ -80,7 +80,7 @@ jobs:
         shard: [ 1, 2, 3 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         if: steps.detect.outputs.cli_e2e == 'true' &&
           steps.cache-go-binary.outputs.cache-hit != 'true'
-        uses: actions/setup-go@v5
+        uses: useblacksmith/setup-go@v5
         with:
           go-version-file: apps/cli-go/go.mod
           cache-dependency-path: apps/cli-go/go.sum


### PR DESCRIPTION
## What

Moves the CI and release pipelines onto [Blacksmith](https://blacksmith.sh/) runners and threads Blacksmith's caching layers through the workflows that benefit from them.

Runner moves:

- PR-critical jobs in `test.yml` (`check`, `test-core`, `test-e2e`) → `blacksmith-8vcpu-ubuntu-2404`.
- `cli-go-ci.yml::test` (Go unit/integration) → `blacksmith-8vcpu-ubuntu-2404`.
- Release `build` (heavy multi-target Bun compile) → `blacksmith-32vcpu-ubuntu-2404`.
- Release `smoke-test` matrix: Linux → `blacksmith-8vcpu-ubuntu-2404`, macOS → `blacksmith-6vcpu-macos-latest`, Windows → `blacksmith-8vcpu-windows-2025`. `macos-15-intel` stays on GitHub-hosted (Blacksmith macOS is ARM-only) and is skipped on prereleases so beta wall-clock isn't gated by the slowest leg — stable releases on `main` still run it.
- Release `publish` / `publish-homebrew` / `publish-scoop` → `blacksmith-2vcpu-ubuntu-2404`.
- Low-frequency Linux jobs (`cli-go-api-sync`, `cli-go-mirror`, `cli-go-codeql` non-Swift legs) → matching Blacksmith sizes for consistency.

Caching:

- `useblacksmith/checkout@v1` on `test-e2e` to exploit Blacksmith's sticky-disk git mirror with `fetch-depth: 0` (the cli-e2e shards need full history for `nx affected`).
- Upstream `actions/cache@v5`, `actions/setup-node@v6`, `actions/setup-go@v6` — all SHA-pinned — for cache + toolchain setup. Initially this PR swapped to the `useblacksmith/cache`, `useblacksmith/setup-node`, `useblacksmith/setup-go` forks; partway through, those forks were [archived in favor of Blacksmith's runner-level interception](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions), which transparently routes upstream cache API calls to the same colocated backend. The final commit reverts to upstream and bumps the residual `actions/cache@v4` in `test.yml` to `@v5` so every cache step gets the new acceleration with continued upstream security patches.

All third-party action pins use full commit SHAs with trailing `# v<N>` comments.

## Why

The CI wall-clock on this repo had grown into the territory where it visibly slowed merges (test.yml routinely ~20+ min, release build ~30+ min). Blacksmith's larger runners + colocated cache cut both materially, and the `test-e2e` checkout in particular benefits from the sticky-disk git mirror because `fetch-depth: 0` was the dominant fixed cost in that job.

The upstream-vs-fork pivot matters for hygiene: the archived `useblacksmith/*` cache forks still execute when SHA-pinned, but get no future security patches and miss out on Blacksmith's newer transparent acceleration. Going through upstream actions gives us both — Blacksmith routing *and* normal upstream maintenance — at no behavioral cost.

## Scope deliberately excluded

- `cli-go-pg-prove.yml` / `cli-go-publish-migra.yml` Docker builds: separate follow-up, requires migrating to `useblacksmith/setup-docker-builder@v1` + `useblacksmith/build-push-action@v2` and dropping `cache-from: type=gha` (the GHA cache backend is *not* transparently routed by Blacksmith). Tracked, not in this PR.
- Native arm64 smoke runner (replacing the QEMU emulation in the Linux smoke leg): planned follow-up.
- Whether to delete `test.yml`'s explicit Go-binary cache step now that `$GOCACHE` is colocated: deferred until warm-cache rebuild time can be measured on Blacksmith.

https://claude.ai/code/session_01KgHCbVTurxo4K9KivytQbt