### PR TITLE
fix: alias and telemetry docs link

### DIFF
--- a/apps/cli/src/legacy/commands/link/link.command.ts
+++ b/apps/cli/src/legacy/commands/link/link.command.ts
@@ -8,6 +8,7 @@ const config = {
     Flag.optional,
   ),
   password: Flag.string("password").pipe(
+    Flag.withAlias("p"),
     Flag.withDescription("Password to your remote Postgres database."),
     Flag.optional,
   ),

--- a/apps/cli/src/shared/telemetry/runtime.layer.ts
+++ b/apps/cli/src/shared/telemetry/runtime.layer.ts
@@ -48,7 +48,7 @@ export const telemetryRuntimeLayer = Layer.effect(
       if (config === null && isTty) {
         yield* Effect.sync(() =>
           note(
-            "Supabase collects anonymous usage data to improve the CLI.\nYou can opt out at any time:\n\n  supabase telemetry disable\n\nLearn more: https://supabase.com/docs/cli/telemetry",
+            "Supabase collects anonymous usage data to improve the CLI.\nYou can opt out at any time:\n\n  supabase telemetry disable\n\nLearn more: https://supabase.com/docs/guides/local-development/cli/getting-started#telemetry",
             "Telemetry",
           ),
         );


### PR DESCRIPTION
## TL;DR

fixes a stale 404 telemetry link and 
a smol fix regarding the missing `-p` alias for `supabase link --password` to match go cli/

## ref:

- closes https://github.com/supabase/supabase/issues/46101