### PR TITLE
docs(cli): clarify password field limitations for main branch

### DIFF
--- a/apps/cli-go/cmd/branches.go
+++ b/apps/cli-go/cmd/branches.go
@@ -78,7 +78,9 @@ var (
 	branchGetCmd = &cobra.Command{
 		Use:   "get [name]",
 		Short: "Retrieve details of a preview branch",
-		Long:  "Retrieve details of the specified preview branch.",
+		Long: `Retrieve details of the specified preview branch.
+
+Note: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.`,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/apps/cli-go/cmd/branches.go
+++ b/apps/cli-go/cmd/branches.go
@@ -81,7 +81,7 @@ var (
 		Long: `Retrieve details of the specified preview branch.
 
 Note: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.`,
-		Args:  cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			fsys := afero.NewOsFs()

--- a/apps/cli/src/legacy/commands/branches/get/get.command.ts
+++ b/apps/cli/src/legacy/commands/branches/get/get.command.ts
@@ -16,7 +16,9 @@ const config = {
 export type LegacyBranchesGetFlags = CliCommand.Command.Config.Infer<typeof config>;
 
 export const legacyBranchesGetCommand = Command.make("get", config).pipe(
-  Command.withDescription("Retrieve details of the specified preview branch."),
+  Command.withDescription(
+    "Retrieve details of the specified preview branch.\n\nNote: For the main branch, password-dependent fields (POSTGRES_URL, POSTGRES_URL_NON_POOLING) are not populated because production database credentials are not retrievable via API.",
+  ),
   Command.withShortDescription("Retrieve details of a preview branch"),
   Command.withHandler((flags) => legacyBranchesGet(flags)),
 );


### PR DESCRIPTION
Updates the help text for the `branches get` command in both the Go and TypeScript CLI implementations to clarify that password-dependent database fields are not populated for the main branch.

**Changes:**
- Updated `branchGetCmd` long description in `apps/cli-go/cmd/branches.go` to include a note explaining that `POSTGRES_URL` and `POSTGRES_URL_NON_POOLING` fields are not available for the main branch because production database credentials cannot be retrieved via API
- Updated the command description in `apps/cli/src/legacy/commands/branches/get/get.command.ts` with the same clarification for consistency across CLI implementations

This improves user experience by setting correct expectations when querying main branch details and reduces confusion about missing credential fields.

Closes: CLI-1450

https://claude.ai/code/session_01Dq9V9d8nxzfFkqk3MaHBWB