### PR TITLE
ci(release): conditionally exclude macos-15-intel from smoke test matrix

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -98,15 +98,17 @@ jobs:
 
   smoke-test:
     needs: build
-    # macos-15-intel is the slowest smoke leg and the only one not on
-    # Blacksmith (Blacksmith macOS is ARM-only). Skip it on prereleases
-    # (PR smoke + develop -> beta) so beta wall-clock isn't gated by it;
-    # stable releases on main still run the full matrix.
-    if: ${{ !(matrix.runner == 'macos-15-intel' && inputs.prerelease) }}
     strategy:
       fail-fast: false
+      # macos-15-intel is the slowest smoke leg and the only one not on
+      # Blacksmith (Blacksmith macOS is ARM-only). Drop it from the matrix
+      # on prereleases (PR smoke + develop -> beta) so beta wall-clock isn't
+      # gated by it; stable releases on main still run the full matrix.
+      # The matrix list is built via fromJSON because GitHub Actions does
+      # not allow the `matrix` context in a job-level `if:` (matrix
+      # expansion happens after job conditions are evaluated).
       matrix:
-        runner: [blacksmith-8vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, macos-15-intel, blacksmith-8vcpu-windows-2025]
+        runner: ${{ fromJSON(inputs.prerelease && '["blacksmith-8vcpu-ubuntu-2404","blacksmith-6vcpu-macos-latest","blacksmith-8vcpu-windows-2025"]' || '["blacksmith-8vcpu-ubuntu-2404","blacksmith-6vcpu-macos-latest","macos-15-intel","blacksmith-8vcpu-windows-2025"]') }}
     runs-on: ${{ matrix.runner }}
     env:
       NPM_TAG: ${{ inputs.npm_tag }}


### PR DESCRIPTION
Refactor the smoke test job to conditionally exclude the slowest runner (`macos-15-intel`) from the test matrix on prerelease builds, rather than using a job-level `if:` condition.

**Changes:**
- Moved the prerelease exclusion logic from a job-level `if:` condition into the strategy matrix itself using `fromJSON()`
- The matrix now dynamically expands to either 3 runners (prerelease) or 4 runners (stable release) based on the `inputs.prerelease` flag
- Updated comments to explain the rationale: `macos-15-intel` is the slowest leg and not available on Blacksmith, so excluding it from prerelease builds prevents it from blocking beta wall-clock time while stable releases still run the full matrix

**Implementation details:**
- Uses GitHub Actions' `fromJSON()` to conditionally build the matrix list, since the `matrix` context is not available in job-level `if:` conditions
- The conditional expression selects between two hardcoded runner arrays based on the prerelease flag
- This approach ensures the job runs with the correct matrix expansion rather than skipping the entire job conditionally

https://claude.ai/code/session_01RDNmHeyREpf3ZBQLggK75q