### PR TITLE
fix(cli): inject version into Go binary via ldflags

### DIFF
--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -125,7 +125,8 @@ async function buildGoTarget(target: (typeof TARGETS)[number]) {
   const outfile = path.join(binDir, `supabase-go${target.ext}`);
 
   console.log(`[${target.pkg}] Compiling Go CLI (${goos}/${goarch})...`);
-  await $`go build -trimpath -ldflags="-s -w" -o ${outfile} .`.cwd(goSource).env({
+  const goLdflags = `-s -w -X github.com/supabase/cli/internal/utils.Version=${version}`;
+  await $`go build -trimpath -ldflags=${goLdflags} -o ${outfile} .`.cwd(goSource).env({
     ...process.env,
     GOOS: goos,
     GOARCH: goarch,


### PR DESCRIPTION
## What changed

Pass the npm release version into the bundled `supabase-go` binary via `-ldflags -X github.com/supabase/cli/internal/utils.Version=...` in `apps/cli/scripts/build.ts`.

## Why

The legacy CLI shell forwards most commands to the bundled Go binary. That binary's upgrade banner reports the currently installed version from `utils.Version`, which is a string assigned at compile time via `-ldflags -X`. The Bun build script was only passing `-s -w`, so every release shipped a Go binary with `utils.Version=""`. The user-visible symptom was:

```
A new version of Supabase CLI is available: v2.100.1 (currently installed v)
```

`semver.Compare` treats the empty string as less than any valid version, so the upgrade prompt fired on every invocation regardless of the installed version.

The `-X` injection had been part of the prior `.goreleaser.yml` build but was dropped during the goreleaser → Bun build-script migration. The bug only became user-visible once the `beta` and `stable` channels started building `shell=legacy` again, which is what bundles `supabase-go` into the release tarballs.

## Reviewer notes

- The npm version (no leading `v`) is the right form to inject — `apps/cli-go/cmd/root.go:199` constructs `"v"+utils.Version` for the comparison and other callsites use the raw value.
- The same migration also dropped `-X` injections for `utils.SentryDsn`, `utils.PostHogAPIKey`, and `utils.PostHogEndpoint`. The Go binary in current releases runs without Sentry/PostHog credentials. Out of scope for this PR — worth a separate ticket so the secret-handling and CI-secret wiring can be designed deliberately.

Fixes #5308