### PR TITLE
fix(cli): inject Sentry DSN and PostHog credentials into Go binary

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -49,6 +49,9 @@ jobs:
     env:
       BUN_SHELL: ${{ inputs.shell }}
       VERSION: ${{ inputs.version }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -125,7 +125,20 @@ async function buildGoTarget(target: (typeof TARGETS)[number]) {
   const outfile = path.join(binDir, `supabase-go${target.ext}`);
 
   console.log(`[${target.pkg}] Compiling Go CLI (${goos}/${goarch})...`);
-  const goLdflags = `-s -w -X github.com/supabase/cli/internal/utils.Version=${version}`;
+  const ldflagParts = ["-s", "-w", `-X github.com/supabase/cli/internal/utils.Version=${version}`];
+  const { SENTRY_DSN, POSTHOG_API_KEY, POSTHOG_ENDPOINT } = process.env;
+  if (SENTRY_DSN) {
+    ldflagParts.push(`-X github.com/supabase/cli/internal/utils.SentryDsn=${SENTRY_DSN}`);
+  }
+  if (POSTHOG_API_KEY) {
+    ldflagParts.push(`-X github.com/supabase/cli/internal/utils.PostHogAPIKey=${POSTHOG_API_KEY}`);
+  }
+  if (POSTHOG_ENDPOINT) {
+    ldflagParts.push(
+      `-X github.com/supabase/cli/internal/utils.PostHogEndpoint=${POSTHOG_ENDPOINT}`,
+    );
+  }
+  const goLdflags = ldflagParts.join(" ");
   await $`go build -trimpath -ldflags=${goLdflags} -o ${outfile} .`.cwd(goSource).env({
     ...process.env,
     GOOS: goos,


### PR DESCRIPTION
## What changed

- `apps/cli/scripts/build.ts` — `buildGoTarget` now reads `SENTRY_DSN`, `POSTHOG_API_KEY`, and `POSTHOG_ENDPOINT` from `process.env` and appends a matching `-X github.com/supabase/cli/internal/utils.{SentryDsn,PostHogAPIKey,PostHogEndpoint}=...` segment to the Go linker flags when the value is set.
- `.github/workflows/release-shared.yml` — the `build` job's `env:` block now exposes the three repo secrets so release builds get the values populated.

## Why

Companion fix to #5313. The legacy CLI shell forwards telemetry through the bundled `supabase-go` binary, which reads its Sentry DSN and PostHog credentials from `-ldflags -X`-injected vars. The bun build script only injected `utils.Version`, so every release after the goreleaser → bun-script migration shipped with empty credentials:

- `apps/cli-go/internal/telemetry/service.go:61` constructs the PostHog client with an empty key and host → the client returns a no-op (`internal/telemetry/client.go:32-56`).
- `apps/cli-go/cmd/root.go:78` initializes Sentry with an empty DSN → no-op client.

PostHog event flow stopped on 2026-05-18 with v2.98.2 (the last build produced by the prior pipeline). Restoring these injections matches the historical `.goreleaser.yml` behavior using the same three repo secrets, which already exist (`gh secret list --repo supabase/cli`).

## Reviewer notes

- The TS shells don't need build-time injection. The `next` shell carries hardcoded PostHog defaults with runtime env overrides (`apps/cli/src/next/config/cli-config.layer.ts`), and `legacy` delegates everything to the Go binary via `LegacyGoProxy`.
- The env vars are conditionally appended in the build script, so local builds and PR smoke builds (which don't expose the secrets) produce binaries with empty telemetry credentials and the existing safe no-op runtime behavior — no leakage and no test breakage.
- Verified locally: `SENTRY_DSN=… POSTHOG_API_KEY=… POSTHOG_ENDPOINT=… pnpm exec bun apps/cli/scripts/build.ts --version 2.100.1 --shell legacy` produces a `supabase-go` whose `strings` output contains the three sentinel values; running the same command with the envs unset produces a binary with none of them.

Fixes CLI-1506