### PR TITLE
chore(ci): add setup-cli smoke test workflow

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -329,23 +329,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit "v${VERSION}" --draft=false
 
-  # Post-publish smoke test for the `supabase/setup-cli` GitHub Action against
-  # the just-released beta. The action fetches the binary from the GitHub
-  # release we just published, so it must run after `publish`.
-  #
-  # Gated to beta releases only: beta is where setup-cli regressions need to
-  # be caught fast (it's the channel CI users typically pin via
-  # `version: latest` on `develop`), and running the full matrix on stable
-  # would double the post-publish wall-clock for no extra signal. The same
-  # reusable workflow can be dispatched manually against an arbitrary
-  # already-published version when debugging setup-cli regressions.
-  setup-cli-smoke:
-    needs: publish
-    if: ${{ !inputs.dry_run && inputs.channel == 'beta' }}
-    uses: ./.github/workflows/setup-cli-smoke-test.yml
-    with:
-      version: ${{ inputs.version }}
-
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
@@ -429,3 +412,22 @@ jobs:
         run: pnpm exec bun apps/cli/scripts/update-scoop.ts --version "${VERSION}" --name "${SCOOP_NAME}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  # Post-publish smoke test for the `supabase/setup-cli` GitHub Action against
+  # the just-released CLI. Runs last and intentionally does not gate
+  # publish-homebrew / publish-scoop — by the time the smoke runs, the npm
+  # package and GitHub release are already live and the brew/scoop pushes
+  # have either succeeded or skipped, so a setup-cli regression surfaces as
+  # a red post-release signal without holding back the rest of the channel.
+  #
+  # Depends on the publish jobs only via `needs` for ordering; the `if`
+  # uses `always() && needs.publish.result == 'success'` so the smoke still
+  # runs when publish-homebrew / publish-scoop are skipped (alpha) or fail.
+  # The reusable workflow can also be dispatched manually against any
+  # already-published version when debugging setup-cli regressions.
+  setup-cli-smoke:
+    needs: [publish, publish-homebrew, publish-scoop]
+    if: ${{ always() && !inputs.dry_run && needs.publish.result == 'success' }}
+    uses: ./.github/workflows/setup-cli-smoke-test.yml
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -331,80 +331,20 @@ jobs:
 
   # Post-publish smoke test for the `supabase/setup-cli` GitHub Action against
   # the just-released beta. The action fetches the binary from the GitHub
-  # release we just published, so it must run after `publish`. It exists to
-  # catch regressions like supabase/setup-cli#427 where the action silently
-  # stopped working on Alpine-based containers (musl libc + archive layout
-  # changes broke PATH resolution and binary execution).
+  # release we just published, so it must run after `publish`.
   #
   # Gated to beta releases only: beta is where setup-cli regressions need to
   # be caught fast (it's the channel CI users typically pin via
   # `version: latest` on `develop`), and running the full matrix on stable
-  # would double the post-publish wall-clock for no extra signal.
-  setup-cli-smoke-test:
+  # would double the post-publish wall-clock for no extra signal. The same
+  # reusable workflow can be dispatched manually against an arbitrary
+  # already-published version when debugging setup-cli regressions.
+  setup-cli-smoke:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.channel == 'beta' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.runner }}
-    env:
-      VERSION: ${{ inputs.version }}
-    steps:
-      - name: Install Supabase CLI via setup-cli
-        uses: supabase/setup-cli@v1
-        with:
-          version: ${{ inputs.version }}
-      - name: Verify supabase --version matches the published beta
-        shell: bash
-        run: |
-          set -euo pipefail
-          actual="$(supabase --version | tr -d '\r' | head -n1)"
-          echo "supabase --version: ${actual}"
-          if [ "${actual}" != "${VERSION}" ]; then
-            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
-            exit 1
-          fi
-
-  # Alpine leg of the setup-cli smoke test. Kept as a separate job because
-  # GitHub Actions only honours the `container:` field on Linux runners, and
-  # mixing container + non-container entries in a single matrix via
-  # `container: ${{ matrix.container }}` is fragile when the value is empty.
-  #
-  # The musl-vs-glibc + archive layout regressions tracked in
-  # supabase/setup-cli#427 only reproduce inside a real Alpine container, so
-  # this job is the actual signal the task in CLI-1507 was created for.
-  setup-cli-smoke-test-alpine:
-    needs: publish
-    if: ${{ !inputs.dry_run && inputs.channel == 'beta' }}
-    runs-on: ubuntu-latest
-    # `node:20-alpine` ships a musl-linked Node, which is required for
-    # JavaScript-based actions (setup-cli included) to launch inside an
-    # Alpine container — the runner's mounted glibc Node won't execute here.
-    container:
-      image: node:20-alpine
-    env:
-      VERSION: ${{ inputs.version }}
-    steps:
-      - name: Install Alpine prerequisites
-        run: apk add --no-cache bash curl tar
-      - name: Install Supabase CLI via setup-cli
-        uses: supabase/setup-cli@v1
-        with:
-          version: ${{ inputs.version }}
-      - name: Verify supabase --version matches the published beta
-        shell: bash
-        run: |
-          set -euo pipefail
-          actual="$(supabase --version | tr -d '\r' | head -n1)"
-          echo "supabase --version: ${actual}"
-          if [ "${actual}" != "${VERSION}" ]; then
-            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
-            exit 1
-          fi
+    uses: ./.github/workflows/setup-cli-smoke-test.yml
+    with:
+      version: ${{ inputs.version }}
 
   publish-homebrew:
     needs: publish

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -329,6 +329,83 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit "v${VERSION}" --draft=false
 
+  # Post-publish smoke test for the `supabase/setup-cli` GitHub Action against
+  # the just-released beta. The action fetches the binary from the GitHub
+  # release we just published, so it must run after `publish`. It exists to
+  # catch regressions like supabase/setup-cli#427 where the action silently
+  # stopped working on Alpine-based containers (musl libc + archive layout
+  # changes broke PATH resolution and binary execution).
+  #
+  # Gated to beta releases only: beta is where setup-cli regressions need to
+  # be caught fast (it's the channel CI users typically pin via
+  # `version: latest` on `develop`), and running the full matrix on stable
+  # would double the post-publish wall-clock for no extra signal.
+  setup-cli-smoke-test:
+    needs: publish
+    if: ${{ !inputs.dry_run && inputs.channel == 'beta' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Install Supabase CLI via setup-cli
+        uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Verify supabase --version matches the published beta
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(supabase --version | tr -d '\r' | head -n1)"
+          echo "supabase --version: ${actual}"
+          if [ "${actual}" != "${VERSION}" ]; then
+            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+            exit 1
+          fi
+
+  # Alpine leg of the setup-cli smoke test. Kept as a separate job because
+  # GitHub Actions only honours the `container:` field on Linux runners, and
+  # mixing container + non-container entries in a single matrix via
+  # `container: ${{ matrix.container }}` is fragile when the value is empty.
+  #
+  # The musl-vs-glibc + archive layout regressions tracked in
+  # supabase/setup-cli#427 only reproduce inside a real Alpine container, so
+  # this job is the actual signal the task in CLI-1507 was created for.
+  setup-cli-smoke-test-alpine:
+    needs: publish
+    if: ${{ !inputs.dry_run && inputs.channel == 'beta' }}
+    runs-on: ubuntu-latest
+    # `node:20-alpine` ships a musl-linked Node, which is required for
+    # JavaScript-based actions (setup-cli included) to launch inside an
+    # Alpine container — the runner's mounted glibc Node won't execute here.
+    container:
+      image: node:20-alpine
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Install Alpine prerequisites
+        run: apk add --no-cache bash curl tar
+      - name: Install Supabase CLI via setup-cli
+        uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Verify supabase --version matches the published beta
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(supabase --version | tr -d '\r' | head -n1)"
+          echo "supabase --version: ${actual}"
+          if [ "${actual}" != "${VERSION}" ]; then
+            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+            exit 1
+          fi
+
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}

--- a/.github/workflows/setup-cli-smoke-test.yml
+++ b/.github/workflows/setup-cli-smoke-test.yml
@@ -1,0 +1,90 @@
+name: setup-cli Smoke Test
+
+# Smoke test for the `supabase/setup-cli` GitHub Action against a specific
+# published CLI version. Run automatically after every beta release (called
+# from release-shared.yml's `setup-cli-smoke` job) and also manually via
+# workflow_dispatch when debugging setup-cli regressions or verifying that
+# a previously broken environment (e.g. Alpine) is back to green.
+#
+# Exists primarily to catch regressions like supabase/setup-cli#427 where
+# musl libc + archive layout changes broke the action on Alpine silently.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Supabase CLI version to install via setup-cli (must already be published to GitHub Releases)
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Supabase CLI version to install via setup-cli (must already be published to GitHub Releases)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  setup-cli-smoke-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Install Supabase CLI via setup-cli
+        uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Verify supabase --version matches the expected version
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(supabase --version | tr -d '\r' | head -n1)"
+          echo "supabase --version: ${actual}"
+          if [ "${actual}" != "${VERSION}" ]; then
+            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+            exit 1
+          fi
+
+  # Alpine leg of the setup-cli smoke test. Kept as a separate job because
+  # GitHub Actions only honours the `container:` field on Linux runners, and
+  # mixing container + non-container entries in a single matrix via
+  # `container: ${{ matrix.container }}` is fragile when the value is empty.
+  #
+  # The musl-vs-glibc + archive layout regressions tracked in
+  # supabase/setup-cli#427 only reproduce inside a real Alpine container, so
+  # this job is the actual signal the workflow was created for.
+  setup-cli-smoke-test-alpine:
+    runs-on: ubuntu-latest
+    # `node:20-alpine` ships a musl-linked Node, which is required for
+    # JavaScript-based actions (setup-cli included) to launch inside an
+    # Alpine container — the runner's mounted glibc Node won't execute here.
+    container:
+      image: node:20-alpine
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Install Alpine prerequisites
+        run: apk add --no-cache bash curl tar
+      - name: Install Supabase CLI via setup-cli
+        uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Verify supabase --version matches the expected version
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(supabase --version | tr -d '\r' | head -n1)"
+          echo "supabase --version: ${actual}"
+          if [ "${actual}" != "${VERSION}" ]; then
+            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+            exit 1
+          fi

--- a/.github/workflows/setup-cli-smoke-test.yml
+++ b/.github/workflows/setup-cli-smoke-test.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   setup-cli-smoke-test:
+    name: setup-cli ${{ matrix.major-version }} (${{ matrix.runner }})
     strategy:
       fail-fast: false
       matrix:
@@ -35,12 +36,24 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        # GitHub Actions doesn't allow expressions in `uses:`, so the action
+        # ref is selected via two `if:`-gated install steps below rather than
+        # interpolating `matrix.major-version` into a single `uses:` line.
+        major-version:
+          - v1
+          - v2
     runs-on: ${{ matrix.runner }}
     env:
       VERSION: ${{ inputs.version }}
     steps:
-      - name: Install Supabase CLI via setup-cli
+      - name: Install Supabase CLI via setup-cli@v1
+        if: matrix.major-version == 'v1'
         uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Install Supabase CLI via setup-cli@v2
+        if: matrix.major-version == 'v2'
+        uses: supabase/setup-cli@v2
         with:
           version: ${{ inputs.version }}
       - name: Verify supabase --version matches the expected version
@@ -63,6 +76,13 @@ jobs:
   # supabase/setup-cli#427 only reproduce inside a real Alpine container, so
   # this job is the actual signal the workflow was created for.
   setup-cli-smoke-test-alpine:
+    name: setup-cli ${{ matrix.major-version }} (alpine)
+    strategy:
+      fail-fast: false
+      matrix:
+        major-version:
+          - v1
+          - v2
     runs-on: ubuntu-latest
     # `node:20-alpine` ships a musl-linked Node, which is required for
     # JavaScript-based actions (setup-cli included) to launch inside an
@@ -74,8 +94,14 @@ jobs:
     steps:
       - name: Install Alpine prerequisites
         run: apk add --no-cache bash curl tar
-      - name: Install Supabase CLI via setup-cli
+      - name: Install Supabase CLI via setup-cli@v1
+        if: matrix.major-version == 'v1'
         uses: supabase/setup-cli@v1
+        with:
+          version: ${{ inputs.version }}
+      - name: Install Supabase CLI via setup-cli@v2
+        if: matrix.major-version == 'v2'
+        uses: supabase/setup-cli@v2
         with:
           version: ${{ inputs.version }}
       - name: Verify supabase --version matches the expected version


### PR DESCRIPTION
Add a new GitHub Actions workflow to smoke test the `supabase/setup-cli` action against published CLI versions. This catches regressions like setup-cli#427 where musl libc and archive layout changes broke the action on Alpine silently.

**Key changes:**

- New `.github/workflows/setup-cli-smoke-test.yml` workflow that:
  - Tests CLI installation across Ubuntu, macOS, and Windows runners
  - Includes a dedicated Alpine container job to catch musl libc regressions
  - Verifies the installed CLI version matches the expected version
  - Can be triggered manually via `workflow_dispatch` or called from other workflows
  
- Updated `.github/workflows/release-shared.yml` to:
  - Add a `setup-cli-smoke` job that runs after beta releases
  - Runs as a post-publish signal without gating other release jobs
  - Uses `always() && needs.publish.result == 'success'` to run even when homebrew/scoop jobs are skipped or fail

The Alpine job is kept separate because GitHub Actions only honors the `container:` field on Linux runners, and the musl-vs-glibc regressions only reproduce inside a real Alpine container.

Closes: CLI-1507

https://claude.ai/code/session_01NzzeYET8sYhpCVdSvBBJhC