### PR TITLE
ci(release): add manual backfill-release-notes workflow

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -1,0 +1,91 @@
+name: Backfill release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to refresh (e.g. v2.100.1)
+        required: true
+        type: string
+      apply:
+        description: Update the GitHub release body (otherwise dry-run only)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ inputs.tag }}
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      # semantic-release computes the *next* release based on commits since the
+      # latest channel tag. To re-derive notes for an existing tag, delete the
+      # tag locally and synthesise a branch name that matches the channel
+      # config in apps/cli/package.json (main / develop) at the tag's commit.
+      - name: Re-stage repo as if $TAG were unpublished
+        run: |
+          set -euo pipefail
+          sha=$(git rev-list -n 1 "$TAG")
+          git tag -d "$TAG"
+          if [[ "$TAG" == *-beta.* ]]; then
+            branch=develop
+          else
+            branch=main
+          fi
+          git checkout -B "$branch" "$sha"
+          echo "Re-staged on $branch @ $sha (without tag $TAG)"
+
+      - id: sr
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        with:
+          working_directory: apps/cli
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Verify computed version matches $TAG
+        env:
+          SR_VERSION: ${{ steps.sr.outputs.new_release_version }}
+        run: |
+          set -euo pipefail
+          want="${TAG#v}"
+          if [[ "$SR_VERSION" != "$want" ]]; then
+            echo "::error::semantic-release computed v$SR_VERSION but tag is $TAG; check channel config / tag history"
+            exit 1
+          fi
+
+      - name: Show generated notes
+        env:
+          NOTES: ${{ steps.sr.outputs.new_release_notes }}
+        run: |
+          {
+            echo "## Notes for $TAG"
+            echo
+            printf '%s\n' "$NOTES"
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "$NOTES" > notes.md
+
+      - name: Update GitHub Release body
+        if: inputs.apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$TAG" --notes-file notes.md

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -85,7 +85,8 @@
       }
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer"
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator"
     ]
   },
   "knip": {


### PR DESCRIPTION
The plan job in release.yml runs cycjimmy/semantic-release-action in dry-run mode purely to compute the next version, never reading new_release_notes, and softprops/action-gh-release in release-shared.yml gets no body. The result: GH Releases since the monorepo move publish with empty bodies (e.g. v2.100.1).

A subsequent change will plumb release notes through the production publish path. This commit lands the prerequisites only:

- apps/cli/package.json: add @semantic-release/release-notes-generator to release.plugins. It's a default semantic-release plugin bundled in cycjimmy/semantic-release-action's image, so no devDep is needed. Without this, new_release_notes would be empty even after wiring.

- .github/workflows/backfill-release-notes.yml: workflow_dispatch with tag and apply inputs. Re-stages the repo on develop/main at the tag's commit (without the tag, so semantic-release computes it as the next release), asserts the computed version matches the tag, dumps the notes to the job summary, and only updates the GH Release body when apply=true. Lets us validate the changelog format end-to-end against an existing tag before touching the production publish path, and doubles as a fix-forward tool for releases that ship with an empty body (e.g. v2.100.1, the recent betas, or any future workflow_dispatch re-cut).

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
