### PR TITLE
chore(ci): drop co-incident tags in backfill-release-notes so it picks the right baseline

### DIFF
--- a/apps/cli/scripts/backfill-release-notes.ts
+++ b/apps/cli/scripts/backfill-release-notes.ts
@@ -91,7 +91,20 @@ try {
     .quiet();
 
   const sha = (await $`git -C ${clone} rev-list -n 1 ${tag}`.text()).trim();
-  await $`git -C ${clone} tag -d ${tag}`.quiet();
+  // Delete the target tag *and* any other local tags pointing at the same
+  // commit. When a stable and a beta share a commit (e.g. v2.100.0 and
+  // v2.100.0-beta.2 both at 9a22aff6), semantic-release picks the higher-
+  // semver one as lastRelease - which becomes HEAD itself, leaving 0
+  // commits and "no release". Dropping the co-incident tags lets it fall
+  // back to the genuine prior release on the channel.
+  const coincidentTagsOut = await $`git -C ${clone} tag --points-at ${sha}`.text();
+  const coincidentTags = coincidentTagsOut
+    .split("\n")
+    .map((t) => t.trim())
+    .filter(Boolean);
+  for (const ct of coincidentTags) {
+    await $`git -C ${clone} tag -d ${ct}`.quiet().nothrow();
+  }
   await $`git -C ${clone} checkout -B ${branch} ${sha} --quiet`;
 
   // The clone only carries refs/heads/$BRANCH locally; seed the other


### PR DESCRIPTION
Fixes `bun apps/cli/scripts/backfill-release-notes.ts --tag v2.100.0-beta.2`, which currently errors with `semantic-release did not compute a next release for v2.100.0-beta.2`.

## Why it fails today

semantic-release's `lastRelease` picker accepts both prerelease tags on the branch's channel **and** stable tags via the prerelease filter's stable-fallback clause, then sorts the survivors by semver. When a stable and a beta share a commit (e.g. `v2.100.0` and `v2.100.0-beta.2` are both at `9a22aff6`), the stable wins the sort — and since it points at HEAD itself, semantic-release reports "Found 0 commits since last release" and emits no `nextRelease`. The script's version-mismatch guard then exits with the "did not compute a next release" error.

## Fix

After resolving the target tag's commit, delete *every* local tag that points at that commit, not just the target. Co-located tags are by definition the same release, and dropping them lets semantic-release fall back to the genuine prior release on the channel (`v2.100.0-beta.1` in the example).

## Sample output (`v2.100.0-beta.2`)

```sh
$ bun apps/cli/scripts/backfill-release-notes.ts --tag v2.100.0-beta.2
```

```markdown
# [2.100.0-beta.2](https://github.com/supabase/cli/compare/v2.100.0-beta.1...v2.100.0-beta.2) (2026-05-20)


### Features

* **cli:** add hidden flag support for legacy commands ([#5278](https://github.com/supabase/cli/issues/5278)) ([9a22aff](https://github.com/supabase/cli/commit/9a22aff6f109ab1577f2b5ef004f1c59fec1f38b)), closes [#5277](https://github.com/supabase/cli/issues/5277)
```

Regression-checked locally that `v2.99.0-beta.2` (where stable and beta are on different commits) and `v2.100.1` (stable backfill) still produce the same output as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_016p4TNXziTipWocxmgLDc8b)_