### PR TITLE
chore(ci): configure git identity for release notes backfill

### DIFF
--- a/apps/cli/scripts/backfill-release-notes.ts
+++ b/apps/cli/scripts/backfill-release-notes.ts
@@ -75,6 +75,18 @@ try {
   console.error(`==> Cloning ${repoRoot} -> ${clone}`);
   await $`git clone --quiet --no-local ${repoRoot} ${clone}`;
 
+  // `git notes add` (used below to seed channel notes) requires a committer
+  // identity. CI runners don't ship one in ~/.gitconfig, so without this the
+  // seeding loop silently fails - semantic-release then can't see prior beta
+  // tags on the beta channel and computes the wrong next version.
+  await $`git -C ${clone} config --local user.email backfill-release-notes@supabase.local`;
+  await $`git -C ${clone} config --local user.name backfill-release-notes`;
+  // Same reason - and `commit.gpgsign`/`tag.gpgsign` inherited from a user's
+  // global config would make `git notes add` fail in environments without a
+  // signing key. The temp clone never publishes anything, so disable signing.
+  await $`git -C ${clone} config --local commit.gpgsign false`;
+  await $`git -C ${clone} config --local tag.gpgsign false`;
+
   const originUrl = (await $`git -C ${repoRoot} remote get-url origin`.text()).trim();
 
   // Notes refs aren't fetched by `git clone`. Pull from the source repo first
@@ -139,9 +151,7 @@ try {
         ? "alpha"
         : "latest";
     const payload = JSON.stringify({ channels: [channel] });
-    await $`git -C ${clone} notes --ref semantic-release add -f -m ${payload} ${prevTag}^{commit}`
-      .nothrow()
-      .quiet();
+    await $`git -C ${clone} notes --ref semantic-release add -f -m ${payload} ${prevTag}^{commit}`.quiet();
   }
 
   // Apply the *current* release config to the historical checkout. Before


### PR DESCRIPTION
Fixes a silent failure in the `backfill-release-notes` script where `git notes add` would fail in CI environments that lack a configured git committer identity and GPG signing setup.

**Changes:**
- Configure local git user email and name in the temporary clone before seeding channel notes
- Disable `commit.gpgsign` and `tag.gpgsign` in the clone to prevent failures when global signing config is inherited but no signing key is available
- Remove `.nothrow()` from the `git notes add` call since the git config is now properly set up and failures should be surfaced

This ensures that semantic-release can correctly identify prior beta tags and compute the correct next version during the backfill process.

https://claude.ai/code/session_01FX5hRgt2dXeZzMoLGcyU9A