### PR TITLE
chore(ci): strip GitHub Actions env vars in backfill-release-notes

### DIFF
--- a/apps/cli/scripts/backfill-release-notes.ts
+++ b/apps/cli/scripts/backfill-release-notes.ts
@@ -175,11 +175,32 @@ try {
   console.error(`==> Re-staged on ${branch} @ ${sha} (without tag ${tag})`);
   console.error(`==> Running semantic-release --dry-run`);
 
+  // semantic-release uses env-ci to detect the current branch, which reads
+  // GITHUB_REF (and friends) from the GitHub Actions environment. `noCi: true`
+  // only bypasses the "not in CI" guard - it does not stop env-ci from
+  // resolving the branch from CI vars. When backfilling v2.100.1 from a
+  // workflow that ran on develop, env-ci returns "develop" even though the
+  // clone's HEAD points at main, and semantic-release then complains that
+  // local develop is behind remote. Strip the GitHub Actions detection vars
+  // so env-ci falls back to reading the branch from git HEAD in the clone.
+  const childEnv = { ...process.env };
+  for (const key of [
+    "GITHUB_ACTIONS",
+    "GITHUB_REF",
+    "GITHUB_REF_NAME",
+    "GITHUB_HEAD_REF",
+    "GITHUB_BASE_REF",
+    "GITHUB_EVENT_NAME",
+    "CI",
+  ]) {
+    delete childEnv[key];
+  }
+
   const result = await semanticRelease(
     { dryRun: true, noCi: true, repositoryUrl: repoUrl },
     {
       cwd: path.join(clone, "apps/cli"),
-      env: process.env,
+      env: childEnv,
       stdout: process.stderr,
       stderr: process.stderr,
     },


### PR DESCRIPTION
Fix the backfill-release-notes script to correctly detect the git branch when running semantic-release in dry-run mode.

The script was passing the full process environment to semantic-release, which includes GitHub Actions detection variables (GITHUB_REF, GITHUB_ACTIONS, etc.). The semantic-release library uses env-ci to detect the current branch, and env-ci prioritizes these CI environment variables over the actual git HEAD state. This caused env-ci to report the wrong branch when backfilling from a workflow that ran on a different branch than the current clone's HEAD, leading to semantic-release errors about local branches being behind remote.

**Key changes:**
- Create a filtered child environment that strips GitHub Actions detection variables (GITHUB_ACTIONS, GITHUB_REF, GITHUB_REF_NAME, GITHUB_HEAD_REF, GITHUB_BASE_REF, GITHUB_EVENT_NAME, CI)
- Pass the filtered environment to semantic-release instead of the full process environment
- This allows env-ci to fall back to reading the branch from git HEAD in the clone, which is the correct source of truth for the backfill operation

https://claude.ai/code/session_01QQsjHNdZTJHhLWr2FYSjhe