### PR TITLE
chore(ci): strip leading `v` from VERSION before comparing

### DIFF
--- a/.github/workflows/setup-cli-smoke-test.yml
+++ b/.github/workflows/setup-cli-smoke-test.yml
@@ -60,10 +60,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # `supabase --version` prints the version without the leading `v`,
+          # while release tags / setup-cli inputs include it, so strip it
+          # before comparing.
+          expected="${VERSION#v}"
           actual="$(supabase --version | tr -d '\r' | head -n1)"
           echo "supabase --version: ${actual}"
-          if [ "${actual}" != "${VERSION}" ]; then
-            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+          if [ "${actual}" != "${expected}" ]; then
+            echo "Version mismatch: expected ${expected}, got ${actual}" >&2
             exit 1
           fi
 
@@ -108,9 +112,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # `supabase --version` prints the version without the leading `v`,
+          # while release tags / setup-cli inputs include it, so strip it
+          # before comparing.
+          expected="${VERSION#v}"
           actual="$(supabase --version | tr -d '\r' | head -n1)"
           echo "supabase --version: ${actual}"
-          if [ "${actual}" != "${VERSION}" ]; then
-            echo "Version mismatch: expected ${VERSION}, got ${actual}" >&2
+          if [ "${actual}" != "${expected}" ]; then
+            echo "Version mismatch: expected ${expected}, got ${actual}" >&2
             exit 1
           fi


### PR DESCRIPTION
The smoke test workflow compares the output of `supabase --version` against the `VERSION` environment variable. However, `supabase --version` outputs the version without a leading `v`, while release tags and setup-cli inputs include it. This causes version mismatches during testing.

**Changes:**
- Strip the leading `v` from `VERSION` before comparison in both smoke test jobs
- Add clarifying comments explaining why the stripping is necessary

The fix uses bash parameter expansion (`${VERSION#v}`) to remove the leading `v` if present, ensuring the comparison is between two consistently formatted version strings.

https://claude.ai/code/session_01S5jBFMNp5mHAWhS9inCagB