### PR TITLE
fix(cli): support older x64 CPUs

### DIFF
--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -12,7 +12,7 @@ const MUSL_TARGETS = [
     nfpmArch: "arm64",
   },
   {
-    bunTarget: "bun-linux-x64-musl",
+    bunTarget: "bun-linux-x64-musl-baseline",
     pkg: "cli-linux-x64-musl",
     nfpmArch: "amd64",
   },
@@ -62,14 +62,14 @@ const TARGETS = [
     ext: "",
   },
   {
-    bunTarget: "bun-linux-x64",
+    bunTarget: "bun-linux-x64-baseline",
     pkg: "cli-linux-x64",
     archive: `supabase_${version}_linux_amd64.tar.gz`,
     nfpmArch: "amd64",
     ext: "",
   },
   {
-    bunTarget: "bun-windows-x64",
+    bunTarget: "bun-windows-x64-baseline",
     pkg: "cli-windows-x64",
     archive: `supabase_${version}_windows_amd64.zip`,
     ext: ".exe",
@@ -93,8 +93,8 @@ const GO_TARGETS: Record<BunTarget, { goos: string; goarch: string }> = {
   "bun-darwin-arm64": { goos: "darwin", goarch: "arm64" },
   "bun-darwin-x64": { goos: "darwin", goarch: "amd64" },
   "bun-linux-arm64": { goos: "linux", goarch: "arm64" },
-  "bun-linux-x64": { goos: "linux", goarch: "amd64" },
-  "bun-windows-x64": { goos: "windows", goarch: "amd64" },
+  "bun-linux-x64-baseline": { goos: "linux", goarch: "amd64" },
+  "bun-windows-x64-baseline": { goos: "windows", goarch: "amd64" },
   "bun-windows-arm64": { goos: "windows", goarch: "arm64" },
 };
 
@@ -102,7 +102,7 @@ function libcForBunTarget(target: string): "glibc" | "musl" | "" {
   if (!target.startsWith("bun-linux-")) {
     return "";
   }
-  return target.endsWith("-musl") ? "musl" : "glibc";
+  return target.includes("-musl") ? "musl" : "glibc";
 }
 
 async function buildTarget(target: (typeof TARGETS)[number]) {

--- a/tools/release/local-release.ts
+++ b/tools/release/local-release.ts
@@ -25,294 +25,278 @@ const tokenPath = path.join(root, "tmp", "verdaccio-token");
 
 // All seven platform packages that appear in optionalDependencies.
 const PLATFORM_PACKAGES = [
-	"cli-darwin-arm64",
-	"cli-darwin-x64",
-	"cli-linux-arm64",
-	"cli-linux-arm64-musl",
-	"cli-linux-x64",
-	"cli-linux-x64-musl",
-	"cli-windows-arm64",
-	"cli-windows-x64",
+  "cli-darwin-arm64",
+  "cli-darwin-x64",
+  "cli-linux-arm64",
+  "cli-linux-arm64-musl",
+  "cli-linux-x64",
+  "cli-linux-x64-musl",
+  "cli-windows-arm64",
+  "cli-windows-x64",
 ] as const;
 
 type PlatformInfo = {
-	bunTarget: string;
-	platformPkg: string;
-	ext: string;
-	goos: string;
-	goarch: string;
+  bunTarget: string;
+  platformPkg: string;
+  ext: string;
+  goos: string;
+  goarch: string;
 };
 
 const PLATFORM_MAP: Record<string, PlatformInfo> = {
-	"darwin-arm64": {
-		bunTarget: "bun-darwin-arm64",
-		platformPkg: "cli-darwin-arm64",
-		ext: "",
-		goos: "darwin",
-		goarch: "arm64",
-	},
-	"darwin-x64": {
-		bunTarget: "bun-darwin-x64",
-		platformPkg: "cli-darwin-x64",
-		ext: "",
-		goos: "darwin",
-		goarch: "amd64",
-	},
-	"linux-arm64": {
-		bunTarget: "bun-linux-arm64",
-		platformPkg: "cli-linux-arm64",
-		ext: "",
-		goos: "linux",
-		goarch: "arm64",
-	},
-	"linux-x64": {
-		bunTarget: "bun-linux-x64",
-		platformPkg: "cli-linux-x64",
-		ext: "",
-		goos: "linux",
-		goarch: "amd64",
-	},
-	"win32-x64": {
-		bunTarget: "bun-windows-x64",
-		platformPkg: "cli-windows-x64",
-		ext: ".exe",
-		goos: "windows",
-		goarch: "amd64",
-	},
-	"win32-arm64": {
-		bunTarget: "bun-windows-arm64",
-		platformPkg: "cli-windows-arm64",
-		ext: ".exe",
-		goos: "windows",
-		goarch: "arm64",
-	},
+  "darwin-arm64": {
+    bunTarget: "bun-darwin-arm64",
+    platformPkg: "cli-darwin-arm64",
+    ext: "",
+    goos: "darwin",
+    goarch: "arm64",
+  },
+  "darwin-x64": {
+    bunTarget: "bun-darwin-x64",
+    platformPkg: "cli-darwin-x64",
+    ext: "",
+    goos: "darwin",
+    goarch: "amd64",
+  },
+  "linux-arm64": {
+    bunTarget: "bun-linux-arm64",
+    platformPkg: "cli-linux-arm64",
+    ext: "",
+    goos: "linux",
+    goarch: "arm64",
+  },
+  "linux-x64": {
+    bunTarget: "bun-linux-x64-baseline",
+    platformPkg: "cli-linux-x64",
+    ext: "",
+    goos: "linux",
+    goarch: "amd64",
+  },
+  "win32-x64": {
+    bunTarget: "bun-windows-x64-baseline",
+    platformPkg: "cli-windows-x64",
+    ext: ".exe",
+    goos: "windows",
+    goarch: "amd64",
+  },
+  "win32-arm64": {
+    bunTarget: "bun-windows-arm64",
+    platformPkg: "cli-windows-arm64",
+    ext: ".exe",
+    goos: "windows",
+    goarch: "arm64",
+  },
 };
 
 function getPlatformInfo(): PlatformInfo {
-	const key = `${process.platform}-${process.arch}`;
-	const info = PLATFORM_MAP[key];
-	if (!info) {
-		console.error(`\nError: Unsupported platform: ${key}`);
-		console.error(
-			"Supported: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-x64\n",
-		);
-		process.exit(1);
-	}
-	return info;
+  const key = `${process.platform}-${process.arch}`;
+  const info = PLATFORM_MAP[key];
+  if (!info) {
+    console.error(`\nError: Unsupported platform: ${key}`);
+    console.error("Supported: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-x64\n");
+    process.exit(1);
+  }
+  return info;
 }
 
 function libcForBunTarget(target: string): "glibc" | "musl" | "" {
-	if (!target.startsWith("bun-linux-")) {
-		return "";
-	}
-	return target.endsWith("-musl") ? "musl" : "glibc";
+  if (!target.startsWith("bun-linux-")) {
+    return "";
+  }
+  return target.includes("-musl") ? "musl" : "glibc";
 }
 
 async function checkRegistry(): Promise<void> {
-	try {
-		const res = await fetch(`${REGISTRY}/-/ping`, {
-			signal: AbortSignal.timeout(3000),
-		});
-		if (!res.ok) throw new Error(`HTTP ${res.status}`);
-	} catch {
-		console.error(`\nError: Local registry not responding at ${REGISTRY}`);
-		console.error("Start it first with: pnpm local-registry\n");
-		process.exit(1);
-	}
+  try {
+    const res = await fetch(`${REGISTRY}/-/ping`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  } catch {
+    console.error(`\nError: Local registry not responding at ${REGISTRY}`);
+    console.error("Start it first with: pnpm local-registry\n");
+    process.exit(1);
+  }
 }
 
 async function readToken(): Promise<string> {
-	try {
-		return (await Bun.file(tokenPath).text()).trim();
-	} catch {
-		console.error(`\nError: Auth token not found at ${tokenPath}`);
-		console.error(
-			"The local registry must be running before you release: pnpm local-registry\n",
-		);
-		process.exit(1);
-	}
+  try {
+    return (await Bun.file(tokenPath).text()).trim();
+  } catch {
+    console.error(`\nError: Auth token not found at ${tokenPath}`);
+    console.error("The local registry must be running before you release: pnpm local-registry\n");
+    process.exit(1);
+  }
 }
 
 async function checkGo(): Promise<void> {
-	try {
-		await $`go version`.quiet();
-	} catch {
-		console.error("\nError: `go` not found in PATH.");
-		console.error("Install Go from https://go.dev/dl/ to build the legacy shell.\n");
-		process.exit(1);
-	}
+  try {
+    await $`go version`.quiet();
+  } catch {
+    console.error("\nError: `go` not found in PATH.");
+    console.error("Install Go from https://go.dev/dl/ to build the legacy shell.\n");
+    process.exit(1);
+  }
 }
 
 async function checkGoSource(): Promise<string> {
-	const goSource = path.join(root, "apps", "cli-go");
-	const goMod = Bun.file(path.join(goSource, "go.mod"));
-	if (!(await goMod.exists())) {
-		console.error("\nError: Go CLI source not found at apps/cli-go");
-		console.error("Run: pnpm repos:install\n");
-		process.exit(1);
-	}
-	return goSource;
+  const goSource = path.join(root, "apps", "cli-go");
+  const goMod = Bun.file(path.join(goSource, "go.mod"));
+  if (!(await goMod.exists())) {
+    console.error("\nError: Go CLI source not found at apps/cli-go");
+    console.error("Run: pnpm repos:install\n");
+    process.exit(1);
+  }
+  return goSource;
 }
 
 async function main() {
-	const { values } = parseArgs({
-		options: {
-			legacy: { type: "boolean", default: false },
-			next: { type: "boolean", default: false },
-			version: { type: "string" },
-		},
-	});
+  const { values } = parseArgs({
+    options: {
+      legacy: { type: "boolean", default: false },
+      next: { type: "boolean", default: false },
+      version: { type: "string" },
+    },
+  });
 
-	if (!values.legacy && !values.next) {
-		console.error("Usage: pnpm cli-release --next | --legacy [--version <v>]");
-		process.exit(1);
-	}
-	if (values.legacy && values.next) {
-		console.error("Error: Specify either --next or --legacy, not both.");
-		process.exit(1);
-	}
+  if (!values.legacy && !values.next) {
+    console.error("Usage: pnpm cli-release --next | --legacy [--version <v>]");
+    process.exit(1);
+  }
+  if (values.legacy && values.next) {
+    console.error("Error: Specify either --next or --legacy, not both.");
+    process.exit(1);
+  }
 
-	const shell = values.legacy ? "legacy" : "next";
-	const version = values.version ?? `0.0.0-local.${Math.floor(Date.now() / 1000)}`;
+  const shell = values.legacy ? "legacy" : "next";
+  const version = values.version ?? `0.0.0-local.${Math.floor(Date.now() / 1000)}`;
 
-	await checkRegistry();
-	const token = await readToken();
-	const platform = getPlatformInfo();
+  await checkRegistry();
+  const token = await readToken();
+  const platform = getPlatformInfo();
 
-	let goSource: string | undefined;
-	if (shell === "legacy") {
-		await checkGo();
-		goSource = await checkGoSource();
+  let goSource: string | undefined;
+  if (shell === "legacy") {
+    await checkGo();
+    goSource = await checkGoSource();
 
-		if (process.platform === "linux") {
-			console.warn(
-				"Note: local-release builds the glibc variant only (cli-linux-*). " +
-					"The musl variant is skipped for local dev.\n",
-			);
-		}
-	}
+    if (process.platform === "linux") {
+      console.warn(
+        "Note: local-release builds the glibc variant only (cli-linux-*). " +
+          "The musl variant is skipped for local dev.\n",
+      );
+    }
+  }
 
-	// All build output goes into a system temp directory — never into the git repo.
-	const tmpDir = await mkdtemp(path.join(tmpdir(), "supabase-local-release-"));
+  // All build output goes into a system temp directory — never into the git repo.
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "supabase-local-release-"));
 
-	try {
-		// Read once up front so log lines and the published package.json agree.
-		const cliPkgJson = await Bun.file(
-			path.join(root, "apps", "cli", "package.json"),
-		).json();
-		const umbrellaName: string = cliPkgJson.name;
+  try {
+    // Read once up front so log lines and the published package.json agree.
+    const cliPkgJson = await Bun.file(path.join(root, "apps", "cli", "package.json")).json();
+    const umbrellaName: string = cliPkgJson.name;
 
-		console.log(
-			`\nBuilding ${umbrellaName}@${version} (${shell}, ${platform.platformPkg})...\n`,
-		);
+    console.log(`\nBuilding ${umbrellaName}@${version} (${shell}, ${platform.platformPkg})...\n`);
 
-		// ── Build platform package ────────────────────────────────────────────
+    // ── Build platform package ────────────────────────────────────────────
 
-		const tmpPlatformDir = path.join(tmpDir, platform.platformPkg);
-		const tmpPlatformBinDir = path.join(tmpPlatformDir, "bin");
-		await mkdir(tmpPlatformBinDir, { recursive: true });
+    const tmpPlatformDir = path.join(tmpDir, platform.platformPkg);
+    const tmpPlatformBinDir = path.join(tmpPlatformDir, "bin");
+    await mkdir(tmpPlatformBinDir, { recursive: true });
 
-		const entrypoint = path.join(root, "apps", "cli", "src", shell, "main.ts");
-		const bunBinary = path.join(tmpPlatformBinDir, `supabase${platform.ext}`);
-		const libc = libcForBunTarget(platform.bunTarget);
+    const entrypoint = path.join(root, "apps", "cli", "src", shell, "main.ts");
+    const bunBinary = path.join(tmpPlatformBinDir, `supabase${platform.ext}`);
+    const libc = libcForBunTarget(platform.bunTarget);
 
-		console.log(`[1/${shell === "legacy" ? 3 : 2}] Compiling ${shell} CLI binary...`);
-		await $`bun build ${entrypoint} --compile --target=${platform.bunTarget} --define=SUPABASE_LIBC=${JSON.stringify(libc)} --outfile=${bunBinary}`;
+    console.log(`[1/${shell === "legacy" ? 3 : 2}] Compiling ${shell} CLI binary...`);
+    await $`bun build ${entrypoint} --compile --target=${platform.bunTarget} --define=SUPABASE_LIBC=${JSON.stringify(libc)} --outfile=${bunBinary}`;
 
-		if (shell === "legacy" && goSource) {
-			const goBinary = path.join(tmpPlatformBinDir, `supabase-go${platform.ext}`);
-			console.log(
-				`[2/3] Compiling Go CLI binary (${platform.goos}/${platform.goarch})...`,
-			);
-			// Run go build from within the Go source directory so Go can find
-			// the go.mod there. Passing an absolute path as a positional arg
-			// causes Go to resolve the module from CWD instead, which fails
-			// because the repo root has no go.mod.
-			await $`go build -trimpath -ldflags="-s -w" -o ${goBinary} .`
-				.cwd(goSource)
-				.env({
-					...process.env,
-					GOOS: platform.goos,
-					GOARCH: platform.goarch,
-					CGO_ENABLED: "0",
-				});
-		}
+    if (shell === "legacy" && goSource) {
+      const goBinary = path.join(tmpPlatformBinDir, `supabase-go${platform.ext}`);
+      console.log(`[2/3] Compiling Go CLI binary (${platform.goos}/${platform.goarch})...`);
+      // Run go build from within the Go source directory so Go can find
+      // the go.mod there. Passing an absolute path as a positional arg
+      // causes Go to resolve the module from CWD instead, which fails
+      // because the repo root has no go.mod.
+      await $`go build -trimpath -ldflags="-s -w" -o ${goBinary} .`.cwd(goSource).env({
+        ...process.env,
+        GOOS: platform.goos,
+        GOARCH: platform.goarch,
+        CGO_ENABLED: "0",
+      });
+    }
 
-		// ── Build umbrella package shim ───────────────────────────────────────
+    // ── Build umbrella package shim ───────────────────────────────────────
 
-		const tmpCliDir = path.join(tmpDir, "cli");
-		const tmpCliDistDir = path.join(tmpCliDir, "dist");
-		await mkdir(tmpCliDistDir, { recursive: true });
+    const tmpCliDir = path.join(tmpDir, "cli");
+    const tmpCliDistDir = path.join(tmpCliDir, "dist");
+    await mkdir(tmpCliDistDir, { recursive: true });
 
-		const shimSrc = path.join(root, "apps", "cli", "src", "shared", "cli", "bin.ts");
-		const shimOut = path.join(tmpCliDistDir, "supabase.js");
-		const shimStep = shell === "legacy" ? 3 : 2;
-		console.log(`[${shimStep}/${shimStep}] Building Node.js shim...`);
-		await $`bun build ${shimSrc} --outfile=${shimOut} --target=node`;
+    const shimSrc = path.join(root, "apps", "cli", "src", "shared", "cli", "bin.ts");
+    const shimOut = path.join(tmpCliDistDir, "supabase.js");
+    const shimStep = shell === "legacy" ? 3 : 2;
+    console.log(`[${shimStep}/${shimStep}] Building Node.js shim...`);
+    await $`bun build ${shimSrc} --outfile=${shimOut} --target=node`;
 
-		// ── Write package.json files ──────────────────────────────────────────
+    // ── Write package.json files ──────────────────────────────────────────
 
-		// Platform package: copy as-is, bump version.
-		const platformPkgJson = await Bun.file(
-			path.join(root, "packages", platform.platformPkg, "package.json"),
-		).json();
-		platformPkgJson.version = version;
-		await Bun.write(
-			path.join(tmpPlatformDir, "package.json"),
-			`${JSON.stringify(platformPkgJson, null, "\t")}\n`,
-		);
+    // Platform package: copy as-is, bump version.
+    const platformPkgJson = await Bun.file(
+      path.join(root, "packages", platform.platformPkg, "package.json"),
+    ).json();
+    platformPkgJson.version = version;
+    await Bun.write(
+      path.join(tmpPlatformDir, "package.json"),
+      `${JSON.stringify(platformPkgJson, null, "\t")}\n`,
+    );
 
-		// Umbrella package: build a minimal package.json.
-		// The shim only uses Node built-ins — all @supabase/* and catalog: deps
-		// are bundled in the platform binary and must not appear in the published
-		// package.json (catalog: and workspace:* are invalid outside pnpm workspaces).
-		const resolvedOptionalDeps: Record<string, string> = {};
-		for (const pkg of PLATFORM_PACKAGES) {
-			resolvedOptionalDeps[`@supabase/${pkg}`] = version;
-		}
+    // Umbrella package: build a minimal package.json.
+    // The shim only uses Node built-ins — all @supabase/* and catalog: deps
+    // are bundled in the platform binary and must not appear in the published
+    // package.json (catalog: and workspace:* are invalid outside pnpm workspaces).
+    const resolvedOptionalDeps: Record<string, string> = {};
+    for (const pkg of PLATFORM_PACKAGES) {
+      resolvedOptionalDeps[`@supabase/${pkg}`] = version;
+    }
 
-		const publishPkgJson = {
-			name: cliPkgJson.name,
-			version,
-			type: cliPkgJson.type,
-			bin: cliPkgJson.bin,
-			files: cliPkgJson.files,
-			publishConfig: cliPkgJson.publishConfig,
-			optionalDependencies: resolvedOptionalDeps,
-		};
-		await Bun.write(
-			path.join(tmpCliDir, "package.json"),
-			`${JSON.stringify(publishPkgJson, null, "\t")}\n`,
-		);
+    const publishPkgJson = {
+      name: cliPkgJson.name,
+      version,
+      type: cliPkgJson.type,
+      bin: cliPkgJson.bin,
+      files: cliPkgJson.files,
+      publishConfig: cliPkgJson.publishConfig,
+      optionalDependencies: resolvedOptionalDeps,
+    };
+    await Bun.write(
+      path.join(tmpCliDir, "package.json"),
+      `${JSON.stringify(publishPkgJson, null, "\t")}\n`,
+    );
 
-		// ── Write .npmrc with registry and auth token ─────────────────────────
+    // ── Write .npmrc with registry and auth token ─────────────────────────
 
-		const npmrc = [
-			`registry=${REGISTRY}`,
-			`//localhost:${PORT}/:_authToken=${token}`,
-			"",
-		].join("\n");
-		await Bun.write(path.join(tmpPlatformDir, ".npmrc"), npmrc);
-		await Bun.write(path.join(tmpCliDir, ".npmrc"), npmrc);
+    const npmrc = [`registry=${REGISTRY}`, `//localhost:${PORT}/:_authToken=${token}`, ""].join(
+      "\n",
+    );
+    await Bun.write(path.join(tmpPlatformDir, ".npmrc"), npmrc);
+    await Bun.write(path.join(tmpCliDir, ".npmrc"), npmrc);
 
-		// ── Publish ───────────────────────────────────────────────────────────
+    // ── Publish ───────────────────────────────────────────────────────────
 
-		console.log(
-			`\nPublishing @supabase/${platform.platformPkg}@${version} to local registry...`,
-		);
-		// Use bun publish for the platform binary package: pnpm normalises file
-		// modes in tarballs and strips the execute bit from files not in the
-		// package's `bin` field. bun publish preserves modes, matching production.
-		await $`bun publish --access public --tag local --registry ${REGISTRY} --no-git-checks`.cwd(
-			tmpPlatformDir,
-		);
+    console.log(`\nPublishing @supabase/${platform.platformPkg}@${version} to local registry...`);
+    // Use bun publish for the platform binary package: pnpm normalises file
+    // modes in tarballs and strips the execute bit from files not in the
+    // package's `bin` field. bun publish preserves modes, matching production.
+    await $`bun publish --access public --tag local --registry ${REGISTRY} --no-git-checks`.cwd(
+      tmpPlatformDir,
+    );
 
-		console.log(`Publishing ${umbrellaName}@${version} to local registry...`);
-		await $`pnpm publish --access public --tag local --registry ${REGISTRY} --no-git-checks`.cwd(
-			tmpCliDir,
-		);
+    console.log(`Publishing ${umbrellaName}@${version} to local registry...`);
+    await $`pnpm publish --access public --tag local --registry ${REGISTRY} --no-git-checks`.cwd(
+      tmpCliDir,
+    );
 
-		console.log(`
+    console.log(`
 ✓ Published ${umbrellaName}@${version}
 
 Test with npx:
@@ -322,10 +306,10 @@ Or install globally:
   npm install -g --registry ${REGISTRY} ${umbrellaName}@${version}
   supabase --version
 `);
-	} finally {
-		// Always remove the temp directory — even on failure.
-		await rm(tmpDir, { recursive: true, force: true });
-	}
+  } finally {
+    // Always remove the temp directory — even on failure.
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 }
 
 await main();


### PR DESCRIPTION
Switch the x64 Bun compile targets to baseline for the published Linux glibc, Linux musl, and Windows platform builds.

Bun's default x64 targets can require newer AVX2-capable CPUs, while the baseline targets are intended for older x64 machines. Using the baseline targets avoids illegal-instruction failures on those systems without changing the published package names, release archive names, or amd64 packaging metadata.

This also keeps the local release helper aligned with the production build matrix and updates libc detection so the Linux x64 musl baseline target is still classified as musl.

Fixes https://github.com/supabase/cli/issues/5338