### PR TITLE
fix: skip local runtime checks for gen types --db-url

### DIFF
--- a/apps/cli-go/cmd/gen.go
+++ b/apps/cli-go/cmd/gen.go
@@ -96,7 +96,8 @@ var (
 					return err
 				}
 			}
-			return types.Run(ctx, flags.ProjectRef, flags.DbConfig, lang.Value, schema, postgrestV9Compat, swiftAccessControl.Value, queryTimeout, afero.NewOsFs())
+			useDirectDBURL := cmd.Flags().Changed("db-url")
+			return types.Run(ctx, flags.ProjectRef, flags.DbConfig, lang.Value, schema, postgrestV9Compat, swiftAccessControl.Value, queryTimeout, afero.NewOsFs(), useDirectDBURL)
 		},
 		Example: `  supabase gen types --local
   supabase gen types --linked --lang=go

--- a/apps/cli-go/internal/gen/types/types.go
+++ b/apps/cli-go/internal/gen/types/types.go
@@ -33,7 +33,7 @@ const (
 	SwiftInternalAccessControl = "internal"
 )
 
-func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, swiftAccessControl string, queryTimeout time.Duration, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {
+func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang string, schemas []string, postgrestV9Compat bool, swiftAccessControl string, queryTimeout time.Duration, fsys afero.Fs, useDirectDBURL bool, options ...func(*pgx.ConnConfig)) error {
 	originalURL := utils.ToPostgresURL(dbConfig)
 	// Add default schemas if --schema flag is not specified
 	if len(schemas) == 0 {
@@ -61,7 +61,7 @@ func Run(ctx context.Context, projectId string, dbConfig pgconn.Config, lang str
 	}
 
 	hostConfig := container.HostConfig{}
-	if utils.IsLocalDatabase(dbConfig) {
+	if !useDirectDBURL && utils.IsLocalDatabase(dbConfig) {
 		if err := utils.AssertSupabaseDbIsRunning(); err != nil {
 			return err
 		}

--- a/apps/cli-go/internal/gen/types/types_test.go
+++ b/apps/cli-go/internal/gen/types/types_test.go
@@ -31,7 +31,7 @@ func TestGenLocalCommand(t *testing.T) {
 		Password: "password",
 	}
 
-	t.Run("generates typescript types", func(t *testing.T) {
+		t.Run("generates typescript types", func(t *testing.T) {
 		const containerId = "test-pgmeta"
 		imageUrl := utils.GetRegistryImageUrl(utils.Config.Studio.PgmetaImage)
 		// Setup in-memory fs
@@ -49,10 +49,29 @@ func TestGenLocalCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys, conn.Intercept))
+			assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys, false, conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
+
+		t.Run("skips local db check when using direct db url", func(t *testing.T) {
+			const containerId = "test-pgmeta"
+			imageUrl := utils.GetRegistryImageUrl(utils.Config.Studio.PgmetaImage)
+			// Setup in-memory fs
+			fsys := afero.NewMemMapFs()
+			// Setup mock docker
+			require.NoError(t, apitest.MockDocker(utils.Docker))
+			defer gock.OffAll()
+			apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
+			require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world\n"))
+			// Setup mock postgres
+			conn := pgtest.NewConn()
+			defer conn.Close(t)
+			// Run test
+			assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys, true, conn.Intercept))
+			// Validate api
+			assert.Empty(t, apitest.ListUnmatchedRequests())
+		})
 
 	t.Run("throws error when db is not started", func(t *testing.T) {
 		// Setup in-memory fs
@@ -64,7 +83,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys, false))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -84,7 +103,7 @@ func TestGenLocalCommand(t *testing.T) {
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys))
+		assert.Error(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{}, true, "", time.Second, fsys, false))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -107,7 +126,7 @@ func TestGenLocalCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, LangSwift, []string{}, true, SwiftInternalAccessControl, time.Second, fsys, conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, LangSwift, []string{}, true, SwiftInternalAccessControl, time.Second, fsys, false, conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -130,7 +149,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Reply(200).
 			JSON(api.TypescriptResponse{Types: ""})
 		// Run test
-		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys))
+		assert.NoError(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys, false))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
@@ -145,7 +164,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			ReplyError(errNetwork)
 		// Run test
-		err := Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys)
+		err := Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys, false)
 		// Validate api
 		assert.ErrorIs(t, err, errNetwork)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
@@ -160,7 +179,7 @@ func TestGenLinkedCommand(t *testing.T) {
 			Get("/v1/projects/" + projectId + "/types/typescript").
 			Reply(http.StatusServiceUnavailable)
 		// Run test
-		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys))
+		assert.Error(t, Run(context.Background(), projectId, pgconn.Config{}, LangTypescript, []string{}, true, "", time.Second, fsys, false))
 	})
 }
 
@@ -185,7 +204,7 @@ func TestGenRemoteCommand(t *testing.T) {
 		conn := pgtest.NewConn()
 		defer conn.Close(t)
 		// Run test
-		assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{"public"}, true, "", time.Second, afero.NewMemMapFs(), conn.Intercept))
+		assert.NoError(t, Run(context.Background(), "", dbConfig, LangTypescript, []string{"public"}, true, "", time.Second, afero.NewMemMapFs(), false, conn.Intercept))
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?

`supabase gen types --db-url ...` still attempts to load local Supabase runtime/profile state and fails with:

```bash
supabase start is not running
```

even when a direct PostgreSQL connection URL is explicitly provided.

Fixes #5283

## What is the new behavior?

When `--db-url` is explicitly provided, the CLI now bypasses local runtime validation and directly uses the supplied PostgreSQL connection.

This prevents unnecessary:

* local profile loading
* local runtime checks
* dependency on `supabase start`

## Additional context

The fix adds explicit detection for `--db-url` usage in the command flow and skips local runtime validation in the legacy Go type generation path.

Added targeted regression coverage for the `--db-url` bypass behavior in `internal/gen/types/types_test.go`.
