### PR TITLE
fix(cli): support legacy migrations alias

### DIFF
--- a/apps/cli/docs/go-cli-porting-status.md
+++ b/apps/cli/docs/go-cli-porting-status.md
@@ -204,6 +204,7 @@ These route-first equivalents are intentionally lower-level than the old Go comm
 ## Legacy Shell Wrapping Status
 
 Phase 0 proxy wrappers in the legacy shell (`src/legacy/`). Each wrapped command forwards to the bundled Go binary via `LegacyGoProxy`.
+The `migration` command group also accepts Go's top-level `migrations` alias and forwards singular `migration` argv to Go.
 
 Legend:
 

--- a/apps/cli/src/legacy/commands/migration/migration.command.ts
+++ b/apps/cli/src/legacy/commands/migration/migration.command.ts
@@ -10,6 +10,7 @@ import { legacyMigrationFetchCommand } from "./fetch/fetch.command.ts";
 export const legacyMigrationCommand = Command.make("migration").pipe(
   Command.withDescription("Manage database migration scripts."),
   Command.withShortDescription("Manage database migration scripts"),
+  Command.withAlias("migrations"),
   Command.withSubcommands([
     legacyMigrationListCommand,
     legacyMigrationNewCommand,

--- a/apps/cli/src/legacy/commands/migration/migration.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/migration.integration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { CliOutput, Command } from "effect/unstable/cli";
+
+import { textCliOutputFormatter } from "../../../shared/output/text-formatter.ts";
+import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { legacyMigrationCommand } from "./migration.command.ts";
+
+function mockLegacyGoProxy() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push([...args]);
+      }),
+  });
+
+  return { layer, calls };
+}
+
+const legacyTestRoot = Command.make("supabase").pipe(
+  Command.withSubcommands([legacyMigrationCommand]),
+);
+
+describe("legacy migration command integration", () => {
+  it.live("accepts the Go-compatible plural migrations alias", () => {
+    const proxy = mockLegacyGoProxy();
+    const run = Effect.gen(function* () {
+      yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })([
+        "migrations",
+        "new",
+        "create_widgets",
+      ]);
+
+      expect(proxy.calls).toEqual([["migration", "new", "create_widgets"]]);
+    }).pipe(Effect.provide(Layer.mergeAll(proxy.layer, CliOutput.layer(textCliOutputFormatter()))));
+
+    // Command.runWith's Environment type is retained even though this path only needs CliOutput
+    // and the mocked proxy at runtime.
+    return run as Effect.Effect<void>;
+  });
+});


### PR DESCRIPTION
## Summary

- Restores Go CLI parity for the legacy TS proxy by accepting `supabase migrations ...` as an alias for `supabase migration ...`.
- Adds a regression test proving the plural alias resolves through the TS command tree while forwarding canonical `migration` argv to the bundled Go binary.
- Documents the alias in the legacy Go porting status.