### PR TITLE
feat(cli): align legacy telemetry payload with Go CLI

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -269,6 +269,32 @@ When porting a Management-API-style command, verify each item before marking the
 
 6. **Both `--output` (Go) and `--output-format` (TS) must be honored** — Go's `--output` (`pretty|json|yaml|toml|env`) takes priority when set. Pattern in `backups/list/list.handler.ts:85-113`: branch on `goOutputFlag` first, then fall through to TS `--output-format` text/json/stream-json.
 
+7. **PostHog telemetry payload matches Go 1:1** — see the next section.
+
+---
+
+## Legacy Port: Telemetry Parity
+
+The legacy shell sends the same PostHog events to the same product analytics pipeline as the Go CLI. Drift is silent (no test will catch it) and breaks dashboards. The rules:
+
+- **The canonical catalog is `shared/telemetry/event-catalog.ts`** — a 1:1 mirror of `apps/cli-go/internal/telemetry/events.go`. Reference its exported constants (`EventCommandExecuted`, `PropFlags`, `EnvSignalPresenceKeys`, …) instead of writing bare strings. When the Go catalog changes, update the TS catalog in the same PR.
+- **Native legacy commands wrap with `withLegacyCommandInstrumentation`** (from `legacy/telemetry/legacy-command-instrumentation.ts`) — _not_ the shared `withCommandInstrumentation`. The legacy variant emits Go-shape properties: a single `flags` map (vs `flags_used`/`flag_values`), `is_agent: boolean` (vs `ai_tool: string`), and `env_signals`.
+- **Pass `flags` to the wrapper** so boolean flag values can be detected and logged verbatim: `handler(flags).pipe(withLegacyCommandInstrumentation({ flags }), ...)`. Sensitive values become the literal string `"<redacted>"` to match Go.
+- **Use `safeFlags: ["flag-name"]`** to whitelist flags that Go marks with `markFlagTelemetrySafe` (grep `apps/cli-go/cmd/*.go`). Today these are `--project-ref` (sso, branches, link, functions, projects/api-keys), `--project-id` (gen/types), `--org-id` (projects/create), and `--version` (migration/squash).
+- **Proxy handlers (`LegacyGoProxy.exec`) must NOT wrap with any instrumentation.** The Go subprocess fires its own telemetry; a TS wrapper would double-count `cli_command_executed`.
+- **When promoting a command from proxy to native, reproduce every `phtelemetry.*` call in the Go counterpart.** Grep `apps/cli-go/internal/<command>/` for `service.Capture`, `service.Alias`, `service.Identify`, `service.GroupIdentify`, and `TrackUpgradeSuggested`. The current Go custom events that legacy ports must reproduce when natively ported:
+
+  | Command                                                       | Event                   | Identity / groups                                                                                                  | Go source                                     |
+  | ------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+  | `login`                                                       | `cli_login_completed`   | `analytics.alias(gotrueId, deviceId)` + `analytics.identify(gotrueId)` after token persists                        | `internal/login/login.go:283-296`             |
+  | `link`                                                        | `cli_project_linked`    | `analytics.groupIdentify("organization", slug, …)` + `analytics.groupIdentify("project", ref, …)` after link write | `internal/link/link.go:60`                    |
+  | `start`                                                       | `cli_stack_started`     | none — fired after stack health check passes                                                                       | `internal/start/start.go:1245`                |
+  | `sso/{list,create,update,remove}`, `branches/{create,update}` | `cli_upgrade_suggested` | none — payload is `{feature_key, org_slug}`, fired inside billing-gate error branch                                | 7 call-sites under `internal/{sso,branches}/` |
+
+  Reference pattern for login: `next/commands/login/login.handler.ts:38-62`.
+
+- **Tracing layer is local-only observability**, not PostHog. Span names (`legacy.<command>.<sub>`) and the NDJSON exporter never leave the user's machine. No parity implication.
+
 ---
 
 ## Legacy Port: File Location Compatibility

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -101,7 +101,8 @@
     ],
     "ignore": [
       "scripts/*.ts",
-      "tests/**/*.ts"
+      "tests/**/*.ts",
+      "src/shared/telemetry/event-catalog.ts"
     ],
     "ignoreBinaries": [
       "nx"

--- a/apps/cli/src/legacy/SIDE_EFFECTS_TEMPLATE.md
+++ b/apps/cli/src/legacy/SIDE_EFFECTS_TEMPLATE.md
@@ -74,6 +74,19 @@
 | `1`  | authentication error (no token found) |
 | `1`  | network / connection failure          |
 
+## Telemetry Events Fired
+
+<!-- List every PostHog event the command emits, including the universal cli_command_executed.
+     Source of truth for what Go emits: apps/cli-go/internal/<command>/*.go (grep for
+     `service.Capture`, `service.Alias`, `service.Identify`, `service.GroupIdentify`,
+     `TrackUpgradeSuggested`). If the legacy command is still a Phase 0 proxy, write
+     "proxy — see Go binary" and leave the table empty; the Go subprocess fires telemetry.
+     Constants live in apps/cli/src/shared/telemetry/event-catalog.ts. -->
+
+| Event                  | When                                       | Notable properties / groups         |
+| ---------------------- | ------------------------------------------ | ----------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` |
+
 ## Output
 
 <!-- Describe the user-visible output for each --output-format mode.

--- a/apps/cli/src/legacy/cli/main.ts
+++ b/apps/cli/src/legacy/cli/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { runCli } from "../../shared/cli/run.ts";
+import { legacyAnalyticsLayer } from "../telemetry/legacy-analytics.layer.ts";
 import { legacyRoot } from "./root.ts";
 
-await runCli(legacyRoot);
+await runCli(legacyRoot, { analyticsLayer: legacyAnalyticsLayer });

--- a/apps/cli/src/legacy/commands/backups/list/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/backups/list/SIDE_EFFECTS.md
@@ -45,6 +45,14 @@
 | `1`  | `LegacyBackupListUnexpectedStatusError` — non-2xx response from the backups endpoint       |
 | `1`  | `LegacyBackupListNetworkError` — transport-level network failure                           |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                          |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/backups/list/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 The legacy `--output {pretty,json,yaml,toml,env}` flag (Go-compatible) and the new global `--output-format {text,json,stream-json}` flag are both honored. `--output` wins when both are supplied. `pretty` and `text` map to the same render path.

--- a/apps/cli/src/legacy/commands/backups/list/list.command.ts
+++ b/apps/cli/src/legacy/commands/backups/list/list.command.ts
@@ -2,8 +2,8 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyBackupsList } from "./list.handler.ts";
 
 const config = {
@@ -29,7 +29,10 @@ export const legacyBackupsListCommand = Command.make("list", config).pipe(
     },
   ]),
   Command.withHandler((flags) =>
-    legacyBackupsList(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacyBackupsList(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["backups", "list"])),
 );

--- a/apps/cli/src/legacy/commands/backups/restore/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/backups/restore/SIDE_EFFECTS.md
@@ -45,6 +45,14 @@
 | `1`  | `LegacyBackupRestoreUnexpectedStatusError` — non-201 response from the restore endpoint    |
 | `1`  | `LegacyBackupRestoreNetworkError` — transport-level network failure                        |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                                          |
+| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` / `--timestamp` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/backups/restore/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 Go's `restore` command ignores `--output` entirely (`apps/cli-go/internal/backups/restore/restore.go:22`) and always writes the success line to **stderr**. The legacy port mirrors that for every Go `--output` value. The `--output-format` (TS-only) JSON modes get a structured payload — non-breaking because Go has no JSON for restore.

--- a/apps/cli/src/legacy/commands/backups/restore/restore.command.ts
+++ b/apps/cli/src/legacy/commands/backups/restore/restore.command.ts
@@ -2,8 +2,8 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyBackupsRestore } from "./restore.handler.ts";
 
 const config = {
@@ -30,7 +30,10 @@ export const legacyBackupsRestoreCommand = Command.make("restore", config).pipe(
     },
   ]),
   Command.withHandler((flags) =>
-    legacyBackupsRestore(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacyBackupsRestore(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["backups", "restore"])),
 );

--- a/apps/cli/src/legacy/commands/secrets/list/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/secrets/list/SIDE_EFFECTS.md
@@ -47,6 +47,14 @@
 | `1`  | `LegacySecretsListNetworkError` — transport-level network failure                          |
 | `1`  | `LegacySecretsEnvNotSupportedError` — `--output env` flag is rejected                      |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                          |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/secrets/list/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 The legacy `--output {pretty,json,yaml,toml,env}` flag (Go-compatible) and the new global `--output-format {text,json,stream-json}` flag are both honored. `--output` wins when both are supplied. `pretty` and `text` map to the same render path.

--- a/apps/cli/src/legacy/commands/secrets/list/list.command.ts
+++ b/apps/cli/src/legacy/commands/secrets/list/list.command.ts
@@ -2,8 +2,8 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySecretsList } from "./list.handler.ts";
 
 const config = {
@@ -29,7 +29,10 @@ export const legacySecretsListCommand = Command.make("list", config).pipe(
     },
   ]),
   Command.withHandler((flags) =>
-    legacySecretsList(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacySecretsList(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["secrets", "list"])),
 );

--- a/apps/cli/src/legacy/commands/secrets/set/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/secrets/set/SIDE_EFFECTS.md
@@ -56,6 +56,14 @@
 | `1`  | `LegacySecretsSetUnexpectedStatusError` — non-2xx response from POST                         |
 | `1`  | `LegacySecretsSetNetworkError` — transport-level network failure                             |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                                         |
+| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` / `--env-file` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/secrets/set/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 ### `--output pretty` (Go default) / `--output-format text`

--- a/apps/cli/src/legacy/commands/secrets/set/set.command.ts
+++ b/apps/cli/src/legacy/commands/secrets/set/set.command.ts
@@ -2,8 +2,8 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySecretsSet } from "./set.handler.ts";
 
 const config = {
@@ -37,7 +37,10 @@ export const legacySecretsSetCommand = Command.make("set", config).pipe(
     },
   ]),
   Command.withHandler((flags) =>
-    legacySecretsSet(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacySecretsSet(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["secrets", "set"])),
 );

--- a/apps/cli/src/legacy/commands/secrets/unset/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/secrets/unset/SIDE_EFFECTS.md
@@ -51,6 +51,14 @@
 | `1`  | `LegacySecretsUnsetUnexpectedStatusError` — non-2xx response from DELETE                   |
 | `1`  | `LegacySecretsUnsetNetworkError` — DELETE transport failure                                |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                          |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/secrets/unset/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 ### `--output pretty` (Go default) / `--output-format text`

--- a/apps/cli/src/legacy/commands/secrets/unset/unset.command.ts
+++ b/apps/cli/src/legacy/commands/secrets/unset/unset.command.ts
@@ -2,8 +2,8 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySecretsUnset } from "./unset.handler.ts";
 
 const config = {
@@ -33,7 +33,10 @@ export const legacySecretsUnsetCommand = Command.make("unset", config).pipe(
     },
   ]),
   Command.withHandler((flags) =>
-    legacySecretsUnset(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacySecretsUnset(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["secrets", "unset"])),
 );

--- a/apps/cli/src/legacy/commands/ssl-enforcement/get/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/get/SIDE_EFFECTS.md
@@ -37,6 +37,14 @@
 | `1`  | API non-200 (`LegacySslEnforcementGetUnexpectedStatusError`)                            |
 | `1`  | transport failure (`LegacySslEnforcementGetNetworkError`)                               |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                          |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` → `<redacted>`) |
+
+Matches `apps/cli-go/internal/sslenforcement/get/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 ### `--output-format text` (default) — Go CLI compatible

--- a/apps/cli/src/legacy/commands/ssl-enforcement/get/get.command.ts
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/get/get.command.ts
@@ -2,8 +2,8 @@ import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySslEnforcementGet } from "./get.handler.ts";
 
 const config = {
@@ -19,7 +19,10 @@ export const legacySslEnforcementGetCommand = Command.make("get", config).pipe(
   Command.withDescription("Get the current SSL enforcement configuration."),
   Command.withShortDescription("Get SSL enforcement configuration"),
   Command.withHandler((flags) =>
-    legacySslEnforcementGet(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacySslEnforcementGet(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["ssl-enforcement", "get"])),
 );

--- a/apps/cli/src/legacy/commands/ssl-enforcement/update/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/update/SIDE_EFFECTS.md
@@ -39,6 +39,14 @@
 | `1`  | API non-200 (`LegacySslEnforcementUpdateUnexpectedStatusError`)                                                               |
 | `1`  | transport failure (`LegacySslEnforcementUpdateNetworkError`)                                                                  |
 
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups                                                                                                                                |
+| ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--project-ref` → `<redacted>`; `--enable-db-ssl-enforcement` / `--disable-db-ssl-enforcement` booleans pass through) |
+
+Matches `apps/cli-go/internal/sslenforcement/update/`. Go does not fire any custom telemetry event for this command.
+
 ## Output
 
 ### `--output-format text` (default) — Go CLI compatible

--- a/apps/cli/src/legacy/commands/ssl-enforcement/update/update.command.ts
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/update/update.command.ts
@@ -2,8 +2,8 @@ import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySslEnforcementUpdate } from "./update.handler.ts";
 
 const config = {
@@ -29,7 +29,10 @@ export const legacySslEnforcementUpdateCommand = Command.make("update", config).
   Command.withDescription("Update SSL enforcement configuration."),
   Command.withShortDescription("Update SSL enforcement configuration"),
   Command.withHandler((flags) =>
-    legacySslEnforcementUpdate(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+    legacySslEnforcementUpdate(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
   ),
   Command.provide(legacyManagementApiRuntimeLayer(["ssl-enforcement", "update"])),
 );

--- a/apps/cli/src/legacy/telemetry/legacy-analytics.layer.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-analytics.layer.ts
@@ -1,0 +1,246 @@
+import { Effect, FileSystem, Layer, Option, Path } from "effect";
+import { PostHog } from "posthog-node";
+import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
+import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
+import {
+  CurrentAnalyticsContext,
+  type AnalyticsContext,
+} from "../../shared/telemetry/analytics-context.ts";
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import {
+  EnvSignalPresenceKeys,
+  EnvSignalValueKeys,
+  GroupOrganization,
+  GroupProject,
+  MaxEnvSignalValueLength,
+  PropArch,
+  PropCliVersion,
+  PropDeviceId,
+  PropEnvSignals,
+  PropIsAgent,
+  PropIsCi,
+  PropIsFirstRun,
+  PropIsTty,
+  PropOs,
+  PropPlatform,
+  PropSchemaVersion,
+  PropSessionId,
+} from "../../shared/telemetry/event-catalog.ts";
+import { posthogConfig } from "../../shared/telemetry/posthog-config.ts";
+import { telemetryRuntimeLayer } from "../../shared/telemetry/runtime.layer.ts";
+import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
+
+interface LinkedProjectCacheValue {
+  readonly ref: string;
+  readonly name: string;
+  readonly organization_id: string;
+  readonly organization_slug: string;
+}
+
+function stripUndefined(properties: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(properties).filter(([, value]) => value !== undefined));
+}
+
+function contextProperties(context: AnalyticsContext): Record<string, unknown> {
+  return stripUndefined({
+    command_run_id: context.command_run_id,
+    command: context.command,
+    flags: context.flags,
+  });
+}
+
+function resolveGroups(
+  context: AnalyticsContext,
+  linkedProject: Option.Option<LinkedProjectCacheValue>,
+): { organization: string; project: string } | undefined {
+  if (context.groups?.organization !== undefined && context.groups.project !== undefined) {
+    return {
+      organization: context.groups.organization,
+      project: context.groups.project,
+    };
+  }
+
+  return Option.match(linkedProject, {
+    onNone: () => undefined,
+    onSome: (linked) => ({
+      organization: linked.organization_slug,
+      project: linked.ref,
+    }),
+  });
+}
+
+// Mirrors apps/cli-go/cmd/root_analytics.go:149-165 envSignals().
+export function collectEnvSignals(): Record<string, true | string> | undefined {
+  const signals: Record<string, true | string> = {};
+
+  for (const key of EnvSignalPresenceKeys) {
+    const raw = process.env[key];
+    if (raw === undefined) continue;
+    if (raw.trim().length === 0) continue;
+    signals[key] = true;
+  }
+
+  for (const key of EnvSignalValueKeys) {
+    const raw = process.env[key];
+    if (raw === undefined) continue;
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    signals[key] =
+      trimmed.length > MaxEnvSignalValueLength
+        ? trimmed.slice(0, MaxEnvSignalValueLength)
+        : trimmed;
+  }
+
+  return Object.keys(signals).length === 0 ? undefined : signals;
+}
+
+// Mirrors apps/cli-go/internal/telemetry/project.go:40 LoadLinkedProject(fsys).
+// Best-effort: any error returns None. Resolves workdir from `SUPABASE_WORKDIR`
+// env or `process.cwd()`. The `--workdir` flag value is not accessible at
+// root scope where the analytics layer is constructed (Effect CLI's global
+// flag services are only available inside Command.runWith). When `--workdir` is
+// set but the user invokes from outside that directory, the linked-project
+// cache lookup misses and the event loses group attribution — matches Go's
+// behaviour when the user runs without first `cd`-ing into the project.
+function makeLoadLinkedProject(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+): Effect.Effect<Option.Option<LinkedProjectCacheValue>> {
+  const workdir = process.env.SUPABASE_WORKDIR ?? process.cwd();
+  const cachePath = path.join(workdir, "supabase", ".temp", "linked-project.json");
+  return Effect.gen(function* () {
+    const exists = yield* fs.exists(cachePath).pipe(Effect.orElseSucceed(() => false));
+    if (!exists) return Option.none<LinkedProjectCacheValue>();
+
+    const content = yield* fs.readFileString(cachePath).pipe(Effect.option);
+    if (Option.isNone(content)) return Option.none<LinkedProjectCacheValue>();
+
+    try {
+      const parsed = JSON.parse(content.value) as Partial<LinkedProjectCacheValue>;
+      if (typeof parsed.ref !== "string" || typeof parsed.organization_slug !== "string") {
+        return Option.none<LinkedProjectCacheValue>();
+      }
+      return Option.some<LinkedProjectCacheValue>({
+        ref: parsed.ref,
+        name: typeof parsed.name === "string" ? parsed.name : "",
+        organization_id: typeof parsed.organization_id === "string" ? parsed.organization_id : "",
+        organization_slug: parsed.organization_slug,
+      });
+    } catch {
+      return Option.none<LinkedProjectCacheValue>();
+    }
+  }).pipe(Effect.catch(() => Effect.succeed(Option.none<LinkedProjectCacheValue>())));
+}
+
+export const legacyAnalyticsLayer = Layer.effect(
+  Analytics,
+  Effect.gen(function* () {
+    const runtime = yield* TelemetryRuntime;
+    const aiTool = yield* AiTool;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    if (runtime.consent !== "granted") {
+      return Analytics.of({
+        capture: () => Effect.void,
+        identify: () => Effect.void,
+        alias: () => Effect.void,
+        groupIdentify: () => Effect.void,
+      });
+    }
+
+    const client = new PostHog(posthogConfig.key, {
+      host: posthogConfig.host,
+      flushAt: 1,
+      flushInterval: 0,
+    });
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(() => client._shutdown(5_000)).pipe(Effect.ignore),
+    );
+
+    const loadLinkedProject = makeLoadLinkedProject(fs, path);
+
+    const isAgent = Option.isSome(aiTool.name) || runtime.isCi;
+    const envSignals = collectEnvSignals();
+
+    const baseProperties = stripUndefined({
+      [PropPlatform]: "cli",
+      [PropSchemaVersion]: 1,
+      [PropDeviceId]: runtime.deviceId,
+      [PropSessionId]: runtime.sessionId,
+      [PropIsFirstRun]: runtime.isFirstRun,
+      [PropIsTty]: runtime.isTty,
+      [PropIsCi]: runtime.isCi,
+      [PropIsAgent]: isAgent,
+      [PropOs]: runtime.os,
+      [PropArch]: runtime.arch,
+      [PropCliVersion]: runtime.cliVersion,
+      [PropEnvSignals]: envSignals,
+    });
+
+    const capture = (event: string, properties: Record<string, unknown> = {}) =>
+      Effect.gen(function* () {
+        const context = yield* CurrentAnalyticsContext;
+        const linkedProject = yield* loadLinkedProject;
+        const groups = resolveGroups(context, linkedProject);
+
+        client.capture({
+          event,
+          distinctId: context.distinct_id ?? runtime.distinctId ?? runtime.deviceId,
+          ...(groups === undefined
+            ? {}
+            : {
+                groups: {
+                  [GroupOrganization]: groups.organization,
+                  [GroupProject]: groups.project,
+                },
+              }),
+          properties: {
+            ...baseProperties,
+            ...contextProperties(context),
+            ...stripUndefined(properties),
+          },
+        });
+      });
+
+    const identify = (distinctId: string, properties: Record<string, unknown> = {}) =>
+      Effect.sync(() => {
+        client.identify({
+          distinctId,
+          properties: stripUndefined({
+            cli_version: runtime.cliVersion,
+            os: runtime.os,
+            arch: runtime.arch,
+            ...properties,
+          }),
+        });
+      });
+
+    const alias = (distinctId: string, aliasValue: string) =>
+      Effect.sync(() => {
+        client.alias({ distinctId, alias: aliasValue });
+      });
+
+    const groupIdentify = (
+      groupType: string,
+      groupKey: string,
+      properties: Record<string, unknown> = {},
+    ) =>
+      Effect.gen(function* () {
+        const context = yield* CurrentAnalyticsContext;
+        client.groupIdentify({
+          groupType,
+          groupKey,
+          distinctId: context.distinct_id ?? runtime.distinctId ?? runtime.deviceId,
+          properties: stripUndefined(properties),
+        });
+      });
+
+    return Analytics.of({
+      capture,
+      identify,
+      alias,
+      groupIdentify,
+    });
+  }),
+).pipe(Layer.provide(telemetryRuntimeLayer), Layer.provide(aiToolLayer));

--- a/apps/cli/src/legacy/telemetry/legacy-analytics.layer.unit.test.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-analytics.layer.unit.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  EnvSignalPresenceKeys,
+  EnvSignalValueKeys,
+  MaxEnvSignalValueLength,
+} from "../../shared/telemetry/event-catalog.ts";
+import { collectEnvSignals } from "./legacy-analytics.layer.ts";
+
+const RESET_KEYS = [...EnvSignalPresenceKeys, ...EnvSignalValueKeys];
+
+function snapshotEnv() {
+  const original: Record<string, string | undefined> = {};
+  for (const key of RESET_KEYS) {
+    original[key] = process.env[key];
+    delete process.env[key];
+  }
+  return original;
+}
+
+function restoreEnv(original: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(original)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("collectEnvSignals", () => {
+  let original: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    original = snapshotEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv(original);
+  });
+
+  it("returns undefined when no relevant env vars are set", () => {
+    expect(collectEnvSignals()).toBeUndefined();
+  });
+
+  it("records presence keys as boolean `true`", () => {
+    process.env.CI = "1";
+    process.env.CLAUDECODE = "true";
+
+    const signals = collectEnvSignals();
+    expect(signals).toEqual({
+      CI: true,
+      CLAUDECODE: true,
+    });
+  });
+
+  it("records value keys as trimmed strings", () => {
+    process.env.AI_AGENT = "  claude-code  ";
+    process.env.TERM = "xterm-256color";
+
+    const signals = collectEnvSignals();
+    expect(signals).toEqual({
+      AI_AGENT: "claude-code",
+      TERM: "xterm-256color",
+    });
+  });
+
+  it("caps value-key strings at MaxEnvSignalValueLength chars", () => {
+    const long = "a".repeat(MaxEnvSignalValueLength + 50);
+    process.env.AI_AGENT = long;
+
+    const signals = collectEnvSignals();
+    const aiAgent = signals?.AI_AGENT;
+    expect(aiAgent).toBe("a".repeat(MaxEnvSignalValueLength));
+    expect(typeof aiAgent === "string" ? aiAgent.length : -1).toBe(MaxEnvSignalValueLength);
+  });
+
+  it("skips presence keys with empty/whitespace-only values", () => {
+    process.env.CI = "";
+    process.env.GITHUB_ACTIONS = "   ";
+
+    expect(collectEnvSignals()).toBeUndefined();
+  });
+
+  it("skips value keys with empty/whitespace-only values", () => {
+    process.env.AI_AGENT = "   ";
+
+    expect(collectEnvSignals()).toBeUndefined();
+  });
+});

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
@@ -1,0 +1,161 @@
+import { Clock, Effect, Exit, Option, Stdio } from "effect";
+import {
+  CommandRuntime,
+  getCommandRuntimeCommand,
+  getCommandRuntimeSpanName,
+} from "../../shared/runtime/command-runtime.service.ts";
+import { withAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import {
+  EventCommandExecuted,
+  PropDurationMs,
+  PropExitCode,
+} from "../../shared/telemetry/event-catalog.ts";
+
+interface LegacyCommandInstrumentationOptions<Flags extends Record<string, unknown> = never> {
+  readonly analytics?: boolean;
+  readonly flags?: Flags;
+  // Flag names (kebab-case) whose values are safe to log verbatim, mirroring
+  // Go's `markFlagTelemetrySafe` annotation in cmd/root_analytics.go. Boolean
+  // flag values are always passed through, matching Go's isBooleanFlag branch.
+  readonly safeFlags?: ReadonlyArray<string>;
+}
+
+const REDACTED_VALUE = "<redacted>";
+
+function toCliFlagName(key: string): string {
+  return key.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+}
+
+function extractChangedFlagNames(args: ReadonlyArray<string>): ReadonlyArray<string> {
+  const used = new Set<string>();
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === undefined || !arg.startsWith("--")) continue;
+
+    const raw = arg.slice(2);
+    const [flagName] = raw.split("=", 2);
+    if (flagName === undefined || flagName.length === 0) continue;
+
+    used.add(flagName);
+  }
+
+  // Match Go's sort.Slice(...flag.Name < flag.Name) in changedFlags().
+  return [...used].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeFlagValue(value: unknown): unknown | undefined {
+  if (value === undefined) return undefined;
+  if (!Option.isOption(value)) return value;
+  if (Option.isNone(value)) return undefined;
+  return normalizeFlagValue(value.value);
+}
+
+function buildFlagsMap<Flags extends Record<string, unknown>>(
+  flags: Flags | undefined,
+  safeFlagSet: ReadonlySet<string>,
+  changedFlagNames: ReadonlyArray<string>,
+): Record<string, unknown> | undefined {
+  if (changedFlagNames.length === 0) return undefined;
+
+  const result: Record<string, unknown> = {};
+  const handlerFlagsByCliName = new Map<string, unknown>();
+  if (flags !== undefined) {
+    for (const [key, value] of Object.entries(flags)) {
+      handlerFlagsByCliName.set(toCliFlagName(key), value);
+    }
+  }
+
+  for (const cliName of changedFlagNames) {
+    const rawValue = handlerFlagsByCliName.get(cliName);
+    const value = normalizeFlagValue(rawValue);
+
+    if (safeFlagSet.has(cliName) || typeof value === "boolean") {
+      result[cliName] = value ?? REDACTED_VALUE;
+      continue;
+    }
+
+    result[cliName] = REDACTED_VALUE;
+  }
+
+  return result;
+}
+
+function withLegacyCommandTracingImplementation() {
+  return <A, E, R>(self: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const commandRuntime = yield* CommandRuntime;
+      const command = getCommandRuntimeCommand(commandRuntime);
+
+      return yield* Effect.gen(function* () {
+        yield* Effect.annotateCurrentSpan({
+          command_run_id: commandRuntime.commandRunId,
+          command,
+        });
+        return yield* self;
+      }).pipe(Effect.withSpan(getCommandRuntimeSpanName(commandRuntime)));
+    });
+}
+
+function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, unknown>>(
+  options?: LegacyCommandInstrumentationOptions<Flags>,
+) {
+  const safeFlagSet = new Set(options?.safeFlags ?? []);
+  return <A, E, R>(self: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const commandRuntime = yield* CommandRuntime;
+      const command = getCommandRuntimeCommand(commandRuntime);
+
+      return yield* Effect.gen(function* () {
+        yield* Effect.annotateCurrentSpan({
+          command_run_id: commandRuntime.commandRunId,
+          command,
+        });
+
+        const analytics = yield* Analytics;
+        const stdio = yield* Stdio.Stdio;
+        const args = yield* stdio.args;
+        const startedAt = yield* Clock.currentTimeMillis;
+        const changedFlagNames = extractChangedFlagNames(args);
+        const flags = buildFlagsMap(options?.flags, safeFlagSet, changedFlagNames);
+        const analyticsContext = {
+          command_run_id: commandRuntime.commandRunId,
+          command,
+          flags,
+        } as const;
+
+        const exit = yield* self.pipe(withAnalyticsContext(analyticsContext), Effect.exit);
+        const finishedAt = yield* Clock.currentTimeMillis;
+
+        yield* analytics
+          .capture(EventCommandExecuted, {
+            [PropExitCode]: Exit.isSuccess(exit) ? 0 : 1,
+            [PropDurationMs]: finishedAt - startedAt,
+          })
+          .pipe(withAnalyticsContext(analyticsContext));
+
+        if (Exit.isFailure(exit)) {
+          return yield* Effect.failCause(exit.cause);
+        }
+        return exit.value;
+      }).pipe(Effect.withSpan(getCommandRuntimeSpanName(commandRuntime)));
+    });
+}
+
+export function withLegacyCommandInstrumentation(): <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+export function withLegacyCommandInstrumentation<Flags extends Record<string, unknown>>(
+  options: LegacyCommandInstrumentationOptions<Flags>,
+): <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+export function withLegacyCommandInstrumentation<Flags extends Record<string, unknown>>(
+  options?: LegacyCommandInstrumentationOptions<Flags>,
+) {
+  if (options?.analytics === false) {
+    return withLegacyCommandTracingImplementation();
+  }
+  return withLegacyCommandAnalyticsImplementation(options);
+}

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Stdio } from "effect";
+import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.ts";
+import { CurrentAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import { withLegacyCommandInstrumentation } from "./legacy-command-instrumentation.ts";
+
+function mockContextualAnalytics() {
+  const captured: Array<{
+    event: string;
+    properties: Record<string, unknown>;
+  }> = [];
+
+  const layer = Layer.succeed(
+    Analytics,
+    Analytics.of({
+      capture: (event: string, properties: Record<string, unknown> = {}) =>
+        Effect.gen(function* () {
+          const context = yield* CurrentAnalyticsContext;
+          captured.push({
+            event,
+            properties: {
+              ...context,
+              ...properties,
+            },
+          });
+        }),
+      identify: () => Effect.void,
+      alias: () => Effect.void,
+      groupIdentify: () => Effect.void,
+    }),
+  );
+
+  return { layer, captured };
+}
+
+describe("withLegacyCommandInstrumentation", () => {
+  it.live("annotates the command span and emits cli_command_executed", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.gen(function* () {
+      const span = yield* Effect.currentSpan;
+      expect(span.name).toBe("command.backups.list");
+      expect(span.attributes.get("command")).toBe("backups list");
+      expect(typeof span.attributes.get("command_run_id")).toBe("string");
+    }).pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed(["backups", "list"]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["backups", "list"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured).toHaveLength(1);
+          const event = analytics.captured[0];
+          expect(event?.event).toBe("cli_command_executed");
+          expect(event?.properties.command).toBe("backups list");
+          expect(event?.properties.exit_code).toBe(0);
+          expect(typeof event?.properties.duration_ms).toBe("number");
+        }),
+      ),
+    );
+  });
+
+  it.live("emits a single `flags` map (no `flags_used`/`flag_values`)", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({
+        flags: { projectRef: Option.some("abcdefghijklmnopqrst") },
+      }),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed(["secrets", "list", "--project-ref", "abcdefghijklmnopqrst"]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["secrets", "list"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured).toHaveLength(1);
+          const event = analytics.captured[0];
+          expect(event?.properties.flags).toEqual({ "project-ref": "<redacted>" });
+          expect(event?.properties).not.toHaveProperty("flags_used");
+          expect(event?.properties).not.toHaveProperty("flag_values");
+        }),
+      ),
+    );
+  });
+
+  it.live("redacts unsafe string flag values", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({
+        flags: { envFile: Option.some("/path/to/.env") },
+      }),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed(["secrets", "set", "--env-file=/path/to/.env"]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["secrets", "set"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const event = analytics.captured[0];
+          expect(event?.properties.flags).toEqual({ "env-file": "<redacted>" });
+        }),
+      ),
+    );
+  });
+
+  it.live("passes boolean flag values through verbatim", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({
+        flags: {
+          enableDbSslEnforcement: true,
+          disableDbSslEnforcement: false,
+        },
+      }),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed([
+            "ssl-enforcement",
+            "update",
+            "--enable-db-ssl-enforcement",
+            "--disable-db-ssl-enforcement",
+          ]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["ssl-enforcement", "update"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const event = analytics.captured[0];
+          expect(event?.properties.flags).toEqual({
+            "disable-db-ssl-enforcement": false,
+            "enable-db-ssl-enforcement": true,
+          });
+        }),
+      ),
+    );
+  });
+
+  it.live("passes safeFlags values through verbatim", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({
+        flags: { projectRef: Option.some("abcdefghijklmnopqrst") },
+        safeFlags: ["project-ref"],
+      }),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed(["link", "--project-ref", "abcdefghijklmnopqrst"]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["link"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const event = analytics.captured[0];
+          expect(event?.properties.flags).toEqual({
+            "project-ref": "abcdefghijklmnopqrst",
+          });
+        }),
+      ),
+    );
+  });
+
+  it.live("omits the `flags` property when no flags changed", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({ flags: {} }),
+      Effect.provide(analytics.layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["backups", "list"]) })),
+      Effect.provide(commandRuntimeLayer(["backups", "list"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const event = analytics.captured[0];
+          expect(event?.properties.flags).toBeUndefined();
+        }),
+      ),
+    );
+  });
+
+  it.live("captures failed commands with exit_code=1", () => {
+    const analytics = mockContextualAnalytics();
+
+    return withLegacyCommandInstrumentation()(Effect.fail(new Error("boom"))).pipe(
+      Effect.provide(analytics.layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["backups", "list"]) })),
+      Effect.provide(commandRuntimeLayer(["backups", "list"])),
+      Effect.exit,
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured).toHaveLength(1);
+          expect(analytics.captured[0]?.properties.exit_code).toBe(1);
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("skips analytics capture when analytics are disabled", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.sync(() => "ok").pipe(
+      withLegacyCommandInstrumentation({ analytics: false }),
+      Effect.provide(analytics.layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["telemetry", "enable"]) })),
+      Effect.provide(commandRuntimeLayer(["telemetry", "enable"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured).toEqual([]);
+        }),
+      ),
+    );
+  });
+
+  it.live("sorts flag names alphabetically to match Go", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation({
+        flags: {
+          projectRef: Option.some("abcdefghijklmnopqrst"),
+          timestamp: Option.some(1707407047),
+        },
+      }),
+      Effect.provide(analytics.layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed([
+            "backups",
+            "restore",
+            "--timestamp=1707407047",
+            "--project-ref",
+            "abcdefghijklmnopqrst",
+          ]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["backups", "restore"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const event = analytics.captured[0];
+          const flags = event?.properties.flags as Record<string, unknown>;
+          // Keys should be insertion-ordered alphabetically.
+          expect(Object.keys(flags)).toEqual(["project-ref", "timestamp"]);
+        }),
+      ),
+    );
+  });
+});

--- a/apps/cli/src/next/cli/main.ts
+++ b/apps/cli/src/next/cli/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { runCli } from "../../shared/cli/run.ts";
+import { analyticsLayer } from "../../shared/telemetry/analytics.layer.ts";
 import { nextRoot } from "./root.ts";
 
-await runCli(nextRoot);
+await runCli(nextRoot, { analyticsLayer });

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -21,7 +21,7 @@ import { runtimeInfoLayer } from "../runtime/runtime-info.layer.ts";
 import { ttyLayer } from "../runtime/tty.layer.ts";
 import { CommandRuntime } from "../runtime/command-runtime.service.ts";
 import { ProcessControl } from "../runtime/process-control.service.ts";
-import { analyticsLayer } from "../telemetry/analytics.layer.ts";
+import type { Analytics } from "../telemetry/analytics.service.ts";
 import { telemetryRuntimeLayer } from "../telemetry/runtime.layer.ts";
 import { tracingLayer } from "../telemetry/tracing.layer.ts";
 
@@ -65,7 +65,17 @@ function projectHomeLayerFor(runtimeLayer: Layer.Layer<never>) {
   );
 }
 
-function cliProgramFor(rootCommand: Command.Command.Any, args: ReadonlyArray<string>) {
+type AnyAnalyticsLayer = Layer.Layer<Analytics, never, any>;
+
+export interface RunCliOptions {
+  readonly analyticsLayer: AnyAnalyticsLayer;
+}
+
+function cliProgramFor(
+  rootCommand: Command.Command.Any,
+  args: ReadonlyArray<string>,
+  options: RunCliOptions,
+) {
   const runtimeLayer = Layer.mergeAll(processControlLayer, runtimeInfoLayer, ttyLayer);
   const fallbackCommandLayer = Layer.mergeAll(
     // Root command env inference currently leaks some subcommand-provided services.
@@ -92,7 +102,7 @@ function cliProgramFor(rootCommand: Command.Command.Any, args: ReadonlyArray<str
   );
   return Command.runWith(rootCommand, { version: CLI_VERSION })(args).pipe(
     Effect.provide(formatterLayerFor(args)),
-    Effect.provide(analyticsLayer),
+    Effect.provide(options.analyticsLayer),
     Effect.provide(tracingLayer),
     Effect.provide(telemetryRuntimeLayer),
     Effect.provide(cliConfigLayerFor(runtimeLayer)),
@@ -106,7 +116,7 @@ function cliProgramFor(rootCommand: Command.Command.Any, args: ReadonlyArray<str
   );
 }
 
-export async function runCli(rootCommand: Command.Command.Any) {
+export async function runCli(rootCommand: Command.Command.Any, options: RunCliOptions) {
   const args = await Effect.runPromise(
     Effect.gen(function* () {
       const stdio = yield* Stdio.Stdio;
@@ -115,7 +125,7 @@ export async function runCli(rootCommand: Command.Command.Any) {
   );
 
   const useGlobalSignalInterrupt = !args.includes("start");
-  const cliProgram = cliProgramFor(rootCommand, args);
+  const cliProgram = cliProgramFor(rootCommand, args, options);
 
   const signalAwareProgram = Effect.scoped(
     Effect.gen(function* () {

--- a/apps/cli/src/shared/telemetry/analytics-context.ts
+++ b/apps/cli/src/shared/telemetry/analytics-context.ts
@@ -3,8 +3,11 @@ import { Effect, Context } from "effect";
 export type AnalyticsContext = {
   readonly command_run_id?: string;
   readonly command?: string;
+  // next/ shell shape — separate `flags_used` (names) and `flag_values` (allowlist).
   readonly flags_used?: ReadonlyArray<string>;
   readonly flag_values?: Record<string, unknown>;
+  // legacy/ shell shape — single `flags` map mirroring Go's redaction.
+  readonly flags?: Record<string, unknown>;
   readonly distinct_id?: string;
   readonly groups?: {
     readonly organization?: string;

--- a/apps/cli/src/shared/telemetry/event-catalog.ts
+++ b/apps/cli/src/shared/telemetry/event-catalog.ts
@@ -1,0 +1,91 @@
+// CLI telemetry catalog. Mirrors apps/cli-go/internal/telemetry/events.go
+// 1:1 so legacy/ ports send byte-identical PostHog payloads. When the Go
+// catalog changes, update this file in the same PR.
+
+export const EventCommandExecuted = "cli_command_executed";
+export const EventProjectLinked = "cli_project_linked";
+export const EventLoginCompleted = "cli_login_completed";
+export const EventStackStarted = "cli_stack_started";
+export const EventUpgradeSuggested = "cli_upgrade_suggested";
+
+export const PropFeatureKey = "feature_key";
+export const PropOrgSlug = "org_slug";
+
+export const PropPlatform = "platform";
+export const PropSchemaVersion = "schema_version";
+export const PropDeviceId = "device_id";
+export const PropSessionId = "$session_id";
+export const PropIsFirstRun = "is_first_run";
+export const PropIsTty = "is_tty";
+export const PropIsCi = "is_ci";
+export const PropIsAgent = "is_agent";
+export const PropOs = "os";
+export const PropArch = "arch";
+export const PropCliVersion = "cli_version";
+export const PropEnvSignals = "env_signals";
+export const PropCommandRunId = "command_run_id";
+export const PropCommand = "command";
+export const PropFlags = "flags";
+export const PropExitCode = "exit_code";
+export const PropDurationMs = "duration_ms";
+
+export const GroupOrganization = "organization";
+export const GroupProject = "project";
+
+export const MaxEnvSignalValueLength = 80;
+
+// Env vars whose presence (any non-empty value) is recorded as `true` in env_signals.
+// Order matches apps/cli-go/internal/telemetry/events.go:126-167.
+export const EnvSignalPresenceKeys: ReadonlyArray<string> = [
+  // AI tools signals
+  "CURSOR_AGENT",
+  "CURSOR_TRACE_ID",
+  "GEMINI_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_CI",
+  "CODEX_THREAD_ID",
+  "ANTIGRAVITY_AGENT",
+  "AUGMENT_AGENT",
+  "OPENCODE_CLIENT",
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "REPL_ID",
+  "COPILOT_MODEL",
+  "COPILOT_ALLOW_ALL",
+  "COPILOT_GITHUB_TOKEN",
+  // CI signals
+  "CI",
+  "GITHUB_ACTIONS",
+  "BUILDKITE",
+  "TF_BUILD",
+  "JENKINS_URL",
+  "GITLAB_CI",
+  // Extra signals
+  "GITHUB_TOKEN",
+  "GITHUB_HEAD_REF",
+  "BITBUCKET_CLONE_DIR",
+  // Supabase environment signals
+  "SUPABASE_ACCESS_TOKEN",
+  "SUPABASE_HOME",
+  "SYSTEMROOT",
+  "SUPABASE_SSL_DEBUG",
+  "SUPABASE_CA_SKIP_VERIFY",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NPM_CONFIG_REGISTRY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_PROJECT_ID",
+  "SUPABASE_POSTGRES_URL",
+  "SUPABASE_ENV",
+];
+
+// Env vars whose trimmed values are recorded in env_signals, capped at
+// MaxEnvSignalValueLength chars. Order matches events.go:171-178.
+export const EnvSignalValueKeys: ReadonlyArray<string> = [
+  "AI_AGENT",
+  "CURSOR_EXTENSION_HOST_ROLE",
+  "TERM",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERM_COLOR_MODE",
+];

--- a/apps/cli/src/shared/telemetry/posthog-config.ts
+++ b/apps/cli/src/shared/telemetry/posthog-config.ts
@@ -1,0 +1,14 @@
+// PostHog connection config shared by both shells' analytics layers.
+// Defaults match apps/cli-go/internal/utils/misc.go PostHogAPIKey / PostHogEndpoint
+// (set via Go's -ldflags at build time, hard-coded here for the TS build).
+
+const DEFAULT_HOST = "https://eu.i.posthog.com";
+const DEFAULT_KEY = "phc_ihjC3EeB2wXCt87yccX5idgIgeZsub7WG0XR5hGFhJz";
+
+export const posthogConfig: {
+  readonly host: string;
+  readonly key: string;
+} = {
+  host: process.env.SUPABASE_TELEMETRY_POSTHOG_HOST ?? DEFAULT_HOST,
+  key: process.env.SUPABASE_TELEMETRY_POSTHOG_KEY ?? DEFAULT_KEY,
+};


### PR DESCRIPTION
## Summary

Audit (CLI-1531) found the native legacy ports were emitting a `cli_command_executed` payload that diverged from `apps/cli-go/` in three ways:

- `flags_used` (string array) + `flag_values` (allowlisted) instead of Go's single `flags` map with `"<redacted>"` for non-safe values.
- `ai_tool: string` instead of `is_agent: boolean`.
- Missing `env_signals` map.

Since the legacy/ shell sends events to the same PostHog pipeline as the Go binary, this drift was breaking dashboards and funnels silently.

## What changed

- **`shared/telemetry/event-catalog.ts`** — single literal-string source mirroring `apps/cli-go/internal/telemetry/events.go` (5 events, 18 props, 35 env-presence + 6 env-value keys, 80-char cap).
- **`shared/telemetry/posthog-config.ts`** — extracted PostHog host/key constants out of `next/config/cli-config.layer.ts` so both shells' analytics layers can share them without a cross-shell import.
- **`legacy/telemetry/legacy-analytics.layer.ts`** — implements `Analytics` with Go-shape base properties (`is_agent`, `env_signals`, no `ai_tool`). Loads linked-project cache from `SUPABASE_WORKDIR ?? process.cwd()` so it doesn't depend on per-command flag services.
- **`legacy/telemetry/legacy-command-instrumentation.ts`** — `withLegacyCommandInstrumentation({ flags, safeFlags })` emits a single `flags` map. Booleans + explicit `safeFlags` pass through verbatim (mirrors Go's `markFlagTelemetrySafe` annotation); everything else becomes `"<redacted>"`. Flag-name sort matches Go's `sort.Slice`.
- **`shared/cli/run.ts`** no longer hard-wires the analytics layer; `legacy/cli/main.ts` and `next/cli/main.ts` each provide their own.
- **7 native command files** (backups/{list,restore}, secrets/{list,set,unset}, ssl-enforcement/{get,update}) switched to `withLegacyCommandInstrumentation({ flags })`.
- The `next/` shell intentionally keeps the richer `ai_tool` / `flags_used` / `flag_values` payload — parity is scoped to `legacy/` only.

## Scope decision: custom events deferred

Every command that emits a custom event in Go — `login` (`cli_login_completed` + Alias/Identify stitching), `link` (`cli_project_linked`), `start` (`cli_stack_started`), `sso/*` and `branches/*` (`cli_upgrade_suggested`) — is still a Phase 0 `LegacyGoProxy` in the TS shell. The Go subprocess fires those events on its own; a TS wrapper would double-count. The native ports of those commands will need to reproduce the Go calls when they land — the canonical table is now documented in `AGENTS.md § Legacy Port: Telemetry Parity` and `apps/cli/src/legacy/SIDE_EFFECTS_TEMPLATE.md`.

## Reviewer notes

- Native handlers wrap with `withLegacyCommandInstrumentation`; proxy handlers stay unwrapped.
- `event-catalog.ts` is exempted from `knip:check` so future-use constants (e.g. `EventLoginCompleted`) don't get pruned before they're consumed.
- The legacy `AnalyticsContext` shape now carries both `flags` (legacy) and `flags_used`/`flag_values` (next); each shell's analytics layer reads only its own fields.
- Bundled `dist/supabase-legacy` was smoke-tested against both a native command (`backups list --help`) and a proxy command (`init --help`) per the [[feedback-layer-provide-semantics]] memory.

Fixes CLI-1531