### PR TITLE
fix(docker): restore Dependabot image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "pkg/config/templates"
+    directory: "/apps/cli-go/pkg/config/templates"
     schedule:
       interval: "cron"
       cronjob: "0 0 * * *"


### PR DESCRIPTION
## Summary

Fixes the Dependabot Docker manifest path after the Go CLI was moved under `apps/cli-go`.

Dependabot was still scanning `pkg/config/templates`, so it no longer found `apps/cli-go/pkg/config/templates/Dockerfile` and stopped opening Docker image update PRs for local `supabase start` services.