### PR TITLE
fix(docker): repair mirror image workflow dispatch

### DIFF
--- a/.github/workflows/cli-go-mirror-image.yml
+++ b/.github/workflows/cli-go-mirror-image.yml
@@ -15,8 +15,6 @@ on:
         description: "org/image:tag"
         required: true
         type: string
-    paths:
-      - apps/cli-go/**
 
 permissions:
   contents: read
@@ -50,6 +48,3 @@ jobs:
           dst: |
             public.ecr.aws/supabase/${{ steps.strip.outputs.image }}
             ghcr.io/supabase/${{ steps.strip.outputs.image }}
-defaults:
-  run:
-    working-directory: apps/cli-go


### PR DESCRIPTION
## Summary

Fixes the `Mirror Image` workflow so `repository_dispatch` runs can mirror Docker images without requiring a checked-out `apps/cli-go` directory.

The workflow was failing before any mirroring because it set `defaults.run.working-directory: apps/cli-go`, but dispatch-triggered runs do not checkout the repo. This also removes an invalid `workflow_dispatch.paths` entry from the same workflow.