### PR TITLE
fix(cli): restore completion subcommand tree in legacy shell

### DIFF
--- a/apps/cli/docs/go-cli-porting-status.md
+++ b/apps/cli/docs/go-cli-porting-status.md
@@ -10,7 +10,7 @@ Reference:
 ## Legend
 
 - `ported`: TS command exists and the flag/parameter surface is materially aligned with the old Go CLI
-- `partial`: TS feature exists but differs materially from the old Go CLI shape, flag surface, or invocation style. This includes feature parity delivered through framework-built global flags such as `--help` and `--completions` instead of matching Go subcommands exactly.
+- `partial`: TS feature exists but differs materially from the old Go CLI shape, flag surface, or invocation style. This includes feature parity delivered through framework-built global flags such as `--help` instead of matching Go subcommands exactly.
 - `missing`: no TS command/subcommand exists yet
 
 Percentages and counts below are based on final leaf commands only. Command groups like `db`, `functions`, and `completion` are not counted as commands.
@@ -19,29 +19,29 @@ Percentages and counts below are based on final leaf commands only. Command grou
 
 | Metric                    |   Count | Percent |
 | ------------------------- | ------: | ------: |
-| Fully ported commands     |  2 / 94 |    2.1% |
-| Partially ported commands | 59 / 94 |   62.8% |
+| Fully ported commands     |  6 / 94 |    6.4% |
+| Partially ported commands | 55 / 94 |   58.5% |
 
 ## Family Summary
 
-| Family                    | Final commands |  `ported` |  `partial` | `missing` | Represented in TS |
-| ------------------------- | -------------: | --------: | ---------: | --------: | ----------------: |
-| Quick Start               |              1 |    0 (0%) |     0 (0%) |  1 (100%) |            0 (0%) |
-| Project / Stack Lifecycle |              9 | 2 (22.2%) |  7 (77.8%) |    0 (0%) |          9 (100%) |
-| Database                  |             19 |    0 (0%) |     0 (0%) | 19 (100%) |            0 (0%) |
-| Code Generation           |              3 |    0 (0%) |     0 (0%) |  3 (100%) |            0 (0%) |
-| Functions                 |              6 |    0 (0%) |     0 (0%) |  6 (100%) |            0 (0%) |
-| Storage                   |              4 |    0 (0%) |     0 (0%) |  4 (100%) |            0 (0%) |
-| Management APIs           |             47 |    0 (0%) |  47 (100%) |    0 (0%) |         47 (100%) |
-| Additional Commands       |              5 |    0 (0%) | 5 (100.0%) |    0 (0%) |        5 (100.0%) |
+| Family                    | Final commands |  `ported` | `partial` | `missing` | Represented in TS |
+| ------------------------- | -------------: | --------: | --------: | --------: | ----------------: |
+| Quick Start               |              1 |    0 (0%) |    0 (0%) |  1 (100%) |            0 (0%) |
+| Project / Stack Lifecycle |              9 | 2 (22.2%) | 7 (77.8%) |    0 (0%) |          9 (100%) |
+| Database                  |             19 |    0 (0%) |    0 (0%) | 19 (100%) |            0 (0%) |
+| Code Generation           |              3 |    0 (0%) |    0 (0%) |  3 (100%) |            0 (0%) |
+| Functions                 |              6 |    0 (0%) |    0 (0%) |  6 (100%) |            0 (0%) |
+| Storage                   |              4 |    0 (0%) |    0 (0%) |  4 (100%) |            0 (0%) |
+| Management APIs           |             47 |    0 (0%) | 47 (100%) |    0 (0%) |         47 (100%) |
+| Additional Commands       |              5 |   4 (80%) |   1 (20%) |    0 (0%) |        5 (100.0%) |
 
 ## Global Flags Overview
 
 This tracker is command-focused, but root global flag drift is large enough to note separately.
 
-| Surface                 | TS path                                                                  | Missing old flags/params                                                                                                        | Extra TS flags/params | Notes                                                                                                                                                                                                                                        |
-| ----------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `supabase` global flags | [`../src/shared/cli/global-flags.ts`](../src/shared/cli/global-flags.ts) | `--create-ticket`, `--debug`, `--dns-resolver`, `--experimental`, `--network-id`, `--output`, `--profile`, `--workdir`, `--yes` | `--output-format`     | Root flag parity is still far from the Go CLI, but the framework already provides global `--help` and `--completions`, so help and shell completion have feature parity even though they no longer live under explicit Go-style subcommands. |
+| Surface                 | TS path                                                                  | Missing old flags/params                                                                                                        | Extra TS flags/params | Notes                                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supabase` global flags | [`../src/shared/cli/global-flags.ts`](../src/shared/cli/global-flags.ts) | `--create-ticket`, `--debug`, `--dns-resolver`, `--experimental`, `--network-id`, `--output`, `--profile`, `--workdir`, `--yes` | `--output-format`     | Root flag parity is still far from the Go CLI, but the framework already provides global `--help`, and `supabase completion <shell>` is restored as a Go-style subcommand. The framework's `--completions` global flag remains available for `next/` users. |
 
 ## TS-only Commands
 
@@ -193,13 +193,13 @@ These route-first equivalents are intentionally lower-level than the old Go comm
 
 ## Additional Commands
 
-| Old command             | TS status | TS command path or `missing`        | Missing flags/params                              | Extra TS flags/params | Notes                                                                                                                |
-| ----------------------- | --------- | ----------------------------------- | ------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `completion bash`       | `partial` | `supabase --completions bash`       | Go-style `completion bash` subcommand shape       | `-`                   | Feature parity exists via the framework-provided global `--completions` flag instead of a dedicated subcommand tree. |
-| `completion fish`       | `partial` | `supabase --completions fish`       | Go-style `completion fish` subcommand shape       | `-`                   | Feature parity exists via the framework-provided global `--completions` flag instead of a dedicated subcommand tree. |
-| `completion powershell` | `partial` | `supabase --completions powershell` | Go-style `completion powershell` subcommand shape | `-`                   | Feature parity exists via the framework-provided global `--completions` flag instead of a dedicated subcommand tree. |
-| `completion zsh`        | `partial` | `supabase --completions zsh`        | Go-style `completion zsh` subcommand shape        | `-`                   | Feature parity exists via the framework-provided global `--completions` flag instead of a dedicated subcommand tree. |
-| `help`                  | `partial` | `supabase --help`                   | Go-style top-level `help` command shape           | `-`                   | Feature parity exists via the framework-provided global `--help` flag instead of a dedicated `help` command.         |
+| Old command             | TS status | TS command path or `missing`     | Missing flags/params                    | Extra TS flags/params | Notes                                                                                                        |
+| ----------------------- | --------- | -------------------------------- | --------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `completion bash`       | `ported`  | `supabase completion bash`       | `-`                                     | `-`                   | Proxies verbatim to the Go binary so the emitted script is byte-identical to Cobra's output (CLI-1532).      |
+| `completion fish`       | `ported`  | `supabase completion fish`       | `-`                                     | `-`                   | Proxies verbatim to the Go binary so the emitted script is byte-identical to Cobra's output (CLI-1532).      |
+| `completion powershell` | `ported`  | `supabase completion powershell` | `-`                                     | `-`                   | Proxies verbatim to the Go binary so the emitted script is byte-identical to Cobra's output (CLI-1532).      |
+| `completion zsh`        | `ported`  | `supabase completion zsh`        | `-`                                     | `-`                   | Proxies verbatim to the Go binary so the emitted script is byte-identical to Cobra's output (CLI-1532).      |
+| `help`                  | `partial` | `supabase --help`                | Go-style top-level `help` command shape | `-`                   | Feature parity exists via the framework-provided global `--help` flag instead of a dedicated `help` command. |
 
 ## Legacy Shell Wrapping Status
 

--- a/apps/cli/src/legacy/cli/complete-passthrough.ts
+++ b/apps/cli/src/legacy/cli/complete-passthrough.ts
@@ -1,0 +1,60 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import process from "node:process";
+import {
+  type BinaryResolution,
+  formatGoBinaryNotFoundError,
+  resolveBinary,
+} from "../../shared/legacy/go-proxy.layer.ts";
+
+export interface CompletePassthroughDeps {
+  readonly argv: ReadonlyArray<string>;
+  readonly resolveBinary: () => BinaryResolution;
+  readonly spawn: (cmd: string, args: ReadonlyArray<string>) => SpawnSyncReturns<Buffer>;
+  readonly stderrWrite: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+/**
+ * Cobra-generated completion scripts (`supabase completion {bash,zsh,fish,powershell}`)
+ * call back into `supabase __complete <args>` on every tab press. The args may
+ * include partial flag tokens (e.g. `--de` while the user is mid-completion of a
+ * flag name) that Effect's structured parser would reject. Bypass Effect entirely
+ * for this code path and proxy the raw argv to the bundled Go binary, which is
+ * the authority on completion behavior for the legacy shell.
+ *
+ * Returns `true` when the call was intercepted (caller must not continue), `false`
+ * otherwise.
+ */
+export function tryCompletePassthrough(deps: CompletePassthroughDeps): boolean {
+  if (deps.argv[0] !== "__complete") return false;
+
+  const resolved = deps.resolveBinary();
+  if (!("found" in resolved)) {
+    deps.stderrWrite(`${formatGoBinaryNotFoundError(resolved.notFound)}\n`);
+    deps.exit(1);
+    return true;
+  }
+
+  const result = deps.spawn(resolved.found, deps.argv);
+  if (result.error) {
+    deps.stderrWrite(`${result.error.message}\n`);
+    deps.exit(1);
+    return true;
+  }
+  deps.exit(result.status ?? 1);
+  return true;
+}
+
+export function defaultCompletePassthroughDeps(): CompletePassthroughDeps {
+  return {
+    argv: process.argv.slice(2),
+    resolveBinary,
+    spawn: (cmd, args) => spawnSync(cmd, [...args], { stdio: "inherit" }),
+    stderrWrite: (message) => {
+      process.stderr.write(message);
+    },
+    exit: (code) => {
+      process.exit(code);
+    },
+  };
+}

--- a/apps/cli/src/legacy/cli/complete-passthrough.unit.test.ts
+++ b/apps/cli/src/legacy/cli/complete-passthrough.unit.test.ts
@@ -1,0 +1,103 @@
+import type { SpawnSyncReturns } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { type BinaryResolution } from "../../shared/legacy/go-proxy.layer.ts";
+import { type CompletePassthroughDeps, tryCompletePassthrough } from "./complete-passthrough.ts";
+
+function spawnResult(status: number | null, error?: Error): SpawnSyncReturns<Buffer> {
+  return {
+    pid: 1,
+    output: [],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status,
+    signal: null,
+    error,
+  };
+}
+
+function makeDeps(overrides: Partial<CompletePassthroughDeps> = {}): {
+  deps: CompletePassthroughDeps;
+  spawnCalls: Array<{ cmd: string; args: ReadonlyArray<string> }>;
+  stderr: Array<string>;
+  exits: Array<number>;
+} {
+  const spawnCalls: Array<{ cmd: string; args: ReadonlyArray<string> }> = [];
+  const stderr: Array<string> = [];
+  const exits: Array<number> = [];
+  const deps: CompletePassthroughDeps = {
+    argv: ["__complete", "migration", "li"],
+    resolveBinary: (): BinaryResolution => ({ found: "/path/to/supabase-go" }),
+    spawn: (cmd, args) => {
+      spawnCalls.push({ cmd, args });
+      return spawnResult(0);
+    },
+    stderrWrite: (msg) => {
+      stderr.push(msg);
+    },
+    exit: (code) => {
+      exits.push(code);
+    },
+    ...overrides,
+  };
+  return { deps, spawnCalls, stderr, exits };
+}
+
+describe("tryCompletePassthrough", () => {
+  it("returns false and does nothing when first argv is not __complete", () => {
+    const { deps, spawnCalls, exits } = makeDeps({ argv: ["migration", "list"] });
+    expect(tryCompletePassthrough(deps)).toBe(false);
+    expect(spawnCalls).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+
+  it("returns false on empty argv (e.g. bare `supabase`)", () => {
+    const { deps, spawnCalls, exits } = makeDeps({ argv: [] });
+    expect(tryCompletePassthrough(deps)).toBe(false);
+    expect(spawnCalls).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+
+  it("forwards verbatim argv (including flag-like tokens) to the Go binary on __complete", () => {
+    const { deps, spawnCalls, exits } = makeDeps({
+      argv: ["__complete", "--debug", "migration", "--de"],
+    });
+    expect(tryCompletePassthrough(deps)).toBe(true);
+    expect(spawnCalls).toEqual([
+      { cmd: "/path/to/supabase-go", args: ["__complete", "--debug", "migration", "--de"] },
+    ]);
+    expect(exits).toEqual([0]);
+  });
+
+  it("propagates the child's non-zero exit code", () => {
+    const spawn = vi.fn(() => spawnResult(7));
+    const { deps, exits } = makeDeps({ spawn });
+    tryCompletePassthrough(deps);
+    expect(exits).toEqual([7]);
+  });
+
+  it("exits 1 when the child has a null status (e.g. signal-terminated)", () => {
+    const spawn = vi.fn(() => spawnResult(null));
+    const { deps, exits } = makeDeps({ spawn });
+    tryCompletePassthrough(deps);
+    expect(exits).toEqual([1]);
+  });
+
+  it("prints the diagnostic and exits 1 when the Go binary cannot be resolved", () => {
+    const { deps, spawnCalls, stderr, exits } = makeDeps({
+      resolveBinary: () => ({ notFound: ["a", "b"] }),
+    });
+    tryCompletePassthrough(deps);
+    expect(spawnCalls).toEqual([]);
+    expect(exits).toEqual([1]);
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toContain("Could not find the `supabase-go` binary.");
+  });
+
+  it("prints the spawn error and exits 1 when spawnSync surfaces an error", () => {
+    const spawn = vi.fn(() => spawnResult(0, new Error("ENOENT")));
+    const { deps, stderr, exits } = makeDeps({ spawn });
+    tryCompletePassthrough(deps);
+    expect(exits).toEqual([1]);
+    expect(stderr).toEqual(["ENOENT\n"]);
+  });
+});

--- a/apps/cli/src/legacy/cli/main.ts
+++ b/apps/cli/src/legacy/cli/main.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 import { runCli } from "../../shared/cli/run.ts";
 import { legacyAnalyticsLayer } from "../telemetry/legacy-analytics.layer.ts";
+import { defaultCompletePassthroughDeps, tryCompletePassthrough } from "./complete-passthrough.ts";
 import { legacyRoot } from "./root.ts";
 
-await runCli(legacyRoot, { analyticsLayer: legacyAnalyticsLayer });
+if (!tryCompletePassthrough(defaultCompletePassthroughDeps())) {
+  await runCli(legacyRoot, { analyticsLayer: legacyAnalyticsLayer });
+}

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -3,6 +3,7 @@ import { Command } from "effect/unstable/cli";
 import { legacyBackupsCommand } from "../commands/backups/backups.command.ts";
 import { legacyBootstrapCommand } from "../commands/bootstrap/bootstrap.command.ts";
 import { legacyBranchesCommand } from "../commands/branches/branches.command.ts";
+import { legacyCompletionCommand } from "../commands/completion/completion.command.ts";
 import { legacyConfigCommand } from "../commands/config/config.command.ts";
 import { legacyDbCommand } from "../commands/db/db.command.ts";
 import { legacyDomainsCommand } from "../commands/domains/domains.command.ts";
@@ -58,6 +59,7 @@ export const legacyRoot = Command.make("supabase").pipe(
     legacyBackupsCommand,
     legacyBootstrapCommand,
     legacyBranchesCommand,
+    legacyCompletionCommand,
     legacyConfigCommand,
     legacyDbCommand,
     legacyDomainsCommand,

--- a/apps/cli/src/legacy/commands/completion/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/completion/SIDE_EFFECTS.md
@@ -1,0 +1,60 @@
+# `supabase completion`
+
+## Files Read
+
+| Path | Format | When |
+| ---- | ------ | ---- |
+| —    | —      | —    |
+
+## Files Written
+
+| Path | Format | When |
+| ---- | ------ | ---- |
+| —    | —      | —    |
+
+## API Routes
+
+| Method | Path | Auth | Request body | Response (used fields) |
+| ------ | ---- | ---- | ------------ | ---------------------- |
+| —      | —    | —    | —            | —                      |
+
+## Environment Variables
+
+| Variable | Purpose | Required? |
+| -------- | ------- | --------- |
+| —        | —       | —         |
+
+## Exit Codes
+
+| Code | Condition                                                          |
+| ---- | ------------------------------------------------------------------ |
+| `0`  | success — completion script for the chosen shell printed to stdout |
+| `1`  | invocation error (missing or unknown shell subcommand)             |
+
+## Output
+
+`supabase completion <shell>` prints a shell-specific autocompletion script to stdout.
+The subcommand tree mirrors the Go CLI exactly: `bash`, `fish`, `powershell`, `zsh`.
+
+In the legacy shell every subcommand proxies verbatim to the bundled Go binary via
+`LegacyGoProxy`, so the emitted scripts are byte-for-byte identical to what the Go
+CLI produced. This matters because users who installed completions with the Go CLI
+have those exact bytes cached in their `~/.zshrc` (`eval "$(supabase completion zsh)"`),
+brew-managed `_supabase` files in their `fpath`, or analogous bash/fish/powershell
+artifacts. Drift would break tab completion for those users.
+
+The generated scripts call back to `supabase __complete <args>` on every tab press to
+fetch dynamic completion candidates — see `apps/cli/src/legacy/commands/__complete/`,
+which provides the matching hidden command.
+
+## Notes
+
+- No native TS reimplementation is attempted. Effect's `Completions.generate` API
+  emits a static `_arguments`-based zsh function that diverges from Cobra's runtime-
+  callback shape; using it here would break the existing user setups described above.
+- Effect CLI's `--completions` global flag remains exposed at the root for `next/`
+  users; it does not satisfy the legacy parity contract and is not what this
+  subcommand routes through.
+- The Go CLI exits non-zero when called without a shell subcommand (e.g.
+  `supabase completion`). Effect CLI surfaces the same condition through its usual
+  "missing subcommand" help-with-exit-1 behavior.

--- a/apps/cli/src/legacy/commands/completion/bash/bash.command.ts
+++ b/apps/cli/src/legacy/commands/completion/bash/bash.command.ts
@@ -1,0 +1,12 @@
+import { Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { legacyCompletionBash } from "./bash.handler.ts";
+
+const config = {};
+export type LegacyCompletionBashFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyCompletionBashCommand = Command.make("bash", config).pipe(
+  Command.withDescription("Generate the autocompletion script for bash"),
+  Command.withShortDescription("Generate the autocompletion script for bash"),
+  Command.withHandler((flags) => legacyCompletionBash(flags)),
+);

--- a/apps/cli/src/legacy/commands/completion/bash/bash.handler.ts
+++ b/apps/cli/src/legacy/commands/completion/bash/bash.handler.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import type { LegacyCompletionBashFlags } from "./bash.command.ts";
+
+export const legacyCompletionBash = Effect.fn("legacy.completion.bash")(function* (
+  _flags: LegacyCompletionBashFlags,
+) {
+  const proxy = yield* LegacyGoProxy;
+  yield* proxy.exec(["completion", "bash"]);
+});

--- a/apps/cli/src/legacy/commands/completion/bash/bash.integration.test.ts
+++ b/apps/cli/src/legacy/commands/completion/bash/bash.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import { legacyCompletionBash } from "./bash.handler.ts";
+
+function setupLegacyCompletionBash() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+  });
+  return { layer, calls };
+}
+
+describe("legacy completion bash", () => {
+  it.live("forwards `completion bash` to the Go binary", () => {
+    const { layer, calls } = setupLegacyCompletionBash();
+    return Effect.gen(function* () {
+      yield* legacyCompletionBash({});
+      expect(calls).toEqual([["completion", "bash"]]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/cli/src/legacy/commands/completion/completion.command.ts
+++ b/apps/cli/src/legacy/commands/completion/completion.command.ts
@@ -1,0 +1,19 @@
+import { Command } from "effect/unstable/cli";
+import { legacyCompletionBashCommand } from "./bash/bash.command.ts";
+import { legacyCompletionFishCommand } from "./fish/fish.command.ts";
+import { legacyCompletionPowershellCommand } from "./powershell/powershell.command.ts";
+import { legacyCompletionZshCommand } from "./zsh/zsh.command.ts";
+
+export const legacyCompletionCommand = Command.make("completion").pipe(
+  Command.withDescription(
+    "Generate the autocompletion script for supabase for the specified shell.\n" +
+      "See each sub-command's help for details on how to use the generated script.",
+  ),
+  Command.withShortDescription("Generate autocompletion scripts"),
+  Command.withSubcommands([
+    legacyCompletionBashCommand,
+    legacyCompletionFishCommand,
+    legacyCompletionPowershellCommand,
+    legacyCompletionZshCommand,
+  ]),
+);

--- a/apps/cli/src/legacy/commands/completion/fish/fish.command.ts
+++ b/apps/cli/src/legacy/commands/completion/fish/fish.command.ts
@@ -1,0 +1,12 @@
+import { Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { legacyCompletionFish } from "./fish.handler.ts";
+
+const config = {};
+export type LegacyCompletionFishFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyCompletionFishCommand = Command.make("fish", config).pipe(
+  Command.withDescription("Generate the autocompletion script for fish"),
+  Command.withShortDescription("Generate the autocompletion script for fish"),
+  Command.withHandler((flags) => legacyCompletionFish(flags)),
+);

--- a/apps/cli/src/legacy/commands/completion/fish/fish.handler.ts
+++ b/apps/cli/src/legacy/commands/completion/fish/fish.handler.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import type { LegacyCompletionFishFlags } from "./fish.command.ts";
+
+export const legacyCompletionFish = Effect.fn("legacy.completion.fish")(function* (
+  _flags: LegacyCompletionFishFlags,
+) {
+  const proxy = yield* LegacyGoProxy;
+  yield* proxy.exec(["completion", "fish"]);
+});

--- a/apps/cli/src/legacy/commands/completion/fish/fish.integration.test.ts
+++ b/apps/cli/src/legacy/commands/completion/fish/fish.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import { legacyCompletionFish } from "./fish.handler.ts";
+
+function setupLegacyCompletionFish() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+  });
+  return { layer, calls };
+}
+
+describe("legacy completion fish", () => {
+  it.live("forwards `completion fish` to the Go binary", () => {
+    const { layer, calls } = setupLegacyCompletionFish();
+    return Effect.gen(function* () {
+      yield* legacyCompletionFish({});
+      expect(calls).toEqual([["completion", "fish"]]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/cli/src/legacy/commands/completion/powershell/powershell.command.ts
+++ b/apps/cli/src/legacy/commands/completion/powershell/powershell.command.ts
@@ -1,0 +1,12 @@
+import { Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { legacyCompletionPowershell } from "./powershell.handler.ts";
+
+const config = {};
+export type LegacyCompletionPowershellFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyCompletionPowershellCommand = Command.make("powershell", config).pipe(
+  Command.withDescription("Generate the autocompletion script for powershell"),
+  Command.withShortDescription("Generate the autocompletion script for powershell"),
+  Command.withHandler((flags) => legacyCompletionPowershell(flags)),
+);

--- a/apps/cli/src/legacy/commands/completion/powershell/powershell.handler.ts
+++ b/apps/cli/src/legacy/commands/completion/powershell/powershell.handler.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import type { LegacyCompletionPowershellFlags } from "./powershell.command.ts";
+
+export const legacyCompletionPowershell = Effect.fn("legacy.completion.powershell")(function* (
+  _flags: LegacyCompletionPowershellFlags,
+) {
+  const proxy = yield* LegacyGoProxy;
+  yield* proxy.exec(["completion", "powershell"]);
+});

--- a/apps/cli/src/legacy/commands/completion/powershell/powershell.integration.test.ts
+++ b/apps/cli/src/legacy/commands/completion/powershell/powershell.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import { legacyCompletionPowershell } from "./powershell.handler.ts";
+
+function setupLegacyCompletionPowershell() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+  });
+  return { layer, calls };
+}
+
+describe("legacy completion powershell", () => {
+  it.live("forwards `completion powershell` to the Go binary", () => {
+    const { layer, calls } = setupLegacyCompletionPowershell();
+    return Effect.gen(function* () {
+      yield* legacyCompletionPowershell({});
+      expect(calls).toEqual([["completion", "powershell"]]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/cli/src/legacy/commands/completion/zsh/zsh.command.ts
+++ b/apps/cli/src/legacy/commands/completion/zsh/zsh.command.ts
@@ -1,0 +1,12 @@
+import { Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { legacyCompletionZsh } from "./zsh.handler.ts";
+
+const config = {};
+export type LegacyCompletionZshFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyCompletionZshCommand = Command.make("zsh", config).pipe(
+  Command.withDescription("Generate the autocompletion script for zsh"),
+  Command.withShortDescription("Generate the autocompletion script for zsh"),
+  Command.withHandler((flags) => legacyCompletionZsh(flags)),
+);

--- a/apps/cli/src/legacy/commands/completion/zsh/zsh.handler.ts
+++ b/apps/cli/src/legacy/commands/completion/zsh/zsh.handler.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import type { LegacyCompletionZshFlags } from "./zsh.command.ts";
+
+export const legacyCompletionZsh = Effect.fn("legacy.completion.zsh")(function* (
+  _flags: LegacyCompletionZshFlags,
+) {
+  const proxy = yield* LegacyGoProxy;
+  yield* proxy.exec(["completion", "zsh"]);
+});

--- a/apps/cli/src/legacy/commands/completion/zsh/zsh.integration.test.ts
+++ b/apps/cli/src/legacy/commands/completion/zsh/zsh.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import { legacyCompletionZsh } from "./zsh.handler.ts";
+
+function setupLegacyCompletionZsh() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+  });
+  return { layer, calls };
+}
+
+describe("legacy completion zsh", () => {
+  it.live("forwards `completion zsh` to the Go binary", () => {
+    const { layer, calls } = setupLegacyCompletionZsh();
+    return Effect.gen(function* () {
+      yield* legacyCompletionZsh({});
+      expect(calls).toEqual([["completion", "zsh"]]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/cli/src/shared/legacy/go-proxy.layer.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.layer.ts
@@ -36,7 +36,7 @@ export type BinaryResolution =
   | { readonly found: string }
   | { readonly notFound: ReadonlyArray<string> };
 
-function resolveBinary(): BinaryResolution {
+export function resolveBinary(): BinaryResolution {
   const tried: string[] = [];
 
   const envBin = process.env["SUPABASE_GO_BINARY"];


### PR DESCRIPTION
## Current Behavior

The Go CLI ships `supabase completion {bash,zsh,fish,powershell}` via Cobra. Users routinely install completions via `eval "$(supabase completion zsh)"` in their `.zshrc` (or have brew-installed `_supabase` files in their zsh `fpath`), and Cobra's generated scripts call back into `supabase __complete <args>` on every tab press to fetch dynamic completion candidates.

When the TypeScript CLI replaced the Go binary on user PATHs the legacy shell dropped the `completion` subcommand entirely — Effect CLI only exposes shell completion via a `--completions` global flag, which is not what existing user setups invoke. Result: at shell startup, users hit:

```
(eval):1: _supabase: function definition file not found
(eval):1: _supabase: function definition file not found
(eval):1: _supabase: function definition file not found
```

## Expected Behavior

`supabase completion <shell>` succeeds and emits the same script bytes the Go CLI would. Existing `.zshrc` setups, brew-managed `_supabase` files in `fpath`, and the equivalents for bash/fish/powershell all keep working without modification. Tab completion works end-to-end, including for partial flag tokens (`supabase --de<TAB>`).

## What this PR does

Scoped to the legacy shell only — `next/` keeps using the framework-provided `--completions` flag and is untouched.

- Adds `supabase completion {bash,fish,powershell,zsh}` under `apps/cli/src/legacy/commands/completion/`. Each handler is a thin `LegacyGoProxy.exec(["completion", "<shell>"])` proxy, so the emitted scripts are byte-for-byte identical to Cobra's output. This is what existing user setups already have cached and depend on, and avoids the drift risk of regenerating the scripts from a different source of truth.
- Adds an argv intercept in `legacy/cli/main.ts` (via `complete-passthrough.ts`) for the hidden `__complete` callback. Cobra's generated scripts call `supabase __complete <args>` on every tab press, and the args may include partial-flag tokens like `--de` that Effect's structured parser would reject. The intercept bypasses Effect entirely and proxies the raw argv to the bundled Go binary, which is the authority on completion behavior for the legacy shell. `__complete` is intentionally not registered as an Effect Command, so it stays out of `--help`.
- Updates `docs/go-cli-porting-status.md`: the four `completion <shell>` rows are promoted from `partial` to `ported`, with summary/family totals adjusted.

## Verification

Ran locally against a freshly-built Go binary (`SUPABASE_GO_BINARY=…`):

- `supabase completion zsh` emits `#compdef supabase\ncompdef _supabase supabase ...` — byte-exact match with `go run ./apps/cli-go completion zsh`.
- `supabase completion --help` lists `bash`, `fish`, `powershell`, `zsh` subcommands.
- `supabase __complete mi` → `migration\t...`.
- `supabase __complete --debug branches lis` → `list\t...` (verbatim flag passthrough confirmed).
- `supabase --help` shows `completion` and hides `__complete`.

Fixes CLI-1532