### PR TITLE
fix(functions): pass deno config as import map

### DIFF
--- a/apps/cli-go/internal/functions/deploy/bundle.go
+++ b/apps/cli-go/internal/functions/deploy/bundle.go
@@ -50,7 +50,7 @@ func (b *dockerBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	hostOutputPath := filepath.Join(hostOutputDir, "output.eszip")
 	// Create exec command
 	cmd := []string{"bundle", "--entrypoint", utils.ToDockerPath(entrypoint), "--output", utils.ToDockerPath(hostOutputPath)}
-	if len(importMap) > 0 && !function.ShouldUseDenoJsonDiscovery(entrypoint, importMap) {
+	if len(importMap) > 0 {
 		cmd = append(cmd, "--import-map", utils.ToDockerPath(importMap))
 	}
 	for _, sf := range staticFiles {

--- a/apps/cli-go/pkg/function/bundle.go
+++ b/apps/cli-go/pkg/function/bundle.go
@@ -59,7 +59,7 @@ func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	outputPath := filepath.Join(b.tempDir, slug+".eszip")
 	// TODO: make edge runtime write to stdout
 	args := []string{"bundle", "--entrypoint", entrypoint, "--output", outputPath}
-	if len(importMap) > 0 && !ShouldUseDenoJsonDiscovery(entrypoint, importMap) {
+	if len(importMap) > 0 {
 		args = append(args, "--import-map", importMap)
 	}
 	for _, staticFile := range staticFiles {
@@ -88,10 +88,6 @@ func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 	}
 	defer eszipBytes.Close()
 	return meta, Compress(eszipBytes, output)
-}
-
-func ShouldUseDenoJsonDiscovery(entrypoint, importMap string) bool {
-	return isDeno(filepath.Base(importMap)) && filepath.Dir(importMap) == filepath.Dir(entrypoint)
 }
 
 func ShouldUsePackageJsonDiscovery(entrypoint, importMap string, fsys fs.StatFS) bool {

--- a/apps/cli-go/pkg/function/bundle_test.go
+++ b/apps/cli-go/pkg/function/bundle_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	fs "testing/fstest"
 
@@ -17,6 +18,12 @@ import (
 func TestMain(m *testing.M) {
 	// Setup mock edge runtime binary
 	if len(os.Args) > 1 && os.Args[1] == "bundle" {
+		if path := os.Getenv("TEST_BUNDLE_ARGS_FILE"); len(path) > 0 {
+			if err := os.WriteFile(path, []byte(strings.Join(os.Args[1:], "\n")), 0600); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+		}
 		if msg := os.Getenv("TEST_BUNDLE_ERROR"); len(msg) > 0 {
 			fmt.Fprintln(os.Stderr, msg)
 			os.Exit(1)
@@ -61,6 +68,32 @@ func TestBundleFunction(t *testing.T) {
 		staticFile := fmt.Sprintf("file://%s/hello/data.pdf", filepath.ToSlash(cwd))
 		assert.Equal(t, cast.Ptr([]string{staticFile}), meta.StaticPatterns)
 		assert.Nil(t, meta.VerifyJwt)
+	})
+
+	t.Run("passes deno config as import map", func(t *testing.T) {
+		argsFile := filepath.Join(t.TempDir(), "args")
+		t.Setenv("TEST_BUNDLE_ARGS_FILE", argsFile)
+		var body bytes.Buffer
+		fsys := fs.MapFS{
+			"hello.eszip": &fs.MapFile{},
+		}
+		bundler := nativeBundler{fsys: fsys}
+
+		_, err := bundler.Bundle(
+			context.Background(),
+			"hello",
+			"hello/index.ts",
+			"hello/deno.json",
+			nil,
+			&body,
+		)
+
+		require.NoError(t, err)
+		data, err := os.ReadFile(argsFile)
+		require.NoError(t, err)
+		args := strings.Split(string(data), "\n")
+		assert.Contains(t, args, "--import-map")
+		assert.Contains(t, args, "hello/deno.json")
 	})
 
 	t.Run("ignores empty value", func(t *testing.T) {


### PR DESCRIPTION
## What changed

Pass the resolved import map to edge-runtime whenever one is configured, including `deno.json` and `deno.jsonc` files that live beside the function entrypoint.

This fixes the regression described in #5069 where bare imports from `deno.json` were no longer resolved during `supabase functions deploy` because the CLI skipped `--import-map` and relied on edge-runtime auto-discovery.

## Why

The CLI already resolves the correct import map path before bundling. Passing it explicitly keeps legacy `import_map.json` behavior and restores `deno.json`/`deno.jsonc` import resolution for both native and Docker bundling.

## Verification

- `GOCACHE=... GOMODCACHE=... go test ./function` from `apps/cli-go/pkg` passed
- `GOCACHE=... GOMODCACHE=... go test ./internal/functions/deploy` from `apps/cli-go` was attempted, but the runner volume ran out of temp build space while compiling dependencies before package tests could run