### PR TITLE
chore(cli): replace legacy hidden subcommands

### DIFF
--- a/apps/cli/src/legacy/commands/branches/branches.command.ts
+++ b/apps/cli/src/legacy/commands/branches/branches.command.ts
@@ -1,5 +1,4 @@
 import { Command } from "effect/unstable/cli";
-import { withHiddenSubcommands } from "../../../shared/cli/hidden-flag.ts";
 import { legacyBranchesListCommand } from "./list/list.command.ts";
 import { legacyBranchesCreateCommand } from "./create/create.command.ts";
 import { legacyBranchesGetCommand } from "./get/get.command.ts";
@@ -12,7 +11,6 @@ import { legacyBranchesDisableCommand } from "./disable/disable.command.ts";
 export const legacyBranchesCommand = Command.make("branches").pipe(
   Command.withDescription("Manage Supabase preview branches."),
   Command.withShortDescription("Manage preview branches"),
-  withHiddenSubcommands(["disable"]),
   Command.withSubcommands([
     legacyBranchesListCommand,
     legacyBranchesCreateCommand,
@@ -21,6 +19,6 @@ export const legacyBranchesCommand = Command.make("branches").pipe(
     legacyBranchesPauseCommand,
     legacyBranchesUnpauseCommand,
     legacyBranchesDeleteCommand,
-    legacyBranchesDisableCommand,
+    legacyBranchesDisableCommand.pipe(Command.withHidden),
   ]),
 );

--- a/apps/cli/src/legacy/commands/db/db.command.ts
+++ b/apps/cli/src/legacy/commands/db/db.command.ts
@@ -1,5 +1,4 @@
 import { Command } from "effect/unstable/cli";
-import { withHiddenSubcommands } from "../../../shared/cli/hidden-flag.ts";
 import { legacyDbDiffCommand } from "./diff/diff.command.ts";
 import { legacyDbDumpCommand } from "./dump/dump.command.ts";
 import { legacyDbPushCommand } from "./push/push.command.ts";
@@ -17,7 +16,6 @@ import { legacyDbSchemaCommand } from "./schema/schema.command.ts";
 export const legacyDbCommand = Command.make("db").pipe(
   Command.withDescription("Manage Postgres databases."),
   Command.withShortDescription("Manage databases"),
-  withHiddenSubcommands(["branch", "remote", "test"]),
   Command.withSubcommands([
     legacyDbDiffCommand,
     legacyDbDumpCommand,
@@ -28,9 +26,9 @@ export const legacyDbCommand = Command.make("db").pipe(
     legacyDbStartCommand,
     legacyDbQueryCommand,
     legacyDbAdvisorsCommand,
-    legacyDbTestCommand,
-    legacyDbBranchCommand,
-    legacyDbRemoteCommand,
+    legacyDbTestCommand.pipe(Command.withHidden),
+    legacyDbBranchCommand.pipe(Command.withHidden),
+    legacyDbRemoteCommand.pipe(Command.withHidden),
     legacyDbSchemaCommand,
   ]),
 );

--- a/apps/cli/src/shared/cli/hidden-flag.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.ts
@@ -13,12 +13,6 @@ export const LegacyHiddenFlags: Context.Reference<ReadonlySet<string>> = Context
   defaultValue: () => new Set<string>(),
 });
 
-export const LegacyHiddenSubcommands: Context.Reference<ReadonlySet<string>> = Context.Reference<
-  ReadonlySet<string>
->("supabase/legacy/LegacyHiddenSubcommands", {
-  defaultValue: () => new Set<string>(),
-});
-
 const hiddenFlagNames = new WeakMap<object, ReadonlyArray<string>>();
 
 const collectSingleNames = (param: Param.Param<Param.ParamKind, unknown>): Array<string> => {
@@ -76,36 +70,14 @@ export const withHiddenFromConfig =
     return Command.annotate(cmd, LegacyHiddenFlags, hidden);
   };
 
-export const withHiddenSubcommands =
-  (names: ReadonlyArray<string>) =>
-  <Name extends string, Input, ContextInput, E, R>(
-    cmd: Command.Command<Name, Input, ContextInput, E, R>,
-  ): Command.Command<Name, Input, ContextInput, E, R> =>
-    Command.annotate(cmd, LegacyHiddenSubcommands, new Set(names));
-
 export const stripHiddenFlagsFromHelpDoc = (doc: HelpDoc.HelpDoc): HelpDoc.HelpDoc => {
   const hiddenFlags = Context.get(doc.annotations, LegacyHiddenFlags);
-  const hiddenSubcommands = Context.get(doc.annotations, LegacyHiddenSubcommands);
-  if (hiddenFlags.size === 0 && hiddenSubcommands.size === 0) return doc;
+  if (hiddenFlags.size === 0) return doc;
   const filteredFlags = doc.flags.filter((flag) => !hiddenFlags.has(flag.name));
   const filteredGlobalFlags = doc.globalFlags?.filter((flag) => !hiddenFlags.has(flag.name));
-  const filteredSubcommands = doc.subcommands?.flatMap((group) => {
-    const commands = group.commands.filter((command) => !hiddenSubcommands.has(command.name));
-    if (commands.length === 0) return [];
-    return [
-      {
-        ...group,
-        commands: commands as unknown as readonly [
-          HelpDoc.SubcommandDoc,
-          ...Array<HelpDoc.SubcommandDoc>,
-        ],
-      },
-    ];
-  });
   return {
     ...doc,
     flags: filteredFlags,
-    ...(filteredSubcommands !== undefined && { subcommands: filteredSubcommands }),
     ...(filteredGlobalFlags !== undefined && { globalFlags: filteredGlobalFlags }),
   };
 };

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -1,13 +1,15 @@
-import { Context, Option } from "effect";
-import { Command, Flag, type HelpDoc } from "effect/unstable/cli";
+import { Context, Effect, Layer, Option } from "effect";
+import { CliOutput, Command, Flag, type HelpDoc } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
+import { legacyBranchesCommand } from "../../legacy/commands/branches/branches.command.ts";
+import { legacyDbCommand } from "../../legacy/commands/db/db.command.ts";
+import { LegacyGoProxy } from "../legacy/go-proxy.service.ts";
+import { textCliOutputFormatter } from "../output/text-formatter.ts";
 import {
   LegacyHiddenFlags,
-  LegacyHiddenSubcommands,
   stripHiddenFlagsFromHelpDoc,
   withHidden,
   withHiddenFromConfig,
-  withHiddenSubcommands,
 } from "./hidden-flag.ts";
 
 const flagDoc = (name: string): HelpDoc.FlagDoc => ({
@@ -35,15 +37,6 @@ const helpDocWithHidden = (
     annotations: Context.make(LegacyHiddenFlags, new Set(hidden)),
   });
 
-const helpDocWithHiddenSubcommands = (
-  hidden: ReadonlyArray<string>,
-  overrides: Partial<HelpDoc.HelpDoc>,
-): HelpDoc.HelpDoc =>
-  helpDoc({
-    ...overrides,
-    annotations: Context.make(LegacyHiddenSubcommands, new Set(hidden)),
-  });
-
 // Reach into the internal command shape to obtain the help doc the formatter
 // would render. Effect builds this from `Command.annotations`, which is the
 // contract `withHiddenFromConfig` relies on.
@@ -53,6 +46,22 @@ interface CommandImpl {
 const buildHelpDoc = <Name extends string, Input, ContextInput, E, R>(
   cmd: Command.Command<Name, Input, ContextInput, E, R>,
 ): HelpDoc.HelpDoc => (cmd as unknown as CommandImpl).buildHelpDoc([]);
+
+function mockLegacyGoProxy() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push([...args]);
+      }),
+  });
+
+  return { layer, calls };
+}
+
+const legacyTestRoot = Command.make("supabase").pipe(
+  Command.withSubcommands([legacyBranchesCommand, legacyDbCommand]),
+);
 
 describe("withHidden", () => {
   it("returns the same flag instance", () => {
@@ -121,15 +130,6 @@ describe("withHiddenFromConfig", () => {
   });
 });
 
-describe("withHiddenSubcommands", () => {
-  it("adds hidden subcommand annotations to the command help doc", () => {
-    const cmd = Command.make("demo").pipe(withHiddenSubcommands(["legacy"]));
-    const annotated = Context.get(buildHelpDoc(cmd).annotations, LegacyHiddenSubcommands);
-
-    expect([...annotated]).toEqual(["legacy"]);
-  });
-});
-
 describe("stripHiddenFlagsFromHelpDoc", () => {
   it("returns the doc unchanged when annotations are empty", () => {
     const doc = helpDoc({ flags: [flagDoc("foo")] });
@@ -154,26 +154,52 @@ describe("stripHiddenFlagsFromHelpDoc", () => {
     expect(stripped.globalFlags).toBeUndefined();
     expect(stripped.flags.map((f) => f.name)).toEqual(["bar"]);
   });
+});
 
-  it("filters hidden subcommands by the doc's annotation", () => {
-    const doc = helpDocWithHiddenSubcommands(["legacy"], {
-      subcommands: [
-        {
-          group: undefined,
-          commands: [
-            {
-              name: "visible",
-              alias: undefined,
-              shortDescription: "visible",
-              description: "visible",
-            },
-            { name: "legacy", alias: undefined, shortDescription: "legacy", description: "legacy" },
-          ],
-        },
-      ],
-    });
+describe("legacy hidden subcommands", () => {
+  it("omits hidden branch and db subcommands from help docs", () => {
+    const branchesHelp = buildHelpDoc(legacyBranchesCommand);
+    expect(branchesHelp.subcommands?.[0]?.commands.map((command) => command.name)).toEqual([
+      "list",
+      "create",
+      "get",
+      "update",
+      "pause",
+      "unpause",
+      "delete",
+    ]);
 
-    const stripped = stripHiddenFlagsFromHelpDoc(doc);
-    expect(stripped.subcommands?.[0]?.commands.map((command) => command.name)).toEqual(["visible"]);
+    const dbHelp = buildHelpDoc(legacyDbCommand);
+    expect(dbHelp.subcommands?.[0]?.commands.map((command) => command.name)).toEqual([
+      "diff",
+      "dump",
+      "push",
+      "pull",
+      "reset",
+      "lint",
+      "start",
+      "query",
+      "advisors",
+      "schema",
+    ]);
+  });
+
+  it("still executes hidden subcommands by exact name", async () => {
+    const proxy = mockLegacyGoProxy();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["branches", "disable"]);
+        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "test"]);
+        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "branch", "list"]);
+        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "remote", "changes"]);
+      }).pipe(Effect.provide(Layer.mergeAll(proxy.layer, CliOutput.layer(textCliOutputFormatter())))) as Effect.Effect<void>,
+    );
+
+    expect(proxy.calls).toEqual([
+      ["branches", "disable"],
+      ["db", "test"],
+      ["db", "branch", "list"],
+      ["db", "remote", "changes"],
+    ]);
   });
 });

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -191,8 +191,14 @@ describe("legacy hidden subcommands", () => {
         yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["branches", "disable"]);
         yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "test"]);
         yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "branch", "list"]);
-        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(["db", "remote", "changes"]);
-      }).pipe(Effect.provide(Layer.mergeAll(proxy.layer, CliOutput.layer(textCliOutputFormatter())))) as Effect.Effect<void>,
+        yield* Command.runWith(legacyTestRoot, { version: "0.0.0-test" })([
+          "db",
+          "remote",
+          "changes",
+        ]);
+      }).pipe(
+        Effect.provide(Layer.mergeAll(proxy.layer, CliOutput.layer(textCliOutputFormatter()))),
+      ) as Effect.Effect<void>,
     );
 
     expect(proxy.calls).toEqual([


### PR DESCRIPTION
## TL;DR

Switch legacy hidden subcommands to native `Command.withHidden`

## What's introduced:

- hide legacy `branches disable` with `Command.withHidden`
- hide legacy `db test`, `db branch`, and `db remote` with `Command.withHidden`
- remove the local hidden subcommand annotation/filtering path
- adds coverage to ensure stay callable by exact name while staying out of help output

## Why:

Effect now supports hidden subcommands natively, so legacy commands can express that behavior directly at the subcommand definition 
this removes custom local handling and leaves the path smaller, clearer, and easier to maintain :D

## ref:

- extends: https://github.com/Effect-TS/effect-smol/pull/2228
- followup to: https://github.com/supabase/cli/pull/5295