### PR TITLE
fix(cli): update effect beta

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@effect/atom-react':
-      specifier: 4.0.0-beta.72
-      version: 4.0.0-beta.72
+      specifier: 4.0.0-beta.74
+      version: 4.0.0-beta.74
     '@effect/platform-bun':
-      specifier: 4.0.0-beta.72
-      version: 4.0.0-beta.72
+      specifier: 4.0.0-beta.74
+      version: 4.0.0-beta.74
     '@effect/platform-node':
-      specifier: 4.0.0-beta.72
-      version: 4.0.0-beta.72
+      specifier: 4.0.0-beta.74
+      version: 4.0.0-beta.74
     '@effect/vitest':
-      specifier: ^4.0.0-beta.72
-      version: 4.0.0-beta.72
+      specifier: ^4.0.0-beta.74
+      version: 4.0.0-beta.74
     '@nx/devkit':
       specifier: ^22.7.5
       version: 22.7.5
@@ -85,13 +85,13 @@ importers:
         version: 1.4.0
       '@effect/atom-react':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
@@ -274,10 +274,10 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.74
@@ -363,10 +363,10 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(ioredis@5.10.1)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
@@ -409,14 +409,14 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.74
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@tsconfig/bun':
         specifier: 'catalog:'
         version: 1.0.10
@@ -449,10 +449,10 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(ioredis@5.10.1)
       '@supabase/config':
         specifier: workspace:*
         version: link:../config
@@ -465,7 +465,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
+        version: 4.0.0-beta.74(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@supabase/supabase-js':
         specifier: ^2.106.2
         version: 2.106.2
@@ -607,35 +607,35 @@ packages:
     resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
     engines: {node: '>= 6'}
 
-  '@effect/atom-react@4.0.0-beta.72':
-    resolution: {integrity: sha512-QIE9hKpI/er6ZF9WWJCGOs5Yt5kd1c1AJlN49mEKDOugON1h4avkCLqvLaWh5+Z8LATO6WCKRLeZ/vagqkjkQQ==}
+  '@effect/atom-react@4.0.0-beta.74':
+    resolution: {integrity: sha512-ZuBSclpU6z4w21n7nfaYn/ou10rAnSmuT9zQPUDz8d2gm617c9I5rlF5TfqZNLhRslLyx9NzvObz+avNToxsIA==}
     peerDependencies:
-      effect: ^4.0.0-beta.72
+      effect: ^4.0.0-beta.74
       react: ^19.2.4
       scheduler: '*'
 
-  '@effect/platform-bun@4.0.0-beta.72':
-    resolution: {integrity: sha512-JL5ScKARXrmCLO7xy0n0QscSO/PMq26Ob84L+Qc0DZuNLWl46gG/VokZwwd9+70sHuQJ4qZ3h72JKuYPqkY9BQ==}
+  '@effect/platform-bun@4.0.0-beta.74':
+    resolution: {integrity: sha512-HPozsTKom3v8uGITYX+blua0wVSk/I7ak802FoX13t4zWhHfprT8I/A8VBO4SxmcDYb/izABtHBXBgEmp612MA==}
     peerDependencies:
-      effect: ^4.0.0-beta.72
+      effect: ^4.0.0-beta.74
 
-  '@effect/platform-node-shared@4.0.0-beta.72':
-    resolution: {integrity: sha512-BP0migc1dxUxqNsaf6MZx9yo+m/gpw5+AlsTBUWRw14h4Vb/GiZbS7rFDZY0ofJ9z1BYails9F6IaiEP+P27sQ==}
+  '@effect/platform-node-shared@4.0.0-beta.74':
+    resolution: {integrity: sha512-C6C2hXixNcZXLaFF2u7B/FtOsqpdY7luaPuiGFBJza0P7EnYDkwaT3kB6lv7l/qctmkADc24qOsSCWIKRbC4jg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.72
+      effect: ^4.0.0-beta.74
 
-  '@effect/platform-node@4.0.0-beta.72':
-    resolution: {integrity: sha512-QbHFPI8JRa74ytvgz4xMNwryJvyvLj5wCCwm0uzJDhTseNIv22VnqjmneEmPAfqCorGE1mG+K0kcMC7162g3sg==}
+  '@effect/platform-node@4.0.0-beta.74':
+    resolution: {integrity: sha512-/W16mKqxvhWINLjufzc0log1sl57exXQfwd+em398/zKCbmU3S7snXTDMN6w0ju2TtgK35qrsoGBXEochij6Sg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.72
+      effect: ^4.0.0-beta.74
       ioredis: ^5.7.0
 
-  '@effect/vitest@4.0.0-beta.72':
-    resolution: {integrity: sha512-ST7gwbFZZWU0FacGOQJGJ6ibUcqA9E2MBrih6EJHUs9MjKjH0Wp+uD3xRg62I/xMDfLYEKLaYh7PLS+E03fKBQ==}
+  '@effect/vitest@4.0.0-beta.74':
+    resolution: {integrity: sha512-+SFcjtbboJdWA+cP7JFW7Gp1PL7vj7uqvBnh9xY7JFU8VMsrHN5mblsqE7l7+ZFGpJvBGLgjGrhfe8QZ7f5vgg==}
     peerDependencies:
-      effect: ^4.0.0-beta.72
+      effect: ^4.0.0-beta.74
       vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
@@ -6703,21 +6703,21 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@effect/atom-react@4.0.0-beta.72(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.74(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)':
     dependencies:
       effect: 4.0.0-beta.74
       react: 19.2.6
       scheduler: 0.27.0
 
-  '@effect/platform-bun@4.0.0-beta.72(effect@4.0.0-beta.74)':
+  '@effect/platform-bun@4.0.0-beta.74(effect@4.0.0-beta.74)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.74)
+      '@effect/platform-node-shared': 4.0.0-beta.74(effect@4.0.0-beta.74)
       effect: 4.0.0-beta.74
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.72(effect@4.0.0-beta.74)':
+  '@effect/platform-node-shared@4.0.0-beta.74(effect@4.0.0-beta.74)':
     dependencies:
       '@types/ws': 8.18.1
       effect: 4.0.0-beta.74
@@ -6726,9 +6726,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.74(effect@4.0.0-beta.74)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.74)
+      '@effect/platform-node-shared': 4.0.0-beta.74(effect@4.0.0-beta.74)
       effect: 4.0.0-beta.74
       ioredis: 5.10.1
       mime: 4.1.0
@@ -6737,7 +6737,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)':
+  '@effect/vitest@4.0.0-beta.74(effect@4.0.0-beta.74)(vitest@4.1.7)':
     dependencies:
       effect: 4.0.0-beta.74
       vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(vite@8.0.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^4.1.7
       version: 4.1.7
     effect:
-      specifier: 4.0.0-beta.72
-      version: 4.0.0-beta.72
+      specifier: 4.0.0-beta.74
+      version: 4.0.0-beta.74
     knip:
       specifier: ^6.14.2
       version: 6.14.2
@@ -85,13 +85,13 @@ importers:
         version: 1.4.0
       '@effect/atom-react':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(react@19.2.6)(scheduler@0.27.0)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(vitest@4.1.7)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
@@ -133,7 +133,7 @@ importers:
         version: 17.4.2
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.72
+        version: 4.0.0-beta.74
       ink:
         specifier: ^7.0.4
         version: 7.0.4(@types/react@19.2.15)(react-devtools-core@7.0.1)(react@19.2.6)
@@ -274,13 +274,13 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(ioredis@5.10.1)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.72
+        version: 4.0.0-beta.74
       undici:
         specifier: ^8.3.0
         version: 8.3.0
@@ -363,16 +363,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(ioredis@5.10.1)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.72
+        version: 4.0.0-beta.74
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -409,14 +409,14 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.72
+        version: 4.0.0-beta.74
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(vitest@4.1.7)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@tsconfig/bun':
         specifier: 'catalog:'
         version: 1.0.10
@@ -449,10 +449,10 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(ioredis@5.10.1)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)
       '@supabase/config':
         specifier: workspace:*
         version: link:../config
@@ -461,11 +461,11 @@ importers:
         version: link:../process-compose
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.72
+        version: 4.0.0-beta.74
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.72(effect@4.0.0-beta.72)(vitest@4.1.7)
+        version: 4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)
       '@supabase/supabase-js':
         specifier: ^2.106.2
         version: 2.106.2
@@ -3625,8 +3625,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.72:
-    resolution: {integrity: sha512-EMmlKthKQ3xyb+Waev3DWlMWYY2ZSnr8GensPc2APInw5seTHLkhrTxeWu1Yb+t5nuqMmV7RUkaW+vgWB0N8gA==}
+  effect@4.0.0-beta.74:
+    resolution: {integrity: sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==}
 
   ejs@5.0.1:
     resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
@@ -6703,33 +6703,33 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@effect/atom-react@4.0.0-beta.72(effect@4.0.0-beta.72)(react@19.2.6)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.72(effect@4.0.0-beta.74)(react@19.2.6)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.72
+      effect: 4.0.0-beta.74
       react: 19.2.6
       scheduler: 0.27.0
 
-  '@effect/platform-bun@4.0.0-beta.72(effect@4.0.0-beta.72)':
+  '@effect/platform-bun@4.0.0-beta.72(effect@4.0.0-beta.74)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.72)
-      effect: 4.0.0-beta.72
+      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.74)
+      effect: 4.0.0-beta.74
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.72(effect@4.0.0-beta.72)':
+  '@effect/platform-node-shared@4.0.0-beta.72(effect@4.0.0-beta.74)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.72
+      effect: 4.0.0-beta.74
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.72(effect@4.0.0-beta.72)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.72(effect@4.0.0-beta.74)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.72)
-      effect: 4.0.0-beta.72
+      '@effect/platform-node-shared': 4.0.0-beta.72(effect@4.0.0-beta.74)
+      effect: 4.0.0-beta.74
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -6737,9 +6737,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.72(effect@4.0.0-beta.72)(vitest@4.1.7)':
+  '@effect/vitest@4.0.0-beta.72(effect@4.0.0-beta.74)(vitest@4.1.7)':
     dependencies:
-      effect: 4.0.0-beta.72
+      effect: 4.0.0-beta.74
       vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(vite@8.0.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -9204,7 +9204,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.72:
+  effect@4.0.0-beta.74:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   "@types/bun": "^1.3.14"
   "@typescript/native-preview": "7.0.0-dev.20260527.2"
   "@vitest/coverage-istanbul": "^4.1.7"
-  "effect": "4.0.0-beta.72"
+  "effect": "4.0.0-beta.74"
   "knip": "^6.14.2"
   "nx": "^22.7.5"
   "oxfmt": "^0.52.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,10 +11,10 @@ allowBuilds:
   sharp: true
 
 catalog:
-  "@effect/atom-react": "4.0.0-beta.72"
-  "@effect/platform-bun": "4.0.0-beta.72"
-  "@effect/platform-node": "4.0.0-beta.72"
-  "@effect/vitest": "^4.0.0-beta.72"
+  "@effect/atom-react": "4.0.0-beta.74"
+  "@effect/platform-bun": "4.0.0-beta.74"
+  "@effect/platform-node": "4.0.0-beta.74"
+  "@effect/vitest": "^4.0.0-beta.74"
   "@nx/devkit": "^22.7.5"
   "@swc-node/register": "^1.10.9"
   "@swc/core": "^1.15.40"


### PR DESCRIPTION
## Description

Updates the Effect package family to `4.0.0-beta.74`, including `effect`, `@effect/platform-bun`, `@effect/platform-node`, `@effect/vitest`, and `@effect/atom-react`.

This picks up the CLI parser fix for command-local flags overriding colliding global flags, restoring the expected behavior for `db reset --version <migration>` and `db query` / `db diff` command-local `-o` flags.

Fixes #5350.
Fixes #5373.