### PR TITLE
chore(codeowners): allow dependabot dependency updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
+# Default all repository changes to the CLI team.
 * @supabase/cli
+
+# Dependabot-only dependency surfaces. These ownerless rules override the
+# catch-all above so CI-green Dependabot PRs can be auto-approved and merged.
+/.github/workflows/*.yml
+**/package.json
+**/go.mod
+**/go.sum
+/apps/cli-go/pkg/config/templates/Dockerfile
+/pnpm-lock.yaml
+/pnpm-workspace.yaml


### PR DESCRIPTION
## What changed

Adds ownerless CODEOWNERS overrides for dependency files that Dependabot updates automatically: GitHub Actions workflows, package manifests, Go module files, the Supabase Docker template, and pnpm lock/workspace files.

## Why

Dependabot PRs already have an auto-approval path, but the repository-wide CODEOWNERS catch-all still requires `@supabase/cli` review. These more specific ownerless rules let CI-green Dependabot dependency PRs merge without waiting for CLI team approval, while keeping normal source changes owned by the CLI team.