### PR TITLE
fix(cli): suppress legacy task spinner when stdout is not a TTY

### DIFF
--- a/apps/cli/src/shared/output/output.layer.ts
+++ b/apps/cli/src/shared/output/output.layer.ts
@@ -181,6 +181,20 @@ export const textOutputLayer = Layer.effect(
           : Effect.sync(() => log.info(JSON.stringify(event))),
       task: (message: string) =>
         Effect.sync(() => {
+          if (!tty.stdoutIsTty) {
+            // Non-TTY stdout (CI, pipe, redirect) — suppress the @clack spinner,
+            // which writes cursor-hide and animated-frame ANSI to stdout and
+            // pollutes machine-parsed output. See supabase/cli#5397.
+            const noop = () => Effect.void;
+            return {
+              message: noop,
+              succeed: noop,
+              fail: noop,
+              info: noop,
+              cancel: noop,
+              clear: noop,
+            };
+          }
           let shown = false;
           let settled = false;
           let currentMessage = message;

--- a/apps/cli/src/shared/output/output.layer.unit.test.ts
+++ b/apps/cli/src/shared/output/output.layer.unit.test.ts
@@ -154,6 +154,21 @@ describe("Output", () => {
         }).pipe(Effect.provide(layer)),
     );
 
+    it.effect("task suppresses the spinner entirely when stdout is not a TTY", () =>
+      Effect.gen(function* () {
+        vi.useFakeTimers();
+        const out = yield* Output;
+        const task = yield* out.task("Fetching branches...");
+        vi.advanceTimersByTime(1000);
+        yield* task.clear();
+
+        expect(mockClack.spinnerFactory).not.toHaveBeenCalled();
+        expect(mockClack.spinnerHandle.start).not.toHaveBeenCalled();
+      }).pipe(
+        Effect.provide(textOutputLayer.pipe(Layer.provide(mockTty({ stdoutIsTty: false })))),
+      ),
+    );
+
     it.effect("task prefixes continuation lines for multiline completions", () =>
       Effect.gen(function* () {
         vi.useFakeTimers();


### PR DESCRIPTION
v2.102.0 ported `branches`, `secrets`, `orgs`, `sso`, `ssl-enforcement`, `network-restrictions`, `backups`, etc. to TS. Each ported handler wraps its API call in:

```ts
const fetching = output.format === "text" ? yield* output.task("...") : undefined;
```

`output.format` is the TS `--output-format` flag, not the Go `--output` flag (`goFmt`). Passing Go-style `--output json` leaves `output.format === "text"`, so the `@clack` spinner starts after 200ms and writes cursor-hide (`ESC [?25l`) + a frame to stdout ahead of the JSON — breaking jq in CI. Go pre-2.102.0 emitted clean JSON.

Fix at the source: `textOutputLayer.task` returns a no-op task when `tty.stdoutIsTty` is false. Covers all 28+ ported call sites without per-handler patches; the `jsonOutputLayer` / `streamJsonOutputLayer` task impls already route through stderr / events.

Test asserts `spinner()` is never called when `stdoutIsTty: false`.

Fixes #5397