### PR TITLE
fix(auth): propagate passkey config to env

### DIFF
--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -747,6 +747,7 @@ EOF
 			)
 		}
 
+		env = appendGotruePasskeyEnv(env)
 		env = appendGotrueExternalProviderEnv(env)
 		env = append(env,
 			fmt.Sprintf("GOTRUE_EXTERNAL_WEB3_SOLANA_ENABLED=%v", utils.Config.Auth.Web3.Solana.Enabled),
@@ -1352,6 +1353,24 @@ func buildGotrueEnv(dbConfig pgconn.Config) []string {
 		fmt.Sprintf("GOTRUE_RATE_LIMIT_SMS_SENT=%v", utils.Config.Auth.RateLimit.SmsSent),
 		fmt.Sprintf("GOTRUE_RATE_LIMIT_WEB3=%v", utils.Config.Auth.RateLimit.Web3),
 	}
+}
+
+// appendGotruePasskeyEnv wires the Auth container with passkey/WebAuthn
+// settings from the [auth.passkey] and [auth.webauthn] config sections. Both
+// sections are optional (nil when unset), so each block is guarded.
+func appendGotruePasskeyEnv(env []string) []string {
+	if utils.Config.Auth.Passkey != nil {
+		env = append(env, fmt.Sprintf("GOTRUE_PASSKEY_ENABLED=%v", utils.Config.Auth.Passkey.Enabled))
+	}
+	if w := utils.Config.Auth.Webauthn; w != nil {
+		env = append(
+			env,
+			"GOTRUE_WEBAUTHN_RP_ID="+w.RpId,
+			"GOTRUE_WEBAUTHN_RP_DISPLAY_NAME="+w.RpDisplayName,
+			"GOTRUE_WEBAUTHN_RP_ORIGINS="+strings.Join(w.RpOrigins, ","),
+		)
+	}
+	return env
 }
 
 func appendGotrueExternalProviderEnv(env []string) []string {

--- a/apps/cli-go/internal/start/start_test.go
+++ b/apps/cli-go/internal/start/start_test.go
@@ -353,6 +353,34 @@ func TestBuildGotrueEnv(t *testing.T) {
 		assert.Equal(t, "http://127.0.0.1:54321/auth/v1/verify", env["GOTRUE_MAILER_URLPATHS_INVITE"])
 		assert.Equal(t, "https://example.com/custom/callback", env["GOTRUE_EXTERNAL_AZURE_REDIRECT_URI"])
 	})
+
+	t.Run("wires passkey and webauthn settings", func(t *testing.T) {
+		utils.Config = config.NewConfig()
+		utils.Config.Auth.Passkey = &config.Passkey{Enabled: true}
+		utils.Config.Auth.Webauthn = &config.Webauthn{
+			RpDisplayName: "Supabase",
+			RpId:          "localhost",
+			RpOrigins:     []string{"http://127.0.0.1:5173", "http://localhost:5173"},
+		}
+
+		env := envToMap(appendGotruePasskeyEnv(buildGotrueEnv(pgconn.Config{})))
+
+		assert.Equal(t, "true", env["GOTRUE_PASSKEY_ENABLED"])
+		assert.Equal(t, "localhost", env["GOTRUE_WEBAUTHN_RP_ID"])
+		assert.Equal(t, "Supabase", env["GOTRUE_WEBAUTHN_RP_DISPLAY_NAME"])
+		assert.Equal(t, "http://127.0.0.1:5173,http://localhost:5173", env["GOTRUE_WEBAUTHN_RP_ORIGINS"])
+	})
+
+	t.Run("omits passkey and webauthn env when sections are unset", func(t *testing.T) {
+		utils.Config = config.NewConfig()
+
+		env := envToMap(appendGotruePasskeyEnv(buildGotrueEnv(pgconn.Config{})))
+
+		_, hasPasskey := env["GOTRUE_PASSKEY_ENABLED"]
+		_, hasRpId := env["GOTRUE_WEBAUTHN_RP_ID"]
+		assert.False(t, hasPasskey)
+		assert.False(t, hasRpId)
+	})
 }
 
 func TestFormatMapForEnvConfig(t *testing.T) {

--- a/apps/cli-go/pkg/config/auth.go
+++ b/apps/cli-go/pkg/config/auth.go
@@ -163,8 +163,8 @@ type (
 		PasswordRequirements       PasswordRequirements `toml:"password_requirements" json:"password_requirements"`
 		SigningKeysPath            string               `toml:"signing_keys_path" json:"signing_keys_path"`
 		SigningKeys                []JWK                `toml:"-" json:"-"`
-		Passkey                    *passkey             `toml:"passkey" json:"passkey"`
-		Webauthn                   *webauthn            `toml:"webauthn" json:"webauthn"`
+		Passkey                    *Passkey             `toml:"passkey" json:"passkey"`
+		Webauthn                   *Webauthn            `toml:"webauthn" json:"webauthn"`
 
 		RateLimit   rateLimit   `toml:"rate_limit" json:"rate_limit"`
 		Captcha     *captcha    `toml:"captcha" json:"captcha"`
@@ -381,11 +381,11 @@ type (
 		Ethereum ethereum `toml:"ethereum" json:"ethereum"`
 	}
 
-	passkey struct {
+	Passkey struct {
 		Enabled bool `toml:"enabled" json:"enabled"`
 	}
 
-	webauthn struct {
+	Webauthn struct {
 		RpDisplayName string   `toml:"rp_display_name" json:"rp_display_name"`
 		RpId          string   `toml:"rp_id" json:"rp_id"`
 		RpOrigins     []string `toml:"rp_origins" json:"rp_origins"`
@@ -517,11 +517,11 @@ func (c *captcha) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	c.Enabled = ValOrDefault(remoteConfig.SecurityCaptchaEnabled, false)
 }
 
-func (p passkey) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
+func (p Passkey) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
 	body.PasskeyEnabled = cast.Ptr(p.Enabled)
 }
 
-func (p *passkey) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
+func (p *Passkey) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	// When local config is not set, we assume platform defaults should not change
 	if p == nil {
 		return
@@ -529,13 +529,13 @@ func (p *passkey) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	p.Enabled = remoteConfig.PasskeyEnabled
 }
 
-func (w webauthn) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
+func (w Webauthn) toAuthConfigBody(body *v1API.UpdateAuthConfigBody) {
 	body.WebauthnRpDisplayName = nullable.NewNullableWithValue(w.RpDisplayName)
 	body.WebauthnRpId = nullable.NewNullableWithValue(w.RpId)
 	body.WebauthnRpOrigins = nullable.NewNullableWithValue(strings.Join(w.RpOrigins, ","))
 }
 
-func (w *webauthn) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
+func (w *Webauthn) fromAuthConfig(remoteConfig v1API.AuthConfigResponse) {
 	// When local config is not set, we assume platform defaults should not change
 	if w == nil {
 		return

--- a/apps/cli-go/pkg/config/auth_test.go
+++ b/apps/cli-go/pkg/config/auth_test.go
@@ -215,8 +215,8 @@ func TestCaptchaDiff(t *testing.T) {
 func TestPasskeyConfigMapping(t *testing.T) {
 	t.Run("serializes passkey config to update body", func(t *testing.T) {
 		c := newWithDefaults()
-		c.Passkey = &passkey{Enabled: true}
-		c.Webauthn = &webauthn{
+		c.Passkey = &Passkey{Enabled: true}
+		c.Webauthn = &Webauthn{
 			RpDisplayName: "Supabase CLI",
 			RpId:          "localhost",
 			RpOrigins: []string{
@@ -237,7 +237,7 @@ func TestPasskeyConfigMapping(t *testing.T) {
 
 	t.Run("does not serialize rp fields when webauthn is undefined", func(t *testing.T) {
 		c := newWithDefaults()
-		c.Passkey = &passkey{Enabled: false}
+		c.Passkey = &Passkey{Enabled: false}
 		// Run test
 		body := c.ToUpdateAuthConfigBody()
 		// Check result
@@ -254,7 +254,7 @@ func TestPasskeyConfigMapping(t *testing.T) {
 
 	t.Run("serializes webauthn fields independently of passkey", func(t *testing.T) {
 		c := newWithDefaults()
-		c.Webauthn = &webauthn{
+		c.Webauthn = &Webauthn{
 			RpDisplayName: "Supabase CLI",
 			RpId:          "localhost",
 			RpOrigins:     []string{"http://127.0.0.1:3000"},
@@ -270,8 +270,8 @@ func TestPasskeyConfigMapping(t *testing.T) {
 
 	t.Run("hydrates passkey and webauthn config from remote", func(t *testing.T) {
 		c := newWithDefaults()
-		c.Passkey = &passkey{Enabled: true}
-		c.Webauthn = &webauthn{}
+		c.Passkey = &Passkey{Enabled: true}
+		c.Webauthn = &Webauthn{}
 		// Run test
 		c.FromRemoteAuthConfig(v1API.AuthConfigResponse{
 			PasskeyEnabled:        true,


### PR DESCRIPTION
Propagates the Passkey and WebAuthn config to the env vars correctly to work with `supabase start` locally.