### PR TITLE
fix(cli): suppress spinner on stdout for legacy -o machine formats

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -367,6 +367,18 @@ yield * creating.clear(); // dismiss without a message
 yield * creating.succeed("Branch created");
 ```
 
+### Invariant: `-o json|yaml|toml|env` must suppress the spinner (CLI-1546)
+
+The Go-compat `-o`/`--output` flag (`LegacyOutputFlag`, values `env|pretty|json|toml|yaml`) is **independent** of `--output-format`. It does not change `output.format`, so a command run with `-o json` (and no `--output-format`) keeps `output.format === "text"` and the spinner gate `output.format === "text"` stays `true`. If the plain `textOutputLayer` is active, clack writes spinner ANSI (e.g. the hide-cursor `\x1b[?25l`) to **stdout** and corrupts the machine payload the handler emits via `output.raw` — exactly the CLI-1546 regression (`branches list -o json` → broken `JSON.parse`).
+
+`legacy/cli/root.ts` therefore selects **`legacyQuietProgressTextOutputLayer`** (in `legacy/output/`) for any Go machine format (`json|yaml|toml|env`). It is a legacy-only wrapper over the shared `textOutputLayer` that no-ops only `task` and `progress`; everything else — `format: "text"`, `raw`, logs, and error rendering (red text on **stderr**) — delegates unchanged, so Go output parity is preserved exactly.
+
+Rules:
+
+- **stdout is payload-only whenever a machine format is requested** (`-o json|yaml|toml|env` or `--output-format json|stream-json`). All progress/diagnostic output goes to stderr.
+- **Do not** fix spinner-on-stdout by routing the shared spinner to stderr or otherwise editing `shared/output/output.layer.ts` — that changes `next/` text rendering. Keep the fix legacy-scoped.
+- A handler reaching this path still emits its machine payload through the Go encoder (`output.raw(encodeGoJson(...))` etc.), checked **before** the `output.format` branch, so output stays byte-identical to before — minus the spinner.
+
 ---
 
 ## Testing

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -37,6 +37,7 @@ import { legacyUnlinkCommand } from "../commands/unlink/unlink.command.ts";
 import { legacyVanitySubdomainsCommand } from "../commands/vanity-subdomains/vanity-subdomains.command.ts";
 import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
 import { outputLayerFor } from "../../shared/output/output.layer.ts";
+import { legacyQuietProgressTextOutputLayer } from "../output/legacy-quiet-progress-text-output.layer.ts";
 import { makeGoProxyLayer } from "../../shared/legacy/go-proxy.layer.ts";
 import {
   LEGACY_GLOBAL_FLAGS,
@@ -125,7 +126,18 @@ export const legacyRoot = Command.make("supabase").pipe(
         if (createTicket) globalArgs.push("--create-ticket");
         if (agent !== "auto") globalArgs.push("--agent", agent);
 
-        return Layer.mergeAll(outputLayerFor(outputFormat), makeGoProxyLayer({ globalArgs }));
+        // Go's `-o {json,yaml,toml,env}` selects a machine encoder the handler
+        // writes via `output.raw`. Keep the text layer (so errors still render
+        // as red text on stderr, matching Go), but suppress its progress spinner
+        // — otherwise clack writes ANSI to stdout and corrupts the payload
+        // (CLI-1546). `-o pretty` / no `-o` keep the normal text/json layers.
+        const goFmt = Option.getOrUndefined(goOutput);
+        const isGoMachineFormat = goFmt !== undefined && goFmt !== "pretty";
+        const outputLayer = isGoMachineFormat
+          ? legacyQuietProgressTextOutputLayer
+          : outputLayerFor(outputFormat);
+
+        return Layer.mergeAll(outputLayer, makeGoProxyLayer({ globalArgs }));
       }),
     ),
   ),

--- a/apps/cli/src/legacy/output/legacy-quiet-progress-text-output.layer.ts
+++ b/apps/cli/src/legacy/output/legacy-quiet-progress-text-output.layer.ts
@@ -1,0 +1,45 @@
+import { Effect, Layer } from "effect";
+
+import { textOutputLayer } from "../../shared/output/output.layer.ts";
+import { Output } from "../../shared/output/output.service.ts";
+
+/**
+ * Legacy wrapper over the shared text output layer for Go machine-format
+ * requests (`-o json|yaml|toml|env`).
+ *
+ * Go's `--output` selects a machine encoder that the handler writes via
+ * `output.raw`. If the text layer stays fully active, its progress spinner
+ * writes ANSI escape sequences to stdout and corrupts that payload — see
+ * CLI-1546, where `branches list -o json` emitted a hide-cursor sequence ahead
+ * of the JSON and broke `JSON.parse`.
+ *
+ * This layer suppresses ONLY the transient progress UI (`task`/`progress`).
+ * Everything else (errors -> red text on stderr, `raw`, logs, `format: "text"`)
+ * delegates to the text layer unchanged, so Go output parity is preserved
+ * exactly while stdout stays parseable.
+ */
+export const legacyQuietProgressTextOutputLayer = Layer.effect(
+  Output,
+  Effect.gen(function* () {
+    const base = yield* Output;
+    return Output.of({
+      ...base,
+      task: () =>
+        Effect.succeed({
+          message: () => Effect.void,
+          succeed: () => Effect.void,
+          fail: () => Effect.void,
+          info: () => Effect.void,
+          cancel: () => Effect.void,
+          clear: () => Effect.void,
+        }),
+      progress: () =>
+        Effect.succeed({
+          start: () => Effect.void,
+          advance: () => Effect.void,
+          message: () => Effect.void,
+          stop: () => Effect.void,
+        }),
+    });
+  }),
+).pipe(Layer.provide(textOutputLayer));

--- a/apps/cli/src/legacy/output/legacy-quiet-progress-text-output.layer.unit.test.ts
+++ b/apps/cli/src/legacy/output/legacy-quiet-progress-text-output.layer.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "@effect/vitest";
+import { beforeEach, vi } from "vitest";
+import { Effect, Layer } from "effect";
+
+import { mockTty } from "../../../tests/helpers/mocks.ts";
+import { Output } from "../../shared/output/output.service.ts";
+import { legacyQuietProgressTextOutputLayer } from "./legacy-quiet-progress-text-output.layer.ts";
+
+// Mirror the shared text-layer test so the wrapped textOutputLayer resolves the
+// clack spinner through a spy we can assert was never created.
+const mockClack = vi.hoisted(() => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinnerFactory: vi.fn(),
+  progressFactory: vi.fn(),
+  spinnerHandle: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    cancel: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+    clear: vi.fn(),
+    isCancelled: false,
+  },
+  log: {
+    message: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+  text: vi.fn(),
+  password: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  autocomplete: vi.fn(),
+  multiselect: vi.fn(),
+  cancel: vi.fn(),
+  isCancel: vi.fn((_v: unknown) => false),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  intro: (a: unknown) => mockClack.intro(a),
+  outro: (a: unknown) => mockClack.outro(a),
+  log: mockClack.log,
+  spinner: () => mockClack.spinnerFactory(),
+  progress: () => mockClack.progressFactory(),
+  text: (a: unknown) => mockClack.text(a),
+  password: (a: unknown) => mockClack.password(a),
+  confirm: (a: unknown) => mockClack.confirm(a),
+  select: (a: unknown) => mockClack.select(a),
+  autocomplete: (a: unknown) => mockClack.autocomplete(a),
+  multiselect: (a: unknown) => mockClack.multiselect(a),
+  cancel: (a: unknown) => mockClack.cancel(a),
+  isCancel: (a: unknown) => mockClack.isCancel(a),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useRealTimers();
+  mockClack.isCancel.mockReturnValue(false);
+  mockClack.spinnerFactory.mockReturnValue(mockClack.spinnerHandle);
+});
+
+describe("legacyQuietProgressTextOutputLayer", () => {
+  const layer = legacyQuietProgressTextOutputLayer.pipe(
+    Layer.provide(mockTty({ stdoutIsTty: true })),
+  );
+
+  it.effect("never starts a spinner, even after the spinner delay elapses", () =>
+    Effect.gen(function* () {
+      vi.useFakeTimers();
+      const out = yield* Output;
+      const task = yield* out.task("Fetching branches...");
+      yield* task.message("Still fetching...");
+      // Past TASK_SPINNER_DELAY_MS (200ms) — the text layer would have shown a
+      // spinner by now; the quiet wrapper must not.
+      vi.advanceTimersByTime(500);
+      yield* task.clear();
+
+      expect(mockClack.spinnerFactory).not.toHaveBeenCalled();
+      expect(mockClack.spinnerHandle.start).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("never starts a progress bar", () =>
+    Effect.gen(function* () {
+      const out = yield* Output;
+      const bar = yield* out.progress({ max: 3 });
+      yield* bar.start("Working...");
+      yield* bar.advance(1);
+      yield* bar.stop("Done.");
+
+      expect(mockClack.progressFactory).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("stays on the text layer so errors keep Go parity (red text on stderr)", () =>
+    Effect.gen(function* () {
+      const out = yield* Output;
+      // `format === "text"` is what routes withJsonErrorHandling back to the
+      // top-level text `output.fail` (red text on stderr) instead of a JSON
+      // envelope on stdout — i.e. it preserves Go error-output parity.
+      expect(out.format).toBe("text");
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("delegates non-progress output to the text layer", () =>
+    Effect.gen(function* () {
+      const out = yield* Output;
+      yield* out.info("hello");
+      expect(mockClack.log.info).toHaveBeenCalledWith("hello");
+    }).pipe(Effect.provide(layer)),
+  );
+});


### PR DESCRIPTION
## What changed

`supabase branches list -o json` (and any legacy command run with `-o json|yaml|toml|env`) wrote a clack progress-spinner ANSI sequence — the hide-cursor `\x1b[?25l` plus a spinner frame — to **stdout** ahead of the machine payload, so `JSON.parse` of the captured output threw. Regressed in v2.102.0 when `branches` was ported to TypeScript.

### Why it happened

The legacy shell has two independent output-format flags:

- `--output-format` (TS-native) — drives **output-layer selection**.
- `-o`/`--output` (Go-compat: `env|pretty|json|toml|yaml`) — consumed inside handlers.

`legacy/cli/root.ts` selected the output layer using only `--output-format`, ignoring `-o`. So `-o json` (with no `--output-format`) left `output.format === "text"` and the spinner-emitting `textOutputLayer` active. The handler's `output.task(...)` gate (`output.format === "text"`) was `true`, so clack rendered a spinner to stdout, and the Go JSON encoder (`output.raw(encodeGoJson(...))`) appended the JSON — corrupting it.

This affected every legacy command that wraps API calls in `output.task` (~32 commands), not just `branches list`.

### The fix

Added a legacy-only `legacyQuietProgressTextOutputLayer` (`legacy/output/`) that wraps the shared `textOutputLayer` and no-ops **only** `task`/`progress`. `legacy/cli/root.ts` selects it for any Go machine format (`-o json|yaml|toml|env`).

Because the text layer stays active, everything else delegates unchanged:

- errors still render as red text on **stderr** (`withJsonErrorHandling` re-fails on `format === "text"`),
- the handler still emits its Go-byte-exact payload via `output.raw` (checked before the `output.format` branch).

So stdout output is **byte-identical to before, minus the spinner** — Go output parity is preserved exactly. No `shared/` or `next/` changes, so the `next/` shell's text rendering is untouched.

Also documents the `-o` vs `--output-format` layer-selection invariant in `apps/cli/AGENTS.md`.

Fixes #5397