### PR TITLE
fix(cli): read Go Windows credentials in legacy TS

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
@@ -15,6 +15,7 @@ const ACCESS_TOKEN_PATTERN = /^sbp_(oauth_)?[a-f0-9]{40}$/;
 const INVALID_TOKEN_MESSAGE = "Invalid access token format. Must be like `sbp_0102...1920`.";
 
 type KeyringModule = typeof import("@napi-rs/keyring");
+type KeyringEntry = InstanceType<KeyringModule["Entry"]>;
 
 const detectWsl = (fs: FileSystem.FileSystem): Effect.Effect<boolean> =>
   Effect.gen(function* () {
@@ -32,11 +33,14 @@ const tryKeyringRead = (
 ): Effect.Effect<Option.Option<string>> =>
   Effect.try({
     try: () => {
-      const entry = new module.Entry(KEYRING_SERVICE, account);
-      const value = entry.getPassword();
-      return value && value.length > 0
-        ? Option.some(normalizeKeyringToken(value))
-        : Option.none<string>();
+      for (const entry of [
+        new module.Entry(KEYRING_SERVICE, account),
+        module.Entry.withTarget(`${KEYRING_SERVICE}:${account}`, KEYRING_SERVICE, account),
+      ]) {
+        const value = readEntryPassword(entry);
+        if (value && value.length > 0) return Option.some(normalizeKeyringToken(value));
+      }
+      return Option.none<string>();
     },
     catch: () => Option.none<string>(),
   }).pipe(Effect.orElseSucceed(() => Option.none<string>()));
@@ -58,14 +62,28 @@ const tryKeyringWrite = (
 const tryKeyringDelete = (module: KeyringModule, account: string): Effect.Effect<boolean> =>
   Effect.try({
     try: () => {
-      const entry = new module.Entry(KEYRING_SERVICE, account);
-      const value = entry.getPassword();
-      if (!value) return false;
-      entry.deleteCredential();
-      return true;
+      let deleted = false;
+      for (const entry of [
+        new module.Entry(KEYRING_SERVICE, account),
+        module.Entry.withTarget(`${KEYRING_SERVICE}:${account}`, KEYRING_SERVICE, account),
+      ]) {
+        const value = readEntryPassword(entry);
+        if (!value) continue;
+        entry.deleteCredential();
+        deleted = true;
+      }
+      return deleted;
     },
     catch: () => false,
   }).pipe(Effect.orElseSucceed(() => false));
+
+function readEntryPassword(entry: KeyringEntry): string | null {
+  try {
+    return entry.getPassword();
+  } catch {
+    return null;
+  }
+}
 
 const makeLegacyCredentials = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
@@ -26,12 +26,22 @@ vi.mock("@napi-rs/keyring", () => ({
   Entry: class Entry {
     service: string;
     account: string;
-    constructor(service: string, account: string) {
+    target?: string;
+    constructor(service: string, account: string, target?: string) {
       this.service = service;
       this.account = account;
+      this.target = target;
+    }
+    static withTarget(target: string, service: string, account: string) {
+      return new this(service, account, target);
+    }
+    key(): string {
+      return this.target === undefined
+        ? `${this.service}/${this.account}`
+        : `${this.target}/${this.service}/${this.account}`;
     }
     getPassword(): string | null {
-      const key = `${this.service}/${this.account}`;
+      const key = this.key();
       if (throwOnGetPasswordAccounts.has(key)) {
         throw new Error("Keyring unavailable");
       }
@@ -39,10 +49,10 @@ vi.mock("@napi-rs/keyring", () => ({
     }
     setPassword(value: string): void {
       if (throwOnSetPassword) throw new Error("Keyring unavailable");
-      passwords.set(`${this.service}/${this.account}`, value);
+      passwords.set(this.key(), value);
     }
     deleteCredential(): boolean {
-      const key = `${this.service}/${this.account}`;
+      const key = this.key();
       if (!passwords.has(key)) throw new Error("not found");
       passwords.delete(key);
       return true;
@@ -90,6 +100,7 @@ const VALID_TOKEN = "sbp_" + "a".repeat(40);
 const VALID_OAUTH_TOKEN = "sbp_oauth_" + "b".repeat(40);
 const encodeGoKeyringBase64 = (token: string) =>
   `go-keyring-base64:${Buffer.from(token).toString("base64")}`;
+const goWindowsKey = (account: string) => `Supabase CLI:${account}/Supabase CLI/${account}`;
 
 const expectSomeToken = (token: Option.Option<Redacted.Redacted<string>>, expected: string) => {
   expect(Option.isSome(token)).toBe(true);
@@ -119,6 +130,15 @@ describe("legacyCredentialsLayer.getAccessToken", () => {
 
   it.effect("decodes Go keyring base64 values from the keyring profile account", () => {
     passwords.set("Supabase CLI/supabase", encodeGoKeyringBase64(VALID_TOKEN));
+    return Effect.gen(function* () {
+      const { getAccessToken } = yield* LegacyCredentials;
+      const token = yield* getAccessToken;
+      expectSomeToken(token, VALID_TOKEN);
+    }).pipe(Effect.provide(makeLayer()));
+  });
+
+  it.effect("reads Windows credentials created by Go keyring", () => {
+    passwords.set(goWindowsKey("supabase"), VALID_TOKEN);
     return Effect.gen(function* () {
       const { getAccessToken } = yield* LegacyCredentials;
       const token = yield* getAccessToken;
@@ -224,6 +244,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
   it.effect("removes both keyring entries plus the filesystem file", () => {
     passwords.set("Supabase CLI/supabase", VALID_TOKEN);
     passwords.set("Supabase CLI/access-token", VALID_OAUTH_TOKEN);
+    passwords.set(goWindowsKey("supabase"), VALID_TOKEN);
     const supaDir = join(tempHome, ".supabase");
     mkdirSync(supaDir, { recursive: true });
     writeFileSync(join(supaDir, "access-token"), VALID_TOKEN, { mode: 0o600 });
@@ -232,6 +253,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
       expect(yield* deleteAccessToken).toBe(true);
       expect(passwords.has("Supabase CLI/supabase")).toBe(false);
       expect(passwords.has("Supabase CLI/access-token")).toBe(false);
+      expect(passwords.has(goWindowsKey("supabase"))).toBe(false);
       expect(existsSync(join(supaDir, "access-token"))).toBe(false);
     }).pipe(Effect.provide(makeLayer()));
   });


### PR DESCRIPTION
Fixes https://github.com/supabase/cli/issues/5415

Fixes a credential lookup mismatch between the Go CLI and the legacy TypeScript CLI on Windows.

The Go keyring implementation writes Windows credentials with an explicit target in the form `Supabase CLI:<profile>`, while the legacy TypeScript credentials layer only checked the default `@napi-rs/keyring` entry. As commands are ported from Go to TypeScript, this meant a token written by Go login could be missed by legacy TS command code.

This adds a fallback read/delete path for the Go Windows target while preserving the existing default keyring lookup and filesystem fallback behavior. The legacy credentials unit tests now cover reading and deleting credentials stored with the Go Windows target shape.