### PR TITLE
fix(ci): pass release channel to PR smoke workflow

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -51,6 +51,7 @@ jobs:
       version: 0.0.0-pr-${{ github.event.pull_request.number }}
       shell: legacy
       npm_tag: latest
+      channel: beta
       prerelease: true
       dry_run: true
     # release-shared.yml's publish/homebrew/scoop jobs reference


### PR DESCRIPTION
The PR smoke workflow calls `release-shared.yml`, which declares `channel` as a required `workflow_call` input.

Because `smoke-test-pr.yml` did not pass that input, GitHub rejected the workflow during startup before creating any jobs. This adds `channel: beta` to the PR smoke workflow call, matching the prerelease semantics used by the release workflow while keeping `dry_run: true` for PR validation.