### PR TITLE
fix(cli): enable vector buckets by default

### DIFF
--- a/apps/cli-e2e/fixtures/scenarios/seed-buckets-creates-buckets-defined-in-config/interactions.json
+++ b/apps/cli-e2e/fixtures/scenarios/seed-buckets-creates-buckets-defined-in-config/interactions.json
@@ -62,5 +62,37 @@
         "name": "my-bucket"
       }
     }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "path": "/storage/v1/vector/ListVectorBuckets",
+      "query": {},
+      "headers": {
+        "accept-encoding": "gzip",
+        "apikey": "__JWT__",
+        "authorization": "Bearer __ACCESS_TOKEN__",
+        "content-length": "3",
+        "content-type": "application/json",
+        "host": "localhost:__PORT__",
+        "user-agent": "SupabaseCLI/"
+      },
+      "body": {}
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "content-type": "application/json; charset=utf-8",
+        "sb-gateway-mode": "direct",
+        "sb-gateway-version": "1",
+        "sb-project-ref": "__PROJECT_REF__",
+        "sb-request-id": "__UUID__",
+        "x-content-type-options": "nosniff"
+      },
+      "body": {
+        "vectorBuckets": []
+      }
+    }
   }
 ]

--- a/apps/cli-go/internal/start/start_test.go
+++ b/apps/cli-go/internal/start/start_test.go
@@ -241,6 +241,10 @@ func TestDatabaseStart(t *testing.T) {
 			Get("/storage/v1/bucket").
 			Reply(http.StatusOK).
 			JSON([]storage.BucketResponse{})
+		gock.New(utils.Config.Api.ExternalUrl).
+			Post("/storage/v1/vector/ListVectorBuckets").
+			Reply(http.StatusOK).
+			JSON(storage.ListVectorBucketsResponse{})
 		// Run test
 		err = run(ctx, fsys, []string{}, pgconn.Config{Host: utils.DbId}, conn.Intercept)
 		// Check error

--- a/apps/cli-go/pkg/config/config_test.go
+++ b/apps/cli-go/pkg/config/config_test.go
@@ -37,6 +37,7 @@ func TestConfigParsing(t *testing.T) {
 		err := config.Load("", fs.MapFS{})
 		// Check error
 		assert.NoError(t, err)
+		assert.True(t, config.Storage.VectorBuckets.Enabled)
 	})
 
 	t.Run("auth external url defaults from api external url", func(t *testing.T) {

--- a/apps/cli-go/pkg/config/templates/config.toml
+++ b/apps/cli-go/pkg/config/templates/config.toml
@@ -145,7 +145,7 @@ max_catalogs = 2
 
 # Store vector embeddings in S3 for large and durable datasets
 [storage.vector]
-enabled = false
+enabled = true
 max_buckets = 10
 max_indexes = 5
 


### PR DESCRIPTION
## Summary

Enable local storage vector bucket support by default in generated CLI config.

This makes fresh and missing `storage.vector.enabled` config paths opt in to vector buckets automatically, while still allowing users to explicitly disable the feature with `enabled = false`.

The local start happy path now expects the default vector bucket seed call so the test coverage matches the new behavior.
