### PR TITLE
fix(docker): restore daily Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
     directory: "/apps/cli-go/pkg/config/templates"
     schedule:
       interval: "cron"
-      cronjob: "0 * * * *"
+      cronjob: "0 0 * * *"
     commit-message:
       prefix: "fix(docker): "
     groups:


### PR DESCRIPTION
## What changed

Restores the Docker Dependabot cron expression to the known-good once-daily schedule.

The `supabase/*` cooldown exclusion remains in place, so first-party Supabase Docker images can still update without the 7-day cooldown.

## Why

The hourly cron expression may be rejected by GitHub Dependabot even though cron scheduling is documented. Using the existing daily cron shape avoids breaking Dependabot configuration while preserving the important first-party cooldown exemption.