### PR TITLE
chore(ci): update Dependabot Go module paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
       default-days: 7
   - package-ecosystem: "gomod"
     directories:
-      - "/"
-      - "pkg"
+      - "/apps/cli-go"
+      - "/apps/cli-go/pkg"
     schedule:
       interval: "cron"
       cronjob: "0 0 * * *"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Use `nx show project <name> --json` to discover available targets before running
 ## Pull Requests
 
 PR titles must follow conventional-commits format because the `Lint Pull Request` workflow runs `amannn/action-semantic-pull-request` against the title. Use `<type>(<scope>): <subject>` (e.g. `fix(cli): …`, `test(cli): …`, `feat(api): …`). A bare descriptive title like "Build TypeScript CLI as compiled Bun binaries" will fail the lint. When a PR is created (including by the Claude Code UI or someone else), check the title against this rule and update it if needed.
+Avoid semantic-release-triggering types for non-release changes. For CI, docs, tests, tooling, agent instructions, and other repository-maintenance changes, do not use `fix`, `feat`, `perf`, or breaking-change markers just to satisfy the PR title linter. Prefer non-releasing conventional types such as `chore`, `docs`, `test`, or `ci` when the change should not produce a package release.
 Do not include a validation, test plan, or list of checks in PR descriptions. CI enforces validation for PRs, so PR descriptions should focus on what changed, why it changed, and any reviewer-relevant context that CI cannot infer.
 
 ## Refactoring Policy


### PR DESCRIPTION
## What changed

Updates the Go Dependabot directories from the old root-level module paths to the current Go module locations under `apps/cli-go`.

## Why

The Dependabot Go updater is currently failing with `dependency_file_not_found` because `/` and `/pkg` no longer contain the relevant `go.mod` files after the CLI Go sources moved under `apps/cli-go`.