### PR TITLE
chore(ci): use non-releasing actions dependabot prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 * * *"
+    commit-message:
+      prefix: "chore(ci): "
     groups:
       actions-major:
         patterns:


### PR DESCRIPTION
Updates the GitHub Actions Dependabot group to use a `chore(ci):` commit-message prefix.

This keeps future grouped workflow-only dependency updates from using `fix(deps):`, which would be release-significant when the PR is squash-merged into `develop`.
