### PR TITLE
ci(preview): allow preview package PR comment

### DIFF
--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -87,7 +87,7 @@ jobs:
     name: Post preview command comment
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What changed

Changes the preview package comment job permission from `issues: write` to `pull-requests: write`.

## Why

The preview package published successfully, but the custom `pkg.pr.new` PR comment failed with `Resource not accessible by integration`. The failing run was for a same-repository maintainer branch, so the issue was not fork trust. The workflow token needs PR write permission for the pull request comment operation in this repo/org context.
