### PR TITLE
chore(ci): fix propose release workflow dispatch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-32vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-6vcpu-macos-latest
+    - blacksmith-8vcpu-windows-2025

--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  apply:
+  authorize:
     # `state == 'open'` makes re-approvals on an already-closed PR a no-op
     # (a reviewer can re-approve from the GitHub UI even after close).
     if: |
@@ -27,19 +27,21 @@ jobs:
       github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
     steps:
       # App token: needs `orgs/.../teams/.../memberships` read (the org-installed
       # App has it), repo write to edit the release, and PR write to comment
       # and close. Matches release.yml's fast-forward step.
       - id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Authorize approver against supabase/cli team
+        id: check
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APPROVER: ${{ github.event.review.user.login }}
@@ -57,25 +59,37 @@ jobs:
             echo "Approver @${APPROVER} is not an active supabase/cli team member (state='${status:-none}'); ignoring approval." >&2
             gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body \
               "@${APPROVER} is not an active \`supabase/cli\` team member, so this approval was ignored. Ask a team member to approve to publish the notes."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "AUTHORIZED=true" >> "$GITHUB_ENV"
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+  apply:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       # Checkout the PR head so any reviewer edits made in the GitHub UI before
       # approval are captured. apply-release-notes.ts reads from the working
       # tree.
-      - if: env.AUTHORIZED == 'true'
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           persist-credentials: false
 
-      - if: env.AUTHORIZED == 'true'
-        uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup
 
       - name: Apply notes, comment, and close
-        if: env.AUTHORIZED == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -4,7 +4,8 @@ name: Apply release notes
 # release-notes PR (head ref `release-notes/v<VERSION>`), this workflow pushes
 # the proposed notes to the GitHub Release body for the corresponding tag,
 # comments the release URL on the PR, and closes the PR without merging. The
-# release-notes file never lands on `main`.
+# release-notes PR targets `develop` (not `main`) so an accidental merge can
+# never rewrite `main`'s history; the file is not meant to land on any branch.
 #
 # Mirrors the fast-forward job in release.yml, which already gates on a
 # `pull_request_review` + `approved` event.
@@ -23,7 +24,7 @@ jobs:
     if: |
       github.event.review.state == 'approved' &&
       startsWith(github.event.pull_request.head.ref, 'release-notes/') &&
-      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.base.ref == 'develop' &&
       github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/propose-release-notes.yml
+++ b/.github/workflows/propose-release-notes.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -49,9 +54,9 @@ jobs:
       # App token gets us push to a protected default branch *and* PR creation
       # under the App identity, matching the rest of release.yml.
       - id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1

--- a/.github/workflows/propose-release-notes.yml
+++ b/.github/workflows/propose-release-notes.yml
@@ -43,7 +43,7 @@ jobs:
     # allow any tag so reviewers can opt in for beta/alpha from the Actions tab.
     if: ${{ github.event_name == 'workflow_dispatch' || (!contains(inputs.tag, '-beta.') && !contains(inputs.tag, '-alpha.')) }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ inputs.non_blocking }}
+    continue-on-error: ${{ inputs.non_blocking || false }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -51,6 +51,8 @@ on:
         required: false
       GH_APP_PRIVATE_KEY:
         required: false
+      ANTHROPIC_API_KEY:
+        required: false
 jobs:
   build:
     name: Build CLI artifacts
@@ -335,7 +337,9 @@ jobs:
     with:
       tag: v${{ inputs.version }}
       non_blocking: true
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   publish-homebrew:
     needs: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
       # `persist-credentials: false` is required: otherwise checkout caches the
@@ -208,6 +208,7 @@ jobs:
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # Posts to the release Slack channel once the pipeline succeeds. Listing
   # `release` in `needs` without a status function in `if:` keeps the implicit

--- a/apps/cli/scripts/propose-release-notes.ts
+++ b/apps/cli/scripts/propose-release-notes.ts
@@ -19,7 +19,9 @@
 //      `release-notes/v<VERSION>` and opens a PR. Approving the PR (as a
 //      supabase/cli team member) triggers apply-release-notes.yml, which
 //      pushes the file's contents to the GH release body and closes the PR
-//      without merging — the file never lands on `main`.
+//      without merging. The PR targets `develop` (not `main`) so an
+//      accidental merge can never rewrite `main`'s history; in practice the
+//      file never lands on any branch.
 //
 // Usage:
 //   bun apps/cli/scripts/propose-release-notes.ts --tag v2.101.0 --dry-run
@@ -145,10 +147,17 @@ await writeFile(notesPath, normalized);
 console.error(`==> Wrote ${path.relative(repoRoot, notesPath)}`);
 
 const branch = `release-notes/v${version}`;
-const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`.cwd(repoRoot).text()).trim();
-if (currentBranch !== branch) {
-  await $`git checkout -B ${branch}`.cwd(repoRoot);
-}
+// Always cut the notes branch from origin/develop — the PR base. The workflow
+// can be dispatched from an arbitrary feature branch that has diverged from
+// the base by many commits; branching off the checked-out ref would drag
+// every one of those commits into the PR (so the PR shows N changed files
+// instead of just the proposed notes). The notes file is untracked at this
+// point, so resetting HEAD to origin/develop leaves it untouched in the
+// working tree. We target `develop` rather than `main` so that an accidental
+// merge of this approval-only PR lands on the integration branch instead of
+// rewriting `main`'s history.
+await $`git fetch --no-tags origin develop`.cwd(repoRoot).nothrow();
+await $`git checkout -B ${branch} origin/develop`.cwd(repoRoot);
 await $`git add ${notesPath}`.cwd(repoRoot);
 const commitMessage = `docs(release): propose user-facing notes for ${tag}`;
 await $`git commit -m ${commitMessage}`.cwd(repoRoot);
@@ -194,7 +203,7 @@ Approve this PR as a \`supabase/cli\` team member. The \`.github/workflows/apply
 2. Comment the release URL on this PR.
 3. Close this PR and delete the \`${branch}\` branch.
 
-**This PR is not merged** — the \`do not merge\` label is a reminder. Nothing lands on \`main\`.
+**This PR is not merged** — the \`do not merge\` label is a reminder. It targets \`develop\` so that even an accidental merge never rewrites \`main\`. Nothing is meant to land on any branch.
 
 Approvals from anyone outside the \`supabase/cli\` team are ignored; the workflow will post a comment explaining that and leave the release untouched.
 
@@ -207,7 +216,7 @@ Close the PR without approving. The auto-generated semantic-release body for \`$
 After this PR is closed, rerun the **Propose release notes** workflow from the Actions tab against \`${tag}\` to get a fresh proposal.
 `;
 
-await $`gh pr create --title ${`docs(release): notes for ${tag}`} --body ${prBody} --base main --head ${branch} --label ${labelName}`.cwd(
+await $`gh pr create --title ${`docs(release): notes for ${tag}`} --body ${prBody} --base develop --head ${branch} --label ${labelName}`.cwd(
   repoRoot,
 );
 console.error(`==> PR opened for ${branch}`);


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix workflow propose-release manual dispatch with for `non_blocking` input
- Uses `client-id` instead of `app-id` everywhere / fix actionlint self-hosted runner labels
- Rework `.github/workflows/apply-release-notes.yml` to use github output