### PR TITLE
chore(ci): update workflows to skip CI for release-notes PRs

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -1,5 +1,7 @@
 name: Lint Pull Request
 
+# Release-notes PRs (head ref `release-notes/*`) skip CI; only
+# apply-release-notes.yml runs for those.
 on:
   pull_request_target:
     types:
@@ -23,7 +25,11 @@ concurrency:
 
 jobs:
   main:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
+    if: |
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request_target' &&
+        !startsWith(github.event.pull_request.head.ref, 'release-notes/') &&
+        github.event.pull_request.draft == false)
     name: Lint Pull Request
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -1,5 +1,7 @@
 name: Publish Preview CLI Packages
 
+# Release-notes PRs (head ref `release-notes/*`) are markdown-only and are not
+# meant to produce installable preview packages.
 on:
   pull_request:
     types:
@@ -20,7 +22,9 @@ concurrency:
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      github.event.pull_request.draft == false
     name: Build preview CLI packages
     uses: ./.github/workflows/build-cli-artifacts.yml
     with:
@@ -29,7 +33,10 @@ jobs:
 
   publish:
     needs: build
-    if: github.event.pull_request.draft == false && needs.build.result == 'success'
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      github.event.pull_request.draft == false &&
+      needs.build.result == 'success'
     name: Publish preview package
     runs-on: ubuntu-latest
     env:
@@ -83,7 +90,10 @@ jobs:
 
   comment:
     needs: publish
-    if: github.event.pull_request.draft == false && needs.publish.result == 'success'
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      github.event.pull_request.draft == false &&
+      needs.publish.result == 'success'
     name: Post preview command comment
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test
 
+# Release-notes PRs (head ref `release-notes/*`) only add markdown under
+# `release-notes/` and are published via approval — skip the full CI suite.
 on:
   push:
     branches:
@@ -23,7 +25,9 @@ concurrency:
 
 jobs:
   check:
-    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      (github.event.pull_request.draft == false || github.event_name == 'push')
     name: Check code quality
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
@@ -49,7 +53,9 @@ jobs:
         run: pnpm run check:all
 
   test-core:
-    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      (github.event.pull_request.draft == false || github.event_name == 'push')
     name: Run unit and integration tests
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
@@ -75,7 +81,9 @@ jobs:
         run: pnpm run test:core
 
   test-e2e:
-    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    if: |
+      !startsWith(github.head_ref, 'release-notes/') &&
+      (github.event.pull_request.draft == false || github.event_name == 'push')
     name: Run end-to-end tests (shard ${{ matrix.shard }}/3)
     runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
@@ -173,8 +181,10 @@ jobs:
   # branch protection rules already require.  It succeeds iff every shard
   # succeeded (or skipped — `success()` is true for skipped jobs).
   test-e2e-summary:
-    if: always() && (github.event.pull_request.draft == false || github.event_name
-      == 'push')
+    if: |
+      always() &&
+      !startsWith(github.head_ref, 'release-notes/') &&
+      (github.event.pull_request.draft == false || github.event_name == 'push')
     name: Run end-to-end tests
     needs: test-e2e
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Skip the tests / lint / release preview for the `release-notes/*` pr's.

This also have the nice benefit of blocking any accidental merge for those PR's since those checks are required to pass to allow merge on develop.