### PR TITLE
fix(cli): restore Go debug output parity

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
@@ -2,6 +2,7 @@ import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
 
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { normalizeKeyringToken } from "../../shared/auth/keyring-token.ts";
+import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import {
@@ -140,6 +141,10 @@ function normalizeGoWindowsPassword(value: string): string {
     if (high !== 0) bytes.push(high);
   }
   return Buffer.from(bytes).toString("utf8");
+}
+
+function debugLog(debug: boolean, message: string): void {
+  if (debug) process.stderr.write(`${message}\n`);
 }
 
 function writeGoWindowsTarget(module: KeyringModule, account: string, token: string): boolean {
@@ -318,6 +323,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
   const path = yield* Path.Path;
   const runtimeInfo = yield* RuntimeInfo;
   const cliConfig = yield* LegacyCliConfig;
+  const debug = yield* LegacyDebugFlag;
   const profileAccount = cliConfig.profile;
 
   // ~/.supabase/access-token — fallback file path
@@ -347,8 +353,19 @@ const makeLegacyCredentials = Effect.gen(function* () {
       profileAccount,
       runtimeInfo.platform,
     );
-    if (Option.isSome(profileResult)) return profileResult;
-    return yield* tryKeyringRead(keyringModule.value, LEGACY_KEYRING_ACCOUNT, runtimeInfo.platform);
+    if (Option.isSome(profileResult)) {
+      debugLog(debug, `Using access token for profile: ${profileAccount}`);
+      return profileResult;
+    }
+    const legacyResult = yield* tryKeyringRead(
+      keyringModule.value,
+      LEGACY_KEYRING_ACCOUNT,
+      runtimeInfo.platform,
+    );
+    if (Option.isSome(legacyResult)) {
+      debugLog(debug, "Using access token from credentials store...");
+    }
+    return legacyResult;
   });
 
   const readFile = Effect.gen(function* () {
@@ -363,6 +380,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
     getAccessToken: Effect.gen(function* () {
       // Env takes precedence (matches access_token.go:38).
       if (Option.isSome(cliConfig.accessToken)) {
+        debugLog(debug, "Using access token from env var...");
         yield* validate(Redacted.value(cliConfig.accessToken.value));
         return Option.some(cliConfig.accessToken.value);
       }
@@ -377,6 +395,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
       // Filesystem fallback at ~/.supabase/access-token.
       const fileValue = yield* readFile;
       if (Option.isSome(fileValue)) {
+        debugLog(debug, `Using access token from file: ${fallbackPath}`);
         yield* validate(fileValue.value);
         return Option.some(Redacted.make(fileValue.value));
       }

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
@@ -2,7 +2,7 @@ import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
 
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { normalizeKeyringToken } from "../../shared/auth/keyring-token.ts";
-import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
+import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import {
@@ -141,10 +141,6 @@ function normalizeGoWindowsPassword(value: string): string {
     if (high !== 0) bytes.push(high);
   }
   return Buffer.from(bytes).toString("utf8");
-}
-
-function debugLog(debug: boolean, message: string): void {
-  if (debug) process.stderr.write(`${message}\n`);
 }
 
 function writeGoWindowsTarget(module: KeyringModule, account: string, token: string): boolean {
@@ -323,7 +319,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
   const path = yield* Path.Path;
   const runtimeInfo = yield* RuntimeInfo;
   const cliConfig = yield* LegacyCliConfig;
-  const debug = yield* LegacyDebugFlag;
+  const debugLogger = yield* LegacyDebugLogger;
   const profileAccount = cliConfig.profile;
 
   // ~/.supabase/access-token — fallback file path
@@ -354,7 +350,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
       runtimeInfo.platform,
     );
     if (Option.isSome(profileResult)) {
-      debugLog(debug, `Using access token for profile: ${profileAccount}`);
+      yield* debugLogger.debug(`Using access token for profile: ${profileAccount}`);
       return profileResult;
     }
     const legacyResult = yield* tryKeyringRead(
@@ -363,7 +359,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
       runtimeInfo.platform,
     );
     if (Option.isSome(legacyResult)) {
-      debugLog(debug, "Using access token from credentials store...");
+      yield* debugLogger.debug("Using access token from credentials store...");
     }
     return legacyResult;
   });
@@ -380,7 +376,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
     getAccessToken: Effect.gen(function* () {
       // Env takes precedence (matches access_token.go:38).
       if (Option.isSome(cliConfig.accessToken)) {
-        debugLog(debug, "Using access token from env var...");
+        yield* debugLogger.debug("Using access token from env var...");
         yield* validate(Redacted.value(cliConfig.accessToken.value));
         return Option.some(cliConfig.accessToken.value);
       }
@@ -395,7 +391,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
       // Filesystem fallback at ~/.supabase/access-token.
       const fileValue = yield* readFile;
       if (Option.isSome(fileValue)) {
-        debugLog(debug, `Using access token from file: ${fallbackPath}`);
+        yield* debugLogger.debug(`Using access token from file: ${fallbackPath}`);
         yield* validate(fileValue.value);
         return Option.some(Redacted.make(fileValue.value));
       }

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../shared/legacy/global-flags.ts";
 import { mockRuntimeInfo, processEnvLayer } from "../../../tests/helpers/mocks.ts";
 import { legacyCliConfigLayer } from "../config/legacy-cli-config.layer.ts";
+import { legacyDebugLoggerLayer } from "../shared/legacy-debug-logger.layer.ts";
 import { legacyCredentialsLayer } from "./legacy-credentials.layer.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import {
@@ -114,6 +115,7 @@ function makeLayer(
     platform: opts.platform,
   });
   const cliConfigLayer = legacyCliConfigLayer.pipe(
+    Layer.provide(legacyDebugLoggerLayer),
     Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(Layer.succeed(LegacyProfileFlag, "supabase")),
     Layer.provide(Layer.succeed(LegacyWorkdirFlag, Option.none<string>())),
@@ -123,6 +125,7 @@ function makeLayer(
   );
   return legacyCredentialsLayer.pipe(
     Layer.provide(cliConfigLayer),
+    Layer.provide(legacyDebugLoggerLayer),
     Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(runtimeInfoLayer),
     Layer.provide(BunServices.layer),
@@ -427,6 +430,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
         }),
       );
       const cliConfigLayer = legacyCliConfigLayer.pipe(
+        Layer.provide(legacyDebugLoggerLayer),
         Layer.provide(Layer.succeed(LegacyDebugFlag, false)),
         Layer.provide(Layer.succeed(LegacyProfileFlag, "supabase")),
         Layer.provide(Layer.succeed(LegacyWorkdirFlag, Option.none<string>())),
@@ -436,6 +440,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
       );
       const layer = legacyCredentialsLayer.pipe(
         Layer.provide(cliConfigLayer),
+        Layer.provide(legacyDebugLoggerLayer),
         Layer.provide(Layer.succeed(LegacyDebugFlag, false)),
         Layer.provide(runtimeInfoLayer),
         Layer.provide(fsLayer),

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
@@ -7,7 +7,11 @@ import { BunServices } from "@effect/platform-bun";
 import { Effect, FileSystem, Layer, Option, PlatformError, Redacted } from "effect";
 import { afterEach, beforeEach, vi } from "vitest";
 
-import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
+import {
+  LegacyDebugFlag,
+  LegacyProfileFlag,
+  LegacyWorkdirFlag,
+} from "../../shared/legacy/global-flags.ts";
 import { mockRuntimeInfo, processEnvLayer } from "../../../tests/helpers/mocks.ts";
 import { legacyCliConfigLayer } from "../config/legacy-cli-config.layer.ts";
 import { legacyCredentialsLayer } from "./legacy-credentials.layer.ts";
@@ -99,6 +103,7 @@ function makeLayer(
     env?: Record<string, string | undefined>;
     home?: string;
     platform?: NodeJS.Platform;
+    debug?: boolean;
   } = {},
 ) {
   const home = opts.home ?? tempHome;
@@ -109,6 +114,7 @@ function makeLayer(
     platform: opts.platform,
   });
   const cliConfigLayer = legacyCliConfigLayer.pipe(
+    Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(Layer.succeed(LegacyProfileFlag, "supabase")),
     Layer.provide(Layer.succeed(LegacyWorkdirFlag, Option.none<string>())),
     Layer.provide(runtimeInfoLayer),
@@ -117,6 +123,7 @@ function makeLayer(
   );
   return legacyCredentialsLayer.pipe(
     Layer.provide(cliConfigLayer),
+    Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(runtimeInfoLayer),
     Layer.provide(BunServices.layer),
     Layer.provide(processEnvLayer(env)),
@@ -158,6 +165,10 @@ const expectSomeToken = (token: Option.Option<Redacted.Redacted<string>>, expect
   }
 };
 
+function captureStderr() {
+  return vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+}
+
 describe("legacyCredentialsLayer.getAccessToken", () => {
   it.effect("returns the SUPABASE_ACCESS_TOKEN env value (highest precedence)", () => {
     passwords.set("Supabase CLI/supabase", "sbp_" + "9".repeat(40));
@@ -175,6 +186,22 @@ describe("legacyCredentialsLayer.getAccessToken", () => {
       const token = yield* getAccessToken;
       expectSomeToken(token, VALID_TOKEN);
     }).pipe(Effect.provide(makeLayer()));
+  });
+
+  it.effect("debug logs the access token source", () => {
+    passwords.set("Supabase CLI/supabase", VALID_TOKEN);
+    const stderr = captureStderr();
+    return Effect.gen(function* () {
+      const { getAccessToken } = yield* LegacyCredentials;
+      const token = yield* getAccessToken;
+      expectSomeToken(token, VALID_TOKEN);
+      expect(stderr.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain(
+        "Using access token for profile: supabase\n",
+      );
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => stderr.mockRestore())),
+      Effect.provide(makeLayer({ debug: true })),
+    );
   });
 
   it.effect("decodes Go keyring base64 values from the keyring profile account", () => {
@@ -400,6 +427,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
         }),
       );
       const cliConfigLayer = legacyCliConfigLayer.pipe(
+        Layer.provide(Layer.succeed(LegacyDebugFlag, false)),
         Layer.provide(Layer.succeed(LegacyProfileFlag, "supabase")),
         Layer.provide(Layer.succeed(LegacyWorkdirFlag, Option.none<string>())),
         Layer.provide(runtimeInfoLayer),
@@ -408,6 +436,7 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
       );
       const layer = legacyCredentialsLayer.pipe(
         Layer.provide(cliConfigLayer),
+        Layer.provide(Layer.succeed(LegacyDebugFlag, false)),
         Layer.provide(runtimeInfoLayer),
         Layer.provide(fsLayer),
         Layer.provide(BunServices.layer),

--- a/apps/cli/src/legacy/auth/legacy-http-debug.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-http-debug.layer.ts
@@ -14,9 +14,8 @@ export const legacyHttpClientLayer = Layer.effect(
   Effect.gen(function* () {
     const logger = yield* LegacyDebugLogger;
     const base = yield* HttpClient.HttpClient;
-    return HttpClient.mapRequest(base, (req) => {
-      Effect.runSync(logger.http(req.method, req.url));
-      return req;
-    });
+    return HttpClient.mapRequestEffect(base, (req) =>
+      logger.http(req.method, req.url).pipe(Effect.as(req)),
+    );
   }),
 ).pipe(Layer.provide(FetchHttpClient.layer));

--- a/apps/cli/src/legacy/auth/legacy-http-debug.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-http-debug.layer.ts
@@ -2,42 +2,21 @@ import { Effect, Layer } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 
-import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
-
-const pad = (n: number): string => String(n).padStart(2, "0");
-
-/** Formats a timestamp matching Go's `log.LstdFlags`: `YYYY/MM/DD HH:MM:SS`. */
-function formatTimestamp(now: Date): string {
-  return (
-    `${now.getFullYear()}/${pad(now.getMonth() + 1)}/${pad(now.getDate())} ` +
-    `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
-  );
-}
+import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
 
 /**
- * Wraps `FetchHttpClient.layer` so that, when `--debug` is set, every HTTP
- * request is logged to stderr in the exact format Go uses
- * (`apps/cli-go/internal/debug/http.go`): `HTTP <YYYY/MM/DD HH:MM:SS> <METHOD>: <URL>\n`.
- *
- * When `--debug` is unset, this is identity over `FetchHttpClient.layer` — no
- * runtime overhead beyond a single boolean check at layer-construction time.
+ * Wraps `FetchHttpClient.layer` so every HTTP request can go through the
+ * legacy Go-parity debug side channel. The logger itself owns the `--debug`
+ * guard and byte-for-byte line formatting.
  */
-export const legacyHttpClientLayer = Layer.unwrap(
+export const legacyHttpClientLayer = Layer.effect(
+  HttpClient.HttpClient,
   Effect.gen(function* () {
-    const debug = yield* LegacyDebugFlag;
-    if (!debug) {
-      return FetchHttpClient.layer;
-    }
-
-    return Layer.effect(
-      HttpClient.HttpClient,
-      Effect.gen(function* () {
-        const base = yield* HttpClient.HttpClient;
-        return HttpClient.mapRequest(base, (req) => {
-          process.stderr.write(`HTTP ${formatTimestamp(new Date())} ${req.method}: ${req.url}\n`);
-          return req;
-        });
-      }),
-    ).pipe(Layer.provide(FetchHttpClient.layer));
+    const logger = yield* LegacyDebugLogger;
+    const base = yield* HttpClient.HttpClient;
+    return HttpClient.mapRequest(base, (req) => {
+      Effect.runSync(logger.http(req.method, req.url));
+      return req;
+    });
   }),
-);
+).pipe(Layer.provide(FetchHttpClient.layer));

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
@@ -115,10 +115,9 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
     });
 
   const transformClient = (client: HttpClient.HttpClient) => {
-    const debugClient = HttpClient.mapRequest(client, (request) => {
-      Effect.runSync(debugLogger.http(request.method, request.url));
-      return request;
-    });
+    const debugClient = HttpClient.mapRequestEffect(client, (request) =>
+      debugLogger.http(request.method, request.url).pipe(Effect.as(request)),
+    );
 
     return Effect.succeed(
       HttpClient.transform(debugClient, (requestEffect) =>

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
@@ -4,8 +4,8 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
 import { CLI_VERSION } from "../../shared/cli/version.ts";
-import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
@@ -17,19 +17,6 @@ const MISSING_TOKEN_MESSAGE =
 
 const HEADER_GOTRUE_ID = "x-gotrue-id";
 const TELEMETRY_SCHEMA_VERSION = 1;
-
-const pad = (n: number): string => String(n).padStart(2, "0");
-
-function formatTimestamp(now: Date): string {
-  return (
-    `${now.getFullYear()}/${pad(now.getMonth() + 1)}/${pad(now.getDate())} ` +
-    `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
-  );
-}
-
-function debugLog(debug: boolean, message: string): void {
-  if (debug) process.stderr.write(`${message}\n`);
-}
 
 interface LegacyTelemetryState {
   readonly enabled: boolean;
@@ -82,7 +69,7 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
   const runtime = yield* TelemetryRuntime;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const debug = yield* LegacyDebugFlag;
+  const debugLogger = yield* LegacyDebugLogger;
   let stitchAttempted = false;
 
   const needsIdentityStitch =
@@ -128,14 +115,10 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
     });
 
   const transformClient = (client: HttpClient.HttpClient) => {
-    const debugClient = debug
-      ? HttpClient.mapRequest(client, (request) => {
-          process.stderr.write(
-            `${formatTimestamp(new Date())} HTTP ${request.method}: ${request.url}\n`,
-          );
-          return request;
-        })
-      : client;
+    const debugClient = HttpClient.mapRequest(client, (request) => {
+      Effect.runSync(debugLogger.http(request.method, request.url));
+      return request;
+    });
 
     return Effect.succeed(
       HttpClient.transform(debugClient, (requestEffect) =>
@@ -153,7 +136,7 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
   const configuredToken = cliConfig.accessToken;
   const resolveAccessToken = Effect.gen(function* () {
     if (Option.isSome(configuredToken)) {
-      debugLog(debug, "Using access token from env var...");
+      yield* debugLogger.debug("Using access token from env var...");
       return configuredToken;
     }
     return yield* credentials.getAccessToken;
@@ -165,8 +148,8 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
       new LegacyPlatformAuthRequiredError({ message: MISSING_TOKEN_MESSAGE }),
     );
   }
-  debugLog(debug, `Supabase CLI ${CLI_VERSION}`);
-  debugLog(debug, `Using profile: ${cliConfig.profile} (${cliConfig.projectHost})`);
+  yield* debugLogger.debug(`Supabase CLI ${CLI_VERSION}`);
+  yield* debugLogger.debug(`Using profile: ${cliConfig.profile} (${cliConfig.projectHost})`);
   const storedToken = yield* resolveAccessToken;
   if (Option.isNone(storedToken)) {
     return yield* Effect.fail(

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
@@ -3,6 +3,8 @@ import { Effect, FileSystem, Layer, Option, Path } from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
+import { CLI_VERSION } from "../../shared/cli/version.ts";
+import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
@@ -15,6 +17,19 @@ const MISSING_TOKEN_MESSAGE =
 
 const HEADER_GOTRUE_ID = "x-gotrue-id";
 const TELEMETRY_SCHEMA_VERSION = 1;
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+
+function formatTimestamp(now: Date): string {
+  return (
+    `${now.getFullYear()}/${pad(now.getMonth() + 1)}/${pad(now.getDate())} ` +
+    `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+  );
+}
+
+function debugLog(debug: boolean, message: string): void {
+  if (debug) process.stderr.write(`${message}\n`);
+}
 
 interface LegacyTelemetryState {
   readonly enabled: boolean;
@@ -67,6 +82,7 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
   const runtime = yield* TelemetryRuntime;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const debug = yield* LegacyDebugFlag;
   let stitchAttempted = false;
 
   const needsIdentityStitch =
@@ -111,9 +127,18 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
       yield* fs.writeFileString(telemetryPath, JSON.stringify(state));
     });
 
-  const transformClient = (client: HttpClient.HttpClient) =>
-    Effect.succeed(
-      HttpClient.transform(client, (requestEffect) =>
+  const transformClient = (client: HttpClient.HttpClient) => {
+    const debugClient = debug
+      ? HttpClient.mapRequest(client, (request) => {
+          process.stderr.write(
+            `${formatTimestamp(new Date())} HTTP ${request.method}: ${request.url}\n`,
+          );
+          return request;
+        })
+      : client;
+
+    return Effect.succeed(
+      HttpClient.transform(debugClient, (requestEffect) =>
         requestEffect.pipe(
           Effect.tap((response) => {
             const gotrueId = gotrueIdFromResponse(response);
@@ -123,14 +148,26 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
         ),
       ),
     );
+  };
 
-  // Env takes precedence over keyring/file (already inside LegacyCredentials), but
-  // LegacyCliConfig.accessToken is the env value alone — read in the same order Go uses.
   const configuredToken = cliConfig.accessToken;
-  const storedToken = Option.isSome(configuredToken)
-    ? configuredToken
-    : yield* credentials.getAccessToken;
+  const resolveAccessToken = Effect.gen(function* () {
+    if (Option.isSome(configuredToken)) {
+      debugLog(debug, "Using access token from env var...");
+      return configuredToken;
+    }
+    return yield* credentials.getAccessToken;
+  });
 
+  const authGateToken = yield* resolveAccessToken;
+  if (Option.isNone(authGateToken)) {
+    return yield* Effect.fail(
+      new LegacyPlatformAuthRequiredError({ message: MISSING_TOKEN_MESSAGE }),
+    );
+  }
+  debugLog(debug, `Supabase CLI ${CLI_VERSION}`);
+  debugLog(debug, `Using profile: ${cliConfig.profile} (${cliConfig.projectHost})`);
+  const storedToken = yield* resolveAccessToken;
   if (Option.isNone(storedToken)) {
     return yield* Effect.fail(
       new LegacyPlatformAuthRequiredError({ message: MISSING_TOKEN_MESSAGE }),

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.unit.test.ts
@@ -13,6 +13,7 @@ import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { legacyDebugLoggerLayer } from "../shared/legacy-debug-logger.layer.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import { legacyPlatformApiLayer } from "./legacy-platform-api.layer.ts";
 import { LegacyPlatformApi } from "./legacy-platform-api.service.ts";
@@ -177,6 +178,7 @@ function withBaseDeps(
           isCi: opts.isCi,
         }),
       ),
+      Layer.provide(legacyDebugLoggerLayer),
       Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
       Layer.provide(nodeFileSystemLayer()),
       Layer.provide(nodePathLayer()),

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.unit.test.ts
@@ -7,7 +7,9 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { vi } from "vitest";
 
+import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
@@ -18,11 +20,17 @@ import { LegacyPlatformApi } from "./legacy-platform-api.service.ts";
 const VALID_TOKEN = "sbp_" + "a".repeat(40);
 const SESSION_LAST_ACTIVE = 1_777_200_000_000;
 
-function mockCliConfig(opts: { accessToken?: string; apiUrl?: string; userAgent?: string }) {
+function mockCliConfig(opts: {
+  accessToken?: string;
+  apiUrl?: string;
+  userAgent?: string;
+  profile?: string;
+  projectHost?: string;
+}) {
   return Layer.succeed(LegacyCliConfig, {
-    profile: "supabase",
+    profile: opts.profile ?? "supabase",
     apiUrl: opts.apiUrl ?? "https://api.supabase.com",
-    projectHost: "supabase.co",
+    projectHost: opts.projectHost ?? "supabase.co",
     accessToken:
       opts.accessToken === undefined ? Option.none() : Option.some(Redacted.make(opts.accessToken)),
     projectId: Option.none(),
@@ -49,6 +57,7 @@ function mockTelemetryRuntime(
     isFirstRun?: boolean;
     isTty?: boolean;
     isCi?: boolean;
+    debug?: boolean;
   } = {},
 ) {
   return Layer.succeed(
@@ -152,6 +161,7 @@ function withBaseDeps(
     isFirstRun?: boolean;
     isTty?: boolean;
     isCi?: boolean;
+    debug?: boolean;
   } = {},
 ) {
   const analytics = opts.analytics ?? mockAnalytics();
@@ -167,6 +177,7 @@ function withBaseDeps(
           isCi: opts.isCi,
         }),
       ),
+      Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
       Layer.provide(nodeFileSystemLayer()),
       Layer.provide(nodePathLayer()),
     );
@@ -280,6 +291,35 @@ describe("legacyPlatformApiLayer", () => {
       yield* api.v1.listAllProjects();
       expect(http.requests[0]?.url).toContain("https://api.supabase.green/");
     }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("debug logs the CLI profile and fully resolved request URL", () => {
+    const http = captureRequests();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const layer = legacyPlatformApiLayer.pipe(
+      Layer.provide(
+        mockCliConfig({
+          accessToken: VALID_TOKEN,
+          apiUrl: "https://api.supabase.green",
+          profile: "supabase-staging",
+          projectHost: "supabase.red",
+        }),
+      ),
+      Layer.provide(mockCredentials(Option.none())),
+      Layer.provide(http.layer),
+      withBaseDeps({ debug: true }),
+    );
+    return Effect.gen(function* () {
+      const api = yield* LegacyPlatformApi;
+      yield* api.v1.listAllProjects();
+      const output = stderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(output).toContain("Supabase CLI ");
+      expect(output).toContain("Using profile: supabase-staging (supabase.red)\n");
+      expect(output.match(/Using access token from env var\.\.\.\n/g)).toHaveLength(2);
+      expect(output).toMatch(
+        /\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} HTTP GET: https:\/\/api\.supabase\.green\/v1\/projects\n/,
+      );
+    }).pipe(Effect.ensuring(Effect.sync(() => stderr.mockRestore())), Effect.provide(layer));
   });
 
   it.effect("stitches identity from X-Gotrue-Id responses outside CI", () => {

--- a/apps/cli/src/legacy/commands/login/login.layers.ts
+++ b/apps/cli/src/legacy/commands/login/login.layers.ts
@@ -3,6 +3,7 @@ import { Layer } from "effect";
 import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
 import { legacyHttpClientLayer } from "../../auth/legacy-http-debug.layer.ts";
 import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
 import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
 import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
 import { browserLayer } from "../../../shared/runtime/browser.layer.ts";
@@ -21,16 +22,18 @@ import { legacyLoginCryptoLayer } from "./login-crypto.layer.ts";
 // memoised by reference to avoid building two keyring readers / config loaders.
 // `Analytics`, `Output`, `Stdio`, `Tty`, `TelemetryRuntime`, `FileSystem`, and
 // `Path` come from the root layer.
-const credentials = legacyCredentialsLayer.pipe(Layer.provide(legacyCliConfigLayer));
-const loginApi = legacyLoginApiLayer.pipe(
-  Layer.provide(legacyHttpClientLayer),
-  Layer.provide(legacyCliConfigLayer),
+const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+const httpClient = legacyHttpClientLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+const credentials = legacyCredentialsLayer.pipe(
+  Layer.provide(cliConfig),
+  Layer.provide(legacyDebugLoggerLayer),
 );
+const loginApi = legacyLoginApiLayer.pipe(Layer.provide(httpClient), Layer.provide(cliConfig));
 
 export const legacyLoginRuntimeLayer = Layer.mergeAll(
   credentials,
-  legacyCliConfigLayer,
-  legacyHttpClientLayer,
+  cliConfig,
+  httpClient,
   loginApi,
   legacyLoginCryptoLayer,
   legacyTelemetryStateLayer,

--- a/apps/cli/src/legacy/commands/logout/logout.layers.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.layers.ts
@@ -2,6 +2,7 @@ import { Layer } from "effect";
 
 import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
 import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
 import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
 import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
 
@@ -16,9 +17,15 @@ import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.lay
  * legacy CLAUDE.md item 5). `Analytics`, `Output`, `Stdio`, `FileSystem`,
  * `Path`, `TelemetryRuntime`, and `LegacyYesFlag` come from the root layer.
  */
+const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+const credentials = legacyCredentialsLayer.pipe(
+  Layer.provide(cliConfig),
+  Layer.provide(legacyDebugLoggerLayer),
+);
+
 export const legacyLogoutRuntimeLayer = Layer.mergeAll(
-  legacyCredentialsLayer.pipe(Layer.provide(legacyCliConfigLayer)),
-  legacyCliConfigLayer,
+  credentials,
+  cliConfig,
   legacyTelemetryStateLayer,
   commandRuntimeLayer(["logout"]),
 );

--- a/apps/cli/src/legacy/commands/unlink/unlink.command.ts
+++ b/apps/cli/src/legacy/commands/unlink/unlink.command.ts
@@ -3,6 +3,7 @@ import { Command } from "effect/unstable/cli";
 
 import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
 import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
 import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
 import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
 import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
@@ -15,9 +16,15 @@ import { legacyUnlink } from "./unlink.handler.ts";
 // `unlink`. It provides only the services the handler + instrumentation consume.
 // `legacyCliConfigLayer` is provided to credentials AND exposed at the top level
 // (Layer.provide does not share to siblings inside a merge — legacy CLAUDE.md item 5).
+const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+const credentials = legacyCredentialsLayer.pipe(
+  Layer.provide(cliConfig),
+  Layer.provide(legacyDebugLoggerLayer),
+);
+
 const legacyUnlinkRuntimeLayer = Layer.mergeAll(
-  legacyCredentialsLayer.pipe(Layer.provide(legacyCliConfigLayer)),
-  legacyCliConfigLayer,
+  credentials,
+  cliConfig,
   legacyTelemetryStateLayer,
   commandRuntimeLayer(["unlink"]),
 );

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
@@ -1,12 +1,12 @@
 import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
 import { parse as parseYaml } from "yaml";
 import { CLI_VERSION } from "../../shared/cli/version.ts";
-import {
-  LegacyDebugFlag,
-  LegacyProfileFlag,
-  LegacyWorkdirFlag,
-} from "../../shared/legacy/global-flags.ts";
+import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
 import { legacyProjectHost } from "../shared/legacy-profile.ts";
+import {
+  LegacyDebugLogger,
+  type LegacyDebugLoggerShape,
+} from "../shared/legacy-debug-logger.service.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { LegacyCliConfig, type LegacyProfileName } from "./legacy-cli-config.service.ts";
 import { legacyProfileFilePath } from "./legacy-profile-file.ts";
@@ -52,10 +52,6 @@ function safeParseYaml(
   }
 }
 
-function debugLog(debug: boolean, message: string): void {
-  if (debug) process.stderr.write(`${message}\n`);
-}
-
 function unknownMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -83,32 +79,27 @@ function resolveProfile(
   fs: FileSystem.FileSystem,
   path: Path.Path,
   homeDir: string,
-  debug: boolean,
+  debugLogger: LegacyDebugLoggerShape,
 ): Effect.Effect<ResolvedProfile> {
   return Effect.gen(function* () {
     let token: string;
     if (flagValue !== "supabase") {
-      debugLog(debug, `Loading profile from flag: ${flagValue}`);
+      yield* debugLogger.debug(`Loading profile from flag: ${flagValue}`);
       token = flagValue;
     } else if (envValue !== undefined && envValue.length > 0) {
       // Go reads SUPABASE_PROFILE through viper's PROFILE key, so debug output
       // cannot distinguish env from an explicitly changed flag.
-      debugLog(debug, `Loading profile from flag: ${envValue}`);
+      yield* debugLogger.debug(`Loading profile from flag: ${envValue}`);
       token = envValue;
     } else {
       // Lowest precedence: the persisted `~/.supabase/profile` file (Go's
       // `getProfileName` file fallback, `profile.go:129-131`).
       const filePath = legacyProfileFilePath(path, homeDir);
       const content = yield* fs.readFileString(filePath).pipe(
-        Effect.tap(() =>
-          Effect.sync(() => debugLog(debug, `Loading profile from file: ${filePath}`)),
-        ),
+        Effect.tap(() => debugLogger.debug(`Loading profile from file: ${filePath}`)),
         Effect.map(Option.some),
         Effect.catch((error) =>
-          Effect.sync(() => {
-            debugLog(debug, unknownMessage(error));
-            return Option.none<string>();
-          }),
+          debugLogger.debug(unknownMessage(error)).pipe(Effect.as(Option.none<string>())),
         ),
       );
       token = Option.match(content, {
@@ -176,7 +167,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
   Effect.gen(function* () {
     const profileFlag = yield* LegacyProfileFlag;
     const workdirFlag = yield* LegacyWorkdirFlag;
-    const debug = yield* LegacyDebugFlag;
+    const debugLogger = yield* LegacyDebugLogger;
 
     return Layer.effect(
       LegacyCliConfig,
@@ -196,7 +187,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
           fs,
           path,
           runtimeInfo.homeDir,
-          debug,
+          debugLogger,
         );
 
         const rawAccessToken = env["SUPABASE_ACCESS_TOKEN"];

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
@@ -1,11 +1,15 @@
 import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
 import { parse as parseYaml } from "yaml";
 import { CLI_VERSION } from "../../shared/cli/version.ts";
-import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
+import {
+  LegacyDebugFlag,
+  LegacyProfileFlag,
+  LegacyWorkdirFlag,
+} from "../../shared/legacy/global-flags.ts";
 import { legacyProjectHost } from "../shared/legacy-profile.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { LegacyCliConfig, type LegacyProfileName } from "./legacy-cli-config.service.ts";
-import { readLegacyProfileFile } from "./legacy-profile-file.ts";
+import { legacyProfileFilePath } from "./legacy-profile-file.ts";
 
 interface ResolvedProfile {
   readonly name: string;
@@ -48,6 +52,14 @@ function safeParseYaml(
   }
 }
 
+function debugLog(debug: boolean, message: string): void {
+  if (debug) process.stderr.write(`${message}\n`);
+}
+
+function unknownMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Resolves the profile that produces the API URL. Mirrors Go's `LoadProfile`
  * (`apps/cli-go/internal/utils/profile.go:96-118`):
@@ -71,18 +83,41 @@ function resolveProfile(
   fs: FileSystem.FileSystem,
   path: Path.Path,
   homeDir: string,
+  debug: boolean,
 ): Effect.Effect<ResolvedProfile> {
   return Effect.gen(function* () {
     let token: string;
     if (flagValue !== "supabase") {
+      debugLog(debug, `Loading profile from flag: ${flagValue}`);
       token = flagValue;
     } else if (envValue !== undefined && envValue.length > 0) {
+      // Go reads SUPABASE_PROFILE through viper's PROFILE key, so debug output
+      // cannot distinguish env from an explicitly changed flag.
+      debugLog(debug, `Loading profile from flag: ${envValue}`);
       token = envValue;
     } else {
       // Lowest precedence: the persisted `~/.supabase/profile` file (Go's
       // `getProfileName` file fallback, `profile.go:129-131`).
-      const fileName = yield* readLegacyProfileFile(fs, path, homeDir);
-      token = Option.getOrElse(fileName, () => "supabase");
+      const filePath = legacyProfileFilePath(path, homeDir);
+      const content = yield* fs.readFileString(filePath).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => debugLog(debug, `Loading profile from file: ${filePath}`)),
+        ),
+        Effect.map(Option.some),
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            debugLog(debug, unknownMessage(error));
+            return Option.none<string>();
+          }),
+        ),
+      );
+      token = Option.match(content, {
+        onNone: () => "supabase",
+        onSome: (value) => {
+          const trimmed = value.trim();
+          return trimmed.length === 0 ? "supabase" : trimmed;
+        },
+      });
     }
 
     if (isBuiltinProfileName(token)) {
@@ -141,6 +176,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
   Effect.gen(function* () {
     const profileFlag = yield* LegacyProfileFlag;
     const workdirFlag = yield* LegacyWorkdirFlag;
+    const debug = yield* LegacyDebugFlag;
 
     return Layer.effect(
       LegacyCliConfig,
@@ -160,6 +196,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
           fs,
           path,
           runtimeInfo.homeDir,
+          debug,
         );
 
         const rawAccessToken = env["SUPABASE_ACCESS_TOKEN"];

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
@@ -13,6 +13,7 @@ import {
   LegacyWorkdirFlag,
 } from "../../shared/legacy/global-flags.ts";
 import { mockRuntimeInfo, processEnvLayer } from "../../../tests/helpers/mocks.ts";
+import { legacyDebugLoggerLayer } from "../shared/legacy-debug-logger.layer.ts";
 import { legacyCliConfigLayer } from "./legacy-cli-config.layer.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 
@@ -27,6 +28,7 @@ function makeLayer(opts: {
   const profileFlag = opts.profileFlag ?? "supabase";
   const workdirFlag = opts.workdirFlag ?? Option.none<string>();
   return legacyCliConfigLayer.pipe(
+    Layer.provide(legacyDebugLoggerLayer),
     Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(Layer.succeed(LegacyProfileFlag, profileFlag)),
     Layer.provide(Layer.succeed(LegacyWorkdirFlag, workdirFlag)),

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
@@ -5,9 +5,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { Effect, Layer, Option, Redacted } from "effect";
-import { afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
-import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
+import {
+  LegacyDebugFlag,
+  LegacyProfileFlag,
+  LegacyWorkdirFlag,
+} from "../../shared/legacy/global-flags.ts";
 import { mockRuntimeInfo, processEnvLayer } from "../../../tests/helpers/mocks.ts";
 import { legacyCliConfigLayer } from "./legacy-cli-config.layer.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
@@ -18,10 +22,12 @@ function makeLayer(opts: {
   env?: Record<string, string | undefined>;
   cwd?: string;
   home?: string;
+  debug?: boolean;
 }) {
   const profileFlag = opts.profileFlag ?? "supabase";
   const workdirFlag = opts.workdirFlag ?? Option.none<string>();
   return legacyCliConfigLayer.pipe(
+    Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(Layer.succeed(LegacyProfileFlag, profileFlag)),
     Layer.provide(Layer.succeed(LegacyWorkdirFlag, workdirFlag)),
     Layer.provide(mockRuntimeInfo({ cwd: opts.cwd ?? "/test/cwd", homeDir: opts.home })),
@@ -84,6 +90,24 @@ describe("legacyCliConfigLayer", () => {
       const config = yield* LegacyCliConfig;
       expect(config.profile).toBe("supabase-staging");
     }).pipe(Effect.provide(makeLayer({ home, cwd: tempRoot })));
+  });
+
+  it.effect("debug logs the persisted profile file source", () => {
+    const home = join(tempRoot, "home");
+    const profilePath = join(home, ".supabase", "profile");
+    mkdirSync(join(home, ".supabase"), { recursive: true });
+    writeFileSync(profilePath, "supabase-staging\n");
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    return Effect.gen(function* () {
+      const config = yield* LegacyCliConfig;
+      expect(config.profile).toBe("supabase-staging");
+      expect(stderr.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain(
+        `Loading profile from file: ${profilePath}\n`,
+      );
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => stderr.mockRestore())),
+      Effect.provide(makeLayer({ home, cwd: tempRoot, debug: true })),
+    );
   });
 
   it.effect("flag and env take precedence over the persisted profile file", () => {

--- a/apps/cli/src/legacy/config/legacy-profile-file.ts
+++ b/apps/cli/src/legacy/config/legacy-profile-file.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, FileSystem, Option, Path } from "effect";
+import { Data, Effect, FileSystem, Path } from "effect";
 
 /**
  * Helpers for the persisted profile-name file `~/.supabase/profile`, mirroring
@@ -17,23 +17,9 @@ export class LegacyProfileSaveError extends Data.TaggedError("LegacyProfileSaveE
   readonly message: string;
 }> {}
 
-function legacyProfileFilePath(path: Path.Path, homeDir: string): string {
+export function legacyProfileFilePath(path: Path.Path, homeDir: string): string {
   return path.join(homeDir, ".supabase", "profile");
 }
-
-/** Reads `~/.supabase/profile`, returning `None` when missing or empty. */
-export const readLegacyProfileFile = (
-  fs: FileSystem.FileSystem,
-  path: Path.Path,
-  homeDir: string,
-): Effect.Effect<Option.Option<string>> =>
-  Effect.gen(function* () {
-    const filePath = legacyProfileFilePath(path, homeDir);
-    const content = yield* fs.readFileString(filePath).pipe(Effect.option);
-    if (Option.isNone(content)) return Option.none<string>();
-    const trimmed = content.value.trim();
-    return trimmed.length === 0 ? Option.none<string>() : Option.some(trimmed);
-  });
 
 /** Writes the profile name to `~/.supabase/profile`. Fatal on failure (Go parity). */
 export const saveLegacyProfileName = (

--- a/apps/cli/src/legacy/shared/legacy-debug-logger.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-debug-logger.layer.ts
@@ -1,0 +1,31 @@
+import { Effect, Layer } from "effect";
+
+import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
+import { LegacyDebugLogger } from "./legacy-debug-logger.service.ts";
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+
+/** Formats a timestamp matching Go's `log.LstdFlags`: `YYYY/MM/DD HH:MM:SS`. */
+function formatTimestamp(now: Date): string {
+  return (
+    `${now.getFullYear()}/${pad(now.getMonth() + 1)}/${pad(now.getDate())} ` +
+    `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+  );
+}
+
+export const legacyDebugLoggerLayer = Layer.effect(
+  LegacyDebugLogger,
+  Effect.gen(function* () {
+    const debug = yield* LegacyDebugFlag;
+
+    const writeLine = (message: string) =>
+      Effect.sync(() => {
+        if (debug) process.stderr.write(`${message}\n`);
+      });
+
+    return LegacyDebugLogger.of({
+      debug: writeLine,
+      http: (method, url) => writeLine(`${formatTimestamp(new Date())} HTTP ${method}: ${url}`),
+    });
+  }),
+);

--- a/apps/cli/src/legacy/shared/legacy-debug-logger.layer.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-debug-logger.layer.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { afterEach, vi } from "vitest";
+
+import { LegacyDebugFlag } from "../../shared/legacy/global-flags.ts";
+import { legacyDebugLoggerLayer } from "./legacy-debug-logger.layer.ts";
+import { LegacyDebugLogger } from "./legacy-debug-logger.service.ts";
+
+function makeLayer(debug: boolean) {
+  return legacyDebugLoggerLayer.pipe(Layer.provide(Layer.succeed(LegacyDebugFlag, debug)));
+}
+
+function captureStderr() {
+  return vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("legacyDebugLoggerLayer", () => {
+  it.effect("does not write stderr bytes when debug is disabled", () => {
+    const stderr = captureStderr();
+    return Effect.gen(function* () {
+      const logger = yield* LegacyDebugLogger;
+      yield* logger.debug("hidden");
+      yield* logger.http("GET", "https://api.supabase.green/v1/projects");
+      expect(stderr).not.toHaveBeenCalled();
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => stderr.mockRestore())),
+      Effect.provide(makeLayer(false)),
+    );
+  });
+
+  it.effect("debug emits the exact newline-terminated message", () => {
+    const stderr = captureStderr();
+    return Effect.gen(function* () {
+      const logger = yield* LegacyDebugLogger;
+      yield* logger.debug("Using profile: supabase-staging (supabase.red)");
+      expect(stderr.mock.calls.map(([chunk]) => String(chunk)).join("")).toBe(
+        "Using profile: supabase-staging (supabase.red)\n",
+      );
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => stderr.mockRestore())),
+      Effect.provide(makeLayer(true)),
+    );
+  });
+
+  it.effect("http emits Go timestamp order and method/url format", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 4, 8, 24, 47));
+    const stderr = captureStderr();
+    return Effect.gen(function* () {
+      const logger = yield* LegacyDebugLogger;
+      yield* logger.http("GET", "https://api.supabase.green/v1/projects");
+      expect(stderr.mock.calls.map(([chunk]) => String(chunk)).join("")).toBe(
+        "2026/06/04 08:24:47 HTTP GET: https://api.supabase.green/v1/projects\n",
+      );
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => stderr.mockRestore())),
+      Effect.provide(makeLayer(true)),
+    );
+  });
+});

--- a/apps/cli/src/legacy/shared/legacy-debug-logger.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-debug-logger.service.ts
@@ -1,0 +1,11 @@
+import type { Effect } from "effect";
+import { Context } from "effect";
+
+export interface LegacyDebugLoggerShape {
+  readonly debug: (message: string) => Effect.Effect<void>;
+  readonly http: (method: string, url: string) => Effect.Effect<void>;
+}
+
+export class LegacyDebugLogger extends Context.Service<LegacyDebugLogger, LegacyDebugLoggerShape>()(
+  "supabase/legacy/DebugLogger",
+) {}

--- a/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
@@ -11,6 +11,7 @@ import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { legacyCliConfigLayer } from "../config/legacy-cli-config.layer.ts";
 import { LegacyProjectRefResolver } from "../config/legacy-project-ref.service.ts";
 import { legacyProjectRefLayer } from "../config/legacy-project-ref.layer.ts";
+import { legacyDebugLoggerLayer } from "./legacy-debug-logger.layer.ts";
 import { LegacyLinkedProjectCache } from "../telemetry/legacy-linked-project-cache.service.ts";
 import { legacyLinkedProjectCacheLayer } from "../telemetry/legacy-linked-project-cache.layer.ts";
 import { LegacyTelemetryState } from "../telemetry/legacy-telemetry-state.service.ts";
@@ -18,28 +19,18 @@ import { legacyTelemetryStateLayer } from "../telemetry/legacy-telemetry-state.l
 import { CommandRuntime } from "../../shared/runtime/command-runtime.service.ts";
 import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.ts";
 
-// Shared platform-API stack used by every Management-API legacy subcommand.
-// `legacyPlatformApiLayer` applies typed API debug logging after generated
-// requests have been prefixed with the active profile's API URL.
-const legacyPlatformApiStack = legacyPlatformApiLayer.pipe(
-  Layer.provide(legacyCredentialsLayer),
-  Layer.provide(legacyCliConfigLayer),
-  Layer.provide(FetchHttpClient.layer),
-);
-
 /**
  * Composes the runtime layer for a Management-API-style `supabase <command> <subcommand>`
  * invocation.
  *
- * `legacyCliConfigLayer` must be piped to both `legacyPlatformApiStack` and
+ * `legacyCliConfigLayer` must be piped to both the platform API stack and
  * `legacyProjectRefLayer`. `Layer.provide` satisfies a requirement on the target layer;
  * it does not expose the provided service to siblings of a `Layer.mergeAll(...)`. The
  * project-ref layer reads `LegacyCliConfig` directly for workdir/projectId resolution,
  * so without an explicit provide here the bundled runtime panics with
  * `Service not found: supabase/legacy/CliConfig`. Handlers that yield `LegacyCliConfig`
  * directly (e.g. `branches get`, `legacySuggestUpgrade`) also need the service exposed
- * at the top level of the merged layer, hence the bare `legacyCliConfigLayer` entry
- * below.
+ * at the top level of the merged layer, hence the top-level `cliConfig` entry below.
  *
  * `legacyHttpClientLayer` and `LegacyCredentials` are exposed at the top level so
  * handlers / helpers that bypass the typed Management API client can read them
@@ -57,23 +48,33 @@ const legacyPlatformApiStack = legacyPlatformApiLayer.pipe(
  * @param subcommand - command path segments after `supabase`, e.g. `["backups", "list"]`.
  */
 export function legacyManagementApiRuntimeLayer(subcommand: ReadonlyArray<string>) {
-  // Memoise the credentials layer so the top-level surface and the linked-project
-  // cache pipeline share one keyring/file lookup. Same rationale applies to the
-  // HTTP client + CLI config layers below.
-  const credentials = legacyCredentialsLayer.pipe(Layer.provide(legacyCliConfigLayer));
+  // Memoise the shared layers so the platform API, top-level service surface,
+  // project resolver, and linked-project cache all reuse the same config /
+  // credentials / HTTP instances.
+  const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const httpClient = legacyHttpClientLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const credentials = legacyCredentialsLayer.pipe(
+    Layer.provide(cliConfig),
+    Layer.provide(legacyDebugLoggerLayer),
+  );
+  // `legacyPlatformApiLayer` applies typed API debug logging after generated
+  // requests have been prefixed with the active profile's API URL.
+  const platformApiStack = legacyPlatformApiLayer.pipe(
+    Layer.provide(credentials),
+    Layer.provide(cliConfig),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(legacyDebugLoggerLayer),
+  );
   const built = Layer.mergeAll(
-    legacyPlatformApiStack,
-    legacyHttpClientLayer,
+    platformApiStack,
+    httpClient,
     credentials,
-    legacyCliConfigLayer,
-    legacyProjectRefLayer.pipe(
-      Layer.provide(legacyPlatformApiStack),
-      Layer.provide(legacyCliConfigLayer),
-    ),
+    cliConfig,
+    legacyProjectRefLayer.pipe(Layer.provide(platformApiStack), Layer.provide(cliConfig)),
     legacyLinkedProjectCacheLayer.pipe(
       Layer.provide(credentials),
-      Layer.provide(legacyCliConfigLayer),
-      Layer.provide(legacyHttpClientLayer),
+      Layer.provide(cliConfig),
+      Layer.provide(httpClient),
     ),
     legacyTelemetryStateLayer,
     commandRuntimeLayer([...subcommand]),

--- a/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
@@ -1,5 +1,6 @@
 import { Layer } from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
+import { FetchHttpClient } from "effect/unstable/http";
 
 import { LegacyCredentials } from "../auth/legacy-credentials.service.ts";
 import { legacyCredentialsLayer } from "../auth/legacy-credentials.layer.ts";
@@ -18,11 +19,12 @@ import { CommandRuntime } from "../../shared/runtime/command-runtime.service.ts"
 import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.ts";
 
 // Shared platform-API stack used by every Management-API legacy subcommand.
-// `legacyHttpClientLayer` wraps the default fetch transport with a debug logger when `--debug` is set.
+// `legacyPlatformApiLayer` applies typed API debug logging after generated
+// requests have been prefixed with the active profile's API URL.
 const legacyPlatformApiStack = legacyPlatformApiLayer.pipe(
   Layer.provide(legacyCredentialsLayer),
   Layer.provide(legacyCliConfigLayer),
-  Layer.provide(legacyHttpClientLayer),
+  Layer.provide(FetchHttpClient.layer),
 );
 
 /**


### PR DESCRIPTION
Restores the Go CLI debug side effects for native TypeScript legacy Management API commands.

The TypeScript path was resolving profiles, credentials, and generated API URLs correctly, but it no longer emitted the debug breadcrumbs that Go printed from profile loading, access-token lookup, root command setup, and HTTP transport logging. That made `supabase --profile supabase projects list --debug` hide which profile file, resolved profile host, token source, and Management API host were used.

This ports those debug side effects into the TS legacy config, credentials, and platform API layers, and moves typed Management API HTTP debug logging to the point where generated requests have the active profile base URL attached. The output order now matches the Go management-command flow, including the repeated token-source line around the root debug banner.
