### PR TITLE
ci(release): add pull-requests permission to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,9 +189,15 @@ jobs:
     name: Release
     needs: plan
     if: needs.plan.outputs.should_release == 'true'
+    # pull-requests: write is required by the nested propose-release-notes
+    # workflow (release-shared.yml -> propose-release-notes.yml). For nested
+    # reusable workflows, a called job's permissions can't exceed those granted
+    # to the calling job, so this must be declared here even though the propose
+    # job uses an App token for its actual PR creation.
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     uses: ./.github/workflows/release-shared.yml
     with:
       version: ${{ needs.plan.outputs.version }}


### PR DESCRIPTION
The release job uses a nested reusable workflow (release-shared.yml) that calls propose-release-notes.yml, which requires `pull-requests: write` permission to create pull requests. For nested reusable workflows, a called job's permissions cannot exceed those granted to the calling job, so this permission must be declared at the release job level even though the propose job uses an App token for its actual PR creation.

**Changes:**
- Added `pull-requests: write` permission to the release job in `.github/workflows/release.yml`
- Added explanatory comments documenting why this permission is required for nested reusable workflows

https://claude.ai/code/session_017eKVgHfYw2vb26wX4xh61q