### PR TITLE
ci(release): unblock release workflow startup

### DIFF
--- a/.github/workflows/propose-release-notes.yml
+++ b/.github/workflows/propose-release-notes.yml
@@ -33,6 +33,11 @@ on:
         description: Release tag to propose notes for (e.g. v2.101.0 or v2.99.0-beta.1)
         required: true
         type: string
+      non_blocking:
+        description: Do not fail the workflow run when proposing fails
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -51,8 +51,6 @@ on:
         required: false
       GH_APP_PRIVATE_KEY:
         required: false
-      ANTHROPIC_API_KEY:
-        required: false
 jobs:
   build:
     name: Build CLI artifacts
@@ -324,22 +322,6 @@ jobs:
       tag: v${{ inputs.version }}
       apply: true
       non_blocking: true
-
-  # Once the raw semantic-release block is in the release body, ask Claude to
-  # rewrite it into user-centric notes and open a PR for human approval. Stable
-  # releases only on this path — prereleases keep the raw body. Non-blocking so
-  # an LLM hiccup never gates a published release; reviewers can propose beta/
-  # alpha notes manually from the Actions tab (workflow_dispatch).
-  propose-release-notes:
-    uses: ./.github/workflows/propose-release-notes.yml
-    needs: backfill-release-notes
-    if: ${{ !inputs.dry_run && !inputs.prerelease && needs.backfill-release-notes.result == 'success' }}
-    with:
-      tag: v${{ inputs.version }}
-      non_blocking: true
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   publish-homebrew:
     needs: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,6 @@ jobs:
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # Posts to the release Slack channel once the pipeline succeeds. Listing
   # `release` in `needs` without a status function in `if:` keeps the implicit


### PR DESCRIPTION
## What changed

Removed the automatic `propose-release-notes` nested reusable workflow from the production release graph and stopped passing its Anthropic secret through `release.yml` / `release-shared.yml`.

The manual `propose-release-notes` workflow remains available, and now declares the `non_blocking` dispatch input used by its job-level expression.

## Why

The Release workflow was failing at startup before GitHub created any jobs, which points at workflow graph validation rather than runtime release logic. The failures started when the optional release-notes proposer was added to the nested reusable workflow graph. Decoupling that post-publish notes automation returns the production release path to the known-good graph shape while preserving manual notes generation.
