### PR TITLE
fix(cli): decode sso providers when saml id/entity_id are absent

### DIFF
--- a/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
@@ -151,6 +151,23 @@ describe("legacy sso list integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  // CLI-1558: the Management API list response omits `saml.id` (and can omit
+  // `saml.entity_id`), which the OpenAPI spec wrongly marks required. Strict
+  // schema decoding rejected the payload with
+  // `SchemaError(Missing key at ["items"][0]["saml"]["id"])`. The generated
+  // schema now treats both as optional, matching the Go CLI's tolerant JSON.
+  it.live("renders providers when the API omits saml.id / entity_id (CLI-1558)", () => {
+    const body = {
+      items: [{ ...PROVIDER_ITEM, saml: { metadata_url: "https://example.com" } }],
+    };
+    const { layer, out } = setup({ body });
+    return Effect.gen(function* () {
+      yield* legacySsoList({ projectRef: Option.none() });
+      expect(out.stdoutText).toContain("0b0d48f6-878b-4190-88d7-2ca33ed800bc");
+      expect(out.stdoutText).toContain("SAML 2.0");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.live("emits a success payload via --output-format=json", () => {
     const { layer, out } = setup({ format: "json" });
     return Effect.gen(function* () {

--- a/packages/api/scripts/generate.ts
+++ b/packages/api/scripts/generate.ts
@@ -160,7 +160,9 @@ function loadSpec(): OpenApiDocument {
     const schemas: Record<string, OpenApiSchema> = {};
     for (const [name, schema] of Object.entries(parsed.components.schemas)) {
       if (isRecord(schema)) {
-        schemas[name] = schema;
+        schemas[name] = SSO_PROVIDER_RESPONSE_SCHEMAS.has(name)
+          ? relaxSsoSamlRequired(schema)
+          : schema;
       }
     }
     components = { schemas };
@@ -270,6 +272,77 @@ function sanitizeOpenApiSchema(schema: OpenApiSchema, inPropertiesMap = false): 
   }
 
   return sanitized;
+}
+
+// The Management API OpenAPI spec marks the SSO provider `saml` descriptor's
+// `id` and `entity_id` as `required`, but the list/get responses omit them in
+// practice. Strict response decoding then rejects valid payloads with
+// `SchemaError(Missing key at ["items"][0]["saml"]["id"])` (CLI-1558) — the Go
+// CLI tolerated this via `encoding/json`. Relax the `saml` descriptor's
+// `required` set within the SSO provider response schemas so decoding matches
+// the real API. Mirrors the inline UUID patch above; applied in `loadSpec` so
+// both the regenerated `contracts.ts` and `openapi.json` reflect it. The
+// request bodies (`CreateProviderBody`, `UpdateProviderBody`) are intentionally
+// excluded — input validation stays strict.
+const SSO_PROVIDER_RESPONSE_SCHEMAS = new Set([
+  "CreateProviderResponse",
+  "ListProvidersResponse",
+  "GetProviderResponse",
+  "UpdateProviderResponse",
+  "DeleteProviderResponse",
+]);
+const SSO_SAML_OPTIONAL_FIELDS = new Set(["id", "entity_id"]);
+
+function dropSamlRequiredFields(schema: OpenApiSchema): OpenApiSchema {
+  if (!Array.isArray(schema.required)) {
+    return schema;
+  }
+  const required = schema.required.filter((field) => !SSO_SAML_OPTIONAL_FIELDS.has(field));
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "required") {
+      continue;
+    }
+    next[key] = value;
+  }
+  if (required.length > 0) {
+    next.required = required;
+  }
+  return next;
+}
+
+// Walks an SSO provider response schema and relaxes the `required` set of any
+// nested `saml` descriptor object. `saml` appears at `properties.saml` for the
+// single-provider responses and at `properties.items.items.properties.saml`
+// for the list response, so we recurse through `properties`, arrays, and
+// nested objects to reach it wherever it lives.
+function relaxSsoSamlRequired(schema: OpenApiSchema): OpenApiSchema {
+  const patched: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "properties" && isRecord(value)) {
+      const properties: Record<string, unknown> = {};
+      for (const [propName, propSchema] of Object.entries(value)) {
+        if (!isRecord(propSchema)) {
+          properties[propName] = propSchema;
+          continue;
+        }
+        const descended = relaxSsoSamlRequired(propSchema);
+        properties[propName] = propName === "saml" ? dropSamlRequiredFields(descended) : descended;
+      }
+      patched[key] = properties;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      patched[key] = value.map((entry) => (isRecord(entry) ? relaxSsoSamlRequired(entry) : entry));
+      continue;
+    }
+    if (isRecord(value)) {
+      patched[key] = relaxSsoSamlRequired(value);
+      continue;
+    }
+    patched[key] = value;
+  }
+  return patched;
 }
 
 function containsBinarySchema(schema: OpenApiSchema): boolean {

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -783,8 +783,8 @@ export const V1CreateASsoProviderOutput = Schema.Struct({
   id: Schema.String,
   saml: Schema.optionalKey(
     Schema.Struct({
-      id: Schema.String,
-      entity_id: Schema.String,
+      id: Schema.optionalKey(Schema.String),
+      entity_id: Schema.optionalKey(Schema.String),
       metadata_url: Schema.optionalKey(Schema.String),
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
@@ -1139,8 +1139,8 @@ export const V1DeleteASsoProviderOutput = Schema.Struct({
   id: Schema.String,
   saml: Schema.optionalKey(
     Schema.Struct({
-      id: Schema.String,
-      entity_id: Schema.String,
+      id: Schema.optionalKey(Schema.String),
+      entity_id: Schema.optionalKey(Schema.String),
       metadata_url: Schema.optionalKey(Schema.String),
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
@@ -1582,8 +1582,8 @@ export const V1GetASsoProviderOutput = Schema.Struct({
   id: Schema.String,
   saml: Schema.optionalKey(
     Schema.Struct({
-      id: Schema.String,
-      entity_id: Schema.String,
+      id: Schema.optionalKey(Schema.String),
+      entity_id: Schema.optionalKey(Schema.String),
       metadata_url: Schema.optionalKey(Schema.String),
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
@@ -3555,8 +3555,8 @@ export const V1ListAllSsoProviderOutput = Schema.Struct({
       id: Schema.String,
       saml: Schema.optionalKey(
         Schema.Struct({
-          id: Schema.String,
-          entity_id: Schema.String,
+          id: Schema.optionalKey(Schema.String),
+          entity_id: Schema.optionalKey(Schema.String),
           metadata_url: Schema.optionalKey(Schema.String),
           metadata_xml: Schema.optionalKey(Schema.String),
           attribute_mapping: Schema.optionalKey(
@@ -4315,8 +4315,8 @@ export const V1UpdateASsoProviderOutput = Schema.Struct({
   id: Schema.String,
   saml: Schema.optionalKey(
     Schema.Struct({
-      id: Schema.String,
-      entity_id: Schema.String,
+      id: Schema.optionalKey(Schema.String),
+      entity_id: Schema.optionalKey(Schema.String),
       metadata_url: Schema.optionalKey(Schema.String),
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -18789,7 +18789,7 @@
                 ]
               }
             },
-            "required": ["id", "entity_id"]
+            "required": []
           },
           "domains": {
             "type": "array",
@@ -18900,7 +18900,7 @@
                       ]
                     }
                   },
-                  "required": ["id", "entity_id"]
+                  "required": []
                 },
                 "domains": {
                   "type": "array",
@@ -19010,7 +19010,7 @@
                 ]
               }
             },
-            "required": ["id", "entity_id"]
+            "required": []
           },
           "domains": {
             "type": "array",
@@ -19189,7 +19189,7 @@
                 ]
               }
             },
-            "required": ["id", "entity_id"]
+            "required": []
           },
           "domains": {
             "type": "array",
@@ -19295,7 +19295,7 @@
                 ]
               }
             },
-            "required": ["id", "entity_id"]
+            "required": []
           },
           "domains": {
             "type": "array",


### PR DESCRIPTION
## What changed

`supabase sso list` (and `sso show`) failed on v2.102.0+ with:

```
failed to list sso providers: SchemaError(Missing key at ["items"][0]["saml"]["id"])
```

When `sso list` was ported to a native TS handler in v2.102.0, it began decoding Management API responses with a strict Effect Schema generated from the OpenAPI spec. The spec over-declares the SSO provider `saml` descriptor as `"required": ["id", "entity_id"]`, but the real `GET /v1/projects/{ref}/config/auth/sso/providers` response omits `saml.id` (and can omit `entity_id`). Strict decoding therefore rejected a well-formed response. The Go CLI used `encoding/json`, which silently tolerates missing fields — hence ≤2.101.0 worked.

## Why this way

- The fix lives in the codegen (`packages/api/scripts/generate.ts`): a documented spec-normalization step relaxes the `saml` descriptor's `required` fields for the five SSO provider **response** schemas (`Create/List/Get/Update/DeleteProviderResponse`). Request bodies stay strict. This mirrors the existing UUID-pattern patch precedent.
- The matching change is hand-mirrored into the committed `contracts.ts`/`openapi.json` (5 saml blocks). A full regen was not used because the committed generated files carry large pre-existing toolchain drift, which would bury this fix in an unrelated diff.
- The formatter never reads `saml.id` and already treats every `saml` field as optional, so there is no downstream type impact.

A regression test in `list.integration.test.ts` returns a provider whose `saml` omits `id`/`entity_id` and asserts the command renders — it reproduces the exact error without the schema change.

Follow-up worth filing separately: the upstream Management API OpenAPI spec should not mark `saml.id`/`entity_id` as required on these responses.

Fixes #5475