### PR TITLE
fix(cli): missing saml.id in sso list 

### DIFF
--- a/apps/cli/src/legacy/commands/sso/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/sso/list/list.handler.ts
@@ -1,4 +1,4 @@
-import type { SupabaseApiError } from "@supabase/api/effect";
+import { operationDefinitions } from "@supabase/api/effect";
 import { Effect, Option } from "effect";
 
 import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
@@ -11,7 +11,7 @@ import {
   encodeToml,
   encodeYaml,
 } from "../../../shared/legacy-go-output.encoders.ts";
-import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
+import { sanitizeLegacyErrorBody } from "../../../shared/legacy-http-errors.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { legacySuggestUpgrade } from "../../../shared/legacy-upgrade-suggest.ts";
@@ -20,36 +20,69 @@ import {
   LegacySsoListSamlDisabledError,
   LegacySsoListUnexpectedStatusError,
 } from "../sso.errors.ts";
-import { renderListProviders } from "../sso.format.ts";
+import { renderListProviders, toLegacySsoProviderView } from "../sso.format.ts";
 import type { LegacySsoListFlags } from "./list.command.ts";
 
 const SAML_DISABLED_MESSAGE =
   "Looks like SAML 2.0 support is not enabled for this project. Please use the dashboard to enable it.";
 
-const mapStatusOrNetwork = mapLegacyHttpError({
-  networkError: LegacySsoListNetworkError,
-  statusError: LegacySsoListUnexpectedStatusError,
-  networkMessage: (cause) => `failed to list sso providers: ${cause}`,
-  statusMessage: (_status, body) => `unexpected error listing identity providers: ${body}`,
-});
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
 
-const handleListError = (ref: string, cause: SupabaseApiError) =>
-  Effect.gen(function* () {
-    const mapped = yield* Effect.flip(mapStatusOrNetwork(cause));
-    if (mapped._tag === "LegacySsoListUnexpectedStatusError") {
-      yield* legacySuggestUpgrade({
-        projectRef: ref,
-        featureKey: "auth.saml_2",
-        statusCode: mapped.status,
-      });
-      if (mapped.status === 404) {
-        return yield* Effect.fail(
-          new LegacySsoListSamlDisabledError({ message: SAML_DISABLED_MESSAGE }),
-        );
-      }
-    }
-    return yield* Effect.fail(mapped);
-  });
+function readString(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readRequiredString(obj: Record<string, unknown>, key: string): string {
+  return readString(obj, key) ?? "";
+}
+
+function listNetworkError(cause: unknown): LegacySsoListNetworkError {
+  return new LegacySsoListNetworkError({ message: `failed to list sso providers: ${cause}` });
+}
+
+function normalizeProviderItem(raw: unknown): Record<string, unknown> {
+  const item = asRecord(raw);
+  const saml = asRecord(item["saml"]);
+  const domainsRaw = item["domains"];
+  return {
+    id: readRequiredString(item, "id"),
+    saml:
+      Object.keys(saml).length === 0
+        ? undefined
+        : {
+            id: readRequiredString(saml, "id"),
+            entity_id: readRequiredString(saml, "entity_id"),
+            metadata_url: readString(saml, "metadata_url"),
+            metadata_xml: readString(saml, "metadata_xml"),
+            name_id_format: readString(saml, "name_id_format"),
+            attribute_mapping: saml["attribute_mapping"],
+          },
+    domains: Array.isArray(domainsRaw)
+      ? domainsRaw.map((domain) => {
+          const entry = asRecord(domain);
+          return {
+            id: readRequiredString(entry, "id"),
+            domain: readString(entry, "domain"),
+            created_at: readString(entry, "created_at"),
+            updated_at: readString(entry, "updated_at"),
+          };
+        })
+      : undefined,
+    created_at: readString(item, "created_at"),
+    updated_at: readString(item, "updated_at"),
+  };
+}
+
+function readProviderItems(body: unknown): ReadonlyArray<Record<string, unknown>> | undefined {
+  const items = asRecord(body)["items"];
+  if (!Array.isArray(items)) {
+    return undefined;
+  }
+  return items.map(normalizeProviderItem);
+}
 
 export const legacySsoList = Effect.fn("legacy.sso.list")(function* (flags: LegacySsoListFlags) {
   const output = yield* Output;
@@ -65,14 +98,59 @@ export const legacySsoList = Effect.fn("legacy.sso.list")(function* (flags: Lega
     yield* Effect.gen(function* () {
       const fetching =
         output.format === "text" ? yield* output.task("Fetching SSO providers...") : undefined;
-      const response = yield* api.v1.listAllSsoProvider({ ref }).pipe(
+
+      // The real list payload can omit `items[].saml.id`, while the generated
+      // contract still requires it. Use the raw API response here so we can
+      // keep Go-parity list behavior without weakening the shared schema for
+      // other SSO operations.
+      const response = yield* api
+        .executeRaw(operationDefinitions.v1ListAllSsoProvider, { ref })
+        .pipe(
+          Effect.tapError(() => fetching?.fail() ?? Effect.void),
+          Effect.mapError(listNetworkError),
+        );
+
+      if (response.status !== 200) {
+        const body = sanitizeLegacyErrorBody(
+          yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+        );
+        yield* fetching?.fail() ?? Effect.void;
+        yield* legacySuggestUpgrade({
+          projectRef: ref,
+          featureKey: "auth.saml_2",
+          statusCode: response.status,
+        });
+        if (response.status === 404) {
+          return yield* Effect.fail(
+            new LegacySsoListSamlDisabledError({ message: SAML_DISABLED_MESSAGE }),
+          );
+        }
+        return yield* Effect.fail(
+          new LegacySsoListUnexpectedStatusError({
+            status: response.status,
+            body,
+            message: `unexpected error listing identity providers: ${body}`,
+          }),
+        );
+      }
+
+      const parsed = yield* response.json.pipe(
         Effect.tapError(() => fetching?.fail() ?? Effect.void),
-        Effect.catch((cause) => handleListError(ref, cause)),
+        Effect.mapError(listNetworkError),
       );
+      const items = readProviderItems(parsed);
+      if (items === undefined) {
+        yield* fetching?.fail() ?? Effect.void;
+        return yield* Effect.fail(
+          new LegacySsoListNetworkError({
+            message: "failed to list sso providers: response.items was not an array",
+          }),
+        );
+      }
       yield* fetching?.clear() ?? Effect.void;
 
       const goFmt = Option.getOrUndefined(goOutputFlag);
-      const payload = { providers: response.items };
+      const payload = { providers: items };
 
       if (goFmt === "json") {
         yield* output.raw(encodeGoJson(payload));
@@ -96,7 +174,7 @@ export const legacySsoList = Effect.fn("legacy.sso.list")(function* (flags: Lega
         return;
       }
 
-      yield* output.raw(renderListProviders(response.items));
+      yield* output.raw(renderListProviders(items.map(toLegacySsoProviderView)));
     }).pipe(Effect.ensuring(linkedProjectCache.cache(ref)));
   }).pipe(Effect.ensuring(telemetryState.flush));
 });

--- a/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
@@ -37,6 +37,16 @@ const PROVIDER_ITEM = {
   updated_at: "2023-03-28T13:50:14.464Z",
 };
 
+const PROVIDER_ITEM_WITHOUT_SAML_ID = {
+  ...PROVIDER_ITEM,
+  saml: {
+    entity_id: PROVIDER_ITEM.saml.entity_id,
+    metadata_url: PROVIDER_ITEM.saml.metadata_url,
+    metadata_xml: PROVIDER_ITEM.saml.metadata_xml,
+    attribute_mapping: PROVIDER_ITEM.saml.attribute_mapping,
+  },
+};
+
 const tempRoot = useLegacyTempWorkdir("supabase-sso-list-int-");
 
 interface SetupOpts {
@@ -161,6 +171,32 @@ describe("legacy sso list integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.live("accepts list responses when saml.id is omitted", () => {
+    const { layer, out } = setup({
+      body: { items: [PROVIDER_ITEM_WITHOUT_SAML_ID] },
+    });
+    return Effect.gen(function* () {
+      yield* legacySsoList({ projectRef: Option.none() });
+      expect(out.stdoutText).toContain("0b0d48f6-878b-4190-88d7-2ca33ed800bc");
+      expect(out.stdoutText).toContain("https://example.com");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("normalizes missing saml.id to an empty string in Go --output=json", () => {
+    const { layer, out } = setup({
+      body: { items: [PROVIDER_ITEM_WITHOUT_SAML_ID] },
+      goOutput: "json",
+    });
+    return Effect.gen(function* () {
+      yield* legacySsoList({ projectRef: Option.none() });
+      const payload = JSON.parse(out.stdoutText) as {
+        providers: Array<{ saml?: { id?: string; entity_id?: string } }>;
+      };
+      expect(payload.providers[0]?.saml?.id).toBe("");
+      expect(payload.providers[0]?.saml?.entity_id).toBe("https://example.com");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.live("emits a result event via --output-format=stream-json", () => {
     const { layer, out } = setup({ format: "stream-json" });
     return Effect.gen(function* () {
@@ -271,6 +307,19 @@ describe("legacy sso list integration", () => {
         const dump = JSON.stringify(exit.cause);
         expect(dump).toContain("LegacySsoListNetworkError");
         expect(dump).toContain("failed to list sso providers");
+      }
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("reports network error when the success response body is malformed", () => {
+    const { layer } = setup({ body: { items: {} } });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacySsoList({ projectRef: Option.none() }));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const dump = JSON.stringify(exit.cause);
+        expect(dump).toContain("LegacySsoListNetworkError");
+        expect(dump).toContain("response.items was not an array");
       }
     }).pipe(Effect.provide(layer));
   });


### PR DESCRIPTION
## TL;DR


fixes `supabase sso list` failing when the Management API omits `items[].saml.id`

This regression was introduced in the native ts sso port, which decoded the list response more strictly than the API returns in practice
basically this makes `sso list` handle that response shape safely while keeping the existing behaviour..

## ref:
- closes https://github.com/supabase/cli/issues/5475