### PR TITLE
ci(deps): auto-merge all Dependabot updates

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Generate token
         id: app-token
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_APP_CLIENT_ID }}
@@ -33,16 +32,14 @@ jobs:
 
       # Here the PR gets approved.
       - name: Approve a PR
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         run: gh pr review --approve "${GITHUB_EVENT_PULL_REQUEST_HTML_URL}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
 
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
+      # Finally, this sets the PR to allow auto-merging once all required
+      # checks pass.
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         run: gh pr merge --auto --squash "${GITHUB_EVENT_PULL_REQUEST_HTML_URL}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Dependabot PRs should be approved and placed into auto-merge regardless of semver update type.

This removes the semver gate from the auto-merge workflow so branch protection and required CI checks are the only merge gate for dependency updates.