### PR TITLE
test(stack): stabilize e2e warmup tests

### DIFF
--- a/packages/stack/tests/helpers/warmup.ts
+++ b/packages/stack/tests/helpers/warmup.ts
@@ -14,7 +14,7 @@ interface WarmStackE2eDependenciesOptions {
 
 export function hasDockerDaemon(): boolean {
   try {
-    execSync("docker info", { stdio: "ignore" });
+    execSync("docker info", { stdio: "ignore", timeout: 2_000 });
     return true;
   } catch {
     return false;

--- a/packages/stack/tests/helpers/warmup.unit.test.ts
+++ b/packages/stack/tests/helpers/warmup.unit.test.ts
@@ -79,6 +79,7 @@ describe("stack e2e warmup", () => {
     await expect(
       warmStackE2eDependencies({
         failOnError: true,
+        hasDockerDaemon: () => false,
         logger,
         prefetch: async () => {
           throw new Error("pull failed");
@@ -94,6 +95,7 @@ describe("stack e2e warmup", () => {
     await expect(
       warmStackE2eDependencies({
         failOnError: false,
+        hasDockerDaemon: () => false,
         logger,
         prefetch: async () => {
           throw new Error("pull failed");


### PR DESCRIPTION
## What changed

- Make the warmup failure-path unit tests inject the Docker availability probe instead of touching the real Docker daemon.
- Add a short timeout to the real `docker info` probe used by stack e2e warmup.

## Why

The failing CI job timed out in the warmup failure-path test. Those tests were meant to exercise mocked prefetch failures, but they still ran the real Docker daemon probe first. If that probe stalls on a CI runner, the test never reaches the mocked failure path. Keeping the probe injected in those unit tests makes them hermetic, while the timeout prevents e2e warmup from hanging indefinitely on an unhealthy Docker socket.
