### PR TITLE
fix(cli): Exclude partition children from pg-delta diffs

### DIFF
--- a/apps/cli-go/internal/db/diff/pgdelta_test.go
+++ b/apps/cli-go/internal/db/diff/pgdelta_test.go
@@ -2,10 +2,31 @@ package diff
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+const partitionFilterSnippet = `"table/is_partition": true`
+
+func TestPgDeltaTemplatesExcludePartitionChildren(t *testing.T) {
+	t.Run("pgdelta.ts applies default partition filter", func(t *testing.T) {
+		assert.Contains(t, pgDeltaScript, partitionFilterSnippet)
+		assert.Contains(t, pgDeltaScript, "partitionFilter")
+	})
+
+	t.Run("pgdelta_declarative_export.ts applies default partition filter", func(t *testing.T) {
+		assert.Contains(t, pgDeltaDeclarativeExportScript, partitionFilterSnippet)
+		assert.Contains(t, pgDeltaDeclarativeExportScript, "partitionFilter")
+	})
+
+	t.Run("partition filter is always composed into supabase.filter", func(t *testing.T) {
+		for _, script := range []string{pgDeltaScript, pgDeltaDeclarativeExportScript} {
+			assert.True(t, strings.Contains(script, "filterParts = [supabase.filter!, partitionFilter]"))
+		}
+	})
+}
 
 func TestContainerRef(t *testing.T) {
 	t.Run("passes empty string through", func(t *testing.T) {

--- a/apps/cli-go/internal/db/diff/templates/pgdelta.ts
+++ b/apps/cli-go/internal/db/diff/templates/pgdelta.ts
@@ -19,17 +19,21 @@ async function resolveInput(ref: string | undefined) {
 const source = Deno.env.get("SOURCE");
 const target = Deno.env.get("TARGET");
 
+// Runtime partition children (e.g. pg_partman) are operational state, not declarative schema.
+const partitionFilter = { not: { "table/is_partition": true } };
+
 const includedSchemas = Deno.env.get("INCLUDED_SCHEMAS");
+const filterParts = [supabase.filter!, partitionFilter];
 if (includedSchemas) {
   const schemas = includedSchemas.split(",");
-  const schemaFilter = {
+  filterParts.push({
     or: [{ "*/schema": schemas }, { "schema/name": schemas }],
-  };
-  // CompositionPattern `and` is valid FilterDSL; Deno's structural typing is strict on `or` branches.
-  supabase.filter = {
-    and: [supabase.filter!, schemaFilter],
-  } as typeof supabase.filter;
+  });
 }
+// CompositionPattern `and` is valid FilterDSL; Deno's structural typing is strict on `or` branches.
+supabase.filter = {
+  and: filterParts,
+} as typeof supabase.filter;
 
 const formatOptionsRaw = Deno.env.get("FORMAT_OPTIONS");
 let formatOptions = undefined;

--- a/apps/cli-go/internal/db/diff/templates/pgdelta_declarative_export.ts
+++ b/apps/cli-go/internal/db/diff/templates/pgdelta_declarative_export.ts
@@ -22,16 +22,20 @@ async function resolveInput(ref: string | undefined) {
 const source = Deno.env.get("SOURCE");
 const target = Deno.env.get("TARGET");
 
+// Runtime partition children (e.g. pg_partman) are operational state, not declarative schema.
+const partitionFilter = { not: { "table/is_partition": true } };
+
 const includedSchemas = Deno.env.get("INCLUDED_SCHEMAS");
+const filterParts = [supabase.filter!, partitionFilter];
 if (includedSchemas) {
   const schemas = includedSchemas.split(",");
-  const schemaFilter = {
+  filterParts.push({
     or: [{ "*/schema": schemas }, { "schema/name": schemas }],
-  };
-  supabase.filter = {
-    and: [supabase.filter!, schemaFilter],
-  } as unknown as typeof supabase.filter;
+  });
 }
+supabase.filter = {
+  and: filterParts,
+} as unknown as typeof supabase.filter;
 
 const formatOptionsRaw = Deno.env.get("FORMAT_OPTIONS");
 let formatOptions = undefined;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Declarative sync compares migrations-side and declarative-side catalogs. When runtime partition children exist on the source (for example from pg_partman) but declarative files only define the parent table, pg-delta proposed DROP TABLE statements for every child partition.

## What is the new behavior?

This change adds a default FilterDSL rule into the embedded pg-delta scripts to ignore tables with table/is_partition: true. Parent partitioned tables remain in scope; operational child partitions are left out of diff and declarative export plans.

## Additional context

Closes #5445 