### PR TITLE
fix(cli): detect IPv6 connectivity errors and suggest the IPv4 pooler

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Generate token
         id: app-token
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_APP_CLIENT_ID }}
@@ -33,16 +32,14 @@ jobs:
 
       # Here the PR gets approved.
       - name: Approve a PR
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         run: gh pr review --approve "${GITHUB_EVENT_PULL_REQUEST_HTML_URL}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
 
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
+      # Finally, this sets the PR to allow auto-merging once all required
+      # checks pass.
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || (!startsWith(steps.meta.outputs.previous-version, '0.') && steps.meta.outputs.update-type == 'version-update:semver-minor') }}
         run: gh pr merge --auto --squash "${GITHUB_EVENT_PULL_REQUEST_HTML_URL}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/apps/cli-e2e/src/tests/stack.e2e.test.ts
+++ b/apps/cli-e2e/src/tests/stack.e2e.test.ts
@@ -60,8 +60,8 @@ function testParityStack(cmd: string[], opts?: { workspaceSetup?: (dir: string) 
 // ---------------------------------------------------------------------------
 // services
 // ---------------------------------------------------------------------------
-// `services` reads service image names from config (not Docker) so DOCKER_HOST
-// is not needed.
+// `services` prints a baked-in Go-parity service matrix, so DOCKER_HOST is not
+// needed.
 
 describe("services", () => {
   testBehaviour("lists known service images", async ({ run }) => {

--- a/apps/cli-go/go.mod
+++ b/apps/cli-go/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/multigres/multigres v0.0.0-20260126223308-f5a52171bbc4
 	github.com/oapi-codegen/nullable v1.1.0
 	github.com/olekukonko/tablewriter v1.1.4
-	github.com/posthog/posthog-go v1.13.0
+	github.com/posthog/posthog-go v1.13.1
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/apps/cli-go/go.sum
+++ b/apps/cli-go/go.sum
@@ -941,8 +941,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.8.0 h1:DL4RestQqRLr8U4LygLw8g2DX6RN1eBJOpa2mzsrl1Q=
 github.com/polyfloyd/go-errorlint v1.8.0/go.mod h1:G2W0Q5roxbLCt0ZQbdoxQxXktTjwNyDbEaj3n7jvl4s=
-github.com/posthog/posthog-go v1.13.0 h1:+i+t6txCczJcGZj7ME2ry4sLhPYvq3q7RYuUZ0z6NpQ=
-github.com/posthog/posthog-go v1.13.0/go.mod h1:xsVOW9YImilUcazwPNEq4PJDqEZf2KeCS758zXjwkPg=
+github.com/posthog/posthog-go v1.13.1 h1:7OtfgOEM9fC2n4Hbs4e5mK1uaLuNguoYWFEI4kEnTUY=
+github.com/posthog/posthog-go v1.13.1/go.mod h1:xsVOW9YImilUcazwPNEq4PJDqEZf2KeCS758zXjwkPg=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/apps/cli-go/internal/utils/connect.go
+++ b/apps/cli-go/internal/utils/connect.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -173,6 +174,24 @@ func ConnectByUrl(ctx context.Context, url string, options ...func(*pgx.ConnConf
 
 const SuggestEnvVar = "Connect to your database by setting the env var correctly: SUPABASE_DB_PASSWORD"
 
+// ipv6LiteralPattern matches a bracketed IPv6 address (e.g. [2406:da18:...]) as
+// it appears in a Go dial error such as
+// "dial tcp [2406:da18:...]:5432: connect: network is unreachable".
+var ipv6LiteralPattern = regexp.MustCompile(`\[[0-9a-fA-F:]*:[0-9a-fA-F:]*\]`)
+
+// isIPv6ConnectivityError reports whether the connection failure stems from the
+// host resolving to an IPv6 address that the current network cannot route to.
+// Supabase direct database connections (db.<ref>.supabase.co:5432) are
+// IPv6-only unless the IPv4 add-on is enabled, so users on IPv4-only networks
+// hit "network is unreachable" / "no route to host" against an IPv6 literal.
+func isIPv6ConnectivityError(msg string) bool {
+	if !strings.Contains(msg, "network is unreachable") &&
+		!strings.Contains(msg, "no route to host") {
+		return false
+	}
+	return ipv6LiteralPattern.MatchString(msg)
+}
+
 // Sets CmdSuggestion to an actionable hint based on the given pg connection error.
 func SetConnectSuggestion(err error) {
 	if err == nil {
@@ -190,6 +209,11 @@ func SetConnectSuggestion(err error) {
 	} else if strings.Contains(msg, "SCRAM exchange: Wrong password") || strings.Contains(msg, "failed SASL auth") {
 		// password authentication failed for user / invalid SCRAM server-final-message received from server
 		CmdSuggestion = SuggestEnvVar
+	} else if isIPv6ConnectivityError(msg) {
+		CmdSuggestion = fmt.Sprintf(
+			"Your network does not support IPv6, which is required for direct connections to the database.\nRun %s to connect through the IPv4 connection pooler instead.",
+			Aqua("supabase link"),
+		)
 	} else if strings.Contains(msg, "connect: no route to host") || strings.Contains(msg, "Tenant or user not found") {
 		// Assumes IPv6 check has been performed before this
 		CmdSuggestion = "Make sure your project exists on profile: " + CurrentProfile.Name

--- a/apps/cli-go/internal/utils/connect_test.go
+++ b/apps/cli-go/internal/utils/connect_test.go
@@ -221,7 +221,17 @@ func TestSetConnectSuggestion(t *testing.T) {
 			suggestion: "Connect to your database by setting the env var correctly: SUPABASE_DB_PASSWORD",
 		},
 		{
-			name:       "no route to host",
+			name:       "ipv6 no route to host",
+			err:        errors.New("dial tcp [2406:da18:4fd:9b0d:80ec:9812:3e65:450b]:5432: connect: no route to host"),
+			suggestion: "Your network does not support IPv6",
+		},
+		{
+			name:       "ipv6 network is unreachable",
+			err:        errors.New("dial tcp [2406:da18:4fd:9b0d:80ec:9812:3e65:450b]:5432: connect: network is unreachable"),
+			suggestion: "Your network does not support IPv6",
+		},
+		{
+			name:       "no route to host without ipv6 address",
 			err:        errors.New("connect: no route to host"),
 			suggestion: "Make sure your project exists on profile: " + CurrentProfile.Name,
 		},

--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -3,7 +3,7 @@ FROM supabase/postgres:17.6.1.132 AS pg
 # Append to ServiceImages when adding new dependencies below
 FROM library/kong:2.8.1 AS kong
 FROM axllent/mailpit:v1.22.3 AS mailpit
-FROM postgrest/postgrest:v14.12 AS postgrest
+FROM postgrest/postgrest:v14.13 AS postgrest
 FROM supabase/postgres-meta:v0.96.6 AS pgmeta
 FROM supabase/studio:2026.06.03-sha-0bca601 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
@@ -11,9 +11,9 @@ FROM supabase/edge-runtime:v1.74.0 AS edgeruntime
 FROM timberio/vector:0.53.0-alpine AS vector
 FROM supabase/supavisor:2.9.7 AS supavisor
 FROM supabase/gotrue:v2.189.0 AS gotrue
-FROM supabase/realtime:v2.103.2 AS realtime
+FROM supabase/realtime:v2.103.4 AS realtime
 FROM supabase/storage-api:v1.60.4 AS storage
-FROM supabase/logflare:1.43.3 AS logflare
+FROM supabase/logflare:1.43.4 AS logflare
 # Append to JobImages when adding new dependencies below
 FROM supabase/pgadmin-schema-diff:cli-0.0.5 AS differ
 FROM supabase/migra:3.0.1663481299 AS migra

--- a/apps/cli/docs/go-cli-porting-status.md
+++ b/apps/cli/docs/go-cli-porting-status.md
@@ -57,9 +57,9 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
 
 ## Quick Start
 
-| Old command | TS status | TS command path or `missing` | Missing flags/params | Extra TS flags/params | Notes                                       |
-| ----------- | --------- | ---------------------------- | -------------------- | --------------------- | ------------------------------------------- |
-| `bootstrap` | `missing` | `missing`                    | `n/a`                | `n/a`                 | No TS command yet. Wrapped in legacy shell. |
+| Old command | TS status | TS command path or `missing` | Missing flags/params | Extra TS flags/params | Notes                                                                                                                                                                                  |
+| ----------- | --------- | ---------------------------- | -------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bootstrap` | `missing` | `missing`                    | `n/a`                | `n/a`                 | No `next/` command yet. Ported to native TS in the legacy shell; the migration-push sub-step is delegated to the Go binary as a documented interim until `db push` is natively ported. |
 
 ## Project / Stack Lifecycle
 
@@ -265,7 +265,7 @@ Legend:
 | `logout`                               | `ported`      | [`../src/legacy/commands/logout/logout.command.ts`](../src/legacy/commands/logout/logout.command.ts)                                                                                      |
 | `link`                                 | `ported`      | [`../src/legacy/commands/link/link.command.ts`](../src/legacy/commands/link/link.command.ts)                                                                                              |
 | `unlink`                               | `ported`      | [`../src/legacy/commands/unlink/unlink.command.ts`](../src/legacy/commands/unlink/unlink.command.ts)                                                                                      |
-| `bootstrap`                            | `wrapped`     | [`../src/legacy/commands/bootstrap/bootstrap.command.ts`](../src/legacy/commands/bootstrap/bootstrap.command.ts)                                                                          |
+| `bootstrap`                            | `ported`      | [`../src/legacy/commands/bootstrap/bootstrap.command.ts`](../src/legacy/commands/bootstrap/bootstrap.command.ts) (native; `db push` step delegated to the Go binary — interim)            |
 | `init`                                 | `ported`      | [`../src/legacy/commands/init/init.command.ts`](../src/legacy/commands/init/init.command.ts)                                                                                              |
 | `services`                             | `ported`      | [`../src/legacy/commands/services/services.command.ts`](../src/legacy/commands/services/services.command.ts)                                                                              |
 | `start`                                | `wrapped`     | [`../src/legacy/commands/start/start.command.ts`](../src/legacy/commands/start/start.command.ts)                                                                                          |

--- a/apps/cli/docs/go-cli-porting-status.md
+++ b/apps/cli/docs/go-cli-porting-status.md
@@ -76,7 +76,7 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
 
 <!-- Note: start, stop, and status are also wrapped in the legacy shell — see Legacy Shell Wrapping Status below. -->
 
-| `services` | `partial` | `supabase status` + `supabase stack update` | Go-style dedicated `services` command shape | `--stack` | The old version-reporting and linked-version drift behavior exists in TS, but it is split across `status` for per-service versions and `stack update` for refreshing pinned versions instead of a single `services` command. |
+| `services` | `ported` | [`../src/next/commands/services/services.command.ts`](../src/next/commands/services/services.command.ts) | `--output` remains a global legacy-shell concern rather than a next-only command flag | `--output-format` | TS restores the dedicated `services` command, prints the bundled local service image matrix, and best-effort compares linked remote versions without proxying to Go. |
 
 ## Database
 
@@ -267,7 +267,7 @@ Legend:
 | `unlink`                               | `ported`      | [`../src/legacy/commands/unlink/unlink.command.ts`](../src/legacy/commands/unlink/unlink.command.ts)                                                                                      |
 | `bootstrap`                            | `wrapped`     | [`../src/legacy/commands/bootstrap/bootstrap.command.ts`](../src/legacy/commands/bootstrap/bootstrap.command.ts)                                                                          |
 | `init`                                 | `ported`      | [`../src/legacy/commands/init/init.command.ts`](../src/legacy/commands/init/init.command.ts)                                                                                              |
-| `services`                             | `wrapped`     | [`../src/legacy/commands/services/services.command.ts`](../src/legacy/commands/services/services.command.ts)                                                                              |
+| `services`                             | `ported`      | [`../src/legacy/commands/services/services.command.ts`](../src/legacy/commands/services/services.command.ts)                                                                              |
 | `start`                                | `wrapped`     | [`../src/legacy/commands/start/start.command.ts`](../src/legacy/commands/start/start.command.ts)                                                                                          |
 | `stop`                                 | `wrapped`     | [`../src/legacy/commands/stop/stop.command.ts`](../src/legacy/commands/stop/stop.command.ts)                                                                                              |
 | `status`                               | `wrapped`     | [`../src/legacy/commands/status/status.command.ts`](../src/legacy/commands/status/status.command.ts)                                                                                      |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -37,8 +37,8 @@
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.146",
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.156",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@clack/prompts": "^1.4.0",
     "@effect/atom-react": "catalog:",
     "@effect/platform-bun": "catalog:",
@@ -64,7 +64,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
-    "posthog-node": "^5.35.5",
+    "posthog-node": "^5.35.6",
     "react": "^19.2.6",
     "react-devtools-core": "^7.0.1",
     "semantic-release": "^25.0.3",

--- a/apps/cli/scripts/update-scoop.ts
+++ b/apps/cli/scripts/update-scoop.ts
@@ -58,34 +58,46 @@ const baseUrl = local
   ? `file:///${distDir.replace(/\\/g, "/")}`
   : `https://github.com/${repo}/releases/download/v${version}`;
 
+// Main-bucket layout uses unversioned Windows tarballs on GitHub Releases
+// (release-shared.yml copies versioned builds to supabase_windows_*.tar.gz).
+// Local builds only emit versioned archives, so --local keeps those names.
+const amd64Tar = local
+  ? `supabase_${version}_windows_amd64.tar.gz`
+  : "supabase_windows_amd64.tar.gz";
+const arm64Tar = local
+  ? `supabase_${version}_windows_arm64.tar.gz`
+  : "supabase_windows_arm64.tar.gz";
+
 const manifest = {
   version,
   description: "Supabase CLI",
-  homepage: "https://supabase.com",
+  homepage: "https://supabase.com/",
   license: "MIT",
   architecture: {
     "64bit": {
-      url: `${baseUrl}/supabase_${version}_windows_amd64.zip`,
-      hash: sha(`supabase_${version}_windows_amd64.zip`),
-      bin: [binEntry],
+      url: `${baseUrl}/${amd64Tar}`,
+      hash: sha(`supabase_${version}_windows_amd64.tar.gz`),
     },
     arm64: {
-      url: `${baseUrl}/supabase_${version}_windows_arm64.zip`,
-      hash: sha(`supabase_${version}_windows_arm64.zip`),
-      bin: [binEntry],
+      url: `${baseUrl}/${arm64Tar}`,
+      hash: sha(`supabase_${version}_windows_arm64.tar.gz`),
     },
   },
+  bin: binEntry,
   checkver: {
     github: `https://github.com/${repo}`,
   },
   autoupdate: {
     architecture: {
       "64bit": {
-        url: `https://github.com/${repo}/releases/download/v$version/supabase_$version_windows_amd64.zip`,
+        url: `https://github.com/${repo}/releases/download/v$version/supabase_windows_amd64.tar.gz`,
       },
       arm64: {
-        url: `https://github.com/${repo}/releases/download/v$version/supabase_$version_windows_arm64.zip`,
+        url: `https://github.com/${repo}/releases/download/v$version/supabase_windows_arm64.tar.gz`,
       },
+    },
+    hash: {
+      url: "$baseurl/supabase_$version_checksums.txt",
     },
   },
 };

--- a/apps/cli/src/legacy/commands/bootstrap/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/bootstrap/SIDE_EFFECTS.md
@@ -1,71 +1,119 @@
 # `supabase bootstrap [template]`
 
+`bootstrap` is a meta-orchestrator: it chains a workdir prompt → template fetch/download →
+blank `init` → ensure-login → `projects create` → `projects api-keys` → `link` services →
+health poll → write `.env` → `db push` → start suggestion. Every step is native TypeScript
+**except** the migration push, which is delegated to the bundled Go binary (interim — see Notes).
+
 ## Files Read
 
-| Path                       | Format                    | When                                                       |
-| -------------------------- | ------------------------- | ---------------------------------------------------------- |
-| `~/.supabase/access-token` | plain text (token string) | when `SUPABASE_ACCESS_TOKEN` unset and keyring unavailable |
+| Path                                   | Format     | When                                                        |
+| -------------------------------------- | ---------- | ----------------------------------------------------------- |
+| `~/.supabase/access-token`             | plain text | ensure-login token miss (env unset and keyring unavailable) |
+| `<workdir>/.env.example`               | dotenv     | optional; merged into the generated `.env`                  |
+| `<workdir>/supabase/.temp/project-ref` | plain text | read by the delegated `db push` subprocess (post-`chdir`)   |
 
 ## Files Written
 
-| Path                             | Format | When                                                          |
-| -------------------------------- | ------ | ------------------------------------------------------------- |
-| `<workdir>/supabase/config.toml` | TOML   | always on success; created from selected template             |
-| `<workdir>/.env`                 | env    | always on success; populated with API keys and project config |
-| `<workdir>/<template files>`     | varies | template-specific files cloned or copied from GitHub          |
+| Path                                                                                                  | Format     | When                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<workdir>/supabase/config.toml`                                                                      | TOML       | blank/`scratch` path only (via `initProject`)                                                                                                                     |
+| `<workdir>/<template files>`                                                                          | varies     | template path only (GitHub download)                                                                                                                              |
+| `<workdir>/supabase/.temp/project-ref`                                                                | plain text | always (mandatory; fails the command on write error)                                                                                                              |
+| `<workdir>/supabase/.temp/{pooler-url,rest-version,gotrue-version,storage-version,storage-migration}` | plain text | best-effort, from `link.LinkServices`                                                                                                                             |
+| `<workdir>/.env`                                                                                      | dotenv     | best-effort (write failure prints a warning and continues)                                                                                                        |
+| `<workdir>/supabase/.temp/linked-project.json`                                                        | JSON       | PersistentPostRun linked-project cache (`Effect.ensuring`); resolves against the bootstrap workdir (the prompted/`--workdir`/env target), not `cliConfig.workdir` |
+| `~/.supabase/telemetry.json`                                                                          | JSON       | PersistentPostRun telemetry flush (`Effect.ensuring`)                                                                                                             |
+
+**Process side effect:** `process.chdir(<workdir>)` mirrors Go's `ChangeWorkDir` and prints
+`Using workdir <workdir>\n` to stderr (`workdir` bolded on a TTY). The original cwd is restored
+in a finalizer so the delegated `db push` subprocess inherits the bootstrap workdir without
+leaking the change to the surrounding process.
 
 ## API Routes
 
-| Method | Path                                                      | Auth         | Request body                    | Response (used fields)                   |
-| ------ | --------------------------------------------------------- | ------------ | ------------------------------- | ---------------------------------------- |
-| `GET`  | `https://api.github.com/repos/supabase/samples/contents/` | none         | none                            | `[{name, type, ...}]` (template listing) |
-| `POST` | `/v1/projects`                                            | Bearer token | `{name, region, db_pass, plan}` | `{id, ref, ...}`                         |
-| `GET`  | `/v1/projects/{ref}/api-keys`                             | Bearer token | none                            | `[{name, api_key}]`                      |
+| Method          | Path                                                                                      | Auth                           | Notes                                                                                        |
+| --------------- | ----------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------- |
+| `GET`           | `api.github.com/repos/supabase-community/supabase-samples/contents/samples.json?ref=main` | optional `Bearer GITHUB_TOKEN` | base64 `content` → `{samples:[…]}`                                                           |
+| `GET`           | `api.github.com/repos/<owner>/<repo>/contents/<path>?ref=<ref>` + raw `download_url`      | optional `Bearer GITHUB_TOKEN` | template download (BFS, concurrency 5)                                                       |
+| `GET`           | `/v1/organizations`                                                                       | Bearer                         | interactive org picker (create core)                                                         |
+| `POST`          | `/v1/projects`                                                                            | Bearer                         | `{name, organization_slug, db_pass, region?, desired_instance_size?, template_url?}` → `201` |
+| `GET`           | `/v1/projects/{ref}/api-keys`                                                             | Bearer                         | retried with exponential backoff (no `reveal`)                                               |
+| `GET`           | `/v1/projects/{ref}` + storage/pooler config + tenant version probes                      | Bearer / service key           | `link.LinkServices` (best-effort)                                                            |
+| `GET`           | `/v1/projects/{ref}/health?services=db`                                                   | Bearer                         | retried with exponential backoff                                                             |
+| login endpoints | —                                                                                         | —                              | ensure-login browser flow (token miss)                                                       |
+| db push routes  | —                                                                                         | —                              | fired by the **Go subprocess** (interim)                                                     |
 
 ## Environment Variables
 
-| Variable                | Purpose                                              | Required?                                               |
-| ----------------------- | ---------------------------------------------------- | ------------------------------------------------------- |
-| `SUPABASE_ACCESS_TOKEN` | auth token (bypasses credential file/keyring lookup) | no (falls back to keyring → `~/.supabase/access-token`) |
-| `SUPABASE_API_URL`      | override Management API base URL                     | no (defaults to `https://api.supabase.com`)             |
-| `WORKDIR`               | target directory for bootstrapping                   | no (prompts interactively if not set)                   |
-| `DB_PASSWORD`           | database password (bound from `--password` flag)     | no (generated if not provided)                          |
+| Variable                               | Purpose                                            | Required? |
+| -------------------------------------- | -------------------------------------------------- | --------- |
+| `SUPABASE_WORKDIR`                     | target dir (`--workdir` flag → env → prompt → cwd) | no        |
+| `SUPABASE_DB_PASSWORD`                 | DB password (`-p` flag → env → prompt/generate)    | no        |
+| `GITHUB_TOKEN`                         | raise the GitHub API rate limit for template fetch | no        |
+| `SUPABASE_ACCESS_TOKEN`                | auth bypass for ensure-login                       | no        |
+| `SUPABASE_API_URL`, `SUPABASE_PROFILE` | API host / profile                                 | no        |
 
 ## Exit Codes
 
-| Code | Condition                                                         |
-| ---- | ----------------------------------------------------------------- |
-| `0`  | success — project created, files written, start command suggested |
-| `1`  | invalid template name provided as argument                        |
-| `1`  | GitHub API unavailable for template listing                       |
-| `1`  | authentication error — no valid token found for project creation  |
-| `1`  | project creation failure (API error)                              |
-| `1`  | network / connection failure                                      |
+| Code | Condition                                                                                                                                                                                                                                                                                                                                      |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | success                                                                                                                                                                                                                                                                                                                                        |
+| `1`  | invalid template arg; overwrite declined (`context canceled`); template list/download failure; login failure; create failure; api-keys exhausted; health unhealthy / error status; db-push subprocess non-zero exit; any network failure. The `.env` derive/write is **non-fatal** (prints `Failed to create .env file: <err>` and continues). |
+
+## Telemetry
+
+- `cli_command_executed` — once (via `withLegacyCommandInstrumentation`).
+- `cli_login_completed` — once, **only** on the browser-login path (token miss).
+- **No `cli_project_linked`** — Go's `bootstrap` calls `link.LinkServices` (services only), **not**
+  `link.Run`, so it deliberately skips the project-linked telemetry, status check, and the
+  `linked-project.json` temp write that the standalone `link` command performs.
+- `create` fires no custom event.
+- db-push events are emitted by the **Go subprocess**, not the TS shell.
 
 ## Output
 
-### `--output-format text` (Go CLI compatible)
+### `--output-format text` (Go-compatible)
 
-Interactive prompts for working directory and template selection (if not provided). On success, prints project details and suggested start command:
+stderr progress only: `Using workdir …`, `Created a new project at …`, `Linking project…`,
+`Checking project health…`, and the final `To start your app:` suggestion (Aqua command lines).
+`Downloading: <url>` goes to stdout (text mode only). The `create` sub-step also echoes the new
+project per `-o` (`pretty|json|yaml|toml|env`); bootstrap adds no `-o` output of its own.
 
+### `--output-format json` / `stream-json`
+
+Human banners are suppressed; a single structured result is emitted:
+
+```json
+{
+  "workdir": "…",
+  "project_ref": "…",
+  "template": "scratch",
+  "start_command": "supabase start",
+  "env_file": "…/.env"
+}
 ```
-To start your app:
-  <start command>
-```
-
-### `--output-format json`
-
-Not applicable — bootstrap is an interactive command.
-
-### `--output-format stream-json`
-
-Not applicable — bootstrap is an interactive command.
 
 ## Notes
 
-- Accepts an optional positional `[template]` argument to skip template selection prompt.
-- Without `WORKDIR`, prompts the user to enter a directory (defaulting to `CurrentDirAbs`).
-- Templates are fetched from `https://api.github.com/repos/supabase/samples/contents/`.
-- A "scratch" (empty) template is always available as fallback without GitHub access.
-- The `--password` flag sets the database password, bound to `DB_PASSWORD` viper key.
-- On success, the Go CLI prints a suggestion like `To start your app: supabase start`.
+- **Interim Go-proxy delegation for migration push.** The push step shells out to the bundled
+  Go binary (`db push --include-roles --include-seed [--password …]`) until `db push` gets its
+  own native port (separate Linear issue). The sub-step is **not** instrumentation-wrapped (the
+  subprocess fires its own push telemetry). Known divergence: `LegacyGoProxy.exec` propagates the
+  exit code, so Go's push backoff is **not** reproduced (single attempt) — to be restored when
+  `db push` is natively ported. (`LegacyGoProxy.exec` exits the process on a non-zero exit rather
+  than returning a failure, so the step cannot be wrapped in `Effect.retry`.)
+- **Interim credential exposure.** Because the push step runs in a subprocess, the DB password is
+  passed as `--password <value>` and is therefore briefly visible in the OS process table for the
+  lifetime of that subprocess (Go runs `push.Run` in-process and never exposes it). The same
+  password is already written in plaintext to `<workdir>/.env` in the same directory, so the
+  incremental exposure is small; it is eliminated when `db push` is natively ported (no subprocess).
+- The api-keys and health retries use the full Go `utils.NewBackoffPolicy` policy: exponential
+  backoff, 3s initial interval, multiplier 1.5, 60s max interval (capped before jitter), ±50% jitter
+  (randomization factor 0.5), 15m max-elapsed cap, and 8 retries (9 total attempts). The per-attempt
+  `Linking project…` / `Checking project health…` lines are reproduced, **and** Go's
+  `NewErrorCallback` notice — `<err>\nRetry (n/8): ` after each failed attempt — is reproduced:
+  failures 1-2 go to the debug logger (shown only under `--debug`), failures 3+ to stderr; the final
+  exhausted attempt prints no notice (matches `backoff.RetryNotify`).
+- `Downloading:` / progress banners are gated to text mode to keep machine stdout payload-only
+  (CLI-1546).

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.command.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.command.ts
@@ -1,5 +1,9 @@
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
+
+import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
+import { withLegacyCommandInstrumentation } from "../../telemetry/legacy-command-instrumentation.ts";
+import { legacyBootstrapRuntimeLayer } from "./bootstrap.layers.ts";
 import { legacyBootstrap } from "./bootstrap.handler.ts";
 
 const config = {
@@ -19,5 +23,9 @@ export type LegacyBootstrapFlags = CliCommand.Command.Config.Infer<typeof config
 export const legacyBootstrapCommand = Command.make("bootstrap", config).pipe(
   Command.withDescription("Bootstrap a Supabase project from a starter template."),
   Command.withShortDescription("Bootstrap a Supabase project from a starter template"),
-  Command.withHandler((flags) => legacyBootstrap(flags)),
+  Command.withHandler((flags) =>
+    // Go marks no bootstrap flag `markFlagTelemetrySafe`, so no `safeFlags`.
+    legacyBootstrap(flags).pipe(withLegacyCommandInstrumentation({ flags }), withJsonErrorHandling),
+  ),
+  Command.provide(legacyBootstrapRuntimeLayer),
 );

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.dotenv.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.dotenv.ts
@@ -1,0 +1,174 @@
+import type { ApiKeyResponse } from "@supabase/api/effect";
+
+import { apiKeysToEnv } from "../../shared/legacy-api-keys.format.ts";
+import { type LegacyDbConfig, toPostgresUrl } from "./bootstrap.pgconfig.ts";
+
+type ApiKey = typeof ApiKeyResponse.Type;
+
+// Env-var keys bootstrap writes / derives. Mirrors the constants in
+// `apps/cli-go/internal/bootstrap/bootstrap.go:131-150`.
+const SUPABASE_SERVICE_ROLE_KEY = "SUPABASE_SERVICE_ROLE_KEY";
+const SUPABASE_ANON_KEY = "SUPABASE_ANON_KEY";
+const SUPABASE_URL = "SUPABASE_URL";
+const POSTGRES_URL = "POSTGRES_URL";
+// Derived keys (only populated when present in .env.example).
+const POSTGRES_PRISMA_URL = "POSTGRES_PRISMA_URL";
+const POSTGRES_URL_NON_POOLING = "POSTGRES_URL_NON_POOLING";
+const POSTGRES_USER = "POSTGRES_USER";
+const POSTGRES_HOST = "POSTGRES_HOST";
+const POSTGRES_PASSWORD = "POSTGRES_PASSWORD";
+const POSTGRES_DATABASE = "POSTGRES_DATABASE";
+const NEXT_PUBLIC_SUPABASE_ANON_KEY = "NEXT_PUBLIC_SUPABASE_ANON_KEY";
+const NEXT_PUBLIC_SUPABASE_URL = "NEXT_PUBLIC_SUPABASE_URL";
+const EXPO_PUBLIC_SUPABASE_ANON_KEY = "EXPO_PUBLIC_SUPABASE_ANON_KEY";
+const EXPO_PUBLIC_SUPABASE_URL = "EXPO_PUBLIC_SUPABASE_URL";
+
+/**
+ * Reproduces Go's `writeDotEnv` env-map construction (`bootstrap.go:166-243`).
+ *
+ * Seeds the api-key env vars (`SUPABASE_<NAME>_KEY`), the project `SUPABASE_URL`,
+ * and the pooled `POSTGRES_URL` (transaction mode, port 6543). When a `.env.example`
+ * map is supplied, each of its keys is merged via Go's switch: the four seeded keys
+ * are preserved, the derived `POSTGRES_*` / `NEXT_PUBLIC_*` / `EXPO_PUBLIC_*` keys are
+ * computed from the db config + seeded values, and any other key copies its example
+ * value verbatim.
+ */
+export function buildDotEnv(
+  keys: ReadonlyArray<ApiKey>,
+  config: LegacyDbConfig,
+  supabaseUrl: string,
+  example: Readonly<Record<string, string>> | undefined,
+): Record<string, string> {
+  const initial = apiKeysToEnv(keys);
+  initial[SUPABASE_URL] = supabaseUrl;
+  initial[POSTGRES_URL] = toPostgresUrl({ ...config, port: 6543 });
+
+  if (example === undefined) {
+    return initial;
+  }
+
+  for (const [key, value] of Object.entries(example)) {
+    switch (key) {
+      // Seeded keys win over any example value.
+      case SUPABASE_SERVICE_ROLE_KEY:
+      case SUPABASE_ANON_KEY:
+      case SUPABASE_URL:
+      case POSTGRES_URL:
+        break;
+      case POSTGRES_PRISMA_URL:
+        initial[key] = initial[POSTGRES_URL] ?? "";
+        break;
+      case POSTGRES_URL_NON_POOLING:
+        initial[key] = toPostgresUrl(config);
+        break;
+      case POSTGRES_USER:
+        initial[key] = config.user;
+        break;
+      case POSTGRES_HOST:
+        initial[key] = config.host;
+        break;
+      case POSTGRES_PASSWORD:
+        initial[key] = config.password;
+        break;
+      case POSTGRES_DATABASE:
+        initial[key] = config.database;
+        break;
+      case NEXT_PUBLIC_SUPABASE_ANON_KEY:
+      case EXPO_PUBLIC_SUPABASE_ANON_KEY:
+        initial[key] = initial[SUPABASE_ANON_KEY] ?? "";
+        break;
+      case NEXT_PUBLIC_SUPABASE_URL:
+      case EXPO_PUBLIC_SUPABASE_URL:
+        initial[key] = initial[SUPABASE_URL] ?? "";
+        break;
+      default:
+        initial[key] = value;
+    }
+  }
+  return initial;
+}
+
+// godotenv's `doubleQuoteSpecialChars` (`joho/godotenv/godotenv.go`): backslash,
+// newline, carriage return, double-quote, `!`, `$`, backtick.
+const DOUBLE_QUOTE_SPECIAL = ["\\", "\n", "\r", '"', "!", "$", "`"] as const;
+
+function doubleQuoteEscape(line: string): string {
+  let out = line;
+  for (const char of DOUBLE_QUOTE_SPECIAL) {
+    const replacement = char === "\n" ? "\\n" : char === "\r" ? "\\r" : `\\${char}`;
+    out = out.replaceAll(char, replacement);
+  }
+  return out;
+}
+
+// strconv.Atoi surface: optional sign + base-10 digits, parsed within int range.
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+
+/**
+ * Reproduces `godotenv.Marshal`: each entry renders as `KEY=<int>` when the value
+ * parses as an integer (Go's `strconv.Atoi` + `%d`), otherwise `KEY="<escaped>"`.
+ * Lines are sorted lexicographically (Go sorts the rendered lines, which orders
+ * by key) and joined with `\n` (no trailing newline).
+ */
+export function marshalDotEnv(env: Readonly<Record<string, string>>): string {
+  const lines: Array<string> = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (INTEGER_PATTERN.test(value)) {
+      const parsed = Number(value);
+      if (Number.isSafeInteger(parsed)) {
+        lines.push(`${key}=${parsed}`);
+        continue;
+      }
+    }
+    lines.push(`${key}="${doubleQuoteEscape(value)}"`);
+  }
+  lines.sort();
+  return lines.join("\n");
+}
+
+// godotenv.Parse-compatible enough for `.env.example`: `KEY=VALUE` / `KEY="VALUE"`
+// lines, `#` comments, blank lines. A line with an empty / invalid variable name
+// throws (Go's `godotenv.Parse` surfaces `unexpected character ... in variable name`).
+const EXPORT_PREFIX = /^\s*export\s+/;
+
+/**
+ * Minimal godotenv parser for `.env.example`. Returns the parsed key/value map.
+ * Throws an `Error` whose message mirrors Go's parser for a malformed variable
+ * name so the caller can surface the same failure (`"!="` → unexpected character).
+ */
+export function parseDotEnv(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.replace(EXPORT_PREFIX, "").trim();
+    if (line.length === 0 || line.startsWith("#")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0) {
+      const offending = line.slice(0, eq < 0 ? line.length : eq + 1);
+      throw new Error(
+        `unexpected character "${line[0] ?? ""}" in variable name near "${offending}"`,
+      );
+    }
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_.]*$/.test(key)) {
+      throw new Error(`unexpected character "${key[0] ?? ""}" in variable name near "${line}"`);
+    }
+    let value = line.slice(eq + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+      // godotenv expands escapes inside double-quoted values: `\n` / `\r` become
+      // real newlines, and a backslash before any other char (except `$`) is
+      // dropped (`\"` -> `"`, `\\` -> `\`).
+      value = value
+        .slice(1, -1)
+        .replaceAll("\\n", "\n")
+        .replaceAll("\\r", "\r")
+        .replace(/\\([^$])/g, "$1");
+    } else if (value.startsWith("'") && value.endsWith("'") && value.length >= 2) {
+      // Single-quoted values are taken literally (no escape expansion).
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.dotenv.unit.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.dotenv.unit.test.ts
@@ -1,0 +1,121 @@
+import type { ApiKeyResponse } from "@supabase/api/effect";
+import { describe, expect, it } from "vitest";
+
+import { buildDotEnv, marshalDotEnv, parseDotEnv } from "./bootstrap.dotenv.ts";
+import type { LegacyDbConfig } from "./bootstrap.pgconfig.ts";
+
+type ApiKey = typeof ApiKeyResponse.Type;
+
+// Mirrors Go's `bootstrap_test.go::TestWriteEnv` fixtures.
+const API_KEYS: ReadonlyArray<ApiKey> = [
+  { name: "anon", api_key: "anonkey" },
+  { name: "service_role", api_key: "servicekey" },
+];
+
+const DB_CONFIG: LegacyDbConfig = {
+  host: "db.supabase.co",
+  port: 5432,
+  user: "admin",
+  password: "password",
+  database: "postgres",
+};
+
+const SUPABASE_URL = "https://testing.supabase.co";
+
+describe("buildDotEnv + marshalDotEnv", () => {
+  it("writes the api keys, project URL and pooled POSTGRES_URL", () => {
+    const env = buildDotEnv(API_KEYS, DB_CONFIG, SUPABASE_URL, undefined);
+    expect(marshalDotEnv(env)).toBe(
+      `POSTGRES_URL="postgresql://admin:password@db.supabase.co:6543/postgres?connect_timeout=10"
+SUPABASE_ANON_KEY="anonkey"
+SUPABASE_SERVICE_ROLE_KEY="servicekey"
+SUPABASE_URL="https://testing.supabase.co"`,
+    );
+  });
+
+  it("merges the derived keys from a .env.example (every switch branch)", () => {
+    const example: Record<string, string> = {
+      POSTGRES_PRISMA_URL: "example",
+      POSTGRES_URL_NON_POOLING: "example",
+      POSTGRES_USER: "example",
+      POSTGRES_HOST: "example",
+      POSTGRES_PASSWORD: "example",
+      POSTGRES_DATABASE: "example",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "example",
+      NEXT_PUBLIC_SUPABASE_URL: "example",
+      no_match: "example",
+      SUPABASE_SERVICE_ROLE_KEY: "example",
+      SUPABASE_ANON_KEY: "example",
+      SUPABASE_URL: "example",
+      POSTGRES_URL: "example",
+    };
+    const env = buildDotEnv(API_KEYS, DB_CONFIG, SUPABASE_URL, example);
+    expect(marshalDotEnv(env)).toBe(
+      `NEXT_PUBLIC_SUPABASE_ANON_KEY="anonkey"
+NEXT_PUBLIC_SUPABASE_URL="https://testing.supabase.co"
+POSTGRES_DATABASE="postgres"
+POSTGRES_HOST="db.supabase.co"
+POSTGRES_PASSWORD="password"
+POSTGRES_PRISMA_URL="postgresql://admin:password@db.supabase.co:6543/postgres?connect_timeout=10"
+POSTGRES_URL="postgresql://admin:password@db.supabase.co:6543/postgres?connect_timeout=10"
+POSTGRES_URL_NON_POOLING="postgresql://admin:password@db.supabase.co:5432/postgres?connect_timeout=10"
+POSTGRES_USER="admin"
+SUPABASE_ANON_KEY="anonkey"
+SUPABASE_SERVICE_ROLE_KEY="servicekey"
+SUPABASE_URL="https://testing.supabase.co"
+no_match="example"`,
+    );
+  });
+
+  it("mirrors the EXPO_PUBLIC_* keys to the anon key and project URL", () => {
+    const env = buildDotEnv(API_KEYS, DB_CONFIG, SUPABASE_URL, {
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: "example",
+      EXPO_PUBLIC_SUPABASE_URL: "example",
+    });
+    expect(env["EXPO_PUBLIC_SUPABASE_ANON_KEY"]).toBe("anonkey");
+    expect(env["EXPO_PUBLIC_SUPABASE_URL"]).toBe(SUPABASE_URL);
+  });
+
+  it("masks a nullable-null api key as ******", () => {
+    const env = buildDotEnv(
+      [{ name: "service_role", api_key: null }],
+      DB_CONFIG,
+      SUPABASE_URL,
+      undefined,
+    );
+    expect(env["SUPABASE_SERVICE_ROLE_KEY"]).toBe("******");
+  });
+});
+
+describe("marshalDotEnv", () => {
+  it("emits integer-valued entries unquoted and escapes special characters", () => {
+    expect(marshalDotEnv({ COUNT: "42", PATH: 'a"b\\c', NOTE: "hi!" })).toBe(
+      `COUNT=42\nNOTE="hi\\!"\nPATH="a\\"b\\\\c"`,
+    );
+  });
+});
+
+describe("parseDotEnv", () => {
+  it("parses KEY=VALUE lines, skipping comments and blanks, and strips quotes", () => {
+    expect(parseDotEnv('# comment\nFOO=bar\n\nBAZ="quoted"\nexport QUX=1')).toEqual({
+      FOO: "bar",
+      BAZ: "quoted",
+      QUX: "1",
+    });
+  });
+
+  it("expands escape sequences in double-quoted values (godotenv parity)", () => {
+    expect(parseDotEnv('A="line1\\nline2"\nB="a\\"b\\\\c"')).toEqual({
+      A: "line1\nline2",
+      B: 'a"b\\c',
+    });
+  });
+
+  it("takes single-quoted values literally (no escape expansion)", () => {
+    expect(parseDotEnv("A='line1\\nline2'")).toEqual({ A: "line1\\nline2" });
+  });
+
+  it("throws Go's 'unexpected character' error on a malformed variable name", () => {
+    expect(() => parseDotEnv("!=")).toThrow(/unexpected character "!" in variable name/);
+  });
+});

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
@@ -1,0 +1,54 @@
+import { Data } from "effect";
+
+// ---------------------------------------------------------------------------
+// Bootstrap-specific tagged errors. Each maps to a Go `errors.New` / failure
+// site in `apps/cli-go/cmd/bootstrap.go` + `internal/bootstrap/bootstrap.go`.
+// Login / create / api-keys / link failures are surfaced by the extracted
+// shared cores (`legacy/shared/legacy-*`), so they are NOT redefined here.
+// ---------------------------------------------------------------------------
+
+/** Positional template arg with no case-insensitive match — Go's `"Invalid template: " + name` (`cmd/bootstrap.go:48`). */
+export class LegacyBootstrapInvalidTemplateError extends Data.TaggedError(
+  "LegacyBootstrapInvalidTemplateError",
+)<{
+  readonly message: string;
+}> {}
+
+/** GitHub samples listing failure — Go's `failed to list samples` (`bootstrap.go:ListSamples`). */
+export class LegacyBootstrapTemplateListError extends Data.TaggedError(
+  "LegacyBootstrapTemplateListError",
+)<{
+  readonly message: string;
+}> {}
+
+/** Reading the target workdir failed — Go's `failed to read workdir: %w` (`bootstrap.go:44`). */
+export class LegacyBootstrapWorkdirReadError extends Data.TaggedError(
+  "LegacyBootstrapWorkdirReadError",
+)<{
+  readonly message: string;
+}> {}
+
+/**
+ * User declined the overwrite prompt — Go returns `errors.New(context.Canceled)`
+ * (`bootstrap.go:51`). Carries no suggestion frame (cancellation, not a fault).
+ */
+export class LegacyBootstrapOverwriteDeclinedError extends Data.TaggedError(
+  "LegacyBootstrapOverwriteDeclinedError",
+)<{
+  readonly message: string;
+}> {}
+
+/** Template download failure — Go's `failed to download template: %w` (`bootstrap.go:downloadSample`). */
+export class LegacyBootstrapTemplateDownloadError extends Data.TaggedError(
+  "LegacyBootstrapTemplateDownloadError",
+)<{
+  readonly message: string;
+}> {}
+
+/**
+ * Project health probe failed — Go's `Error status %d: %s` (non-200) or
+ * `Service not healthy: %s (%s)` (`bootstrap.go:checkProjectHealth`).
+ */
+export class LegacyBootstrapHealthError extends Data.TaggedError("LegacyBootstrapHealthError")<{
+  readonly message: string;
+}> {}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
@@ -1,13 +1,307 @@
-import { Effect, Option } from "effect";
+import { Effect, FileSystem, Option, Path, Schedule } from "effect";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
+
+import { LegacyPlatformApi } from "../../auth/legacy-platform-api.service.ts";
+import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
+import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
+import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
+import { LegacyWorkdirFlag, LegacyYesFlag } from "../../../shared/legacy/global-flags.ts";
+import { Output } from "../../../shared/output/output.service.ts";
 import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import { Tty } from "../../../shared/runtime/tty.service.ts";
+import { legacyAqua, legacyBold } from "../../shared/legacy-colors.ts";
+import { legacyEnsureLogin } from "../../shared/legacy-ensure-login.ts";
+import { legacyGetProjectApiKeys } from "../../shared/legacy-get-api-keys.ts";
+import { sanitizeLegacyErrorBody } from "../../shared/legacy-http-errors.ts";
+import { legacyLinkServicesCore } from "../../shared/legacy-link-services-core.ts";
+import { legacyProjectCreateCore } from "../../shared/legacy-project-create-core.ts";
+import { legacyTempPaths } from "../../shared/legacy-temp-paths.ts";
+import { legacyExtractServiceKeys } from "../../shared/legacy-tenant-keys.ts";
+import { initProject } from "../../../shared/init/project-init.ts";
+import { buildDotEnv, marshalDotEnv, parseDotEnv } from "./bootstrap.dotenv.ts";
+import {
+  LegacyBootstrapHealthError,
+  LegacyBootstrapInvalidTemplateError,
+  LegacyBootstrapOverwriteDeclinedError,
+  LegacyBootstrapWorkdirReadError,
+} from "./bootstrap.errors.ts";
+import { deriveDbConfig } from "./bootstrap.pgconfig.ts";
+import { suggestAppStart } from "./bootstrap.suggest.ts";
+import {
+  LEGACY_BOOTSTRAP_MAX_RETRIES,
+  legacyBootstrapBackoff,
+  legacyBootstrapRetryNotify,
+} from "./bootstrap.retry.ts";
+import { type LegacyStarterTemplate, LegacyTemplateService } from "./bootstrap.templates.ts";
 import type { LegacyBootstrapFlags } from "./bootstrap.command.ts";
+
+// Go's built-in starter (`cmd/bootstrap.go:17-21`).
+const SCRATCH_TEMPLATE: LegacyStarterTemplate = {
+  name: "scratch",
+  description: "An empty project from scratch.",
+  url: "",
+  start: "supabase start",
+};
 
 export const legacyBootstrap = Effect.fn("legacy.bootstrap")(function* (
   flags: LegacyBootstrapFlags,
+  retrySchedule: Schedule.Schedule<unknown> = legacyBootstrapBackoff,
 ) {
+  const output = yield* Output;
+  const tty = yield* Tty;
+  const runtimeInfo = yield* RuntimeInfo;
+  const cliConfig = yield* LegacyCliConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const templateService = yield* LegacyTemplateService;
   const proxy = yield* LegacyGoProxy;
-  const args: string[] = ["bootstrap"];
-  if (Option.isSome(flags.template)) args.push(flags.template.value);
-  if (Option.isSome(flags.password)) args.push("--password", flags.password.value);
-  yield* proxy.exec(args);
+  const api = yield* LegacyPlatformApi;
+  const linkedProjectCache = yield* LegacyLinkedProjectCache;
+  const telemetryState = yield* LegacyTelemetryState;
+  const workdirFlag = yield* LegacyWorkdirFlag;
+  const yesFlag = yield* LegacyYesFlag;
+
+  const isText = output.format === "text";
+  const retry = { schedule: retrySchedule, times: LEGACY_BOOTSTRAP_MAX_RETRIES } as const;
+
+  // `process.chdir` mirrors Go's `ChangeWorkDir`; restore the original cwd in a
+  // finalizer so the (mocked) proxy step still inherits the bootstrap workdir
+  // while leaving the surrounding process untouched.
+  const originalCwd = process.cwd();
+  let createdRef: string | undefined;
+  // Resolved bootstrap workdir, hoisted so the linked-project-cache finalizer writes
+  // beside the other `supabase/.temp/` files instead of `cliConfig.workdir`. Go achieves
+  // this by re-running `flags.LoadConfig` after `ChangeWorkDir` (`bootstrap.go:98-100`).
+  let resolvedWorkdir: string | undefined;
+
+  yield* Effect.gen(function* () {
+    // A. Resolve workdir (flag -> env -> prompt -> cwd). `bootstrap.go:30-40`.
+    // Go's viper uses `SetEnvPrefix("SUPABASE")`, so `viper.IsSet("WORKDIR")` reads
+    // the prefixed `SUPABASE_WORKDIR` only (never plain `WORKDIR`).
+    const workdirRaw = Option.isSome(workdirFlag)
+      ? workdirFlag.value
+      : process.env["SUPABASE_WORKDIR"];
+    const workdirInput =
+      workdirRaw ??
+      (yield* output.promptText(
+        `Enter a directory to bootstrap your project (or leave blank to use ${legacyBold(
+          runtimeInfo.cwd,
+        )}): `,
+      ));
+    const workdir = path.isAbsolute(workdirInput)
+      ? workdirInput
+      : path.join(runtimeInfo.cwd, workdirInput);
+    resolvedWorkdir = workdir;
+
+    // B. List templates + resolve the starter. `bootstrap.go:38-58` / `cmd:25-58`.
+    const samples = yield* templateService.listSamples;
+    const allTemplates = [...samples, SCRATCH_TEMPLATE];
+    let starter: LegacyStarterTemplate;
+    if (Option.isSome(flags.template)) {
+      const name = flags.template.value;
+      const match = allTemplates.find((t) => t.name.toLowerCase() === name.toLowerCase());
+      if (match === undefined) {
+        return yield* new LegacyBootstrapInvalidTemplateError({
+          message: `Invalid template: ${name}`,
+        });
+      }
+      starter = match;
+    } else {
+      const choice = yield* output.promptSelect(
+        "Which starter template do you want to use?",
+        allTemplates.map((t) => ({ value: t.name, label: t.name, hint: t.description })),
+      );
+      starter = allTemplates.find((t) => t.name === choice) ?? SCRATCH_TEMPLATE;
+    }
+
+    // C. mkdir + overwrite prompt. `bootstrap.go:41-53`.
+    yield* fs.makeDirectory(workdir, { recursive: true });
+    const entries = yield* fs
+      .readDirectory(workdir)
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new LegacyBootstrapWorkdirReadError({ message: `failed to read workdir: ${cause}` }),
+        ),
+      );
+    if (entries.length > 0) {
+      const overwrite = yesFlag
+        ? true
+        : yield* output.promptConfirm(
+            `Do you want to overwrite existing files in ${legacyBold(workdir)} directory?`,
+            { defaultValue: true },
+          );
+      if (!overwrite) {
+        return yield* new LegacyBootstrapOverwriteDeclinedError({ message: "context canceled" });
+      }
+    }
+
+    // D. chdir + "Using workdir" to stderr. `bootstrap.go:54` + `misc.go:240-247`.
+    // Go only prints the line when the resolved workdir differs from the original
+    // cwd (`cwd != CurrentDirAbs`); match that guard.
+    yield* Effect.sync(() => process.chdir(workdir));
+    if (workdir !== runtimeInfo.cwd) {
+      yield* output.raw(`Using workdir ${legacyBold(workdir)}\n`, "stderr");
+    }
+
+    // E. Download template OR scaffold a blank project. `bootstrap.go:57-65`.
+    if (starter.url.length > 0) {
+      if (isText) yield* output.raw(`Downloading: ${starter.url}\n`, "stdout");
+      yield* templateService.download(starter.url, workdir);
+    } else {
+      yield* initProject({
+        cwd: workdir,
+        force: true,
+        interactive: false,
+        useOrioledb: false,
+        withVscodeSettings: false,
+        withIntellijSettings: false,
+      });
+    }
+
+    // F. Ensure login (browser flow when no token). `bootstrap.go:66-77`.
+    yield* legacyEnsureLogin({ openBrowser: tty.stdinIsTty });
+
+    // G. Create project (echoes via the shared create core). `bootstrap.go:78-87`.
+    // Go binds `-p` to viper `DB_PASSWORD`; with the `SUPABASE` env prefix the env
+    // fallback is `SUPABASE_DB_PASSWORD` (consumed by `flags.PromptPassword`).
+    const seededPassword = Option.isSome(flags.password)
+      ? flags.password.value
+      : (process.env["SUPABASE_DB_PASSWORD"] ?? "");
+    const created = yield* legacyProjectCreateCore({
+      name: path.basename(workdir),
+      orgId: "",
+      dbPassword: seededPassword,
+      region: undefined,
+      size: undefined,
+      templateUrl: starter.url.length > 0 ? starter.url : undefined,
+      emitStructuredResult: false,
+    });
+    const projectRef = created.ref;
+    createdRef = projectRef.length > 0 ? projectRef : undefined;
+
+    // H. Fetch api keys with backoff; each attempt prints "Linking project...".
+    // `bootstrap.go:88-97`. The notify wrapper reproduces Go's `NewErrorCallback`
+    // (`<err>\nRetry (n/8):` after each failed attempt); a fresh counter per block.
+    const apiKeysNotify = legacyBootstrapRetryNotify();
+    const keys = yield* Effect.gen(function* () {
+      if (isText) yield* output.raw("Linking project...\n", "stderr");
+      return yield* legacyGetProjectApiKeys(projectRef);
+    }).pipe(apiKeysNotify, Effect.retry(retry));
+    const { anon } = legacyExtractServiceKeys(keys);
+
+    // I. Link services (best-effort, anon key) + mandatory project-ref write.
+    // `bootstrap.go:98-105`. Go calls `link.LinkServices` (no telemetry / status).
+    yield* legacyLinkServicesCore({
+      ref: projectRef,
+      serviceKey: anon,
+      skipPooler: false,
+      workdir,
+    });
+    const paths = legacyTempPaths(path, workdir);
+    yield* fs.makeDirectory(path.dirname(paths.projectRef), { recursive: true });
+    yield* fs.writeFileString(paths.projectRef, projectRef);
+
+    // J. Poll health until db is healthy. `bootstrap.go:106-113`.
+    const healthNotify = legacyBootstrapRetryNotify();
+    yield* Effect.gen(function* () {
+      if (isText) yield* output.raw("Checking project health...\n", "stderr");
+      const services = yield* api.v1
+        .getServicesHealth({ ref: projectRef, services: ["db"] })
+        .pipe(Effect.catch(mapHealthError));
+      for (const service of services) {
+        if (!service.healthy) {
+          return yield* new LegacyBootstrapHealthError({
+            message: `Service not healthy: ${service.name} (${service.status})`,
+          });
+        }
+      }
+    }).pipe(healthNotify, Effect.retry(retry));
+
+    // K. Derive db config + write .env (non-fatal). `bootstrap.go:114-121`.
+    const dbConfig = deriveDbConfig(projectRef, created.dbPassword, cliConfig.projectHost);
+    const supabaseUrl = `https://${projectRef}.${cliConfig.projectHost}`;
+    const envFilePath = path.join(workdir, ".env");
+    let envFileWritten = true;
+    yield* Effect.gen(function* () {
+      const examplePath = path.join(workdir, ".env.example");
+      const hasExample = yield* fs.exists(examplePath);
+      let example: Record<string, string> | undefined;
+      if (hasExample) {
+        const content = yield* fs.readFileString(examplePath);
+        example = yield* Effect.try({
+          try: () => parseDotEnv(content),
+          catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+        });
+      }
+      const env = buildDotEnv(keys, dbConfig, supabaseUrl, example);
+      yield* fs.writeFileString(envFilePath, marshalDotEnv(env));
+    }).pipe(
+      Effect.catch((cause) =>
+        Effect.gen(function* () {
+          envFileWritten = false;
+          yield* output.raw(
+            `Failed to create .env file: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+            "stderr",
+          );
+        }),
+      ),
+    );
+
+    // L. Push migrations — DELEGATED to the Go binary (interim; see SIDE_EFFECTS.md).
+    // No instrumentation wrap: the subprocess fires its own push telemetry.
+    // `bootstrap.go:122-127` -> push.Run(..., includeRoles, includeSeed) =>
+    // `--include-roles --include-seed` (no `--include-all`).
+    const pushArgs = ["db", "push", "--include-roles", "--include-seed"];
+    if (created.dbPassword.length > 0) pushArgs.push("--password", created.dbPassword);
+    yield* proxy.exec(pushArgs);
+
+    // M. Start suggestion. `bootstrap.go:128-130`.
+    if (isText) {
+      const suggestion = suggestAppStart(runtimeInfo.cwd, workdir, starter.start, legacyAqua);
+      yield* output.raw(`${suggestion}\n`, "stderr");
+    } else {
+      yield* output.success("", {
+        workdir,
+        project_ref: projectRef,
+        template: starter.name,
+        start_command: starter.start,
+        env_file: envFileWritten ? envFilePath : null,
+      });
+    }
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        try {
+          process.chdir(originalCwd);
+        } catch {
+          /* original cwd vanished — nothing to restore to */
+        }
+      }),
+    ),
+    Effect.ensuring(
+      Effect.suspend(() =>
+        createdRef === undefined
+          ? Effect.void
+          : linkedProjectCache.cache(createdRef, resolvedWorkdir),
+      ),
+    ),
+    Effect.ensuring(telemetryState.flush),
+  );
 });
+
+// Mirrors Go's `checkProjectHealth` non-200 branch: `Error status %d: %s`.
+const mapHealthError = (cause: unknown): Effect.Effect<never, LegacyBootstrapHealthError> => {
+  if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
+    const status = cause.response.status;
+    return cause.response.text.pipe(
+      Effect.orElseSucceed(() => ""),
+      Effect.map(sanitizeLegacyErrorBody),
+      Effect.flatMap((body) =>
+        Effect.fail(new LegacyBootstrapHealthError({ message: `Error status ${status}: ${body}` })),
+      ),
+    );
+  }
+  return Effect.fail(new LegacyBootstrapHealthError({ message: `Error status 0: ${cause}` }));
+};

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.integration.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.integration.test.ts
@@ -1,0 +1,452 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { BunServices } from "@effect/platform-bun";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Layer, Option, Schedule } from "effect";
+
+import {
+  mockAnalytics,
+  mockBrowser,
+  mockOutput,
+  mockRuntimeInfo,
+  mockStdin,
+  mockTty,
+} from "../../../../tests/helpers/mocks.ts";
+import {
+  type LegacyApiHandler,
+  LEGACY_VALID_REF,
+  legacyJsonResponse,
+  mockLegacyCliConfig,
+  mockLegacyCredentialsTracked,
+  mockLegacyLinkedProjectCacheTracked,
+  mockLegacyLoginApi,
+  mockLegacyLoginCrypto,
+  mockLegacyPlatformApi,
+  mockLegacyTelemetryStateTracked,
+  useLegacyTempWorkdir,
+} from "../../../../tests/helpers/legacy-mocks.ts";
+import {
+  LegacyDebugFlag,
+  LegacyWorkdirFlag,
+  LegacyYesFlag,
+  LegacyOutputFlag,
+} from "../../../shared/legacy/global-flags.ts";
+import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { LegacyTemplateService, type LegacyStarterTemplate } from "./bootstrap.templates.ts";
+import { legacyBootstrap } from "./bootstrap.handler.ts";
+import type { LegacyBootstrapFlags } from "./bootstrap.command.ts";
+
+const FAST_BACKOFF = Schedule.exponential("1 milli");
+
+const CREATED = {
+  id: LEGACY_VALID_REF,
+  ref: LEGACY_VALID_REF,
+  organization_id: "org-1",
+  organization_slug: "acme",
+  name: "alpha",
+  region: "us-east-1",
+  created_at: "2026-01-01T00:00:00Z",
+  status: "COMING_UP",
+};
+
+const ORGS = [{ id: "org-1", slug: "acme", name: "Acme Inc" }];
+
+const API_KEYS = [
+  { name: "anon", api_key: "anon-key" },
+  { name: "service_role", api_key: "svc-key" },
+];
+
+const HEALTHY = [{ name: "db", healthy: true, status: "ACTIVE_HEALTHY" }];
+
+const tempRoot = useLegacyTempWorkdir("supabase-bootstrap-int-");
+
+const NEXTJS_TEMPLATE: LegacyStarterTemplate = {
+  name: "nextjs",
+  description: "Next.js starter.",
+  url: "https://github.com/supabase/supabase/tree/master/examples/nextjs",
+  start: "npm ci && npm run dev",
+};
+
+interface SetupOpts {
+  readonly format?: "text" | "json" | "stream-json";
+  readonly workdir?: Option.Option<string>;
+  readonly yes?: boolean;
+  readonly stdinIsTty?: boolean;
+  readonly loggedIn?: boolean;
+  readonly debug?: boolean;
+  readonly samples?: ReadonlyArray<LegacyStarterTemplate>;
+  readonly apiKeysFailTimes?: number;
+  readonly health?: { readonly status: number; readonly body: unknown };
+  readonly promptTextResponses?: ReadonlyArray<string>;
+  readonly promptConfirmResponses?: ReadonlyArray<boolean>;
+}
+
+function setup(opts: SetupOpts = {}) {
+  const out = mockOutput({
+    format: opts.format ?? "text",
+    promptTextResponses: opts.promptTextResponses,
+    promptConfirmResponses: opts.promptConfirmResponses,
+  });
+  const telemetry = mockLegacyTelemetryStateTracked();
+  const linkedCache = mockLegacyLinkedProjectCacheTracked();
+  const analytics = mockAnalytics();
+  const credentials = mockLegacyCredentialsTracked();
+
+  let apiKeysCalls = 0;
+  const handler: LegacyApiHandler = (request, recorded) => {
+    const url = recorded.urlWithParams;
+    if (recorded.method === "POST" && /\/v1\/projects(\?|$)/.test(url)) {
+      return Effect.succeed(legacyJsonResponse(request, 201, CREATED));
+    }
+    if (url.includes("/api-keys")) {
+      apiKeysCalls += 1;
+      // 403 (not 5xx) so the api client's internal 5xx retry does not absorb it,
+      // forcing the bootstrap-level backoff to drive the retry.
+      if (apiKeysCalls <= (opts.apiKeysFailTimes ?? 0)) {
+        return Effect.succeed(legacyJsonResponse(request, 403, { message: "not ready" }));
+      }
+      return Effect.succeed(legacyJsonResponse(request, 200, API_KEYS));
+    }
+    if (url.includes("/health")) {
+      const health = opts.health ?? { status: 200, body: HEALTHY };
+      return Effect.succeed(legacyJsonResponse(request, health.status, health.body));
+    }
+    if (url.includes("/v1/organizations")) {
+      return Effect.succeed(legacyJsonResponse(request, 200, ORGS));
+    }
+    // storage/pooler config + tenant version probes — best-effort, ignored.
+    return Effect.succeed(legacyJsonResponse(request, 404, {}));
+  };
+  const api = mockLegacyPlatformApi({ handler });
+
+  const cliConfig = mockLegacyCliConfig({
+    workdir: tempRoot.current,
+    projectHost: "supabase.co",
+    accessToken: opts.loggedIn === false ? Option.none() : undefined,
+  });
+
+  const samples = opts.samples ?? [];
+  const downloads: Array<{ url: string; targetDir: string }> = [];
+  const templateLayer = Layer.succeed(LegacyTemplateService, {
+    listSamples: Effect.succeed(samples),
+    download: (url: string, targetDir: string) =>
+      Effect.sync(() => {
+        downloads.push({ url, targetDir });
+      }),
+  });
+
+  const proxyCalls: Array<ReadonlyArray<string>> = [];
+  const proxyLayer = Layer.succeed(LegacyGoProxy, {
+    exec: (args: ReadonlyArray<string>) =>
+      Effect.sync(() => {
+        proxyCalls.push(args);
+      }),
+  });
+
+  const loginApi = mockLegacyLoginApi({ gotrueId: "gotrue-user" });
+  const loginCrypto = mockLegacyLoginCrypto();
+
+  const layer = Layer.mergeAll(
+    BunServices.layer,
+    out.layer,
+    api.layer,
+    api.httpClientLayer,
+    cliConfig,
+    mockTty({ stdinIsTty: opts.stdinIsTty ?? true, stdoutIsTty: false }),
+    // cwd differs from the (absolute) workdir so the "Using workdir" line prints,
+    // matching Go's `cwd != CurrentDirAbs` guard.
+    mockRuntimeInfo({ cwd: dirname(tempRoot.current) }),
+    telemetry.layer,
+    linkedCache.layer,
+    analytics.layer,
+    credentials.layer,
+    templateLayer,
+    proxyLayer,
+    loginApi.layer,
+    loginCrypto.layer,
+    mockBrowser(),
+    mockStdin(opts.stdinIsTty ?? true),
+    Layer.succeed(LegacyOutputFlag, Option.none()),
+    Layer.succeed(LegacyWorkdirFlag, opts.workdir ?? Option.some(tempRoot.current)),
+    Layer.succeed(LegacyYesFlag, opts.yes ?? false),
+    Layer.succeed(LegacyDebugFlag, opts.debug ?? false),
+  );
+
+  return {
+    layer,
+    out,
+    telemetry,
+    linkedCache,
+    analytics,
+    credentials,
+    api,
+    workdir: tempRoot.current,
+    downloads,
+    proxyCalls,
+    loginApi,
+    get apiKeysCalls() {
+      return apiKeysCalls;
+    },
+  };
+}
+
+function flags(overrides: Partial<LegacyBootstrapFlags> = {}): LegacyBootstrapFlags {
+  return {
+    template: Option.none(),
+    password: Option.some("s3cret"),
+    ...overrides,
+  };
+}
+
+describe("legacy bootstrap integration", () => {
+  it.live("bootstraps the scratch template into the workdir (blank init, logged in)", () => {
+    const s = setup();
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      // Blank init scaffolded config.toml.
+      expect(existsSync(join(s.workdir, "supabase", "config.toml"))).toBe(true);
+      // Project ref written for the delegated db push.
+      expect(readFileSync(join(s.workdir, "supabase", ".temp", "project-ref"), "utf8")).toBe(
+        LEGACY_VALID_REF,
+      );
+      // .env populated with derived keys.
+      const env = readFileSync(join(s.workdir, ".env"), "utf8");
+      expect(env).toContain('SUPABASE_ANON_KEY="anon-key"');
+      expect(env).toContain("SUPABASE_URL=");
+      expect(env).toContain("POSTGRES_URL=");
+      // Progress + create echo on stderr.
+      expect(s.out.stderrText).toContain("Using workdir");
+      expect(s.out.stderrText).toContain("Created a new project at");
+      expect(s.out.stderrText).toContain("To start your app:");
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("downloads a named template matched by argument", () => {
+    const s = setup({ samples: [NEXTJS_TEMPLATE] });
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("NextJS") }), FAST_BACKOFF);
+      expect(s.downloads).toHaveLength(1);
+      expect(s.downloads[0]).toEqual({ url: NEXTJS_TEMPLATE.url, targetDir: s.workdir });
+      // No blank config.toml when a template is downloaded.
+      expect(existsSync(join(s.workdir, "supabase", "config.toml"))).toBe(false);
+      expect(s.out.stdoutText).toContain(`Downloading: ${NEXTJS_TEMPLATE.url}`);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("rejects an unknown template argument", () => {
+    const s = setup({ samples: [NEXTJS_TEMPLATE] });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        legacyBootstrap(flags({ template: Option.some("nope") }), FAST_BACKOFF),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const json = JSON.stringify(exit.cause);
+        expect(json).toContain("LegacyBootstrapInvalidTemplateError");
+        expect(json).toContain("Invalid template: nope");
+      }
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("prompts for a template when none is given", () => {
+    const s = setup({ samples: [NEXTJS_TEMPLATE] });
+    return Effect.gen(function* () {
+      // Default mock promptSelect picks the first option (the nextjs template).
+      yield* legacyBootstrap(flags(), FAST_BACKOFF);
+      expect(s.out.promptSelectCalls[0]?.message).toBe(
+        "Which starter template do you want to use?",
+      );
+      expect(s.downloads).toHaveLength(1);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("prompts for a workdir when none is configured", () => {
+    const s = setup({
+      workdir: Option.none(),
+      promptTextResponses: [tempRoot.current],
+    });
+    const prevWorkdir = process.env["SUPABASE_WORKDIR"];
+    delete process.env["SUPABASE_WORKDIR"];
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(existsSync(join(s.workdir, "supabase", "config.toml"))).toBe(true);
+    }).pipe(
+      Effect.provide(s.layer),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (prevWorkdir !== undefined) process.env["SUPABASE_WORKDIR"] = prevWorkdir;
+        }),
+      ),
+    );
+  });
+
+  it.live("aborts when the user declines to overwrite a non-empty workdir", () => {
+    const s = setup({ promptConfirmResponses: [false] });
+    writeFileSync(join(tempRoot.current, "existing.txt"), "keep me");
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("LegacyBootstrapOverwriteDeclinedError");
+      }
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("proceeds past a non-empty workdir with --yes", () => {
+    const s = setup({ yes: true });
+    writeFileSync(join(tempRoot.current, "existing.txt"), "keep me");
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(existsSync(join(s.workdir, "supabase", "config.toml"))).toBe(true);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("runs the browser login flow when no token is present (one cli_login_completed)", () => {
+    const s = setup({ loggedIn: false });
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(s.credentials.savedToken).toBeDefined();
+      expect(
+        s.analytics.captured.map((c) => c.event).filter((e) => e === "cli_login_completed"),
+      ).toHaveLength(1);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live(
+    "skips login when already authenticated (no login event, no project-linked event)",
+    () => {
+      const s = setup({ loggedIn: true });
+      return Effect.gen(function* () {
+        yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+        const events = s.analytics.captured.map((c) => c.event);
+        expect(events).not.toContain("cli_login_completed");
+        // Go's bootstrap calls link.LinkServices (not link.Run) — no cli_project_linked.
+        expect(events).not.toContain("cli_project_linked");
+      }).pipe(Effect.provide(s.layer));
+    },
+  );
+
+  it.live("retries fetching api keys until they are available", () => {
+    const s = setup({ apiKeysFailTimes: 2 });
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(s.apiKeysCalls).toBe(3);
+      const linkingLines = s.out.stderrText.match(/Linking project\.\.\./g) ?? [];
+      expect(linkingLines.length).toBeGreaterThanOrEqual(3);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("fails when a service stays unhealthy", () => {
+    const s = setup({
+      health: { status: 200, body: [{ name: "db", healthy: false, status: "UNHEALTHY" }] },
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("Service not healthy: db (UNHEALTHY)");
+      }
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("fails with an Error status when the health endpoint returns non-200", () => {
+    const s = setup({ health: { status: 503, body: { message: "down" } } });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("Error status 503");
+      }
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("merges .env.example derived keys", () => {
+    const s = setup();
+    mkdirSync(tempRoot.current, { recursive: true });
+    writeFileSync(
+      join(tempRoot.current, ".env.example"),
+      "POSTGRES_USER=example\nNEXT_PUBLIC_SUPABASE_ANON_KEY=example\n",
+    );
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      const env = readFileSync(join(s.workdir, ".env"), "utf8");
+      expect(env).toContain('POSTGRES_USER="postgres"');
+      expect(env).toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY="anon-key"');
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("continues (non-fatal) when the .env.example is malformed", () => {
+    const s = setup();
+    mkdirSync(tempRoot.current, { recursive: true });
+    writeFileSync(join(tempRoot.current, ".env.example"), "!=");
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(s.out.stderrText).toContain("Failed to create .env file:");
+      // Bootstrap still completes through the db push step.
+      expect(s.proxyCalls).toHaveLength(1);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("delegates the db push step to the Go proxy with the resolved password", () => {
+    const s = setup();
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(
+        flags({ template: Option.some("scratch"), password: Option.some("pw123") }),
+        FAST_BACKOFF,
+      );
+      expect(s.proxyCalls).toHaveLength(1);
+      expect(s.proxyCalls[0]).toEqual([
+        "db",
+        "push",
+        "--include-roles",
+        "--include-seed",
+        "--password",
+        "pw123",
+      ]);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("flushes telemetry and caches the linked project via ensuring", () => {
+    const s = setup();
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      expect(s.telemetry.flushed).toBe(true);
+      expect(s.linkedCache.cached).toBe(true);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("emits a single structured result in json mode", () => {
+    const s = setup({ format: "json" });
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      const successes = s.out.messages.filter((m) => m.type === "success");
+      expect(successes).toHaveLength(1);
+      expect(successes[0]?.data).toMatchObject({
+        project_ref: LEGACY_VALID_REF,
+        template: "scratch",
+        start_command: "supabase start",
+        workdir: s.workdir,
+      });
+      // No human progress banners on stdout in json mode.
+      expect(s.out.stdoutText).not.toContain("To start your app:");
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.live("reports env_file: null in the json result when the .env write fails", () => {
+    const s = setup({ format: "json" });
+    mkdirSync(tempRoot.current, { recursive: true });
+    writeFileSync(join(tempRoot.current, ".env.example"), "!=");
+    return Effect.gen(function* () {
+      yield* legacyBootstrap(flags({ template: Option.some("scratch") }), FAST_BACKOFF);
+      const success = s.out.messages.find((m) => m.type === "success");
+      expect(success?.data).toMatchObject({ env_file: null });
+    }).pipe(Effect.provide(s.layer));
+  });
+});

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
@@ -1,0 +1,64 @@
+import { Layer } from "effect";
+
+import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
+import { legacyHttpClientLayer } from "../../auth/legacy-http-debug.layer.ts";
+import { legacyPlatformApiLayer } from "../../auth/legacy-platform-api.layer.ts";
+import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyProjectRefLayer } from "../../config/legacy-project-ref.layer.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
+import { legacyLinkedProjectCacheLayer } from "../../telemetry/legacy-linked-project-cache.layer.ts";
+import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
+import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
+import { browserLayer } from "../../../shared/runtime/browser.layer.ts";
+import { stdinLayer } from "../../../shared/runtime/stdin.layer.ts";
+import { legacyLoginApiLayer } from "../../shared/legacy-login-api.layer.ts";
+import { legacyLoginCryptoLayer } from "../../shared/legacy-login-crypto.layer.ts";
+import { legacyTemplateServiceLayer } from "./bootstrap.templates.ts";
+
+// `bootstrap` is a meta-orchestrator: it needs the full Management-API stack
+// (create / api-keys / link cores), the browser-login stack (ensure-login), and
+// the GitHub template service. `Layer.provide` does not share to siblings inside
+// a `Layer.mergeAll` (legacy CLAUDE.md item 5), so every sub-layer that requires
+// `LegacyCliConfig` / `HttpClient` / `LegacyCredentials` is fed those explicitly.
+// Shared sub-layers are memoised by reference so the merge reuses one keyring
+// reader / one debug-logging HTTP wrapper / one config loader.
+//
+// `Output`, `Analytics`, `Stdio`, `Tty`, `RuntimeInfo`, `ProcessControl`,
+// `LegacyGoProxy`, and `BunServices` (`FileSystem` / `Path` / `ChildProcessSpawner`)
+// come from the root layer (`legacy/cli/root.ts` + `runCli`). `LegacyDebugLogger` is
+// NOT provided by the root, so every base layer that reads it for `--debug` traces
+// (`legacyCliConfigLayer`, `legacyHttpClientLayer`, `legacyCredentialsLayer`,
+// `legacyPlatformApiLayer`) is fed `legacyDebugLoggerLayer` here — matching `login.layers.ts`.
+const debugLogger = legacyDebugLoggerLayer;
+const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(debugLogger));
+const httpClient = legacyHttpClientLayer.pipe(Layer.provide(debugLogger));
+const credentials = legacyCredentialsLayer.pipe(
+  Layer.provide(cliConfig),
+  Layer.provide(debugLogger),
+);
+const platformApi = legacyPlatformApiLayer.pipe(
+  Layer.provide(credentials),
+  Layer.provide(cliConfig),
+  Layer.provide(httpClient),
+  Layer.provide(debugLogger),
+);
+
+export const legacyBootstrapRuntimeLayer = Layer.mergeAll(
+  platformApi,
+  httpClient,
+  credentials,
+  cliConfig,
+  legacyProjectRefLayer.pipe(Layer.provide(platformApi), Layer.provide(cliConfig)),
+  legacyLinkedProjectCacheLayer.pipe(
+    Layer.provide(credentials),
+    Layer.provide(cliConfig),
+    Layer.provide(httpClient),
+  ),
+  legacyTelemetryStateLayer,
+  legacyLoginApiLayer.pipe(Layer.provide(httpClient), Layer.provide(cliConfig)),
+  legacyLoginCryptoLayer,
+  legacyTemplateServiceLayer.pipe(Layer.provide(httpClient)),
+  browserLayer,
+  stdinLayer,
+  commandRuntimeLayer(["bootstrap"]),
+);

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.pgconfig.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.pgconfig.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure Postgres connection-string helpers. Ports of Go's `utils.ToPostgresURL`
+ * (`apps/cli-go/internal/utils/connect.go`) and the db-config derivation in
+ * `flags.NewDbConfigWithPassword`, reduced to just the connection-string
+ * components bootstrap needs (no live DB connection).
+ */
+
+export interface LegacyDbConfig {
+  readonly host: string;
+  readonly port: number;
+  readonly user: string;
+  readonly password: string;
+  readonly database: string;
+}
+
+// Go's `url.UserPassword` escapes userinfo with the `encodeUserPassword` mode:
+// unreserved chars + the sub-delims `$ & + , ; =` pass through; the reserved
+// `@ / ? :` and everything else are percent-encoded (`net/url.shouldEscape`).
+const USERINFO_UNESCAPED = new Set(
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~$&+,;=".split(""),
+);
+
+// Go's `url.PathEscape` uses `encodePathSegment`: escape `/ ; , ?` and anything
+// outside unreserved + the remaining reserved sub-delims `$ & + : = @`.
+const PATH_SEGMENT_UNESCAPED = new Set(
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~$&+:=@".split(""),
+);
+
+function percentEscape(value: string, allowed: ReadonlySet<string>): string {
+  const bytes = new TextEncoder().encode(value);
+  let out = "";
+  for (const byte of bytes) {
+    const char = String.fromCharCode(byte);
+    if (byte < 0x80 && allowed.has(char)) {
+      out += char;
+    } else {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+/**
+ * Reproduces Go's `ToPostgresURL`:
+ * `postgresql://<user>:<pass>@<host>:<port>/<db>?connect_timeout=10`, with
+ * percent-encoded userinfo, a path-escaped database, and IPv6 hosts wrapped in
+ * square brackets. Bootstrap passes no `RuntimeParams`, so the only query
+ * parameter is the default `connect_timeout=10`.
+ */
+export function toPostgresUrl(config: LegacyDbConfig): string {
+  const userinfo = `${percentEscape(config.user, USERINFO_UNESCAPED)}:${percentEscape(
+    config.password,
+    USERINFO_UNESCAPED,
+  )}`;
+  const host = config.host.includes(":") ? `[${config.host}]` : config.host;
+  const database = percentEscape(config.database, PATH_SEGMENT_UNESCAPED);
+  return `postgresql://${userinfo}@${host}:${config.port}/${database}?connect_timeout=10`;
+}
+
+/**
+ * Derives the remote project's direct (session-mode) connection config. Mirrors
+ * Go's `flags.NewDbConfigWithPassword`: `host = db.<ref>.<projectHost>`,
+ * `user = postgres`, `database = postgres`, direct port `5432`. The pooled
+ * (transaction-mode) variant uses the same config with port `6543`.
+ */
+export function deriveDbConfig(ref: string, password: string, projectHost: string): LegacyDbConfig {
+  return {
+    host: `db.${ref}.${projectHost}`,
+    port: 5432,
+    user: "postgres",
+    password,
+    database: "postgres",
+  };
+}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.pgconfig.unit.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.pgconfig.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveDbConfig, toPostgresUrl } from "./bootstrap.pgconfig.ts";
+
+describe("deriveDbConfig", () => {
+  it("derives the direct (session-mode) connection config from ref + host", () => {
+    expect(deriveDbConfig("testing", "s3cret", "supabase.co")).toEqual({
+      host: "db.testing.supabase.co",
+      port: 5432,
+      user: "postgres",
+      password: "s3cret",
+      database: "postgres",
+    });
+  });
+});
+
+describe("toPostgresUrl", () => {
+  it("renders the transaction-mode (6543) pooled URL", () => {
+    expect(
+      toPostgresUrl({
+        host: "db.supabase.co",
+        port: 6543,
+        user: "admin",
+        password: "password",
+        database: "postgres",
+      }),
+    ).toBe("postgresql://admin:password@db.supabase.co:6543/postgres?connect_timeout=10");
+  });
+
+  it("renders the direct (5432) URL", () => {
+    expect(
+      toPostgresUrl({
+        host: "db.supabase.co",
+        port: 5432,
+        user: "admin",
+        password: "password",
+        database: "postgres",
+      }),
+    ).toBe("postgresql://admin:password@db.supabase.co:5432/postgres?connect_timeout=10");
+  });
+
+  it("percent-encodes reserved characters in the userinfo (Go's url.UserPassword)", () => {
+    // `@ / ? :` and space are escaped; the sub-delim `$` passes through.
+    expect(
+      toPostgresUrl({
+        host: "db.supabase.co",
+        port: 5432,
+        user: "ad:min",
+        password: "p@ss/w?rd $1",
+        database: "postgres",
+      }),
+    ).toBe(
+      "postgresql://ad%3Amin:p%40ss%2Fw%3Frd%20$1@db.supabase.co:5432/postgres?connect_timeout=10",
+    );
+  });
+
+  it("wraps an IPv6 host in square brackets", () => {
+    expect(
+      toPostgresUrl({
+        host: "2001:db8::1",
+        port: 5432,
+        user: "postgres",
+        password: "pw",
+        database: "postgres",
+      }),
+    ).toBe("postgresql://postgres:pw@[2001:db8::1]:5432/postgres?connect_timeout=10");
+  });
+});

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.retry.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.retry.ts
@@ -1,0 +1,77 @@
+import { Duration, Effect, Random, Schedule } from "effect";
+
+import { LegacyDebugFlag } from "../../../shared/legacy/global-flags.ts";
+import { Output } from "../../../shared/output/output.service.ts";
+
+/**
+ * `maxRetries` from Go's `utils.NewBackoffPolicy` (`internal/utils/retry.go:12`).
+ * `backoff.WithMaxRetries(b, 8)` performs 8 retries -> 9 total attempts, matching
+ * `Effect.retry({ schedule, times: 8 })`.
+ */
+export const LEGACY_BOOTSTRAP_MAX_RETRIES = 8;
+
+const MAX_INTERVAL = Duration.seconds(60);
+
+/**
+ * Go-parity backoff for the api-keys and health retry loops
+ * (`utils.NewBackoffPolicy` -> `cenkalti/backoff` `NewExponentialBackOff`):
+ *
+ *  - 3s initial interval, multiplier `1.5`
+ *  - `MaxInterval` capped at 60s (applied to the base interval **before** jitter,
+ *    matching cenkalti's order — so an individual delay can reach ~90s)
+ *  - `RandomizationFactor` `0.5` -> each delay is jittered into `[0.5x, 1.5x]`
+ *  - `MaxElapsedTime` 15m (intersected via `during`; in practice the 8-retry cap
+ *    always trips first, but reproduced for completeness)
+ */
+export const legacyBootstrapBackoff: Schedule.Schedule<[Duration.Duration, Duration.Duration]> =
+  Schedule.exponential("3 seconds", 1.5).pipe(
+    Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, MAX_INTERVAL))),
+    Schedule.modifyDelay((_, delay) =>
+      Random.next.pipe(
+        Effect.map((random) => Duration.millis(Duration.toMillis(delay) * (0.5 + random))),
+      ),
+    ),
+    Schedule.both(Schedule.during("15 minutes")),
+  );
+
+/**
+ * Reproduces Go's `utils.NewErrorCallback` (`internal/utils/retry.go:19-35`): after
+ * each failed attempt it prints `<err>\nRetry (n/8): ` to a logger that starts as the
+ * debug logger (discarded unless `--debug`) and switches to stderr once
+ * `failureCount*3 > maxRetries` (i.e. from the 3rd failure on). Notify fires only for
+ * attempts that will be retried, never the final exhausted one.
+ *
+ * Returns a fresh wrapper with its own failure counter per call, mirroring Go's
+ * per-`RetryNotify` `NewErrorCallback()` + `policy.Reset()`.
+ */
+export const legacyBootstrapRetryNotify = () => {
+  let failureCount = 0;
+  return <A, E, R>(operation: Effect.Effect<A, E, R>) =>
+    operation.pipe(
+      Effect.tapError((error) =>
+        Effect.gen(function* () {
+          failureCount += 1;
+          // No notify on the final attempt (cenkalti returns `Stop` before notifying).
+          if (failureCount > LEGACY_BOOTSTRAP_MAX_RETRIES) return;
+          const toStderr = failureCount * 3 > LEGACY_BOOTSTRAP_MAX_RETRIES;
+          const debug = yield* LegacyDebugFlag;
+          // Failures 1-2 go to the debug logger (discarded unless `--debug`); 3+ to stderr.
+          if (!toStderr && !debug) return;
+          const output = yield* Output;
+          const message = stringifyError(error);
+          yield* output.raw(
+            `${message}\nRetry (${failureCount}/${LEGACY_BOOTSTRAP_MAX_RETRIES}): `,
+            "stderr",
+          );
+        }),
+      ),
+    );
+};
+
+function stringifyError(error: unknown): string {
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(error);
+}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.retry.unit.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.retry.unit.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, Layer, Pull, Schedule } from "effect";
+
+import { mockOutput } from "../../../../tests/helpers/mocks.ts";
+import { LegacyDebugFlag } from "../../../shared/legacy/global-flags.ts";
+import { legacyBootstrapBackoff, legacyBootstrapRetryNotify } from "./bootstrap.retry.ts";
+
+// Drive the schedule's step function directly (no real sleeping): each call returns the
+// next delay, and we feed an artificial `now` advanced by that delay so the `during`
+// (max-elapsed) gate sees virtual time pass.
+const collectDelays = (maxAttempts: number) =>
+  Effect.gen(function* () {
+    const step = yield* Schedule.toStep(legacyBootstrapBackoff);
+    const delays: Array<number> = [];
+    let now = 0;
+    let stopped = false;
+    for (let i = 0; i < maxAttempts; i++) {
+      const result = yield* step(now, undefined).pipe(
+        Effect.map((output) => ({ kind: "delay" as const, delay: output[1] })),
+        Pull.catchDone(() => Effect.succeed({ kind: "done" as const })),
+      );
+      if (result.kind === "done") {
+        stopped = true;
+        break;
+      }
+      const ms = Duration.toMillis(result.delay);
+      delays.push(ms);
+      now += ms;
+    }
+    return { delays, stopped };
+  });
+
+describe("legacyBootstrapBackoff", () => {
+  it.effect("caps each delay at the 60s max interval (plus 50% jitter)", () =>
+    Effect.gen(function* () {
+      const { delays } = yield* collectDelays(40);
+      // 60s `MaxInterval` capped before jitter, then jittered up to 1.5x => 90s ceiling.
+      // Without the cap, the exponential base alone would exceed 90s within ~9 attempts.
+      for (const ms of delays) {
+        expect(ms).toBeGreaterThan(0);
+        expect(ms).toBeLessThanOrEqual(90_000);
+      }
+    }),
+  );
+
+  it.effect("jitters the 3s initial interval into [1.5s, 4.5s]", () =>
+    Effect.gen(function* () {
+      const { delays } = yield* collectDelays(1);
+      expect(delays[0]).toBeGreaterThanOrEqual(1_500);
+      expect(delays[0]).toBeLessThanOrEqual(4_500);
+    }),
+  );
+
+  it.effect("stops at the 15m max-elapsed cap, independent of the 8-retry limit", () =>
+    Effect.gen(function* () {
+      const { delays, stopped } = yield* collectDelays(60);
+      // The schedule itself is bounded by elapsed time (15m), not the `times: 8` the
+      // handler layers on, so it yields more than 8 delays before halting.
+      expect(stopped).toBe(true);
+      expect(delays.length).toBeGreaterThan(8);
+    }),
+  );
+});
+
+const BOOM = new Error("boom");
+
+// Always-failing effect retried 8 times (9 attempts) to exercise the notify routing.
+const runNotify = (opts: { debug: boolean; error?: unknown }) => {
+  const out = mockOutput({ format: "text" });
+  const notify = legacyBootstrapRetryNotify();
+  const program = Effect.fail(opts.error ?? BOOM).pipe(
+    notify,
+    Effect.retry({ times: 8 }),
+    Effect.exit,
+  );
+  return Effect.gen(function* () {
+    yield* program;
+    return out;
+  }).pipe(Effect.provide(Layer.mergeAll(out.layer, Layer.succeed(LegacyDebugFlag, opts.debug))));
+};
+
+describe("legacyBootstrapRetryNotify", () => {
+  it.effect("routes failures 1-2 to the debug logger (suppressed without --debug)", () =>
+    Effect.gen(function* () {
+      const out = yield* runNotify({ debug: false });
+      // Failures 1-2 are debug-only; with --debug unset they must not reach stderr.
+      expect(out.stderrText).not.toContain("Retry (1/8): ");
+      expect(out.stderrText).not.toContain("Retry (2/8): ");
+      // Failures 3+ always print to stderr, preceded by the error message.
+      expect(out.stderrText).toContain("boom\nRetry (3/8): ");
+      expect(out.stderrText).toContain("Retry (8/8): ");
+    }),
+  );
+
+  it.effect("prints every notice to stderr under --debug", () =>
+    Effect.gen(function* () {
+      const out = yield* runNotify({ debug: true });
+      expect(out.stderrText).toContain("boom\nRetry (1/8): ");
+      expect(out.stderrText).toContain("Retry (2/8): ");
+      expect(out.stderrText).toContain("Retry (8/8): ");
+    }),
+  );
+
+  it.effect("emits no notice on the final exhausted attempt", () =>
+    Effect.gen(function* () {
+      const out = yield* runNotify({ debug: true });
+      // 8 retries => 9 attempts, but cenkalti returns Stop before notifying the last one.
+      expect(out.stderrText).not.toContain("Retry (9/8): ");
+    }),
+  );
+
+  it.effect("stringifies a non-Error failure value", () =>
+    Effect.gen(function* () {
+      const out = yield* runNotify({ debug: true, error: "plain string failure" });
+      expect(out.stderrText).toContain("plain string failure\nRetry (1/8): ");
+    }),
+  );
+
+  it.effect("falls back to String() when the failure has a non-string message", () =>
+    Effect.gen(function* () {
+      const out = yield* runNotify({ debug: true, error: { message: 123 } });
+      expect(out.stderrText).toContain("[object Object]\nRetry (1/8): ");
+    }),
+  );
+});

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.suggest.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.suggest.ts
@@ -1,0 +1,34 @@
+import { relative } from "node:path";
+
+/**
+ * Reproduces Go's `suggestAppStart` (`apps/cli-go/internal/bootstrap/bootstrap.go`).
+ *
+ * Builds the "To start your app:" hint printed at the end of bootstrap. Go computes
+ * the relative path from the original working directory (`utils.CurrentDirAbs`) to
+ * the (post-chdir) project directory; a non-trivial relative path adds a `cd <rel>`
+ * line, and a non-empty start command adds a second line.
+ *
+ * Colour is applied via the injected `colorize` callback (Go wraps each command
+ * line in `utils.Aqua`). It defaults to identity so unit tests assert the raw text,
+ * matching Go's `TestSuggestAppStart` which runs under a non-TTY (uncoloured) profile.
+ */
+export function suggestAppStart(
+  currentDirAbs: string,
+  workdir: string,
+  command: string,
+  colorize: (line: string) => string = (line) => line,
+): string {
+  const rel = relative(currentDirAbs, workdir);
+  const lines: Array<string> = [];
+  if (rel.length > 0 && rel !== ".") {
+    lines.push(`cd ${rel}`);
+  }
+  if (command.length > 0) {
+    lines.push(command);
+  }
+  let suggestion = "To start your app:";
+  for (const line of lines) {
+    suggestion += `\n  ${colorize(line)}`;
+  }
+  return suggestion;
+}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.suggest.unit.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.suggest.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { suggestAppStart } from "./bootstrap.suggest.ts";
+
+// Ports Go's `bootstrap_test.go::TestSuggestAppStart`. Colour is identity here so
+// the assertions match Go's non-TTY (uncoloured) output byte-for-byte.
+describe("suggestAppStart", () => {
+  it("suggests the start command when the workdir is the current directory", () => {
+    expect(suggestAppStart("/home/me/app", "/home/me/app", "npm ci && npm run dev")).toBe(
+      "To start your app:\n  npm ci && npm run dev",
+    );
+  });
+
+  it("prefixes a cd line when the workdir is nested", () => {
+    expect(suggestAppStart("/home/me", "/home/me/app", "npm ci && npm run dev")).toBe(
+      "To start your app:\n  cd app\n  npm ci && npm run dev",
+    );
+  });
+
+  it("omits the cd line for a '.' relative path", () => {
+    expect(suggestAppStart("/home/me/app", "/home/me/app", "supabase start")).toBe(
+      "To start your app:\n  supabase start",
+    );
+  });
+
+  it("omits the command line when the start command is empty", () => {
+    expect(suggestAppStart("/home/me", "/home/me/app", "")).toBe("To start your app:\n  cd app");
+  });
+
+  it("applies the colorize callback to each command line", () => {
+    const aqua = (line: string) => `<${line}>`;
+    expect(suggestAppStart("/home/me", "/home/me/app", "npm run dev", aqua)).toBe(
+      "To start your app:\n  <cd app>\n  <npm run dev>",
+    );
+  });
+});

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.templates.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.templates.ts
@@ -1,0 +1,246 @@
+import { Context, Effect, FileSystem, Layer, Path } from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+import { Output } from "../../../shared/output/output.service.ts";
+import { sanitizeLegacyErrorBody } from "../../shared/legacy-http-errors.ts";
+import {
+  LegacyBootstrapTemplateDownloadError,
+  LegacyBootstrapTemplateListError,
+} from "./bootstrap.errors.ts";
+
+export interface LegacyStarterTemplate {
+  readonly name: string;
+  readonly description: string;
+  readonly url: string;
+  readonly start: string;
+}
+
+interface LegacyTemplateServiceShape {
+  /**
+   * Fetches and decodes `samples.json` from the `supabase-community/supabase-samples`
+   * repo (Go's `ListSamples`). Returns the declared starter templates.
+   */
+  readonly listSamples: Effect.Effect<
+    ReadonlyArray<LegacyStarterTemplate>,
+    LegacyBootstrapTemplateListError
+  >;
+  /**
+   * Downloads every file under a `https://github.com/<owner>/<repo>/tree/<ref>/<root>`
+   * template URL into `targetDir`, preserving the directory layout below `<root>`
+   * (Go's `downloadSample`). Concurrency matches Go's job queue (5).
+   */
+  readonly download: (
+    templateUrl: string,
+    targetDir: string,
+  ) => Effect.Effect<void, LegacyBootstrapTemplateDownloadError>;
+}
+
+export class LegacyTemplateService extends Context.Service<
+  LegacyTemplateService,
+  LegacyTemplateServiceShape
+>()("supabase/legacy/TemplateService") {}
+
+const GITHUB_API = "https://api.github.com";
+const SAMPLES_OWNER = "supabase-community";
+const SAMPLES_REPO = "supabase-samples";
+const DOWNLOAD_CONCURRENCY = 5;
+
+interface GithubContentEntry {
+  readonly type?: string;
+  readonly name?: string;
+  readonly path?: string;
+  readonly content?: string;
+  readonly encoding?: string;
+  readonly download_url?: string | null;
+}
+
+function isStarterTemplate(value: unknown): value is LegacyStarterTemplate {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as LegacyStarterTemplate).name === "string"
+  );
+}
+
+// Preserve an explicit non-200 / parse failure (already a tagged error); wrap any
+// transport / filesystem cause in the same tagged error so the channel stays narrow.
+const mapDownloadError = (
+  cause: unknown,
+): Effect.Effect<never, LegacyBootstrapTemplateDownloadError> =>
+  Effect.fail(
+    cause instanceof LegacyBootstrapTemplateDownloadError
+      ? cause
+      : new LegacyBootstrapTemplateDownloadError({
+          message: `failed to download template: ${cause}`,
+        }),
+  );
+
+export const legacyTemplateServiceLayer = Layer.effect(
+  LegacyTemplateService,
+  Effect.gen(function* () {
+    const httpClient = yield* HttpClient.HttpClient;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const output = yield* Output;
+
+    // Go reads `GITHUB_TOKEN` directly (`utils.GetGitHubClient`) to raise the
+    // anonymous GitHub API rate limit. When unset, requests are anonymous.
+    const githubToken = process.env["GITHUB_TOKEN"];
+
+    const contentsRequest = (owner: string, repo: string, contentPath: string, ref: string) => {
+      const encodedPath = contentPath
+        .split("/")
+        .map((segment) => encodeURIComponent(segment))
+        .join("/");
+      let request = HttpClientRequest.get(
+        `${GITHUB_API}/repos/${owner}/${repo}/contents/${encodedPath}?ref=${ref}`,
+      ).pipe(HttpClientRequest.setHeader("Accept", "application/vnd.github.v3+json"));
+      if (githubToken !== undefined && githubToken.length > 0) {
+        request = request.pipe(
+          HttpClientRequest.setHeader("Authorization", `Bearer ${githubToken}`),
+        );
+      }
+      return request;
+    };
+
+    const listSamples: Effect.Effect<
+      ReadonlyArray<LegacyStarterTemplate>,
+      LegacyBootstrapTemplateListError
+    > = Effect.gen(function* () {
+      const response = yield* httpClient
+        .execute(contentsRequest(SAMPLES_OWNER, SAMPLES_REPO, "samples.json", "main"))
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new LegacyBootstrapTemplateListError({
+                message: `failed to list samples: ${cause}`,
+              }),
+          ),
+        );
+      if (response.status !== 200) {
+        const body = sanitizeLegacyErrorBody(
+          yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+        );
+        return yield* new LegacyBootstrapTemplateListError({
+          message: `failed to list samples: status ${response.status}: ${body}`,
+        });
+      }
+      const payload = yield* response.json.pipe(
+        Effect.mapError(
+          (cause) =>
+            new LegacyBootstrapTemplateListError({ message: `failed to decode samples: ${cause}` }),
+        ),
+      );
+      const decoded = Buffer.from(
+        ((payload as GithubContentEntry).content ?? "").replaceAll("\n", ""),
+        "base64",
+      ).toString("utf8");
+      const parsed = yield* Effect.try({
+        try: () => JSON.parse(decoded) as { samples?: ReadonlyArray<unknown> },
+        catch: (cause) =>
+          new LegacyBootstrapTemplateListError({
+            message: `failed to unmarshal samples: ${cause}`,
+          }),
+      });
+      return (parsed.samples ?? []).filter(isStarterTemplate);
+    });
+
+    const downloadFile = (localPath: string, remoteUrl: string) =>
+      Effect.gen(function* () {
+        const response = yield* httpClient.execute(HttpClientRequest.get(remoteUrl));
+        if (response.status !== 200) {
+          return yield* new LegacyBootstrapTemplateDownloadError({
+            message: `failed to download template: status ${response.status}`,
+          });
+        }
+        const bytes = new Uint8Array(yield* response.arrayBuffer);
+        yield* fs.makeDirectory(path.dirname(localPath), { recursive: true });
+        yield* fs.writeFile(localPath, bytes);
+      }).pipe(Effect.catch(mapDownloadError));
+
+    const download = (templateUrl: string, targetDir: string) =>
+      Effect.gen(function* () {
+        // e.g. https://github.com/supabase/supabase/tree/master/examples/user-management
+        const parsed = new URL(templateUrl);
+        const parts = parsed.pathname.split("/");
+        const owner = parts[1] ?? "";
+        const repo = parts[2] ?? "";
+        const ref = parts[4] ?? "";
+        const root = parts.slice(5).join("/");
+
+        const downloads: Array<{ readonly localPath: string; readonly remoteUrl: string }> = [];
+        const queue: Array<string> = [root];
+        while (queue.length > 0) {
+          const contentPath = queue.shift() ?? "";
+          const response = yield* httpClient.execute(
+            contentsRequest(owner, repo, contentPath, ref),
+          );
+          if (response.status !== 200) {
+            const body = sanitizeLegacyErrorBody(
+              yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+            );
+            return yield* new LegacyBootstrapTemplateDownloadError({
+              message: `failed to download template: status ${response.status}: ${body}`,
+            });
+          }
+          const payload = yield* response.json;
+          if (!Array.isArray(payload)) {
+            return yield* new LegacyBootstrapTemplateDownloadError({
+              message: `failed to download template: expected a directory listing for ${contentPath}`,
+            });
+          }
+          const listing = payload as ReadonlyArray<GithubContentEntry>;
+          for (const entry of listing) {
+            const entryPath = entry.path ?? "";
+            if (entry.type === "file") {
+              // Strip `<root>` on a path-segment boundary so a sibling directory that
+              // merely shares the prefix (e.g. `examples/app-2` under `root="examples/app"`)
+              // is never mis-sliced. The contents API only returns children of the queried
+              // directory, but matching on `root + "/"` is the obviously-correct form.
+              const relative =
+                root === ""
+                  ? entryPath
+                  : entryPath === root
+                    ? ""
+                    : entryPath.startsWith(`${root}/`)
+                      ? entryPath.slice(root.length + 1)
+                      : entryPath;
+              const localPath = path.join(targetDir, ...relative.split("/").filter(Boolean));
+              // Defence-in-depth: reject a malicious `path` (e.g. `../../etc/x`)
+              // that would escape the target directory.
+              const resolvedTarget = path.resolve(targetDir);
+              const resolvedLocal = path.resolve(localPath);
+              if (
+                resolvedLocal !== resolvedTarget &&
+                !resolvedLocal.startsWith(resolvedTarget + path.sep)
+              ) {
+                return yield* new LegacyBootstrapTemplateDownloadError({
+                  message: `failed to download template: entry escapes target directory: ${entryPath}`,
+                });
+              }
+              // GitHub returns a null `download_url` for files over 1 MB and for
+              // submodules; without an explicit guard the `?? ""` fallback would issue
+              // `GET ""` and surface a confusing transport error instead of a clear one.
+              if (entry.download_url == null || entry.download_url.length === 0) {
+                return yield* new LegacyBootstrapTemplateDownloadError({
+                  message: `failed to download template: unsupported entry (no download URL): ${entryPath}`,
+                });
+              }
+              downloads.push({ localPath, remoteUrl: entry.download_url });
+            } else if (entry.type === "dir") {
+              queue.push(entryPath);
+            } else {
+              yield* output.raw(`Ignoring ${entry.type}: ${entryPath}\n`, "stderr");
+            }
+          }
+        }
+
+        yield* Effect.forEach(downloads, (job) => downloadFile(job.localPath, job.remoteUrl), {
+          concurrency: DOWNLOAD_CONCURRENCY,
+        });
+      }).pipe(Effect.catch(mapDownloadError));
+
+    return { listSamples, download };
+  }),
+);

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.workdir-cache.integration.test.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.workdir-cache.integration.test.ts
@@ -1,0 +1,184 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { BunServices } from "@effect/platform-bun";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Schedule } from "effect";
+
+import {
+  mockAnalytics,
+  mockBrowser,
+  mockOutput,
+  mockRuntimeInfo,
+  mockStdin,
+  mockTty,
+} from "../../../../tests/helpers/mocks.ts";
+import {
+  type LegacyApiHandler,
+  LEGACY_VALID_REF,
+  legacyJsonResponse,
+  mockLegacyCredentialsTracked,
+  mockLegacyLoginApi,
+  mockLegacyLoginCrypto,
+  mockLegacyPlatformApi,
+  mockLegacyTelemetryStateTracked,
+} from "../../../../tests/helpers/legacy-mocks.ts";
+import {
+  LegacyDebugFlag,
+  LegacyOutputFlag,
+  LegacyProfileFlag,
+  LegacyWorkdirFlag,
+  LegacyYesFlag,
+} from "../../../shared/legacy/global-flags.ts";
+import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
+import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyLinkedProjectCacheLayer } from "../../telemetry/legacy-linked-project-cache.layer.ts";
+import { LegacyTemplateService } from "./bootstrap.templates.ts";
+import { legacyBootstrap } from "./bootstrap.handler.ts";
+import type { LegacyBootstrapFlags } from "./bootstrap.command.ts";
+
+const FAST_BACKOFF = Schedule.exponential("1 milli");
+
+const PROJECT = {
+  id: LEGACY_VALID_REF,
+  ref: LEGACY_VALID_REF,
+  organization_id: "org-1",
+  organization_slug: "acme",
+  name: "alpha",
+  region: "us-east-1",
+  status: "COMING_UP",
+};
+const ORGS = [{ id: "org-1", slug: "acme", name: "Acme Inc" }];
+const API_KEYS = [{ name: "anon", api_key: "anon-key" }];
+const HEALTHY = [{ name: "db", healthy: true, status: "ACTIVE_HEALTHY" }];
+
+// Drives the handler through the *prompt* workdir path (no `--workdir` flag and no
+// `SUPABASE_WORKDIR` env) with the real config + linked-project-cache layers. This is
+// the case the rest of the suite never covers: when the workdir comes from the prompt,
+// `cliConfig.workdir` (the cwd-walk result) diverges from the bootstrap workdir, and the
+// cache must follow the bootstrap workdir so `linked-project.json` lands beside
+// `project-ref` (matching Go's `flags.LoadConfig` after `ChangeWorkDir`).
+describe("legacy bootstrap linked-project cache location", () => {
+  it.live(
+    "writes linked-project.json into the prompted bootstrap workdir, not cliConfig.workdir",
+    () => {
+      const parent = mkdtempSync(join(tmpdir(), "bootstrap-cache-"));
+      const subdir = "myproj";
+      const bootstrapWorkdir = join(parent, subdir);
+
+      // Token via env => ensure-login is a no-op and the cache has a bearer token.
+      const prevToken = process.env["SUPABASE_ACCESS_TOKEN"];
+      const prevWorkdir = process.env["SUPABASE_WORKDIR"];
+      process.env["SUPABASE_ACCESS_TOKEN"] = "sbp_" + "a".repeat(40);
+      delete process.env["SUPABASE_WORKDIR"];
+
+      const out = mockOutput({ format: "text", promptTextResponses: [subdir] });
+
+      const handler: LegacyApiHandler = (request, recorded) => {
+        const url = recorded.urlWithParams;
+        if (recorded.method === "POST" && /\/v1\/projects(\?|$)/.test(url)) {
+          return Effect.succeed(legacyJsonResponse(request, 201, PROJECT));
+        }
+        if (url.includes("/api-keys")) {
+          return Effect.succeed(legacyJsonResponse(request, 200, API_KEYS));
+        }
+        if (url.includes("/health")) {
+          return Effect.succeed(legacyJsonResponse(request, 200, HEALTHY));
+        }
+        if (url.includes("/v1/organizations")) {
+          return Effect.succeed(legacyJsonResponse(request, 200, ORGS));
+        }
+        // GET /v1/projects/{ref} — read by the linked-project cache.
+        if (recorded.method === "GET" && url.includes(`/v1/projects/${LEGACY_VALID_REF}`)) {
+          return Effect.succeed(legacyJsonResponse(request, 200, PROJECT));
+        }
+        return Effect.succeed(legacyJsonResponse(request, 404, {}));
+      };
+      const api = mockLegacyPlatformApi({ handler });
+
+      const proxyLayer = Layer.succeed(LegacyGoProxy, { exec: () => Effect.void });
+      const templateLayer = Layer.succeed(LegacyTemplateService, {
+        listSamples: Effect.succeed([]),
+        download: () => Effect.void,
+      });
+
+      // GlobalFlag services don't cross sibling boundaries in Layer.mergeAll
+      // (apps/cli/CLAUDE.md item 5), so provide them explicitly into the real config layer.
+      const flagsLayer = Layer.mergeAll(
+        Layer.succeed(LegacyProfileFlag, "supabase"),
+        Layer.succeed(LegacyWorkdirFlag, Option.none()),
+        Layer.succeed(LegacyYesFlag, false),
+        Layer.succeed(LegacyOutputFlag, Option.none()),
+        Layer.succeed(LegacyDebugFlag, false),
+      );
+      const runtime = mockRuntimeInfo({ cwd: parent });
+      const credentials = mockLegacyCredentialsTracked();
+      const debugLoggerLayer = legacyDebugLoggerLayer.pipe(Layer.provide(flagsLayer));
+
+      const configLayer = legacyCliConfigLayer.pipe(
+        Layer.provide(flagsLayer),
+        Layer.provide(debugLoggerLayer),
+        Layer.provide(runtime),
+        Layer.provide(BunServices.layer),
+      );
+      const cacheLayer = legacyLinkedProjectCacheLayer.pipe(
+        Layer.provide(configLayer),
+        Layer.provide(credentials.layer),
+        Layer.provide(api.httpClientLayer),
+        Layer.provide(BunServices.layer),
+      );
+
+      const layer = Layer.mergeAll(
+        BunServices.layer,
+        out.layer,
+        api.layer,
+        api.httpClientLayer,
+        configLayer,
+        cacheLayer,
+        credentials.layer,
+        mockTty({ stdinIsTty: true, stdoutIsTty: false }),
+        runtime,
+        mockLegacyTelemetryStateTracked().layer,
+        mockAnalytics().layer,
+        templateLayer,
+        proxyLayer,
+        mockLegacyLoginApi({ gotrueId: "gotrue-user" }).layer,
+        mockLegacyLoginCrypto().layer,
+        mockBrowser(),
+        mockStdin(true),
+        flagsLayer,
+      );
+
+      const flags: LegacyBootstrapFlags = {
+        template: Option.some("scratch"),
+        password: Option.some("s3cret"),
+      };
+
+      return Effect.gen(function* () {
+        yield* legacyBootstrap(flags, FAST_BACKOFF);
+
+        const projectRef = join(bootstrapWorkdir, "supabase", ".temp", "project-ref");
+        const cacheInWorkdir = join(bootstrapWorkdir, "supabase", ".temp", "linked-project.json");
+        const cacheInParent = join(parent, "supabase", ".temp", "linked-project.json");
+
+        // project-ref already goes to the right place...
+        expect(existsSync(projectRef)).toBe(true);
+        // ...so linked-project.json must land beside it (Go writes both into workdir).
+        expect(existsSync(cacheInWorkdir)).toBe(true);
+        expect(existsSync(cacheInParent)).toBe(false);
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (prevToken !== undefined) process.env["SUPABASE_ACCESS_TOKEN"] = prevToken;
+            else delete process.env["SUPABASE_ACCESS_TOKEN"];
+            if (prevWorkdir !== undefined) process.env["SUPABASE_WORKDIR"] = prevWorkdir;
+            rmSync(parent, { recursive: true, force: true });
+          }),
+        ),
+      );
+    },
+  );
+});

--- a/apps/cli/src/legacy/commands/link/link.handler.ts
+++ b/apps/cli/src/legacy/commands/link/link.handler.ts
@@ -18,12 +18,9 @@ import {
 } from "../../../shared/telemetry/event-catalog.ts";
 import { legacyDashboardUrl } from "../../shared/legacy-profile.ts";
 import { mapLegacyHttpError, sanitizeLegacyErrorBody } from "../../shared/legacy-http-errors.ts";
+import { legacyLinkServicesCore } from "../../shared/legacy-link-services-core.ts";
+import { legacyExtractServiceKeys } from "../../shared/legacy-tenant-keys.ts";
 import { legacyTempPaths } from "../../shared/legacy-temp-paths.ts";
-import {
-  legacyFetchGotrueVersion,
-  legacyFetchPostgrestVersion,
-  legacyFetchStorageVersion,
-} from "../../shared/legacy-tenant-versions.ts";
 import {
   LegacyLinkApiKeysNetworkError,
   LegacyLinkAuthTokenError,
@@ -74,46 +71,7 @@ const classifyProjectError = (
   );
 };
 
-interface ApiKeyEntry {
-  readonly api_key?: string | null;
-  readonly type?: string | null;
-  readonly name: string;
-  readonly secret_jwt_template?: Record<string, unknown> | null;
-}
-
 type WriteTempFile = (filePath: string, content: string) => Effect.Effect<void, PlatformError>;
-
-// Mirrors `tenant.NewApiKey` (`apps/cli-go/internal/utils/tenant/client.go:28-57`):
-// publishable -> anon, secret w/ role=service_role -> service_role, else legacy
-// name-based fallback (`anon` / `service_role`).
-function extractServiceKeys(keys: ReadonlyArray<ApiKeyEntry>): {
-  anon: string;
-  serviceRole: string;
-} {
-  let anon = "";
-  let serviceRole = "";
-  for (const key of keys) {
-    const value = key.api_key;
-    if (value === undefined || value === null) continue;
-    if (key.type === "publishable") {
-      anon = value;
-      continue;
-    }
-    if (key.type === "secret") {
-      const role = key.secret_jwt_template?.["role"];
-      if (typeof role === "string" && role.toLowerCase() === "service_role") {
-        serviceRole = value;
-      }
-      continue;
-    }
-    if (key.name === "anon" && anon.length === 0) {
-      anon = value;
-    } else if (key.name === "service_role" && serviceRole.length === 0) {
-      serviceRole = value;
-    }
-  }
-  return { anon, serviceRole };
-}
 
 const mapApiKeysError = mapLegacyHttpError({
   networkError: LegacyLinkApiKeysNetworkError,
@@ -181,46 +139,18 @@ export const legacyLink = Effect.fn("legacy.link")(function* (flags: LegacyLinkF
     const keys = yield* api.v1
       .getProjectApiKeys({ ref, reveal: true })
       .pipe(Effect.catch(mapApiKeysError));
-    const { anon, serviceRole } = extractServiceKeys(keys);
+    const { anon, serviceRole } = legacyExtractServiceKeys(keys);
     if (anon.length === 0 && serviceRole.length === 0) {
       return yield* Effect.fail(new LegacyLinkMissingKeyError({ message: "Anon key not found." }));
     }
 
-    // 3. Link services — best-effort. Every error is swallowed so a single
-    // unreachable service never fails the link (link.go:91-100).
-    yield* linkStorageMigration(api, ref, paths.storageMigration, writeTempFile);
-    yield* linkPooler({
-      api,
+    // 3. Link services — best-effort, using the service-role key for tenant probes.
+    yield* legacyLinkServicesCore({
       ref,
-      skipPooler: flags.skipPooler,
-      fs,
-      poolerUrlPath: paths.poolerUrl,
-      writeTempFile,
-    });
-    const tenantOpts = {
-      ref,
-      projectHost: cliConfig.projectHost,
       serviceKey: serviceRole,
-      userAgent: cliConfig.userAgent,
-    };
-    yield* legacyFetchPostgrestVersion(tenantOpts).pipe(
-      Effect.flatMap((v) =>
-        Option.isSome(v) ? writeTempFile(paths.restVersion, v.value) : Effect.void,
-      ),
-      Effect.ignore,
-    );
-    yield* legacyFetchGotrueVersion(tenantOpts).pipe(
-      Effect.flatMap((v) =>
-        Option.isSome(v) ? writeTempFile(paths.gotrueVersion, v.value) : Effect.void,
-      ),
-      Effect.ignore,
-    );
-    yield* legacyFetchStorageVersion(tenantOpts).pipe(
-      Effect.flatMap((v) =>
-        Option.isSome(v) ? writeTempFile(paths.storageVersion, v.value) : Effect.void,
-      ),
-      Effect.ignore,
-    );
+      skipPooler: flags.skipPooler,
+      workdir: cliConfig.workdir,
+    });
 
     // 4. Save project ref (mandatory — a write failure fails the command).
     yield* writeTempFile(paths.projectRef, ref);
@@ -264,40 +194,3 @@ export const legacyLink = Effect.fn("legacy.link")(function* (flags: LegacyLinkF
     }
   }).pipe(Effect.ensuring(linkedProjectCache.cache(ref)), Effect.ensuring(telemetryState.flush));
 });
-
-const linkStorageMigration = (
-  api: ApiClient,
-  ref: string,
-  storageMigrationPath: string,
-  writeTempFile: WriteTempFile,
-) =>
-  api.v1.getStorageConfig({ ref }).pipe(
-    Effect.flatMap((config) => writeTempFile(storageMigrationPath, config.migrationVersion)),
-    Effect.ignore,
-  );
-
-const linkPooler = (opts: {
-  api: ApiClient;
-  ref: string;
-  skipPooler: boolean;
-  fs: FileSystem.FileSystem;
-  poolerUrlPath: string;
-  writeTempFile: WriteTempFile;
-}) =>
-  Effect.gen(function* () {
-    if (opts.skipPooler) {
-      // Use direct connection: drop any cached pooler URL (link.go:81-84).
-      yield* opts.fs.remove(opts.poolerUrlPath, { recursive: true }).pipe(Effect.ignore);
-      return;
-    }
-    const configs = yield* opts.api.v1.getPoolerConfig({ ref: opts.ref });
-    const primary = configs.find((c) => c.database_type === "PRIMARY");
-    if (primary === undefined) return;
-    // Strip the [YOUR-PASSWORD] placeholder; force session mode 5432 unless the
-    // pooler already reports session mode (link.go:221-229).
-    let connectionString = primary.connection_string.replaceAll(":[YOUR-PASSWORD]", "");
-    if (primary.pool_mode !== "session") {
-      connectionString = connectionString.replaceAll(":6543/", ":5432/");
-    }
-    yield* opts.writeTempFile(opts.poolerUrlPath, connectionString);
-  }).pipe(Effect.ignore);

--- a/apps/cli/src/legacy/commands/login/login.handler.ts
+++ b/apps/cli/src/legacy/commands/login/login.handler.ts
@@ -4,49 +4,34 @@ import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
 import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
 import { saveLegacyProfileName } from "../../config/legacy-profile-file.ts";
 import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
-import { legacyDashboardUrl } from "../../shared/legacy-profile.ts";
+import {
+  LEGACY_LOGGED_IN_MSG,
+  legacyBrowserLogin,
+  legacyPostLoginTelemetry,
+} from "../../shared/legacy-ensure-login.ts";
 import { LegacyProfileFlag } from "../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../shared/output/output.service.ts";
-import type { NonInteractiveError } from "../../../shared/output/errors.ts";
-import { Browser } from "../../../shared/runtime/browser.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
 import { Stdin } from "../../../shared/runtime/stdin.service.ts";
 import { Tty } from "../../../shared/runtime/tty.service.ts";
-import { Analytics } from "../../../shared/telemetry/analytics.service.ts";
-import { withAnalyticsContext } from "../../../shared/telemetry/analytics-context.ts";
-import { EventLoginCompleted } from "../../../shared/telemetry/event-catalog.ts";
-import { LegacyLoginApi, type LegacyLoginSessionResponse } from "./login-api.service.ts";
-import { LegacyLoginCrypto } from "./login-crypto.service.ts";
 import { legacySuggestClaudePlugin } from "./login-claude-hint.ts";
 import {
   LEGACY_LOGIN_MISSING_TOKEN_MESSAGE,
-  LegacyLoginFailedError,
   LegacyLoginMissingTokenError,
   LegacyLoginSaveTokenError,
 } from "./login.errors.ts";
 import type { LegacyLoginFlags } from "./login.command.ts";
 
-// Go's `maxRetries` (`login.go:130`): the initial probe plus 2 retries (3 total).
-const MAX_LOGIN_RETRIES = 2;
-
-const LOGGED_IN_MSG = "You are now logged in. Happy coding!\n";
-
 export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLoginFlags) {
   const output = yield* Output;
-  const cliConfig = yield* LegacyCliConfig;
   const credentials = yield* LegacyCredentials;
-  const crypto = yield* LegacyLoginCrypto;
-  const loginApi = yield* LegacyLoginApi;
   const telemetryState = yield* LegacyTelemetryState;
-  const analytics = yield* Analytics;
-  const browser = yield* Browser;
   const tty = yield* Tty;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runtimeInfo = yield* RuntimeInfo;
   const profileFlag = yield* LegacyProfileFlag;
 
-  const apiHost = cliConfig.apiUrl;
   const claudeHint = legacySuggestClaudePlugin({ stdoutIsTty: tty.stdoutIsTty });
 
   // Mirrors Go's login `PostRunE` (`cmd/login.go:42-48`): when a profile was
@@ -67,28 +52,6 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
       ? Effect.void
       : saveLegacyProfileName(fs, path, runtimeInfo.homeDir, profileToken);
 
-  // Mirrors Go's `handleTelemetryAfterLogin` (`login.go:273-299`): fetch the
-  // gotrue id (best-effort), stitch or clear the telemetry identity, then always
-  // capture `cli_login_completed`. The capture rides the just-stitched identity
-  // so PostHog attributes it to the user (Go's `s.distinctID()` after StitchLogin).
-  //
-  // NOTE: Go's `StitchLogin` only *aliases* (`service.go:137`) — it does NOT
-  // call `identify`. Do not add `analytics.identify` here; that is a `next/`
-  // shell behavior and would emit an event Go never sends.
-  const postLoginTelemetry = (token: string) =>
-    Effect.gen(function* () {
-      const gotrueId = yield* loginApi.fetchGotrueId(apiHost, token);
-      if (Option.isSome(gotrueId)) {
-        yield* telemetryState.stitchLogin(gotrueId.value);
-        yield* analytics
-          .capture(EventLoginCompleted)
-          .pipe(withAnalyticsContext({ distinct_id: gotrueId.value }));
-      } else {
-        yield* telemetryState.clearDistinctId;
-        yield* analytics.capture(EventLoginCompleted);
-      }
-    });
-
   const tokenPath = (token: string) =>
     Effect.gen(function* () {
       yield* credentials.saveAccessToken(token).pipe(
@@ -100,99 +63,15 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
           ),
         ),
       );
-      yield* postLoginTelemetry(token);
+      yield* legacyPostLoginTelemetry(token);
 
       if (output.format !== "text") {
         yield* output.success("You are now logged in.");
         return;
       }
-      yield* output.raw(LOGGED_IN_MSG, "stdout");
+      yield* output.raw(LEGACY_LOGGED_IN_MSG, "stdout");
       if (claudeHint.length > 0) yield* output.raw(`${claudeHint}\n`, "stderr");
     });
-
-  const browserPath = Effect.gen(function* () {
-    const { ecdh, publicKeyHex } = yield* crypto.generateKeyPair;
-    const sessionId = yield* crypto.generateSessionId;
-    const tokenName = Option.isSome(flags.name) ? flags.name.value : yield* crypto.defaultTokenName;
-
-    // Go concatenates the query string without URL-encoding (`login.go:197-198`).
-    const loginUrl =
-      `${legacyDashboardUrl(cliConfig.profile)}/cli/login` +
-      `?session_id=${sessionId}&token_name=${tokenName}&public_key=${publicKeyHex}`;
-
-    // The banners are human-facing text — suppressed in json / stream-json so
-    // stdout stays payload-only. The prompts still run (and fail cleanly with
-    // `NonInteractiveError` in a non-interactive machine mode).
-    const isText = output.format === "text";
-    if (!flags.noBrowser) {
-      if (isText) {
-        yield* output.raw(
-          "Hello from Supabase! Press Enter to open browser and login automatically.\n",
-          "stdout",
-        );
-      }
-      yield* output.promptText("");
-      if (isText) {
-        yield* output.raw(
-          `Here is your login link in case browser did not open ${loginUrl}\n\n`,
-          "stdout",
-        );
-      }
-      yield* Effect.ignore(browser.open(loginUrl));
-    } else if (isText) {
-      yield* output.raw(
-        `Here is your login link, open it in the browser ${loginUrl}\n\n`,
-        "stdout",
-      );
-    }
-
-    // Verify + retry, mirroring Go's `pollForAccessToken` backoff
-    // (`login.go:132-166`): the notifier prints `<err>\nRetry (n/2): ` after the
-    // first 2 failures; the 3rd failure gives up without a notice.
-    const verifyWithRetries = (
-      failuresSoFar: number,
-    ): Effect.Effect<LegacyLoginSessionResponse, LegacyLoginFailedError | NonInteractiveError> =>
-      Effect.gen(function* () {
-        const code = yield* output.promptText("Enter your verification code: ", {
-          validate: (v) => (v.trim().length > 0 ? undefined : "Verification code is required"),
-        });
-        return yield* loginApi.fetchLoginSession(apiHost, sessionId, code.trim());
-      }).pipe(
-        Effect.catchTag("LegacyLoginVerificationError", (err) =>
-          Effect.gen(function* () {
-            const failures = failuresSoFar + 1;
-            if (failures > MAX_LOGIN_RETRIES) {
-              return yield* Effect.fail(new LegacyLoginFailedError({ message: err.message }));
-            }
-            yield* output.raw(
-              `${err.message}\nRetry (${failures}/${MAX_LOGIN_RETRIES}): `,
-              "stderr",
-            );
-            return yield* verifyWithRetries(failures);
-          }),
-        ),
-      );
-
-    const session = yield* verifyWithRetries(0);
-
-    const token = yield* crypto.decryptToken(ecdh, {
-      ciphertext: session.access_token,
-      publicKey: session.public_key,
-      nonce: session.nonce,
-    });
-    // Go returns the raw save error here (`login.go:222-224`) — not the
-    // "cannot save provided token" wrapper used on the token path.
-    yield* credentials.saveAccessToken(token);
-    yield* postLoginTelemetry(token);
-
-    if (output.format !== "text") {
-      yield* output.success("You are now logged in.", { token_name: tokenName });
-      return;
-    }
-    yield* output.raw(`Token ${tokenName} created successfully.\n\n`, "stdout");
-    yield* output.raw(LOGGED_IN_MSG, "stdout");
-    if (claudeHint.length > 0) yield* output.raw(`${claudeHint}\n`, "stderr");
-  });
 
   const body = Effect.gen(function* () {
     // Token resolution priority: --token → SUPABASE_ACCESS_TOKEN → piped stdin
@@ -201,7 +80,7 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
     if (Option.isSome(resolved)) {
       return yield* tokenPath(resolved.value);
     }
-    return yield* browserPath;
+    return yield* legacyBrowserLogin({ openBrowser: !flags.noBrowser, tokenName: flags.name });
   });
 
   // `Effect.tap` runs the profile save only on success (Go's `PostRunE`);

--- a/apps/cli/src/legacy/commands/login/login.layers.ts
+++ b/apps/cli/src/legacy/commands/login/login.layers.ts
@@ -8,8 +8,8 @@ import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-stat
 import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
 import { browserLayer } from "../../../shared/runtime/browser.layer.ts";
 import { stdinLayer } from "../../../shared/runtime/stdin.layer.ts";
-import { legacyLoginApiLayer } from "./login-api.layer.ts";
-import { legacyLoginCryptoLayer } from "./login-crypto.layer.ts";
+import { legacyLoginApiLayer } from "../../shared/legacy-login-api.layer.ts";
+import { legacyLoginCryptoLayer } from "../../shared/legacy-login-crypto.layer.ts";
 
 // `login` is the only command that writes the access token, so it builds its own
 // lean runtime instead of `legacyManagementApiRuntimeLayer` — it must NOT eagerly

--- a/apps/cli/src/legacy/commands/projects/api-keys/api-keys.handler.ts
+++ b/apps/cli/src/legacy/commands/projects/api-keys/api-keys.handler.ts
@@ -1,42 +1,29 @@
 import type { V1GetProjectApiKeysOutput } from "@supabase/api/effect";
 import { Effect, Option } from "effect";
 
-import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { LegacyOutputFlag } from "../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { apiKeysToEnv } from "../../../shared/legacy-api-keys.format.ts";
+import { legacyGetProjectApiKeys } from "../../../shared/legacy-get-api-keys.ts";
 import {
   encodeEnv,
   encodeGoJson,
   encodeToml,
   encodeYaml,
 } from "../../../shared/legacy-go-output.encoders.ts";
-import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
-import {
-  LegacyProjectsApiKeysNetworkError,
-  LegacyProjectsApiKeysUnexpectedStatusError,
-} from "../projects.errors.ts";
 import { renderProjectApiKeysTable } from "../projects.format.ts";
 import type { LegacyProjectsApiKeysFlags } from "./api-keys.command.ts";
 
 type ApiKeys = typeof V1GetProjectApiKeysOutput.Type;
-
-const mapApiKeysError = mapLegacyHttpError({
-  networkError: LegacyProjectsApiKeysNetworkError,
-  statusError: LegacyProjectsApiKeysUnexpectedStatusError,
-  networkMessage: (cause) => `failed to get api keys: ${cause}`,
-  statusMessage: (status, body) => `unexpected get api keys status ${status}: ${body}`,
-});
 
 export const legacyProjectsApiKeys = Effect.fn("legacy.projects.api-keys")(function* (
   flags: LegacyProjectsApiKeysFlags,
 ) {
   const output = yield* Output;
   const goOutputFlag = yield* LegacyOutputFlag;
-  const api = yield* LegacyPlatformApi;
   const resolver = yield* LegacyProjectRefResolver;
   const linkedProjectCache = yield* LegacyLinkedProjectCache;
   const telemetryState = yield* LegacyTelemetryState;
@@ -48,9 +35,8 @@ export const legacyProjectsApiKeys = Effect.fn("legacy.projects.api-keys")(funct
   yield* Effect.gen(function* () {
     const fetching =
       output.format === "text" ? yield* output.task("Fetching API keys...") : undefined;
-    const keys: ApiKeys = yield* api.v1.getProjectApiKeys({ ref }).pipe(
+    const keys: ApiKeys = yield* legacyGetProjectApiKeys(ref).pipe(
       Effect.tapError(() => fetching?.fail() ?? Effect.void),
-      Effect.catch(mapApiKeysError),
     );
     yield* fetching?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/projects/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.handler.ts
@@ -1,52 +1,17 @@
-import { type V1CreateAProjectInput, operationDefinitions } from "@supabase/api/effect";
 import { Effect, Option } from "effect";
 
-import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
-import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
-import { LegacyOutputFlag } from "../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../shared/runtime/tty.service.ts";
-import {
-  encodeEnv,
-  encodeGoJson,
-  encodeToml,
-  encodeYaml,
-} from "../../../shared/legacy-go-output.encoders.ts";
-import { sanitizeLegacyErrorBody } from "../../../shared/legacy-http-errors.ts";
-import {
-  LegacyProjectsCreateMissingArgError,
-  LegacyProjectsCreateNetworkError,
-  LegacyProjectsCreateUnexpectedStatusError,
-} from "../projects.errors.ts";
-import {
-  dashboardUrlForProfile,
-  readProjectField,
-  renderProjectCreateTable,
-} from "../projects.format.ts";
-import {
-  legacyPromptDbPassword,
-  legacyPromptOrgId,
-  legacyPromptProjectName,
-  legacyPromptProjectRegion,
-} from "../projects.prompt.ts";
+import { legacyProjectCreateCore } from "../../../shared/legacy-project-create-core.ts";
+import { LegacyProjectsCreateMissingArgError } from "../projects.errors.ts";
 import type { LegacyProjectsCreateFlags } from "./create.command.ts";
-
-type CreateInput = typeof V1CreateAProjectInput.Type;
-
-/** Go's `printKeyValue` (`create.go:52-56`): `key` + `:` + pad to width 20 + value. */
-function printKeyValue(key: string, value: string): string {
-  return `${key}:${" ".repeat(Math.max(0, 20 - key.length))}${value}`;
-}
 
 export const legacyProjectsCreate = Effect.fn("legacy.projects.create")(function* (
   flags: LegacyProjectsCreateFlags,
 ) {
   const output = yield* Output;
-  const goOutputFlag = yield* LegacyOutputFlag;
-  const api = yield* LegacyPlatformApi;
-  const cliConfig = yield* LegacyCliConfig;
   const linkedProjectCache = yield* LegacyLinkedProjectCache;
   const telemetryState = yield* LegacyTelemetryState;
   const tty = yield* Tty;
@@ -60,10 +25,10 @@ export const legacyProjectsCreate = Effect.fn("legacy.projects.create")(function
     const interactive = Option.getOrElse(flags.interactive, () => true);
     const effectiveInteractive = interactive && tty.stdinIsTty && output.interactive;
 
-    let name = Option.getOrElse(flags.name, () => "");
-    let orgId = Option.getOrElse(flags.orgId, () => "");
-    let region: CreateInput["region"] = Option.getOrUndefined(flags.region);
-    let dbPassword = Option.getOrElse(flags.dbPassword, () => "");
+    const name = Option.getOrElse(flags.name, () => "");
+    const orgId = Option.getOrElse(flags.orgId, () => "");
+    const region = Option.getOrUndefined(flags.region);
+    const dbPassword = Option.getOrElse(flags.dbPassword, () => "");
     const size = Option.getOrUndefined(flags.size);
 
     // Non-interactive: Go's PreRunE marks `--org-id`, `--db-password`,
@@ -81,99 +46,16 @@ export const legacyProjectsCreate = Effect.fn("legacy.projects.create")(function
       }
     }
 
-    // promptMissingParams (`create.go:58-85`): prompt for each empty value and
-    // echo the resolved value to stderr in text mode.
-    if (name.length === 0) {
-      name = yield* legacyPromptProjectName();
-    } else if (output.format === "text") {
-      yield* output.raw(printKeyValue("Creating project", name) + "\n", "stderr");
-    }
-    if (orgId.length === 0) {
-      orgId = yield* legacyPromptOrgId();
-      if (output.format === "text") {
-        yield* output.raw(printKeyValue("Selected org-id", orgId) + "\n", "stderr");
-      }
-    }
-    if (region === undefined) {
-      const chosenRegion = yield* legacyPromptProjectRegion();
-      region = chosenRegion;
-      if (output.format === "text") {
-        yield* output.raw(printKeyValue("Selected region", chosenRegion) + "\n", "stderr");
-      }
-    }
-    if (dbPassword.length === 0) {
-      dbPassword = yield* legacyPromptDbPassword();
-    }
-
-    const input: CreateInput = {
+    const { ref } = yield* legacyProjectCreateCore({
       name,
-      organization_slug: orgId,
-      db_pass: dbPassword,
-      ...(region !== undefined ? { region } : {}),
-      ...(size !== undefined ? { desired_instance_size: size } : {}),
-    };
-
-    const creating =
-      output.format === "text" ? yield* output.task("Creating project...") : undefined;
-
-    // `executeRaw` sends the body with Go-sorted keys (matching `json.Marshal`)
-    // and skips output decoding: the 201 response's `ref` can be the cli-e2e
-    // `__PROJECT_REF__` placeholder, which the generated schema rejects.
-    const response = yield* api.executeRaw(operationDefinitions.v1CreateAProject, input).pipe(
-      Effect.tapError(() => creating?.fail() ?? Effect.void),
-      Effect.mapError(
-        (cause) =>
-          new LegacyProjectsCreateNetworkError({ message: `failed to create project: ${cause}` }),
-      ),
-    );
-
-    if (response.status !== 201) {
-      const body = sanitizeLegacyErrorBody(
-        yield* response.text.pipe(Effect.orElseSucceed(() => "")),
-      );
-      yield* creating?.fail() ?? Effect.void;
-      return yield* new LegacyProjectsCreateUnexpectedStatusError({
-        status: response.status,
-        body,
-        message: `Unexpected error creating project: ${body}`,
-      });
-    }
-
-    const created = yield* response.json.pipe(Effect.orElseSucceed((): unknown => ({})));
-    yield* creating?.clear() ?? Effect.void;
-
-    const id = readProjectField(created, "id");
-    createdRef = id.length > 0 ? id : undefined;
-
-    // Go prints this to stderr for every output format (`create.go:33-34`).
-    const projectUrl = `${dashboardUrlForProfile(cliConfig.profile)}/project/${id}`;
-    yield* output.raw(`Created a new project at ${projectUrl}\n`, "stderr");
-
-    const goFmt = Option.getOrUndefined(goOutputFlag);
-    if (goFmt === "json") {
-      yield* output.raw(encodeGoJson(created));
-      return;
-    }
-    if (goFmt === "yaml") {
-      yield* output.raw(encodeYaml(created));
-      return;
-    }
-    if (goFmt === "toml") {
-      yield* output.raw(encodeToml(created) + "\n");
-      return;
-    }
-    if (goFmt === "env") {
-      yield* output.raw(encodeEnv(created) + "\n");
-      return;
-    }
-
-    if (output.format === "json" || output.format === "stream-json") {
-      const data = typeof created === "object" && created !== null ? created : {};
-      yield* output.success("Created project", { ...data });
-      return;
-    }
-
-    yield* output.raw(renderProjectCreateTable(created));
+      orgId,
+      dbPassword,
+      region,
+      size,
+      templateUrl: undefined,
+      emitStructuredResult: true,
+    });
+    createdRef = ref.length > 0 ? ref : undefined;
   }).pipe(
     Effect.ensuring(
       Effect.suspend(() =>

--- a/apps/cli/src/legacy/commands/services/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/services/SIDE_EFFECTS.md
@@ -2,68 +2,78 @@
 
 ## Files Read
 
-| Path                       | Format     | When                                                                          |
-| -------------------------- | ---------- | ----------------------------------------------------------------------------- |
-| `.supabase/project.json`   | JSON       | to resolve linked project ref for remote version check                        |
-| `supabase/config.toml`     | TOML       | to read local service image versions                                          |
-| `~/.supabase/access-token` | plain text | when `SUPABASE_ACCESS_TOKEN` unset and keyring unavailable (for linked check) |
+| Path                         | Format     | When                                                                                       |
+| ---------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `supabase/.temp/project-ref` | plain text | when the checkout is linked and no explicit ref is already loaded                          |
+| `~/.supabase/access-token`   | plain text | when `SUPABASE_ACCESS_TOKEN` is unset and keyring access falls back to the home token file |
 
 ## Files Written
 
-| Path | Format | When |
-| ---- | ------ | ---- |
-| —    | —      | —    |
+| Path                                 | Format | When                                                                                                                                             |
+| ------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `supabase/.temp/linked-project.json` | JSON   | when a project ref resolves and no cache exists yet (`Effect.ensuring(linkedProjectCache.cache(ref))`, mirrors Go's `ensureProjectGroupsCached`) |
+| `~/.supabase/telemetry.json`         | JSON   | always (`Effect.ensuring(telemetryState.flush)`) at end of the command                                                                           |
 
 ## API Routes
 
-| Method | Path                                           | Auth         | Request body | Response (used fields)                                  |
-| ------ | ---------------------------------------------- | ------------ | ------------ | ------------------------------------------------------- |
-| `GET`  | `/v1/projects/{ref}/api-keys`                  | Bearer token | none         | `[{name, api_key}]` (used to authenticate tenant calls) |
-| `GET`  | `/v1/projects/{ref}`                           | Bearer token | none         | `{database.version}` (postgres image version)           |
-| `GET`  | `https://{ref}.supabase.co/auth/v1/health`     | service key  | none         | `{version}` (auth service version)                      |
-| `GET`  | `https://{ref}.supabase.co/rest/v1/`           | service key  | none         | `{info.version}` (postgrest version)                    |
-| `GET`  | `https://{ref}.supabase.co/storage/v1/version` | service key  | none         | body as plain text (storage version)                    |
+The resolved project ref must match `^[a-z]{20}$` (Go's `utils.ProjectRefPattern`)
+before any remote lookup runs; a malformed ref skips the linked-version checks
+and only the local matrix is printed. Tenant calls send `apikey: <serviceKey>`
+and additionally `Authorization: Bearer <serviceKey>` unless the key is a
+new-style `sb_…` key (which authenticates via the `apikey` header alone),
+matching `apps/cli-go/pkg/fetcher/gateway.go`.
+
+| Method | Path                                           | Auth                           | Request body | Response (used fields)                                             |
+| ------ | ---------------------------------------------- | ------------------------------ | ------------ | ------------------------------------------------------------------ |
+| `GET`  | `/v1/projects/{ref}`                           | Bearer token                   | none         | `{ref, name, region, status, organization_slug, database.version}` |
+| `GET`  | `/v1/projects/{ref}/api-keys?reveal=true`      | Bearer token                   | none         | `[{name, type, api_key, secret_jwt_template}]`                     |
+| `GET`  | `https://{ref}.supabase.co/auth/v1/health`     | apikey (+ Bearer if non-`sb_`) | none         | `{version}`                                                        |
+| `GET`  | `https://{ref}.supabase.co/rest/v1/`           | apikey (+ Bearer if non-`sb_`) | none         | `{info.version}`                                                   |
+| `GET`  | `https://{ref}.supabase.co/storage/v1/version` | apikey (+ Bearer if non-`sb_`) | none         | plain text version body                                            |
 
 ## Environment Variables
 
-| Variable                | Purpose                                              | Required?                                               |
-| ----------------------- | ---------------------------------------------------- | ------------------------------------------------------- |
-| `SUPABASE_ACCESS_TOKEN` | auth token for Management API (linked version check) | no (falls back to keyring → `~/.supabase/access-token`) |
-| `SUPABASE_API_URL`      | override Management API base URL                     | no (defaults to `https://api.supabase.com`)             |
+| Variable                | Purpose                                             | Required?                                                   |
+| ----------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
+| `SUPABASE_ACCESS_TOKEN` | auth token for Management API linked-version checks | no (falls back to keyring, then `~/.supabase/access-token`) |
+| `SUPABASE_API_URL`      | override Management API base URL                    | no (defaults to `https://api.supabase.com`)                 |
 
 ## Exit Codes
 
-| Code | Condition                                                                 |
-| ---- | ------------------------------------------------------------------------- |
-| `0`  | success — local service versions printed; remote versions shown if linked |
-| `0`  | not linked — local versions still printed, remote column shows `-`        |
-| `1`  | `--output env` format — explicitly not supported (`ErrEnvNotSupported`)   |
+| Code | Condition                                                                      |
+| ---- | ------------------------------------------------------------------------------ |
+| `0`  | success; always prints the local service matrix and optionally linked versions |
+| `1`  | `--output env` is requested; Go explicitly treats it as unsupported            |
 
 ## Output
 
-### `--output-format text` (Go CLI compatible)
+### Default / text
 
-Prints a Markdown-style table to stdout with local and linked (remote) service image versions:
+Prints a Markdown table with `SERVICE IMAGE`, `LOCAL`, and `LINKED` columns.
 
-```
-|SERVICE IMAGE|LOCAL|LINKED|
-|-|-|-|
-|`supabase/postgres:15.1.0.117`|`15.1.0.117`|`15.1.0.117`|
-|`supabase/gotrue:v2.74.2`|`v2.74.2`|`-`|
-```
+### `--output json`
+
+Prints the JSON array of service rows.
+
+### `--output toml`
+
+Prints a TOML object with a top-level `services = [...]` array.
+
+### `--output yaml`
+
+Prints the YAML array of service rows.
 
 ### `--output-format json`
 
-Not defined in Go CLI. Emits structured service version data as JSON.
+TS-only structured success event: `{ services: [...] }`.
 
 ### `--output-format stream-json`
 
-Not defined in Go CLI. Emits NDJSON result event.
+TS-only NDJSON success event with the same `{ services: [...] }` payload.
 
 ## Notes
 
-- The remote version check is best-effort: failures are printed to stderr but do not cause a non-zero exit.
-- If the project is not linked, the LINKED column shows `-` for all services.
-- Uses concurrent requests to check remote service versions via a work queue.
-- The Go CLI also supports `--output toml` (TOML format) and `--output json` via `utils.OutputFormat`.
-- The `--output env` format is explicitly unsupported and returns `ErrEnvNotSupported`.
+- Local versions come from the command's baked-in service matrix; the command does not inspect Docker state or local config files.
+- Linked-version checks are best-effort. Remote lookup failures do not change the exit code; they only leave the `LINKED` column empty for unavailable services.
+- Version mismatches are reported to stderr as a warning.
+- `telemetry.json` is written on every invocation, including `--output env` failures, to match the legacy Go command lifecycle.

--- a/apps/cli/src/legacy/commands/services/services.command.ts
+++ b/apps/cli/src/legacy/commands/services/services.command.ts
@@ -1,4 +1,7 @@
 import { Command } from "effect/unstable/cli";
+import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
+import { legacyManagementApiRuntimeLayer } from "../../shared/legacy-management-api-runtime.layer.ts";
+import { withLegacyCommandInstrumentation } from "../../telemetry/legacy-command-instrumentation.ts";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { legacyServices } from "./services.handler.ts";
 
@@ -8,5 +11,8 @@ export type LegacyServicesFlags = CliCommand.Command.Config.Infer<typeof config>
 export const legacyServicesCommand = Command.make("services", config).pipe(
   Command.withDescription("Show versions of all Supabase services."),
   Command.withShortDescription("Show versions of all Supabase services"),
-  Command.withHandler((_flags) => legacyServices(_flags)),
+  Command.withHandler((flags) =>
+    legacyServices(flags).pipe(withLegacyCommandInstrumentation({ flags }), withJsonErrorHandling),
+  ),
+  Command.provide(legacyManagementApiRuntimeLayer(["services"])),
 );

--- a/apps/cli/src/legacy/commands/services/services.errors.ts
+++ b/apps/cli/src/legacy/commands/services/services.errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class LegacyServicesEnvNotSupportedError extends Data.TaggedError(
+  "LegacyServicesEnvNotSupportedError",
+)<{
+  readonly message: string;
+}> {}

--- a/apps/cli/src/legacy/commands/services/services.handler.ts
+++ b/apps/cli/src/legacy/commands/services/services.handler.ts
@@ -1,8 +1,112 @@
-import { Effect } from "effect";
-import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { Effect, Exit, FileSystem, Option, Path } from "effect";
+import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
+import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
+import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
+import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
+import { LegacyOutputFlag } from "../../../shared/legacy/global-flags.ts";
+import { Output } from "../../../shared/output/output.service.ts";
+import { encodeGoJson, encodeToml, encodeYaml } from "../../shared/legacy-go-output.encoders.ts";
+import {
+  encodeLegacyTomlRows,
+  fetchLinkedServiceVersions,
+  formatServicesWarning,
+  listLocalServiceVersions,
+  mergeRemoteServiceVersions,
+  renderServicesTable,
+  renderServicesWarning,
+} from "../../../shared/services/services.shared.ts";
 import type { LegacyServicesFlags } from "./services.command.ts";
+import { LegacyServicesEnvNotSupportedError } from "./services.errors.ts";
 
 export const legacyServices = Effect.fn("legacy.services")(function* (_flags: LegacyServicesFlags) {
-  const proxy = yield* LegacyGoProxy;
-  yield* proxy.exec(["services"]);
+  const output = yield* Output;
+  const legacyOutput = yield* LegacyOutputFlag;
+  const cliConfig = yield* LegacyCliConfig;
+  const credentials = yield* LegacyCredentials;
+  const linkedProjectCache = yield* LegacyLinkedProjectCache;
+  const telemetryState = yield* LegacyTelemetryState;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const projectRefPath = path.join(cliConfig.workdir, "supabase", ".temp", "project-ref");
+  const linkedProjectRef = yield* Effect.gen(function* () {
+    if (Option.isSome(cliConfig.projectId)) {
+      return cliConfig.projectId;
+    }
+
+    const exists = yield* fs.exists(projectRefPath).pipe(Effect.orElseSucceed(() => false));
+    if (!exists) {
+      return Option.none<string>();
+    }
+
+    const content = yield* fs.readFileString(projectRefPath).pipe(Effect.orElseSucceed(() => ""));
+    const trimmed = content.trim();
+    return trimmed.length === 0 ? Option.none<string>() : Option.some(trimmed);
+  });
+
+  // Mirror Go's PersistentPostRun (`apps/cli-go/cmd/root.go:176`): when a project
+  // ref is resolved, refresh the linked-project cache on success and failure so
+  // PostHog org/project groups stay attached. Persist the telemetry state too.
+  const cacheLinkedProject = Option.match(linkedProjectRef, {
+    onNone: () => Effect.void,
+    onSome: (ref) => linkedProjectCache.cache(ref),
+  });
+
+  yield* Effect.gen(function* () {
+    const accessTokenExit = yield* credentials.getAccessToken.pipe(Effect.exit);
+    const accessToken = Exit.isSuccess(accessTokenExit) ? accessTokenExit.value : Option.none();
+
+    let rows = listLocalServiceVersions();
+    if (Option.isSome(linkedProjectRef) && Option.isSome(accessToken)) {
+      const remote = yield* fetchLinkedServiceVersions({
+        apiUrl: cliConfig.apiUrl,
+        projectHost: cliConfig.projectHost,
+        projectRef: linkedProjectRef.value,
+        accessToken: accessToken.value,
+        userAgent: cliConfig.userAgent,
+      });
+      rows = mergeRemoteServiceVersions(remote);
+    }
+
+    const warning = renderServicesWarning(rows);
+    if (warning !== undefined) {
+      yield* output.raw(formatServicesWarning(warning, output.format === "text"), "stderr");
+    }
+
+    const goOutput = Option.getOrUndefined(legacyOutput);
+
+    if (goOutput === "env") {
+      return yield* Effect.fail(
+        new LegacyServicesEnvNotSupportedError({
+          message: "--output env flag is not supported",
+        }),
+      );
+    }
+
+    if (goOutput === "json") {
+      yield* output.raw(encodeGoJson(rows));
+      return;
+    }
+
+    if (goOutput === "yaml") {
+      yield* output.raw(encodeYaml(rows));
+      return;
+    }
+
+    if (goOutput === "toml") {
+      yield* output.raw(encodeToml(encodeLegacyTomlRows(rows)));
+      return;
+    }
+
+    // goOutput is undefined or "pretty" — defer to the TS --output-format flag for
+    // machine output, otherwise render the Go `--output pretty` table. Guarding the
+    // table behind this (rather than treating "pretty" as force-table) keeps
+    // `--output pretty --output-format json` emitting JSON, per CLI-1546.
+    if (output.format === "json" || output.format === "stream-json") {
+      yield* output.success("", { services: rows });
+      return;
+    }
+
+    yield* output.raw(renderServicesTable(rows));
+  }).pipe(Effect.ensuring(cacheLinkedProject), Effect.ensuring(telemetryState.flush));
 });

--- a/apps/cli/src/legacy/commands/services/services.integration.test.ts
+++ b/apps/cli/src/legacy/commands/services/services.integration.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "@effect/vitest";
+import { BunServices } from "@effect/platform-bun";
+import { Cause, Effect, Exit, Layer, Option } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
+import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
+import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
+import { LegacyOutputFlag } from "../../../shared/legacy/global-flags.ts";
+import { mockOutput } from "../../../../tests/helpers/mocks.ts";
+import { mockLegacyTelemetryStateTracked } from "../../../../tests/helpers/legacy-mocks.ts";
+import { legacyServices } from "./services.handler.ts";
+
+function setup(
+  opts: {
+    format?: "text" | "json" | "stream-json";
+    goOutput?: Option.Option<"env" | "pretty" | "json" | "toml" | "yaml">;
+  } = {},
+) {
+  const out = mockOutput({
+    format: opts.format ?? "text",
+    interactive: (opts.format ?? "text") === "text",
+  });
+  const telemetry = mockLegacyTelemetryStateTracked();
+  const cachedRefs: string[] = [];
+
+  return {
+    out,
+    telemetry,
+    cachedRefs,
+    layer: Layer.mergeAll(
+      BunServices.layer,
+      FetchHttpClient.layer,
+      out.layer,
+      telemetry.layer,
+      Layer.succeed(LegacyOutputFlag, opts.goOutput ?? Option.none()),
+      Layer.succeed(
+        LegacyCliConfig,
+        LegacyCliConfig.of({
+          profile: "supabase",
+          apiUrl: "https://api.supabase.com",
+          projectHost: "supabase.co",
+          accessToken: Option.none(),
+          projectId: Option.none(),
+          workdir: process.cwd(),
+          userAgent: "SupabaseCLI/test",
+        }),
+      ),
+      Layer.succeed(LegacyCredentials, LegacyCredentials.of(legacyCredentialsMock)),
+      Layer.succeed(
+        LegacyLinkedProjectCache,
+        LegacyLinkedProjectCache.of({
+          cache: (ref) =>
+            Effect.sync(() => {
+              cachedRefs.push(ref);
+            }),
+        }),
+      ),
+    ),
+  };
+}
+
+const legacyCredentialsMock = {
+  getAccessToken: Effect.succeed(Option.none()),
+  saveAccessToken: () => Effect.die("unexpected saveAccessToken"),
+  deleteAccessToken: Effect.die("unexpected deleteAccessToken"),
+  deleteAllProjectCredentials: Effect.void,
+  deleteProjectCredential: () => Effect.succeed(false),
+};
+
+function expectFailureTag(exit: Exit.Exit<unknown, unknown>, tag: string) {
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (!Exit.isFailure(exit)) {
+    return;
+  }
+
+  const failure = Cause.findErrorOption(exit.cause);
+  expect(Option.isSome(failure)).toBe(true);
+  if (Option.isSome(failure)) {
+    expect((failure.value as { _tag: string })._tag).toBe(tag);
+  }
+}
+
+describe("legacy services", () => {
+  it.live("prints the services table by default", () => {
+    const { layer, out } = setup();
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      expect(out.stdoutText).toContain("supabase/postgres");
+      expect(out.stdoutText).toContain("supabase/gotrue");
+      expect(out.stdoutText).toContain("supabase/storage-api");
+      expect(out.stderrText).toBe("");
+    });
+  });
+
+  it.live("emits a services JSON array for --output json", () => {
+    const { layer, out } = setup({ goOutput: Option.some("json") });
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      const rows = JSON.parse(out.stdoutText) as Array<{
+        name: string;
+        local: string;
+        remote: string;
+      }>;
+      expect(rows).toHaveLength(10);
+      expect(rows[0]).toMatchObject({ name: "supabase/postgres", local: "17.6.1.132" });
+    });
+  });
+
+  it.live("emits structured JSON for --output pretty combined with --output-format json", () => {
+    // Regression guard (CLI-1546): a Go `--output pretty` must defer to the TS
+    // `--output-format json` flag instead of forcing the human-readable table.
+    const { layer, out } = setup({ format: "json", goOutput: Option.some("pretty") });
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      expect(success?.data).toMatchObject({
+        services: expect.arrayContaining([
+          expect.objectContaining({ name: "supabase/postgres", local: "17.6.1.132" }),
+        ]),
+      });
+    });
+  });
+
+  it.live("emits structured JSON for --output-format stream-json", () => {
+    const { layer, out } = setup({ format: "stream-json" });
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      expect(success?.data).toMatchObject({
+        services: expect.arrayContaining([
+          expect.objectContaining({ name: "supabase/postgres", local: "17.6.1.132" }),
+        ]),
+      });
+    });
+  });
+
+  it.live("emits a TOML services array for --output toml", () => {
+    const { layer, out } = setup({ goOutput: Option.some("toml") });
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      expect(out.stdoutText).toContain("[[services]]");
+      expect(out.stdoutText).toContain('name = "supabase/postgres"');
+    });
+  });
+
+  it.live("emits a YAML services array for --output yaml", () => {
+    const { layer, out } = setup({ goOutput: Option.some("yaml") });
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+
+      expect(out.stdoutText).toContain("- name: supabase/postgres");
+      expect(out.stdoutText).toContain("local: 17.6.1.132");
+    });
+  });
+
+  it.live("rejects --output env", () => {
+    const { layer } = setup({ goOutput: Option.some("env") });
+
+    return Effect.gen(function* () {
+      const exit = yield* legacyServices({}).pipe(Effect.provide(layer), Effect.exit);
+      expectFailureTag(exit, "LegacyServicesEnvNotSupportedError");
+    });
+  });
+
+  it.live("flushes telemetry state after the command finishes", () => {
+    const { layer, telemetry } = setup();
+
+    return Effect.gen(function* () {
+      yield* legacyServices({}).pipe(Effect.provide(layer));
+      expect(telemetry.flushed).toBe(true);
+    });
+  });
+});

--- a/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/list/list.integration.test.ts
@@ -37,6 +37,16 @@ const PROVIDER_ITEM = {
   updated_at: "2023-03-28T13:50:14.464Z",
 };
 
+const PROVIDER_ITEM_WITHOUT_SAML_ID = {
+  ...PROVIDER_ITEM,
+  saml: {
+    entity_id: "https://example.com",
+    metadata_url: "https://example.com",
+    metadata_xml: '<?xml version="2.0"?>',
+    attribute_mapping: { keys: { a: { name: "xyz", default: 3 } } },
+  },
+};
+
 const tempRoot = useLegacyTempWorkdir("supabase-sso-list-int-");
 
 interface SetupOpts {
@@ -148,6 +158,15 @@ describe("legacy sso list integration", () => {
       expect(out.stdoutText).toContain("0b0d48f6-878b-4190-88d7-2ca33ed800bc");
       expect(out.stdoutText).toContain("example.com");
       expect(out.stdoutText).toContain("2023-03-28 13:50:14");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("lists providers when the API omits items[].saml.id", () => {
+    const { layer, out } = setup({ body: { items: [PROVIDER_ITEM_WITHOUT_SAML_ID] } });
+    return Effect.gen(function* () {
+      yield* legacySsoList({ projectRef: Option.none() });
+      expect(out.stdoutText).toContain("0b0d48f6-878b-4190-88d7-2ca33ed800bc");
+      expect(out.stdoutText).toContain("example.com");
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/shared/legacy-colors.ts
+++ b/apps/cli/src/legacy/shared/legacy-colors.ts
@@ -1,0 +1,22 @@
+import { styleText } from "node:util";
+
+/**
+ * Ports of Go's `utils.Aqua` / `utils.Bold` (`apps/cli-go/internal/utils/colors.go`).
+ *
+ * Go uses lipgloss, which auto-detects the output profile and renders **plain**
+ * text when the stream is not a TTY (piped output, CI, tests). `styleText`
+ * mirrors that: with `validateStream` (the default) it checks the target stream
+ * and `NO_COLOR`, returning the unstyled string when colour is unsupported. We
+ * point it at `process.stderr` because the bootstrap progress / suggestion lines
+ * these style are written to stderr.
+ *
+ * lipgloss colour "14" is bright cyan; `"cyan"` is the closest faithful match,
+ * matching `branches.prompt.ts`'s existing port of `utils.Aqua`.
+ */
+export function legacyAqua(text: string): string {
+  return styleText("cyan", text, { stream: process.stderr });
+}
+
+export function legacyBold(text: string): string {
+  return styleText("bold", text, { stream: process.stderr });
+}

--- a/apps/cli/src/legacy/shared/legacy-ensure-login.ts
+++ b/apps/cli/src/legacy/shared/legacy-ensure-login.ts
@@ -1,0 +1,181 @@
+import { Effect, Option } from "effect";
+
+import { LegacyCredentials } from "../auth/legacy-credentials.service.ts";
+import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { LegacyTelemetryState } from "../telemetry/legacy-telemetry-state.service.ts";
+import type { NonInteractiveError } from "../../shared/output/errors.ts";
+import { Output } from "../../shared/output/output.service.ts";
+import { Browser } from "../../shared/runtime/browser.service.ts";
+import { Tty } from "../../shared/runtime/tty.service.ts";
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import { withAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
+import { EventLoginCompleted } from "../../shared/telemetry/event-catalog.ts";
+import {
+  LegacyLoginApi,
+  type LegacyLoginSessionResponse,
+} from "../commands/login/login-api.service.ts";
+import { LegacyLoginCrypto } from "../commands/login/login-crypto.service.ts";
+import { legacySuggestClaudePlugin } from "../commands/login/login-claude-hint.ts";
+import {
+  LegacyLoginFailedError,
+  type LegacyLoginVerificationError,
+} from "../commands/login/login.errors.ts";
+import { legacyDashboardUrl } from "./legacy-profile.ts";
+import { resolveLegacyAccessToken } from "./legacy-resolve-token.ts";
+
+// Go's `maxRetries` (`login.go:130`): the initial probe plus 2 retries (3 total).
+const MAX_LOGIN_RETRIES = 2;
+
+export const LEGACY_LOGGED_IN_MSG = "You are now logged in. Happy coding!\n";
+
+/**
+ * Mirrors Go's `handleTelemetryAfterLogin` (`login.go:273-299`): fetch the gotrue
+ * id (best-effort), stitch or clear the telemetry identity, then always capture
+ * `cli_login_completed`. The capture rides the just-stitched identity so PostHog
+ * attributes it to the user.
+ *
+ * NOTE: Go's `StitchLogin` only *aliases* — it does NOT call `identify`. Do not add
+ * `analytics.identify` here; that is a `next/` behavior and would emit an event Go
+ * never sends. Shared by the token path (`login`) and the browser flow.
+ */
+export const legacyPostLoginTelemetry = Effect.fnUntraced(function* (token: string) {
+  const loginApi = yield* LegacyLoginApi;
+  const telemetryState = yield* LegacyTelemetryState;
+  const analytics = yield* Analytics;
+  const cliConfig = yield* LegacyCliConfig;
+
+  const gotrueId = yield* loginApi.fetchGotrueId(cliConfig.apiUrl, token);
+  if (Option.isSome(gotrueId)) {
+    yield* telemetryState.stitchLogin(gotrueId.value);
+    yield* analytics
+      .capture(EventLoginCompleted)
+      .pipe(withAnalyticsContext({ distinct_id: gotrueId.value }));
+  } else {
+    yield* telemetryState.clearDistinctId;
+    yield* analytics.capture(EventLoginCompleted);
+  }
+});
+
+export interface LegacyBrowserLoginOptions {
+  /** When true, prompt + open the browser; when false, just print the login link. */
+  readonly openBrowser: boolean;
+  /** Token name (Go's `--name`); `None` falls back to the generated default. */
+  readonly tokenName: Option.Option<string>;
+}
+
+/**
+ * The interactive browser login flow, extracted from `login`'s handler so
+ * `bootstrap` can reuse it: generate an ECDH keypair, surface the dashboard
+ * login link (optionally opening the browser), poll for the verification code
+ * with Go's retry/notify cadence, decrypt + persist the token, then run the
+ * post-login telemetry and print the success banners. Owns the single
+ * `cli_login_completed` capture for this path.
+ */
+export const legacyBrowserLogin = Effect.fnUntraced(function* (opts: LegacyBrowserLoginOptions) {
+  const output = yield* Output;
+  const crypto = yield* LegacyLoginCrypto;
+  const loginApi = yield* LegacyLoginApi;
+  const credentials = yield* LegacyCredentials;
+  const cliConfig = yield* LegacyCliConfig;
+  const browser = yield* Browser;
+  const tty = yield* Tty;
+
+  const claudeHint = legacySuggestClaudePlugin({ stdoutIsTty: tty.stdoutIsTty });
+  const apiHost = cliConfig.apiUrl;
+
+  const { ecdh, publicKeyHex } = yield* crypto.generateKeyPair;
+  const sessionId = yield* crypto.generateSessionId;
+  const tokenName = Option.isSome(opts.tokenName)
+    ? opts.tokenName.value
+    : yield* crypto.defaultTokenName;
+
+  // Go concatenates the query string without URL-encoding (`login.go:197-198`).
+  const loginUrl =
+    `${legacyDashboardUrl(cliConfig.profile)}/cli/login` +
+    `?session_id=${sessionId}&token_name=${tokenName}&public_key=${publicKeyHex}`;
+
+  // The banners are human-facing text — suppressed in json / stream-json so
+  // stdout stays payload-only. The prompts still run (and fail cleanly with
+  // `NonInteractiveError` in a non-interactive machine mode).
+  const isText = output.format === "text";
+  if (opts.openBrowser) {
+    if (isText) {
+      yield* output.raw(
+        "Hello from Supabase! Press Enter to open browser and login automatically.\n",
+        "stdout",
+      );
+    }
+    yield* output.promptText("");
+    if (isText) {
+      yield* output.raw(
+        `Here is your login link in case browser did not open ${loginUrl}\n\n`,
+        "stdout",
+      );
+    }
+    yield* Effect.ignore(browser.open(loginUrl));
+  } else if (isText) {
+    yield* output.raw(`Here is your login link, open it in the browser ${loginUrl}\n\n`, "stdout");
+  }
+
+  // Verify + retry, mirroring Go's `pollForAccessToken` backoff
+  // (`login.go:132-166`): the notifier prints `<err>\nRetry (n/2): ` after the
+  // first 2 failures; the 3rd failure gives up without a notice.
+  const verifyWithRetries = (
+    failuresSoFar: number,
+  ): Effect.Effect<
+    LegacyLoginSessionResponse,
+    LegacyLoginFailedError | NonInteractiveError,
+    Output | LegacyLoginApi
+  > =>
+    Effect.gen(function* () {
+      const code = yield* output.promptText("Enter your verification code: ", {
+        validate: (v) => (v.trim().length > 0 ? undefined : "Verification code is required"),
+      });
+      return yield* loginApi.fetchLoginSession(apiHost, sessionId, code.trim());
+    }).pipe(
+      Effect.catchTag("LegacyLoginVerificationError", (err: LegacyLoginVerificationError) =>
+        Effect.gen(function* () {
+          const failures = failuresSoFar + 1;
+          if (failures > MAX_LOGIN_RETRIES) {
+            return yield* Effect.fail(new LegacyLoginFailedError({ message: err.message }));
+          }
+          yield* output.raw(`${err.message}\nRetry (${failures}/${MAX_LOGIN_RETRIES}): `, "stderr");
+          return yield* verifyWithRetries(failures);
+        }),
+      ),
+    );
+
+  const session = yield* verifyWithRetries(0);
+
+  const token = yield* crypto.decryptToken(ecdh, {
+    ciphertext: session.access_token,
+    publicKey: session.public_key,
+    nonce: session.nonce,
+  });
+  // Go returns the raw save error here (`login.go:222-224`) — not the
+  // "cannot save provided token" wrapper used on the token path.
+  yield* credentials.saveAccessToken(token);
+  yield* legacyPostLoginTelemetry(token);
+
+  if (output.format !== "text") {
+    yield* output.success("You are now logged in.", { token_name: tokenName });
+    return;
+  }
+  yield* output.raw(`Token ${tokenName} created successfully.\n\n`, "stdout");
+  yield* output.raw(LEGACY_LOGGED_IN_MSG, "stdout");
+  if (claudeHint.length > 0) yield* output.raw(`${claudeHint}\n`, "stderr");
+});
+
+/**
+ * Ensures a Management API access token exists. Mirrors Go's `bootstrap` login
+ * step (`bootstrap.go:67-77`): if a token is already resolvable (env / keyring /
+ * file) it is a no-op; otherwise the browser login flow runs and fires
+ * `cli_login_completed` once.
+ */
+export const legacyEnsureLogin = Effect.fnUntraced(function* (opts: { openBrowser: boolean }) {
+  const existing = yield* resolveLegacyAccessToken;
+  if (Option.isSome(existing)) {
+    return;
+  }
+  yield* legacyBrowserLogin({ openBrowser: opts.openBrowser, tokenName: Option.none() });
+});

--- a/apps/cli/src/legacy/shared/legacy-get-api-keys.ts
+++ b/apps/cli/src/legacy/shared/legacy-get-api-keys.ts
@@ -1,0 +1,33 @@
+import type { V1GetProjectApiKeysOutput } from "@supabase/api/effect";
+import { Effect } from "effect";
+
+import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import {
+  LegacyProjectsApiKeysNetworkError,
+  LegacyProjectsApiKeysUnexpectedStatusError,
+} from "../commands/projects/projects.errors.ts";
+import { mapLegacyHttpError } from "./legacy-http-errors.ts";
+
+type ApiKeys = typeof V1GetProjectApiKeysOutput.Type;
+
+const mapApiKeysError = mapLegacyHttpError({
+  networkError: LegacyProjectsApiKeysNetworkError,
+  statusError: LegacyProjectsApiKeysUnexpectedStatusError,
+  networkMessage: (cause) => `failed to get api keys: ${cause}`,
+  statusMessage: (status, body) => `unexpected get api keys status ${status}: ${body}`,
+});
+
+/**
+ * Ports Go's `apiKeys.RunGetApiKeys` (`apps/cli-go/internal/projects/apiKeys/api_keys.go:41-49`):
+ * `GET /v1/projects/{ref}/api-keys` with no `reveal` param, mapping transport /
+ * non-200 failures to the same `failed to get api keys` / `unexpected get api keys
+ * status` errors Go raises. Shared by `projects api-keys` (display) and `bootstrap`
+ * (which derives the `.env` keys).
+ */
+export const legacyGetProjectApiKeys = Effect.fnUntraced(function* (ref: string) {
+  const api = yield* LegacyPlatformApi;
+  const keys: ApiKeys = yield* api.v1
+    .getProjectApiKeys({ ref })
+    .pipe(Effect.catch(mapApiKeysError));
+  return keys;
+});

--- a/apps/cli/src/legacy/shared/legacy-link-services-core.ts
+++ b/apps/cli/src/legacy/shared/legacy-link-services-core.ts
@@ -1,0 +1,126 @@
+import type { ApiClient } from "@supabase/api/effect";
+import { Effect, FileSystem, Option, Path } from "effect";
+import type { PlatformError } from "effect/PlatformError";
+
+import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import { legacyTempPaths } from "./legacy-temp-paths.ts";
+import {
+  legacyFetchGotrueVersion,
+  legacyFetchPostgrestVersion,
+  legacyFetchStorageVersion,
+} from "./legacy-tenant-versions.ts";
+
+export interface LegacyLinkServicesInput {
+  readonly ref: string;
+  /**
+   * Tenant API key used for the service version probes. `link` passes the
+   * service-role key; `bootstrap` passes the anon key (mirroring Go's
+   * `link.LinkServices(ctx, ref, tenant.NewApiKey(keys).Anon, …)`).
+   */
+  readonly serviceKey: string;
+  readonly skipPooler: boolean;
+  /**
+   * Absolute project directory whose `supabase/.temp/*` files receive the linked
+   * service metadata. Passed explicitly (never read from `LegacyCliConfig.workdir`)
+   * because `bootstrap` links a freshly created project directory that differs
+   * from the cwd-walked config workdir.
+   */
+  readonly workdir: string;
+}
+
+type WriteTempFile = (filePath: string, content: string) => Effect.Effect<void, PlatformError>;
+
+/**
+ * Ports Go's `link.LinkServices` (`apps/cli-go/internal/link/link.go:71-103`): the
+ * best-effort portion of linking that writes `supabase/.temp/{storage-migration,
+ * pooler-url,rest-version,gotrue-version,storage-version}`. Every probe is
+ * best-effort — a single unreachable service never fails the caller. This core
+ * does NOT write `project-ref`, the linked-project cache, or fire
+ * `cli_project_linked`; `link.Run` (the standalone command) owns those, and Go's
+ * `bootstrap` deliberately skips them by calling `LinkServices` directly.
+ */
+export const legacyLinkServicesCore = Effect.fnUntraced(function* (input: LegacyLinkServicesInput) {
+  const api = yield* LegacyPlatformApi;
+  const cliConfig = yield* LegacyCliConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const paths = legacyTempPaths(path, input.workdir);
+
+  const writeTempFile: WriteTempFile = (filePath, content) =>
+    fs
+      .makeDirectory(path.dirname(filePath), { recursive: true })
+      .pipe(Effect.andThen(() => fs.writeFileString(filePath, content)));
+
+  yield* linkStorageMigration(api, input.ref, paths.storageMigration, writeTempFile);
+  yield* linkPooler({
+    api,
+    ref: input.ref,
+    skipPooler: input.skipPooler,
+    fs,
+    poolerUrlPath: paths.poolerUrl,
+    writeTempFile,
+  });
+
+  const tenantOpts = {
+    ref: input.ref,
+    projectHost: cliConfig.projectHost,
+    serviceKey: input.serviceKey,
+    userAgent: cliConfig.userAgent,
+  };
+  yield* legacyFetchPostgrestVersion(tenantOpts).pipe(
+    Effect.flatMap((v) =>
+      Option.isSome(v) ? writeTempFile(paths.restVersion, v.value) : Effect.void,
+    ),
+    Effect.ignore,
+  );
+  yield* legacyFetchGotrueVersion(tenantOpts).pipe(
+    Effect.flatMap((v) =>
+      Option.isSome(v) ? writeTempFile(paths.gotrueVersion, v.value) : Effect.void,
+    ),
+    Effect.ignore,
+  );
+  yield* legacyFetchStorageVersion(tenantOpts).pipe(
+    Effect.flatMap((v) =>
+      Option.isSome(v) ? writeTempFile(paths.storageVersion, v.value) : Effect.void,
+    ),
+    Effect.ignore,
+  );
+});
+
+const linkStorageMigration = (
+  api: ApiClient,
+  ref: string,
+  storageMigrationPath: string,
+  writeTempFile: WriteTempFile,
+) =>
+  api.v1.getStorageConfig({ ref }).pipe(
+    Effect.flatMap((config) => writeTempFile(storageMigrationPath, config.migrationVersion)),
+    Effect.ignore,
+  );
+
+const linkPooler = (opts: {
+  api: ApiClient;
+  ref: string;
+  skipPooler: boolean;
+  fs: FileSystem.FileSystem;
+  poolerUrlPath: string;
+  writeTempFile: WriteTempFile;
+}) =>
+  Effect.gen(function* () {
+    if (opts.skipPooler) {
+      // Use direct connection: drop any cached pooler URL (link.go:81-84).
+      yield* opts.fs.remove(opts.poolerUrlPath, { recursive: true }).pipe(Effect.ignore);
+      return;
+    }
+    const configs = yield* opts.api.v1.getPoolerConfig({ ref: opts.ref });
+    const primary = configs.find((c) => c.database_type === "PRIMARY");
+    if (primary === undefined) return;
+    // Strip the [YOUR-PASSWORD] placeholder; force session mode 5432 unless the
+    // pooler already reports session mode (link.go:221-229).
+    let connectionString = primary.connection_string.replaceAll(":[YOUR-PASSWORD]", "");
+    if (primary.pool_mode !== "session") {
+      connectionString = connectionString.replaceAll(":6543/", ":5432/");
+    }
+    yield* opts.writeTempFile(opts.poolerUrlPath, connectionString);
+  }).pipe(Effect.ignore);

--- a/apps/cli/src/legacy/shared/legacy-login-api.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-login-api.layer.ts
@@ -2,9 +2,12 @@ import { Effect, Layer, Option } from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 
-import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
-import { LegacyLoginApi, type LegacyLoginSessionResponse } from "./login-api.service.ts";
-import { LegacyLoginVerificationError } from "./login.errors.ts";
+import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import {
+  LegacyLoginApi,
+  type LegacyLoginSessionResponse,
+} from "../commands/login/login-api.service.ts";
+import { LegacyLoginVerificationError } from "../commands/login/login.errors.ts";
 
 const POLL_TIMEOUT = "10 seconds";
 

--- a/apps/cli/src/legacy/shared/legacy-login-crypto.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-login-crypto.layer.ts
@@ -3,8 +3,11 @@ import { createDecipheriv, createECDH, randomUUID, type ECDH } from "node:crypto
 import { hostname, userInfo } from "node:os";
 import { Effect, Layer } from "effect";
 
-import { LegacyLoginCrypto, type LegacyEncryptedPayload } from "./login-crypto.service.ts";
-import { LegacyLoginCryptoError, LegacyLoginDecryptError } from "./login.errors.ts";
+import {
+  LegacyLoginCrypto,
+  type LegacyEncryptedPayload,
+} from "../commands/login/login-crypto.service.ts";
+import { LegacyLoginCryptoError, LegacyLoginDecryptError } from "../commands/login/login.errors.ts";
 
 const DECRYPTION_ERROR_MSG = "cannot decrypt access token";
 

--- a/apps/cli/src/legacy/shared/legacy-project-create-core.ts
+++ b/apps/cli/src/legacy/shared/legacy-project-create-core.ts
@@ -1,0 +1,167 @@
+import { type V1CreateAProjectInput, operationDefinitions } from "@supabase/api/effect";
+import { Effect, Option } from "effect";
+
+import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { LegacyOutputFlag } from "../../shared/legacy/global-flags.ts";
+import { Output } from "../../shared/output/output.service.ts";
+import { encodeEnv, encodeGoJson, encodeToml, encodeYaml } from "./legacy-go-output.encoders.ts";
+import { sanitizeLegacyErrorBody } from "./legacy-http-errors.ts";
+import {
+  LegacyProjectsCreateNetworkError,
+  LegacyProjectsCreateUnexpectedStatusError,
+} from "../commands/projects/projects.errors.ts";
+import {
+  dashboardUrlForProfile,
+  readProjectField,
+  renderProjectCreateTable,
+} from "../commands/projects/projects.format.ts";
+import {
+  legacyPromptDbPassword,
+  legacyPromptOrgId,
+  legacyPromptProjectName,
+  legacyPromptProjectRegion,
+} from "../commands/projects/projects.prompt.ts";
+
+type CreateInput = typeof V1CreateAProjectInput.Type;
+
+export interface LegacyProjectCreateInput {
+  readonly name: string;
+  readonly orgId: string;
+  readonly dbPassword: string;
+  readonly region: CreateInput["region"];
+  readonly size: CreateInput["desired_instance_size"];
+  readonly templateUrl: string | undefined;
+  /**
+   * Standalone `projects create` emits a `--output-format` json/stream-json
+   * success result; `bootstrap` suppresses it (it emits its own top-level
+   * result), matching Go's `create.Run` which only ever echoes via `-o`.
+   */
+  readonly emitStructuredResult: boolean;
+}
+
+/** Go's `printKeyValue` (`create.go`): `key` + `:` + pad to width 20 + value. */
+function printKeyValue(key: string, value: string): string {
+  return `${key}:${" ".repeat(Math.max(0, 20 - key.length))}${value}`;
+}
+
+/**
+ * Ports Go's `create.Run` (`apps/cli-go/internal/projects/create/create.go:16-50`):
+ * `promptMissingParams` (prompt for / echo each empty field), `POST /v1/projects`,
+ * and the project echo (`Created a new project at …` plus the `-o`/pretty render).
+ *
+ * Returns the created ref + the resolved db password (Go stores both globally via
+ * `flags.ProjectRef` / `viper.Set("DB_PASSWORD", …)`). Does NOT validate required
+ * flags (that is the standalone command's cobra PreRunE) and does NOT write the
+ * linked-project cache (the caller owns that via `Effect.ensuring`).
+ */
+export const legacyProjectCreateCore = Effect.fnUntraced(function* (
+  input: LegacyProjectCreateInput,
+) {
+  const output = yield* Output;
+  const goOutputFlag = yield* LegacyOutputFlag;
+  const api = yield* LegacyPlatformApi;
+  const cliConfig = yield* LegacyCliConfig;
+
+  let name = input.name;
+  let orgId = input.orgId;
+  let region: CreateInput["region"] = input.region;
+  let dbPassword = input.dbPassword;
+  const size = input.size;
+
+  // promptMissingParams (`create.go:58-85`): prompt for each empty value and
+  // echo the resolved value to stderr in text mode.
+  if (name.length === 0) {
+    name = yield* legacyPromptProjectName();
+  } else if (output.format === "text") {
+    yield* output.raw(printKeyValue("Creating project", name) + "\n", "stderr");
+  }
+  if (orgId.length === 0) {
+    orgId = yield* legacyPromptOrgId();
+    if (output.format === "text") {
+      yield* output.raw(printKeyValue("Selected org-id", orgId) + "\n", "stderr");
+    }
+  }
+  if (region === undefined) {
+    const chosenRegion = yield* legacyPromptProjectRegion();
+    region = chosenRegion;
+    if (output.format === "text") {
+      yield* output.raw(printKeyValue("Selected region", chosenRegion) + "\n", "stderr");
+    }
+  }
+  if (dbPassword.length === 0) {
+    dbPassword = yield* legacyPromptDbPassword();
+  }
+
+  const body: CreateInput = {
+    name,
+    organization_slug: orgId,
+    db_pass: dbPassword,
+    ...(region !== undefined ? { region } : {}),
+    ...(size !== undefined ? { desired_instance_size: size } : {}),
+    ...(input.templateUrl !== undefined ? { template_url: input.templateUrl } : {}),
+  };
+
+  const creating = output.format === "text" ? yield* output.task("Creating project...") : undefined;
+
+  // `executeRaw` sends the body with Go-sorted keys (matching `json.Marshal`)
+  // and skips output decoding: the 201 response's `ref` can be the cli-e2e
+  // `__PROJECT_REF__` placeholder, which the generated schema rejects.
+  const response = yield* api.executeRaw(operationDefinitions.v1CreateAProject, body).pipe(
+    Effect.tapError(() => creating?.fail() ?? Effect.void),
+    Effect.mapError(
+      (cause) =>
+        new LegacyProjectsCreateNetworkError({ message: `failed to create project: ${cause}` }),
+    ),
+  );
+
+  if (response.status !== 201) {
+    const errorBody = sanitizeLegacyErrorBody(
+      yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+    );
+    yield* creating?.fail() ?? Effect.void;
+    return yield* new LegacyProjectsCreateUnexpectedStatusError({
+      status: response.status,
+      body: errorBody,
+      message: `Unexpected error creating project: ${errorBody}`,
+    });
+  }
+
+  const created = yield* response.json.pipe(Effect.orElseSucceed((): unknown => ({})));
+  yield* creating?.clear() ?? Effect.void;
+
+  const id = readProjectField(created, "id");
+
+  // Go prints this to stderr for every output format (`create.go:33-34`).
+  const projectUrl = `${dashboardUrlForProfile(cliConfig.profile)}/project/${id}`;
+  yield* output.raw(`Created a new project at ${projectUrl}\n`, "stderr");
+
+  const goFmt = Option.getOrUndefined(goOutputFlag);
+  if (goFmt === "json") {
+    yield* output.raw(encodeGoJson(created));
+    return { ref: id, dbPassword };
+  }
+  if (goFmt === "yaml") {
+    yield* output.raw(encodeYaml(created));
+    return { ref: id, dbPassword };
+  }
+  if (goFmt === "toml") {
+    yield* output.raw(encodeToml(created) + "\n");
+    return { ref: id, dbPassword };
+  }
+  if (goFmt === "env") {
+    yield* output.raw(encodeEnv(created) + "\n");
+    return { ref: id, dbPassword };
+  }
+
+  if (output.format === "json" || output.format === "stream-json") {
+    if (input.emitStructuredResult) {
+      const data = typeof created === "object" && created !== null ? created : {};
+      yield* output.success("Created project", { ...data });
+    }
+    return { ref: id, dbPassword };
+  }
+
+  yield* output.raw(renderProjectCreateTable(created));
+  return { ref: id, dbPassword };
+});

--- a/apps/cli/src/legacy/shared/legacy-tenant-keys.ts
+++ b/apps/cli/src/legacy/shared/legacy-tenant-keys.ts
@@ -1,0 +1,43 @@
+export interface LegacyApiKeyEntry {
+  readonly api_key?: string | null;
+  readonly type?: string | null;
+  readonly name: string;
+  readonly secret_jwt_template?: Record<string, unknown> | null;
+}
+
+/**
+ * Mirrors `tenant.NewApiKey` (`apps/cli-go/internal/utils/tenant/client.go:28-57`):
+ * `publishable` -> anon, `secret` with `role=service_role` -> service_role, else the
+ * legacy name-based fallback (`anon` / `service_role`).
+ *
+ * Shared by `link` (which writes the service-role key into `.temp` version probes)
+ * and `bootstrap` (which derives the anon key for the generated `.env`).
+ */
+export function legacyExtractServiceKeys(keys: ReadonlyArray<LegacyApiKeyEntry>): {
+  readonly anon: string;
+  readonly serviceRole: string;
+} {
+  let anon = "";
+  let serviceRole = "";
+  for (const key of keys) {
+    const value = key.api_key;
+    if (value === undefined || value === null) continue;
+    if (key.type === "publishable") {
+      anon = value;
+      continue;
+    }
+    if (key.type === "secret") {
+      const role = key.secret_jwt_template?.["role"];
+      if (typeof role === "string" && role.toLowerCase() === "service_role") {
+        serviceRole = value;
+      }
+      continue;
+    }
+    if (key.name === "anon" && anon.length === 0) {
+      anon = value;
+    } else if (key.name === "service_role" && serviceRole.length === 0) {
+      serviceRole = value;
+    }
+  }
+  return { anon, serviceRole };
+}

--- a/apps/cli/src/legacy/telemetry/legacy-linked-project-cache.layer.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-linked-project-cache.layer.ts
@@ -41,9 +41,9 @@ export const legacyLinkedProjectCacheLayer = Layer.effect(
     const path = yield* Path.Path;
 
     return LegacyLinkedProjectCache.of({
-      cache: (ref: string) =>
+      cache: (ref: string, workdir?: string) =>
         Effect.gen(function* () {
-          const cachePath = legacyTempPaths(path, cliConfig.workdir).linkedProjectCache;
+          const cachePath = legacyTempPaths(path, workdir ?? cliConfig.workdir).linkedProjectCache;
           const exists = yield* fs.exists(cachePath).pipe(Effect.orElseSucceed(() => false));
           if (exists) return;
 

--- a/apps/cli/src/legacy/telemetry/legacy-linked-project-cache.service.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-linked-project-cache.service.ts
@@ -6,11 +6,17 @@ interface LegacyLinkedProjectCacheShape {
    * Fire-and-forget: fetches the project metadata from the Management API and
    * writes `<workdir>/supabase/.temp/linked-project.json` if no cache exists yet.
    *
+   * `workdir` overrides the directory the cache resolves against. Callers that have
+   * already changed the working directory (e.g. `bootstrap`, whose target workdir can
+   * come from an interactive prompt rather than `cliConfig.workdir`) pass their resolved
+   * workdir so the cache lands beside the other `supabase/.temp/` files. When omitted it
+   * falls back to `cliConfig.workdir` (the cwd-walk result), matching every other caller.
+   *
    * Best-effort. Never fails the calling effect — auth errors, network errors,
    * and write errors are all swallowed (matches Go's `ensureProjectGroupsCached`
    * which logs to debug and returns).
    */
-  readonly cache: (ref: string) => Effect.Effect<void>;
+  readonly cache: (ref: string, workdir?: string) => Effect.Effect<void>;
 }
 
 export class LegacyLinkedProjectCache extends Context.Service<

--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -10,6 +10,7 @@ import { loginCommand } from "../commands/login/login.command.ts";
 import { logoutCommand } from "../commands/logout/logout.command.ts";
 import { logsCommand } from "../commands/logs/logs.command.ts";
 import { apiCommand } from "../commands/platform/api.command.ts";
+import { servicesCommand } from "../commands/services/services.command.ts";
 import { startCommand } from "../commands/start/start.command.ts";
 import { statusCommand } from "../commands/status/status.command.ts";
 import { stopCommand } from "../commands/stop/stop.command.ts";
@@ -35,6 +36,7 @@ export const nextRoot = Command.make("supabase").pipe(
     branchesCommand,
     linkCommand,
     unlinkCommand,
+    servicesCommand,
     stackCommand,
     startCommand,
     stopCommand,

--- a/apps/cli/src/next/commands/services/services.command.ts
+++ b/apps/cli/src/next/commands/services/services.command.ts
@@ -1,0 +1,30 @@
+import { Layer } from "effect";
+import { Command } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+import { credentialsLayer } from "../../auth/credentials.layer.ts";
+import { projectLinkStateLayer } from "../../config/project-link-state.layer.ts";
+import { provideProjectCommandRuntime } from "../../config/project-runtime.layer.ts";
+import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../shared/telemetry/command-instrumentation.ts";
+import { services } from "./services.handler.ts";
+
+const servicesRuntimeLayer = provideProjectCommandRuntime(
+  Layer.mergeAll(
+    credentialsLayer,
+    projectLinkStateLayer,
+    commandRuntimeLayer(["services"]),
+    // `fetchLinkedServiceVersions` builds its management/tenant API clients from
+    // the ambient HttpClient rather than self-provisioning one.
+    FetchHttpClient.layer,
+  ),
+);
+
+export const servicesCommand = Command.make("services").pipe(
+  Command.withDescription(
+    "Show versions of local Supabase services.\n\nPrints the local image matrix and, when this checkout is linked and authenticated, best-effort linked service versions for comparison.",
+  ),
+  Command.withShortDescription("Show versions of all Supabase services"),
+  Command.withHandler(() => services().pipe(withCommandInstrumentation(), withJsonErrorHandling)),
+  Command.provide(servicesRuntimeLayer),
+);

--- a/apps/cli/src/next/commands/services/services.handler.ts
+++ b/apps/cli/src/next/commands/services/services.handler.ts
@@ -1,0 +1,57 @@
+import { Effect, Exit, Option } from "effect";
+import { Credentials } from "../../auth/credentials.service.ts";
+import { CliConfig } from "../../config/cli-config.service.ts";
+import { ProjectLinkState } from "../../config/project-link-state.service.ts";
+import { Output } from "../../../shared/output/output.service.ts";
+import {
+  CommandRuntime,
+  getCommandRuntimeCommand,
+} from "../../../shared/runtime/command-runtime.service.ts";
+import {
+  fetchLinkedServiceVersions,
+  formatServicesWarning,
+  listLocalServiceVersions,
+  mergeRemoteServiceVersions,
+  renderServicesTable,
+  renderServicesWarning,
+} from "../../../shared/services/services.shared.ts";
+
+export const services = Effect.fnUntraced(function* () {
+  const output = yield* Output;
+  const cliConfig = yield* CliConfig;
+  const credentials = yield* Credentials;
+  const projectLinkState = yield* ProjectLinkState;
+  const commandRuntime = yield* CommandRuntime;
+
+  const linkedStateExit = yield* projectLinkState.load.pipe(Effect.exit);
+  const linkedState = Exit.isSuccess(linkedStateExit) ? linkedStateExit.value : Option.none();
+  const accessToken = yield* credentials.getAccessToken;
+
+  let rows = listLocalServiceVersions();
+  if (Option.isSome(linkedState) && Option.isSome(accessToken)) {
+    const remote = yield* fetchLinkedServiceVersions({
+      apiUrl: cliConfig.apiUrl,
+      projectHost: cliConfig.projectHost,
+      projectRef: linkedState.value.project.ref,
+      accessToken: accessToken.value,
+      userAgent: "@supabase/cli",
+      headers: {
+        "X-Supabase-Command": getCommandRuntimeCommand(commandRuntime),
+        "X-Supabase-Command-Run-ID": commandRuntime.commandRunId,
+      },
+    });
+    rows = mergeRemoteServiceVersions(remote);
+  }
+
+  const warning = renderServicesWarning(rows);
+  if (warning !== undefined) {
+    yield* output.raw(formatServicesWarning(warning, output.format === "text"), "stderr");
+  }
+
+  if (output.format === "text") {
+    yield* output.raw(renderServicesTable(rows));
+    return;
+  }
+
+  yield* output.success("", { services: rows });
+});

--- a/apps/cli/src/next/commands/services/services.integration.test.ts
+++ b/apps/cli/src/next/commands/services/services.integration.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Redacted } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { CliConfig } from "../../config/cli-config.service.ts";
+import {
+  ProjectLinkState,
+  type ProjectLinkStateValue,
+} from "../../config/project-link-state.service.ts";
+import { InvalidProjectLinkStateError } from "../../config/project-link-state.service.ts";
+import { Credentials } from "../../auth/credentials.service.ts";
+import { mockOutput } from "../../../../tests/helpers/mocks.ts";
+import { CommandRuntime } from "../../../shared/runtime/command-runtime.service.ts";
+import { services } from "./services.handler.ts";
+
+const LINKED_REF = "abcdefghijklmnopqrst";
+
+function linkedStateFixture(): ProjectLinkStateValue {
+  return {
+    project: {
+      ref: LINKED_REF,
+      name: "Linked Project",
+      organization_id: "org-id",
+      organization_slug: "org",
+    },
+    active_branch: { ref: "branch-ref", name: "main", is_default: true },
+    fetchedAt: "2026-03-13T12:00:00.000Z",
+    versions: {},
+  };
+}
+
+function setup(
+  opts: {
+    format?: "text" | "json" | "stream-json";
+    linkedState?: Option.Option<ProjectLinkStateValue>;
+    invalidLinkedState?: boolean;
+    accessToken?: string;
+    apiUrl?: string;
+  } = {},
+) {
+  const out = mockOutput({
+    format: opts.format ?? "text",
+    interactive: (opts.format ?? "text") === "text",
+  });
+  const linkedState = opts.linkedState ?? Option.none<ProjectLinkStateValue>();
+
+  return {
+    out,
+    layer: Layer.mergeAll(
+      out.layer,
+      FetchHttpClient.layer,
+      Layer.succeed(
+        CliConfig,
+        CliConfig.of({
+          apiUrl: opts.apiUrl ?? "https://api.supabase.com",
+          dashboardUrl: "https://supabase.com/dashboard",
+          projectHost: "supabase.co",
+          telemetryPosthogHost: "https://ph.supabase.com",
+          telemetryPosthogKey: Option.none(),
+          accessToken: Option.none(),
+          noKeyring: Option.none(),
+          supabaseHome: "/tmp/supabase-home",
+          debug: Option.none(),
+          telemetryDebug: Option.none(),
+          telemetryDisabled: Option.none(),
+          doNotTrack: Option.none(),
+        }),
+      ),
+      Layer.succeed(
+        Credentials,
+        Credentials.of({
+          getAccessToken: Effect.succeed(
+            opts.accessToken === undefined
+              ? Option.none()
+              : Option.some(Redacted.make(opts.accessToken)),
+          ),
+          saveAccessToken: () => Effect.die("unexpected saveAccessToken"),
+          deleteAccessToken: Effect.die("unexpected deleteAccessToken"),
+        }),
+      ),
+      Layer.succeed(
+        ProjectLinkState,
+        ProjectLinkState.of({
+          load: opts.invalidLinkedState
+            ? Effect.fail(
+                new InvalidProjectLinkStateError({
+                  detail: "broken project link state",
+                  suggestion: "fix it",
+                }),
+              )
+            : Effect.succeed(linkedState),
+          save: () => Effect.die("unexpected save"),
+          clear: Effect.die("unexpected clear"),
+          getActiveBranch: Effect.succeed(Option.none()),
+          setActiveBranch: () => Effect.die("unexpected setActiveBranch"),
+        }),
+      ),
+      Layer.succeed(
+        CommandRuntime,
+        CommandRuntime.of({
+          commandPath: ["services"],
+          commandRunId: "run-services-test",
+        }),
+      ),
+    ),
+  };
+}
+
+describe("next services", () => {
+  it.live("prints the services table in text mode", () => {
+    const { layer, out } = setup();
+
+    return Effect.gen(function* () {
+      yield* services().pipe(Effect.provide(layer));
+
+      expect(out.stdoutText).toContain("supabase/postgres");
+      expect(out.stdoutText).toContain("supabase/gotrue");
+      expect(out.stdoutText).toContain("supabase/storage-api");
+      expect(out.stderrText).toBe("");
+    });
+  });
+
+  it.live("emits structured services data in json mode", () => {
+    const { layer, out } = setup({ format: "json" });
+
+    return Effect.gen(function* () {
+      yield* services().pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      expect(success?.data).toMatchObject({
+        services: expect.arrayContaining([
+          expect.objectContaining({ name: "supabase/postgres", local: "17.6.1.132" }),
+        ]),
+      });
+    });
+  });
+
+  it.live("falls back to local output when linked state is invalid", () => {
+    const { layer, out } = setup({ invalidLinkedState: true });
+
+    return Effect.gen(function* () {
+      yield* services().pipe(Effect.provide(layer));
+
+      expect(out.stdoutText).toContain("supabase/postgres");
+      expect(out.stderrText).toBe("");
+    });
+  });
+
+  it.live("merges linked service versions and warns on a version mismatch", () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === `/v1/projects/${LINKED_REF}/api-keys`) {
+          return Response.json([
+            {
+              name: "anon",
+              id: "publishable-id",
+              type: "publishable",
+              api_key: "publishable-key",
+              description: null,
+            },
+          ]);
+        }
+
+        if (url.pathname === `/v1/projects/${LINKED_REF}`) {
+          return Response.json({
+            id: LINKED_REF,
+            ref: LINKED_REF,
+            organization_id: "org-id",
+            organization_slug: "org",
+            name: "Linked Project",
+            region: "us-east-1",
+            created_at: "2026-03-13T12:00:00.000Z",
+            status: "ACTIVE_HEALTHY",
+            database: {
+              host: "db.supabase.internal",
+              version: "17.6.1.200",
+              postgres_engine: "17",
+              release_channel: "ga",
+            },
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const { layer, out } = setup({
+      format: "json",
+      linkedState: Option.some(linkedStateFixture()),
+      accessToken: "sbp_token",
+      apiUrl: server.url.origin,
+    });
+
+    return Effect.gen(function* () {
+      yield* services().pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      expect(success?.data).toMatchObject({
+        services: expect.arrayContaining([
+          expect.objectContaining({
+            name: "supabase/postgres",
+            local: "17.6.1.132",
+            remote: "17.6.1.200",
+          }),
+        ]),
+      });
+      expect(out.stderrText).toContain("WARNING:");
+    }).pipe(Effect.ensuring(Effect.promise(() => server.stop(true))));
+  });
+});

--- a/apps/cli/src/shared/services/services.shared.ts
+++ b/apps/cli/src/shared/services/services.shared.ts
@@ -1,0 +1,383 @@
+import { styleText } from "node:util";
+import { makeApiClient, type ApiClient } from "@supabase/api/effect";
+import { Data, Duration, Effect, Exit, Redacted } from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { renderGlamourTable } from "../../legacy/output/legacy-glamour-table.ts";
+
+export type RemoteServiceName = "postgres" | "auth" | "postgrest" | "storage";
+export type OptionalRemoteServiceName = Exclude<RemoteServiceName, "postgres">;
+
+// Mirrors Go's `utils.ProjectRefPattern` (`apps/cli-go/internal/utils/misc.go`).
+// Validating the ref before it reaches the management API path param or the
+// tenant gateway hostname keeps a tampered/malformed value from redirecting the
+// service-role key to an attacker-controlled host.
+const PROJECT_REF_PATTERN = /^[a-z]{20}$/;
+
+interface ServiceImageSpec {
+  readonly image: string;
+  readonly remoteService: RemoteServiceName | undefined;
+}
+
+// Mirrors the legacy `services` image matrix:
+// - source versions: `apps/cli-go/pkg/config/templates/Dockerfile`
+// - source order: `apps/cli-go/pkg/config/config.go` `GetServiceImages()`
+//
+// We keep this compiled into the TS CLI because the published package does not
+// ship the Go source tree at runtime, but the user-visible `services` output
+// still needs to match the bundled image manifest.
+export const LOCAL_SERVICE_IMAGES = [
+  { image: "supabase/postgres:17.6.1.132", remoteService: "postgres" },
+  { image: "supabase/gotrue:v2.189.0", remoteService: "auth" },
+  { image: "postgrest/postgrest:v14.12", remoteService: "postgrest" },
+  { image: "supabase/realtime:v2.103.2", remoteService: undefined },
+  { image: "supabase/storage-api:v1.60.4", remoteService: "storage" },
+  { image: "supabase/edge-runtime:v1.74.0", remoteService: undefined },
+  {
+    image: "supabase/studio:2026.06.03-sha-0bca601",
+    remoteService: undefined,
+  },
+  { image: "supabase/postgres-meta:v0.96.6", remoteService: undefined },
+  { image: "supabase/logflare:1.43.3", remoteService: undefined },
+  { image: "supabase/supavisor:2.9.7", remoteService: undefined },
+] as const satisfies ReadonlyArray<ServiceImageSpec>;
+
+const TABLE_HEADERS = ["SERVICE IMAGE", "LOCAL", "LINKED"] as const;
+
+type ProjectApiKey = {
+  readonly name: string;
+  readonly type?: "legacy" | "publishable" | "secret" | null;
+  readonly api_key?: string | null;
+  readonly secret_jwt_template?: Record<string, unknown> | null;
+};
+
+export interface ServiceVersionRow {
+  readonly name: string;
+  readonly local: string;
+  readonly remote: string;
+}
+
+function toServiceVersionRow(
+  service: ServiceImageSpec,
+  remote: Partial<Record<RemoteServiceName, string>> = {},
+): ServiceVersionRow {
+  const parts = service.image.split(":");
+  const name = parts[0];
+  const local = parts[1];
+
+  if (name === undefined || local === undefined) {
+    throw new Error(`Invalid service image entry: ${service.image}`);
+  }
+
+  return {
+    name,
+    local,
+    remote: service.remoteService === undefined ? "" : (remote[service.remoteService] ?? ""),
+  };
+}
+
+export interface ServiceFetchConfig {
+  readonly apiUrl: string;
+  readonly projectHost: string;
+  readonly projectRef: string;
+  readonly accessToken?: Redacted.Redacted<string>;
+  readonly userAgent: string;
+  readonly headers?: Readonly<Record<string, string | undefined>>;
+  readonly api?: ApiClient;
+  readonly tenantBaseUrlOverride?: string;
+}
+
+class ServiceVersionNotFoundError extends Data.TaggedError("ServiceVersionNotFoundError")<{
+  readonly service: string;
+}> {}
+
+function fieldValue(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return Reflect.get(value, key);
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const field = fieldValue(value, key);
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function selectTenantAccessKey<T extends ProjectApiKey>(
+  keys: ReadonlyArray<T>,
+): Redacted.Redacted<string> | undefined {
+  for (const key of keys) {
+    const template = key.secret_jwt_template;
+    if (
+      key.type === "secret" &&
+      typeof key.api_key === "string" &&
+      template != null &&
+      typeof template === "object" &&
+      !Array.isArray(template) &&
+      typeof template.role === "string" &&
+      template.role.toLowerCase() === "service_role"
+    ) {
+      return Redacted.make(key.api_key);
+    }
+  }
+
+  for (const key of keys) {
+    if (key.name === "service_role" && typeof key.api_key === "string") {
+      return Redacted.make(key.api_key);
+    }
+  }
+}
+
+function hasProjectAccessKey<T extends ProjectApiKey>(keys: ReadonlyArray<T>): boolean {
+  return keys.some((key) => {
+    if (typeof key.api_key !== "string") {
+      return false;
+    }
+
+    if (key.type === "publishable") {
+      return true;
+    }
+
+    if (key.name === "anon") {
+      return true;
+    }
+
+    if (key.name === "service_role") {
+      return true;
+    }
+
+    return (
+      key.type === "secret" &&
+      key.secret_jwt_template != null &&
+      typeof key.secret_jwt_template === "object" &&
+      !Array.isArray(key.secret_jwt_template) &&
+      typeof key.secret_jwt_template.role === "string" &&
+      key.secret_jwt_template.role.toLowerCase() === "service_role"
+    );
+  });
+}
+
+const authenticatedRequest = (url: string, accessKey: Redacted.Redacted<string>) => {
+  const key = Redacted.value(accessKey);
+  const request = HttpClientRequest.get(url).pipe(HttpClientRequest.setHeader("apikey", key));
+  // New-style `sb_…` keys authenticate via the `apikey` header alone; older JWT
+  // keys additionally require a bearer token. Mirrors the conditional auth in
+  // `apps/cli-go/pkg/fetcher/gateway.go` and `legacy/shared/legacy-tenant-versions.ts`.
+  return key.startsWith("sb_")
+    ? request
+    : request.pipe(HttpClientRequest.setHeader("Authorization", `Bearer ${key}`));
+};
+
+const fetchJson = Effect.fnUntraced(function* (
+  client: HttpClient.HttpClient,
+  url: string,
+  accessKey: Redacted.Redacted<string>,
+) {
+  const request = authenticatedRequest(url, accessKey).pipe(HttpClientRequest.acceptJson);
+  const response = yield* client.execute(request);
+  return yield* response.json;
+});
+
+const fetchText = Effect.fnUntraced(function* (
+  client: HttpClient.HttpClient,
+  url: string,
+  accessKey: Redacted.Redacted<string>,
+) {
+  const response = yield* client.execute(authenticatedRequest(url, accessKey));
+  return yield* response.text;
+});
+
+const fetchPostgrestVersion = Effect.fnUntraced(function* (
+  client: HttpClient.HttpClient,
+  baseUrl: string,
+  accessKey: Redacted.Redacted<string>,
+) {
+  const body = yield* fetchJson(client, `${baseUrl}/rest/v1/`, accessKey);
+  const version =
+    typeof body === "object" &&
+    body !== null &&
+    "info" in body &&
+    typeof body.info === "object" &&
+    body.info !== null &&
+    "version" in body.info &&
+    typeof body.info.version === "string"
+      ? body.info.version
+      : undefined;
+
+  const normalized = version?.trim().split(/\s+/)[0];
+  if (normalized === undefined || normalized.length === 0) {
+    return yield* Effect.fail(new ServiceVersionNotFoundError({ service: "postgrest" }));
+  }
+
+  return normalized.startsWith("v") ? normalized : `v${normalized}`;
+});
+
+const fetchAuthVersion = Effect.fnUntraced(function* (
+  client: HttpClient.HttpClient,
+  baseUrl: string,
+  accessKey: Redacted.Redacted<string>,
+) {
+  const body = yield* fetchJson(client, `${baseUrl}/auth/v1/health`, accessKey);
+  const version = stringField(body, "version")?.trim();
+
+  if (version === undefined || version.length === 0) {
+    return yield* Effect.fail(new ServiceVersionNotFoundError({ service: "auth" }));
+  }
+
+  return version;
+});
+
+const fetchStorageVersion = Effect.fnUntraced(function* (
+  client: HttpClient.HttpClient,
+  baseUrl: string,
+  accessKey: Redacted.Redacted<string>,
+) {
+  const version = (yield* fetchText(client, `${baseUrl}/storage/v1/version`, accessKey)).trim();
+  if (version.length === 0 || version === "0.0.0") {
+    return yield* Effect.fail(new ServiceVersionNotFoundError({ service: "storage" }));
+  }
+
+  return version.startsWith("v") ? version : `v${version}`;
+});
+
+const fetchOptionalVersion = (
+  service: OptionalRemoteServiceName,
+  effect: Effect.Effect<string, unknown>,
+) =>
+  effect.pipe(
+    Effect.exit,
+    Effect.map((exit) => ({ service, exit }) as const),
+  );
+
+const makeConfiguredApiClient = Effect.fnUntraced(function* (input: ServiceFetchConfig) {
+  return (
+    input.api ??
+    (yield* makeApiClient({
+      baseUrl: input.apiUrl,
+      accessToken: input.accessToken,
+      userAgent: input.userAgent,
+      headers: input.headers,
+    }))
+  );
+});
+
+export function listLocalServiceVersions(): ReadonlyArray<ServiceVersionRow> {
+  return LOCAL_SERVICE_IMAGES.map((service) => toServiceVersionRow(service));
+}
+
+export function mergeRemoteServiceVersions(
+  remote: Partial<Record<RemoteServiceName, string>>,
+): ReadonlyArray<ServiceVersionRow> {
+  return LOCAL_SERVICE_IMAGES.map((service) => toServiceVersionRow(service, remote));
+}
+
+export function renderServicesTable(rows: ReadonlyArray<ServiceVersionRow>): string {
+  return renderGlamourTable(
+    TABLE_HEADERS,
+    rows.map((row) => [row.name, row.local, row.remote.length === 0 ? "-" : row.remote]),
+  );
+}
+
+export function renderServicesWarning(rows: ReadonlyArray<ServiceVersionRow>): string | undefined {
+  const mismatches = rows.filter((row) => row.remote.length > 0 && row.remote !== row.local);
+  if (mismatches.length === 0) {
+    return undefined;
+  }
+
+  return [
+    "You are running different service versions locally than your linked project:",
+    ...mismatches.map((row) => `${row.name}:${row.local} => ${row.remote}`),
+    "Run supabase link to update them.",
+  ].join("\n");
+}
+
+/**
+ * Renders the linked-version mismatch warning for stderr. In text mode the
+ * `WARNING:` prefix is colorized (matching Go's `utils.Yellow`); machine modes
+ * keep it plain so the stderr line stays parseable.
+ */
+export function formatServicesWarning(message: string, textMode: boolean): string {
+  const lines = message.split("\n");
+  const prefix = textMode ? styleText("yellow", "WARNING:") : "WARNING:";
+  const [first, ...rest] = lines;
+  return `${prefix} ${first}\n${rest.join("\n")}\n`;
+}
+
+export function encodeLegacyTomlRows(rows: ReadonlyArray<ServiceVersionRow>) {
+  return { services: rows } as const;
+}
+
+export function fetchLinkedServiceVersions(input: ServiceFetchConfig) {
+  return Effect.gen(function* () {
+    const exit = yield* Effect.gen(function* () {
+      // Reject malformed refs before they reach the management API path param or
+      // the tenant gateway hostname (`https://<ref>.<host>`). The override is
+      // test-only, so it bypasses the check.
+      if (
+        input.tenantBaseUrlOverride === undefined &&
+        !PROJECT_REF_PATTERN.test(input.projectRef)
+      ) {
+        return {} as Partial<Record<RemoteServiceName, string>>;
+      }
+
+      const client = yield* makeConfiguredApiClient(input);
+      const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+
+      const apiKeysExit = yield* client.v1
+        .getProjectApiKeys({ ref: input.projectRef, reveal: true })
+        .pipe(Effect.exit);
+      if (!Exit.isSuccess(apiKeysExit) || !hasProjectAccessKey(apiKeysExit.value)) {
+        return {} as Partial<Record<RemoteServiceName, string>>;
+      }
+
+      let versions: Partial<Record<RemoteServiceName, string>> = {};
+      const postgresExit = yield* client.v1.getProject({ ref: input.projectRef }).pipe(
+        Effect.map((project) => project.database.version),
+        Effect.exit,
+      );
+      if (Exit.isSuccess(postgresExit)) {
+        versions = { ...versions, postgres: postgresExit.value };
+      }
+
+      const accessKey = selectTenantAccessKey(apiKeysExit.value);
+      if (accessKey === undefined) {
+        return versions;
+      }
+
+      const baseUrl =
+        input.tenantBaseUrlOverride ?? `https://${input.projectRef}.${input.projectHost}`;
+      const results = yield* Effect.all(
+        [
+          fetchOptionalVersion(
+            "postgrest",
+            fetchPostgrestVersion(httpClient, baseUrl, accessKey).pipe(
+              Effect.timeout(Duration.seconds(10)),
+            ),
+          ),
+          fetchOptionalVersion(
+            "auth",
+            fetchAuthVersion(httpClient, baseUrl, accessKey).pipe(
+              Effect.timeout(Duration.seconds(10)),
+            ),
+          ),
+          fetchOptionalVersion(
+            "storage",
+            fetchStorageVersion(httpClient, baseUrl, accessKey).pipe(
+              Effect.timeout(Duration.seconds(10)),
+            ),
+          ),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      for (const result of results) {
+        if (Exit.isSuccess(result.exit)) {
+          versions = { ...versions, [result.service]: result.exit.value };
+        }
+      }
+
+      return versions;
+    }).pipe(Effect.exit);
+    return Exit.isSuccess(exit) ? exit.value : ({} as Partial<Record<RemoteServiceName, string>>);
+  });
+}

--- a/apps/cli/src/shared/services/services.shared.ts
+++ b/apps/cli/src/shared/services/services.shared.ts
@@ -26,7 +26,7 @@ interface ServiceImageSpec {
 // We keep this compiled into the TS CLI because the published package does not
 // ship the Go source tree at runtime, but the user-visible `services` output
 // still needs to match the bundled image manifest.
-export const LOCAL_SERVICE_IMAGES = [
+const LOCAL_SERVICE_IMAGES = [
   { image: "supabase/postgres:17.6.1.132", remoteService: "postgres" },
   { image: "supabase/gotrue:v2.189.0", remoteService: "auth" },
   { image: "postgrest/postgrest:v14.12", remoteService: "postgrest" },

--- a/apps/cli/src/shared/services/services.shared.unit.test.ts
+++ b/apps/cli/src/shared/services/services.shared.unit.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { Effect, Redacted } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
-import { readFileSync } from "node:fs";
 import {
   fetchLinkedServiceVersions,
-  LOCAL_SERVICE_IMAGES,
   listLocalServiceVersions,
   renderServicesTable,
   renderServicesWarning,
@@ -18,56 +16,7 @@ const PROJECT_REF = "abcdefghijklmnopqrst";
 const runLinkedFetch = (input: Parameters<typeof fetchLinkedServiceVersions>[0]) =>
   Effect.runPromise(fetchLinkedServiceVersions(input).pipe(Effect.provide(FetchHttpClient.layer)));
 
-function parseDockerfileServiceImages() {
-  const dockerfile = readFileSync(
-    new URL("../../../../cli-go/pkg/config/templates/Dockerfile", import.meta.url),
-    "utf8",
-  );
-
-  const imagesByAlias = new Map<string, { name: string; version: string }>();
-
-  for (const line of dockerfile.split(/\r?\n/)) {
-    const match = /^FROM\s+([^:]+):(\S+)\s+AS\s+(\S+)$/.exec(line.trim());
-    if (match === null) {
-      continue;
-    }
-
-    const [, imageName, version, alias] = match;
-    if (imageName === undefined || version === undefined || alias === undefined) {
-      throw new Error("Dockerfile service image parse failed");
-    }
-    imagesByAlias.set(alias, { name: imageName, version });
-  }
-
-  return [
-    imagesByAlias.get("pg"),
-    imagesByAlias.get("gotrue"),
-    imagesByAlias.get("postgrest"),
-    imagesByAlias.get("realtime"),
-    imagesByAlias.get("storage"),
-    imagesByAlias.get("edgeruntime"),
-    imagesByAlias.get("studio"),
-    imagesByAlias.get("pgmeta"),
-    imagesByAlias.get("logflare"),
-    imagesByAlias.get("supavisor"),
-  ].map((image) => {
-    if (image === undefined) {
-      throw new Error("Dockerfile service image alias missing");
-    }
-    return image;
-  });
-}
-
 describe("services shared", () => {
-  test("keeps the local image matrix aligned with the bundled Dockerfile manifest", () => {
-    expect(parseDockerfileServiceImages()).toEqual(
-      LOCAL_SERVICE_IMAGES.map((service) => {
-        const [name, version] = service.image.split(":");
-        return { name, version };
-      }),
-    );
-  });
-
   test("returns postgres only when no service-role key is available", async () => {
     const server = Bun.serve({
       port: 0,

--- a/apps/cli/src/shared/services/services.shared.unit.test.ts
+++ b/apps/cli/src/shared/services/services.shared.unit.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "vitest";
+import { Effect, Redacted } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { readFileSync } from "node:fs";
+import {
+  fetchLinkedServiceVersions,
+  LOCAL_SERVICE_IMAGES,
+  listLocalServiceVersions,
+  renderServicesTable,
+  renderServicesWarning,
+} from "./services.shared.ts";
+
+const ACCESS_TOKEN = Redacted.make(`sbp_${"a".repeat(40)}`);
+const PROJECT_REF = "abcdefghijklmnopqrst";
+
+// `fetchLinkedServiceVersions` reads the ambient HttpClient from context instead
+// of self-provisioning one, so each invocation needs a concrete transport.
+const runLinkedFetch = (input: Parameters<typeof fetchLinkedServiceVersions>[0]) =>
+  Effect.runPromise(fetchLinkedServiceVersions(input).pipe(Effect.provide(FetchHttpClient.layer)));
+
+function parseDockerfileServiceImages() {
+  const dockerfile = readFileSync(
+    new URL("../../../../cli-go/pkg/config/templates/Dockerfile", import.meta.url),
+    "utf8",
+  );
+
+  const imagesByAlias = new Map<string, { name: string; version: string }>();
+
+  for (const line of dockerfile.split(/\r?\n/)) {
+    const match = /^FROM\s+([^:]+):(\S+)\s+AS\s+(\S+)$/.exec(line.trim());
+    if (match === null) {
+      continue;
+    }
+
+    const [, imageName, version, alias] = match;
+    if (imageName === undefined || version === undefined || alias === undefined) {
+      throw new Error("Dockerfile service image parse failed");
+    }
+    imagesByAlias.set(alias, { name: imageName, version });
+  }
+
+  return [
+    imagesByAlias.get("pg"),
+    imagesByAlias.get("gotrue"),
+    imagesByAlias.get("postgrest"),
+    imagesByAlias.get("realtime"),
+    imagesByAlias.get("storage"),
+    imagesByAlias.get("edgeruntime"),
+    imagesByAlias.get("studio"),
+    imagesByAlias.get("pgmeta"),
+    imagesByAlias.get("logflare"),
+    imagesByAlias.get("supavisor"),
+  ].map((image) => {
+    if (image === undefined) {
+      throw new Error("Dockerfile service image alias missing");
+    }
+    return image;
+  });
+}
+
+describe("services shared", () => {
+  test("keeps the local image matrix aligned with the bundled Dockerfile manifest", () => {
+    expect(parseDockerfileServiceImages()).toEqual(
+      LOCAL_SERVICE_IMAGES.map((service) => {
+        const [name, version] = service.image.split(":");
+        return { name, version };
+      }),
+    );
+  });
+
+  test("returns postgres only when no service-role key is available", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === `/v1/projects/${PROJECT_REF}`) {
+          return Response.json({
+            id: PROJECT_REF,
+            ref: PROJECT_REF,
+            organization_id: "org-id",
+            organization_slug: "org",
+            name: "Linked Project",
+            region: "us-east-1",
+            created_at: "2026-03-13T12:00:00.000Z",
+            status: "ACTIVE_HEALTHY",
+            database: {
+              host: "db.supabase.internal",
+              version: "17.6.1.200",
+              postgres_engine: "17",
+              release_channel: "ga",
+            },
+          });
+        }
+
+        if (url.pathname === `/v1/projects/${PROJECT_REF}/api-keys`) {
+          return Response.json([
+            {
+              name: "anon",
+              id: "publishable-id",
+              type: "publishable",
+              api_key: "publishable-key",
+              description: null,
+            },
+          ]);
+        }
+
+        if (
+          url.pathname === "/auth/v1/health" ||
+          url.pathname === "/rest/v1/" ||
+          url.pathname === "/storage/v1/version"
+        ) {
+          throw new Error(
+            `tenant endpoint should not be called without a service-role key: ${url.pathname}`,
+          );
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runLinkedFetch({
+        apiUrl: server.url.origin,
+        projectHost: "supabase.co",
+        projectRef: PROJECT_REF,
+        accessToken: ACCESS_TOKEN,
+        userAgent: "supabase",
+        tenantBaseUrlOverride: server.url.origin,
+      });
+
+      expect(result).toEqual({ postgres: "17.6.1.200" });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("returns no linked versions when project api keys cannot be loaded", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === `/v1/projects/${PROJECT_REF}/api-keys`) {
+          return new Response("boom", { status: 500 });
+        }
+
+        if (url.pathname === `/v1/projects/${PROJECT_REF}`) {
+          return Response.json({
+            id: PROJECT_REF,
+            ref: PROJECT_REF,
+            organization_id: "org-id",
+            organization_slug: "org",
+            name: "Linked Project",
+            region: "us-east-1",
+            created_at: "2026-03-13T12:00:00.000Z",
+            status: "ACTIVE_HEALTHY",
+            database: {
+              host: "db.supabase.internal",
+              version: "17.6.1.200",
+              postgres_engine: "17",
+              release_channel: "ga",
+            },
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runLinkedFetch({
+        apiUrl: server.url.origin,
+        projectHost: "supabase.co",
+        projectRef: PROJECT_REF,
+        accessToken: ACCESS_TOKEN,
+        userAgent: "supabase",
+        tenantBaseUrlOverride: server.url.origin,
+      });
+
+      expect(result).toEqual({});
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("still returns tenant service versions when project version lookup fails", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === `/v1/projects/${PROJECT_REF}`) {
+          return new Response("boom", { status: 500 });
+        }
+
+        if (url.pathname === `/v1/projects/${PROJECT_REF}/api-keys`) {
+          return Response.json([
+            {
+              name: "service_role",
+              id: "key-id",
+              type: "secret",
+              api_key: "service-role-key",
+              description: null,
+              secret_jwt_template: { role: "service_role" },
+            },
+          ]);
+        }
+
+        if (url.pathname === "/auth/v1/health") {
+          return Response.json({ version: "v2.190.0" });
+        }
+
+        if (url.pathname === "/rest/v1/") {
+          return Response.json({ info: { version: "14.13" } });
+        }
+
+        if (url.pathname === "/storage/v1/version") {
+          return new Response("1.61.0");
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runLinkedFetch({
+        apiUrl: server.url.origin,
+        projectHost: "supabase.co",
+        projectRef: PROJECT_REF,
+        accessToken: ACCESS_TOKEN,
+        userAgent: "supabase",
+        tenantBaseUrlOverride: server.url.origin,
+      });
+
+      expect(result).toEqual({
+        auth: "v2.190.0",
+        postgrest: "v14.13",
+        storage: "v1.61.0",
+      });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("falls back to empty linked versions when the linked fetch fails", async () => {
+    const result = await runLinkedFetch({
+      apiUrl: "http://127.0.0.1:1",
+      projectHost: "supabase.co",
+      projectRef: PROJECT_REF,
+      accessToken: ACCESS_TOKEN,
+      userAgent: "supabase",
+    });
+
+    expect(result).toEqual({});
+  });
+
+  test("authenticates tenant probes with apikey only for sb_ keys", async () => {
+    const authHeaders: Record<string, string | null> = {};
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === `/v1/projects/${PROJECT_REF}/api-keys`) {
+          return Response.json([
+            {
+              name: "service_role",
+              id: "key-id",
+              type: "secret",
+              api_key: "sb_secret_servicerolekey",
+              description: null,
+              secret_jwt_template: { role: "service_role" },
+            },
+          ]);
+        }
+
+        if (url.pathname === `/v1/projects/${PROJECT_REF}`) {
+          return new Response("boom", { status: 500 });
+        }
+
+        if (url.pathname === "/auth/v1/health") {
+          authHeaders.apikey = request.headers.get("apikey");
+          authHeaders.authorization = request.headers.get("authorization");
+          return Response.json({ version: "v2.190.0" });
+        }
+
+        if (url.pathname === "/rest/v1/" || url.pathname === "/storage/v1/version") {
+          return new Response("not found", { status: 404 });
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runLinkedFetch({
+        apiUrl: server.url.origin,
+        projectHost: "supabase.co",
+        projectRef: PROJECT_REF,
+        accessToken: ACCESS_TOKEN,
+        userAgent: "supabase",
+        tenantBaseUrlOverride: server.url.origin,
+      });
+
+      expect(result).toEqual({ auth: "v2.190.0" });
+      expect(authHeaders.apikey).toBe("sb_secret_servicerolekey");
+      expect(authHeaders.authorization).toBeNull();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("skips remote lookups for a malformed project ref", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        throw new Error("no request should be made for a malformed project ref");
+      },
+    });
+
+    try {
+      const result = await runLinkedFetch({
+        apiUrl: server.url.origin,
+        projectHost: "supabase.co",
+        projectRef: "not-a-valid-ref",
+        accessToken: ACCESS_TOKEN,
+        userAgent: "supabase",
+      });
+
+      expect(result).toEqual({});
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("renders the local services table with expected headers and rows", () => {
+    const rows = listLocalServiceVersions();
+    const table = renderServicesTable(rows);
+
+    expect(table).toContain("SERVICE IMAGE");
+    expect(table).toContain("LOCAL");
+    expect(table).toContain("LINKED");
+
+    for (const row of rows) {
+      expect(table).toContain(row.name);
+      expect(table).toContain(row.local);
+    }
+  });
+
+  test("renders update warning only for mismatched linked versions", () => {
+    expect(
+      renderServicesWarning([
+        { name: "supabase/postgres", local: "17.6.1.132", remote: "17.6.1.200" },
+        { name: "supabase/gotrue", local: "v2.189.0", remote: "v2.189.0" },
+      ]),
+    ).toContain("supabase/postgres:17.6.1.132 => 17.6.1.200");
+  });
+});

--- a/packages/api/scripts/download-openapi.ts
+++ b/packages/api/scripts/download-openapi.ts
@@ -1,20 +1,132 @@
 #!/usr/bin/env bun
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const DEFAULT_SUPABASE_API_URL = "https://api.supabase.com";
-const OPENAPI_SPEC_PATH = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../src/generated/openapi.json",
-);
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const OPENAPI_SPEC_PATH = path.join(scriptDir, "../src/generated/openapi.json");
+const OPENAPI_OVERRIDES_PATH = path.join(scriptDir, "openapi-overrides.json");
 
 type OpenApiDocument = {
+  readonly [key: string]: unknown;
   readonly paths: Record<string, unknown>;
+};
+
+type JsonPatchOperation = {
+  readonly op: "test" | "replace";
+  readonly path: string;
+  readonly value: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function unescapeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function jsonPointerSegments(pointer: string): ReadonlyArray<string> {
+  if (pointer === "") {
+    return [];
+  }
+  if (!pointer.startsWith("/")) {
+    throw new Error(`Invalid JSON pointer ${JSON.stringify(pointer)}.`);
+  }
+  return pointer.slice(1).split("/").map(unescapeJsonPointerSegment);
+}
+
+function getJsonPointerValue(document: unknown, pointer: string): unknown {
+  let current = document;
+  for (const segment of jsonPointerSegments(pointer)) {
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+        throw new Error(`JSON pointer ${JSON.stringify(pointer)} does not exist.`);
+      }
+      current = current[index];
+    } else if (isRecord(current) && segment in current) {
+      current = current[segment];
+    } else {
+      throw new Error(`JSON pointer ${JSON.stringify(pointer)} does not exist.`);
+    }
+  }
+  return current;
+}
+
+function replaceJsonPointerValue(document: unknown, pointer: string, value: unknown): void {
+  const segments = jsonPointerSegments(pointer);
+  if (segments.length === 0) {
+    throw new Error("Replacing the document root is not supported.");
+  }
+
+  let parent = document;
+  for (const segment of segments.slice(0, -1)) {
+    parent = getJsonPointerValue(parent, `/${segment.replace(/~/g, "~0").replace(/\//g, "~1")}`);
+  }
+
+  const key = segments[segments.length - 1]!;
+  if (Array.isArray(parent)) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+      throw new Error(`JSON pointer ${JSON.stringify(pointer)} does not exist.`);
+    }
+    parent[index] = value;
+    return;
+  }
+
+  if (!isRecord(parent) || !(key in parent)) {
+    throw new Error(`JSON pointer ${JSON.stringify(pointer)} does not exist.`);
+  }
+  parent[key] = value;
+}
+
+function assertJsonPatchOperation(value: unknown): asserts value is JsonPatchOperation {
+  if (!isRecord(value)) {
+    throw new Error("OpenAPI override entry must be an object.");
+  }
+  if (value.op !== "test" && value.op !== "replace") {
+    throw new Error("OpenAPI overrides only support test and replace operations.");
+  }
+  if (typeof value.path !== "string") {
+    throw new Error("OpenAPI override path must be a string.");
+  }
+  if (!("value" in value)) {
+    throw new Error("OpenAPI override value is required.");
+  }
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function applyOpenApiOverrides(
+  document: OpenApiDocument,
+  overrides: ReadonlyArray<unknown>,
+): OpenApiDocument {
+  for (const override of overrides) {
+    assertJsonPatchOperation(override);
+    if (override.op === "test") {
+      const actual = getJsonPointerValue(document, override.path);
+      if (!valuesEqual(actual, override.value)) {
+        throw new Error(
+          `OpenAPI override test failed at ${override.path}: expected ${JSON.stringify(override.value)}, got ${JSON.stringify(actual)}.`,
+        );
+      }
+      continue;
+    }
+    replaceJsonPointerValue(document, override.path, override.value);
+  }
+  return document;
+}
+
+async function loadOpenApiOverrides(): Promise<ReadonlyArray<unknown>> {
+  const parsed = JSON.parse(await readFile(OPENAPI_OVERRIDES_PATH, "utf8"));
+  if (!Array.isArray(parsed)) {
+    throw new Error("OpenAPI overrides file must contain a JSON Patch array.");
+  }
+  return parsed;
 }
 
 export function resolveOpenApiSpecUrl(baseUrl = process.env.SUPABASE_API_URL): string {
@@ -37,6 +149,8 @@ export async function downloadOpenApiSpec(specUrl = resolveOpenApiSpecUrl()): Pr
 
   const document = await response.json();
   assertOpenApiDocument(document);
+
+  applyOpenApiOverrides(document, await loadOpenApiOverrides());
 
   await writeFile(OPENAPI_SPEC_PATH, `${JSON.stringify(document, null, 2)}\n`);
 }

--- a/packages/api/scripts/download-openapi.unit.test.ts
+++ b/packages/api/scripts/download-openapi.unit.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { assertOpenApiDocument, resolveOpenApiSpecUrl } from "./download-openapi.ts";
+import {
+  applyOpenApiOverrides,
+  assertOpenApiDocument,
+  resolveOpenApiSpecUrl,
+} from "./download-openapi.ts";
 
 describe("download-openapi", () => {
   test("defaults to the production API spec URL", () => {
@@ -24,5 +28,61 @@ describe("download-openapi", () => {
     expect(() => assertOpenApiDocument({})).toThrow(
       "Downloaded spec is not a valid OpenAPI document with a paths object.",
     );
+  });
+
+  test("applies OpenAPI JSON Patch overrides", () => {
+    const document = {
+      paths: {},
+      components: {
+        schemas: {
+          ListProvidersResponse: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    saml: {
+                      required: ["id", "entity_id"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyOpenApiOverrides(document, [
+      {
+        op: "test",
+        path: "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/required",
+        value: ["id", "entity_id"],
+      },
+      {
+        op: "replace",
+        path: "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/required",
+        value: ["entity_id"],
+      },
+    ]);
+
+    expect(
+      document.components.schemas.ListProvidersResponse.properties.items.items.properties.saml
+        .required,
+    ).toEqual(["entity_id"]);
+  });
+
+  test("fails when an OpenAPI override test no longer matches", () => {
+    expect(() =>
+      applyOpenApiOverrides(
+        { paths: {}, components: { schemas: { ListProvidersResponse: { required: [] } } } },
+        [
+          {
+            op: "test",
+            path: "/components/schemas/ListProvidersResponse/required",
+            value: ["items"],
+          },
+        ],
+      ),
+    ).toThrow("OpenAPI override test failed");
   });
 });

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "test",
+    "path": "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/required",
+    "value": ["id", "entity_id"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/required",
+    "value": ["entity_id"]
+  }
+]

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -2584,6 +2584,25 @@ export const V1GetPostgresConfigInput = Schema.Struct({
 export const V1GetPostgresConfigOutput = Schema.Struct({
   effective_cache_size: Schema.optionalKey(Schema.String),
   logical_decoding_work_mem: Schema.optionalKey(Schema.String),
+  "cron.log_statement": Schema.optionalKey(Schema.Boolean),
+  log_autovacuum_min_duration: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_checkpoints: Schema.optionalKey(Schema.Boolean),
+  log_connections: Schema.optionalKey(Schema.Boolean),
+  log_disconnections: Schema.optionalKey(Schema.Boolean),
+  log_duration: Schema.optionalKey(Schema.Boolean),
+  log_lock_waits: Schema.optionalKey(Schema.Boolean),
+  log_recovery_conflict_waits: Schema.optionalKey(Schema.Boolean),
+  log_replication_commands: Schema.optionalKey(Schema.Boolean),
+  log_startup_progress_interval: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_temp_files: Schema.optionalKey(Schema.String),
   maintenance_work_mem: Schema.optionalKey(Schema.String),
   track_activity_query_size: Schema.optionalKey(Schema.String),
   max_connections: Schema.optionalKey(
@@ -3555,7 +3574,7 @@ export const V1ListAllSsoProviderOutput = Schema.Struct({
       id: Schema.String,
       saml: Schema.optionalKey(
         Schema.Struct({
-          id: Schema.String,
+          id: Schema.optionalKey(Schema.String),
           entity_id: Schema.String,
           metadata_url: Schema.optionalKey(Schema.String),
           metadata_xml: Schema.optionalKey(Schema.String),
@@ -5353,6 +5372,25 @@ export const V1UpdatePostgresConfigInput = Schema.Struct({
     .check(Schema.isPattern(new RegExp("^[a-z]+$"))),
   effective_cache_size: Schema.optionalKey(Schema.String),
   logical_decoding_work_mem: Schema.optionalKey(Schema.String),
+  "cron.log_statement": Schema.optionalKey(Schema.Boolean),
+  log_autovacuum_min_duration: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_checkpoints: Schema.optionalKey(Schema.Boolean),
+  log_connections: Schema.optionalKey(Schema.Boolean),
+  log_disconnections: Schema.optionalKey(Schema.Boolean),
+  log_duration: Schema.optionalKey(Schema.Boolean),
+  log_lock_waits: Schema.optionalKey(Schema.Boolean),
+  log_recovery_conflict_waits: Schema.optionalKey(Schema.Boolean),
+  log_replication_commands: Schema.optionalKey(Schema.Boolean),
+  log_startup_progress_interval: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_temp_files: Schema.optionalKey(Schema.String),
   maintenance_work_mem: Schema.optionalKey(Schema.String),
   track_activity_query_size: Schema.optionalKey(Schema.String),
   max_connections: Schema.optionalKey(
@@ -5417,6 +5455,25 @@ export const V1UpdatePostgresConfigInput = Schema.Struct({
 export const V1UpdatePostgresConfigOutput = Schema.Struct({
   effective_cache_size: Schema.optionalKey(Schema.String),
   logical_decoding_work_mem: Schema.optionalKey(Schema.String),
+  "cron.log_statement": Schema.optionalKey(Schema.Boolean),
+  log_autovacuum_min_duration: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_checkpoints: Schema.optionalKey(Schema.Boolean),
+  log_connections: Schema.optionalKey(Schema.Boolean),
+  log_disconnections: Schema.optionalKey(Schema.Boolean),
+  log_duration: Schema.optionalKey(Schema.Boolean),
+  log_lock_waits: Schema.optionalKey(Schema.Boolean),
+  log_recovery_conflict_waits: Schema.optionalKey(Schema.Boolean),
+  log_replication_commands: Schema.optionalKey(Schema.Boolean),
+  log_startup_progress_interval: Schema.optionalKey(
+    Schema.String.annotate({ description: "Default unit: ms" }).check(
+      Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")),
+    ),
+  ),
+  log_temp_files: Schema.optionalKey(Schema.String),
   maintenance_work_mem: Schema.optionalKey(Schema.String),
   track_activity_query_size: Schema.optionalKey(Schema.String),
   max_connections: Schema.optionalKey(
@@ -8359,6 +8416,17 @@ export const operationDefinitions = {
       fields: [
         "effective_cache_size",
         "logical_decoding_work_mem",
+        "cron.log_statement",
+        "log_autovacuum_min_duration",
+        "log_checkpoints",
+        "log_connections",
+        "log_disconnections",
+        "log_duration",
+        "log_lock_waits",
+        "log_recovery_conflict_waits",
+        "log_replication_commands",
+        "log_startup_progress_interval",
+        "log_temp_files",
         "maintenance_work_mem",
         "track_activity_query_size",
         "max_connections",

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -1034,7 +1034,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "",
             "content": {
               "application/json": {
@@ -4263,6 +4263,9 @@
               }
             }
           },
+          "400": {
+            "description": "This feature requires the Pro, Team, or Enterprise organization plan."
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -4286,10 +4289,15 @@
         ],
         "summary": "[Beta] Gets current vanity subdomain config",
         "tags": ["Domains"],
+        "x-allowed-plans": ["Pro", "Team", "Enterprise"],
         "x-badges": [
           {
             "name": "OAuth scope: domains:read",
             "position": "after"
+          },
+          {
+            "name": "Only available on Pro, Team, Enterprise",
+            "position": "before"
           }
         ],
         "x-endpoint-owners": ["infra", "management-api"],
@@ -4388,6 +4396,9 @@
               }
             }
           },
+          "400": {
+            "description": "This feature requires the Pro, Team, or Enterprise organization plan."
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -4411,10 +4422,15 @@
         ],
         "summary": "[Beta] Checks vanity subdomain availability",
         "tags": ["Domains"],
+        "x-allowed-plans": ["Pro", "Team", "Enterprise"],
         "x-badges": [
           {
             "name": "OAuth scope: domains:write",
             "position": "after"
+          },
+          {
+            "name": "Only available on Pro, Team, Enterprise",
+            "position": "before"
           }
         ],
         "x-endpoint-owners": ["infra", "management-api"],
@@ -4460,6 +4476,9 @@
               }
             }
           },
+          "400": {
+            "description": "This feature requires the Pro, Team, or Enterprise organization plan."
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -4483,10 +4502,15 @@
         ],
         "summary": "[Beta] Activates a vanity subdomain for a project.",
         "tags": ["Domains"],
+        "x-allowed-plans": ["Pro", "Team", "Enterprise"],
         "x-badges": [
           {
             "name": "OAuth scope: domains:write",
             "position": "after"
+          },
+          {
+            "name": "Only available on Pro, Team, Enterprise",
+            "position": "before"
           }
         ],
         "x-endpoint-owners": ["infra", "management-api"],
@@ -4850,6 +4874,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "402": {
+            "description": "This feature requires the Pro, Team, or Enterprise organization plan."
+          },
           "403": {
             "description": "Forbidden action"
           },
@@ -4870,6 +4897,13 @@
         ],
         "summary": "[Beta] Set up a read replica",
         "tags": ["Database"],
+        "x-allowed-plans": ["Pro", "Team", "Enterprise"],
+        "x-badges": [
+          {
+            "name": "Only available on Pro, Team, Enterprise",
+            "position": "before"
+          }
+        ],
         "x-endpoint-owners": ["management-api", "infra"]
       }
     },
@@ -10458,7 +10492,7 @@
             "description": "Unauthorized"
           },
           "402": {
-            "description": "Feature requires a higher plan"
+            "description": "This feature requires the Enterprise organization plan."
           },
           "403": {
             "description": "Forbidden action"
@@ -10483,10 +10517,15 @@
         ],
         "summary": "Gets the backup schedule for a project",
         "tags": ["Database"],
+        "x-allowed-plans": ["Enterprise"],
         "x-badges": [
           {
             "name": "OAuth scope: database:read",
             "position": "after"
+          },
+          {
+            "name": "Only available on Enterprise",
+            "position": "before"
           }
         ],
         "x-endpoint-owners": ["infra"],
@@ -10538,7 +10577,7 @@
             "description": "Unauthorized"
           },
           "402": {
-            "description": "Feature requires a higher plan"
+            "description": "This feature requires the Enterprise organization plan."
           },
           "403": {
             "description": "Forbidden action"
@@ -10563,10 +10602,15 @@
         ],
         "summary": "Updates the backup schedule time for a project",
         "tags": ["Database"],
+        "x-allowed-plans": ["Enterprise"],
         "x-badges": [
           {
             "name": "OAuth scope: database:write",
             "position": "after"
+          },
+          {
+            "name": "Only available on Enterprise",
+            "position": "before"
           }
         ],
         "x-endpoint-owners": ["infra"],
@@ -18264,6 +18308,43 @@
           "logical_decoding_work_mem": {
             "type": "string"
           },
+          "cron.log_statement": {
+            "type": "boolean"
+          },
+          "log_autovacuum_min_duration": {
+            "type": "string",
+            "description": "Default unit: ms",
+            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+          },
+          "log_checkpoints": {
+            "type": "boolean"
+          },
+          "log_connections": {
+            "type": "boolean"
+          },
+          "log_disconnections": {
+            "type": "boolean"
+          },
+          "log_duration": {
+            "type": "boolean"
+          },
+          "log_lock_waits": {
+            "type": "boolean"
+          },
+          "log_recovery_conflict_waits": {
+            "type": "boolean"
+          },
+          "log_replication_commands": {
+            "type": "boolean"
+          },
+          "log_startup_progress_interval": {
+            "type": "string",
+            "description": "Default unit: ms",
+            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+          },
+          "log_temp_files": {
+            "type": "string"
+          },
           "maintenance_work_mem": {
             "type": "string"
           },
@@ -18361,6 +18442,43 @@
             "type": "string"
           },
           "logical_decoding_work_mem": {
+            "type": "string"
+          },
+          "cron.log_statement": {
+            "type": "boolean"
+          },
+          "log_autovacuum_min_duration": {
+            "type": "string",
+            "description": "Default unit: ms",
+            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+          },
+          "log_checkpoints": {
+            "type": "boolean"
+          },
+          "log_connections": {
+            "type": "boolean"
+          },
+          "log_disconnections": {
+            "type": "boolean"
+          },
+          "log_duration": {
+            "type": "boolean"
+          },
+          "log_lock_waits": {
+            "type": "boolean"
+          },
+          "log_recovery_conflict_waits": {
+            "type": "boolean"
+          },
+          "log_replication_commands": {
+            "type": "boolean"
+          },
+          "log_startup_progress_interval": {
+            "type": "string",
+            "description": "Default unit: ms",
+            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+          },
+          "log_temp_files": {
             "type": "string"
           },
           "maintenance_work_mem": {
@@ -18900,7 +19018,7 @@
                       ]
                     }
                   },
-                  "required": ["id", "entity_id"]
+                  "required": ["entity_id"]
                 },
                 "domains": {
                   "type": "array",

--- a/packages/cli-test-helpers/src/normalize.ts
+++ b/packages/cli-test-helpers/src/normalize.ts
@@ -40,10 +40,10 @@ export function normalize(output: string): string {
       // 1. Strip ANSI escape codes (color, bold, reset, etc.) — \u001b is ESC
       // eslint-disable-next-line no-control-regex
       .replace(/\u001b\[[0-9;]*[a-zA-Z]/g, "")
-      // 2. Semantic version strings (e.g. 1.187.0, v2.0.0-rc.1).
+      // 2. Semantic version strings (e.g. 1.187.0, v2.0.0-rc.1, v14.13).
       //    Lookbehind prevents matching mid-IP-address (e.g. 0.0.1 inside 127.0.0.1).
       //    Lookahead prevents matching where more dotted-number segments follow.
-      .replace(/(?<![.\d])\bv?\d+\.\d+\.\d+(?:-[\w.]+)?\b(?!\.)/g, "<VERSION>")
+      .replace(/(?<![.\d])\bv?\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?\b(?!\.)/g, "<VERSION>")
       // 3. ISO-8601 timestamps (2026-04-15T10:46:15Z or with milliseconds)
       .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z/g, "<TIMESTAMP>")
       // 4. Display timestamps (2026-04-15 10:46:15 — space-separated, no T)

--- a/packages/cli-test-helpers/src/normalize.unit.test.ts
+++ b/packages/cli-test-helpers/src/normalize.unit.test.ts
@@ -11,6 +11,7 @@ describe("normalize", () => {
   it("normalizes semantic version strings", () => {
     expect(normalize("supabase 1.187.0")).toBe("supabase <VERSION>");
     expect(normalize("v2.0.0")).toBe("<VERSION>");
+    expect(normalize("postgrest/postgrest:v14.13")).toBe("postgrest/postgrest:<VERSION>");
     expect(normalize("Version: 0.1.0-rc.1")).toBe("Version: <VERSION>");
   });
 

--- a/packages/stack/tests/helpers/warmup.ts
+++ b/packages/stack/tests/helpers/warmup.ts
@@ -14,7 +14,7 @@ interface WarmStackE2eDependenciesOptions {
 
 export function hasDockerDaemon(): boolean {
   try {
-    execSync("docker info", { stdio: "ignore" });
+    execSync("docker info", { stdio: "ignore", timeout: 2_000 });
     return true;
   } catch {
     return false;

--- a/packages/stack/tests/helpers/warmup.unit.test.ts
+++ b/packages/stack/tests/helpers/warmup.unit.test.ts
@@ -79,6 +79,7 @@ describe("stack e2e warmup", () => {
     await expect(
       warmStackE2eDependencies({
         failOnError: true,
+        hasDockerDaemon: () => false,
         logger,
         prefetch: async () => {
           throw new Error("pull failed");
@@ -94,6 +95,7 @@ describe("stack e2e warmup", () => {
     await expect(
       warmStackE2eDependencies({
         failOnError: false,
+        hasDockerDaemon: () => false,
         logger,
         prefetch: async () => {
           throw new Error("pull failed");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,11 +84,11 @@ importers:
   apps/cli:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.146
-        version: 0.3.146(@anthropic-ai/sdk@0.97.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.156
+        version: 0.3.156(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@clack/prompts':
         specifier: ^1.4.0
         version: 1.4.0
@@ -165,8 +165,8 @@ importers:
         specifier: 'catalog:'
         version: 0.23.0
       posthog-node:
-        specifier: ^5.35.5
-        version: 5.35.5
+        specifier: ^5.35.6
+        version: 5.35.6
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -536,60 +536,60 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.146':
-    resolution: {integrity: sha512-0IIvlEaenq2CRSVx5Bo5BaCtHQXS87GancM35WKEYveGVLn6DI+5G7ikYuTE4AKRPkMnogFtY4BJt6LulWGj+A==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.156':
+    resolution: {integrity: sha512-IkjcS9dqAUlD4Nb62L9AZtmAXCa+FV4ul8lIlyXXUprh3nlecbKsWOXVd/GORrzAhMmynJaX4+iV1JiutFKXUA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.146':
-    resolution: {integrity: sha512-Dk5xJ03Ff1JXbMRP1t2wc/TyfY6xF/2Ysp31wMhFPjoNiKSPHMWaIg242+T3CHdxLWmJ8plWHL1HL5cyZ/LCkw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.156':
+    resolution: {integrity: sha512-6PKi5fPmGRuzXu+Em/iwLmPG3mqg0hl92wcTU8fmChqyNtxhxsjCw7LTbdFqp/05o5NeZVVV4k3p7YUv5IFD6g==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.146':
-    resolution: {integrity: sha512-QlCid0ucdrmhUAOewfQjaofN2wlokWcfFTxSFePTSj1umk35JO7TDFP700F7jU49r1fPWIdvJpPwWGyB0DeFPA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.156':
+    resolution: {integrity: sha512-R7KEVjxkR4rYgIQoHGBzwPdUJYxRTO8I4vHjRbMLH1eW4FS7BJvVs7ogfKR/NnHFBvMVqtC+l6jHLQv8bobUiw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.146':
-    resolution: {integrity: sha512-mzBXDDWWBAC/vDtAYpO1G/dq5QvJtYSPXsqcb+sNdcDhiuf4IYnYp7ytRncYlsUNDkLmX6Gk2jkWAHUUA2Lozg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.156':
+    resolution: {integrity: sha512-H0Nfd41iw5isto9uQI1FlVSZ0eaDttr8rBpJMR25oK/mj3egMO5EmZ6aAxeeUYSLn2mSU50HA5VNxlGUE118TQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.146':
-    resolution: {integrity: sha512-E3coK1ThQT08KIX80RLcsq7DWXFllCKOzoOe32it/bdtY56TBgPY9xemwXhIJ+cVBHTI9/MpBSIlKBcFCt+yQA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.156':
+    resolution: {integrity: sha512-/Q6WUizI6a+hqZZ6ElwRU0PEuFhOoN4v6CuU35HHbiZ/7uaocGht4A8ZIgK1Fw6wOGtZzGLbc00CA1OU1Zg8EA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.146':
-    resolution: {integrity: sha512-B2baXU1tCBT5CVlD7jJMKjpC4xdO45NUIWpqImmwuOfKvlM/PITjyTXyTY662mGZf1dBmdqBBsqirwFH/jhi8Q==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.156':
+    resolution: {integrity: sha512-ymhrdlbWoYvTACUdaGdhrEv+ZMfwXLsf0BRLkr/IvY5aqybP7URzWmmZGOtDQpqkT/8xu/UCGqUYH3woJwUxfg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.146':
-    resolution: {integrity: sha512-CIwQxGX2r/yWpjCJ6ahB3smKXhghWgGTxL98+LGW52TUwqTiBnlNrH9DPqqgv1/+Hyquw6xfLrKU+StyfMgiLw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.156':
+    resolution: {integrity: sha512-5sAeNObQQrMy4NF9HwxewrMnU7mVxZDHh+/MfJVQSz0GSTvXQ6gOuRH8helMlfspoU6VOdekPxVLRooX/3foEw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.146':
-    resolution: {integrity: sha512-qmxrsyaqA8s4HShqJls7ZCRjdoqN66Jo/hbjQNB3uHepD8tEO1iD19aPV4+osdLT7feMkhDBfLT07Q30R2NB5w==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.156':
+    resolution: {integrity: sha512-/PofeTWoiKgnWNSNk0wG4SsRn22GGLmnLhg2R94WcNhCRFOyOTmiZcYH2DBlWZBIRVTZDsSfa/Pl1DyPvYCGKw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.146':
-    resolution: {integrity: sha512-hK9/Ng+hOyexUemTxdIUsSWJ9o2LFi2YNWzHwz8/YMCohUYOnFMZkBiENvUAb0WIc5hieOyBZrOIlg5OewuJMg==}
+  '@anthropic-ai/claude-agent-sdk@0.3.156':
+    resolution: {integrity: sha512-6nM/Dj+VMds52UXJ2YaV4IKhYamlUqN0HtdDrFzYz5lvPMpDS935qD8YZDAUpy+ltdoD6PJMd1V/CKFY3/oWCQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.97.1':
-    resolution: {integrity: sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==}
+  '@anthropic-ai/sdk@0.100.0':
+    resolution: {integrity: sha512-cAm3aXm6qAiHIvHxyIIGd6tVmsD2gDqlc2h0R20ijNUzGgVnIN822bit4mKbF6CkuV7qIrLQIPoAepHEpanrQQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -652,8 +652,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
@@ -2025,11 +2025,11 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
-  '@posthog/core@1.29.12':
-    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
+  '@posthog/core@1.29.13':
+    resolution: {integrity: sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==}
 
-  '@posthog/types@1.376.3':
-    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
+  '@posthog/types@1.376.4':
+    resolution: {integrity: sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -5462,8 +5462,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@5.35.5:
-    resolution: {integrity: sha512-zPLpjK0uAxVTVmV2TH/hNAq0JN0vUjZdJ8KOBErQS58lIJRHTkMMofNmpolkGq9pijpFITcpLsMYMsFMWvjBmg==}
+  posthog-node@5.35.6:
+    resolution: {integrity: sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -6108,6 +6108,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -6623,46 +6627,46 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.146':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.146(@anthropic-ai/sdk@0.97.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.156(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.97.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.146
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.146
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.156
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.156
 
-  '@anthropic-ai/sdk@0.97.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -6746,7 +6750,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/runtime@7.29.2': {}
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -7705,11 +7709,11 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@posthog/core@1.29.12':
+  '@posthog/core@1.29.13':
     dependencies:
-      '@posthog/types': 1.376.3
+      '@posthog/types': 1.376.4
 
-  '@posthog/types@1.376.3': {}
+  '@posthog/types@1.376.4': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -10313,7 +10317,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -11615,9 +11619,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-node@5.35.5:
+  posthog-node@5.35.6:
     dependencies:
-      '@posthog/core': 1.29.12
+      '@posthog/core': 1.29.13
 
   pretty-ms@9.3.0:
     dependencies:
@@ -12442,6 +12446,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -12730,7 +12739,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.15
       rolldown: 1.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
       esbuild: 0.28.0


### PR DESCRIPTION
Closes [CLI-1593](https://linear.app/supabase/issue/CLI-1593/improve-db-dump-ipv6-error-guidance)

## What

Improves the error message users see when a database connection fails because the host resolves to an IPv6-only address and their network has no IPv6 route.

`SetConnectSuggestion` now recognizes the classic IPv6-unreachable signatures — `connect: network is unreachable` and `connect: no route to host` against a bracketed IPv6 literal — and surfaces an actionable suggestion:

```
Your network does not support IPv6, which is required for direct connections to the database.
Run supabase link to connect through the IPv4 connection pooler instead.
```

## Why

Supabase direct database connections (`db.<ref>.supabase.co:5432`) are IPv6-only unless the IPv4 add-on is enabled. Users on IPv4-only networks previously hit one of two unhelpful outcomes:

- `network is unreachable` → no suggestion at all
- `no route to host` → misreported as *"Make sure your project exists on profile"*

Neither hinted at the real cause (IPv6) or the workaround (the IPv4 transaction pooler, set up by `supabase link`).

## Notes

- The new branch is ordered before the existing `no route to host` / `Tenant or user not found` branch, and requires an IPv6 literal in the message, so genuine "project not found" / Supavisor tenant errors keep their existing suggestion.
- These `db` commands are still proxied to the bundled Go binary, so the fix lives in `apps/cli-go`.

> [!WARNING]
> This currently covers the in-process pgx connection path (`db push` / `db pull` / migration repair). The specific `db dump` symptom in CLI-1593 (`error running container: exit 1`) originates from `pg_dump` running inside a Docker container, whose stderr is streamed to the terminal but never classified — see PR discussion for the follow-up needed to cover that path.

https://claude.ai/code/session_01UaPk7dGPmiCqoKJHyV7SLz