### PR TITLE
fix: skip unconfigured vector bucket seed for linked projects

### DIFF
--- a/apps/cli-go/internal/seed/buckets/buckets.go
+++ b/apps/cli-go/internal/seed/buckets/buckets.go
@@ -11,9 +11,11 @@ import (
 )
 
 func Run(ctx context.Context, projectRef string, interactive bool, fsys afero.Fs) error {
+	shouldSeedVectorBuckets := utils.Config.Storage.VectorBuckets.Enabled &&
+		(len(projectRef) == 0 || len(utils.Config.Storage.VectorBuckets.Buckets) > 0)
 	if len(projectRef) == 0 &&
 		len(utils.Config.Storage.Buckets) == 0 &&
-		!utils.Config.Storage.VectorBuckets.Enabled {
+		!shouldSeedVectorBuckets {
 		return nil
 	}
 	api, err := client.NewStorageAPI(ctx, projectRef)
@@ -49,7 +51,7 @@ func Run(ctx context.Context, projectRef string, interactive bool, fsys afero.Fs
 			return err
 		}
 	}
-	if utils.Config.Storage.VectorBuckets.Enabled {
+	if shouldSeedVectorBuckets {
 		fmt.Fprintln(os.Stderr, "Updating vector buckets...")
 		if err := api.UpsertVectorBuckets(ctx, utils.Config.Storage.VectorBuckets.Buckets, prune); err != nil {
 			return err

--- a/apps/cli-go/internal/seed/buckets/buckets_test.go
+++ b/apps/cli-go/internal/seed/buckets/buckets_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/h2non/gock"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/supabase/cli/internal/testing/apitest"
@@ -120,5 +121,39 @@ public = false`
 		pending := gock.Pending()
 		require.Len(t, pending, 1)
 		assert.Contains(t, pending[0].Request().URLStruct.Path, "DeleteVectorBucket")
+	})
+
+	t.Run("skips unconfigured vector buckets remotely", func(t *testing.T) {
+		t.Cleanup(func() {
+			clear(utils.Config.Storage.Buckets)
+			utils.Config.Storage.VectorBuckets.Enabled = false
+			clear(utils.Config.Storage.VectorBuckets.Buckets)
+			gock.OffAll()
+			viper.Reset()
+		})
+		viper.Set("AUTH_SERVICE_ROLE_KEY", "service-key")
+		utils.Config.Storage.VectorBuckets.Enabled = true
+		utils.Config.Storage.VectorBuckets.Buckets = map[string]struct{}{}
+		config := `
+[test]
+public = true`
+		require.NoError(t, toml.Unmarshal([]byte(config), &utils.Config.Storage.Buckets))
+		projectRef := apitest.RandomProjectRef()
+		gock.New("https://" + utils.GetSupabaseHost(projectRef)).
+			Get("/storage/v1/bucket").
+			Reply(http.StatusOK).
+			JSON([]storage.BucketResponse{{
+				Name: "test",
+				Id:   "test",
+			}})
+		gock.New("https://" + utils.GetSupabaseHost(projectRef)).
+			Put("/storage/v1/bucket/test").
+			Reply(http.StatusOK).
+			JSON(storage.UpdateBucketResponse{})
+		// Run test
+		err := Run(context.Background(), projectRef, false, afero.NewMemMapFs())
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }


### PR DESCRIPTION
## Summary
- skip vector bucket seeding for linked projects when no vector buckets are configured
- keep local vector bucket seeding and configured remote vector buckets unchanged

Fixes #5506

## Testing
- go test ./internal/seed/buckets