### PR TITLE
fix(functions): add apikey compatibility header

### DIFF
--- a/apps/cli-go/internal/functions/serve/templates/main.ts
+++ b/apps/cli-go/internal/functions/serve/templates/main.ts
@@ -111,7 +111,10 @@ function getAuthToken(req: Request) {
   const authHeader = req.headers.get("authorization");
   const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")
 
-  if (!authHeader && !sbApiKeyCompatibilityToken) {
+  // NOTE:(kallebysantos) Kong on legacy CLI stack pass it down as 'Bearer Token' format
+  const cleanSbApiKeyCompatibilityToken = sbApiKeyCompatibilityToken.replace('Bearer', '').trim()
+
+  if (!authHeader && !cleanSbApiKeyCompatibilityToken) {
     throw new Error("Missing authorization header");
   }
 
@@ -120,7 +123,7 @@ function getAuthToken(req: Request) {
   // - Original bearer is not present or is ApiKey
   const bearerToken = extractBearerToken(authHeader ?? '')
   const token = (!bearerToken || bearerToken.startsWith('sb_'))
-    ? sbApiKeyCompatibilityToken
+    ? cleanSbApiKeyCompatibilityToken
     : bearerToken
 
   if (!token) {

--- a/apps/cli-go/internal/functions/serve/templates/main.ts
+++ b/apps/cli-go/internal/functions/serve/templates/main.ts
@@ -212,7 +212,8 @@ export function prepareUserRequest(req: Request): Request {
   const clonedReq = new Request(clonedURL, req.clone())
 
   // remove custom api headers
-  // clonedReq.headers.delete('sb-api-key')
+  clonedReq.headers.delete('sb-api-key')
+  EdgeRuntime.applySupabaseTag(req, clonedReq)
 
   return clonedReq
 }
@@ -316,7 +317,8 @@ Deno.serve({
         staticPatterns,
       });
 
-      return await worker.fetch(req);
+      const userReq = prepareUserRequest(req)
+      return await worker.fetch(userReq);
     } catch (e) {
       console.error(e);
 

--- a/apps/cli-go/internal/functions/serve/templates/main.ts
+++ b/apps/cli-go/internal/functions/serve/templates/main.ts
@@ -112,7 +112,7 @@ function getAuthToken(req: Request) {
   const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")
 
   // NOTE:(kallebysantos) Kong on legacy CLI stack pass it down as 'Bearer Token' format
-  const cleanSbApiKeyCompatibilityToken = sbApiKeyCompatibilityToken.replace('Bearer', '').trim()
+  const cleanSbApiKeyCompatibilityToken = sbApiKeyCompatibilityToken?.replace('Bearer', '')?.trim()
 
   if (!authHeader && !cleanSbApiKeyCompatibilityToken) {
     throw new Error("Missing authorization header");

--- a/apps/cli-go/internal/functions/serve/templates/main.ts
+++ b/apps/cli-go/internal/functions/serve/templates/main.ts
@@ -96,15 +96,37 @@ const functionsConfig: Record<string, FunctionConfig> = (() => {
   }
 })();
 
+/* --- JWT verification --- */
+export function extractBearerToken(rawToken: string) {
+  const tokenParts = rawToken.split(' ')
+  const [bearer, token] = tokenParts
+  if (bearer !== 'Bearer' || tokenParts.length !== 2) {
+    return null
+  }
+
+  return token
+}
+
 function getAuthToken(req: Request) {
   const authHeader = req.headers.get("authorization");
-  if (!authHeader) {
+  const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")
+
+  if (!authHeader && !sbApiKeyCompatibilityToken) {
     throw new Error("Missing authorization header");
   }
-  const [bearer, token] = authHeader.split(" ");
-  if (bearer !== "Bearer") {
+
+  // NOTE:(kallebysantos) Compatibility mode is triggered when all conditions match:
+  // - API proxy mints a temp token
+  // - Original bearer is not present or is ApiKey
+  const bearerToken = extractBearerToken(authHeader ?? '')
+  const token = (!bearerToken || bearerToken.startsWith('sb_'))
+    ? sbApiKeyCompatibilityToken
+    : bearerToken
+
+  if (!token) {
     throw new Error(`Auth header is not 'Bearer {token}'`);
   }
+
   return token;
 }
 
@@ -178,6 +200,18 @@ async function shouldUsePackageJsonDiscovery({ entrypointPath, importMapPath }: 
     }
   }
   return true
+}
+
+export function prepareUserRequest(req: Request): Request {
+  const clonedURL = new URL(req.url)
+  const forwardedHost = req.headers.get('x-forwarded-host')
+  clonedURL.hostname = forwardedHost ?? clonedURL.hostname
+  const clonedReq = new Request(clonedURL, req.clone())
+
+  // remove custom api headers
+  // clonedReq.headers.delete('sb-api-key')
+
+  return clonedReq
 }
 
 Deno.serve({

--- a/apps/cli-go/internal/start/templates/kong.yml
+++ b/apps/cli-go/internal/start/templates/kong.yml
@@ -182,10 +182,10 @@ services:
         config:
           add:
             headers:
-              - "Authorization: {{ .BearerToken }}"
+              - "sb-api-key: {{ .BearerToken }}"
           replace:
             headers:
-              - "Authorization: {{ .BearerToken }}"
+              - "sb-api-key: {{ .BearerToken }}"
   # Management API endpoints
   - name: well-known-oauth
     _comment: "GoTrue: /.well-known/oauth-authorization-server -> http://auth:9999/.well-known/oauth-authorization-server"

--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -37,16 +37,17 @@ function transformAuthorization(
   const apikey = headers["apikey"];
 
   const transformHeaderName = useCustomHeader ? "sb-api-key" : "authorization";
+  const transformPrefix = useCustomHeader ? "" : "Bearer ";
 
   if (auth !== undefined && !auth.startsWith("Bearer sb_")) {
     return headers;
   }
 
   if (apikey === config.publishableKey) {
-    return Headers.set(headers, transformHeaderName, `Bearer ${config.anonJwt}`);
+    return Headers.set(headers, transformHeaderName, transformPrefix + config.anonJwt);
   }
   if (apikey === config.secretKey) {
-    return Headers.set(headers, transformHeaderName, `Bearer ${config.serviceRoleJwt}`);
+    return Headers.set(headers, transformHeaderName, transformPrefix + config.serviceRoleJwt);
   }
   if (apikey !== undefined && apikey !== "") {
     return Headers.set(headers, transformHeaderName, apikey);

--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -28,22 +28,28 @@ export interface ProxyConfig {
   readonly serviceRoleJwt: string;
 }
 
-function transformAuthorization(headers: Headers.Headers, config: ProxyConfig): Headers.Headers {
+function transformAuthorization(
+  headers: Headers.Headers,
+  config: ProxyConfig,
+  useCustomHeader = false,
+): Headers.Headers {
   const auth = headers["authorization"];
   const apikey = headers["apikey"];
+
+  const transformHeaderName = useCustomHeader ? "sb-api-key" : "authorization";
 
   if (auth !== undefined && !auth.startsWith("Bearer sb_")) {
     return headers;
   }
 
   if (apikey === config.publishableKey) {
-    return Headers.set(headers, "authorization", `Bearer ${config.anonJwt}`);
+    return Headers.set(headers, transformHeaderName, `Bearer ${config.anonJwt}`);
   }
   if (apikey === config.secretKey) {
-    return Headers.set(headers, "authorization", `Bearer ${config.serviceRoleJwt}`);
+    return Headers.set(headers, transformHeaderName, `Bearer ${config.serviceRoleJwt}`);
   }
   if (apikey !== undefined && apikey !== "") {
-    return Headers.set(headers, "authorization", apikey);
+    return Headers.set(headers, transformHeaderName, apikey);
   }
 
   return headers;
@@ -103,6 +109,7 @@ interface ProxyHandlerOptions {
   readonly stripPrefix?: string;
   readonly backendPath?: string;
   readonly transformAuth?: boolean;
+  readonly transformAuthCustomHeader?: boolean;
   readonly extraHeaders?: Record<string, string>;
 }
 
@@ -126,7 +133,7 @@ function makeProxyHandler(
 
       let outHeaders = req.headers;
       if (opts.transformAuth === true) {
-        outHeaders = transformAuthorization(outHeaders, config);
+        outHeaders = transformAuthorization(outHeaders, config, opts.transformAuthCustomHeader);
       }
       outHeaders = addProxyHeaders(outHeaders, Option.getOrUndefined(req.remoteAddress));
 
@@ -254,6 +261,7 @@ export class ApiProxy extends Context.Service<
               backendPort: config.edgeRuntimePort,
               stripPrefix: "/functions/v1",
               transformAuth: true,
+              transformAuthCustomHeader: true,
             }),
           ),
           HttpRouter.route(

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -230,7 +230,7 @@ describe("ApiProxy", () => {
       });
       const body = (await res.json()) as { path: string; headers: Record<string, string> };
       expect(body.path).toBe("/test");
-      expect(body.headers["sb-api-key"]).toBe(`Bearer ${SERVICE_ROLE_JWT}`);
+      expect(body.headers["sb-api-key"]).toBe(SERVICE_ROLE_JWT);
     });
 
     test("transforms to custom header without replacing original auth", async () => {
@@ -243,7 +243,7 @@ describe("ApiProxy", () => {
       const body = (await res.json()) as { path: string; headers: Record<string, string> };
       expect(body.path).toBe("/test");
       expect(body.headers["authorization"]).toBe(`Bearer ${SECRET_KEY}`);
-      expect(body.headers["sb-api-key"]).toBe(`Bearer ${SERVICE_ROLE_JWT}`);
+      expect(body.headers["sb-api-key"]).toBe(SERVICE_ROLE_JWT);
     });
   });
 

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -223,13 +223,28 @@ describe("ApiProxy", () => {
     expect(body.path).toBe("/users");
   });
 
-  test("/functions/v1/test strips prefix and transforms auth", async () => {
-    const res = await fetch(`${proxyUrl}/functions/v1/test`, {
-      headers: { apikey: SECRET_KEY },
+  describe("/functions/v1/ test strips prefix and transforms auth", () => {
+    test("transforms to custom header", async () => {
+      const res = await fetch(`${proxyUrl}/functions/v1/test`, {
+        headers: { apikey: SECRET_KEY },
+      });
+      const body = (await res.json()) as { path: string; headers: Record<string, string> };
+      expect(body.path).toBe("/test");
+      expect(body.headers["sb-api-key"]).toBe(`Bearer ${SERVICE_ROLE_JWT}`);
     });
-    const body = (await res.json()) as { path: string; headers: Record<string, string> };
-    expect(body.path).toBe("/test");
-    expect(body.headers["authorization"]).toBe(`Bearer ${SERVICE_ROLE_JWT}`);
+
+    test("transforms to custom header without replacing original auth", async () => {
+      const res = await fetch(`${proxyUrl}/functions/v1/test`, {
+        headers: {
+          apikey: SECRET_KEY,
+          authorization: `Bearer ${SECRET_KEY}`,
+        },
+      });
+      const body = (await res.json()) as { path: string; headers: Record<string, string> };
+      expect(body.path).toBe("/test");
+      expect(body.headers["authorization"]).toBe(`Bearer ${SECRET_KEY}`);
+      expect(body.headers["sb-api-key"]).toBe(`Bearer ${SERVICE_ROLE_JWT}`);
+    });
   });
 
   test("strips upstream content-encoding metadata from proxied function responses", async () => {

--- a/packages/stack/src/services/edge-runtime-main.ts
+++ b/packages/stack/src/services/edge-runtime-main.ts
@@ -63,7 +63,7 @@ async function isValidLocalJwt(secret: string, jwt: string) {
 async function verifyRequest(req: Request, config: any, functionConfig: any) {
   if (!functionConfig.verifyJWT || req.method === "OPTIONS") return null;
   const bearerToken = req.headers.get("authorization")?.slice("Bearer ".length);
-  const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")?.replace('Bearer', '')?.trim()
+  const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")?.replace("Bearer", "")?.trim();
 
   if (!bearerToken && !sbApiKeyCompatibilityToken) {
     return Response.json({ msg: "Missing authorization header" }, { status: 401 });
@@ -72,9 +72,8 @@ async function verifyRequest(req: Request, config: any, functionConfig: any) {
   // NOTE:(kallebysantos) Compatibility mode is triggered when all conditions match:
   // - API proxy mints a temp token
   // - Original bearer is not present or is ApiKey
-  const token = (!bearerToken || bearerToken.startsWith('sb_'))
-    ? sbApiKeyCompatibilityToken
-    : bearerToken
+  const token =
+    !bearerToken || bearerToken.startsWith("sb_") ? sbApiKeyCompatibilityToken : bearerToken;
 
   if (!token) {
     return Response.json({ msg: "Auth header is not 'Bearer {token}'" }, { status: 401 });
@@ -171,7 +170,8 @@ if (typeof Deno !== "undefined") {
         .map((name) => ` - ${config.functionsUrl}/${name}`)
         .join("\n");
       console.log(
-        `Serving functions on ${config.functionsUrl}/<function-name>${examples.length > 0 ? `\n${examples}` : ""
+        `Serving functions on ${config.functionsUrl}/<function-name>${
+          examples.length > 0 ? `\n${examples}` : ""
         }`,
       );
     },

--- a/packages/stack/src/services/edge-runtime-main.ts
+++ b/packages/stack/src/services/edge-runtime-main.ts
@@ -41,6 +41,9 @@ async function isValidLocalJwt(secret: string, jwt: string) {
   if (parts.length !== 3) return false;
   const [header, payload, signature] = parts;
   const decodedHeader = JSON.parse(new TextDecoder().decode(base64UrlToBytes(header!)));
+
+  // WARN:(kallebysantos) Go version supports Asymmetric JWTs (ES256 | RS256) via SUPABASE_JWKS env
+  // It must be ported to TS as well
   if (decodedHeader.alg !== "HS256") return false;
   const key = await crypto.subtle.importKey(
     "raw",
@@ -59,11 +62,24 @@ async function isValidLocalJwt(secret: string, jwt: string) {
 
 async function verifyRequest(req: Request, config: any, functionConfig: any) {
   if (!functionConfig.verifyJWT || req.method === "OPTIONS") return null;
-  const authHeader = req.headers.get("authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
+  const bearerToken = req.headers.get("authorization")?.slice("Bearer ".length);
+  const sbApiKeyCompatibilityToken = req.headers.get("sb-api-key")?.replace('Bearer', '')?.trim()
+
+  if (!bearerToken && !sbApiKeyCompatibilityToken) {
     return Response.json({ msg: "Missing authorization header" }, { status: 401 });
   }
-  const token = authHeader.slice("Bearer ".length);
+
+  // NOTE:(kallebysantos) Compatibility mode is triggered when all conditions match:
+  // - API proxy mints a temp token
+  // - Original bearer is not present or is ApiKey
+  const token = (!bearerToken || bearerToken.startsWith('sb_'))
+    ? sbApiKeyCompatibilityToken
+    : bearerToken
+
+  if (!token) {
+    return Response.json({ msg: "Auth header is not 'Bearer {token}'" }, { status: 401 });
+  }
+
   try {
     if (await isValidLocalJwt(config.jwtSecret, token)) return null;
   } catch (error) {
@@ -155,8 +171,7 @@ if (typeof Deno !== "undefined") {
         .map((name) => ` - ${config.functionsUrl}/${name}`)
         .join("\n");
       console.log(
-        `Serving functions on ${config.functionsUrl}/<function-name>${
-          examples.length > 0 ? `\n${examples}` : ""
+        `Serving functions on ${config.functionsUrl}/<function-name>${examples.length > 0 ? `\n${examples}` : ""
         }`,
       );
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the API proxy is overwriting the `Authorization` header when forwarding to `/functions`

## What is the new behavior?

Uses a custom `sb-api-key` header to handle the minted jwt

## Additional context

Towards [SDK-1153](https://linear.app/supabase/issue/SDK-1153/cli-use-a-custom-header-for-minted-jwts)