### PR TITLE
chore(cli): track output_format and fix is_agent CI parity

### DIFF
--- a/apps/cli-go/cmd/db.go
+++ b/apps/cli-go/cmd/db.go
@@ -308,6 +308,9 @@ without the envelope.`,
 					outputFormat = "table"
 				}
 			}
+			// db query resolves --output into a command-local flag, so mirror the
+			// resolved value onto the global that telemetry's output_format reads.
+			utils.OutputFormat.Value = outputFormat
 			if flag := cmd.Flags().Lookup("linked"); flag != nil && flag.Changed {
 				return query.RunLinked(cmd.Context(), sql, flags.ProjectRef, outputFormat, agentMode, os.Stdout)
 			}

--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -175,8 +175,9 @@ func Execute() {
 		if service := telemetry.FromContext(executedCmd.Context()); service != nil {
 			ensureProjectGroupsCached(executedCmd.Context(), service)
 			_ = service.Capture(executedCmd.Context(), telemetry.EventCommandExecuted, map[string]any{
-				telemetry.PropExitCode:   exitCode(err),
-				telemetry.PropDurationMs: time.Since(startedAt).Milliseconds(),
+				telemetry.PropExitCode:     exitCode(err),
+				telemetry.PropDurationMs:   time.Since(startedAt).Milliseconds(),
+				telemetry.PropOutputFormat: utils.OutputFormat.Value,
 			}, nil)
 			_ = service.Close()
 		}

--- a/apps/cli-go/internal/telemetry/events.go
+++ b/apps/cli-go/internal/telemetry/events.go
@@ -11,9 +11,10 @@ import "context"
 const (
 	//   - EventCommandExecuted: sent after a CLI command finishes, whether it
 	//     succeeds or fails. This helps measure command usage, failure rates, and
-	//     runtime. Event-specific properties are PropExitCode (process exit code)
-	//     and PropDurationMs (command runtime in milliseconds). Related groups:
-	//     none added directly by this event.
+	//     runtime. Event-specific properties are PropExitCode (process exit code),
+	//     PropDurationMs (command runtime in milliseconds), and PropOutputFormat
+	//     (the resolved output format the command used). Related groups: none
+	//     added directly by this event.
 	EventCommandExecuted = "cli_command_executed"
 	//   - EventProjectLinked: sent after the local CLI directory is linked to a
 	//     Supabase project. This helps measure project-linking adoption and connect
@@ -109,6 +110,10 @@ const (
 	PropExitCode = "exit_code"
 	// PropDurationMs is the command runtime in milliseconds.
 	PropDurationMs = "duration_ms"
+	// PropOutputFormat is the resolved output format the command used (for
+	// example "pretty", "json", "yaml"), after agent auto-detection and any
+	// command-local override are applied.
+	PropOutputFormat = "output_format"
 )
 
 // Group identifiers associate events with higher-level entities in PostHog.

--- a/apps/cli/src/legacy/telemetry/legacy-analytics.layer.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-analytics.layer.ts
@@ -161,7 +161,7 @@ export const legacyAnalyticsLayer = Layer.effect(
 
     const loadLinkedProject = makeLoadLinkedProject(fs, path);
 
-    const isAgent = Option.isSome(aiTool.name) || runtime.isCi;
+    const isAgent = Option.isSome(aiTool.name);
     const envSignals = collectEnvSignals();
 
     const baseProperties = stripUndefined({

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
@@ -24,9 +24,46 @@ interface LegacyCommandInstrumentationOptions<Flags extends Record<string, unkno
 }
 
 const REDACTED_VALUE = "<redacted>";
+const LEGACY_GO_MACHINE_OUTPUT_FORMATS = new Set(["env", "json", "toml", "yaml"]);
+const LEGACY_GO_OUTPUT_FORMATS = new Set([...LEGACY_GO_MACHINE_OUTPUT_FORMATS, "pretty"]);
 
 function toCliFlagName(key: string): string {
   return key.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+}
+
+function extractLegacyGoOutputFormat(args: ReadonlyArray<string>): string | undefined {
+  let format: string | undefined;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === undefined) continue;
+
+    if (arg === "--output" || arg === "-o") {
+      const value = args[index + 1];
+      if (value !== undefined && LEGACY_GO_OUTPUT_FORMATS.has(value)) {
+        format = value;
+      }
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith("--output=") || arg.startsWith("-o=")) {
+      const value = arg.slice(arg.indexOf("=") + 1);
+      if (LEGACY_GO_OUTPUT_FORMATS.has(value)) {
+        format = value;
+      }
+    }
+  }
+
+  return format;
+}
+
+function resolveOutputFormatForTelemetry(args: ReadonlyArray<string>, outputFormat: string) {
+  const goOutputFormat = extractLegacyGoOutputFormat(args);
+  if (goOutputFormat !== undefined && LEGACY_GO_MACHINE_OUTPUT_FORMATS.has(goOutputFormat)) {
+    return goOutputFormat;
+  }
+  return outputFormat;
 }
 
 function extractChangedFlagNames(args: ReadonlyArray<string>): ReadonlyArray<string> {
@@ -135,7 +172,7 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
           .capture(EventCommandExecuted, {
             [PropExitCode]: Exit.isSuccess(exit) ? 0 : 1,
             [PropDurationMs]: finishedAt - startedAt,
-            [PropOutputFormat]: output.format,
+            [PropOutputFormat]: resolveOutputFormatForTelemetry(args, output.format),
           })
           .pipe(withAnalyticsContext(analyticsContext));
 

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
@@ -4,12 +4,14 @@ import {
   getCommandRuntimeCommand,
   getCommandRuntimeSpanName,
 } from "../../shared/runtime/command-runtime.service.ts";
+import { Output } from "../../shared/output/output.service.ts";
 import { withAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import {
   EventCommandExecuted,
   PropDurationMs,
   PropExitCode,
+  PropOutputFormat,
 } from "../../shared/telemetry/event-catalog.ts";
 
 interface LegacyCommandInstrumentationOptions<Flags extends Record<string, unknown> = never> {
@@ -114,6 +116,7 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
         });
 
         const analytics = yield* Analytics;
+        const output = yield* Output;
         const stdio = yield* Stdio.Stdio;
         const args = yield* stdio.args;
         const startedAt = yield* Clock.currentTimeMillis;
@@ -132,6 +135,7 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
           .capture(EventCommandExecuted, {
             [PropExitCode]: Exit.isSuccess(exit) ? 0 : 1,
             [PropDurationMs]: finishedAt - startedAt,
+            [PropOutputFormat]: output.format,
           })
           .pipe(withAnalyticsContext(analyticsContext));
 
@@ -145,12 +149,12 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
 
 export function withLegacyCommandInstrumentation(): <A, E, R>(
   self: Effect.Effect<A, E, R>,
-) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio | Output>;
 export function withLegacyCommandInstrumentation<Flags extends Record<string, unknown>>(
   options: LegacyCommandInstrumentationOptions<Flags>,
 ): <A, E, R>(
   self: Effect.Effect<A, E, R>,
-) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio | Output>;
 export function withLegacyCommandInstrumentation<Flags extends Record<string, unknown>>(
   options?: LegacyCommandInstrumentationOptions<Flags>,
 ) {

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
@@ -4,6 +4,7 @@ import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.
 import { CurrentAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { withLegacyCommandInstrumentation } from "./legacy-command-instrumentation.ts";
+import { mockOutput } from "../../../tests/helpers/mocks.ts";
 
 function mockContextualAnalytics() {
   const captured: Array<{
@@ -46,6 +47,7 @@ describe("withLegacyCommandInstrumentation", () => {
     }).pipe(
       withLegacyCommandInstrumentation(),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["backups", "list"]),
@@ -73,6 +75,7 @@ describe("withLegacyCommandInstrumentation", () => {
         flags: { projectRef: Option.some("abcdefghijklmnopqrst") },
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["secrets", "list", "--project-ref", "abcdefghijklmnopqrst"]),
@@ -99,6 +102,7 @@ describe("withLegacyCommandInstrumentation", () => {
         flags: { envFile: Option.some("/path/to/.env") },
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["secrets", "set", "--env-file=/path/to/.env"]),
@@ -125,6 +129,7 @@ describe("withLegacyCommandInstrumentation", () => {
         },
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed([
@@ -157,6 +162,7 @@ describe("withLegacyCommandInstrumentation", () => {
         safeFlags: ["project-ref"],
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["link", "--project-ref", "abcdefghijklmnopqrst"]),
@@ -180,6 +186,7 @@ describe("withLegacyCommandInstrumentation", () => {
     return Effect.void.pipe(
       withLegacyCommandInstrumentation({ flags: {} }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(Stdio.layerTest({ args: Effect.succeed(["backups", "list"]) })),
       Effect.provide(commandRuntimeLayer(["backups", "list"])),
       Effect.tap(() =>
@@ -196,6 +203,7 @@ describe("withLegacyCommandInstrumentation", () => {
 
     return withLegacyCommandInstrumentation()(Effect.fail(new Error("boom"))).pipe(
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(Stdio.layerTest({ args: Effect.succeed(["backups", "list"]) })),
       Effect.provide(commandRuntimeLayer(["backups", "list"])),
       Effect.exit,
@@ -215,6 +223,7 @@ describe("withLegacyCommandInstrumentation", () => {
     return Effect.sync(() => "ok").pipe(
       withLegacyCommandInstrumentation({ analytics: false }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(Stdio.layerTest({ args: Effect.succeed(["telemetry", "enable"]) })),
       Effect.provide(commandRuntimeLayer(["telemetry", "enable"])),
       Effect.tap(() =>
@@ -236,6 +245,7 @@ describe("withLegacyCommandInstrumentation", () => {
         },
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed([

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
@@ -62,6 +62,56 @@ describe("withLegacyCommandInstrumentation", () => {
           expect(event?.properties.command).toBe("backups list");
           expect(event?.properties.exit_code).toBe(0);
           expect(typeof event?.properties.duration_ms).toBe("number");
+          expect(event?.properties.output_format).toBe("text");
+        }),
+      ),
+    );
+  });
+
+  it.live("reports legacy Go machine output formats emitted through the text layer", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed(["backups", "list", "--output", "yaml"]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["backups", "list"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties.output_format).toBe("yaml");
+        }),
+      ),
+    );
+  });
+
+  it.live("keeps the TS output format when legacy --output pretty defers to it", () => {
+    const analytics = mockContextualAnalytics();
+
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "json" }).layer),
+      Effect.provide(
+        Stdio.layerTest({
+          args: Effect.succeed([
+            "backups",
+            "list",
+            "--output",
+            "pretty",
+            "--output-format",
+            "json",
+          ]),
+        }),
+      ),
+      Effect.provide(commandRuntimeLayer(["backups", "list"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties.output_format).toBe("json");
         }),
       ),
     );

--- a/apps/cli/src/next/auth/platform-api.layer.unit.test.ts
+++ b/apps/cli/src/next/auth/platform-api.layer.unit.test.ts
@@ -13,6 +13,7 @@ import { withCommandInstrumentation } from "../../shared/telemetry/command-instr
 import { Credentials } from "./credentials.service.ts";
 import { PlatformApi } from "./platform-api.service.ts";
 import { makePlatformApiServices } from "./platform-api.layer.ts";
+import { mockOutput } from "../../../tests/helpers/mocks.ts";
 
 function httpClientLayer(
   handler: (
@@ -243,6 +244,7 @@ describe("platformApiLayer", () => {
       Effect.provide(layer),
       Effect.provide(runtimeLayer),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["branches", "list"]),

--- a/apps/cli/src/shared/telemetry/command-instrumentation.ts
+++ b/apps/cli/src/shared/telemetry/command-instrumentation.ts
@@ -4,6 +4,7 @@ import {
   getCommandRuntimeCommand,
   getCommandRuntimeSpanName,
 } from "../runtime/command-runtime.service.ts";
+import { Output } from "../output/output.service.ts";
 import { withAnalyticsContext } from "./analytics-context.ts";
 import { Analytics } from "./analytics.service.ts";
 
@@ -99,6 +100,7 @@ function withCommandAnalyticsImplementation<Flags extends Record<string, unknown
         });
 
         const analytics = yield* Analytics;
+        const output = yield* Output;
         const stdio = yield* Stdio.Stdio;
         const args = yield* stdio.args;
         const startedAt = yield* Clock.currentTimeMillis;
@@ -120,6 +122,7 @@ function withCommandAnalyticsImplementation<Flags extends Record<string, unknown
           .capture("cli_command_executed", {
             exit_code: Exit.isSuccess(exit) ? 0 : 1,
             duration_ms: finishedAt - startedAt,
+            output_format: output.format,
           })
           .pipe(withAnalyticsContext(analyticsContext));
 
@@ -133,12 +136,12 @@ function withCommandAnalyticsImplementation<Flags extends Record<string, unknown
 
 export function withCommandInstrumentation(): <A, E, R>(
   self: Effect.Effect<A, E, R>,
-) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio | Output>;
 export function withCommandInstrumentation<Flags extends Record<string, unknown>>(
   options: CommandInstrumentationOptions<Flags>,
 ): <A, E, R>(
   self: Effect.Effect<A, E, R>,
-) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio>;
+) => Effect.Effect<A, E, R | Analytics | CommandRuntime | Stdio.Stdio | Output>;
 export function withCommandInstrumentation<Flags extends Record<string, unknown>>(
   options?: CommandInstrumentationOptions<Flags>,
 ) {

--- a/apps/cli/src/shared/telemetry/command-instrumentation.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/command-instrumentation.unit.test.ts
@@ -4,6 +4,7 @@ import { commandRuntimeLayer } from "../runtime/command-runtime.layer.ts";
 import { CurrentAnalyticsContext } from "./analytics-context.ts";
 import { Analytics } from "./analytics.service.ts";
 import { withCommandInstrumentation } from "./command-instrumentation.ts";
+import { mockOutput } from "../../../tests/helpers/mocks.ts";
 
 function mockContextualAnalytics() {
   const captured: Array<{
@@ -46,6 +47,7 @@ describe("withCommandInstrumentation", () => {
     }).pipe(
       withCommandInstrumentation({ analytics: false }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["branches", "list"]),
@@ -68,6 +70,7 @@ describe("withCommandInstrumentation", () => {
     }).pipe(
       withCommandInstrumentation(),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["start", "--detach", "--exclude=auth"]),
@@ -99,6 +102,7 @@ describe("withCommandInstrumentation", () => {
 
     const program = withCommandInstrumentation()(Effect.fail(new Error("boom"))).pipe(
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["login"]),
@@ -133,6 +137,7 @@ describe("withCommandInstrumentation", () => {
         allowedFlagValues: ["exclude", "mode", "stack"],
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed([
@@ -177,6 +182,7 @@ describe("withCommandInstrumentation", () => {
         allowedFlagValues: ["token", "name", "noBrowser"],
       }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["login", "--name", "my-machine", "--no-browser"]),
@@ -202,6 +208,7 @@ describe("withCommandInstrumentation", () => {
     return Effect.sync(() => "ok").pipe(
       withCommandInstrumentation({ analytics: false }),
       Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
         Stdio.layerTest({
           args: Effect.succeed(["telemetry", "enable"]),

--- a/apps/cli/src/shared/telemetry/event-catalog.ts
+++ b/apps/cli/src/shared/telemetry/event-catalog.ts
@@ -28,6 +28,7 @@ export const PropCommand = "command";
 export const PropFlags = "flags";
 export const PropExitCode = "exit_code";
 export const PropDurationMs = "duration_ms";
+export const PropOutputFormat = "output_format";
 
 export const GroupOrganization = "organization";
 export const GroupProject = "project";


### PR DESCRIPTION
## Summary

Adds an `output_format` property to the `cli_command_executed` telemetry event and fixes a Go/TS divergence in how `is_agent` is computed. Together these make the JSON-vs-human output choice measurable and ensure both CLI shells agree on what counts as an agent. This is the measurement-and-parity groundwork for auto-switching agents to JSON output (next subissue under GROWTH-806).

## Changes

- **Record the resolved output format on every `cli_command_executed`.** Added `output_format` to the Go catalog (`events.go`) and its TS mirror (`event-catalog.ts`), and emit it from the Go capture and both TS instrumentation paths. `db query` resolves its format into a command-local flag, so it now mirrors the resolved value onto the global that telemetry reads, keeping the value accurate for the highest-volume agent command. The property does not exist today, so current JSON usage is unmeasurable without it.
- **Fix `is_agent` Go/TS parity.** The TS legacy analytics layer folded CI into `is_agent` (`is_agent = aiTool || isCi`), tagging CI environments as agents while the Go binary does not. `is_agent` now reflects coding-agent detection only, matching Go on both shells. `is_ci` continues to be reported as its own separate property.

## Notes for reviewers

- `output_format` values are shell-native (Go: `pretty|json|yaml|toml|env`; TS: `text|json|stream-json`), disambiguated by `$lib`; normalize in analysis.
- Deliberately out of scope: aligning the CI env-var lists across the two shells. `runtime.isCi` gates behavior in `legacy-platform-api.layer.ts`, so changing those lists would alter non-interactive behavior for some CI environments. That belongs in a separate change, not this telemetry-parity fix.
- The three instrumentation/platform-api unit tests now provide a mock `Output` because the instrumentation reads `output.format`.

## Linear

- fixes GROWTH-912
- parent GROWTH-806
