### PR TITLE
feat(cli): default output to JSON for coding agents

### DIFF
--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -53,9 +53,9 @@ describe("legacy CLI agent output", () => {
     ]);
   });
 
-  test("keeps parse errors in text mode when --agent=no is explicit", async () => {
+  test("keeps parse errors in text mode when --output-format=text is explicit", async () => {
     const { exitCode, stdout, stderr } = await runSupabase(
-      ["--agent", "no", "definitely-not-a-command"],
+      ["--output-format", "text", "definitely-not-a-command"],
       {
         entrypoint: "legacy",
         env: { CODEX_SANDBOX: "1" },

--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, test } from "vitest";
 import { runSupabase } from "../../../tests/helpers/cli.ts";
 
+function stripAnsi(output: string): string {
+  let stripped = "";
+  for (let i = 0; i < output.length; i++) {
+    const charCode = output.charCodeAt(i);
+    if (charCode !== 0x1b || output[i + 1] !== "[") {
+      stripped += output[i];
+      continue;
+    }
+
+    i += 2;
+    while (i < output.length) {
+      const code = output.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        break;
+      }
+      i++;
+    }
+  }
+  return stripped;
+}
+
 function parseJsonLines(output: string): Array<unknown> {
-  return output
+  return stripAnsi(output)
     .trim()
     .split("\n")
     .filter((line) => line.length > 0)

--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -66,4 +66,61 @@ describe("legacy CLI agent output", () => {
     expect(stdout).toContain("DESCRIPTION");
     expect(stderr).toContain('Unknown subcommand "definitely-not-a-command"');
   });
+
+  test("keeps parse errors in text mode when --agent=no is explicit", async () => {
+    const { exitCode, stdout, stderr } = await runSupabase(
+      ["--agent", "no", "definitely-not-a-command"],
+      {
+        entrypoint: "legacy",
+        env: { CODEX_SANDBOX: "1" },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("DESCRIPTION");
+    expect(stderr).toContain('Unknown subcommand "definitely-not-a-command"');
+  });
+
+  test("formats parse errors as JSON when --agent=yes is explicit", async () => {
+    const { exitCode, stdout, stderr } = await runSupabase(
+      ["--agent", "yes", "definitely-not-a-command"],
+      {
+        entrypoint: "legacy",
+        env: {},
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(parseJsonLines(stdout)).toEqual([
+      expect.objectContaining({ _tag: "Help" }),
+      expect.objectContaining({
+        _tag: "Error",
+        error: expect.objectContaining({ code: "ShowHelp" }),
+      }),
+    ]);
+    expect(parseJsonLines(stderr)).toEqual([
+      expect.objectContaining({
+        _tag: "Errors",
+        errors: [expect.objectContaining({ code: "UnknownSubcommand" })],
+      }),
+    ]);
+  });
+
+  test("keeps built-in version and help in text mode for detected coding agents", async () => {
+    const version = await runSupabase(["--version"], {
+      entrypoint: "legacy",
+      env: { CODEX_SANDBOX: "1" },
+    });
+    const help = await runSupabase(["--help"], {
+      entrypoint: "legacy",
+      env: { CODEX_SANDBOX: "1" },
+    });
+
+    expect(version.exitCode).toBe(0);
+    expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(() => JSON.parse(version.stdout)).toThrow();
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain("DESCRIPTION");
+    expect(() => JSON.parse(help.stdout)).toThrow();
+  });
 });

--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { runSupabase } from "../../../tests/helpers/cli.ts";
+
+function parseJsonLines(output: string): Array<unknown> {
+  return output
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+describe("legacy CLI agent output", () => {
+  test("formats parse errors as JSON for detected coding agents", async () => {
+    const { exitCode, stdout, stderr } = await runSupabase(["definitely-not-a-command"], {
+      entrypoint: "legacy",
+      env: { CODEX_SANDBOX: "1" },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(parseJsonLines(stdout)).toEqual([
+      expect.objectContaining({ _tag: "Help" }),
+      expect.objectContaining({
+        _tag: "Error",
+        error: expect.objectContaining({ code: "ShowHelp" }),
+      }),
+    ]);
+    expect(parseJsonLines(stderr)).toEqual([
+      expect.objectContaining({
+        _tag: "Errors",
+        errors: [expect.objectContaining({ code: "UnknownSubcommand" })],
+      }),
+    ]);
+  });
+
+  test("keeps parse errors in text mode when --agent=no is explicit", async () => {
+    const { exitCode, stdout, stderr } = await runSupabase(
+      ["--agent", "no", "definitely-not-a-command"],
+      {
+        entrypoint: "legacy",
+        env: { CODEX_SANDBOX: "1" },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("DESCRIPTION");
+    expect(stderr).toContain('Unknown subcommand "definitely-not-a-command"');
+  });
+});

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -39,6 +39,9 @@ import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
 import { outputLayerFor } from "../../shared/output/output.layer.ts";
 import { legacyQuietProgressTextOutputLayer } from "../output/legacy-quiet-progress-text-output.layer.ts";
 import { makeGoProxyLayer } from "../../shared/legacy/go-proxy.layer.ts";
+import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
+import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
+import { resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
 import {
   LEGACY_GLOBAL_FLAGS,
   LegacyAgentFlag,
@@ -96,7 +99,7 @@ export const legacyRoot = Command.make("supabase").pipe(
   Command.provide(
     Layer.unwrap(
       Effect.gen(function* () {
-        const outputFormat = yield* OutputFormatFlag;
+        const explicitOutputFormat = yield* OutputFormatFlag;
         const goOutput = yield* LegacyOutputFlag;
         const profile = yield* LegacyProfileFlag;
         const debug = yield* LegacyDebugFlag;
@@ -107,6 +110,10 @@ export const legacyRoot = Command.make("supabase").pipe(
         const dnsResolver = yield* LegacyDnsResolverFlag;
         const createTicket = yield* LegacyCreateTicketFlag;
         const agent = yield* LegacyAgentFlag;
+
+        const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
+        const isCodingAgent = agent === "yes" || (agent !== "no" && Option.isSome(aiTool.name));
+        const outputFormat = resolveAgentOutputFormat(explicitOutputFormat, isCodingAgent);
 
         // Build args to prepend to every proxy exec call.
         // --output: use explicit --output if set, otherwise map from --output-format.

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -44,7 +44,6 @@ import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
 import { resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
 import {
   LEGACY_GLOBAL_FLAGS,
-  LegacyAgentFlag,
   LegacyCreateTicketFlag,
   LegacyDebugFlag,
   LegacyDnsResolverFlag,
@@ -109,7 +108,6 @@ export const legacyRoot = Command.make("supabase").pipe(
         const yes = yield* LegacyYesFlag;
         const dnsResolver = yield* LegacyDnsResolverFlag;
         const createTicket = yield* LegacyCreateTicketFlag;
-        const agent = yield* LegacyAgentFlag;
 
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
         // An explicit Go --output is a complete format choice (even `-o pretty`
@@ -118,7 +116,6 @@ export const legacyRoot = Command.make("supabase").pipe(
         const outputFormat = resolveAgentOutputFormat({
           explicitOutputFormat,
           legacyOutputFormat: goOutput,
-          agentOverride: agent,
           detectedAgentName: aiTool.name,
         });
 
@@ -138,7 +135,6 @@ export const legacyRoot = Command.make("supabase").pipe(
         if (yes) globalArgs.push("--yes");
         if (dnsResolver !== "native") globalArgs.push("--dns-resolver", dnsResolver);
         if (createTicket) globalArgs.push("--create-ticket");
-        if (agent !== "auto") globalArgs.push("--agent", agent);
 
         // Go's `-o {json,yaml,toml,env}` selects a machine encoder the handler
         // writes via `output.raw`. Keep the text layer (so errors still render

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -41,9 +41,11 @@ import { legacyQuietProgressTextOutputLayer } from "../output/legacy-quiet-progr
 import { makeGoProxyLayer } from "../../shared/legacy/go-proxy.layer.ts";
 import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
 import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
-import { resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
+import { isBuiltInTextRequest, resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
 import {
   LEGACY_GLOBAL_FLAGS,
+  LegacyAgentFlag,
   LegacyCreateTicketFlag,
   LegacyDebugFlag,
   LegacyDnsResolverFlag,
@@ -108,6 +110,8 @@ export const legacyRoot = Command.make("supabase").pipe(
         const yes = yield* LegacyYesFlag;
         const dnsResolver = yield* LegacyDnsResolverFlag;
         const createTicket = yield* LegacyCreateTicketFlag;
+        const agent = yield* LegacyAgentFlag;
+        const cliArgs = yield* CliArgs;
 
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
         // An explicit Go --output is a complete format choice (even `-o pretty`
@@ -116,7 +120,9 @@ export const legacyRoot = Command.make("supabase").pipe(
         const outputFormat = resolveAgentOutputFormat({
           explicitOutputFormat,
           legacyOutputFormat: goOutput,
+          agentOverride: agent,
           detectedAgentName: aiTool.name,
+          isBuiltInTextRequest: isBuiltInTextRequest(cliArgs.args),
         });
 
         // Build args to prepend to every proxy exec call.
@@ -135,6 +141,7 @@ export const legacyRoot = Command.make("supabase").pipe(
         if (yes) globalArgs.push("--yes");
         if (dnsResolver !== "native") globalArgs.push("--dns-resolver", dnsResolver);
         if (createTicket) globalArgs.push("--create-ticket");
+        if (agent !== "auto") globalArgs.push("--agent", agent);
 
         // Go's `-o {json,yaml,toml,env}` selects a machine encoder the handler
         // writes via `output.raw`. Keep the text layer (so errors still render

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -113,7 +113,13 @@ export const legacyRoot = Command.make("supabase").pipe(
 
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
         const isCodingAgent = agent === "yes" || (agent !== "no" && Option.isSome(aiTool.name));
-        const outputFormat = resolveAgentOutputFormat(explicitOutputFormat, isCodingAgent);
+        // An explicit Go --output is a complete format choice (even `-o pretty`
+        // must keep its human table), so the agent JSON default only applies
+        // when that flag is absent.
+        const outputFormat = resolveAgentOutputFormat(
+          explicitOutputFormat,
+          isCodingAgent && Option.isNone(goOutput),
+        );
 
         // Build args to prepend to every proxy exec call.
         // --output: use explicit --output if set, otherwise map from --output-format.

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -112,14 +112,15 @@ export const legacyRoot = Command.make("supabase").pipe(
         const agent = yield* LegacyAgentFlag;
 
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
-        const isCodingAgent = agent === "yes" || (agent !== "no" && Option.isSome(aiTool.name));
         // An explicit Go --output is a complete format choice (even `-o pretty`
         // must keep its human table), so the agent JSON default only applies
         // when that flag is absent.
-        const outputFormat = resolveAgentOutputFormat(
+        const outputFormat = resolveAgentOutputFormat({
           explicitOutputFormat,
-          isCodingAgent && Option.isNone(goOutput),
-        );
+          legacyOutputFormat: goOutput,
+          agentOverride: agent,
+          detectedAgentName: aiTool.name,
+        });
 
         // Build args to prepend to every proxy exec call.
         // --output: use explicit --output if set, otherwise map from --output-format.

--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -1,6 +1,9 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { CliOutput, Command } from "effect/unstable/cli";
 import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
+import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
+import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
+import { resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
 import { branchesCommand } from "../commands/branches/branches.command.ts";
 import { functionsCommand } from "../commands/functions/functions.command.ts";
 import { linkCommand } from "../commands/link/link.command.ts";
@@ -47,7 +50,10 @@ export const nextRoot = Command.make("supabase").pipe(
   Command.provide(
     Layer.unwrap(
       Effect.gen(function* () {
-        const outputFormat = yield* OutputFormatFlag;
+        const explicitOutputFormat = yield* OutputFormatFlag;
+        const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
+        const isCodingAgent = Option.isSome(aiTool.name);
+        const outputFormat = resolveAgentOutputFormat(explicitOutputFormat, isCodingAgent);
         const base = outputLayerFor(outputFormat);
         if (outputFormat === "text") return base;
         return Layer.merge(base, CliOutput.layer(jsonCliOutputFormatter()));

--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -3,7 +3,8 @@ import { CliOutput, Command } from "effect/unstable/cli";
 import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
 import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
 import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
-import { resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
+import { isBuiltInTextRequest, resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
 import { branchesCommand } from "../commands/branches/branches.command.ts";
 import { functionsCommand } from "../commands/functions/functions.command.ts";
 import { linkCommand } from "../commands/link/link.command.ts";
@@ -51,10 +52,12 @@ export const nextRoot = Command.make("supabase").pipe(
     Layer.unwrap(
       Effect.gen(function* () {
         const explicitOutputFormat = yield* OutputFormatFlag;
+        const cliArgs = yield* CliArgs;
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
         const outputFormat = resolveAgentOutputFormat({
           explicitOutputFormat,
           detectedAgentName: aiTool.name,
+          isBuiltInTextRequest: isBuiltInTextRequest(cliArgs.args),
         });
         const base = outputLayerFor(outputFormat);
         if (outputFormat === "text") return base;

--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer } from "effect";
 import { CliOutput, Command } from "effect/unstable/cli";
 import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
 import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
@@ -52,8 +52,10 @@ export const nextRoot = Command.make("supabase").pipe(
       Effect.gen(function* () {
         const explicitOutputFormat = yield* OutputFormatFlag;
         const aiTool = yield* AiTool.pipe(Effect.provide(aiToolLayer));
-        const isCodingAgent = Option.isSome(aiTool.name);
-        const outputFormat = resolveAgentOutputFormat(explicitOutputFormat, isCodingAgent);
+        const outputFormat = resolveAgentOutputFormat({
+          explicitOutputFormat,
+          detectedAgentName: aiTool.name,
+        });
         const base = outputLayerFor(outputFormat);
         if (outputFormat === "text") return base;
         return Layer.merge(base, CliOutput.layer(jsonCliOutputFormatter()));

--- a/apps/cli/src/shared/cli/agent-output.ts
+++ b/apps/cli/src/shared/cli/agent-output.ts
@@ -1,9 +1,111 @@
 import { Option } from "effect";
 import type { OutputFormat } from "../output/types.ts";
 
-export function resolveAgentOutputFormat(
-  explicit: Option.Option<OutputFormat>,
-  isCodingAgent: boolean,
+type LegacyOutputFormat = "env" | "pretty" | "json" | "toml" | "yaml";
+type AgentOverride = "auto" | "yes" | "no";
+
+interface AgentOutputOptions {
+  readonly explicitOutputFormat: Option.Option<OutputFormat>;
+  readonly legacyOutputFormat?: Option.Option<LegacyOutputFormat>;
+  readonly agentOverride?: AgentOverride;
+  readonly detectedAgentName?: Option.Option<string>;
+}
+
+function readLongFlag(args: ReadonlyArray<string>, name: string): string | undefined {
+  const prefix = `${name}=`;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) {
+      continue;
+    }
+    if (arg === name) {
+      return args[i + 1];
+    }
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+}
+
+function readOutputFlag(args: ReadonlyArray<string>): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) {
+      continue;
+    }
+    if (arg === "--output" || arg === "-o") {
+      return args[i + 1];
+    }
+    if (arg.startsWith("--output=")) {
+      return arg.slice("--output=".length);
+    }
+    if (arg.startsWith("-o=")) {
+      return arg.slice("-o=".length);
+    }
+    if (arg.length > 2 && arg.startsWith("-o")) {
+      return arg.slice("-o".length);
+    }
+  }
+}
+
+function outputFormatFromArg(value: string | undefined): Option.Option<OutputFormat> {
+  switch (value) {
+    case "text":
+    case "json":
+    case "stream-json":
+      return Option.some(value);
+    default:
+      return Option.none();
+  }
+}
+
+function legacyOutputFormatFromArg(value: string | undefined): Option.Option<LegacyOutputFormat> {
+  switch (value) {
+    case "env":
+    case "pretty":
+    case "json":
+    case "toml":
+    case "yaml":
+      return Option.some(value);
+    default:
+      return Option.none();
+  }
+}
+
+function agentOverrideFromArg(value: string | undefined): AgentOverride {
+  switch (value) {
+    case "yes":
+    case "no":
+      return value;
+    default:
+      return "auto";
+  }
+}
+
+export function resolveAgentOutputFormat(options: AgentOutputOptions): OutputFormat {
+  const legacyOutputFormat = options.legacyOutputFormat ?? Option.none<LegacyOutputFormat>();
+  const agentOverride = options.agentOverride ?? "auto";
+  const detectedAgentName = options.detectedAgentName ?? Option.none<string>();
+  const isCodingAgent =
+    agentOverride === "yes" || (agentOverride !== "no" && Option.isSome(detectedAgentName));
+
+  return Option.getOrElse(options.explicitOutputFormat, () =>
+    isCodingAgent && Option.isNone(legacyOutputFormat) ? "json" : "text",
+  );
+}
+
+export function resolveAgentOutputFormatFromArgs(
+  args: ReadonlyArray<string>,
+  detectedAgentName: Option.Option<string>,
 ): OutputFormat {
-  return Option.getOrElse(explicit, () => (isCodingAgent ? "json" : "text"));
+  const explicitOutputFormat = outputFormatFromArg(readLongFlag(args, "--output-format"));
+  const legacyOutputFormat = legacyOutputFormatFromArg(readOutputFlag(args));
+  const agentOverride = agentOverrideFromArg(readLongFlag(args, "--agent"));
+
+  return resolveAgentOutputFormat({
+    explicitOutputFormat,
+    legacyOutputFormat,
+    agentOverride,
+    detectedAgentName,
+  });
 }

--- a/apps/cli/src/shared/cli/agent-output.ts
+++ b/apps/cli/src/shared/cli/agent-output.ts
@@ -83,10 +83,70 @@ function agentOverrideFromArg(value: string | undefined): AgentOverride {
   }
 }
 
-export function isBuiltInTextRequest(args: ReadonlyArray<string>): boolean {
-  return args.some(
-    (arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v",
+function isRootValueFlag(arg: string): boolean {
+  return (
+    arg === "--output-format" ||
+    arg === "--output" ||
+    arg === "-o" ||
+    arg === "--profile" ||
+    arg === "--workdir" ||
+    arg === "--network-id" ||
+    arg === "--dns-resolver" ||
+    arg === "--agent"
   );
+}
+
+function isRootValueFlagWithInlineValue(arg: string): boolean {
+  return (
+    arg.startsWith("--output-format=") ||
+    arg.startsWith("--output=") ||
+    arg.startsWith("-o=") ||
+    (arg.length > 2 && arg.startsWith("-o")) ||
+    arg.startsWith("--profile=") ||
+    arg.startsWith("--workdir=") ||
+    arg.startsWith("--network-id=") ||
+    arg.startsWith("--dns-resolver=") ||
+    arg.startsWith("--agent=")
+  );
+}
+
+function isRootBooleanFlag(arg: string): boolean {
+  return (
+    arg === "--debug" || arg === "--experimental" || arg === "--yes" || arg === "--create-ticket"
+  );
+}
+
+function hasRootVersionRequest(args: ReadonlyArray<string>): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined || arg === "--") {
+      return false;
+    }
+    if (arg === "--version" || arg === "-v") {
+      return true;
+    }
+    if (isRootValueFlag(arg)) {
+      i++;
+      continue;
+    }
+    if (isRootValueFlagWithInlineValue(arg) || isRootBooleanFlag(arg)) {
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
+function hasHelpRequest(args: ReadonlyArray<string>): boolean {
+  for (const arg of args) {
+    if (arg === "--") return false;
+    if (arg === "--help" || arg === "-h") return true;
+  }
+  return false;
+}
+
+export function isBuiltInTextRequest(args: ReadonlyArray<string>): boolean {
+  return hasHelpRequest(args) || hasRootVersionRequest(args);
 }
 
 export function resolveAgentOutputFormat(options: AgentOutputOptions): OutputFormat {

--- a/apps/cli/src/shared/cli/agent-output.ts
+++ b/apps/cli/src/shared/cli/agent-output.ts
@@ -2,11 +2,14 @@ import { Option } from "effect";
 import type { OutputFormat } from "../output/types.ts";
 
 type LegacyOutputFormat = "env" | "pretty" | "json" | "toml" | "yaml";
+type AgentOverride = "auto" | "yes" | "no";
 
 interface AgentOutputOptions {
   readonly explicitOutputFormat: Option.Option<OutputFormat>;
   readonly legacyOutputFormat?: Option.Option<LegacyOutputFormat>;
+  readonly agentOverride?: AgentOverride;
   readonly detectedAgentName?: Option.Option<string>;
+  readonly isBuiltInTextRequest?: boolean;
 }
 
 function readLongFlag(args: ReadonlyArray<string>, name: string): string | undefined {
@@ -70,13 +73,33 @@ function legacyOutputFormatFromArg(value: string | undefined): Option.Option<Leg
   }
 }
 
+function agentOverrideFromArg(value: string | undefined): AgentOverride {
+  switch (value) {
+    case "yes":
+    case "no":
+      return value;
+    default:
+      return "auto";
+  }
+}
+
+export function isBuiltInTextRequest(args: ReadonlyArray<string>): boolean {
+  return args.some(
+    (arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v",
+  );
+}
+
 export function resolveAgentOutputFormat(options: AgentOutputOptions): OutputFormat {
   const legacyOutputFormat = options.legacyOutputFormat ?? Option.none<LegacyOutputFormat>();
   const detectedAgentName = options.detectedAgentName ?? Option.none<string>();
-  const isCodingAgent = Option.isSome(detectedAgentName);
+  const agentOverride = options.agentOverride ?? "auto";
+  const isCodingAgent =
+    agentOverride === "yes" || (agentOverride === "auto" && Option.isSome(detectedAgentName));
 
   return Option.getOrElse(options.explicitOutputFormat, () =>
-    isCodingAgent && Option.isNone(legacyOutputFormat) ? "json" : "text",
+    isCodingAgent && Option.isNone(legacyOutputFormat) && !options.isBuiltInTextRequest
+      ? "json"
+      : "text",
   );
 }
 
@@ -86,10 +109,13 @@ export function resolveAgentOutputFormatFromArgs(
 ): OutputFormat {
   const explicitOutputFormat = outputFormatFromArg(readLongFlag(args, "--output-format"));
   const legacyOutputFormat = legacyOutputFormatFromArg(readOutputFlag(args));
+  const agentOverride = agentOverrideFromArg(readLongFlag(args, "--agent"));
 
   return resolveAgentOutputFormat({
     explicitOutputFormat,
     legacyOutputFormat,
+    agentOverride,
     detectedAgentName,
+    isBuiltInTextRequest: isBuiltInTextRequest(args),
   });
 }

--- a/apps/cli/src/shared/cli/agent-output.ts
+++ b/apps/cli/src/shared/cli/agent-output.ts
@@ -2,12 +2,10 @@ import { Option } from "effect";
 import type { OutputFormat } from "../output/types.ts";
 
 type LegacyOutputFormat = "env" | "pretty" | "json" | "toml" | "yaml";
-type AgentOverride = "auto" | "yes" | "no";
 
 interface AgentOutputOptions {
   readonly explicitOutputFormat: Option.Option<OutputFormat>;
   readonly legacyOutputFormat?: Option.Option<LegacyOutputFormat>;
-  readonly agentOverride?: AgentOverride;
   readonly detectedAgentName?: Option.Option<string>;
 }
 
@@ -72,22 +70,10 @@ function legacyOutputFormatFromArg(value: string | undefined): Option.Option<Leg
   }
 }
 
-function agentOverrideFromArg(value: string | undefined): AgentOverride {
-  switch (value) {
-    case "yes":
-    case "no":
-      return value;
-    default:
-      return "auto";
-  }
-}
-
 export function resolveAgentOutputFormat(options: AgentOutputOptions): OutputFormat {
   const legacyOutputFormat = options.legacyOutputFormat ?? Option.none<LegacyOutputFormat>();
-  const agentOverride = options.agentOverride ?? "auto";
   const detectedAgentName = options.detectedAgentName ?? Option.none<string>();
-  const isCodingAgent =
-    agentOverride === "yes" || (agentOverride !== "no" && Option.isSome(detectedAgentName));
+  const isCodingAgent = Option.isSome(detectedAgentName);
 
   return Option.getOrElse(options.explicitOutputFormat, () =>
     isCodingAgent && Option.isNone(legacyOutputFormat) ? "json" : "text",
@@ -100,12 +86,10 @@ export function resolveAgentOutputFormatFromArgs(
 ): OutputFormat {
   const explicitOutputFormat = outputFormatFromArg(readLongFlag(args, "--output-format"));
   const legacyOutputFormat = legacyOutputFormatFromArg(readOutputFlag(args));
-  const agentOverride = agentOverrideFromArg(readLongFlag(args, "--agent"));
 
   return resolveAgentOutputFormat({
     explicitOutputFormat,
     legacyOutputFormat,
-    agentOverride,
     detectedAgentName,
   });
 }

--- a/apps/cli/src/shared/cli/agent-output.ts
+++ b/apps/cli/src/shared/cli/agent-output.ts
@@ -1,0 +1,9 @@
+import { Option } from "effect";
+import type { OutputFormat } from "../output/types.ts";
+
+export function resolveAgentOutputFormat(
+  explicit: Option.Option<OutputFormat>,
+  isCodingAgent: boolean,
+): OutputFormat {
+  return Option.getOrElse(explicit, () => (isCodingAgent ? "json" : "text"));
+}

--- a/apps/cli/src/shared/cli/agent-output.unit.test.ts
+++ b/apps/cli/src/shared/cli/agent-output.unit.test.ts
@@ -52,6 +52,40 @@ describe("resolveAgentOutputFormat", () => {
     ).toBe("text");
   });
 
+  it("honors the legacy --agent override", () => {
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        agentOverride: "no",
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("text");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        agentOverride: "yes",
+        detectedAgentName: Option.none(),
+      }),
+    ).toBe("json");
+  });
+
+  it("keeps built-in help and version text unless output-format is explicit", () => {
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        detectedAgentName: Option.some("codex"),
+        isBuiltInTextRequest: true,
+      }),
+    ).toBe("text");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.some("json"),
+        detectedAgentName: Option.some("codex"),
+        isBuiltInTextRequest: true,
+      }),
+    ).toBe("json");
+  });
+
   it("resolves the effective format from raw argv for runtime error formatting", () => {
     expect(resolveAgentOutputFormatFromArgs(["bad-command"], Option.some("codex"))).toBe("json");
     expect(
@@ -69,5 +103,16 @@ describe("resolveAgentOutputFormat", () => {
         Option.some("codex"),
       ),
     ).toBe("stream-json");
+    expect(
+      resolveAgentOutputFormatFromArgs(["--agent", "no", "bad-command"], Option.some("codex")),
+    ).toBe("text");
+    expect(resolveAgentOutputFormatFromArgs(["--agent=yes", "bad-command"], Option.none())).toBe(
+      "json",
+    );
+    expect(resolveAgentOutputFormatFromArgs(["--version"], Option.some("codex"))).toBe("text");
+    expect(resolveAgentOutputFormatFromArgs(["--help"], Option.some("codex"))).toBe("text");
+    expect(
+      resolveAgentOutputFormatFromArgs(["--output-format=json", "--help"], Option.some("codex")),
+    ).toBe("json");
   });
 });

--- a/apps/cli/src/shared/cli/agent-output.unit.test.ts
+++ b/apps/cli/src/shared/cli/agent-output.unit.test.ts
@@ -1,0 +1,19 @@
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import { resolveAgentOutputFormat } from "./agent-output.ts";
+
+describe("resolveAgentOutputFormat", () => {
+  it("defaults a coding agent to json", () => {
+    expect(resolveAgentOutputFormat(Option.none(), true)).toBe("json");
+  });
+
+  it("defaults a non-agent to text", () => {
+    expect(resolveAgentOutputFormat(Option.none(), false)).toBe("text");
+  });
+
+  it("honors an explicit format over agent detection", () => {
+    expect(resolveAgentOutputFormat(Option.some("text"), true)).toBe("text");
+    expect(resolveAgentOutputFormat(Option.some("stream-json"), false)).toBe("stream-json");
+    expect(resolveAgentOutputFormat(Option.some("json"), true)).toBe("json");
+  });
+});

--- a/apps/cli/src/shared/cli/agent-output.unit.test.ts
+++ b/apps/cli/src/shared/cli/agent-output.unit.test.ts
@@ -110,7 +110,16 @@ describe("resolveAgentOutputFormat", () => {
       "json",
     );
     expect(resolveAgentOutputFormatFromArgs(["--version"], Option.some("codex"))).toBe("text");
+    expect(
+      resolveAgentOutputFormatFromArgs(
+        ["--profile", "supabase", "--version"],
+        Option.some("codex"),
+      ),
+    ).toBe("text");
     expect(resolveAgentOutputFormatFromArgs(["--help"], Option.some("codex"))).toBe("text");
+    expect(
+      resolveAgentOutputFormatFromArgs(["db", "reset", "--version", "1"], Option.some("codex")),
+    ).toBe("json");
     expect(
       resolveAgentOutputFormatFromArgs(["--output-format=json", "--help"], Option.some("codex")),
     ).toBe("json");

--- a/apps/cli/src/shared/cli/agent-output.unit.test.ts
+++ b/apps/cli/src/shared/cli/agent-output.unit.test.ts
@@ -1,19 +1,87 @@
 import { Option } from "effect";
 import { describe, expect, it } from "vitest";
-import { resolveAgentOutputFormat } from "./agent-output.ts";
+import { resolveAgentOutputFormat, resolveAgentOutputFormatFromArgs } from "./agent-output.ts";
 
 describe("resolveAgentOutputFormat", () => {
   it("defaults a coding agent to json", () => {
-    expect(resolveAgentOutputFormat(Option.none(), true)).toBe("json");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("json");
   });
 
   it("defaults a non-agent to text", () => {
-    expect(resolveAgentOutputFormat(Option.none(), false)).toBe("text");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        detectedAgentName: Option.none(),
+      }),
+    ).toBe("text");
   });
 
   it("honors an explicit format over agent detection", () => {
-    expect(resolveAgentOutputFormat(Option.some("text"), true)).toBe("text");
-    expect(resolveAgentOutputFormat(Option.some("stream-json"), false)).toBe("stream-json");
-    expect(resolveAgentOutputFormat(Option.some("json"), true)).toBe("json");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.some("text"),
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("text");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.some("stream-json"),
+        detectedAgentName: Option.none(),
+      }),
+    ).toBe("stream-json");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.some("json"),
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("json");
+  });
+
+  it("honors the --agent override", () => {
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        agentOverride: "yes",
+        detectedAgentName: Option.none(),
+      }),
+    ).toBe("json");
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        agentOverride: "no",
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("text");
+  });
+
+  it("keeps legacy --output authoritative over the agent JSON default", () => {
+    expect(
+      resolveAgentOutputFormat({
+        explicitOutputFormat: Option.none(),
+        legacyOutputFormat: Option.some("pretty"),
+        detectedAgentName: Option.some("codex"),
+      }),
+    ).toBe("text");
+  });
+
+  it("resolves the effective format from raw argv for runtime error formatting", () => {
+    expect(resolveAgentOutputFormatFromArgs(["bad-command"], Option.some("codex"))).toBe("json");
+    expect(
+      resolveAgentOutputFormatFromArgs(["--agent", "no", "bad-command"], Option.some("codex")),
+    ).toBe("text");
+    expect(
+      resolveAgentOutputFormatFromArgs(["-o", "pretty", "bad-command"], Option.some("codex")),
+    ).toBe("text");
+    expect(
+      resolveAgentOutputFormatFromArgs(
+        ["--output-format=stream-json", "bad-command"],
+        Option.some("codex"),
+      ),
+    ).toBe("stream-json");
   });
 });

--- a/apps/cli/src/shared/cli/agent-output.unit.test.ts
+++ b/apps/cli/src/shared/cli/agent-output.unit.test.ts
@@ -42,23 +42,6 @@ describe("resolveAgentOutputFormat", () => {
     ).toBe("json");
   });
 
-  it("honors the --agent override", () => {
-    expect(
-      resolveAgentOutputFormat({
-        explicitOutputFormat: Option.none(),
-        agentOverride: "yes",
-        detectedAgentName: Option.none(),
-      }),
-    ).toBe("json");
-    expect(
-      resolveAgentOutputFormat({
-        explicitOutputFormat: Option.none(),
-        agentOverride: "no",
-        detectedAgentName: Option.some("codex"),
-      }),
-    ).toBe("text");
-  });
-
   it("keeps legacy --output authoritative over the agent JSON default", () => {
     expect(
       resolveAgentOutputFormat({
@@ -72,7 +55,10 @@ describe("resolveAgentOutputFormat", () => {
   it("resolves the effective format from raw argv for runtime error formatting", () => {
     expect(resolveAgentOutputFormatFromArgs(["bad-command"], Option.some("codex"))).toBe("json");
     expect(
-      resolveAgentOutputFormatFromArgs(["--agent", "no", "bad-command"], Option.some("codex")),
+      resolveAgentOutputFormatFromArgs(
+        ["--output-format", "text", "bad-command"],
+        Option.some("codex"),
+      ),
     ).toBe("text");
     expect(
       resolveAgentOutputFormatFromArgs(["-o", "pretty", "bad-command"], Option.some("codex")),

--- a/apps/cli/src/shared/cli/cli-args.service.ts
+++ b/apps/cli/src/shared/cli/cli-args.service.ts
@@ -1,0 +1,7 @@
+import { Context } from "effect";
+
+export interface CliArgsShape {
+  readonly args: ReadonlyArray<string>;
+}
+
+export class CliArgs extends Context.Service<CliArgs, CliArgsShape>()("supabase/cli/CliArgs") {}

--- a/apps/cli/src/shared/cli/global-flags.ts
+++ b/apps/cli/src/shared/cli/global-flags.ts
@@ -1,9 +1,8 @@
 import { Flag, GlobalFlag } from "effect/unstable/cli";
-import type { OutputFormat } from "../output/types.ts";
 
 export const OutputFormatFlag = GlobalFlag.setting("output-format")({
   flag: Flag.choice("output-format", ["text", "json", "stream-json"]).pipe(
     Flag.withDescription("Output format: text (default), json, or stream-json (NDJSON)"),
-    Flag.withDefault("text" as OutputFormat),
+    Flag.optional,
   ),
 });

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -22,24 +22,13 @@ import { ttyLayer } from "../runtime/tty.layer.ts";
 import { CommandRuntime } from "../runtime/command-runtime.service.ts";
 import { ProcessControl } from "../runtime/process-control.service.ts";
 import type { Analytics } from "../telemetry/analytics.service.ts";
+import { aiToolLayer } from "../telemetry/ai-tool.layer.ts";
+import { AiTool } from "../telemetry/ai-tool.service.ts";
 import { telemetryRuntimeLayer } from "../telemetry/runtime.layer.ts";
 import { tracingLayer } from "../telemetry/tracing.layer.ts";
+import { resolveAgentOutputFormatFromArgs } from "./agent-output.ts";
 
-function outputFormatFor(args: ReadonlyArray<string>): OutputFormat {
-  const inline = args.find((arg) => arg.startsWith("--output-format="));
-  if (inline) {
-    const value = inline.slice("--output-format=".length);
-    if (value === "json" || value === "stream-json" || value === "text") {
-      return value;
-    }
-  }
-  const formatIdx = args.indexOf("--output-format");
-  const format = formatIdx !== -1 ? args[formatIdx + 1] : undefined;
-  return format === "json" || format === "stream-json" ? format : "text";
-}
-
-function formatterLayerFor(args: ReadonlyArray<string>) {
-  const format = outputFormatFor(args);
+function formatterLayerFor(format: OutputFormat) {
   return format === "json" || format === "stream-json"
     ? CliOutput.layer(jsonCliOutputFormatter())
     : CliOutput.layer(textCliOutputFormatter());
@@ -75,6 +64,7 @@ function cliProgramFor(
   rootCommand: Command.Command.Any,
   args: ReadonlyArray<string>,
   options: RunCliOptions,
+  outputFormat: OutputFormat,
 ) {
   const runtimeLayer = Layer.mergeAll(processControlLayer, runtimeInfoLayer, ttyLayer);
   const fallbackCommandLayer = Layer.mergeAll(
@@ -101,7 +91,7 @@ function cliProgramFor(
     ),
   );
   return Command.runWith(rootCommand, { version: CLI_VERSION })(args).pipe(
-    Effect.provide(formatterLayerFor(args)),
+    Effect.provide(formatterLayerFor(outputFormat)),
     Effect.provide(options.analyticsLayer),
     Effect.provide(tracingLayer),
     Effect.provide(telemetryRuntimeLayer),
@@ -125,7 +115,13 @@ export async function runCli(rootCommand: Command.Command.Any, options: RunCliOp
   );
 
   const useGlobalSignalInterrupt = !args.includes("start");
-  const cliProgram = cliProgramFor(rootCommand, args, options);
+  const outputFormat = await Effect.runPromise(
+    Effect.gen(function* () {
+      const aiTool = yield* AiTool;
+      return resolveAgentOutputFormatFromArgs(args, aiTool.name);
+    }).pipe(Effect.provide(aiToolLayer)),
+  );
+  const cliProgram = cliProgramFor(rootCommand, args, options, outputFormat);
 
   const signalAwareProgram = Effect.scoped(
     Effect.gen(function* () {
@@ -172,7 +168,7 @@ export async function runCli(rootCommand: Command.Command.Any, options: RunCliOp
       const exitCode = yield* processControl.getExitCode;
       return yield* processControl.exit(exitCode ?? 0);
     }).pipe(
-      Effect.provide(outputLayerFor(outputFormatFor(args))),
+      Effect.provide(outputLayerFor(outputFormat)),
       Effect.provide(telemetryRuntimeLayer),
       Effect.provide(projectHomeLayerFor(handledRuntimeLayer)),
       Effect.provide(cliConfigLayerFor(handledRuntimeLayer)),

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -26,6 +26,7 @@ import { aiToolLayer } from "../telemetry/ai-tool.layer.ts";
 import { AiTool } from "../telemetry/ai-tool.service.ts";
 import { telemetryRuntimeLayer } from "../telemetry/runtime.layer.ts";
 import { tracingLayer } from "../telemetry/tracing.layer.ts";
+import { CliArgs } from "./cli-args.service.ts";
 import { resolveAgentOutputFormatFromArgs } from "./agent-output.ts";
 
 function formatterLayerFor(format: OutputFormat) {
@@ -102,6 +103,7 @@ function cliProgramFor(
     Effect.provide(runtimeLayer),
     Effect.provide(unixHttpClientLayer),
     Effect.provide(fallbackCommandLayer),
+    Effect.provide(Layer.succeed(CliArgs, { args })),
     Effect.provide(BunServices.layer),
   );
 }

--- a/apps/cli/src/shared/cli/version.integration.test.ts
+++ b/apps/cli/src/shared/cli/version.integration.test.ts
@@ -6,9 +6,15 @@ import { vi } from "vitest";
 import { legacyRoot } from "../../legacy/cli/root.ts";
 import { nextRoot } from "../../next/cli/root.ts";
 import { textCliOutputFormatter } from "../output/text-formatter.ts";
+import { CliArgs } from "./cli-args.service.ts";
 
 describe("CLI --version (text)", () => {
-  const versionLayer = Layer.mergeAll(CliOutput.layer(textCliOutputFormatter()), BunServices.layer);
+  const versionLayer = (args: ReadonlyArray<string>) =>
+    Layer.mergeAll(
+      CliOutput.layer(textCliOutputFormatter()),
+      Layer.succeed(CliArgs, { args }),
+      BunServices.layer,
+    );
 
   test("legacy shell prints bare semver on stdout", async () => {
     const logs: string[] = [];
@@ -28,7 +34,7 @@ describe("CLI --version (text)", () => {
       // `--version` exits early; only BunServices + CliOutput are needed at runtime here.
       await Effect.runPromise(
         Command.runWith(legacyRoot, { version: "2.99.0-beta.1" })(["--version"]).pipe(
-          Effect.provide(versionLayer),
+          Effect.provide(versionLayer(["--version"])),
         ) as Effect.Effect<void>,
       );
     } finally {
@@ -55,7 +61,7 @@ describe("CLI --version (text)", () => {
     try {
       await Effect.runPromise(
         Command.runWith(nextRoot, { version: "2.99.0-beta.1" })(["--version"]).pipe(
-          Effect.provide(versionLayer),
+          Effect.provide(versionLayer(["--version"])),
         ) as Effect.Effect<void>,
       );
     } finally {

--- a/apps/cli/src/shared/legacy/global-flags.ts
+++ b/apps/cli/src/shared/legacy/global-flags.ts
@@ -54,13 +54,6 @@ export const LegacyCreateTicketFlag = GlobalFlag.setting("create-ticket")({
   ),
 });
 
-export const LegacyAgentFlag = GlobalFlag.setting("agent")({
-  flag: Flag.choice("agent", ["auto", "yes", "no"] as const).pipe(
-    Flag.withDescription("Override agent detection: yes, no, or auto."),
-    Flag.withDefault("auto" as const),
-  ),
-});
-
 export const LEGACY_GLOBAL_FLAGS = [
   LegacyOutputFlag,
   LegacyProfileFlag,
@@ -71,5 +64,4 @@ export const LEGACY_GLOBAL_FLAGS = [
   LegacyYesFlag,
   LegacyDnsResolverFlag,
   LegacyCreateTicketFlag,
-  LegacyAgentFlag,
 ] as const;

--- a/apps/cli/src/shared/legacy/global-flags.ts
+++ b/apps/cli/src/shared/legacy/global-flags.ts
@@ -54,6 +54,13 @@ export const LegacyCreateTicketFlag = GlobalFlag.setting("create-ticket")({
   ),
 });
 
+export const LegacyAgentFlag = GlobalFlag.setting("agent")({
+  flag: Flag.choice("agent", ["auto", "yes", "no"] as const).pipe(
+    Flag.withDescription("Override agent detection: yes, no, or auto (default auto)."),
+    Flag.withDefault("auto" as const),
+  ),
+});
+
 export const LEGACY_GLOBAL_FLAGS = [
   LegacyOutputFlag,
   LegacyProfileFlag,
@@ -64,4 +71,5 @@ export const LEGACY_GLOBAL_FLAGS = [
   LegacyYesFlag,
   LegacyDnsResolverFlag,
   LegacyCreateTicketFlag,
+  LegacyAgentFlag,
 ] as const;

--- a/packages/stack/src/PortAllocator.ts
+++ b/packages/stack/src/PortAllocator.ts
@@ -119,6 +119,12 @@ export const DEFAULT_PORTS: Partial<AllocatedPorts> = {
 interface PortAllocationOptions {
   readonly reserved?: ReadonlySet<number>;
   readonly preferred?: Partial<AllocatedPorts>;
+  readonly probe?: PortProbe;
+}
+
+interface PortProbe {
+  readonly exact: (port: number) => Effect.Effect<number, PortAllocationError>;
+  readonly random: (exclude: ReadonlySet<number>) => Effect.Effect<number, PortAllocationError>;
 }
 
 /** Bind port 0 to get an OS-assigned random port, then close immediately. */
@@ -159,20 +165,25 @@ const probeExactPort = (port: number): Effect.Effect<number, PortAllocationError
 const chooseExactPort = (
   port: number,
   exclude: ReadonlySet<number>,
+  probe: PortProbe,
 ): Effect.Effect<number, PortAllocationError> =>
   exclude.has(port)
     ? Effect.fail(new PortAllocationError({ detail: `Port ${port} is not available` }))
-    : probeExactPort(port);
+    : probe.exact(port);
 
 const choosePreferredPort = (
   port: number,
   exclude: ReadonlySet<number>,
+  probe: PortProbe,
 ): Effect.Effect<number, PortAllocationError> =>
   exclude.has(port)
-    ? probeRandomPort(exclude)
-    : probeExactPort(port).pipe(
-        Effect.catchTag("PortAllocationError", () => probeRandomPort(exclude)),
-      );
+    ? probe.random(exclude)
+    : probe.exact(port).pipe(Effect.catchTag("PortAllocationError", () => probe.random(exclude)));
+
+const defaultPortProbe: PortProbe = {
+  exact: probeExactPort,
+  random: probeRandomPort,
+};
 
 export const allocatePorts = (
   input: PortInput,
@@ -181,6 +192,7 @@ export const allocatePorts = (
   Effect.gen(function* () {
     const reserved = options.reserved ?? new Set<number>();
     const preferred = options.preferred ?? {};
+    const probe = options.probe ?? defaultPortProbe;
     const allocated = new Set<number>();
 
     const alloc = (port: number) => {
@@ -193,15 +205,15 @@ export const allocatePorts = (
     const resolvePort = (field: PortField) => {
       const explicit = input[field];
       if (explicit !== undefined) {
-        return chooseExactPort(explicit, exclude());
+        return chooseExactPort(explicit, exclude(), probe);
       }
 
       const preferredPort = preferred[field];
       if (preferredPort !== undefined) {
-        return choosePreferredPort(preferredPort, exclude());
+        return choosePreferredPort(preferredPort, exclude(), probe);
       }
 
-      return probeRandomPort(exclude());
+      return probe.random(exclude());
     };
 
     const partial: Partial<Record<PortField, number>> = {};

--- a/packages/stack/src/PortAllocator.unit.test.ts
+++ b/packages/stack/src/PortAllocator.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createServer } from "node:net";
 import type { Server } from "node:net";
 import { Effect } from "effect";
-import { allocatePorts, DEFAULT_PORTS } from "./PortAllocator.ts";
+import { allocatePorts, DEFAULT_PORTS, PortAllocationError } from "./PortAllocator.ts";
 
 const listen = (port: number) =>
   Effect.callback<Server, Error>((resume) => {
@@ -22,20 +22,6 @@ const close = (server: Server) =>
     return Effect.void;
   });
 
-const getFreePort = () =>
-  Effect.acquireUseRelease(
-    listen(0),
-    (server) =>
-      Effect.sync(() => {
-        const addr = server.address();
-        if (addr == null || typeof addr === "string") {
-          throw new Error("Expected TCP server address");
-        }
-        return addr.port;
-      }),
-    close,
-  );
-
 /** Occupy an OS-assigned port for the duration of a scoped effect. */
 const occupyFreePort = () =>
   Effect.acquireRelease(
@@ -49,9 +35,45 @@ const occupyFreePort = () =>
     ({ server }) => close(server),
   );
 
+const fakePortProbe = (
+  options: {
+    readonly unavailable?: ReadonlySet<number>;
+    readonly randomPorts?: readonly number[];
+  } = {},
+) => {
+  const unavailable = options.unavailable ?? new Set<number>();
+  const randomPorts =
+    options.randomPorts ?? Array.from({ length: 100 }, (_, index) => 30001 + index);
+  let randomIndex = 0;
+
+  return {
+    exact: (port: number) =>
+      unavailable.has(port)
+        ? Effect.fail(new PortAllocationError({ detail: `Port ${port} is not available` }))
+        : Effect.succeed(port),
+    random: (exclude: ReadonlySet<number>) =>
+      Effect.gen(function* () {
+        while (randomIndex < randomPorts.length) {
+          const port = randomPorts[randomIndex];
+          randomIndex += 1;
+          if (port === undefined) {
+            continue;
+          }
+          if (!exclude.has(port) && !unavailable.has(port)) {
+            return port;
+          }
+        }
+
+        return yield* Effect.fail(
+          new PortAllocationError({ detail: "No fake random ports available" }),
+        );
+      }),
+  };
+};
+
 describe("allocatePorts", () => {
   it("all allocated ports are unique", async () => {
-    const ports = await Effect.runPromise(allocatePorts({}));
+    const ports = await Effect.runPromise(allocatePorts({}, { probe: fakePortProbe() }));
     const values = Object.values(ports) as number[];
     const unique = new Set(values);
     expect(unique.size).toBe(values.length);
@@ -61,9 +83,11 @@ describe("allocatePorts", () => {
   });
 
   it("reserved ports are skipped by later allocations", async () => {
-    const a = await Effect.runPromise(allocatePorts({}));
+    const a = await Effect.runPromise(allocatePorts({}, { probe: fakePortProbe() }));
     const aPorts = new Set(Object.values(a) as number[]);
-    const b = await Effect.runPromise(allocatePorts({}, { reserved: aPorts }));
+    const b = await Effect.runPromise(
+      allocatePorts({}, { reserved: aPorts, probe: fakePortProbe() }),
+    );
     const bPorts = Object.values(b) as number[];
 
     for (const port of bPorts) {
@@ -72,10 +96,13 @@ describe("allocatePorts", () => {
   });
 
   it("explicit port is respected when available", async () => {
-    const requestedApiPort = await Effect.runPromise(getFreePort());
-    const requestedDbPort = await Effect.runPromise(getFreePort());
+    const requestedApiPort = 21001;
+    const requestedDbPort = 21002;
     const ports = await Effect.runPromise(
-      allocatePorts({ apiPort: requestedApiPort, dbPort: requestedDbPort }),
+      allocatePorts(
+        { apiPort: requestedApiPort, dbPort: requestedDbPort },
+        { probe: fakePortProbe() },
+      ),
     );
     expect(ports.apiPort).toBe(requestedApiPort);
     expect(ports.dbPort).toBe(requestedDbPort);
@@ -99,9 +126,9 @@ describe("allocatePorts", () => {
   });
 
   it("preferred ports are reused when available", async () => {
-    const apiPort = await Effect.runPromise(getFreePort());
-    const dbPort = await Effect.runPromise(getFreePort());
-    const studioPort = await Effect.runPromise(getFreePort());
+    const apiPort = 21003;
+    const dbPort = 21004;
+    const studioPort = 21005;
     const ports = await Effect.runPromise(
       allocatePorts(
         {},
@@ -111,6 +138,7 @@ describe("allocatePorts", () => {
             dbPort,
             studioPort,
           },
+          probe: fakePortProbe(),
         },
       ),
     );
@@ -121,27 +149,26 @@ describe("allocatePorts", () => {
   });
 
   it("preferred ports fall back to random ports when unavailable", async () => {
-    const dbPort = await Effect.runPromise(getFreePort());
-    const exit = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const occupied = yield* occupyFreePort();
-
-          return yield* allocatePorts(
-            {},
-            {
-              preferred: {
-                apiPort: occupied.port,
-                dbPort,
-              },
-            },
-          );
-        }),
+    const apiPort = 21006;
+    const dbPort = 21007;
+    const ports = await Effect.runPromise(
+      allocatePorts(
+        {},
+        {
+          preferred: {
+            apiPort,
+            dbPort,
+          },
+          probe: fakePortProbe({
+            unavailable: new Set([apiPort]),
+            randomPorts: Array.from({ length: 20 }, (_, index) => 31001 + index),
+          }),
+        },
       ),
     );
 
-    expect(exit.apiPort).not.toBe(exit.dbPort);
-    expect(exit.dbPort).toBe(dbPort);
+    expect(ports.apiPort).toBe(31001);
+    expect(ports.dbPort).toBe(dbPort);
   });
 
   it("explicit ports cannot override reserved ownership", async () => {
@@ -170,6 +197,7 @@ describe("allocatePorts", () => {
             apiPort: 23001,
           },
           reserved: new Set([23001]),
+          probe: fakePortProbe(),
         },
       ),
     );


### PR DESCRIPTION
## Summary

Coding agents that run the CLI now get JSON output by default, so they can parse structured results instead of scraping human-formatted tables. I resolve the effective output format once at the TypeScript entrypoint (both the legacy and next roots): an explicit `--output` / `--output-format` always wins, otherwise a detected coding agent gets `json` and everyone else keeps `text`. For Go-proxied commands this flows down as `--output json` to the Go subprocess, which renders JSON for the data-returning commands and ignores the flag elsewhere, so no Go changes were needed.

## Changes

- Resolve output format from coding-agent detection in both CLI roots, defaulting agents to `json` when no format is set explicitly.
- Add a shared `resolveAgentOutputFormat` helper (`explicit ?? (agent ? json : text)`) reused by both roots, with unit tests.
- Make the `--output-format` global flag optional so an explicitly-passed format is distinguishable from the default.
- Suppress the agent JSON default whenever the Go-compat `-o`/`--output` flag is passed explicitly: `-o json|yaml|toml|env` already short-circuits inside handlers, and `-o pretty` now keeps rendering the human table on natively ported commands instead of being overridden to JSON.

## Behavior notes

- Humans and CI keep their current output: production telemetry shows ~99.6% of CI invocations carry no coding-agent env signal, so they don't flip.
- Error rendering follows the resolved format. In text mode errors stay as red text on stderr, unchanged. In agent-default JSON mode handler errors emit the existing structured envelope (`{"_tag":"Error","error":{code,message}}`) on stdout with a non-zero exit code, the same behavior `--output-format json` already had, so agents get parseable failures instead of prose.
- Interactive prompts already refuse to block in JSON mode (`NonInteractiveError`), so a detected agent cannot hang on a confirm prompt.
- `--help` and `--version` render before the output layer engages and stay text in both roots.
- `--agent yes|no` overrides detection in both directions for the default-format decision.

## Linear

- fixes GROWTH-913
