### PR TITLE
fix(api): allow missing custom hostname validation records

### DIFF
--- a/apps/cli/src/legacy/commands/domains/domains.emit.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.emit.ts
@@ -10,6 +10,25 @@ import {
 } from "../../shared/legacy-go-output.encoders.ts";
 import { formatHostnameStatus, type LegacyHostnameResponse } from "./domains.format.ts";
 
+function normalizeLegacyHostnameResponse(response: LegacyHostnameResponse): LegacyHostnameResponse {
+  if (response.data.result.ssl.validation_records !== undefined) {
+    return response;
+  }
+  return {
+    ...response,
+    data: {
+      ...response.data,
+      result: {
+        ...response.data.result,
+        ssl: {
+          ...response.data.result.ssl,
+          validation_records: [],
+        },
+      },
+    },
+  };
+}
+
 /**
  * Emit a custom-hostname response across all output modes, mirroring the Go
  * subcommands (`apps/cli-go/internal/hostnames/{get,create,activate,reverify}`):
@@ -36,34 +55,35 @@ export const emitLegacyHostnameResult = Effect.fnUntraced(function* (
 ) {
   const output = yield* Output;
   const goOutputFlag = yield* LegacyOutputFlag;
+  const normalizedResponse = normalizeLegacyHostnameResponse(response);
 
   const goFmt = Option.getOrUndefined(goOutputFlag);
   const effectiveGoFmt =
     includeRawOutput && (goFmt === undefined || goFmt === "pretty") ? "json" : goFmt;
 
   if (effectiveGoFmt === "json") {
-    yield* output.raw(encodeGoJson(response));
+    yield* output.raw(encodeGoJson(normalizedResponse));
     return;
   }
   if (effectiveGoFmt === "yaml") {
-    yield* output.raw(encodeYaml(response));
+    yield* output.raw(encodeYaml(normalizedResponse));
     return;
   }
   if (effectiveGoFmt === "toml") {
-    yield* output.raw(encodeToml(response) + "\n");
+    yield* output.raw(encodeToml(normalizedResponse) + "\n");
     return;
   }
   if (effectiveGoFmt === "env") {
-    yield* output.raw(encodeEnv(response) + "\n");
+    yield* output.raw(encodeEnv(normalizedResponse) + "\n");
     return;
   }
 
   // goFmt is undefined or "pretty" — defer to the TS --output-format mode.
   if (output.format === "json" || output.format === "stream-json") {
-    yield* output.success("", response);
+    yield* output.success("", normalizedResponse);
     return;
   }
 
   // text mode (Go pretty parity): status to stderr, nothing to stdout.
-  yield* output.raw(formatHostnameStatus(response), "stderr");
+  yield* output.raw(formatHostnameStatus(normalizedResponse), "stderr");
 });

--- a/apps/cli/src/legacy/commands/domains/domains.format.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.format.ts
@@ -46,7 +46,8 @@ ${response.custom_hostname} CNAME -> ${response.data.result.custom_origin_server
         // Fprintf with explicit trailing `\n`.
         return `SSL validation errors: \n\t- ${errorMessages.join("\n\t- ")}\n`;
       }
-      if (ssl.validation_records.length !== 1) {
+      const validationRecords = ssl.validation_records ?? [];
+      if (validationRecords.length !== 1) {
         // Fprintf — no trailing newline. Go formats the ssl struct with `%+v`;
         // not byte-reproducible (see formatSslStructDump).
         return `expected a single SSL verification record, received: ${formatSslStructDump(ssl)}`;
@@ -54,7 +55,7 @@ ${response.custom_hostname} CNAME -> ${response.data.result.custom_origin_server
       // Fprintln on the two-line heading, then a tab-indented record (Fprintf, no newline).
       let out =
         "Custom hostname verification in-progress; please configure the appropriate DNS entries and request re-verification.\nRequired outstanding validation records:\n";
-      const rec = ssl.validation_records[0];
+      const rec = validationRecords[0];
       if (rec !== undefined && rec.txt_name !== "") {
         out += `\t${rec.txt_name} TXT -> ${rec.txt_value}`;
       }
@@ -80,7 +81,7 @@ export function formatSslStructDump(ssl: LegacyHostnameSsl): string {
     ssl.validation_errors === undefined
       ? "<nil>"
       : `&[${ssl.validation_errors.map((e) => `{Message:${e.message}}`).join(" ")}]`;
-  const validationRecords = ssl.validation_records
+  const validationRecords = (ssl.validation_records ?? [])
     .map((r) => `{TxtName:${r.txt_name} TxtValue:${r.txt_value}}`)
     .join(" ");
   return `{Status:${ssl.status} ValidationErrors:${validationErrors} ValidationRecords:[${validationRecords}]}`;

--- a/apps/cli/src/legacy/commands/domains/domains.format.unit.test.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.format.unit.test.ts
@@ -119,6 +119,18 @@ describe("formatHostnameStatus", () => {
     );
   });
 
+  it("treats missing validation records as an empty list", () => {
+    const out = formatHostnameStatus(
+      makeResponse({
+        status: "2_initiated",
+        ssl: { status: "pending_validation" },
+      }),
+    );
+    expect(out).toBe(
+      "expected a single SSL verification record, received: {Status:pending_validation ValidationErrors:<nil> ValidationRecords:[]}",
+    );
+  });
+
   it("dumps the ssl struct when there are multiple validation records", () => {
     const out = formatHostnameStatus(
       makeResponse({

--- a/apps/cli/src/legacy/commands/domains/get/get.integration.test.ts
+++ b/apps/cli/src/legacy/commands/domains/get/get.integration.test.ts
@@ -38,6 +38,7 @@ interface SetupOpts {
   readonly goOutput?: GoOutput;
   readonly status?: number;
   readonly network?: "fail";
+  readonly response?: typeof V1GetHostnameConfigOutput.Type;
 }
 
 const tempRoot = useLegacyTempWorkdir("supabase-domains-get-int-");
@@ -45,7 +46,7 @@ const tempRoot = useLegacyTempWorkdir("supabase-domains-get-int-");
 function setup(opts: SetupOpts = {}) {
   const out = mockOutput({ format: opts.format ?? "text" });
   const api = mockLegacyPlatformApi({
-    response: { status: opts.status ?? 200, body: HOSTNAME_RESPONSE },
+    response: { status: opts.status ?? 200, body: opts.response ?? HOSTNAME_RESPONSE },
     network: opts.network,
   });
   const cliConfig = mockLegacyCliConfig({ workdir: tempRoot.current });
@@ -102,6 +103,25 @@ describe("legacy domains get integration", () => {
       // Structured -o output: human status is suppressed (Go's no-newline status
       // is fused with + stripped alongside its version-update notice — see emit).
       expect(out.stderrText).toBe("");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("preserves validation_records in Go JSON output when the API omits it", () => {
+    const response: typeof V1GetHostnameConfigOutput.Type = {
+      ...HOSTNAME_RESPONSE,
+      data: {
+        ...HOSTNAME_RESPONSE.data,
+        result: {
+          ...HOSTNAME_RESPONSE.data.result,
+          ssl: { status: "pending_validation" },
+        },
+      },
+    };
+    const { layer, out } = setup({ goOutput: "json", response });
+    return Effect.gen(function* () {
+      yield* legacyDomainsGet(baseFlags);
+      const parsed = JSON.parse(out.stdoutText) as typeof V1GetHostnameConfigOutput.Type;
+      expect(parsed.data.result.ssl.validation_records).toEqual([]);
     }).pipe(Effect.provide(layer));
   });
 

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -11,6 +11,16 @@
   },
   {
     "op": "test",
+    "path": "/components/schemas/UpdateCustomHostnameResponse/properties/data/properties/result/properties/ssl/required",
+    "value": ["status", "validation_records"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/UpdateCustomHostnameResponse/properties/data/properties/result/properties/ssl/required",
+    "value": ["status"]
+  },
+  {
+    "op": "test",
     "path": "/components/schemas/AuthConfigResponse/required",
     "value": [
       "api_max_request_duration",

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -247,8 +247,8 @@ export const V1ActivateCustomHostnameOutput = Schema.Struct({
       hostname: Schema.String,
       ssl: Schema.Struct({
         status: Schema.String,
-        validation_records: Schema.Array(
-          Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String }),
+        validation_records: Schema.optionalKey(
+          Schema.Array(Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String })),
         ),
         validation_errors: Schema.optionalKey(
           Schema.Array(Schema.Struct({ message: Schema.String })),
@@ -2277,8 +2277,8 @@ export const V1GetHostnameConfigOutput = Schema.Struct({
       hostname: Schema.String,
       ssl: Schema.Struct({
         status: Schema.String,
-        validation_records: Schema.Array(
-          Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String }),
+        validation_records: Schema.optionalKey(
+          Schema.Array(Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String })),
         ),
         validation_errors: Schema.optionalKey(
           Schema.Array(Schema.Struct({ message: Schema.String })),
@@ -5224,8 +5224,8 @@ export const V1UpdateHostnameConfigOutput = Schema.Struct({
       hostname: Schema.String,
       ssl: Schema.Struct({
         status: Schema.String,
-        validation_records: Schema.Array(
-          Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String }),
+        validation_records: Schema.optionalKey(
+          Schema.Array(Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String })),
         ),
         validation_errors: Schema.optionalKey(
           Schema.Array(Schema.Struct({ message: Schema.String })),
@@ -5794,8 +5794,8 @@ export const V1VerifyDnsConfigOutput = Schema.Struct({
       hostname: Schema.String,
       ssl: Schema.Struct({
         status: Schema.String,
-        validation_records: Schema.Array(
-          Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String }),
+        validation_records: Schema.optionalKey(
+          Schema.Array(Schema.Struct({ txt_name: Schema.String, txt_value: Schema.String })),
         ),
         validation_errors: Schema.optionalKey(
           Schema.Array(Schema.Struct({ message: Schema.String })),

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -12590,7 +12590,7 @@
                         }
                       }
                     },
-                    "required": ["status", "validation_records"]
+                    "required": ["status"]
                   },
                   "ownership_verification": {
                     "type": "object",

--- a/packages/api/src/internal/client.unit.test.ts
+++ b/packages/api/src/internal/client.unit.test.ts
@@ -386,6 +386,49 @@ describe("makeSupabaseApiClient", () => {
     ]);
   });
 
+  test("accepts missing custom-hostname SSL validation records", async () => {
+    const result = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.flatMap((client) =>
+          client.execute<"v1GetHostnameConfig">(operationDefinitions.v1GetHostnameConfig, {
+            ref: "abcdefghijklmnopqrst",
+          }),
+        ),
+        Effect.provide(
+          httpClientLayer((request) =>
+            Effect.succeed(
+              jsonResponse(request, 200, {
+                status: "2_initiated",
+                custom_hostname: "shop.acme.dev",
+                data: {
+                  success: true,
+                  errors: [],
+                  messages: [],
+                  result: {
+                    id: "hostname-id",
+                    hostname: "shop.acme.dev",
+                    ssl: {
+                      status: "pending_validation",
+                    },
+                    ownership_verification: {
+                      type: "txt",
+                      name: "_cf-custom-hostname.shop.acme.dev",
+                      value: "verification-token",
+                    },
+                    custom_origin_server: "abcdefghijklmnopqrst.supabase.co",
+                    status: "pending",
+                  },
+                },
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.data.result.ssl.validation_records).toBeUndefined();
+  });
+
   test("does not retry 5xx responses for POST requests", async () => {
     let attempts = 0;
 


### PR DESCRIPTION
Updates the temporary Management API OpenAPI overrides so custom-hostname SSL validation records are optional while the backend response is inconsistent with the published schema.

The generated API contract now accepts responses where `data.result.ssl.validation_records` is absent. The legacy domains formatter treats the absent field like the Go CLI nil-slice behavior when rendering human-readable status output.

This prevents domain commands from failing at schema decode time when staging returns a custom-hostname response without outstanding SSL validation records.