### PR TITLE
test(cli): stabilize domains parity e2e

### DIFF
--- a/apps/cli-e2e/src/tests/domains.e2e.test.ts
+++ b/apps/cli-e2e/src/tests/domains.e2e.test.ts
@@ -3,6 +3,10 @@ import { testBehaviour, testParity } from "./test-context";
 import { isRecording, PROJECT_REF } from "./env";
 
 const CONFIGURED_CNAME = "www.urgsimurksi.xyz";
+const GO_CUSTOM_HOSTNAME_MACHINE_STATUS_PATTERNS = [
+  /^Custom hostname setup completed\. Project is now accessible at [^\n]+\.\n?/gm,
+  /^Custom hostname configuration complete, and ready for activation\.\n\nPlease ensure that your custom domain is set up as a CNAME record to your Supabase subdomain:\n[^\n]+ CNAME -> [^\n]+\n?/gm,
+];
 
 describe("domains", () => {
   describe.todo("domains:create — requires mocking of 1.1.1.1 for DNS queries");
@@ -162,7 +166,9 @@ describe("domains", () => {
       expect(result.stderr).toContain("502");
     });
 
-    testParity(["domains", "get", "--project-ref", PROJECT_REF, "--output", "json"]);
+    testParity(["domains", "get", "--project-ref", PROJECT_REF, "--output", "json"], {
+      normalize: { stderr: { stripPatterns: GO_CUSTOM_HOSTNAME_MACHINE_STATUS_PATTERNS } },
+    });
   });
 
   describe("domains:reverify", () => {

--- a/apps/cli-e2e/src/tests/test-context.ts
+++ b/apps/cli-e2e/src/tests/test-context.ts
@@ -9,6 +9,31 @@ import {
 } from "@supabase/cli-test-helpers";
 import { ACCESS_TOKEN, isRecording, TARGET } from "./env.ts";
 
+type ParityNormalizeOptions = NonNullable<Parameters<typeof runParity>[0]["normalize"]>;
+type ParityChannelNormalizeOptions = Extract<
+  ParityNormalizeOptions,
+  { stdout?: unknown; stderr?: unknown }
+>;
+
+function isChannelNormalizeOptions(
+  options: ParityNormalizeOptions | undefined,
+): options is ParityChannelNormalizeOptions {
+  return options !== undefined && ("stdout" in options || "stderr" in options);
+}
+
+function withNormalizeVersions(
+  normalize: ParityNormalizeOptions | undefined,
+  versions: boolean | undefined,
+): ParityNormalizeOptions | undefined {
+  if (versions === undefined) return normalize;
+  if (normalize === undefined) return { versions };
+  if (!isChannelNormalizeOptions(normalize)) return { ...normalize, versions };
+  return {
+    stdout: { ...normalize.stdout, versions },
+    stderr: { ...normalize.stderr, versions },
+  };
+}
+
 function slugify(name: string): string {
   return name
     .toLowerCase()
@@ -146,6 +171,7 @@ export function testParity(
     workspaceSetup?: (dir: string) => void;
     sortStdoutRows?: boolean;
     normalizeVersions?: boolean;
+    normalize?: ParityNormalizeOptions;
   },
 ): void {
   const label = opts?.failureType
@@ -164,13 +190,14 @@ export function testParity(
     }
 
     try {
+      const normalize = withNormalizeVersions(opts?.normalize, opts?.normalizeVersions);
       await runParity(
         {
           apiUrl: serverUrl,
           accessToken: ACCESS_TOKEN,
           workspaceSetup: opts?.workspaceSetup,
           sortStdoutRows: opts?.sortStdoutRows,
-          normalize: { versions: opts?.normalizeVersions },
+          normalize,
         },
         cmd,
       );

--- a/apps/cli/src/legacy/commands/domains/domains.emit.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.emit.ts
@@ -37,13 +37,10 @@ function normalizeLegacyHostnameResponse(response: LegacyHostnameResponse): Lega
  *     `PrintStatus`), and nothing goes to stdout.
  *   - In a structured Go `-o` mode (`json`/`yaml`/`toml`/`env`) the encoded
  *     response goes to **stdout** and the human status is **suppressed**. Go
- *     technically still writes `PrintStatus` to stderr here, but because the
- *     `5_services_reconfigured`/`4_origin_setup_completed` messages carry no
- *     trailing newline they get fused with — and stripped alongside — Go's
- *     version-update notice (see `normalize.ts` rule 11), so the observable Go
- *     stderr in machine-output mode is empty. Suppressing keeps stdout clean and
- *     matches that contract (verified by the `domains get --output json` parity
- *     e2e).
+ *     technically still writes `PrintStatus` to stderr here. Suppressing keeps
+ *     stdout/stderr stable for machine consumers; the parity e2e opts in to
+ *     normalizing Go's stderr-only status instead of depending on upgrade-check
+ *     output to erase it.
  *   - `--include-raw-output` (deprecated) forces `-o` to `json` when it is unset
  *     or `pretty`.
  *   - For the TS-native `--output-format json|stream-json` modes (no Go `-o`),

--- a/apps/cli/src/next/commands/functions/dev/dev.e2e.test.ts
+++ b/apps/cli/src/next/commands/functions/dev/dev.e2e.test.ts
@@ -11,6 +11,33 @@ import {
 const FUNCTIONS_DEV_STARTUP_TIMEOUT_MS = 60_000;
 const FUNCTIONS_DEV_STEP_TIMEOUT_MS = 30_000;
 const FUNCTIONS_DEV_TEST_TIMEOUT_MS = 90_000;
+const FUNCTION_FILES_RESTART_PATTERN = /Function files changed\. Restarting edge-runtime\./;
+const FUNCTION_FILES_RESTART_PATTERN_GLOBAL = /Function files changed\. Restarting edge-runtime\./g;
+
+type SpawnedSupabase = ReturnType<typeof spawnSupabase>;
+
+function countOutputMatches(proc: SpawnedSupabase, pattern: RegExp): number {
+  return [...`${proc.stdout()}\n${proc.stderr()}`.matchAll(pattern)].length;
+}
+
+async function waitForOutputMatchCount(
+  proc: SpawnedSupabase,
+  pattern: RegExp,
+  expectedCount: number,
+) {
+  const deadline = Date.now() + FUNCTIONS_DEV_STEP_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (countOutputMatches(proc, pattern) >= expectedCount) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Timed out waiting for ${expectedCount.toString()} occurrences of ${pattern.toString()}`,
+  );
+}
 
 async function waitForFunctionResponse(
   url: string,
@@ -74,10 +101,7 @@ describe("supabase functions dev", () => {
         });
         expect(newResult.exitCode).toBe(0);
 
-        await devProc.waitForOutput(
-          /Function files changed\. Restarting edge-runtime\./,
-          FUNCTIONS_DEV_STEP_TIMEOUT_MS,
-        );
+        await devProc.waitForOutput(FUNCTION_FILES_RESTART_PATTERN, FUNCTIONS_DEV_STEP_TIMEOUT_MS);
 
         await waitForFunctionResponse(functionUrl, {}, (response, body) => {
           expect(response.status).toBe(401);
@@ -111,6 +135,7 @@ verify_jwt = false
           },
         );
 
+        const restartCount = countOutputMatches(devProc, FUNCTION_FILES_RESTART_PATTERN_GLOBAL);
         await writeFile(
           functionPath,
           `Deno.serve(() => {
@@ -119,6 +144,11 @@ verify_jwt = false
   });
 });
 `,
+        );
+        await waitForOutputMatchCount(
+          devProc,
+          FUNCTION_FILES_RESTART_PATTERN_GLOBAL,
+          restartCount + 1,
         );
 
         await waitForFunctionResponse(

--- a/apps/cli/tests/helpers/cli.ts
+++ b/apps/cli/tests/helpers/cli.ts
@@ -22,6 +22,39 @@ const NEXT_BINARY_PATH = fileURLToPath(
   new URL(`../../dist/supabase-next${BINARY_EXT}`, import.meta.url),
 );
 
+// E2E subprocesses should only enter agent output mode when a test explicitly
+// opts in via `options.env`. Keep this list aligned with @vercel/detect-agent
+// env probes so a developer's shell cannot accidentally change CLI rendering.
+const AGENT_DETECTION_ENV_KEYS: readonly string[] = [
+  "AI_AGENT",
+  "CURSOR_TRACE_ID",
+  "CURSOR_AGENT",
+  "CURSOR_EXTENSION_HOST_ROLE",
+  "GEMINI_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_CI",
+  "CODEX_THREAD_ID",
+  "ANTIGRAVITY_AGENT",
+  "AUGMENT_AGENT",
+  "OPENCODE_CLIENT",
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "CLAUDE_CODE_IS_COWORK",
+  "REPL_ID",
+  "COPILOT_MODEL",
+  "COPILOT_ALLOW_ALL",
+  "COPILOT_GITHUB_TOKEN",
+];
+
+function subprocessBaseEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  for (const key of AGENT_DETECTION_ENV_KEYS) delete env[key];
+  return env;
+}
+
 function assertBuildArtifactsExist(shell: "legacy" | "next", binaryPath: string): void {
   if (!existsSync(SHIM_PATH) || !existsSync(binaryPath)) {
     throw new Error(
@@ -196,7 +229,7 @@ export function spawnSupabase(
   let execCmd: string;
   let execArgs: string[];
   const env: Record<string, string> = {
-    ...process.env,
+    ...subprocessBaseEnv(),
     SUPABASE_HOME: homeDir,
     SUPABASE_NO_KEYRING: "1",
     SUPABASE_TELEMETRY_DISABLED: "1",

--- a/packages/cli-test-helpers/src/harness.ts
+++ b/packages/cli-test-helpers/src/harness.ts
@@ -54,6 +54,41 @@ const WORKSPACE_ROOT = new URL("../../../", import.meta.url).pathname.replace(/\
 const BINARY_EXT = osPlatform() === "win32" ? ".exe" : "";
 const TS_CLI_SHIM = join(WORKSPACE_ROOT, "apps/cli/dist/supabase.js");
 
+// E2E subprocesses should only enter agent output mode when a test explicitly
+// opts in via `opts.env`. Keep this list aligned with @vercel/detect-agent env
+// probes so a developer's shell cannot accidentally change CLI rendering.
+const AGENT_DETECTION_ENV_KEYS: readonly string[] = [
+  "AI_AGENT",
+  "CURSOR_TRACE_ID",
+  "CURSOR_AGENT",
+  "CURSOR_EXTENSION_HOST_ROLE",
+  "GEMINI_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_CI",
+  "CODEX_THREAD_ID",
+  "ANTIGRAVITY_AGENT",
+  "AUGMENT_AGENT",
+  "OPENCODE_CLIENT",
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "CLAUDE_CODE_IS_COWORK",
+  "REPL_ID",
+  "COPILOT_MODEL",
+  "COPILOT_ALLOW_ALL",
+  "COPILOT_GITHUB_TOKEN",
+];
+
+export function createSubprocessBaseEnv(
+  source: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined) env[key] = value;
+  }
+  for (const key of AGENT_DETECTION_ENV_KEYS) delete env[key];
+  return env;
+}
+
 function tsCliBinary(shell: "next" | "legacy"): string {
   return join(WORKSPACE_ROOT, `apps/cli/dist/supabase-${shell}${BINARY_EXT}`);
 }
@@ -103,7 +138,7 @@ export async function exec(
   const built = buildCommand(harness.target);
 
   const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
+    ...createSubprocessBaseEnv(),
     SUPABASE_ACCESS_TOKEN: harness.options.accessToken,
     SUPABASE_NO_KEYRING: "true",
     SUPABASE_TELEMETRY_DISABLED: "1",

--- a/packages/cli-test-helpers/src/harness.unit.test.ts
+++ b/packages/cli-test-helpers/src/harness.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createSubprocessBaseEnv } from "./harness.ts";
+
+describe("createSubprocessBaseEnv", () => {
+  it("removes inherited agent-detection environment variables", () => {
+    expect(
+      createSubprocessBaseEnv({
+        PATH: "/usr/bin",
+        AI_AGENT: "github-copilot-cli",
+        CLAUDECODE: "1",
+        CODEX_THREAD_ID: "thread",
+        CURSOR_TRACE_ID: "trace",
+      }),
+    ).toEqual({ PATH: "/usr/bin" });
+  });
+
+  it("drops undefined values from the subprocess environment", () => {
+    expect(
+      createSubprocessBaseEnv({
+        PATH: "/usr/bin",
+        SUPABASE_ACCESS_TOKEN: undefined,
+      }),
+    ).toEqual({ PATH: "/usr/bin" });
+  });
+});

--- a/packages/cli-test-helpers/src/normalize.ts
+++ b/packages/cli-test-helpers/src/normalize.ts
@@ -31,6 +31,7 @@ export function sortTableRows(output: string): string {
 
 export interface NormalizeOptions {
   readonly versions?: boolean;
+  readonly stripPatterns?: readonly RegExp[];
 }
 
 /**
@@ -53,9 +54,13 @@ export function normalize(output: string, options: NormalizeOptions = {}): strin
         "<VERSION>",
       )
     : withoutAnsi;
+  const withoutStrippedPatterns = (options.stripPatterns ?? []).reduce(
+    (acc, pattern) => acc.replace(pattern, ""),
+    withoutVersions,
+  );
 
   return (
-    withoutVersions
+    withoutStrippedPatterns
       // 3. ISO-8601 timestamps (2026-04-15T10:46:15Z or with milliseconds)
       .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z/g, "<TIMESTAMP>")
       // 4. Display timestamps (2026-04-15 10:46:15 — space-separated, no T)

--- a/packages/cli-test-helpers/src/normalize.unit.test.ts
+++ b/packages/cli-test-helpers/src/normalize.unit.test.ts
@@ -146,4 +146,10 @@ describe("normalize", () => {
       "\n  \n   ID                   | NAME\n  ----------------------|----------\n   <PROJECT_REF_1>      | My Org\n\n";
     expect(normalize(table)).toBe(table.replace(/[ \t]+$/gm, ""));
   });
+
+  it("can strip caller-provided patterns before shared normalization", () => {
+    expect(
+      normalize("status: transient\nversion: 2.0.0", { stripPatterns: [/^status: .+\n/gm] }),
+    ).toBe("version: <VERSION>");
+  });
 });

--- a/packages/cli-test-helpers/src/parity.ts
+++ b/packages/cli-test-helpers/src/parity.ts
@@ -111,6 +111,27 @@ export interface RunResult {
   files: FileRecord[];
 }
 
+interface ParityChannelNormalizeOptions {
+  readonly stdout?: NormalizeOptions;
+  readonly stderr?: NormalizeOptions;
+}
+
+type ParityNormalizeOptions = NormalizeOptions | ParityChannelNormalizeOptions;
+
+function isChannelNormalizeOptions(
+  options: ParityNormalizeOptions | undefined,
+): options is ParityChannelNormalizeOptions {
+  return options !== undefined && ("stdout" in options || "stderr" in options);
+}
+
+function normalizeChannel(
+  output: string,
+  options: ParityNormalizeOptions | undefined,
+  channel: "stdout" | "stderr",
+): string {
+  return normalize(output, isChannelNormalizeOptions(options) ? options[channel] : options);
+}
+
 // ---------------------------------------------------------------------------
 // Git-based file snapshot
 // ---------------------------------------------------------------------------
@@ -215,14 +236,14 @@ async function collectRunResult(
   dir: string,
   apiUrl: string,
   extraEnv?: Record<string, string>,
-  normalizeOptions?: NormalizeOptions,
+  normalizeOptions?: ParityNormalizeOptions,
 ): Promise<RunResult> {
   const result = await exec(harness, cmd, extraEnv ? { env: extraEnv } : undefined);
   const requests = await fetchRequestLog(apiUrl);
   const files = snapshotChangedFiles(dir);
   return {
-    stdout: normalize(result.stdout, normalizeOptions),
-    stderr: normalize(result.stderr, normalizeOptions),
+    stdout: normalizeChannel(result.stdout, normalizeOptions, "stdout"),
+    stderr: normalizeChannel(result.stderr, normalizeOptions, "stderr"),
     exitCode: result.exitCode,
     requests,
     files,
@@ -313,7 +334,7 @@ export interface ParityOptions {
   /** Additional environment variables injected into both CLI subprocesses. */
   extraEnv?: Record<string, string>;
   /** Fine-grained normalization controls for stdout/stderr parity comparison. */
-  normalize?: NormalizeOptions;
+  normalize?: ParityNormalizeOptions;
 }
 
 /**


### PR DESCRIPTION
This fixes a domains parity failure seen in the merge queue: https://github.com/supabase/cli/actions/runs/27341219425/job/80778254211

The failing domains case compared `domains get --project-ref ... --output json`. The Go CLI still writes the custom-hostname status line to stderr in machine-output mode, and because that status has no trailing newline it was sometimes hidden only when Go also printed an upgrade notice that the parity normalizer stripped. When that upgrade-check side effect was absent, the same command produced a stderr mismatch.

This makes the domains parity expectation explicit by adding a generic, channel-aware normalization hook and keeping the Go custom-hostname patterns local to the domains e2e test. The strip only applies to stderr, so parity will still fail if a command pollutes structured stdout with human status text.

This also fixes a later functions-dev e2e failure from CI: https://github.com/supabase/cli/actions/runs/27352417825/job/80817569233. The test edited function source and immediately asserted the updated response without waiting for the file watcher restart corresponding to that edit. It now waits for the next function-file restart before polling the function endpoint.

While exercising the e2e suite locally, CLI subprocesses were also inheriting agent-detection environment variables from the developer shell, which changed output rendering and made local e2e behavior differ from CI. The e2e helpers now sanitize inherited agent-detection env by default while still allowing tests to opt in through explicit per-test env overrides.