### PR TITLE
fix(cli): avoid auth for local typegen and services

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
@@ -62,7 +62,7 @@ function isEphemeralIdentityRuntime(runtime: {
   return runtime.isCi || (runtime.isFirstRun && !runtime.isTty);
 }
 
-const makeLegacyPlatformApiServices = Effect.gen(function* () {
+export const legacyMakePlatformApi = Effect.gen(function* () {
   const cliConfig = yield* LegacyCliConfig;
   const credentials = yield* LegacyCredentials;
   const analytics = yield* Analytics;
@@ -156,7 +156,7 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
     );
   }
 
-  const api = yield* makeApiClient(
+  return yield* makeApiClient(
     {
       baseUrl: cliConfig.apiUrl,
       accessToken: storedToken.value,
@@ -166,7 +166,6 @@ const makeLegacyPlatformApiServices = Effect.gen(function* () {
       transformClient,
     },
   );
-  return Layer.succeed(LegacyPlatformApi, api);
 });
 
-export const legacyPlatformApiLayer = Layer.unwrap(makeLegacyPlatformApiServices);
+export const legacyPlatformApiLayer = Layer.effect(LegacyPlatformApi, legacyMakePlatformApi);

--- a/apps/cli/src/legacy/auth/legacy-platform-api.service.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.service.ts
@@ -1,6 +1,15 @@
 import type { ApiClient } from "@supabase/api/effect";
-import { Context } from "effect";
+import { type Effect, Context } from "effect";
 
 export class LegacyPlatformApi extends Context.Service<LegacyPlatformApi, ApiClient>()(
   "supabase/legacy/PlatformApi",
 ) {}
+
+export interface LegacyPlatformApiFactoryShape {
+  readonly make: Effect.Effect<ApiClient, unknown>;
+}
+
+export class LegacyPlatformApiFactory extends Context.Service<
+  LegacyPlatformApiFactory,
+  LegacyPlatformApiFactoryShape
+>()("supabase/legacy/PlatformApiFactory") {}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
@@ -1,8 +1,12 @@
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 
 import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
 import { legacyHttpClientLayer } from "../../auth/legacy-http-debug.layer.ts";
 import { legacyPlatformApiLayer } from "../../auth/legacy-platform-api.layer.ts";
+import {
+  LegacyPlatformApi,
+  LegacyPlatformApiFactory,
+} from "../../auth/legacy-platform-api.service.ts";
 import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
 import { legacyProjectRefLayer } from "../../config/legacy-project-ref.layer.ts";
 import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
@@ -42,13 +46,25 @@ const platformApi = legacyPlatformApiLayer.pipe(
   Layer.provide(httpClient),
   Layer.provide(debugLogger),
 );
+const platformApiFactory = Layer.effect(
+  LegacyPlatformApiFactory,
+  LegacyPlatformApi.pipe(
+    Effect.map((api) =>
+      LegacyPlatformApiFactory.of({
+        make: Effect.succeed(api),
+      }),
+    ),
+  ),
+);
+const platformApiFactoryStack = platformApiFactory.pipe(Layer.provide(platformApi));
 
 export const legacyBootstrapRuntimeLayer = Layer.mergeAll(
   platformApi,
+  platformApiFactoryStack,
   httpClient,
   credentials,
   cliConfig,
-  legacyProjectRefLayer.pipe(Layer.provide(platformApi), Layer.provide(cliConfig)),
+  legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
   legacyLinkedProjectCacheLayer.pipe(
     Layer.provide(credentials),
     Layer.provide(cliConfig),

--- a/apps/cli/src/legacy/commands/gen/types/types.command.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.command.ts
@@ -1,9 +1,9 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyGenTypes } from "./types.handler.ts";
+import { legacyGenTypesRuntimeLayer } from "./types.layers.ts";
 
 const LANG_VALUES = ["typescript", "go", "swift", "python"] as const;
 const SWIFT_ACCESS_CONTROL_VALUES = ["internal", "public"] as const;
@@ -74,5 +74,5 @@ export const legacyGenTypesCommand = Command.make("types", config).pipe(
       withJsonErrorHandling,
     ),
   ),
-  Command.provide(legacyManagementApiRuntimeLayer(["gen", "types"])),
+  Command.provide(legacyGenTypesRuntimeLayer),
 );

--- a/apps/cli/src/legacy/commands/gen/types/types.handler.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.handler.ts
@@ -3,11 +3,12 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { Effect, FileSystem, Option, Path, Stdio, Stream } from "effect";
 import { LegacyDebugFlag, LegacyNetworkIdFlag } from "../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
-import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectNotLinkedError } from "../../../config/legacy-project-ref.errors.ts";
-import { PROJECT_NOT_LINKED_MESSAGE } from "../../../config/legacy-project-ref.service.ts";
-import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
+import {
+  LegacyProjectRefResolver,
+  PROJECT_NOT_LINKED_MESSAGE,
+} from "../../../config/legacy-project-ref.service.ts";
 import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
 import { legacyTempPaths } from "../../../shared/legacy-temp-paths.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
@@ -15,6 +16,7 @@ import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.
 import type { LegacyGenTypesFlags } from "./types.command.ts";
 import { LegacyGenTypesNetworkError, LegacyGenTypesUnexpectedStatusError } from "./types.errors.ts";
 import { legacyGetHostname } from "../../../shared/legacy-hostname.ts";
+import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api.service.ts";
 import {
   buildPostgresUrl,
   defaultSchemas,
@@ -159,10 +161,7 @@ function hasExplicitLongFlag(rawArgs: ReadonlyArray<string>, flagName: string): 
 
 export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: LegacyGenTypesFlags) {
   const output = yield* Output;
-  const api = yield* LegacyPlatformApi;
   const cliConfig = yield* LegacyCliConfig;
-  const resolver = yield* LegacyProjectRefResolver;
-  const linkedProjectCache = yield* LegacyLinkedProjectCache;
   const telemetryState = yield* LegacyTelemetryState;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -171,6 +170,9 @@ export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: Le
   const debug = yield* LegacyDebugFlag;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const rawArgs = yield* stdio.args;
+  const platformApi = yield* LegacyPlatformApiFactory;
+  const projectRef = yield* LegacyProjectRefResolver;
+  const linkedProjectCache = yield* LegacyLinkedProjectCache;
 
   yield* ensureMutuallyExclusive(
     ["local", "linked", "project-id", "db-url"],
@@ -235,6 +237,7 @@ export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: Le
         );
       }
 
+      const api = yield* platformApi.make;
       const response = yield* api.v1
         .generateTypescriptTypes({
           ref: projectRef,
@@ -432,7 +435,7 @@ export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: Le
 
     if (flags.linked) {
       const loaded = yield* loadConfig();
-      const ref = yield* resolver.resolve(Option.none());
+      const ref = yield* projectRef.resolve(Option.none());
       yield* runProjectTypes(
         ref,
         schemas.length > 0 ? schemas : defaultSchemas(loaded?.config.api.schemas),
@@ -442,7 +445,7 @@ export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: Le
 
     if (Option.isSome(flags.projectId)) {
       const loaded = yield* loadConfig();
-      const ref = yield* resolver.resolve(flags.projectId);
+      const ref = yield* projectRef.resolve(flags.projectId);
       yield* runProjectTypes(
         ref,
         schemas.length > 0 ? schemas : defaultSchemas(loaded?.config.api.schemas),
@@ -450,7 +453,7 @@ export const legacyGenTypes = Effect.fn("legacy.gen.types")(function* (flags: Le
       return;
     }
 
-    const resolvedRef = yield* resolver.resolve(Option.none()).pipe(
+    const resolvedRef = yield* projectRef.resolve(Option.none()).pipe(
       Effect.catch((cause) => {
         if (
           cause instanceof LegacyProjectNotLinkedError &&

--- a/apps/cli/src/legacy/commands/gen/types/types.integration.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.integration.test.ts
@@ -5,13 +5,26 @@ import { join } from "node:path";
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { CliOutput, Command } from "effect/unstable/cli";
 import { Deferred, Effect, Exit, Layer, Option, Sink, Stdio, Stream } from "effect";
 import {
+  LEGACY_GLOBAL_FLAGS,
   LegacyDebugFlag,
   LegacyNetworkIdFlag,
   LegacyOutputFlag,
 } from "../../../../shared/legacy/global-flags.ts";
-import { mockOutput, mockProcessControl } from "../../../../../tests/helpers/mocks.ts";
+import {
+  LegacyPlatformApi,
+  LegacyPlatformApiFactory,
+} from "../../../auth/legacy-platform-api.service.ts";
+import {
+  mockAnalytics,
+  mockOutput,
+  mockProcessControl,
+  mockRuntimeInfo,
+  mockTty,
+  processEnvLayer,
+} from "../../../../../tests/helpers/mocks.ts";
 import {
   buildLegacyTestRuntime,
   LEGACY_VALID_REF,
@@ -21,6 +34,9 @@ import {
   mockLegacyTelemetryStateTracked,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { mockChildProcessSpawner } from "../../../../../../../packages/process-compose/tests/helpers/mocks.ts";
+import { textCliOutputFormatter } from "../../../../shared/output/text-formatter.ts";
+import { TelemetryRuntime } from "../../../../shared/telemetry/runtime.service.ts";
+import { legacyGenCommand } from "../gen.command.ts";
 import type { LegacyGenTypesFlags } from "./types.command.ts";
 import { legacyGenTypes } from "./types.handler.ts";
 import { parseQueryTimeoutSeconds, resolvePgmetaImage } from "./types.shared.ts";
@@ -169,6 +185,9 @@ function setup(
     Layer.succeed(LegacyOutputFlag, opts.goOutput ?? Option.none()),
     Layer.succeed(LegacyDebugFlag, opts.debug ?? false),
     Layer.succeed(LegacyNetworkIdFlag, opts.networkId ?? Option.none()),
+    Layer.succeed(LegacyPlatformApiFactory, {
+      make: LegacyPlatformApi.pipe(Effect.provide(api.layer)),
+    }),
   );
 
   return {
@@ -275,11 +294,93 @@ async function withSslProbeServer<T>(
   }
 }
 
+const legacyTestRoot = Command.make("supabase").pipe(
+  Command.withGlobalFlags(LEGACY_GLOBAL_FLAGS),
+  Command.withSubcommands([legacyGenCommand]),
+);
+
 describe("legacy gen types", () => {
   it.effect("accepts Go-style microsecond duration aliases", () =>
     Effect.gen(function* () {
       expect(yield* parseQueryTimeoutSeconds(`15${"µ"}s`)).toBe(0);
       expect(yield* parseQueryTimeoutSeconds(`15${"μ"}s`)).toBe(0);
+    }),
+  );
+
+  it.live("runs tokenless local generation through command wiring", () =>
+    Effect.tryPromise({
+      try: () =>
+        withSslProbeServer(async (port) => {
+          const workdir = mkdtempSync(join(tmpdir(), "supabase-gen-types-command-local-"));
+          writeConfig(
+            workdir,
+            [
+              'project_id = "demo"',
+              "",
+              "[api]",
+              'schemas = ["public"]',
+              "",
+              "[db]",
+              `port = ${port}`,
+            ].join("\n"),
+          );
+          const out = mockOutput({ format: "text", interactive: false });
+          const analytics = mockAnalytics();
+          const child = mockSequentialChildProcessSpawner([
+            { exitCode: 0 },
+            { exitCode: 0, stdout: ["export type Database = {};"] },
+          ]);
+          const args = [
+            "gen",
+            "types",
+            "typescript",
+            "--local",
+            "--schema",
+            "public",
+            "--workdir",
+            workdir,
+          ];
+          const layer = Layer.mergeAll(
+            BunServices.layer,
+            CliOutput.layer(textCliOutputFormatter()),
+            out.layer,
+            analytics.layer,
+            processEnvLayer({ SUPABASE_HOME: workdir }),
+            mockRuntimeInfo({ cwd: workdir, homeDir: workdir }),
+            mockTty({ stdinIsTty: false, stdoutIsTty: false }),
+            child.layer,
+            Stdio.layerTest({ args: Effect.succeed(args) }),
+            Layer.succeed(
+              TelemetryRuntime,
+              TelemetryRuntime.of({
+                configDir: join(workdir, ".supabase"),
+                tracesDir: join(workdir, ".supabase", "traces"),
+                consent: "granted",
+                showDebug: false,
+                deviceId: "test-device-id",
+                sessionId: "test-session-id",
+                distinctId: undefined,
+                isFirstRun: false,
+                isTty: false,
+                isCi: false,
+                os: "linux",
+                arch: "x64",
+                cliVersion: "0.1.0",
+              }),
+            ),
+          );
+
+          await Effect.runPromise(
+            Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(args).pipe(
+              Effect.provide(layer),
+            ) as Effect.Effect<void>,
+          );
+
+          expect(out.stdoutText).toContain("export type Database = {};");
+          expect(out.stderrText).not.toContain("Access token not provided");
+          expect(child.spawned).toHaveLength(2);
+        }),
+      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
     }),
   );
 

--- a/apps/cli/src/legacy/commands/gen/types/types.layers.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.layers.ts
@@ -1,0 +1,100 @@
+import { FetchHttpClient } from "effect/unstable/http";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+import { legacyCredentialsLayer } from "../../../auth/legacy-credentials.layer.ts";
+import { LegacyCredentials } from "../../../auth/legacy-credentials.service.ts";
+import { legacyMakePlatformApi } from "../../../auth/legacy-platform-api.layer.ts";
+import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api.service.ts";
+import { legacyCliConfigLayer } from "../../../config/legacy-cli-config.layer.ts";
+import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
+import { legacyProjectRefLayer } from "../../../config/legacy-project-ref.layer.ts";
+import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
+import { legacyDebugLoggerLayer } from "../../../shared/legacy-debug-logger.layer.ts";
+import { LegacyDebugLogger } from "../../../shared/legacy-debug-logger.service.ts";
+import { legacyHttpClientLayer } from "../../../auth/legacy-http-debug.layer.ts";
+import { legacyLinkedProjectCacheLayer } from "../../../telemetry/legacy-linked-project-cache.layer.ts";
+import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
+import { legacyTelemetryStateLayer } from "../../../telemetry/legacy-telemetry-state.layer.ts";
+import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { CommandRuntime } from "../../../../shared/runtime/command-runtime.service.ts";
+import { Analytics } from "../../../../shared/telemetry/analytics.service.ts";
+import { TelemetryRuntime } from "../../../../shared/telemetry/runtime.service.ts";
+
+/**
+ * `gen types --local` and `--db-url` do not use the Management API, so this
+ * runtime deliberately avoids `legacyManagementApiRuntimeLayer`: that layer
+ * eagerly builds the platform API client and requires an access token before
+ * the handler can choose the local/db-url branch.
+ */
+export const legacyGenTypesRuntimeLayer = (() => {
+  const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const httpClient = legacyHttpClientLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const credentials = legacyCredentialsLayer.pipe(
+    Layer.provide(cliConfig),
+    Layer.provide(legacyDebugLoggerLayer),
+  );
+  const platformApiFactory = Layer.effect(
+    LegacyPlatformApiFactory,
+    Effect.gen(function* () {
+      const analytics = yield* Analytics;
+      const cliConfigService = yield* LegacyCliConfig;
+      const credentialsService = yield* LegacyCredentials;
+      const debugLogger = yield* LegacyDebugLogger;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const telemetryRuntime = yield* TelemetryRuntime;
+
+      return LegacyPlatformApiFactory.of({
+        make: legacyMakePlatformApi.pipe(
+          Effect.provideService(Analytics, analytics),
+          Effect.provideService(LegacyCliConfig, cliConfigService),
+          Effect.provideService(LegacyCredentials, credentialsService),
+          Effect.provideService(LegacyDebugLogger, debugLogger),
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.provideService(TelemetryRuntime, telemetryRuntime),
+          Effect.provide(FetchHttpClient.layer),
+        ),
+      });
+    }),
+  );
+  const platformApiFactoryStack = platformApiFactory.pipe(
+    Layer.provide(credentials),
+    Layer.provide(cliConfig),
+    Layer.provide(legacyDebugLoggerLayer),
+  );
+
+  const built = Layer.mergeAll(
+    httpClient,
+    credentials,
+    cliConfig,
+    legacyDebugLoggerLayer,
+    platformApiFactoryStack,
+    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
+    legacyLinkedProjectCacheLayer.pipe(
+      Layer.provide(credentials),
+      Layer.provide(cliConfig),
+      Layer.provide(httpClient),
+    ),
+    legacyTelemetryStateLayer,
+    commandRuntimeLayer(["gen", "types"]),
+  ).pipe(Layer.provide(FetchHttpClient.layer));
+
+  const _serviceCoverageCheck: Layer.Layer<LegacyGenTypesServices, unknown, unknown> = built;
+  void _serviceCoverageCheck;
+
+  return built;
+})();
+
+type LegacyGenTypesServices =
+  | HttpClient.HttpClient
+  | LegacyCredentials
+  | LegacyCliConfig
+  | LegacyDebugLogger
+  | LegacyPlatformApiFactory
+  | LegacyProjectRefResolver
+  | LegacyLinkedProjectCache
+  | LegacyTelemetryState
+  | CommandRuntime;

--- a/apps/cli/src/legacy/commands/services/services.command.ts
+++ b/apps/cli/src/legacy/commands/services/services.command.ts
@@ -1,9 +1,9 @@
 import { Command } from "effect/unstable/cli";
 import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
-import { legacyManagementApiRuntimeLayer } from "../../shared/legacy-management-api-runtime.layer.ts";
 import { withLegacyCommandInstrumentation } from "../../telemetry/legacy-command-instrumentation.ts";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { legacyServices } from "./services.handler.ts";
+import { legacyServicesRuntimeLayer } from "./services.layers.ts";
 
 const config = {};
 export type LegacyServicesFlags = CliCommand.Command.Config.Infer<typeof config>;
@@ -14,5 +14,5 @@ export const legacyServicesCommand = Command.make("services", config).pipe(
   Command.withHandler((flags) =>
     legacyServices(flags).pipe(withLegacyCommandInstrumentation({ flags }), withJsonErrorHandling),
   ),
-  Command.provide(legacyManagementApiRuntimeLayer(["services"])),
+  Command.provide(legacyServicesRuntimeLayer),
 );

--- a/apps/cli/src/legacy/commands/services/services.integration.test.ts
+++ b/apps/cli/src/legacy/commands/services/services.integration.test.ts
@@ -1,14 +1,28 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
+import { CliOutput, Command } from "effect/unstable/cli";
+import { Stdio } from "effect";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
 import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
 import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
-import { LegacyOutputFlag } from "../../../shared/legacy/global-flags.ts";
-import { mockOutput } from "../../../../tests/helpers/mocks.ts";
+import { LEGACY_GLOBAL_FLAGS, LegacyOutputFlag } from "../../../shared/legacy/global-flags.ts";
+import {
+  mockAnalytics,
+  mockOutput,
+  mockRuntimeInfo,
+  mockTty,
+  processEnvLayer,
+} from "../../../../tests/helpers/mocks.ts";
 import { mockLegacyTelemetryStateTracked } from "../../../../tests/helpers/legacy-mocks.ts";
 import { listLocalServiceVersions } from "../../../shared/services/services.shared.ts";
+import { textCliOutputFormatter } from "../../../shared/output/text-formatter.ts";
+import { TelemetryRuntime } from "../../../shared/telemetry/runtime.service.ts";
+import { legacyServicesCommand } from "./services.command.ts";
 import { legacyServices } from "./services.handler.ts";
 
 const LOCAL_POSTGRES_SERVICE = listLocalServiceVersions().find(
@@ -79,6 +93,11 @@ const legacyCredentialsMock = {
   deleteProjectCredential: () => Effect.succeed(false),
 };
 
+const legacyTestRoot = Command.make("supabase").pipe(
+  Command.withGlobalFlags(LEGACY_GLOBAL_FLAGS),
+  Command.withSubcommands([legacyServicesCommand]),
+);
+
 function expectFailureTag(exit: Exit.Exit<unknown, unknown>, tag: string) {
   expect(Exit.isFailure(exit)).toBe(true);
   if (!Exit.isFailure(exit)) {
@@ -93,6 +112,56 @@ function expectFailureTag(exit: Exit.Exit<unknown, unknown>, tag: string) {
 }
 
 describe("legacy services", () => {
+  it.effect("runs tokenless local service listing through command wiring", () =>
+    Effect.tryPromise({
+      try: async () => {
+        const workdir = mkdtempSync(join(tmpdir(), "supabase-services-"));
+        const out = mockOutput({ format: "text", interactive: false });
+        const analytics = mockAnalytics();
+        const args = ["services"];
+        const layer = Layer.mergeAll(
+          BunServices.layer,
+          CliOutput.layer(textCliOutputFormatter()),
+          out.layer,
+          analytics.layer,
+          processEnvLayer({ SUPABASE_HOME: workdir }),
+          mockRuntimeInfo({ cwd: workdir, homeDir: workdir }),
+          mockTty({ stdinIsTty: false, stdoutIsTty: false }),
+          Stdio.layerTest({ args: Effect.succeed(args) }),
+          Layer.succeed(
+            TelemetryRuntime,
+            TelemetryRuntime.of({
+              configDir: join(workdir, ".supabase"),
+              tracesDir: join(workdir, ".supabase", "traces"),
+              consent: "granted",
+              showDebug: false,
+              deviceId: "test-device-id",
+              sessionId: "test-session-id",
+              distinctId: undefined,
+              isFirstRun: false,
+              isTty: false,
+              isCi: false,
+              os: "linux",
+              arch: "x64",
+              cliVersion: "0.1.0",
+            }),
+          ),
+        );
+
+        await Effect.runPromise(
+          Command.runWith(legacyTestRoot, { version: "0.0.0-test" })(args).pipe(
+            Effect.provide(layer),
+          ) as Effect.Effect<void>,
+        );
+
+        expect(out.stdoutText).toContain("supabase/postgres");
+        expect(out.stdoutText).toContain("supabase/gotrue");
+        expect(out.stderrText).not.toContain("Access token not provided");
+      },
+      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    }),
+  );
+
   it.live("prints the services table by default", () => {
     const { layer, out } = setup();
 

--- a/apps/cli/src/legacy/commands/services/services.layers.ts
+++ b/apps/cli/src/legacy/commands/services/services.layers.ts
@@ -1,0 +1,60 @@
+import { FetchHttpClient } from "effect/unstable/http";
+import { Layer } from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+
+import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
+import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
+import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
+import { LegacyDebugLogger } from "../../shared/legacy-debug-logger.service.ts";
+import { legacyHttpClientLayer } from "../../auth/legacy-http-debug.layer.ts";
+import { legacyLinkedProjectCacheLayer } from "../../telemetry/legacy-linked-project-cache.layer.ts";
+import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
+import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
+import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
+import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
+import { CommandRuntime } from "../../../shared/runtime/command-runtime.service.ts";
+
+/**
+ * `services` always prints the local service matrix and only performs linked
+ * version checks when both a linked project ref and an access token are present.
+ * Keep this runtime lean so a tokenless local invocation does not fail before
+ * the handler can choose the local-only path.
+ */
+export const legacyServicesRuntimeLayer = (() => {
+  const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const httpClient = legacyHttpClientLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  const credentials = legacyCredentialsLayer.pipe(
+    Layer.provide(cliConfig),
+    Layer.provide(legacyDebugLoggerLayer),
+  );
+
+  const built = Layer.mergeAll(
+    httpClient,
+    credentials,
+    cliConfig,
+    legacyDebugLoggerLayer,
+    legacyLinkedProjectCacheLayer.pipe(
+      Layer.provide(credentials),
+      Layer.provide(cliConfig),
+      Layer.provide(httpClient),
+    ),
+    legacyTelemetryStateLayer,
+    commandRuntimeLayer(["services"]),
+  ).pipe(Layer.provide(FetchHttpClient.layer));
+
+  const _serviceCoverageCheck: Layer.Layer<LegacyServicesServices, unknown, unknown> = built;
+  void _serviceCoverageCheck;
+
+  return built;
+})();
+
+type LegacyServicesServices =
+  | HttpClient.HttpClient
+  | LegacyCredentials
+  | LegacyCliConfig
+  | LegacyDebugLogger
+  | LegacyLinkedProjectCache
+  | LegacyTelemetryState
+  | CommandRuntime;

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
@@ -1,6 +1,6 @@
 import { Effect, FileSystem, Layer, Option, Path } from "effect";
 
-import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api.service.ts";
 import { Output } from "../../shared/output/output.service.ts";
 import { Tty } from "../../shared/runtime/tty.service.ts";
 import { legacyTempPaths } from "../shared/legacy-temp-paths.ts";
@@ -34,7 +34,7 @@ export const legacyProjectRefLayer = Layer.effect(
     const cliConfig = yield* LegacyCliConfig;
     const tty = yield* Tty;
     const output = yield* Output;
-    const api = yield* LegacyPlatformApi;
+    const platformApi = yield* LegacyPlatformApiFactory;
 
     const refPath = legacyTempPaths(path, cliConfig.workdir).projectRef;
 
@@ -47,6 +47,16 @@ export const legacyProjectRefLayer = Layer.effect(
     });
 
     const promptForProjectRef = Effect.fnUntraced(function* (title: string) {
+      const api = yield* platformApi.make.pipe(
+        Effect.mapError(
+          (cause) =>
+            new LegacyProjectNotLinkedError({
+              message: `${PROJECT_NOT_LINKED_MESSAGE}\n  Reason: failed to retrieve projects: ${String(
+                cause,
+              )}`,
+            }),
+        ),
+      );
       const projects = yield* api.v1.listAllProjects().pipe(
         Effect.mapError(
           (cause) =>

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
@@ -8,7 +8,10 @@ import { BunServices } from "@effect/platform-bun";
 import { Effect, Exit, Layer, Option } from "effect";
 import { afterEach, beforeEach } from "vitest";
 
-import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import {
+  LegacyPlatformApi,
+  LegacyPlatformApiFactory,
+} from "../auth/legacy-platform-api.service.ts";
 import { mockOutput, mockTty } from "../../../tests/helpers/mocks.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "./legacy-project-ref.service.ts";
@@ -67,7 +70,11 @@ function makeLayer(opts: {
     Layer.provide(mockCliConfig(opts)),
     Layer.provide(mockTty({ stdinIsTty: opts.stdinIsTty ?? false, stdoutIsTty: false })),
     Layer.provide(out.layer),
-    Layer.provide(mockPlatformApi(opts.projects ?? [])),
+    Layer.provide(
+      Layer.succeed(LegacyPlatformApiFactory, {
+        make: LegacyPlatformApi.pipe(Effect.provide(mockPlatformApi(opts.projects ?? []))),
+      }),
+    ),
     Layer.provide(BunServices.layer),
   );
   return { layer, out };

--- a/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
@@ -1,11 +1,14 @@
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { LegacyCredentials } from "../auth/legacy-credentials.service.ts";
 import { legacyCredentialsLayer } from "../auth/legacy-credentials.layer.ts";
 import { legacyHttpClientLayer } from "../auth/legacy-http-debug.layer.ts";
-import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
+import {
+  LegacyPlatformApi,
+  LegacyPlatformApiFactory,
+} from "../auth/legacy-platform-api.service.ts";
 import { legacyPlatformApiLayer } from "../auth/legacy-platform-api.layer.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { legacyCliConfigLayer } from "../config/legacy-cli-config.layer.ts";
@@ -65,12 +68,24 @@ export function legacyManagementApiRuntimeLayer(subcommand: ReadonlyArray<string
     Layer.provide(FetchHttpClient.layer),
     Layer.provide(legacyDebugLoggerLayer),
   );
+  const platformApiFactory = Layer.effect(
+    LegacyPlatformApiFactory,
+    LegacyPlatformApi.pipe(
+      Effect.map((api) =>
+        LegacyPlatformApiFactory.of({
+          make: Effect.succeed(api),
+        }),
+      ),
+    ),
+  );
+  const platformApiFactoryStack = platformApiFactory.pipe(Layer.provide(platformApiStack));
   const built = Layer.mergeAll(
     platformApiStack,
+    platformApiFactoryStack,
     httpClient,
     credentials,
     cliConfig,
-    legacyProjectRefLayer.pipe(Layer.provide(platformApiStack), Layer.provide(cliConfig)),
+    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
     legacyLinkedProjectCacheLayer.pipe(
       Layer.provide(credentials),
       Layer.provide(cliConfig),
@@ -115,6 +130,7 @@ export function legacyManagementApiRuntimeLayer(subcommand: ReadonlyArray<string
  */
 type LegacyManagementApiServices =
   | LegacyPlatformApi
+  | LegacyPlatformApiFactory
   | HttpClient.HttpClient
   | LegacyCredentials
   | LegacyCliConfig

--- a/apps/cli/tests/helpers/legacy-mocks.ts
+++ b/apps/cli/tests/helpers/legacy-mocks.ts
@@ -20,7 +20,10 @@ import {
   LegacyInvalidAccessTokenError,
   LegacyNotLoggedInError,
 } from "../../src/legacy/auth/legacy-errors.ts";
-import { LegacyPlatformApi } from "../../src/legacy/auth/legacy-platform-api.service.ts";
+import {
+  LegacyPlatformApi,
+  LegacyPlatformApiFactory,
+} from "../../src/legacy/auth/legacy-platform-api.service.ts";
 import {
   LegacyLoginApi,
   type LegacyLoginSessionResponse,
@@ -679,7 +682,11 @@ export function buildLegacyTestRuntime(opts: BuildLegacyTestRuntimeOpts) {
     processControl,
     runtimeInfo,
     legacyProjectRefLayer.pipe(
-      Layer.provide(opts.api.layer),
+      Layer.provide(
+        Layer.succeed(LegacyPlatformApiFactory, {
+          make: LegacyPlatformApi.pipe(Effect.provide(opts.api.layer)),
+        }),
+      ),
       Layer.provide(opts.cliConfig),
       Layer.provide(tty),
       Layer.provide(opts.out.layer),


### PR DESCRIPTION
Fixes CLI-1619.

This removes eager Management API client construction from command paths that have tokenless behavior:

- `gen types --local` and `--db-url` now use a lean runtime and lazily construct the platform API client only for linked/project-id generation.
- `services` now uses a lean runtime so it can always print local service versions, while keeping the linked-version lookup optional when a token is available.
- Command-wiring regression coverage exercises tokenless `gen types --local` and `services` invocations through the actual CLI command layers.