### PR TITLE
chore(cli): organize lazy platform API factory

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-platform-api-factory.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api-factory.layer.ts
@@ -1,25 +1,12 @@
 import { FetchHttpClient } from "effect/unstable/http";
-import { Effect, FileSystem, Layer, Path } from "effect";
-import type * as HttpClient from "effect/unstable/http/HttpClient";
+import { Effect, Layer } from "effect";
 
-import { Analytics } from "../../shared/telemetry/analytics.service.ts";
-import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
-import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
-import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
-import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import { legacyMakePlatformApi } from "./legacy-platform-api.layer.ts";
 import { LegacyPlatformApi } from "./legacy-platform-api.service.ts";
 import { LegacyPlatformApiFactory } from "./legacy-platform-api-factory.service.ts";
 
 type LegacyPlatformApiDeps =
-  | Analytics
-  | LegacyCliConfig
-  | LegacyCredentials
-  | LegacyDebugLogger
-  | FileSystem.FileSystem
-  | HttpClient.HttpClient
-  | Path.Path
-  | TelemetryRuntime;
+  typeof legacyMakePlatformApi extends Effect.Effect<infer _A, infer _E, infer R> ? R : never;
 
 /**
  * Captures the surrounding Management API context without resolving an access
@@ -30,8 +17,10 @@ export const legacyPlatformApiFactoryLayer = Layer.effect(
   LegacyPlatformApiFactory,
   Effect.gen(function* () {
     const context = yield* Effect.context<LegacyPlatformApiDeps>();
+    const make = yield* legacyMakePlatformApi.pipe(Effect.provideContext(context), Effect.cached);
+
     return LegacyPlatformApiFactory.of({
-      make: legacyMakePlatformApi.pipe(Effect.provideContext(context)),
+      make,
     });
   }),
 ).pipe(Layer.provide(FetchHttpClient.layer));

--- a/apps/cli/src/legacy/auth/legacy-platform-api-factory.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api-factory.layer.ts
@@ -1,0 +1,53 @@
+import { FetchHttpClient } from "effect/unstable/http";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
+import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
+import { LegacyCredentials } from "./legacy-credentials.service.ts";
+import { legacyMakePlatformApi } from "./legacy-platform-api.layer.ts";
+import { LegacyPlatformApi } from "./legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "./legacy-platform-api-factory.service.ts";
+
+type LegacyPlatformApiDeps =
+  | Analytics
+  | LegacyCliConfig
+  | LegacyCredentials
+  | LegacyDebugLogger
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | TelemetryRuntime;
+
+/**
+ * Captures the surrounding Management API context without resolving an access
+ * token. The raw fetch client is provided here so `legacyMakePlatformApi` owns
+ * the single typed-API debug wrapper.
+ */
+export const legacyPlatformApiFactoryLayer = Layer.effect(
+  LegacyPlatformApiFactory,
+  Effect.gen(function* () {
+    const context = yield* Effect.context<LegacyPlatformApiDeps>();
+    return LegacyPlatformApiFactory.of({
+      make: legacyMakePlatformApi.pipe(Effect.provideContext(context)),
+    });
+  }),
+).pipe(Layer.provide(FetchHttpClient.layer));
+
+/**
+ * Adapts an already-built eager `LegacyPlatformApi` into a factory. Use this in
+ * runtimes that intentionally require Management API auth up front but still
+ * need to satisfy services that consume the lazy factory shape.
+ */
+export const legacyPlatformApiFactoryFromApiLayer = Layer.effect(
+  LegacyPlatformApiFactory,
+  LegacyPlatformApi.pipe(
+    Effect.map((api) =>
+      LegacyPlatformApiFactory.of({
+        make: Effect.succeed(api),
+      }),
+    ),
+  ),
+);

--- a/apps/cli/src/legacy/auth/legacy-platform-api-factory.service.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api-factory.service.ts
@@ -1,0 +1,26 @@
+import type { ApiClient, SupabaseApiConfigError } from "@supabase/api/effect";
+import { type Effect, Context } from "effect";
+
+import type {
+  LegacyInvalidAccessTokenError,
+  LegacyPlatformAuthRequiredError,
+} from "./legacy-errors.ts";
+
+/**
+ * Lazy accessor for the typed Management API client.
+ *
+ * Unlike `LegacyPlatformApi`, whose layer resolves an access token when the
+ * command runtime is built, `make` defers client construction until a command
+ * branch actually reaches a Management API call.
+ */
+export interface LegacyPlatformApiFactoryShape {
+  readonly make: Effect.Effect<
+    ApiClient,
+    LegacyInvalidAccessTokenError | LegacyPlatformAuthRequiredError | SupabaseApiConfigError
+  >;
+}
+
+export class LegacyPlatformApiFactory extends Context.Service<
+  LegacyPlatformApiFactory,
+  LegacyPlatformApiFactoryShape
+>()("supabase/legacy/PlatformApiFactory") {}

--- a/apps/cli/src/legacy/auth/legacy-platform-api.service.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.service.ts
@@ -1,15 +1,6 @@
 import type { ApiClient } from "@supabase/api/effect";
-import { type Effect, Context } from "effect";
+import { Context } from "effect";
 
 export class LegacyPlatformApi extends Context.Service<LegacyPlatformApi, ApiClient>()(
   "supabase/legacy/PlatformApi",
 ) {}
-
-export interface LegacyPlatformApiFactoryShape {
-  readonly make: Effect.Effect<ApiClient, unknown>;
-}
-
-export class LegacyPlatformApiFactory extends Context.Service<
-  LegacyPlatformApiFactory,
-  LegacyPlatformApiFactoryShape
->()("supabase/legacy/PlatformApiFactory") {}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.layers.ts
@@ -1,12 +1,9 @@
-import { Effect, Layer } from "effect";
+import { Layer } from "effect";
 
 import { legacyCredentialsLayer } from "../../auth/legacy-credentials.layer.ts";
 import { legacyHttpClientLayer } from "../../auth/legacy-http-debug.layer.ts";
+import { legacyPlatformApiFactoryFromApiLayer } from "../../auth/legacy-platform-api-factory.layer.ts";
 import { legacyPlatformApiLayer } from "../../auth/legacy-platform-api.layer.ts";
-import {
-  LegacyPlatformApi,
-  LegacyPlatformApiFactory,
-} from "../../auth/legacy-platform-api.service.ts";
 import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
 import { legacyProjectRefLayer } from "../../config/legacy-project-ref.layer.ts";
 import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
@@ -46,25 +43,15 @@ const platformApi = legacyPlatformApiLayer.pipe(
   Layer.provide(httpClient),
   Layer.provide(debugLogger),
 );
-const platformApiFactory = Layer.effect(
-  LegacyPlatformApiFactory,
-  LegacyPlatformApi.pipe(
-    Effect.map((api) =>
-      LegacyPlatformApiFactory.of({
-        make: Effect.succeed(api),
-      }),
-    ),
-  ),
-);
-const platformApiFactoryStack = platformApiFactory.pipe(Layer.provide(platformApi));
+const platformApiFactory = legacyPlatformApiFactoryFromApiLayer.pipe(Layer.provide(platformApi));
 
 export const legacyBootstrapRuntimeLayer = Layer.mergeAll(
   platformApi,
-  platformApiFactoryStack,
+  platformApiFactory,
   httpClient,
   credentials,
   cliConfig,
-  legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
+  legacyProjectRefLayer.pipe(Layer.provide(platformApiFactory), Layer.provide(cliConfig)),
   legacyLinkedProjectCacheLayer.pipe(
     Layer.provide(credentials),
     Layer.provide(cliConfig),

--- a/apps/cli/src/legacy/commands/gen/types/types.handler.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.handler.ts
@@ -16,7 +16,7 @@ import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.
 import type { LegacyGenTypesFlags } from "./types.command.ts";
 import { LegacyGenTypesNetworkError, LegacyGenTypesUnexpectedStatusError } from "./types.errors.ts";
 import { legacyGetHostname } from "../../../shared/legacy-hostname.ts";
-import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api-factory.service.ts";
 import {
   buildPostgresUrl,
   defaultSchemas,

--- a/apps/cli/src/legacy/commands/gen/types/types.integration.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.integration.test.ts
@@ -13,10 +13,8 @@ import {
   LegacyNetworkIdFlag,
   LegacyOutputFlag,
 } from "../../../../shared/legacy/global-flags.ts";
-import {
-  LegacyPlatformApi,
-  LegacyPlatformApiFactory,
-} from "../../../auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api-factory.service.ts";
+import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
 import {
   mockAnalytics,
   mockOutput,

--- a/apps/cli/src/legacy/commands/gen/types/types.layers.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.layers.ts
@@ -1,17 +1,13 @@
-import { FetchHttpClient } from "effect/unstable/http";
-import { Effect, FileSystem, Layer, Path } from "effect";
-import * as HttpClient from "effect/unstable/http/HttpClient";
+import { Layer } from "effect";
 
 import { legacyCredentialsLayer } from "../../../auth/legacy-credentials.layer.ts";
-import { LegacyCredentials } from "../../../auth/legacy-credentials.service.ts";
-import { legacyMakePlatformApi } from "../../../auth/legacy-platform-api.layer.ts";
-import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api.service.ts";
+import { legacyPlatformApiFactoryLayer } from "../../../auth/legacy-platform-api-factory.layer.ts";
+import { LegacyPlatformApiFactory } from "../../../auth/legacy-platform-api-factory.service.ts";
 import { legacyCliConfigLayer } from "../../../config/legacy-cli-config.layer.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { legacyProjectRefLayer } from "../../../config/legacy-project-ref.layer.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
 import { legacyDebugLoggerLayer } from "../../../shared/legacy-debug-logger.layer.ts";
-import { LegacyDebugLogger } from "../../../shared/legacy-debug-logger.service.ts";
 import { legacyHttpClientLayer } from "../../../auth/legacy-http-debug.layer.ts";
 import { legacyLinkedProjectCacheLayer } from "../../../telemetry/legacy-linked-project-cache.layer.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
@@ -19,8 +15,6 @@ import { legacyTelemetryStateLayer } from "../../../telemetry/legacy-telemetry-s
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
 import { CommandRuntime } from "../../../../shared/runtime/command-runtime.service.ts";
-import { Analytics } from "../../../../shared/telemetry/analytics.service.ts";
-import { TelemetryRuntime } from "../../../../shared/telemetry/runtime.service.ts";
 
 /**
  * `gen types --local` and `--db-url` do not use the Management API, so this
@@ -35,44 +29,16 @@ export const legacyGenTypesRuntimeLayer = (() => {
     Layer.provide(cliConfig),
     Layer.provide(legacyDebugLoggerLayer),
   );
-  const platformApiFactory = Layer.effect(
-    LegacyPlatformApiFactory,
-    Effect.gen(function* () {
-      const analytics = yield* Analytics;
-      const cliConfigService = yield* LegacyCliConfig;
-      const credentialsService = yield* LegacyCredentials;
-      const debugLogger = yield* LegacyDebugLogger;
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const telemetryRuntime = yield* TelemetryRuntime;
-
-      return LegacyPlatformApiFactory.of({
-        make: legacyMakePlatformApi.pipe(
-          Effect.provideService(Analytics, analytics),
-          Effect.provideService(LegacyCliConfig, cliConfigService),
-          Effect.provideService(LegacyCredentials, credentialsService),
-          Effect.provideService(LegacyDebugLogger, debugLogger),
-          Effect.provideService(FileSystem.FileSystem, fs),
-          Effect.provideService(Path.Path, path),
-          Effect.provideService(TelemetryRuntime, telemetryRuntime),
-          Effect.provide(FetchHttpClient.layer),
-        ),
-      });
-    }),
-  );
-  const platformApiFactoryStack = platformApiFactory.pipe(
+  const platformApiFactory = legacyPlatformApiFactoryLayer.pipe(
     Layer.provide(credentials),
     Layer.provide(cliConfig),
     Layer.provide(legacyDebugLoggerLayer),
   );
 
   const built = Layer.mergeAll(
-    httpClient,
-    credentials,
     cliConfig,
-    legacyDebugLoggerLayer,
-    platformApiFactoryStack,
-    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
+    platformApiFactory,
+    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactory), Layer.provide(cliConfig)),
     legacyLinkedProjectCacheLayer.pipe(
       Layer.provide(credentials),
       Layer.provide(cliConfig),
@@ -80,7 +46,7 @@ export const legacyGenTypesRuntimeLayer = (() => {
     ),
     legacyTelemetryStateLayer,
     commandRuntimeLayer(["gen", "types"]),
-  ).pipe(Layer.provide(FetchHttpClient.layer));
+  );
 
   const _serviceCoverageCheck: Layer.Layer<LegacyGenTypesServices, unknown, unknown> = built;
   void _serviceCoverageCheck;
@@ -89,11 +55,8 @@ export const legacyGenTypesRuntimeLayer = (() => {
 })();
 
 type LegacyGenTypesServices =
-  | HttpClient.HttpClient
-  | LegacyCredentials
-  | LegacyCliConfig
-  | LegacyDebugLogger
   | LegacyPlatformApiFactory
+  | LegacyCliConfig
   | LegacyProjectRefResolver
   | LegacyLinkedProjectCache
   | LegacyTelemetryState

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
@@ -1,6 +1,6 @@
 import { Effect, FileSystem, Layer, Option, Path } from "effect";
 
-import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api-factory.service.ts";
 import { Output } from "../../shared/output/output.service.ts";
 import { Tty } from "../../shared/runtime/tty.service.ts";
 import { legacyTempPaths } from "../shared/legacy-temp-paths.ts";

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
@@ -8,10 +8,8 @@ import { BunServices } from "@effect/platform-bun";
 import { Effect, Exit, Layer, Option } from "effect";
 import { afterEach, beforeEach } from "vitest";
 
-import {
-  LegacyPlatformApi,
-  LegacyPlatformApiFactory,
-} from "../auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api-factory.service.ts";
+import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
 import { mockOutput, mockTty } from "../../../tests/helpers/mocks.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "./legacy-project-ref.service.ts";

--- a/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-management-api-runtime.layer.ts
@@ -1,14 +1,12 @@
-import { Effect, Layer } from "effect";
+import { Layer } from "effect";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { LegacyCredentials } from "../auth/legacy-credentials.service.ts";
 import { legacyCredentialsLayer } from "../auth/legacy-credentials.layer.ts";
 import { legacyHttpClientLayer } from "../auth/legacy-http-debug.layer.ts";
-import {
-  LegacyPlatformApi,
-  LegacyPlatformApiFactory,
-} from "../auth/legacy-platform-api.service.ts";
+import { legacyPlatformApiFactoryFromApiLayer } from "../auth/legacy-platform-api-factory.layer.ts";
+import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
 import { legacyPlatformApiLayer } from "../auth/legacy-platform-api.layer.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { legacyCliConfigLayer } from "../config/legacy-cli-config.layer.ts";
@@ -68,24 +66,16 @@ export function legacyManagementApiRuntimeLayer(subcommand: ReadonlyArray<string
     Layer.provide(FetchHttpClient.layer),
     Layer.provide(legacyDebugLoggerLayer),
   );
-  const platformApiFactory = Layer.effect(
-    LegacyPlatformApiFactory,
-    LegacyPlatformApi.pipe(
-      Effect.map((api) =>
-        LegacyPlatformApiFactory.of({
-          make: Effect.succeed(api),
-        }),
-      ),
-    ),
+  const platformApiFactory = legacyPlatformApiFactoryFromApiLayer.pipe(
+    Layer.provide(platformApiStack),
   );
-  const platformApiFactoryStack = platformApiFactory.pipe(Layer.provide(platformApiStack));
   const built = Layer.mergeAll(
     platformApiStack,
-    platformApiFactoryStack,
+    platformApiFactory,
     httpClient,
     credentials,
     cliConfig,
-    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactoryStack), Layer.provide(cliConfig)),
+    legacyProjectRefLayer.pipe(Layer.provide(platformApiFactory), Layer.provide(cliConfig)),
     legacyLinkedProjectCacheLayer.pipe(
       Layer.provide(credentials),
       Layer.provide(cliConfig),
@@ -130,7 +120,6 @@ export function legacyManagementApiRuntimeLayer(subcommand: ReadonlyArray<string
  */
 type LegacyManagementApiServices =
   | LegacyPlatformApi
-  | LegacyPlatformApiFactory
   | HttpClient.HttpClient
   | LegacyCredentials
   | LegacyCliConfig

--- a/apps/cli/tests/helpers/legacy-mocks.ts
+++ b/apps/cli/tests/helpers/legacy-mocks.ts
@@ -20,10 +20,8 @@ import {
   LegacyInvalidAccessTokenError,
   LegacyNotLoggedInError,
 } from "../../src/legacy/auth/legacy-errors.ts";
-import {
-  LegacyPlatformApi,
-  LegacyPlatformApiFactory,
-} from "../../src/legacy/auth/legacy-platform-api.service.ts";
+import { LegacyPlatformApiFactory } from "../../src/legacy/auth/legacy-platform-api-factory.service.ts";
+import { LegacyPlatformApi } from "../../src/legacy/auth/legacy-platform-api.service.ts";
 import {
   LegacyLoginApi,
   type LegacyLoginSessionResponse,


### PR DESCRIPTION
## Summary

Extracts the lazy Management API client factory into auth-owned service and layer modules so command runtimes can share the same wiring instead of rebuilding it locally.

The lean `gen types` runtime now consumes the shared lazy factory, while eager Management API runtimes adapt their already-built `LegacyPlatformApi` into the factory shape for project-ref resolution. This keeps tokenless command paths lazy without duplicating platform API construction in commands that intentionally authenticate up front.
