### PR TITLE
feat(cli): support high availability project creation

### DIFF
--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
@@ -176,6 +176,7 @@ export const legacyBootstrap = Effect.fn("legacy.bootstrap")(function* (
       dbPassword: seededPassword,
       region: undefined,
       size: undefined,
+      highAvailability: undefined,
       templateUrl: starter.url.length > 0 ? starter.url : undefined,
       emitStructuredResult: false,
     });

--- a/apps/cli/src/legacy/commands/projects/create/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/projects/create/SIDE_EFFECTS.md
@@ -14,10 +14,10 @@
 
 ## API Routes
 
-| Method | Path                | Auth         | Request body                                                                 | Response (used fields)                                           |
-| ------ | ------------------- | ------------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `GET`  | `/v1/organizations` | Bearer token | —                                                                            | `[{id, slug, name}]` — interactive org prompt only               |
-| `POST` | `/v1/projects`      | Bearer token | `{name, organization_slug, db_pass, region?, desired_instance_size?}` (JSON) | `{id, ref, name, organization_slug, region, created_at, status}` |
+| Method | Path                | Auth         | Request body                                                                                     | Response (used fields)                                           |
+| ------ | ------------------- | ------------ | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `GET`  | `/v1/organizations` | Bearer token | —                                                                                                | `[{id, slug, name}]` — interactive org prompt only               |
+| `POST` | `/v1/projects`      | Bearer token | `{name, organization_slug, db_pass, region?, desired_instance_size?, high_availability?}` (JSON) | `{id, ref, name, organization_slug, region, created_at, status}` |
 
 ## Environment Variables
 
@@ -40,21 +40,22 @@
 
 ## Telemetry Events Fired
 
-| Event                  | When                                       | Notable properties / groups                                        |
-| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
-| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--org-id` is telemetry-safe) |
+| Event                  | When                                       | Notable properties / groups                                                                |
+| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` (`--org-id`, `--high-availability` are telemetry-safe) |
 
 ## Flags
 
-| Flag             | Type   | Required (non-interactive) | Description                                     |
-| ---------------- | ------ | -------------------------- | ----------------------------------------------- |
-| `[project name]` | arg    | yes (non-interactive)      | Name of the project (positional argument)       |
-| `--org-id`       | string | yes (non-interactive)      | Organization ID (slug) to create the project in |
-| `--db-password`  | string | yes (non-interactive)      | Database password for the project               |
-| `--region`       | enum   | yes (non-interactive)      | AWS region for the project                      |
-| `--size`         | enum   | no                         | Desired instance size                           |
-| `--interactive`  | bool   | no (default: true)         | Enable interactive mode (hidden flag)           |
-| `--plan`         | string | no                         | Plan selection (hidden flag)                    |
+| Flag                  | Type   | Required (non-interactive) | Description                                     |
+| --------------------- | ------ | -------------------------- | ----------------------------------------------- |
+| `[project name]`      | arg    | yes (non-interactive)      | Name of the project (positional argument)       |
+| `--org-id`            | string | yes (non-interactive)      | Organization ID (slug) to create the project in |
+| `--db-password`       | string | yes (non-interactive)      | Database password for the project               |
+| `--region`            | enum   | yes (non-interactive)      | AWS region for the project                      |
+| `--size`              | enum   | no                         | Desired instance size                           |
+| `--high-availability` | bool   | no                         | Enable high availability for the project        |
+| `--interactive`       | bool   | no (default: true)         | Enable interactive mode (hidden flag)           |
+| `--plan`              | string | no                         | Plan selection (hidden flag)                    |
 
 ## Output
 
@@ -91,4 +92,5 @@ One `result` event on success.
 - In non-interactive mode (when stdin is not a TTY or `--interactive=false`), all three
   flags and the positional project name argument are required.
 - The `--size` flag, when provided, sets the `desired_instance_size` field in the request body.
+- The `--high-availability` flag, when provided, sets the `high_availability` field in the request body.
 - The `--plan` flag is hidden and reserved.

--- a/apps/cli/src/legacy/commands/projects/create/create.command.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.command.ts
@@ -69,6 +69,10 @@ const config = {
     Flag.withDescription("Select a desired instance size for your project."),
     Flag.optional,
   ),
+  highAvailability: Flag.boolean("high-availability").pipe(
+    Flag.withDescription("Enable high availability for the project."),
+    Flag.optional,
+  ),
   interactive: Flag.boolean("interactive").pipe(
     Flag.withDescription("Enables interactive mode."),
     Flag.withAlias("i"),
@@ -95,7 +99,7 @@ export const legacyProjectsCreateCommand = Command.make("create", config).pipe(
   ]),
   Command.withHandler((flags) =>
     legacyProjectsCreate(flags).pipe(
-      withLegacyCommandInstrumentation({ flags, safeFlags: ["org-id"] }),
+      withLegacyCommandInstrumentation({ flags, safeFlags: ["org-id", "high-availability"] }),
       withJsonErrorHandling,
     ),
   ),

--- a/apps/cli/src/legacy/commands/projects/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.handler.ts
@@ -30,6 +30,7 @@ export const legacyProjectsCreate = Effect.fn("legacy.projects.create")(function
     const region = Option.getOrUndefined(flags.region);
     const dbPassword = Option.getOrElse(flags.dbPassword, () => "");
     const size = Option.getOrUndefined(flags.size);
+    const highAvailability = Option.getOrUndefined(flags.highAvailability);
 
     // Non-interactive: Go's PreRunE marks `--org-id`, `--db-password`,
     // `--region` required and the project name positional `ExactArgs(1)`.
@@ -52,6 +53,7 @@ export const legacyProjectsCreate = Effect.fn("legacy.projects.create")(function
       dbPassword,
       region,
       size,
+      highAvailability,
       templateUrl: undefined,
       emitStructuredResult: true,
     });

--- a/apps/cli/src/legacy/commands/projects/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.integration.test.ts
@@ -37,6 +37,7 @@ const BASE_FLAGS: LegacyProjectsCreateFlags = {
   dbPassword: Option.none(),
   region: Option.none(),
   size: Option.none(),
+  highAvailability: Option.none(),
   interactive: Option.none(),
   plan: Option.none(),
 };
@@ -130,6 +131,36 @@ describe("legacy projects create integration", () => {
         size: Option.some("medium"),
       });
       expect(postBody(api)?.desired_instance_size).toBe("medium");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("includes high_availability only when --high-availability is set", () => {
+    const { layer, api } = setup();
+    return Effect.gen(function* () {
+      yield* legacyProjectsCreate({
+        ...BASE_FLAGS,
+        name: Option.some("alpha"),
+        orgId: Option.some("acme"),
+        dbPassword: Option.some("s3cret-pass"),
+        region: Option.some("us-east-1"),
+        highAvailability: Option.some(true),
+      });
+      expect(postBody(api)?.high_availability).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards --high-availability=false when explicitly set", () => {
+    const { layer, api } = setup();
+    return Effect.gen(function* () {
+      yield* legacyProjectsCreate({
+        ...BASE_FLAGS,
+        name: Option.some("alpha"),
+        orgId: Option.some("acme"),
+        dbPassword: Option.some("s3cret-pass"),
+        region: Option.some("us-east-1"),
+        highAvailability: Option.some(false),
+      });
+      expect(postBody(api)?.high_availability).toBe(false);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/shared/legacy-project-create-core.ts
+++ b/apps/cli/src/legacy/shared/legacy-project-create-core.ts
@@ -31,6 +31,7 @@ export interface LegacyProjectCreateInput {
   readonly dbPassword: string;
   readonly region: CreateInput["region"];
   readonly size: CreateInput["desired_instance_size"];
+  readonly highAvailability: CreateInput["high_availability"];
   readonly templateUrl: string | undefined;
   /**
    * Standalone `projects create` emits a `--output-format` json/stream-json
@@ -68,6 +69,7 @@ export const legacyProjectCreateCore = Effect.fnUntraced(function* (
   let region: CreateInput["region"] = input.region;
   let dbPassword = input.dbPassword;
   const size = input.size;
+  const highAvailability = input.highAvailability;
 
   // promptMissingParams (`create.go:58-85`): prompt for each empty value and
   // echo the resolved value to stderr in text mode.
@@ -99,6 +101,7 @@ export const legacyProjectCreateCore = Effect.fnUntraced(function* (
     db_pass: dbPassword,
     ...(region !== undefined ? { region } : {}),
     ...(size !== undefined ? { desired_instance_size: size } : {}),
+    ...(highAvailability !== undefined ? { high_availability: highAvailability } : {}),
     ...(input.templateUrl !== undefined ? { template_url: input.templateUrl } : {}),
   };
 

--- a/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
+++ b/apps/cli/src/shared/cli/hidden-flag.unit.test.ts
@@ -111,6 +111,7 @@ describe("native hidden flags", () => {
       "db-password",
       "region",
       "size",
+      "high-availability",
     ]);
   });
 

--- a/packages/api/scripts/download-openapi.ts
+++ b/packages/api/scripts/download-openapi.ts
@@ -14,7 +14,7 @@ type OpenApiDocument = {
 };
 
 type JsonPatchOperation = {
-  readonly op: "test" | "replace";
+  readonly op: "add" | "test" | "replace";
   readonly path: string;
   readonly value: unknown;
 };
@@ -82,12 +82,39 @@ function replaceJsonPointerValue(document: unknown, pointer: string, value: unkn
   parent[key] = value;
 }
 
+function addJsonPointerValue(document: unknown, pointer: string, value: unknown): void {
+  const segments = jsonPointerSegments(pointer);
+  if (segments.length === 0) {
+    throw new Error("Adding the document root is not supported.");
+  }
+
+  let parent = document;
+  for (const segment of segments.slice(0, -1)) {
+    parent = getJsonPointerValue(parent, `/${segment.replace(/~/g, "~0").replace(/\//g, "~1")}`);
+  }
+
+  const key = segments[segments.length - 1]!;
+  if (Array.isArray(parent)) {
+    const index = key === "-" ? parent.length : Number(key);
+    if (!Number.isInteger(index) || index < 0 || index > parent.length) {
+      throw new Error(`JSON pointer ${JSON.stringify(pointer)} cannot be added.`);
+    }
+    parent.splice(index, 0, value);
+    return;
+  }
+
+  if (!isRecord(parent) || key in parent) {
+    throw new Error(`JSON pointer ${JSON.stringify(pointer)} cannot be added.`);
+  }
+  parent[key] = value;
+}
+
 function assertJsonPatchOperation(value: unknown): asserts value is JsonPatchOperation {
   if (!isRecord(value)) {
     throw new Error("OpenAPI override entry must be an object.");
   }
-  if (value.op !== "test" && value.op !== "replace") {
-    throw new Error("OpenAPI overrides only support test and replace operations.");
+  if (value.op !== "add" && value.op !== "test" && value.op !== "replace") {
+    throw new Error("OpenAPI overrides only support add, test and replace operations.");
   }
   if (typeof value.path !== "string") {
     throw new Error("OpenAPI override path must be a string.");
@@ -114,6 +141,10 @@ export function applyOpenApiOverrides(
           `OpenAPI override test failed at ${override.path}: expected ${JSON.stringify(override.value)}, got ${JSON.stringify(actual)}.`,
         );
       }
+      continue;
+    }
+    if (override.op === "add") {
+      addJsonPointerValue(document, override.path, override.value);
       continue;
     }
     replaceJsonPointerValue(document, override.path, override.value);

--- a/packages/api/scripts/download-openapi.unit.test.ts
+++ b/packages/api/scripts/download-openapi.unit.test.ts
@@ -31,6 +31,7 @@ describe("download-openapi", () => {
   });
 
   test("applies OpenAPI JSON Patch overrides", () => {
+    const samlProperties: Record<string, unknown> = {};
     const document = {
       paths: {},
       components: {
@@ -42,6 +43,7 @@ describe("download-openapi", () => {
                   properties: {
                     saml: {
                       required: ["id", "entity_id"],
+                      properties: samlProperties,
                     },
                   },
                 },
@@ -63,12 +65,17 @@ describe("download-openapi", () => {
         path: "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/required",
         value: ["entity_id"],
       },
+      {
+        op: "add",
+        path: "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/properties/high_availability",
+        value: { type: "boolean" },
+      },
     ]);
 
-    expect(
-      document.components.schemas.ListProvidersResponse.properties.items.items.properties.saml
-        .required,
-    ).toEqual(["entity_id"]);
+    const saml =
+      document.components.schemas.ListProvidersResponse.properties.items.items.properties.saml;
+    expect(saml.required).toEqual(["entity_id"]);
+    expect(samlProperties.high_availability).toEqual({ type: "boolean" });
   });
 
   test("fails when an OpenAPI override test no longer matches", () => {
@@ -84,5 +91,20 @@ describe("download-openapi", () => {
         ],
       ),
     ).toThrow("OpenAPI override test failed");
+  });
+
+  test("fails when an OpenAPI add override already exists", () => {
+    expect(() =>
+      applyOpenApiOverrides(
+        { paths: {}, components: { schemas: { Body: { properties: { enabled: {} } } } } },
+        [
+          {
+            op: "add",
+            path: "/components/schemas/Body/properties/enabled",
+            value: { type: "boolean" },
+          },
+        ],
+      ),
+    ).toThrow("cannot be added");
   });
 });

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -523,5 +523,13 @@
       "custom_oauth_enabled",
       "custom_oauth_max_providers"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/components/schemas/V1CreateProjectBody/properties/high_availability",
+    "value": {
+      "type": "boolean",
+      "description": "Whether to enable high availability for the project."
+    }
   }
 ]

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -709,6 +709,11 @@ export const V1CreateAProjectInput = Schema.Struct({
       format: "uri",
     }),
   ),
+  high_availability: Schema.optionalKey(
+    Schema.Boolean.annotate({
+      description: "Whether to enable high availability for the project.",
+    }),
+  ),
 });
 export const V1CreateAProjectOutput = Schema.Struct({
   id: Schema.String.annotate({ description: "Deprecated: Use `ref` instead." }),
@@ -6341,6 +6346,7 @@ export const operationDefinitions = {
         "kps_enabled",
         "desired_instance_size",
         "template_url",
+        "high_availability",
       ],
     },
     response: { kind: "json" },

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -11627,6 +11627,10 @@
             "type": "string",
             "format": "uri",
             "description": "Template URL used to create the project from the CLI."
+          },
+          "high_availability": {
+            "type": "boolean",
+            "description": "Whether to enable high availability for the project."
           }
         },
         "required": ["db_pass", "name", "organization_slug"],


### PR DESCRIPTION
Adds support for creating projects with high availability from the TypeScript CLI path.

The Management API runtime already accepts `high_availability`, but the published OpenAPI spec has not exposed it yet. This adds the field through the OpenAPI override system so the generated API types include it, then wires `supabase projects create --high-availability` through the shared project creation flow.

Supersedes #5383, which was still draft and conflicted after the TypeScript project creation refactor.