### PR TITLE
fix(cli): handle blank project password prompt

### DIFF
--- a/apps/cli/src/shared/output/output.layer.ts
+++ b/apps/cli/src/shared/output/output.layer.ts
@@ -305,7 +305,7 @@ export const textOutputLayer = Layer.effect(
             cancel("Operation cancelled.");
             return yield* Effect.interrupt;
           }
-          return value.trim();
+          return typeof value === "string" ? value.trim() : "";
         }),
       promptConfirm: (message: string, opts?: { defaultValue?: boolean }) =>
         Effect.gen(function* () {

--- a/apps/cli/src/shared/output/output.layer.unit.test.ts
+++ b/apps/cli/src/shared/output/output.layer.unit.test.ts
@@ -297,6 +297,15 @@ describe("Output", () => {
       }).pipe(Effect.provide(layer));
     });
 
+    it.effect("promptPassword treats an undefined response as blank input", () => {
+      mockClack.password.mockResolvedValue(undefined);
+      return Effect.gen(function* () {
+        const out = yield* Output;
+        const result = yield* out.promptPassword("Enter password");
+        expect(result).toBe("");
+      }).pipe(Effect.provide(layer));
+    });
+
     it.effect("promptConfirm interrupts on cancel", () => {
       mockClack.confirm.mockResolvedValue(Symbol.for("clack:cancel"));
       mockClack.isCancel.mockReturnValue(true);


### PR DESCRIPTION
Fixes the interactive password prompt path used by `projects create` when the user leaves the database password blank.

`@clack/prompts` can return no string value for that blank password entry. The output adapter was calling `.trim()` directly, which crashed before the project creation flow could generate the fallback password. The adapter now normalizes non-string prompt results to an empty string so existing command-level fallback behavior can run.