### PR TITLE
fix(cli): accept nullable function import map paths

### DIFF
--- a/apps/cli/src/next/commands/functions/list/list.handler.ts
+++ b/apps/cli/src/next/commands/functions/list/list.handler.ts
@@ -22,7 +22,7 @@ interface RemoteFunction {
   readonly verify_jwt?: boolean;
   readonly import_map?: boolean;
   readonly entrypoint_path?: string;
-  readonly import_map_path?: string;
+  readonly import_map_path?: string | null;
   readonly ezbr_sha256?: string;
 }
 

--- a/apps/cli/src/next/commands/functions/list/list.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/list/list.integration.test.ts
@@ -295,6 +295,44 @@ describe("functions list", () => {
     );
   });
 
+  it.live("accepts null import_map_path values from the management API", () => {
+    const tempDir = makeTempDir();
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      const { out, layer } = setup({
+        cwd: tempDir,
+        linked: true,
+        accessToken: "test-token",
+        format: "json",
+        remoteFunctions: [makeFunction({ import_map_path: null })],
+      });
+
+      yield* functionsList().pipe(Effect.provide(layer));
+
+      const success = out.messages.find((message) => message.type === "success");
+      const data = success?.data as {
+        functions: Array<{
+          slug: string;
+          local: unknown | null;
+          remote: { slug: string; import_map_path?: string | null } | null;
+        }>;
+        sources: { remote: { checked: boolean; project_ref?: string; reason?: string } };
+      };
+
+      expect(data.sources.remote).toEqual({ checked: true, project_ref: PROJECT_REF });
+      expect(data.functions).toHaveLength(1);
+      expect(data.functions[0]).toMatchObject({
+        slug: "hello-world",
+        local: expect.objectContaining({ entrypoint: "./functions/hello-world/index.ts" }),
+        remote: expect.objectContaining({ slug: "hello-world" }),
+      });
+      expect(data.functions[0]?.remote?.import_map_path).toBeNull();
+    }).pipe(
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
   it.live("keeps local-only functions when remote enrichment succeeds", () => {
     const tempDir = makeTempDir();
 

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -536,21 +536,32 @@
     "op": "replace",
     "path": "/components/schemas/FunctionResponse/properties/import_map_path",
     "value": {
-      "type": ["string", "null"]
+      "type": "string",
+      "nullable": true
     }
   },
   {
     "op": "replace",
     "path": "/components/schemas/BulkUpdateFunctionResponse/properties/functions/items/properties/import_map_path",
     "value": {
-      "type": ["string", "null"]
+      "type": "string",
+      "nullable": true
     }
   },
   {
     "op": "replace",
     "path": "/components/schemas/DeployFunctionResponse/properties/import_map_path",
     "value": {
-      "type": ["string", "null"]
+      "type": "string",
+      "nullable": true
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/FunctionSlugResponse/properties/import_map_path",
+    "value": {
+      "type": "string",
+      "nullable": true
     }
   }
 ]

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -531,5 +531,26 @@
       "type": "boolean",
       "description": "Whether to enable high availability for the project."
     }
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/FunctionResponse/properties/import_map_path",
+    "value": {
+      "type": ["string", "null"]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/BulkUpdateFunctionResponse/properties/functions/items/properties/import_map_path",
+    "value": {
+      "type": ["string", "null"]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/DeployFunctionResponse/properties/import_map_path",
+    "value": {
+      "type": ["string", "null"]
+    }
   }
 ]

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -410,7 +410,7 @@ export const V1BulkUpdateFunctionsInput = Schema.Struct({
       verify_jwt: Schema.optionalKey(Schema.Boolean),
       import_map: Schema.optionalKey(Schema.Boolean),
       entrypoint_path: Schema.optionalKey(Schema.String),
-      import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+      import_map_path: Schema.optionalKey(Schema.String),
       ezbr_sha256: Schema.optionalKey(Schema.String),
     }),
   ),
@@ -571,7 +571,7 @@ export const V1CreateAFunctionInput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+  import_map_path: Schema.optionalKey(Schema.String),
   ezbr_sha256: Schema.optionalKey(Schema.String),
   body: BinaryInput,
 });
@@ -1310,7 +1310,7 @@ export const V1DeployAFunctionInput = Schema.Struct({
     file: Schema.optionalKey(Schema.Array(BinaryInput)),
     metadata: Schema.Struct({
       entrypoint_path: Schema.String,
-      import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+      import_map_path: Schema.optionalKey(Schema.String),
       static_patterns: Schema.optionalKey(Schema.Array(Schema.String)),
       verify_jwt: Schema.optionalKey(Schema.Boolean),
       name: Schema.optionalKey(Schema.String),
@@ -4305,7 +4305,7 @@ export const V1UpdateAFunctionInput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+  import_map_path: Schema.optionalKey(Schema.String),
   ezbr_sha256: Schema.optionalKey(Schema.String),
   body: BinaryInput,
 });

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -189,7 +189,7 @@ export const FunctionResponse = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
 });
 export const V1StorageBucketResponse = Schema.Struct({
@@ -410,7 +410,7 @@ export const V1BulkUpdateFunctionsInput = Schema.Struct({
       verify_jwt: Schema.optionalKey(Schema.Boolean),
       import_map: Schema.optionalKey(Schema.Boolean),
       entrypoint_path: Schema.optionalKey(Schema.String),
-      import_map_path: Schema.optionalKey(Schema.String),
+      import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
       ezbr_sha256: Schema.optionalKey(Schema.String),
     }),
   ),
@@ -428,7 +428,7 @@ export const V1BulkUpdateFunctionsOutput = Schema.Struct({
       verify_jwt: Schema.optionalKey(Schema.Boolean),
       import_map: Schema.optionalKey(Schema.Boolean),
       entrypoint_path: Schema.optionalKey(Schema.String),
-      import_map_path: Schema.optionalKey(Schema.String),
+      import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
       ezbr_sha256: Schema.optionalKey(Schema.String),
     }),
   ),
@@ -571,7 +571,7 @@ export const V1CreateAFunctionInput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
   body: BinaryInput,
 });
@@ -586,7 +586,7 @@ export const V1CreateAFunctionOutput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
 });
 export const V1CreateAProjectInput = Schema.Struct({
@@ -1310,7 +1310,7 @@ export const V1DeployAFunctionInput = Schema.Struct({
     file: Schema.optionalKey(Schema.Array(BinaryInput)),
     metadata: Schema.Struct({
       entrypoint_path: Schema.String,
-      import_map_path: Schema.optionalKey(Schema.String),
+      import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
       static_patterns: Schema.optionalKey(Schema.Array(Schema.String)),
       verify_jwt: Schema.optionalKey(Schema.Boolean),
       name: Schema.optionalKey(Schema.String),
@@ -1328,7 +1328,7 @@ export const V1DeployAFunctionOutput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
 });
 export const V1DiffABranchInput = Schema.Struct({
@@ -1546,7 +1546,7 @@ export const V1GetAFunctionOutput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
 });
 export const V1GetAFunctionBodyInput = Schema.Struct({
@@ -4305,7 +4305,7 @@ export const V1UpdateAFunctionInput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
   body: BinaryInput,
 });
@@ -4320,7 +4320,7 @@ export const V1UpdateAFunctionOutput = Schema.Struct({
   verify_jwt: Schema.optionalKey(Schema.Boolean),
   import_map: Schema.optionalKey(Schema.Boolean),
   entrypoint_path: Schema.optionalKey(Schema.String),
-  import_map_path: Schema.optionalKey(Schema.String),
+  import_map_path: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   ezbr_sha256: Schema.optionalKey(Schema.String),
 });
 export const V1UpdateAProjectInput = Schema.Struct({

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -17533,7 +17533,7 @@
             "type": "string"
           },
           "import_map_path": {
-            "type": "string"
+            "type": ["string", "null"]
           },
           "ezbr_sha256": {
             "type": "string"
@@ -17664,7 +17664,7 @@
                   "type": "string"
                 },
                 "import_map_path": {
-                  "type": "string"
+                  "type": ["string", "null"]
                 },
                 "ezbr_sha256": {
                   "type": "string"
@@ -17758,7 +17758,7 @@
             "type": "string"
           },
           "import_map_path": {
-            "type": "string"
+            "type": ["string", "null"]
           },
           "ezbr_sha256": {
             "type": "string"

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -17533,7 +17533,8 @@
             "type": "string"
           },
           "import_map_path": {
-            "type": ["string", "null"]
+            "type": "string",
+            "nullable": true
           },
           "ezbr_sha256": {
             "type": "string"
@@ -17664,7 +17665,8 @@
                   "type": "string"
                 },
                 "import_map_path": {
-                  "type": ["string", "null"]
+                  "type": "string",
+                  "nullable": true
                 },
                 "ezbr_sha256": {
                   "type": "string"
@@ -17758,7 +17760,8 @@
             "type": "string"
           },
           "import_map_path": {
-            "type": ["string", "null"]
+            "type": "string",
+            "nullable": true
           },
           "ezbr_sha256": {
             "type": "string"
@@ -17803,7 +17806,8 @@
             "type": "string"
           },
           "import_map_path": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "ezbr_sha256": {
             "type": "string"


### PR DESCRIPTION
## TL;DR

fixes nullable function import map paths

## prob

- While testing the ported `functions deploy` flow here: https://github.com/supabase/cli/pull/5561
 I found that `functions list` could fall back to `request_failed` because the management api can return
 `import_map_path: null`

Go already accepted that null shape, but the generated ts contract only accepted a string

basically this updates the generated function response contracts to accept `null` for `import_map_path` 
and adds a integration coverage around it! 

## ref

- smol regression of: (#5185)


