### PR TITLE
ci: fix release macOS cache restore

### DIFF
--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -39,6 +39,8 @@ jobs:
       needs.build.result == 'success'
     name: Publish preview package
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    outputs:
+      preview_url: ${{ steps.preview-metadata.outputs.preview_url }}
     env:
       PREVIEW_VERSION: 0.0.0-pr.${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -86,12 +88,30 @@ jobs:
             './packages/cli-windows-x64' \
             './apps/cli'
 
-      - name: Smoke test preview command
+      - name: Read preview package metadata
+        id: preview-metadata
         run: |
           set -euo pipefail
-          preview_url="https://pkg.pr.new/supabase@${PR_NUMBER}"
-          echo "Preview command: npx ${preview_url}"
-          npx --yes "${preview_url}" --version
+          preview_url="$(
+            node -e "
+              const fs = require('node:fs');
+              const metadata = JSON.parse(fs.readFileSync('pkg-pr-new.json', 'utf8'));
+              const pkg = metadata.packages.find((entry) => entry.name === 'supabase');
+              if (!pkg?.url) {
+                throw new Error('pkg-pr-new.json did not include a supabase package URL');
+              }
+              console.log(pkg.url);
+            "
+          )"
+          echo "Preview command: npx --yes ${preview_url}"
+          echo "preview_url=${preview_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Smoke test preview command
+        env:
+          PREVIEW_URL: ${{ steps.preview-metadata.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          npx --yes "${PREVIEW_URL}" --version
 
   comment:
     needs: publish
@@ -107,13 +127,13 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      PREVIEW_URL: ${{ needs.publish.outputs.preview_url }}
     steps:
       - name: Post preview command comment
         run: |
           set -euo pipefail
 
           marker="<!-- supabase-cli-preview-package -->"
-          preview_url="https://pkg.pr.new/supabase@${PR_NUMBER}"
           short_sha="${HEAD_SHA:0:7}"
           comment_file="$(mktemp)"
 
@@ -122,7 +142,7 @@ jobs:
           ## Supabase CLI preview
 
           \`\`\`sh
-          npx --yes ${preview_url}
+          npx --yes ${PREVIEW_URL}
           \`\`\`
 
           _Preview package for commit [\`${short_sha}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${HEAD_SHA})._

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -67,7 +67,6 @@ jobs:
 
   build-github:
     name: Build CLI artifacts (GitHub hosted)
-    if: ${{ !inputs.dry_run }}
     uses: ./.github/workflows/build-cli-artifacts.yml
     with:
       version: ${{ inputs.version }}
@@ -87,7 +86,6 @@ jobs:
       matrix:
         runner:
           - blacksmith-8vcpu-ubuntu-2404
-          - blacksmith-6vcpu-macos-latest
           - blacksmith-8vcpu-windows-2025
     runs-on: ${{ matrix.runner }}
     env:
@@ -189,10 +187,45 @@ jobs:
         run: pnpm run test:smoke -- --version "${VERSION}" --tag "${NPM_TAG}"
         working-directory: apps/cli
 
+  smoke-test-macos:
+    needs:
+      - build-github
+    runs-on: macos-latest
+    env:
+      NPM_TAG: ${{ inputs.npm_tag }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+
+      - name: Fix binary permissions
+        run: chmod +x packages/cli-*/bin/supabase || true
+
+      - name: Run smoke tests
+        shell: bash
+        run: pnpm run test:smoke -- --version "${VERSION}" --tag "${NPM_TAG}"
+        working-directory: apps/cli
+
   publish:
     needs:
       - build-github
       - smoke-test
+      - smoke-test-macos
     if: ${{ !inputs.dry_run }}
     # npm provenance verification rejects non-GitHub-hosted runners with
     # E422 ("Unsupported GitHub Actions runner environment: self-hosted").


### PR DESCRIPTION
## Summary
- run macOS release smoke on GitHub-hosted macOS so it restores the GitHub-hosted build cache
- keep Linux and Windows smoke tests on Blacksmith using the Blacksmith build cache
- make the GitHub-hosted build available for dry-run release smoke as well as real publishes

## Context
The release run after #5550 saved the Blacksmith build cache successfully, and Linux/Windows smoke restored it, but Blacksmith macOS missed the same key. The macOS smoke job now uses the cache backend produced by the GitHub-hosted build instead of relying on cross-backend visibility.
