### PR TITLE
fix(cli): allow local storage without access token

### DIFF
--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -51,6 +52,32 @@ func promptLogin(fsys afero.Fs) error {
 	} else {
 		return err
 	}
+}
+
+func shouldPromptLogin(cmd *cobra.Command) bool {
+	return IsManagementAPI(cmd) && !isLocalStorageCommand(cmd)
+}
+
+func isLocalStorageCommand(cmd *cobra.Command) bool {
+	if !isCommandOrChild(cmd, storageCmd) {
+		return false
+	}
+	flag := cmd.Flag("local")
+	if flag == nil {
+		return false
+	}
+	local, err := strconv.ParseBool(flag.Value.String())
+	return err == nil && local
+}
+
+func isCommandOrChild(cmd, parent *cobra.Command) bool {
+	for cmd != nil && cmd != cmd.Root() {
+		if cmd == parent {
+			return true
+		}
+		cmd = cmd.Parent()
+	}
+	return false
 }
 
 var experimental = []*cobra.Command{
@@ -105,7 +132,7 @@ var (
 				return err
 			}
 			// Add common flags
-			if IsManagementAPI(cmd) {
+			if shouldPromptLogin(cmd) {
 				if err := promptLogin(fsys); err != nil {
 					return err
 				}

--- a/apps/cli-go/cmd/root_test.go
+++ b/apps/cli-go/cmd/root_test.go
@@ -72,6 +72,40 @@ func TestCommandName(t *testing.T) {
 	assert.Equal(t, "supabase", commandName(root))
 }
 
+func TestShouldPromptLogin(t *testing.T) {
+	t.Run("requires login for linked storage", func(t *testing.T) {
+		setStorageLocalFlag(t, "false", false)
+
+		assert.True(t, shouldPromptLogin(lsCmd))
+	})
+
+	t.Run("skips login for local storage", func(t *testing.T) {
+		setStorageLocalFlag(t, "true", true)
+
+		assert.False(t, shouldPromptLogin(lsCmd))
+	})
+
+	t.Run("does not require login for local dev commands", func(t *testing.T) {
+		assert.False(t, shouldPromptLogin(startCmd))
+	})
+}
+
+func setStorageLocalFlag(t *testing.T, value string, changed bool) {
+	t.Helper()
+
+	flag := storageCmd.PersistentFlags().Lookup("local")
+	require.NotNil(t, flag)
+	prevValue := flag.Value.String()
+	prevChanged := flag.Changed
+	require.NoError(t, flag.Value.Set(value))
+	flag.Changed = changed
+
+	t.Cleanup(func() {
+		require.NoError(t, flag.Value.Set(prevValue))
+		flag.Changed = prevChanged
+	})
+}
+
 func TestTelemetryIsAgent(t *testing.T) {
 	t.Run("returns true for agent env", func(t *testing.T) {
 		clearTelemetryEnv(t)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`supabase storage --local` fails before reaching the storage handler when no `SUPABASE_ACCESS_TOKEN` is configured. The storage command is grouped with Management API commands, so the shared root pre-run prompts for login before the local Storage API client can be selected.

Closes #3455.

## What is the new behavior?

Local storage subcommands bypass the Management API login gate when storage is explicitly targeting the local stack. Default and linked storage usage still requires an access token.

The PR also adds command-level coverage for the linked/default storage auth path and the explicit local storage bypass.

## Additional context

This is separate from the TypeScript typegen port regression discussed in #5551. Storage is still handled by the legacy Go command path; the TypeScript shim forwards `--local`, and the auth failure happens in the Go root pre-run.