### PR TITLE
fix(cli): accept sparse SSO provider responses

### DIFF
--- a/apps/cli-go/api/overlay.yaml
+++ b/apps/cli-go/api/overlay.yaml
@@ -29,6 +29,18 @@ actions:
 - target: $.components.schemas.*.properties.items.items.properties.saml.properties.name_id_format.enum
   description: Converts list of enum with duplicated type to a string
   remove: true
+- target: $.components.schemas.*.properties.saml.required[?(@ == "id")]
+  description: Allows provider responses to omit nested SAML IDs
+  remove: true
+- target: $.components.schemas.ListProvidersResponse.properties.items.items.properties.saml.required[?(@ == "id")]
+  description: Allows provider list responses to omit nested SAML IDs
+  remove: true
+- target: $.components.schemas.*.properties.saml.properties.attribute_mapping.required[?(@ == "keys")]
+  description: Allows provider responses to return an empty SAML attribute mapping object
+  remove: true
+- target: $.components.schemas.ListProvidersResponse.properties.items.items.properties.saml.properties.attribute_mapping.required[?(@ == "keys")]
+  description: Allows provider list responses to return an empty SAML attribute mapping object
+  remove: true
 - target: $.components.schemas.*.properties.connectionString
   description: Removes deprecated field that conflicts with naming convention
   remove: true

--- a/apps/cli-go/internal/sso/get/get_test.go
+++ b/apps/cli-go/internal/sso/get/get_test.go
@@ -67,6 +67,38 @@ func TestSSOProvidersShowCommand(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
+	t.Run("show provider with empty SAML attribute mapping", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+
+		projectRef := "abcdefghijklmnopqrst"
+		providerId := "0b0d48f6-878b-4190-88d7-2ca33ed800bc"
+
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + projectRef + "/config/auth/sso/providers/" + providerId).
+			Reply(200).
+			JSON(map[string]any{
+				"id":         providerId,
+				"created_at": "2023-03-28T13:50:14.464Z",
+				"updated_at": "2023-03-28T13:50:14.464Z",
+				"saml": map[string]any{
+					"metadata_url":      "https://example.com",
+					"metadata_xml":      "<?xml version=\"2.0\"?>",
+					"entity_id":         "https://example.com",
+					"attribute_mapping": map[string]any{},
+				},
+			})
+
+		// Run test
+		assert.NoError(t, Run(context.Background(), projectRef, providerId, utils.OutputPretty))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
 	t.Run("show provider that does not exist", func(t *testing.T) {
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)

--- a/apps/cli-go/internal/sso/internal/render/render.go
+++ b/apps/cli-go/internal/sso/internal/render/render.go
@@ -142,7 +142,7 @@ func SingleMarkdown(provider api.GetProviderResponse) error {
 		formatTimestamp(provider.CreatedAt),
 	))
 
-	if provider.Saml != nil && provider.Saml.AttributeMapping != nil && len(provider.Saml.AttributeMapping.Keys) > 0 {
+	if provider.Saml != nil && provider.Saml.AttributeMapping != nil && provider.Saml.AttributeMapping.Keys != nil && len(*provider.Saml.AttributeMapping.Keys) > 0 {
 		attributeMapping, err := json.MarshalIndent(provider.Saml.AttributeMapping, "", "  ")
 		if err != nil {
 			return errors.Errorf("failed to marshal attribute mapping: %w", err)

--- a/apps/cli-go/internal/sso/list/list_test.go
+++ b/apps/cli-go/internal/sso/list/list_test.go
@@ -70,6 +70,41 @@ func TestSSOProvidersListCommand(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
+	t.Run("lists providers with empty SAML attribute mapping", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+
+		projectRef := "abcdefghijklmnopqrst"
+
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + projectRef + "/config/auth/sso/providers").
+			Reply(200).
+			JSON(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":         "0b0d48f6-878b-4190-88d7-2ca33ed800bc",
+						"created_at": "2023-03-28T13:50:14.464Z",
+						"updated_at": "2023-03-28T13:50:14.464Z",
+						"saml": map[string]any{
+							"metadata_url":      "https://example.com",
+							"metadata_xml":      "<?xml version=\"2.0\"?>",
+							"entity_id":         "https://example.com",
+							"attribute_mapping": map[string]any{},
+						},
+					},
+				},
+			})
+
+		// Run test
+		assert.NoError(t, Run(context.Background(), projectRef, utils.OutputPretty))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
 	t.Run("list providers with disabled SAML", func(t *testing.T) {
 		// Setup valid access token
 		token := apitest.RandomAccessToken(t)

--- a/apps/cli-go/internal/sso/update/update_test.go
+++ b/apps/cli-go/internal/sso/update/update_test.go
@@ -57,6 +57,33 @@ func response(providerId string, domains []string) map[string]any {
 	return resp
 }
 
+func responseWithEmptyAttributeMapping(providerId string, domains []string) map[string]any {
+	resp := map[string]any{
+		"id":         providerId,
+		"created_at": "2023-03-28T13:50:14.464Z",
+		"updated_at": "2023-03-28T13:50:14.464Z",
+		"saml": map[string]any{
+			"metadata_url":      "https://example.com",
+			"metadata_xml":      "<?xml version=\"2.0\"?>",
+			"entity_id":         "https://example.com",
+			"attribute_mapping": map[string]any{},
+		},
+		"domains": []map[string]any{},
+	}
+
+	for _, domain := range domains {
+		respDomains := resp["domains"].([]map[string]any)
+		resp["domains"] = append(respDomains, map[string]any{
+			"id":         "9484591c-a203-4500-bea7-d0aaa845e2f5",
+			"domain":     domain,
+			"created_at": "2023-03-28T13:50:14.464Z",
+			"updated_at": "2023-03-28T13:50:14.464Z",
+		})
+	}
+
+	return resp
+}
+
 func TestSSOProvidersUpdateCommand(t *testing.T) {
 	t.Run("update provider", func(t *testing.T) {
 		// Setup valid access token
@@ -107,6 +134,41 @@ func TestSSOProvidersUpdateCommand(t *testing.T) {
 		// Validate api
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 		assert.Equal(t, 1, observed)
+	})
+
+	t.Run("update provider with empty SAML attribute mapping", func(t *testing.T) {
+		// Setup valid access token
+		token := apitest.RandomAccessToken(t)
+		t.Setenv("SUPABASE_ACCESS_TOKEN", string(token))
+
+		// Flush pending mocks after test execution
+		defer gock.OffAll()
+
+		projectRef := apitest.RandomProjectRef()
+		providerId := uuid.New().String()
+
+		gock.New(utils.DefaultApiHost).
+			Get("/v1/projects/" + projectRef + "/config/auth/sso/providers/" + providerId).
+			Reply(200).
+			JSON(responseWithEmptyAttributeMapping(providerId, []string{"example.com"}))
+
+		gock.New(utils.DefaultApiHost).
+			Put("/v1/projects/" + projectRef + "/config/auth/sso/providers/" + providerId).
+			Reply(200).
+			JSON(responseWithEmptyAttributeMapping(providerId, []string{"new-domain.com"}))
+
+		// Run test
+		assert.NoError(t, Run(context.Background(), RunParams{
+			ProjectRef: projectRef,
+			ProviderID: providerId,
+			Format:     utils.OutputPretty,
+
+			Domains: []string{
+				"new-domain.com",
+			},
+		}))
+		// Validate api
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
 	t.Run("update provider with --add-domains and --remove-domains", func(t *testing.T) {

--- a/apps/cli-go/pkg/api/types.gen.go
+++ b/apps/cli-go/pkg/api/types.gen.go
@@ -2392,15 +2392,15 @@ type CreateProviderResponse struct {
 	Id   string `json:"id"`
 	Saml *struct {
 		AttributeMapping *struct {
-			Keys map[string]struct {
+			Keys *map[string]struct {
 				Array   *bool        `json:"array,omitempty"`
 				Default *interface{} `json:"default,omitempty"`
 				Name    *string      `json:"name,omitempty"`
 				Names   *[]string    `json:"names,omitempty"`
-			} `json:"keys"`
+			} `json:"keys,omitempty"`
 		} `json:"attribute_mapping,omitempty"`
 		EntityId     string  `json:"entity_id"`
-		Id           string  `json:"id"`
+		Id           *string `json:"id,omitempty"`
 		MetadataUrl  *string `json:"metadata_url,omitempty"`
 		MetadataXml  *string `json:"metadata_xml,omitempty"`
 		NameIdFormat *string `json:"name_id_format,omitempty"`
@@ -2607,15 +2607,15 @@ type DeleteProviderResponse struct {
 	Id   string `json:"id"`
 	Saml *struct {
 		AttributeMapping *struct {
-			Keys map[string]struct {
+			Keys *map[string]struct {
 				Array   *bool        `json:"array,omitempty"`
 				Default *interface{} `json:"default,omitempty"`
 				Name    *string      `json:"name,omitempty"`
 				Names   *[]string    `json:"names,omitempty"`
-			} `json:"keys"`
+			} `json:"keys,omitempty"`
 		} `json:"attribute_mapping,omitempty"`
 		EntityId     string  `json:"entity_id"`
-		Id           string  `json:"id"`
+		Id           *string `json:"id,omitempty"`
 		MetadataUrl  *string `json:"metadata_url,omitempty"`
 		MetadataXml  *string `json:"metadata_xml,omitempty"`
 		NameIdFormat *string `json:"name_id_format,omitempty"`
@@ -2833,15 +2833,15 @@ type GetProviderResponse struct {
 	Id   string `json:"id"`
 	Saml *struct {
 		AttributeMapping *struct {
-			Keys map[string]struct {
+			Keys *map[string]struct {
 				Array   *bool        `json:"array,omitempty"`
 				Default *interface{} `json:"default,omitempty"`
 				Name    *string      `json:"name,omitempty"`
 				Names   *[]string    `json:"names,omitempty"`
-			} `json:"keys"`
+			} `json:"keys,omitempty"`
 		} `json:"attribute_mapping,omitempty"`
 		EntityId     string  `json:"entity_id"`
-		Id           string  `json:"id"`
+		Id           *string `json:"id,omitempty"`
 		MetadataUrl  *string `json:"metadata_url,omitempty"`
 		MetadataXml  *string `json:"metadata_xml,omitempty"`
 		NameIdFormat *string `json:"name_id_format,omitempty"`
@@ -3093,15 +3093,15 @@ type ListProvidersResponse struct {
 		Id   string `json:"id"`
 		Saml *struct {
 			AttributeMapping *struct {
-				Keys map[string]struct {
+				Keys *map[string]struct {
 					Array   *bool        `json:"array,omitempty"`
 					Default *interface{} `json:"default,omitempty"`
 					Name    *string      `json:"name,omitempty"`
 					Names   *[]string    `json:"names,omitempty"`
-				} `json:"keys"`
+				} `json:"keys,omitempty"`
 			} `json:"attribute_mapping,omitempty"`
 			EntityId     string  `json:"entity_id"`
-			Id           string  `json:"id"`
+			Id           *string `json:"id,omitempty"`
 			MetadataUrl  *string `json:"metadata_url,omitempty"`
 			MetadataXml  *string `json:"metadata_xml,omitempty"`
 			NameIdFormat *string `json:"name_id_format,omitempty"`
@@ -4349,15 +4349,15 @@ type UpdateProviderResponse struct {
 	Id   string `json:"id"`
 	Saml *struct {
 		AttributeMapping *struct {
-			Keys map[string]struct {
+			Keys *map[string]struct {
 				Array   *bool        `json:"array,omitempty"`
 				Default *interface{} `json:"default,omitempty"`
 				Name    *string      `json:"name,omitempty"`
 				Names   *[]string    `json:"names,omitempty"`
-			} `json:"keys"`
+			} `json:"keys,omitempty"`
 		} `json:"attribute_mapping,omitempty"`
 		EntityId     string  `json:"entity_id"`
-		Id           string  `json:"id"`
+		Id           *string `json:"id,omitempty"`
 		MetadataUrl  *string `json:"metadata_url,omitempty"`
 		MetadataXml  *string `json:"metadata_xml,omitempty"`
 		NameIdFormat *string `json:"name_id_format,omitempty"`


### PR DESCRIPTION
## What changed

- Relax the generated SSO provider response models so nested SAML IDs and `attribute_mapping.keys` can be omitted.
- Keep request payload models strict, while allowing list/show/update response parsing to match the Management API shape.
- Skip rendering empty SAML attribute mappings in pretty output.
- Add regression coverage for `sso list`, `sso show`, and `sso update` with empty `attribute_mapping` objects.

## Why

Hosted projects can return SAML providers with `attribute_mapping: {}` and without a nested `saml.id`. The CLI's generated response types treated those fields as required, causing schema decoding to fail before the commands could render or update providers.

Fixes #5589.
