### PR TITLE
fix(api): accept sparse SSO provider responses

### DIFF
--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -11,6 +11,66 @@
   },
   {
     "op": "test",
+    "path": "/components/schemas/GetProviderResponse/properties/saml/required",
+    "value": ["id", "entity_id"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/GetProviderResponse/properties/saml/required",
+    "value": ["entity_id"]
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/CreateProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": ["keys"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/CreateProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": []
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/GetProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": ["keys"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/GetProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": []
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/properties/attribute_mapping/required",
+    "value": ["keys"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/ListProvidersResponse/properties/items/items/properties/saml/properties/attribute_mapping/required",
+    "value": []
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/UpdateProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": ["keys"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/UpdateProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": []
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/DeleteProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": ["keys"]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/DeleteProviderResponse/properties/saml/properties/attribute_mapping/required",
+    "value": []
+  },
+  {
+    "op": "test",
     "path": "/components/schemas/UpdateCustomHostnameResponse/properties/data/properties/result/properties/ssl/required",
     "value": ["status", "validation_records"]
   },

--- a/packages/api/src/effect.unit.test.ts
+++ b/packages/api/src/effect.unit.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "vitest";
 import { ConfigProvider, Effect, Layer } from "effect";
+import * as Schema from "effect/Schema";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 
 import { makeApiClient, operationDefinitions } from "./effect.ts";
+import { V1GetASsoProviderOutput, V1ListAllSsoProviderOutput } from "./generated/contracts.ts";
 
 const textDecoder = new TextDecoder();
 
@@ -50,6 +52,33 @@ const config = {
 } as const;
 
 describe("makeApiClient", () => {
+  test("decodes SSO provider responses with empty attribute mappings and no SAML ID", () => {
+    const provider = {
+      id: "0b0d48f6-878b-4190-88d7-2ca33ed800bc",
+      saml: {
+        entity_id: "https://example.com",
+        metadata_url: "https://example.com",
+        metadata_xml: '<?xml version="2.0"?>',
+        attribute_mapping: {},
+      },
+      domains: [
+        {
+          id: "9484591c-a203-4500-bea7-d0aaa845e2f5",
+          domain: "example.com",
+          created_at: "2023-03-28T13:50:14.464Z",
+          updated_at: "2023-03-28T13:50:14.464Z",
+        },
+      ],
+      created_at: "2023-03-28T13:50:14.464Z",
+      updated_at: "2023-03-28T13:50:14.464Z",
+    };
+
+    expect(() =>
+      Schema.decodeUnknownSync(V1ListAllSsoProviderOutput)({ items: [provider] }),
+    ).not.toThrow();
+    expect(() => Schema.decodeUnknownSync(V1GetASsoProviderOutput)(provider)).not.toThrow();
+  });
+
   test("allows raw operations to override generated request headers", async () => {
     let accept: string | undefined;
 

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -798,24 +798,26 @@ export const V1CreateASsoProviderOutput = Schema.Struct({
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
         Schema.Struct({
-          keys: Schema.Record(
-            Schema.String,
-            Schema.Struct({
-              name: Schema.optionalKey(Schema.String),
-              names: Schema.optionalKey(Schema.Array(Schema.String)),
-              default: Schema.optionalKey(
-                Schema.Union(
-                  [
-                    Schema.Struct({}),
-                    Schema.Number.check(Schema.isFinite()),
-                    Schema.String,
-                    Schema.Boolean,
-                  ],
-                  { mode: "oneOf" },
+          keys: Schema.optionalKey(
+            Schema.Record(
+              Schema.String,
+              Schema.Struct({
+                name: Schema.optionalKey(Schema.String),
+                names: Schema.optionalKey(Schema.Array(Schema.String)),
+                default: Schema.optionalKey(
+                  Schema.Union(
+                    [
+                      Schema.Struct({}),
+                      Schema.Number.check(Schema.isFinite()),
+                      Schema.String,
+                      Schema.Boolean,
+                    ],
+                    { mode: "oneOf" },
+                  ),
                 ),
-              ),
-              array: Schema.optionalKey(Schema.Boolean),
-            }),
+                array: Schema.optionalKey(Schema.Boolean),
+              }),
+            ),
           ),
         }),
       ),
@@ -1158,24 +1160,26 @@ export const V1DeleteASsoProviderOutput = Schema.Struct({
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
         Schema.Struct({
-          keys: Schema.Record(
-            Schema.String,
-            Schema.Struct({
-              name: Schema.optionalKey(Schema.String),
-              names: Schema.optionalKey(Schema.Array(Schema.String)),
-              default: Schema.optionalKey(
-                Schema.Union(
-                  [
-                    Schema.Struct({}),
-                    Schema.Number.check(Schema.isFinite()),
-                    Schema.String,
-                    Schema.Boolean,
-                  ],
-                  { mode: "oneOf" },
+          keys: Schema.optionalKey(
+            Schema.Record(
+              Schema.String,
+              Schema.Struct({
+                name: Schema.optionalKey(Schema.String),
+                names: Schema.optionalKey(Schema.Array(Schema.String)),
+                default: Schema.optionalKey(
+                  Schema.Union(
+                    [
+                      Schema.Struct({}),
+                      Schema.Number.check(Schema.isFinite()),
+                      Schema.String,
+                      Schema.Boolean,
+                    ],
+                    { mode: "oneOf" },
+                  ),
                 ),
-              ),
-              array: Schema.optionalKey(Schema.Boolean),
-            }),
+                array: Schema.optionalKey(Schema.Boolean),
+              }),
+            ),
           ),
         }),
       ),
@@ -1616,30 +1620,32 @@ export const V1GetASsoProviderOutput = Schema.Struct({
   id: Schema.String,
   saml: Schema.optionalKey(
     Schema.Struct({
-      id: Schema.String,
+      id: Schema.optionalKey(Schema.String),
       entity_id: Schema.String,
       metadata_url: Schema.optionalKey(Schema.String),
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
         Schema.Struct({
-          keys: Schema.Record(
-            Schema.String,
-            Schema.Struct({
-              name: Schema.optionalKey(Schema.String),
-              names: Schema.optionalKey(Schema.Array(Schema.String)),
-              default: Schema.optionalKey(
-                Schema.Union(
-                  [
-                    Schema.Struct({}),
-                    Schema.Number.check(Schema.isFinite()),
-                    Schema.String,
-                    Schema.Boolean,
-                  ],
-                  { mode: "oneOf" },
+          keys: Schema.optionalKey(
+            Schema.Record(
+              Schema.String,
+              Schema.Struct({
+                name: Schema.optionalKey(Schema.String),
+                names: Schema.optionalKey(Schema.Array(Schema.String)),
+                default: Schema.optionalKey(
+                  Schema.Union(
+                    [
+                      Schema.Struct({}),
+                      Schema.Number.check(Schema.isFinite()),
+                      Schema.String,
+                      Schema.Boolean,
+                    ],
+                    { mode: "oneOf" },
+                  ),
                 ),
-              ),
-              array: Schema.optionalKey(Schema.Boolean),
-            }),
+                array: Schema.optionalKey(Schema.Boolean),
+              }),
+            ),
           ),
         }),
       ),
@@ -3623,24 +3629,26 @@ export const V1ListAllSsoProviderOutput = Schema.Struct({
           metadata_xml: Schema.optionalKey(Schema.String),
           attribute_mapping: Schema.optionalKey(
             Schema.Struct({
-              keys: Schema.Record(
-                Schema.String,
-                Schema.Struct({
-                  name: Schema.optionalKey(Schema.String),
-                  names: Schema.optionalKey(Schema.Array(Schema.String)),
-                  default: Schema.optionalKey(
-                    Schema.Union(
-                      [
-                        Schema.Struct({}),
-                        Schema.Number.check(Schema.isFinite()),
-                        Schema.String,
-                        Schema.Boolean,
-                      ],
-                      { mode: "oneOf" },
+              keys: Schema.optionalKey(
+                Schema.Record(
+                  Schema.String,
+                  Schema.Struct({
+                    name: Schema.optionalKey(Schema.String),
+                    names: Schema.optionalKey(Schema.Array(Schema.String)),
+                    default: Schema.optionalKey(
+                      Schema.Union(
+                        [
+                          Schema.Struct({}),
+                          Schema.Number.check(Schema.isFinite()),
+                          Schema.String,
+                          Schema.Boolean,
+                        ],
+                        { mode: "oneOf" },
+                      ),
                     ),
-                  ),
-                  array: Schema.optionalKey(Schema.Boolean),
-                }),
+                    array: Schema.optionalKey(Schema.Boolean),
+                  }),
+                ),
               ),
             }),
           ),
@@ -4388,24 +4396,26 @@ export const V1UpdateASsoProviderOutput = Schema.Struct({
       metadata_xml: Schema.optionalKey(Schema.String),
       attribute_mapping: Schema.optionalKey(
         Schema.Struct({
-          keys: Schema.Record(
-            Schema.String,
-            Schema.Struct({
-              name: Schema.optionalKey(Schema.String),
-              names: Schema.optionalKey(Schema.Array(Schema.String)),
-              default: Schema.optionalKey(
-                Schema.Union(
-                  [
-                    Schema.Struct({}),
-                    Schema.Number.check(Schema.isFinite()),
-                    Schema.String,
-                    Schema.Boolean,
-                  ],
-                  { mode: "oneOf" },
+          keys: Schema.optionalKey(
+            Schema.Record(
+              Schema.String,
+              Schema.Struct({
+                name: Schema.optionalKey(Schema.String),
+                names: Schema.optionalKey(Schema.Array(Schema.String)),
+                default: Schema.optionalKey(
+                  Schema.Union(
+                    [
+                      Schema.Struct({}),
+                      Schema.Number.check(Schema.isFinite()),
+                      Schema.String,
+                      Schema.Boolean,
+                    ],
+                    { mode: "oneOf" },
+                  ),
                 ),
-              ),
-              array: Schema.optionalKey(Schema.Boolean),
-            }),
+                array: Schema.optionalKey(Schema.Boolean),
+              }),
+            ),
           ),
         }),
       ),

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -18957,7 +18957,7 @@
                     }
                   }
                 },
-                "required": ["keys"]
+                "required": []
               },
               "name_id_format": {
                 "type": "string",
@@ -19068,7 +19068,7 @@
                           }
                         }
                       },
-                      "required": ["keys"]
+                      "required": []
                     },
                     "name_id_format": {
                       "type": "string",
@@ -19178,7 +19178,7 @@
                     }
                   }
                 },
-                "required": ["keys"]
+                "required": []
               },
               "name_id_format": {
                 "type": "string",
@@ -19190,7 +19190,7 @@
                 ]
               }
             },
-            "required": ["id", "entity_id"]
+            "required": ["entity_id"]
           },
           "domains": {
             "type": "array",
@@ -19357,7 +19357,7 @@
                     }
                   }
                 },
-                "required": ["keys"]
+                "required": []
               },
               "name_id_format": {
                 "type": "string",
@@ -19463,7 +19463,7 @@
                     }
                   }
                 },
-                "required": ["keys"]
+                "required": []
               },
               "name_id_format": {
                 "type": "string",


### PR DESCRIPTION
## What changed

- Relax SSO provider response schemas so nested SAML IDs and attribute_mapping keys can be omitted when the Management API returns sparse provider payloads.
- Keep request payload schemas strict while updating the generated OpenAPI snapshot and Effect contracts for provider responses.
- Add decoder regression coverage for the list/show payload shape that caused the SSO command failures.

## Why

Hosted projects can return SAML providers with attribute_mapping as an empty object and without a nested saml.id. The TypeScript legacy SSO commands use the generated Management API client for list, show, and update preflight reads, so strict response decoding failed before commands could render or update providers.

Fixes #5589.
