### PR TITLE
fix(cli-go): allow local storage without access token

### DIFF
--- a/apps/cli-go/cmd/storage.go
+++ b/apps/cli-go/cmd/storage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/supabase/cli/internal/storage/ls"
 	"github.com/supabase/cli/internal/storage/mv"
 	"github.com/supabase/cli/internal/storage/rm"
+	"github.com/supabase/cli/internal/utils/flags"
 	"github.com/supabase/cli/pkg/storage"
 )
 
@@ -16,6 +17,21 @@ var (
 		GroupID: groupManagementAPI,
 		Use:     "storage",
 		Short:   "Manage Supabase Storage objects",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			local, err := cmd.Flags().GetBool("local")
+			if err != nil {
+				return err
+			}
+			if local {
+				groupID := cmd.GroupID
+				cmd.GroupID = groupLocalDev
+				defer func() {
+					cmd.GroupID = groupID
+				}()
+				flags.ProjectRef = ""
+			}
+			return cmd.Root().PersistentPreRunE(cmd, args)
+		},
 	}
 
 	recursive bool

--- a/apps/cli-go/cmd/storage_test.go
+++ b/apps/cli-go/cmd/storage_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/utils/flags"
+)
+
+func TestStoragePersistentPreRun(t *testing.T) {
+	t.Run("treats local storage as local development", func(t *testing.T) {
+		flags.ProjectRef = "abcdefghijklmnopqrst"
+		t.Cleanup(func() {
+			flags.ProjectRef = ""
+		})
+
+		isManagementAPI, err := runStoragePreRunForTest([]string{"storage", "ls", "--local"})
+
+		require.NoError(t, err)
+		assert.False(t, isManagementAPI)
+		assert.Empty(t, flags.ProjectRef)
+	})
+
+	t.Run("keeps linked storage as management API", func(t *testing.T) {
+		flags.ProjectRef = "abcdefghijklmnopqrst"
+		t.Cleanup(func() {
+			flags.ProjectRef = ""
+		})
+
+		isManagementAPI, err := runStoragePreRunForTest([]string{"storage", "ls"})
+
+		require.NoError(t, err)
+		assert.True(t, isManagementAPI)
+		assert.Equal(t, "abcdefghijklmnopqrst", flags.ProjectRef)
+	})
+}
+
+func runStoragePreRunForTest(args []string) (bool, error) {
+	var isManagementAPI bool
+	root := &cobra.Command{
+		Use: "supabase",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			isManagementAPI = IsManagementAPI(cmd)
+			return nil
+		},
+	}
+	root.AddGroup(&cobra.Group{ID: groupLocalDev, Title: "Local Development:"})
+	root.AddGroup(&cobra.Group{ID: groupManagementAPI, Title: "Management APIs:"})
+	storage := &cobra.Command{
+		GroupID:           groupManagementAPI,
+		Use:               "storage",
+		PersistentPreRunE: storageCmd.PersistentPreRunE,
+	}
+	storage.PersistentFlags().Bool("linked", true, "")
+	storage.PersistentFlags().Bool("local", false, "")
+	storage.MarkFlagsMutuallyExclusive("linked", "local")
+	storage.AddCommand(&cobra.Command{
+		Use: "ls",
+		Run: func(cmd *cobra.Command, args []string) {},
+	})
+	root.AddCommand(storage)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	return isManagementAPI, err
+}


### PR DESCRIPTION
## What changed

`storage --local` now runs through the local-development command path before the root pre-run checks for Management API authentication. When the local flag is set, the storage command clears the linked project ref so the storage client uses the local service-role key instead of trying to fetch remote API keys.

## Why

The storage command still lives in the Go CLI. It was grouped as a Management API command, so the root pre-run required a logged-in access token even when the user selected the local storage target. This made local storage operations fail in linked projects unless `SUPABASE_ACCESS_TOKEN` was set.