### PR TITLE
chore(github): show issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a reproducible problem with the Supabase CLI.
-title: ""
 labels:
   - 🐛 Bug
 body:

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,6 +1,5 @@
 name: Documentation
 description: Suggest an improvement to Supabase CLI documentation.
-title: ""
 labels:
   - 📘 Docs
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Suggest an improvement or new capability for the Supabase CLI.
-title: ""
 labels:
   - ✨ Feature
 body:


### PR DESCRIPTION
Removes empty `title` keys from the issue form templates merged in #5458.

GitHub treats empty strings as invalid for issue-form string fields. Because each form had `title: ""`, the template chooser hid the bug, feature, and docs forms and only showed the blank issue/contact links.

Leaving the optional title key absent lets GitHub render the forms while preserving the existing form names, labels, and fields.