### PR TITLE
ci: read stale cleanup dispatch inputs

### DIFF
--- a/.github/workflows/close-stale-issues-and-prs.yml
+++ b/.github/workflows/close-stale-issues-and-prs.yml
@@ -45,9 +45,10 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
+            const workflowInputs = context.payload.inputs ?? {};
             const execute =
               eventName === "workflow_dispatch" &&
-              core.getInput("execute", { required: false }) === "true";
+              workflowInput("execute", "false") === "true";
             const issueDays = positiveIntegerInput("issue-days", "45");
             const prDays = positiveIntegerInput("pr-days", "60");
             const maxItems = positiveIntegerInput("max-items", "25");
@@ -163,8 +164,13 @@ jobs:
               cappedCount,
             });
 
+            function workflowInput(name, fallback) {
+              const value = workflowInputs[name];
+              return value === undefined || value === "" ? fallback : value;
+            }
+
             function positiveIntegerInput(name, fallback) {
-              const raw = core.getInput(name, { required: false }) || fallback;
+              const raw = workflowInput(name, fallback);
               const value = Number(raw);
               if (!Number.isInteger(value) || value <= 0) {
                 throw new Error(`${name} must be a positive integer, got ${raw}`);
@@ -173,7 +179,7 @@ jobs:
             }
 
             function commaSeparatedInput(name, fallback) {
-              const raw = core.getInput(name, { required: false }) || fallback;
+              const raw = workflowInput(name, fallback);
               return raw
                 .split(",")
                 .map((value) => value.trim())


### PR DESCRIPTION
## What changed

Updates the stale cleanup workflow to read manual `workflow_dispatch` inputs from the workflow event payload instead of action inputs.

This makes the `execute` checkbox and manual overrides for stale windows, batch size, and excluded labels take effect when maintainers run the workflow manually.

## Why

`actions/github-script`'s `core.getInput()` reads inputs passed to the action itself. The stale cleanup workflow needs the values submitted through GitHub's manual workflow form.
