### PR TITLE
chore(api): simplify OpenAPI sync workflow

### DIFF
--- a/.github/workflows/api-package-sync.yml
+++ b/.github/workflows/api-package-sync.yml
@@ -9,63 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    name: Detect OpenAPI changes
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    outputs:
-      has_changes: ${{ steps.compare.outputs.has_changes }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Compare upstream OpenAPI spec
-        id: compare
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          remote_spec="$RUNNER_TEMP/openapi.remote.json"
-          remote_normalized="$RUNNER_TEMP/openapi.remote.normalized.json"
-          tracked_normalized="$RUNNER_TEMP/openapi.tracked.normalized.json"
-          normalize_filter="$RUNNER_TEMP/normalize-openapi.jq"
-
-          curl -fsS https://api.supabase.com/api/v1-json -o "$remote_spec"
-
-          cat > "$normalize_filter" <<'JQ'
-          def pointer_path($p): $p | split("/")[1:] | map(gsub("~1"; "/") | gsub("~0"; "~"));
-          reduce ($overrides[0] // [])[] as $op (.;
-            if $op.op == "test" then
-              if getpath(pointer_path($op.path)) == $op.value then
-                .
-              else
-                error("OpenAPI override test failed at \($op.path)")
-              end
-            elif $op.op == "replace" then
-              setpath(pointer_path($op.path); $op.value)
-            else
-              error("Unsupported OpenAPI override op \($op.op)")
-            end
-          )
-          JQ
-
-          jq -S --slurpfile overrides packages/api/scripts/openapi-overrides.json \
-            -f "$normalize_filter" "$remote_spec" > "$remote_normalized"
-          jq -S . packages/api/src/generated/openapi.json > "$tracked_normalized"
-
-          if cmp -s "$remote_normalized" "$tracked_normalized"; then
-            echo "No upstream OpenAPI changes detected."
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Upstream OpenAPI changes detected."
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            diff -u "$tracked_normalized" "$remote_normalized" | sed -n '1,160p' || true
-          fi
-
   sync:
     name: Sync API package
-    needs: detect
-    if: needs.detect.outputs.has_changes == 'true'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -585,14 +585,6 @@
     ]
   },
   {
-    "op": "add",
-    "path": "/components/schemas/V1CreateProjectBody/properties/high_availability",
-    "value": {
-      "type": "boolean",
-      "description": "Whether to enable high availability for the project."
-    }
-  },
-  {
     "op": "replace",
     "path": "/components/schemas/FunctionResponse/properties/import_map_path",
     "value": {

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -327,6 +327,7 @@ export const V1ApplyProjectAddonInput = Schema.Struct({
     "auth_mfa_phone",
     "auth_mfa_web_authn",
     "log_drain",
+    "etl_pipeline",
   ]),
 });
 export const V1AuthorizeJitAccessInput = Schema.Struct({
@@ -711,7 +712,7 @@ export const V1CreateAProjectInput = Schema.Struct({
   ),
   high_availability: Schema.optionalKey(
     Schema.Boolean.annotate({
-      description: "Whether to enable high availability for the project.",
+      description: "[Experimental] Whether to enable high availability for the project.",
     }),
   ),
 });
@@ -3757,6 +3758,7 @@ export const V1ListProjectAddonsOutput = Schema.Struct({
         "auth_mfa_phone",
         "auth_mfa_web_authn",
         "log_drain",
+        "etl_pipeline",
       ]),
       variant: Schema.Struct({
         id: Schema.Union(
@@ -3787,6 +3789,7 @@ export const V1ListProjectAddonsOutput = Schema.Struct({
             Schema.Literal("auth_mfa_phone_default"),
             Schema.Literal("auth_mfa_web_authn_default"),
             Schema.Literal("log_drain_default"),
+            Schema.Literal("etl_pipeline_default"),
           ],
           { mode: "oneOf" },
         ),
@@ -3813,6 +3816,7 @@ export const V1ListProjectAddonsOutput = Schema.Struct({
         "auth_mfa_phone",
         "auth_mfa_web_authn",
         "log_drain",
+        "etl_pipeline",
       ]),
       name: Schema.String,
       variants: Schema.Array(
@@ -3845,6 +3849,7 @@ export const V1ListProjectAddonsOutput = Schema.Struct({
               Schema.Literal("auth_mfa_phone_default"),
               Schema.Literal("auth_mfa_web_authn_default"),
               Schema.Literal("log_drain_default"),
+              Schema.Literal("etl_pipeline_default"),
             ],
             { mode: "oneOf" },
           ),

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -11549,7 +11549,6 @@
                   },
                   "code": {
                     "type": "string",
-                    "minLength": 1,
                     "description": "Specific region code. The codes supported are not a stable API, and should be retrieved from the /available-regions endpoint.",
                     "enum": [
                       "us-east-1",
@@ -11630,7 +11629,7 @@
           },
           "high_availability": {
             "type": "boolean",
-            "description": "Whether to enable high availability for the project."
+            "description": "[Experimental] Whether to enable high availability for the project."
           }
         },
         "required": ["db_pass", "name", "organization_slug"],
@@ -16364,7 +16363,8 @@
                     "ipv4",
                     "auth_mfa_phone",
                     "auth_mfa_web_authn",
-                    "log_drain"
+                    "log_drain",
+                    "etl_pipeline"
                   ]
                 },
                 "variant": {
@@ -16418,6 +16418,10 @@
                         {
                           "type": "string",
                           "enum": ["log_drain_default"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["etl_pipeline_default"]
                         }
                       ]
                     },
@@ -16468,7 +16472,8 @@
                     "ipv4",
                     "auth_mfa_phone",
                     "auth_mfa_web_authn",
-                    "log_drain"
+                    "log_drain",
+                    "etl_pipeline"
                   ]
                 },
                 "name": {
@@ -16527,6 +16532,10 @@
                           {
                             "type": "string",
                             "enum": ["log_drain_default"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["etl_pipeline_default"]
                           }
                         ]
                       },
@@ -16618,7 +16627,8 @@
               "ipv4",
               "auth_mfa_phone",
               "auth_mfa_web_authn",
-              "log_drain"
+              "log_drain",
+              "etl_pipeline"
             ]
           }
         },


### PR DESCRIPTION
The scheduled API package sync workflow was failing because its inline OpenAPI comparison logic drifted from the package generator. In particular, the workflow reimplemented override handling in jq, so adding new override operations could break the detector before the real generator ever ran.

This removes the custom detector job and makes the workflow use `pnpm generate` as the source of truth on every scheduled run. The workflow now regenerates the API package, formats it, checks for changes under `packages/api/src/generated`, and only creates a sync PR when generated output actually changes.

This also removes the stale `high_availability` add override now that the upstream spec includes that field directly, and refreshes the generated API files for the current upstream spec.

Reviewer context: future OpenAPI override operation support only needs to be implemented in the generator path; the workflow no longer has a second override interpreter to keep in sync.