### PR TITLE
chore(ci): use app token for API sync automerge

### DIFF
--- a/.github/workflows/cli-go-api-sync.yml
+++ b/.github/workflows/cli-go-api-sync.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check.outputs.has_changes == 'true'
         run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
 defaults:
   run:


### PR DESCRIPTION
Updates the API Sync workflow so the auto-merge step uses the generated GitHub App token instead of the workflow-scoped token.

The workflow already grants the app token pull request and contents write permissions for creating the sync PR. Reusing that token for `gh pr merge --auto` matches the existing automated merge pattern and avoids the authorization failure caused by the workflow-level `contents: read` permission on the built-in token.