### PR TITLE
ci: derive brew/scoop checksums from the published build

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -415,7 +415,9 @@ jobs:
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # github-hosted to share a cache store with build-github/publish, whose
+    # -github-v1 artifacts this job's checksums must match.
+    runs-on: ubuntu-latest
     env:
       BREW_NAME: ${{ inputs.brew_name }}
       VERSION: ${{ inputs.version }}
@@ -430,13 +432,19 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
+      # Must restore the github-hosted build (-github-v1), the same artifacts
+      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
+      # are not byte-for-byte reproducible across the blacksmith and github
+      # builds, so the blacksmith dist/checksums.txt does not match the released
+      # tarballs. Reading it here produced a formula whose sha256 rejected the
+      # downloaded archive ("Formula reports different checksum").
       - name: Restore build artifacts cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             packages/cli-*/bin/
             dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-v1
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
           enableCrossOsArchive: true
           fail-on-cache-miss: true
 
@@ -469,7 +477,9 @@ jobs:
   publish-scoop:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # github-hosted to share a cache store with build-github/publish, whose
+    # -github-v1 artifacts this job's checksums must match.
+    runs-on: ubuntu-latest
     env:
       SCOOP_NAME: ${{ inputs.scoop_name }}
       VERSION: ${{ inputs.version }}
@@ -484,13 +494,19 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
+      # Must restore the github-hosted build (-github-v1), the same artifacts
+      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
+      # are not byte-for-byte reproducible across the blacksmith and github
+      # builds, so the blacksmith dist/checksums.txt does not match the released
+      # tarballs. Reading it here would produce a manifest whose hash rejects the
+      # downloaded archive.
       - name: Restore build artifacts cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             packages/cli-*/bin/
             dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-v1
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
           enableCrossOsArchive: true
           fail-on-cache-miss: true
 


### PR DESCRIPTION
publish-homebrew and publish-scoop restored the blacksmith build cache
(-v1) and computed formula/manifest checksums from its
dist/checksums.txt, but the GitHub Release and npm ship the
github-hosted build (-github-v1). Bun-compiled binaries are not
byte-for-byte reproducible across the two builds, so every sha256 in the
published Homebrew formula referenced a tarball that was never released
and `brew install supabase/tap/supabase` failed with "Formula reports
different checksum". The Scoop manifest had the same latent defect.

Restore the -github-v1 cache in both jobs and run them on github-hosted
runners so they share a cache store with the publish job whose artifacts
they describe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y23nV6fJ78f6RKJHjMNZau