### PR TITLE
ci: enable scheduled stale cleanup

### DIFF
--- a/.github/workflows/close-stale-issues-and-prs.yml
+++ b/.github/workflows/close-stale-issues-and-prs.yml
@@ -17,10 +17,6 @@ on:
         description: "Select PRs with no activity for this many days"
         type: string
         default: "60"
-      max-items:
-        description: "Maximum number of matching issues and PRs to close in one run"
-        type: string
-        default: "25"
       exclude-labels:
         description: "Comma-separated labels that prevent stale cleanup"
         type: string
@@ -47,15 +43,16 @@ jobs:
             const eventName = context.eventName;
             const workflowInputs = context.payload.inputs ?? {};
             const execute =
-              eventName === "workflow_dispatch" &&
-              workflowInput("execute", "false") === "true";
+              eventName === "schedule" ||
+              (eventName === "workflow_dispatch" &&
+                workflowInput("execute", "false") === "true");
             const issueDays = positiveIntegerInput("issue-days", "45");
             const prDays = positiveIntegerInput("pr-days", "60");
-            const maxItems = positiveIntegerInput("max-items", "25");
             const excludeLabels = commaSeparatedInput(
               "exclude-labels",
               "security,pinned,do-not-close,keep-open,do not merge",
             );
+            const staleClosedLabel = "stale-closed";
             const { owner, repo } = context.repo;
 
             const categories = [
@@ -86,10 +83,8 @@ jobs:
             ];
 
             core.info(`${execute ? "EXECUTE" : "DRY RUN"} stale cleanup for ${owner}/${repo}`);
-            core.info("Scheduled runs are always dry runs. Use workflow dispatch with execute=true to close items.");
             core.info(`Issue cutoff: ${issueDays} days`);
             core.info(`PR cutoff: ${prDays} days`);
-            core.info(`Max items per execution: ${maxItems}`);
             core.info(`Excluded labels: ${excludeLabels.length > 0 ? excludeLabels.join(", ") : "(none)"}`);
 
             const candidatesByKey = new Map();
@@ -103,14 +98,8 @@ jobs:
 
             const selected = [...candidatesByKey.values()]
               .sort((a, b) => new Date(a.updated_at) - new Date(b.updated_at));
-            const capped = selected.slice(0, maxItems);
-            const cappedCount = selected.length - capped.length;
 
-            if (cappedCount > 0) {
-              core.warning(`Found ${selected.length} matching items but capped this run at ${maxItems}.`);
-            }
-
-            if (capped.length === 0) {
+            if (selected.length === 0) {
               core.info("No stale issues or PRs found.");
               await core.summary
                 .addHeading("Close stale issues and PRs")
@@ -119,19 +108,18 @@ jobs:
               return;
             }
 
-            for (const item of capped) {
+            for (const item of selected) {
               core.info(`#${item.number} ${item.kind} updated=${item.updated_at} ${item.html_url} ${item.title}`);
             }
 
             if (!execute) {
-              await writeSummary("Close stale issues and PRs dry run", capped, {
+              await writeSummary("Close stale issues and PRs dry run", selected, {
                 matchingCount: selected.length,
-                cappedCount,
               });
               return;
             }
 
-            for (const item of capped) {
+            for (const item of selected) {
               await github.rest.issues.createComment({
                 owner,
                 repo,
@@ -147,6 +135,13 @@ jobs:
                   state: "closed",
                 });
               } else {
+                await ensureLabel(staleClosedLabel, "Issue closed by stale cleanup.");
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  labels: [staleClosedLabel],
+                });
                 await github.rest.issues.update({
                   owner,
                   repo,
@@ -159,9 +154,8 @@ jobs:
               core.info(`Closed ${item.kind} #${item.number}`);
             }
 
-            await writeSummary("Closed stale issues and PRs", capped, {
+            await writeSummary("Closed stale issues and PRs", selected, {
               matchingCount: selected.length,
-              cappedCount,
             });
 
             function workflowInput(name, fallback) {
@@ -184,6 +178,21 @@ jobs:
                 .split(",")
                 .map((value) => value.trim())
                 .filter(Boolean);
+            }
+
+            async function ensureLabel(name, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: "cfd3d7",
+                  description,
+                });
+              }
             }
 
             function cutoffDate(days) {
@@ -240,7 +249,7 @@ jobs:
                 "",
                 `We're closing this because it has not had any activity for ${days} days, and we try to keep the Supabase CLI issue tracker focused on reports that are still current.`,
                 "",
-                "If this still reproduces on the latest Supabase CLI, please feel free to reopen it with your CLI version, updated reproduction steps, and any recent error output. We appreciate the signal and are happy to take another look.",
+                "If this still reproduces on the latest Supabase CLI, please comment with `/reopen` on its own line and include your CLI version, updated reproduction steps, and any recent error output. We appreciate the signal and are happy to take another look.",
               ].join("\n");
             }
 
@@ -254,14 +263,12 @@ jobs:
               ].join("\n");
             }
 
-            async function writeSummary(title, items, { matchingCount, cappedCount }) {
+            async function writeSummary(title, items, { matchingCount }) {
               await core.summary
                 .addHeading(title)
                 .addRaw(`${execute ? "Closed" : "Found"} ${items.length} issue(s) and PR(s).`)
                 .addBreak()
                 .addRaw(`${matchingCount} total item(s) matched the search filters.`)
-                .addBreak()
-                .addRaw(`${cappedCount} item(s) were left for a later run because of the per-run cap.`)
                 .addBreak()
                 .addTable([
                   [

--- a/.github/workflows/reopen-stale-issue.yml
+++ b/.github/workflows/reopen-stale-issue.yml
@@ -1,0 +1,95 @@
+name: Reopen stale issue
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: reopen-stale-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reopen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Reopen issue on command
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const staleClosedLabel = "stale-closed";
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const { owner, repo } = context.repo;
+
+            if (issue.pull_request) {
+              core.info("Ignoring pull request comment.");
+              return;
+            }
+
+            const hasReopenCommand = comment.body
+              .split(/\r?\n/)
+              .some((line) => line.trim() === "/reopen");
+
+            if (!hasReopenCommand) {
+              core.info("Ignoring comment without /reopen command.");
+              return;
+            }
+
+            if (issue.state !== "closed") {
+              core.info("Ignoring /reopen command on an issue that is already open.");
+              return;
+            }
+
+            const wasClosedByStaleCleanup = (issue.labels ?? []).some(
+              (label) => label.name === staleClosedLabel,
+            );
+
+            if (!wasClosedByStaleCleanup) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: [
+                  `@${comment.user.login} thanks for checking in.`,
+                  "",
+                  "The `/reopen` command only reopens issues that were closed by stale cleanup. If this issue should be reopened, please add the current reproduction details so a maintainer can review it.",
+                ].join("\n"),
+              });
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issue.number,
+              state: "open",
+              state_reason: "reopened",
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issue.number,
+                name: staleClosedLabel,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body: [
+                `Reopened because @${comment.user.login} used \`/reopen\`.`,
+                "",
+                "Please add any current CLI version, reproduction steps, or error output that helps confirm this is still relevant.",
+              ].join("\n"),
+            });


### PR DESCRIPTION
Updates the stale cleanup workflow so the daily scheduled run performs the same closing behavior as an executed manual run.

The per-run item cap has also been removed, so every currently eligible issue or pull request is processed in one run.

Issues closed by stale cleanup now receive a stale-closed marker, and a separate issue-comment workflow lets users reopen those issues by commenting with /reopen as the first non-empty line.

Manual dispatches can still be used as a dry run unless execute is enabled.
