### PR TITLE
ci: silence stale reopen confirmation

### DIFF
--- a/.github/workflows/reopen-stale-issue.yml
+++ b/.github/workflows/reopen-stale-issue.yml
@@ -83,13 +83,4 @@ jobs:
               if (error.status !== 404) throw error;
             }
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: issue.number,
-              body: [
-                `Reopened because @${comment.user.login} used \`/reopen\`.`,
-                "",
-                "Please add any current CLI version, reproduction steps, or error output that helps confirm this is still relevant.",
-              ].join("\n"),
-            });
+            core.info(`Reopened issue #${issue.number} because @${comment.user.login} used /reopen.`);


### PR DESCRIPTION
Removes the extra success comment posted after the stale issue reopen workflow reopens an issue.

The workflow still reopens stale-closed issues, removes the marker label, and logs the action in the workflow run.
