### PR TITLE
ci(release): free space before artifact cache save

### DIFF
--- a/.github/workflows/build-cli-artifacts.yml
+++ b/.github/workflows/build-cli-artifacts.yml
@@ -93,6 +93,13 @@ jobs:
           echo "Checking dist/..."
           ls -la dist/
 
+      - name: Free space before saving GitHub-hosted artifacts cache
+        if: inputs.cache_key_suffix == '-github'
+        run: |
+          rm -rf node_modules apps/*/node_modules packages/*/node_modules
+          rm -rf "$(pnpm store path --silent)" "$HOME/.cache/go-build" "$HOME/go/pkg/mod"
+          df -h
+
       - name: Check existing build artifacts cache
         id: build-artifacts-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary
- Free disk space before saving the GitHub-hosted release artifact cache.
- Keep the cleanup scoped to the `-github` cache producer so the Blacksmith artifact cache path is unchanged.

## Context
The release run built the correct `-github-v1` artifacts, but `actions/cache/save` failed while writing `cache.tzst` with `No space left on device`. The downstream macOS smoke test then missed the same `-github-v1` key.

This keeps the published/checksum-sensitive path on GitHub-hosted artifacts while reducing disk pressure before the cache archive is created.
