### PR TITLE
ci(release): tolerate read-only Go cache cleanup

### DIFF
--- a/.github/workflows/build-cli-artifacts.yml
+++ b/.github/workflows/build-cli-artifacts.yml
@@ -97,6 +97,7 @@ jobs:
         if: inputs.cache_key_suffix == '-github'
         run: |
           rm -rf node_modules apps/*/node_modules packages/*/node_modules
+          chmod -R u+w "$HOME/.cache/go-build" "$HOME/go/pkg/mod" 2>/dev/null || true
           rm -rf "$(pnpm store path --silent)" "$HOME/.cache/go-build" "$HOME/go/pkg/mod"
           df -h
 


### PR DESCRIPTION
## Summary

- Allow the GitHub-hosted release artifact cleanup to remove read-only Go cache files.
- Keep the cleanup scoped to the GitHub-hosted artifact cache producer.

## Context

The release workflow failed after building artifacts because the free-space cleanup step tried to remove Go module cache files that were not writable. The chmod guard makes those cache directories writable before deletion so the cleanup can finish and the artifact cache save can continue.
