### PR TITLE
fix(cli): merge matching [remotes.*] block on config push

### DIFF
--- a/apps/cli/src/legacy/commands/config/push/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/config/push/SIDE_EFFECTS.md
@@ -64,7 +64,7 @@ when its local gate is off.
 | ---- | ------------------------------------------------------------------------------------- |
 | `0`  | success, **including** declining a confirmation prompt (Go returns nil and continues) |
 | `1`  | malformed `config.toml`                                                               |
-| `1`  | a `[remotes.*]` block targets the project ref (unsupported — see Known Gaps)          |
+| `1`  | two `[remotes.*]` blocks declare the same `project_id` as the target ref              |
 | `1`  | list-addons failure (network or non-200)                                              |
 | `1`  | any per-service read/update failure (network or unexpected status)                    |
 
@@ -72,7 +72,9 @@ when its local gate is off.
 
 ### `--output-format text` (Go CLI compatible)
 
-All diagnostics on **stderr**, no stdout. `Pushing config to project: <ref>`, then
+All diagnostics on **stderr**, no stdout. When a `[remotes.<name>]` block matches the
+target ref, `Loading config override: [remotes.<name>]` prints first. Then
+`Pushing config to project: <ref>`, then
 per service either `Remote <X> config is up to date.` or
 `Updating <X> service with config: <unified diff>`; experimental prints
 `Enabling webhooks for project: <ref>`. Confirmations render `<title> [Y/n] `
@@ -108,7 +110,7 @@ keys mirror `config.toml` paths.
 
 - Run from the project root (or pass `--workdir`); `config.toml` is read relative to it.
 - Diff bytes are byte-for-byte identical to the Go CLI (BurntSushi TOML encoder + anchored diff ports).
-- Optional `*pointer` sections (`db.ssl_enforcement`, `storage.image_transformation`, `storage.s3_protocol`) are decoded as defaulted-present by `@supabase/config`; their true presence is recovered from the raw `config.toml` so they are skipped when absent, matching Go's nil-pointer behaviour.
+- Optional `*pointer` sections (`db.ssl_enforcement`, `storage.image_transformation`, `storage.s3_protocol`) are decoded as defaulted-present by `@supabase/config`; their true presence is recovered from the raw (merged) config document so they are skipped when absent, matching Go's nil-pointer behaviour.
+- **`[remotes.*]` overrides are merged before push.** When a `[remotes.<name>]` block declares `project_id == <ref>`, `@supabase/config` merges that block's subtree over the base config at the raw (pre-decode) level — Go's `mergeRemoteConfig` (`apps/cli-go/pkg/config/config.go:550`) — so only the keys the block declares override the base. `Loading config override: [remotes.<name>]` prints to stderr. Two remotes sharing the target `project_id` abort with Go's `duplicate project_id for [remotes.<b>] and [remotes.<a>]` message.
 - KNOWN GAPS:
-  - **`[remotes.*]` overrides are not yet supported.** Faithful subset merging (Go's `mergeRemoteConfig`) requires a raw-TOML subtree merge; applying the decoded remote section verbatim would reset every non-overridden field to its schema default and silently corrupt the remote. Until the merge is implemented, `config push` **aborts with exit 1** (before any network call) when a `[remotes.<name>]` block declares `project_id == <ref>`, rather than pushing wrong values. Go-tested paths have no `[remotes.*]`.
   - **`encrypted:` (dotenvx) secret decryption is not reproduced.** The Go CLI decrypts `encrypted:` values before hashing and pushes the plaintext; we cannot decrypt here. Rather than push the ciphertext (which would overwrite the remote secret with garbage), `encrypted:` values are treated as unresolved — exactly like `env()` refs: they hash to `""`, so the empty hash gates them out of both the diff and the update body and the remote secret is left untouched.

--- a/apps/cli/src/legacy/commands/config/push/push.errors.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.errors.ts
@@ -31,18 +31,6 @@ export class LegacyConfigPushLoadConfigError extends Data.TaggedError(
   "LegacyConfigPushLoadConfigError",
 )<NetworkErrorArgs> {}
 
-/**
- * A `[remotes.<name>]` block matches the target project ref. Faithful subset
- * merging (Go's `mergeRemoteConfig`) is not yet implemented, and applying the
- * decoded remote section verbatim would silently reset every field the block
- * does not override to its schema default — overwriting remote config the user
- * never intended to touch. We abort instead of corrupting the remote. Aborts
- * before any network call.
- */
-export class LegacyConfigPushUnsupportedRemoteError extends Data.TaggedError(
-  "LegacyConfigPushUnsupportedRemoteError",
-)<NetworkErrorArgs> {}
-
 // --- cost matrix (list addons) ---------------------------------------------
 
 export class LegacyConfigPushListAddonsNetworkError extends Data.TaggedError(

--- a/apps/cli/src/legacy/commands/config/push/push.handler.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.handler.ts
@@ -39,7 +39,7 @@ import {
   storageToUpdateBody,
 } from "./config-sync/storage.sync.ts";
 import { getCostMatrix } from "./push.cost-matrix.ts";
-import { loadConfigPresence } from "./push.raw-presence.ts";
+import { legacyPresenceIn } from "./push.raw-presence.ts";
 import {
   LegacyConfigPushApiReadNetworkError,
   LegacyConfigPushApiReadStatusError,
@@ -68,14 +68,9 @@ import {
   LegacyConfigPushStorageReadStatusError,
   LegacyConfigPushStorageUpdateNetworkError,
   LegacyConfigPushStorageUpdateStatusError,
-  LegacyConfigPushUnsupportedRemoteError,
 } from "./push.errors.ts";
 import type { LegacyConfigPushFlags } from "./push.command.ts";
-import {
-  matchesRemoteProjectRef,
-  resolveRemoteByProjectRef,
-  type LegacyConfigPushServiceResult,
-} from "./push.types.ts";
+import type { LegacyConfigPushServiceResult } from "./push.types.ts";
 
 const readStatusMessage = (status: number, body: string) => `unexpected status ${status}: ${body}`;
 
@@ -101,7 +96,10 @@ export const legacyConfigPush = Effect.fn("legacy.config.push")(function* (
     // `ProjectConfigParseError` on `env(...)` refs over numeric/bool fields,
     // which Go resolves transparently. Switch to the fixed decoder once
     // CLI-1489 lands; until then this is the conscious tradeoff for this command.
-    const loaded = yield* loadProjectConfig(runtimeInfo.cwd).pipe(
+    // Pass `ref` so a matching `[remotes.*]` block is merged over the base config
+    // before decode (Go's `loadFromFile` with `Config.ProjectId` set). A duplicate
+    // `project_id` across remotes surfaces Go's verbatim message.
+    const loaded = yield* loadProjectConfig(runtimeInfo.cwd, { projectRef: ref }).pipe(
       Effect.catchTag(
         "ProjectConfigParseError",
         (cause) =>
@@ -109,27 +107,29 @@ export const legacyConfigPush = Effect.fn("legacy.config.push")(function* (
             message: `failed to parse supabase/config.toml: ${String(cause.cause)}`,
           }),
       ),
+      Effect.catchTag(
+        "DuplicateRemoteProjectIdError",
+        (cause) => new LegacyConfigPushLoadConfigError({ message: cause.message }),
+      ),
     );
     if (loaded === null) {
       return yield* new LegacyConfigPushLoadConfigError({
         message: "failed to read supabase/config.toml: file not found",
       });
     }
-    // A matching `[remotes.*]` block cannot be applied without corrupting the
-    // remote (see matchesRemoteProjectRef); abort before any network call.
-    if (matchesRemoteProjectRef(loaded.config, ref)) {
-      return yield* new LegacyConfigPushUnsupportedRemoteError({
-        message: `cannot push config: a [remotes.*] block targets project ${ref}, which config push does not yet support. Remove the matching [remotes.*] block, or run config push from a config without it.`,
-      });
+    // Go prints this from inside config load, before any command output.
+    if (loaded.appliedRemote !== undefined) {
+      yield* output.raw(`Loading config override: [remotes.${loaded.appliedRemote}]\n`, "stderr");
     }
-    const { projectId, config } = resolveRemoteByProjectRef(loaded.config, ref);
+    const projectId = ref;
+    const config = loaded.config;
 
     // Optional `*pointer` sections (ssl_enforcement, image_transformation,
     // s3_protocol) are defaulted-present by @supabase/config and cannot be
-    // recovered from the decoded config, so we re-read the raw document to
-    // restore Go's nil-pointer skip semantics. (This second read is independent
-    // of loadProjectConfig above, which reads + schema-decodes its own bytes.)
-    const presence = yield* loadConfigPresence(runtimeInfo.cwd);
+    // recovered from the decoded config, so we inspect the raw (merged) document
+    // to restore Go's nil-pointer skip semantics — including sections a matching
+    // `[remotes.*]` block introduces.
+    const presence = legacyPresenceIn(loaded.document);
 
     // 2. Cost matrix (drives cost-aware prompts).
     const cost = yield* getCostMatrix(ref);

--- a/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
@@ -148,19 +148,54 @@ describe("legacy config push integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("aborts when a [remotes.*] block targets the project, before any network call", () => {
-    const { layer, api } = setup({
-      toml: `${API_ONLY_TOML}[remotes.staging]
+  it.live("merges a matching [remotes.*] block over the base and pushes it", () => {
+    const { layer, out, api } = setup({
+      toml: `${API_ONLY_TOML}[api]
+enabled = true
+schemas = ["public"]
+
+[remotes.staging]
 project_id = "abcdefghijklmnopqrst"
 [remotes.staging.api]
-enabled = true
+schemas = ["public", "remote_schema"]
+`,
+      yes: true,
+      routes: {
+        postgrestGet: { status: 200, body: POSTGREST_DISABLED },
+        postgresGet: { status: 200, body: {} },
+      },
+    });
+    return Effect.gen(function* () {
+      yield* legacyConfigPush({ projectRef: Option.none() });
+      // Go prints the override line, before the "Pushing config to project" line.
+      expect(out.stderrText).toContain("Loading config override: [remotes.staging]");
+      expect(out.stderrText.indexOf("Loading config override: [remotes.staging]")).toBeLessThan(
+        out.stderrText.indexOf("Pushing config to project:"),
+      );
+      // The remote's schema override is what gets pushed (proving the merge).
+      const patch = api.requests.find((r) => r.method === "PATCH" && r.url.includes("/postgrest"));
+      expect(patch).toBeDefined();
+      expect(patch?.body).toMatchObject({ db_schema: "public,remote_schema" });
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("aborts when two [remotes.*] blocks share the target project_id", () => {
+    const { layer, api } = setup({
+      toml: `${API_ONLY_TOML}[remotes.a]
+project_id = "abcdefghijklmnopqrst"
+[remotes.b]
+project_id = "abcdefghijklmnopqrst"
 `,
       yes: true,
     });
     return Effect.gen(function* () {
-      const exit = yield* legacyConfigPush({ projectRef: Option.none() }).pipe(Effect.exit);
-      expect(Exit.isFailure(exit)).toBe(true);
-      // No network call should have fired (guard runs before the cost matrix).
+      const message = yield* legacyConfigPush({ projectRef: Option.none() }).pipe(
+        Effect.catchTag("LegacyConfigPushLoadConfigError", (error) =>
+          Effect.succeed(error.message),
+        ),
+      );
+      expect(message).toContain("duplicate project_id for [remotes.");
+      // The guard runs during config load, before any network call.
       expect(api.requests).toHaveLength(0);
     }).pipe(Effect.provide(layer));
   });

--- a/apps/cli/src/legacy/commands/config/push/push.raw-presence.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.raw-presence.ts
@@ -1,24 +1,18 @@
-import { findProjectPaths } from "@supabase/config";
-import { Effect, FileSystem } from "effect";
-import * as SmolToml from "smol-toml";
-
 import type { AuthPresence } from "./config-sync/auth.sync.ts";
 
 /**
- * Which optional `*pointer` sections are actually present in `config.toml`.
+ * Which optional `*pointer` sections are actually present in the (merged) config
+ * document.
  *
  * Go models `db.ssl_enforcement`, `storage.image_transformation`, and
  * `storage.s3_protocol` as `*pointer` fields that are `nil` unless the user
  * declares them — and `config push` skips them entirely when nil. But
  * `@supabase/config` decodes all three to a defaulted struct (e.g.
  * `{ enabled: false }`) whether or not the section appears, so their presence
- * can't be recovered from the decoded config. We therefore re-read the raw
- * `config.toml`/`.json` document and check key presence directly, matching Go's
- * nil-pointer skip semantics.
- *
- * `[remotes.*]` blocks need no special handling here: the handler aborts before
- * this runs when a remote block targets the ref (see matchesRemoteProjectRef),
- * so only the base config's sections are ever inspected.
+ * can't be recovered from the decoded config. We therefore inspect the raw
+ * config document (`LoadedProjectConfig.document`, with any matching `[remotes.*]`
+ * override already merged in) and check key presence directly, matching Go's
+ * nil-pointer skip semantics — including sections introduced by the remote block.
  */
 export interface LegacyConfigPushPresence {
   readonly sslEnforcement: boolean;
@@ -28,42 +22,12 @@ export interface LegacyConfigPushPresence {
   readonly auth: AuthPresence;
 }
 
-const ABSENT_AUTH: AuthPresence = {
-  captcha: false,
-  smtp: false,
-  hooks: {
-    mfa_verification_attempt: false,
-    password_verification_attempt: false,
-    custom_access_token: false,
-    send_sms: false,
-    send_email: false,
-    before_user_created: false,
-  },
-  externalProviders: [],
-};
-
-const ABSENT: LegacyConfigPushPresence = {
-  sslEnforcement: false,
-  imageTransformation: false,
-  s3Protocol: false,
-  auth: ABSENT_AUTH,
-};
-
 type RawDoc = { readonly [key: string]: unknown };
 
 function asRecord(value: unknown): RawDoc | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as RawDoc)
     : undefined;
-}
-
-/** Best-effort parse of the raw config document; returns `undefined` on any error. */
-function parseDocument(configPath: string, content: string): unknown {
-  try {
-    return configPath.endsWith(".json") ? JSON.parse(content) : SmolToml.parse(content);
-  } catch {
-    return undefined;
-  }
 }
 
 function authPresenceIn(doc: RawDoc | undefined): AuthPresence {
@@ -86,7 +50,11 @@ function authPresenceIn(doc: RawDoc | undefined): AuthPresence {
   };
 }
 
-function presenceIn(doc: RawDoc | undefined): LegacyConfigPushPresence {
+/**
+ * Reports which optional pointer sections are declared in the (already merged)
+ * config document. Returns all `false` / empty when `doc` is undefined.
+ */
+export function legacyPresenceIn(doc: RawDoc | undefined): LegacyConfigPushPresence {
   const db = asRecord(doc?.["db"]);
   const storage = asRecord(doc?.["storage"]);
   return {
@@ -96,20 +64,3 @@ function presenceIn(doc: RawDoc | undefined): LegacyConfigPushPresence {
     auth: authPresenceIn(doc),
   };
 }
-
-/**
- * Reads the raw config document and reports which optional pointer sections are
- * declared in the base config. Returns all `false` when no config file exists.
- */
-export const loadConfigPresence = Effect.fn("legacy.config.push.raw-presence")(function* (
-  cwd: string,
-) {
-  const fs = yield* FileSystem.FileSystem;
-  const paths = yield* findProjectPaths(cwd);
-  if (paths === null) {
-    return ABSENT;
-  }
-  const content = yield* fs.readFileString(paths.configPath).pipe(Effect.orElseSucceed(() => ""));
-  const doc = parseDocument(paths.configPath, content);
-  return presenceIn(asRecord(doc));
-});

--- a/apps/cli/src/legacy/commands/config/push/push.types.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.types.ts
@@ -1,5 +1,3 @@
-import type { ProjectConfig } from "@supabase/config";
-
 /**
  * Outcome of pushing a single service's config to the linked project.
  *
@@ -19,44 +17,4 @@ type LegacyConfigPushServiceStatus = "updated" | "up_to_date" | "skipped" | "dis
 export interface LegacyConfigPushServiceResult {
   readonly service: string;
   readonly status: LegacyConfigPushServiceStatus;
-}
-
-/**
- * The resolved config to push: the base config (with any matching remote
- * override applied) plus the effective project ref.
- */
-export interface LegacyResolvedRemoteConfig {
-  readonly projectId: string;
-  readonly config: ProjectConfig;
-}
-
-/**
- * Whether any `[remotes.<name>]` block declares `project_id == ref`.
- *
- * Go's `config.GetRemoteByProjectRef` (`pkg/config/config.go:1652`) applies the
- * matching remote block over the base config via `mergeRemoteConfig` (a
- * subset-only deep merge performed at load time). `@supabase/config`'s
- * `loadProjectConfig` does not do that merge, and the decoded `remotes[name]`
- * sections carry full schema defaults — so applying one verbatim would reset
- * every field the block does not override to its default and silently overwrite
- * remote config the user never intended to touch. Until a faithful raw-TOML
- * subset merge is implemented, the handler aborts when this returns true rather
- * than corrupting the remote. The dominant (and only Go-tested) path has no
- * `[remotes.*]` block, so this returns false and push proceeds normally.
- */
-export function matchesRemoteProjectRef(config: ProjectConfig, ref: string): boolean {
-  return Object.values(config.remotes ?? {}).some((remote) => remote.project_id === ref);
-}
-
-/**
- * Resolves the config to push: the base config stamped with the effective
- * project ref. Callers must reject `[remotes.*]` matches up front via
- * {@link matchesRemoteProjectRef}; see that function for why the override is not
- * applied here.
- */
-export function resolveRemoteByProjectRef(
-  config: ProjectConfig,
-  ref: string,
-): LegacyResolvedRemoteConfig {
-  return { projectId: ref, config };
 }

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -7,14 +7,11 @@ import { FunctionResponse, operationDefinitions, type ApiClient } from "@supabas
 import {
   inferFunctionsManifest,
   loadProjectConfig,
-  type LoadedProjectConfig,
-  type ProjectConfig,
   type ResolvedFunctionConfig as ManifestFunctionConfig,
 } from "@supabase/config";
 import { Duration, Effect, Option, Schema, Stream } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
-import * as SmolToml from "smol-toml";
 import { Output } from "../output/output.service.ts";
 import { legacyGetRegistryImageUrl } from "../../legacy/shared/legacy-docker-registry.ts";
 import { invalidFunctionSlugDetail, validateFunctionSlugMessage } from "./functions.shared.ts";
@@ -161,18 +158,6 @@ function mapTransportError(prefix: string, error: unknown): Error {
 
 function withOptional(key: string, value: unknown) {
   return value === undefined ? {} : { [key]: value };
-}
-
-type RawConfigDocument = Record<string, unknown>;
-
-function asRecord(value: unknown): RawConfigDocument | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as RawConfigDocument)
-    : undefined;
-}
-
-function hasOwn(value: object, key: string) {
-  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function validateDeploySlug(slug: string): Effect.Effect<void, InvalidFunctionDeploySlugError> {
@@ -1941,76 +1926,6 @@ function resolveEdgeRuntimeVersion(
   );
 }
 
-function parseProjectConfigDocument(path: string, content: string): unknown {
-  return path.endsWith(".json") ? JSON.parse(content) : SmolToml.parse(content);
-}
-
-function mergeFunctionConfigByPresence(
-  base: ManifestFunctionConfig,
-  remote: ManifestFunctionConfig,
-  raw: RawConfigDocument,
-): ManifestFunctionConfig {
-  return {
-    enabled: hasOwn(raw, "enabled") ? remote.enabled : base.enabled,
-    verify_jwt: hasOwn(raw, "verify_jwt") ? remote.verify_jwt : base.verify_jwt,
-    import_map: hasOwn(raw, "import_map") ? remote.import_map : base.import_map,
-    entrypoint: hasOwn(raw, "entrypoint") ? remote.entrypoint : base.entrypoint,
-    static_files: hasOwn(raw, "static_files") ? remote.static_files : base.static_files,
-    env: hasOwn(raw, "env") ? remote.env : base.env,
-  };
-}
-
-async function configForProjectRef(
-  loadedConfig: LoadedProjectConfig,
-  projectRef: string,
-): Promise<ProjectConfig> {
-  const matchedRemoteNames = Object.entries(loadedConfig.config.remotes)
-    .filter(([, candidate]) => candidate.project_id === projectRef)
-    .map(([name]) => name);
-  if (matchedRemoteNames.length === 0) {
-    return loadedConfig.config;
-  }
-  if (matchedRemoteNames.length > 1) {
-    throw new Error(
-      `duplicate project_id for [remotes.${matchedRemoteNames[1]}] and ${matchedRemoteNames[0]}`,
-    );
-  }
-  const matchedRemoteName = matchedRemoteNames[0]!;
-
-  const rawDocument = parseProjectConfigDocument(
-    loadedConfig.path,
-    await readFile(loadedConfig.path, "utf8"),
-  );
-  const rawRemote = asRecord(asRecord(asRecord(rawDocument)?.remotes)?.[matchedRemoteName]);
-  const remote = loadedConfig.config.remotes[matchedRemoteName]!;
-  const functions = { ...loadedConfig.config.functions };
-  const rawFunctions = asRecord(rawRemote?.functions);
-
-  for (const [slug, rawFunction] of Object.entries(rawFunctions ?? {})) {
-    const rawFunctionRecord = asRecord(rawFunction);
-    if (rawFunctionRecord === undefined) {
-      continue;
-    }
-    functions[slug] = mergeFunctionConfigByPresence(
-      functions[slug] ?? defaultManifestFunctionConfig,
-      remote.functions[slug] ?? defaultManifestFunctionConfig,
-      rawFunctionRecord,
-    );
-  }
-
-  return {
-    ...loadedConfig.config,
-    project_id: projectRef,
-    edge_runtime: hasOwn(rawRemote?.edge_runtime ?? {}, "deno_version")
-      ? {
-          ...loadedConfig.config.edge_runtime,
-          deno_version: remote.edge_runtime.deno_version,
-        }
-      : loadedConfig.config.edge_runtime,
-    functions,
-  };
-}
-
 const pruneFunctions = Effect.fnUntraced(function* (
   projectRef: string,
   configs: ReadonlyArray<ResolvedDeployFunctionConfig>,
@@ -2100,11 +2015,11 @@ export function deployFunctions<ResolveError, ResolveRequirements>(
     const debugEnabled = hasGlobalLongFlag(dependencies.rawArgs, "debug");
     const projectRef =
       preResolvedProjectRef ?? (yield* dependencies.resolveProjectRef(flags.projectRef));
-    const loadedConfig = yield* loadProjectConfig(dependencies.projectRoot);
-    const deployConfig =
-      loadedConfig === null
-        ? undefined
-        : yield* Effect.promise(() => configForProjectRef(loadedConfig, projectRef));
+    // `@supabase/config` merges the matching `[remotes.*]` block over the base
+    // config (Go's `loadFromFile` with `Config.ProjectId` set), so the resolved
+    // config already reflects any remote function/edge_runtime overrides.
+    const loadedConfig = yield* loadProjectConfig(dependencies.projectRoot, { projectRef });
+    const deployConfig = loadedConfig?.config;
     const edgeRuntimeVersion = yield* resolveEdgeRuntimeVersion(
       deployConfig?.edge_runtime.deno_version,
       dependencies.edgeRuntimeVersion,

--- a/packages/config/src/errors.ts
+++ b/packages/config/src/errors.ts
@@ -17,3 +17,15 @@ export class MissingProjectConfigValueError extends Data.TaggedError(
 )<{
   readonly configPath: string;
 }> {}
+
+/**
+ * Two `[remotes.*]` blocks declare the same `project_id` as the requested
+ * `projectRef`. Mirrors Go's `loadFromFile` guard
+ * (`apps/cli-go/pkg/config/config.go:508-509`); `message` matches the Go string
+ * verbatim so callers can surface it without rewrapping.
+ */
+export class DuplicateRemoteProjectIdError extends Data.TaggedError(
+  "DuplicateRemoteProjectIdError",
+)<{
+  readonly message: string;
+}> {}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,6 @@
 export { ProjectConfigSchema, type ProjectConfig, type ProjectConfigJson } from "./base.ts";
 export {
+  DuplicateRemoteProjectIdError,
   MissingProjectConfigValueError,
   ProjectConfigParseError,
   ProjectEnvParseError,

--- a/packages/config/src/io.ts
+++ b/packages/config/src/io.ts
@@ -118,7 +118,12 @@ function withDbSeedDisabled(document: Record<string, unknown>): Record<string, u
  * Applies the `[remotes.<name>]` override whose `project_id` matches `projectRef`
  * to `document`, mirroring Go's `loadFromFile` remote resolution
  * (`config.go:503-518`). Returns the merged document (with `remotes` stripped) and
- * the matched remote name. Fails when two remotes share the target `project_id`.
+ * the matched remote name.
+ *
+ * Like Go, duplicate `project_id`s are detected across *all* `[remotes.*]` blocks —
+ * not just the ones matching `projectRef` — before the matching override is applied.
+ * A missing `project_id` reads as `""` (Go's `viper.GetString`), so two remotes that
+ * both omit it collide on the empty key and fail just as in Go.
  */
 const applyRemoteOverride = Effect.fnUntraced(function* (
   document: Record<string, unknown>,
@@ -128,18 +133,27 @@ const applyRemoteOverride = Effect.fnUntraced(function* (
   if (!isObject(remotes)) {
     return { document, appliedRemote: undefined as string | undefined };
   }
-  const matches = Object.entries(remotes)
-    .filter(([, remote]) => isObject(remote) && remote["project_id"] === projectRef)
-    .map(([name]) => name);
-  if (matches.length > 1) {
-    return yield* new DuplicateRemoteProjectIdError({
-      message: `duplicate project_id for [remotes.${matches[1]}] and [remotes.${matches[0]}]`,
-    });
+  // Build a project_id -> "[remotes.<name>]" map over every remote, failing on the
+  // first duplicate, then resolve the single block matching projectRef.
+  const idToName = new Map<string, string>();
+  let name: string | undefined;
+  for (const [remoteName, remote] of Object.entries(remotes)) {
+    const projectId =
+      isObject(remote) && typeof remote["project_id"] === "string" ? remote["project_id"] : "";
+    const other = idToName.get(projectId);
+    if (other !== undefined) {
+      return yield* new DuplicateRemoteProjectIdError({
+        message: `duplicate project_id for [remotes.${remoteName}] and ${other}`,
+      });
+    }
+    idToName.set(projectId, `[remotes.${remoteName}]`);
+    if (projectId === projectRef) {
+      name = remoteName;
+    }
   }
-  if (matches.length === 0) {
+  if (name === undefined) {
     return { document, appliedRemote: undefined as string | undefined };
   }
-  const name = matches[0]!;
   const remoteSubtree = remotes[name];
   let merged = isObject(remoteSubtree)
     ? mergeRemoteSubtree(document, remoteSubtree)
@@ -148,7 +162,7 @@ const applyRemoteOverride = Effect.fnUntraced(function* (
     merged = withDbSeedDisabled(merged);
   }
   delete merged["remotes"];
-  return { document: merged, appliedRemote: name as string | undefined };
+  return { document: merged, appliedRemote: name };
 });
 
 function isEqualValue(left: unknown, right: unknown): boolean {

--- a/packages/config/src/io.ts
+++ b/packages/config/src/io.ts
@@ -1,7 +1,7 @@
 import { Effect, FileSystem, Path, Schema } from "effect";
 import * as SmolToml from "smol-toml";
 import { ProjectConfigSchema, type ProjectConfig } from "./base.ts";
-import { ProjectConfigParseError } from "./errors.ts";
+import { DuplicateRemoteProjectIdError, ProjectConfigParseError } from "./errors.ts";
 import { interpolateEnvReferencesAgainstSchema } from "./lib/env.ts";
 import { findProjectPaths } from "./paths.ts";
 import { loadProjectEnvironment } from "./project.ts";
@@ -16,6 +16,32 @@ export interface LoadedProjectConfig {
   readonly config: ProjectConfig;
   readonly schemaRef?: string;
   readonly ignoredPaths: ReadonlyArray<string>;
+  /**
+   * The raw, post-`env()`-interpolation document the `config` was decoded from,
+   * with any matching `[remotes.*]` override already merged in (see
+   * {@link LoadProjectConfigOptions.projectRef}). Lets callers inspect key
+   * presence — which the decoded `config` loses because the schema defaults
+   * optional sections — without re-reading the file. Present whenever the file
+   * parsed to an object.
+   */
+  readonly document?: Record<string, unknown>;
+  /**
+   * Name of the `[remotes.<name>]` block whose subtree was merged over the base
+   * config because its `project_id` matched the requested `projectRef`.
+   * `undefined` when no `projectRef` was requested or none matched.
+   */
+  readonly appliedRemote?: string;
+}
+
+/**
+ * When `projectRef` is set, the matching `[remotes.<name>]` block (the one whose
+ * `project_id` equals it) is merged over the base config before decode, mirroring
+ * Go's `config.Load` with `Config.ProjectId` set
+ * (`apps/cli-go/pkg/config/config.go:503-562`). Omitting it loads the base config
+ * verbatim, so existing callers are unaffected.
+ */
+export interface LoadProjectConfigOptions {
+  readonly projectRef?: string;
 }
 
 export interface SaveProjectConfigOptions {
@@ -52,6 +78,78 @@ function siblingConfigPathWith(path: Path.Path, cwd: string, format: ConfigForma
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+/**
+ * Deep-merges a `[remotes.*]` subtree over the base document, reproducing Go's
+ * `mergeRemoteConfig` (`apps/cli-go/pkg/config/config.go:550`): nested objects
+ * merge recursively; arrays and scalars replace wholesale (viper sets each leaf
+ * key). Operates on the raw, pre-decode document so only keys the remote block
+ * actually declares override the base — the remote section's schema defaults
+ * never leak in.
+ */
+function mergeRemoteSubtree(
+  base: Record<string, unknown>,
+  remote: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(remote)) {
+    const existing = result[key];
+    result[key] =
+      isObject(existing) && isObject(value) ? mergeRemoteSubtree(existing, value) : value;
+  }
+  return result;
+}
+
+/** Whether a remote subtree explicitly declares `db.seed.enabled`. */
+function remoteSetsDbSeedEnabled(remote: Record<string, unknown>): boolean {
+  const db = remote["db"];
+  const seed = isObject(db) ? db["seed"] : undefined;
+  return isObject(seed) && "enabled" in seed;
+}
+
+/** Forces `db.seed.enabled = false`, immutably, matching Go's mergeRemoteConfig. */
+function withDbSeedDisabled(document: Record<string, unknown>): Record<string, unknown> {
+  const db = isObject(document["db"]) ? document["db"] : {};
+  const seed = isObject(db["seed"]) ? db["seed"] : {};
+  return { ...document, db: { ...db, seed: { ...seed, enabled: false } } };
+}
+
+/**
+ * Applies the `[remotes.<name>]` override whose `project_id` matches `projectRef`
+ * to `document`, mirroring Go's `loadFromFile` remote resolution
+ * (`config.go:503-518`). Returns the merged document (with `remotes` stripped) and
+ * the matched remote name. Fails when two remotes share the target `project_id`.
+ */
+const applyRemoteOverride = Effect.fnUntraced(function* (
+  document: Record<string, unknown>,
+  projectRef: string,
+) {
+  const remotes = document["remotes"];
+  if (!isObject(remotes)) {
+    return { document, appliedRemote: undefined as string | undefined };
+  }
+  const matches = Object.entries(remotes)
+    .filter(([, remote]) => isObject(remote) && remote["project_id"] === projectRef)
+    .map(([name]) => name);
+  if (matches.length > 1) {
+    return yield* new DuplicateRemoteProjectIdError({
+      message: `duplicate project_id for [remotes.${matches[1]}] and [remotes.${matches[0]}]`,
+    });
+  }
+  if (matches.length === 0) {
+    return { document, appliedRemote: undefined as string | undefined };
+  }
+  const name = matches[0]!;
+  const remoteSubtree = remotes[name];
+  let merged = isObject(remoteSubtree)
+    ? mergeRemoteSubtree(document, remoteSubtree)
+    : { ...document };
+  if (!(isObject(remoteSubtree) && remoteSetsDbSeedEnabled(remoteSubtree))) {
+    merged = withDbSeedDisabled(merged);
+  }
+  delete merged["remotes"];
+  return { document: merged, appliedRemote: name as string | undefined };
+});
 
 function isEqualValue(left: unknown, right: unknown): boolean {
   if (Array.isArray(left) && Array.isArray(right)) {
@@ -205,7 +303,10 @@ function encodeProjectConfigToTomlDocument(
   return `${SmolToml.stringify(toConfigDocument(config, schemaRef))}\n`;
 }
 
-export const loadProjectConfigFile = Effect.fnUntraced(function* (filePath: string) {
+export const loadProjectConfigFile = Effect.fnUntraced(function* (
+  filePath: string,
+  options?: LoadProjectConfigOptions,
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const format = filePath.endsWith(".json") ? "json" : "toml";
@@ -232,7 +333,18 @@ export const loadProjectConfigFile = Effect.fnUntraced(function* (filePath: stri
     ProjectConfigSchema,
   );
 
-  const config = yield* parseProjectConfig(interpolated, format, filePath);
+  // Merge the matching `[remotes.*]` override over the base document before
+  // decode (Go's `loadFromFile` with `Config.ProjectId` set). Only requested
+  // when a `projectRef` is supplied, so other callers load the base verbatim.
+  let documentForDecode: unknown = interpolated;
+  let appliedRemote: string | undefined;
+  if (options?.projectRef !== undefined && isObject(interpolated)) {
+    const resolved = yield* applyRemoteOverride(interpolated, options.projectRef);
+    documentForDecode = resolved.document;
+    appliedRemote = resolved.appliedRemote;
+  }
+
+  const config = yield* parseProjectConfig(documentForDecode, format, filePath);
 
   return {
     path: filePath,
@@ -240,10 +352,15 @@ export const loadProjectConfigFile = Effect.fnUntraced(function* (filePath: stri
     config,
     schemaRef: getSchemaRef(document),
     ignoredPaths: [],
+    document: isObject(documentForDecode) ? documentForDecode : undefined,
+    appliedRemote,
   } satisfies LoadedProjectConfig;
 });
 
-export const loadProjectConfig = Effect.fnUntraced(function* (cwd: string) {
+export const loadProjectConfig = Effect.fnUntraced(function* (
+  cwd: string,
+  options?: LoadProjectConfigOptions,
+) {
   const fs = yield* FileSystem.FileSystem;
   const project = yield* findProjectPaths(cwd);
 
@@ -259,7 +376,7 @@ export const loadProjectConfig = Effect.fnUntraced(function* (cwd: string) {
     : project.configPath.replace(/config\.json$/, "config.toml");
 
   if (yield* fs.exists(jsonPath)) {
-    const json = yield* loadProjectConfigFile(jsonPath);
+    const json = yield* loadProjectConfigFile(jsonPath, options);
 
     return {
       ...json,
@@ -268,7 +385,7 @@ export const loadProjectConfig = Effect.fnUntraced(function* (cwd: string) {
   }
 
   if (yield* fs.exists(tomlPath)) {
-    return yield* loadProjectConfigFile(tomlPath);
+    return yield* loadProjectConfigFile(tomlPath, options);
   }
 
   return null;

--- a/packages/config/src/io.unit.test.ts
+++ b/packages/config/src/io.unit.test.ts
@@ -813,3 +813,185 @@ port = "env(SUPABASE_DB_PORT_TEST)"
     }
   });
 });
+
+describe("config io [remotes.*] merge", () => {
+  async function writeTomlProject(toml: string): Promise<string> {
+    const cwd = makeTempProject();
+    await mkdir(join(cwd, "supabase"), { recursive: true });
+    await writeFile(join(cwd, "supabase", "config.toml"), toml);
+    return cwd;
+  }
+
+  const BASE_WITH_REMOTES = `project_id = "baseref"
+
+[api]
+enabled = true
+schemas = ["public", "custom_base"]
+max_rows = 123
+
+[db]
+major_version = 15
+
+[remotes.preview]
+project_id = "previewref"
+[remotes.preview.api]
+schemas = ["remote_only"]
+max_rows = 999
+
+[remotes.staging]
+project_id = "stagingref"
+[remotes.staging.api]
+enabled = false
+`;
+
+  test("merges the matching remote subtree over the base before decode", async () => {
+    const cwd = await writeTomlProject(BASE_WITH_REMOTES);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "previewref" }));
+      expect(loaded!.appliedRemote).toBe("preview");
+      // remote block's project_id overrides the base
+      expect(loaded!.config.project_id).toBe("previewref");
+      // remote scalar wins
+      expect(loaded!.config.api.max_rows).toBe(999);
+      // array replaced wholesale (not element-merged)
+      expect(loaded!.config.api.schemas).toEqual(["remote_only"]);
+      // base-only sibling under the same table survives
+      expect(loaded!.config.api.enabled).toBe(true);
+      // a non-matching remote ([remotes.staging]) is not applied
+      expect(loaded!.config.db.major_version).toBe(15);
+      // remotes are stripped from the merged document before decode
+      expect(loaded!.document?.remotes).toBeUndefined();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("loads the base config verbatim when no remote matches", async () => {
+    const cwd = await writeTomlProject(BASE_WITH_REMOTES);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "unknownref" }));
+      expect(loaded!.appliedRemote).toBeUndefined();
+      expect(loaded!.config.project_id).toBe("baseref");
+      expect(loaded!.config.api.max_rows).toBe(123);
+      expect(loaded!.config.api.schemas).toEqual(["public", "custom_base"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("does not merge remotes when no projectRef is requested", async () => {
+    const cwd = await writeTomlProject(BASE_WITH_REMOTES);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd));
+      expect(loaded!.appliedRemote).toBeUndefined();
+      expect(loaded!.config.api.max_rows).toBe(123);
+      expect(Object.keys(loaded!.config.remotes)).toEqual(["preview", "staging"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects duplicate project_id across remotes with Go's message", async () => {
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[remotes.a]
+project_id = "dupref"
+
+[remotes.b]
+project_id = "dupref"
+`);
+    try {
+      const message = await Effect.runPromise(
+        loadProjectConfig(cwd, { projectRef: "dupref" }).pipe(
+          Effect.catchTag("DuplicateRemoteProjectIdError", (error) =>
+            Effect.succeed(error.message),
+          ),
+          Effect.provide(BunServices.layer),
+        ),
+      );
+      expect(message).toBe("duplicate project_id for [remotes.b] and [remotes.a]");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("the merged document carries pointer sections introduced by the remote", async () => {
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[remotes.preview]
+project_id = "previewref"
+[remotes.preview.db.ssl_enforcement]
+enabled = true
+`);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "previewref" }));
+      // `legacyPresenceIn` reads `document` to detect optional pointer sections;
+      // a remote-introduced `db.ssl_enforcement` must be present there.
+      const db = loaded!.document?.db;
+      expect(typeof db === "object" && db !== null && "ssl_enforcement" in db).toBe(true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("forces db.seed.enabled false when the matching remote omits it", async () => {
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[db.seed]
+enabled = true
+
+[remotes.preview]
+project_id = "previewref"
+[remotes.preview.api]
+max_rows = 5
+`);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "previewref" }));
+      expect(loaded!.config.db.seed.enabled).toBe(false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves db.seed.enabled when the matching remote sets it", async () => {
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[remotes.preview]
+project_id = "previewref"
+[remotes.preview.db.seed]
+enabled = true
+`);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "previewref" }));
+      expect(loaded!.config.db.seed.enabled).toBe(true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves env() references inside the matching remote before merge", async () => {
+    const previous = process.env.SUPABASE_REMOTE_MAX_ROWS_TEST;
+    process.env.SUPABASE_REMOTE_MAX_ROWS_TEST = "777";
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[api]
+max_rows = 1
+
+[remotes.preview]
+project_id = "previewref"
+[remotes.preview.api]
+max_rows = "env(SUPABASE_REMOTE_MAX_ROWS_TEST)"
+`);
+    try {
+      const loaded = await runConfigEffect(loadProjectConfig(cwd, { projectRef: "previewref" }));
+      expect(loaded!.config.api.max_rows).toBe(777);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SUPABASE_REMOTE_MAX_ROWS_TEST;
+      } else {
+        process.env.SUPABASE_REMOTE_MAX_ROWS_TEST = previous;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/config/src/io.unit.test.ts
+++ b/packages/config/src/io.unit.test.ts
@@ -915,6 +915,64 @@ project_id = "dupref"
     }
   });
 
+  test("rejects duplicate project_id among remotes that do not match projectRef", async () => {
+    // Go builds the duplicate map across all [remotes.*] blocks before applying the
+    // matching override, so a clash between two non-target remotes still fails even
+    // though neither shares projectRef (config.go:503-518).
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[remotes.target]
+project_id = "previewref"
+
+[remotes.a]
+project_id = "dupref"
+
+[remotes.b]
+project_id = "dupref"
+`);
+    try {
+      const message = await Effect.runPromise(
+        loadProjectConfig(cwd, { projectRef: "previewref" }).pipe(
+          Effect.catchTag("DuplicateRemoteProjectIdError", (error) =>
+            Effect.succeed(error.message),
+          ),
+          Effect.provide(BunServices.layer),
+        ),
+      );
+      expect(message).toBe("duplicate project_id for [remotes.b] and [remotes.a]");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects two remotes that both omit project_id", async () => {
+    // A missing project_id reads as "" (Go's viper.GetString), so two remotes that
+    // both omit it collide on the empty key.
+    const cwd = await writeTomlProject(`project_id = "baseref"
+
+[remotes.a]
+[remotes.a.api]
+max_rows = 1
+
+[remotes.b]
+[remotes.b.api]
+max_rows = 2
+`);
+    try {
+      const message = await Effect.runPromise(
+        loadProjectConfig(cwd, { projectRef: "previewref" }).pipe(
+          Effect.catchTag("DuplicateRemoteProjectIdError", (error) =>
+            Effect.succeed(error.message),
+          ),
+          Effect.provide(BunServices.layer),
+        ),
+      );
+      expect(message).toBe("duplicate project_id for [remotes.b] and [remotes.a]");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   test("the merged document carries pointer sections introduced by the remote", async () => {
     const cwd = await writeTomlProject(`project_id = "baseref"
 


### PR DESCRIPTION
## What changed

`config push` regressed in v2.106.0 (the native-TS port): when a `[remotes.<name>]` block in `config.toml` targeted the project ref, the command aborted with

> cannot push config: a [remotes.*] block targets project ***, which config push does not yet support.

The Go CLI (v2.105.0) instead merges that remote's subtree over the base config and pushes it. The port had punted on Go's `mergeRemoteConfig`.

This ports the merge faithfully and removes the abort.

## Why this location

The merge is owned by `@supabase/config`, mirroring Go doing it in `pkg/config`. `loadProjectConfig` / `loadProjectConfigFile` now accept an optional `{ projectRef }`. When set, after `env()` interpolation and **before** schema decode, the matching `[remotes.<name>]` raw subtree is deep-merged over the base document (objects recurse; arrays and scalars replace wholesale — viper's `v.Set` semantics), `db.seed.enabled` is forced `false` when the remote omits it, the `remotes` key is stripped, and the merged document is decoded. Doing it on the raw document (not the decoded config) is essential: the decoded remote section carries full schema defaults that would otherwise clobber every field the block doesn't override.

The merge is gated on `projectRef`, so every other `loadProjectConfig` caller is unaffected.

## Notable details for reviewers

- New `DuplicateRemoteProjectIdError` (exported from `@supabase/config`) raised when two remotes share the target `project_id`, carrying Go's verbatim message `duplicate project_id for [remotes.<b>] and [remotes.<a>]`.
- `LoadedProjectConfig` gains optional `document` (merged, post-interpolation raw doc) and `appliedRemote` fields.
- The push handler prints `Loading config override: [remotes.<name>]` to stderr (Go parity) when a remote applies, and now derives optional pointer-section presence (`db.ssl_enforcement`, `storage.image_transformation`, `storage.s3_protocol`, auth subsections) from the merged document instead of re-reading the file — so sections introduced by the remote are detected. Dead code removed (`matchesRemoteProjectRef`, `resolveRemoteByProjectRef`, `LegacyConfigPushUnsupportedRemoteError`).
- `functions deploy` is consolidated onto the same shared merge, deleting its divergent partial copy (`configForProjectRef` / `mergeFunctionConfigByPresence`, which only handled `functions.*` and `edge_runtime.deno_version`). Verified behavior-preserving since deploy reads only those fields. This also corrects deploy's duplicate-`project_id` message to match Go (both remote names bracketed).

Closes CLI-1808