### PR TITLE
fix(cli): mount test file's directory so \ir includes resolve

### DIFF
--- a/apps/cli/src/legacy/commands/test/db/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/test/db/SIDE_EFFECTS.md
@@ -29,7 +29,7 @@
 
 One-shot `docker run --rm <pg_prove image>`, where the image is `supabase/pg_prove:3.36` resolved through the registry (`legacyGetRegistryImageUrl`, mirroring Go's `GetRegistryImageUrl`): `SUPABASE_INTERNAL_IMAGE_REGISTRY` overrides the registry, `docker.io` pulls from Docker Hub unchanged, and the default is `public.ecr.aws/supabase/pg_prove:3.36`.
 
-- `-v <hostpath>:<dockerpath>:ro` for each test path
+- `-v <hostpath>:<dockerpath>:ro` for each test path. A path that is a **file** is mounted via its **containing directory** (not the lone file) so that psql `\ir`/`\i` includes — which resolve relative to the test file's own directory — find their sibling files inside the container (CLI-1139). Directory paths are mounted as-is. Mounts are deduped by container target, so multiple files in the same directory produce a single `-v`. The full file path is still passed to `pg_prove`, so only the requested file runs.
 - `--security-opt label:disable`
 - `--network supabase_network_<project_id>` (local) with env `PGHOST=db PGPORT=5432`, or `--network host` (db-url / linked) with the resolved host/port. `<project_id>` is sanitized exactly as Go's `config.Load` does (`sanitizeProjectId`), so an invalid configured value (e.g. `"my project"`) joins the same network the local stack created
 - `-e PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE`

--- a/apps/cli/src/legacy/commands/test/db/db.integration.test.ts
+++ b/apps/cli/src/legacy/commands/test/db/db.integration.test.ts
@@ -276,12 +276,15 @@ describe("legacy test db integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("passes explicit paths as read-only binds", () => {
+  it.live("mounts a single file's containing directory so `\\ir` includes resolve", () => {
+    // CLI-1139: a lone-file bind leaves sibling files absent in the container, so
+    // `\ir ./sibling.sql` fails. The containing directory is mounted instead; the
+    // file path is still what pg_prove runs.
     const { layer, docker } = setup();
     return Effect.gen(function* () {
       yield* legacyTestDb(flags({ paths: ["/abs/a_test.sql"] }));
       const run = docker.lastOpts;
-      expect(run?.binds).toEqual(["/abs/a_test.sql:/abs/a_test.sql:ro"]);
+      expect(run?.binds).toEqual(["/abs:/abs:ro"]);
       expect(run?.cmd).toContain("/abs/a_test.sql");
     }).pipe(Effect.provide(layer));
   });

--- a/apps/cli/src/legacy/commands/test/db/db.pg-prove-args.ts
+++ b/apps/cli/src/legacy/commands/test/db/db.pg-prove-args.ts
@@ -30,6 +30,11 @@ export function legacyToDockerPath(absHostPath: string): string {
  * - Relative paths resolve against `cwd` (Go's `utils.CurrentDirAbs`, the original
  *   invocation directory).
  * - `--verbose` is appended when debug logging is enabled (Go's `viper.GetBool("DEBUG")`).
+ *
+ * Intentional divergence from Go (CLI-1139): for a file path we mount its parent
+ * *directory* rather than the lone file, so psql `\ir`/`\i` includes resolve. Go
+ * mounts the file alone, which breaks single-file runs that include a sibling.
+ * Output is unchanged — the full file path is still passed to `pg_prove`.
  */
 export function buildLegacyPgProveArgs(opts: {
   readonly paths: ReadonlyArray<string>;
@@ -42,6 +47,7 @@ export function buildLegacyPgProveArgs(opts: {
 
   const cmd: string[] = ["pg_prove", "--ext", ".pg", "--ext", ".sql", "-r"];
   const binds: string[] = [];
+  const seenTargets = new Set<string>();
   // `testFiles` is never empty (it defaults to supabase/tests), so the first
   // iteration always sets this; Go derives workingDir from the first path only.
   let workingDir = "";
@@ -50,11 +56,24 @@ export function buildLegacyPgProveArgs(opts: {
     const fp = nodePath.isAbsolute(candidate) ? candidate : nodePath.join(opts.cwd, candidate);
     const dockerPath = legacyToDockerPath(fp);
     cmd.push(dockerPath);
-    binds.push(`${fp}:${dockerPath}:ro`);
-    if (workingDir === "") {
-      workingDir =
-        nodePath.posix.extname(dockerPath) !== "" ? nodePath.posix.dirname(dockerPath) : dockerPath;
+
+    // Mount the *directory* containing a test file (not the lone file) so psql
+    // `\ir ./sibling.sql` includes resolve: they look relative to the test file's
+    // own directory, and a single-file bind leaves siblings absent in the
+    // container (CLI-1139). Directories are mounted as-is. The file-vs-directory
+    // heuristic (presence of an extension) matches Go's workingDir logic.
+    const isFile = nodePath.posix.extname(dockerPath) !== "";
+    const hostMount = isFile ? nodePath.dirname(fp) : fp;
+    const dockerMount = legacyToDockerPath(hostMount);
+
+    // Dedupe by container target: two files in the same directory (or a file plus
+    // its containing directory) would otherwise emit duplicate `-v` mounts, which
+    // Docker rejects.
+    if (!seenTargets.has(dockerMount)) {
+      seenTargets.add(dockerMount);
+      binds.push(`${hostMount}:${dockerMount}:ro`);
     }
+    if (workingDir === "") workingDir = dockerMount;
   }
 
   if (opts.debug) cmd.push("--verbose");

--- a/apps/cli/src/legacy/commands/test/db/db.pg-prove-args.unit.test.ts
+++ b/apps/cli/src/legacy/commands/test/db/db.pg-prove-args.unit.test.ts
@@ -47,13 +47,43 @@ describe("buildLegacyPgProveArgs", () => {
     expect(Option.getOrNull(result.workingDir)).toBe("/cwd/nested");
   });
 
-  test("uses the parent directory as workingDir when the first path is a file", () => {
+  test("mounts the containing directory (not the lone file) for a single file path", () => {
+    // CLI-1139: mounting only the file leaves sibling `\ir` includes absent in
+    // the container. Mount the parent directory so they resolve; the file path is
+    // still what pg_prove runs.
     const result = buildLegacyPgProveArgs({
       paths: ["/abs/dir/a_test.sql"],
       cwd: "/cwd",
       workdir: "/work",
       debug: false,
     });
+    expect(result.binds).toEqual(["/abs/dir:/abs/dir:ro"]);
+    expect(result.cmd).toContain("/abs/dir/a_test.sql");
+    expect(Option.getOrNull(result.workingDir)).toBe("/abs/dir");
+  });
+
+  test("dedupes the bind when multiple files share a directory", () => {
+    const result = buildLegacyPgProveArgs({
+      paths: ["/abs/dir/a_test.sql", "/abs/dir/b_test.sql"],
+      cwd: "/cwd",
+      workdir: "/work",
+      debug: false,
+    });
+    // A single bind for the shared directory; both files still run.
+    expect(result.binds).toEqual(["/abs/dir:/abs/dir:ro"]);
+    expect(result.cmd).toContain("/abs/dir/a_test.sql");
+    expect(result.cmd).toContain("/abs/dir/b_test.sql");
+  });
+
+  test("dedupes a file's mount against its explicitly-given containing directory", () => {
+    const result = buildLegacyPgProveArgs({
+      paths: ["/abs/dir", "/abs/dir/a_test.sql"],
+      cwd: "/cwd",
+      workdir: "/work",
+      debug: false,
+    });
+    expect(result.binds).toEqual(["/abs/dir:/abs/dir:ro"]);
+    // workingDir is derived from the first path (a directory → itself).
     expect(Option.getOrNull(result.workingDir)).toBe("/abs/dir");
   });
 
@@ -65,7 +95,9 @@ describe("buildLegacyPgProveArgs", () => {
       debug: false,
     });
     expect(result.binds).toEqual([
-      "/abs/first_test.sql:/abs/first_test.sql:ro",
+      // First path is a file → its containing directory is mounted.
+      "/abs:/abs:ro",
+      // Second path is a directory → mounted as-is.
       "/abs/second/dir:/abs/second/dir:ro",
     ]);
     // workingDir is derived from the first path only (a file → its parent).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Running `supabase db test <single_file.sql>` fails when that file pulls in a sibling via psql's `\ir ./other.sql` include:

```
psql:.../storage_object_operations.sql:5: error: .../testing_constants.sql: No such file or directory
```

Running the whole suite (`supabase db test`) works, and so does running a file with no includes.

**Root cause:** `buildLegacyPgProveArgs` bind-mounted each test path exactly as given. For a single **file** that mounts only that one file into the pg_prove container. psql's `\ir` (include-relative) resolves relative to the test file's *own directory*, so it looks for `<dir>/sibling.sql` inside the container — which was never mounted. The whole-suite run works because the entire `tests` **directory** is mounted, so all siblings are present.

Closes #4850
Fixes CLI-1139

## What is the new behavior?

When a test path is a file, its **containing directory** is bind-mounted read-only instead of the lone file, so `\ir`/`\i` siblings resolve. Directories are still mounted as-is. Binds are deduped by container target so multiple files in the same directory don't emit duplicate `-v` mounts (which Docker rejects). The full file path is still passed to `pg_prove`, so only the requested file runs and the TAP output is byte-identical.

Scope is the TS legacy port only (the stable channel). The Go reference has the same latent bug; this is a deliberate, output-preserving divergence noted in the code.