### PR TITLE
fix(cli): respect SUPABASE_HOME across fallback paths

### DIFF
--- a/apps/cli-go/docs/supabase/login.md
+++ b/apps/cli-go/docs/supabase/login.md
@@ -2,7 +2,7 @@
 
 Connect the Supabase CLI to your Supabase account by logging in with your [personal access token](https://supabase.com/dashboard/account/tokens).
 
-Your access token is stored securely in [native credentials storage](https://github.com/zalando/go-keyring#dependencies). If native credentials storage is unavailable, it will be written to a plain text file at `~/.supabase/access-token`.
+Your access token is stored securely in [native credentials storage](https://github.com/zalando/go-keyring#dependencies). If native credentials storage is unavailable, it will be written to a plain text file at `<SUPABASE_HOME or ~/.supabase>/access-token`.
 
 > If this behavior is not desired, such as in a CI environment, you may skip login by specifying the `SUPABASE_ACCESS_TOKEN` environment variable in other commands.
 

--- a/apps/cli-go/internal/telemetry/state.go
+++ b/apps/cli-go/internal/telemetry/state.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/go-errors/errors"
@@ -43,14 +42,11 @@ type rawState struct {
 }
 
 func telemetryPath() (string, error) {
-	if home := strings.TrimSpace(os.Getenv("SUPABASE_HOME")); home != "" {
-		return filepath.Join(home, "telemetry.json"), nil
-	}
-	home, err := os.UserHomeDir()
+	home, err := utils.SupabaseHomeDir()
 	if err != nil {
-		return "", errors.Errorf("failed to get $HOME directory: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, ".supabase", "telemetry.json"), nil
+	return filepath.Join(home, "telemetry.json"), nil
 }
 
 func parseConsent(raw rawState) (bool, bool, error) {

--- a/apps/cli-go/internal/utils/access_token.go
+++ b/apps/cli-go/internal/utils/access_token.go
@@ -130,10 +130,9 @@ func fallbackDeleteToken(fsys afero.Fs) error {
 }
 
 func getAccessTokenPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := SupabaseHomeDir()
 	if err != nil {
-		return "", errors.Errorf("failed to get $HOME directory: %w", err)
+		return "", err
 	}
-	// TODO: fallback to workdir
-	return filepath.Join(home, ".supabase", AccessTokenKey), nil
+	return filepath.Join(home, AccessTokenKey), nil
 }

--- a/apps/cli-go/internal/utils/access_token_test.go
+++ b/apps/cli-go/internal/utils/access_token_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -128,6 +129,24 @@ func TestSaveTokenFallback(t *testing.T) {
 		contents, err := afero.ReadFile(fsys, path)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte(token), contents)
+	})
+
+	t.Run("fallback saves to SUPABASE_HOME when configured", func(t *testing.T) {
+		t.Setenv("HOME", "/home/test")
+		t.Setenv("SUPABASE_HOME", "/custom/supabase")
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		assert.NoError(t, fallbackSaveToken(token, fsys))
+		// Validate saved token
+		configuredPath := filepath.Join("/custom/supabase", AccessTokenKey)
+		contents, err := afero.ReadFile(fsys, configuredPath)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(token), contents)
+		defaultPath := filepath.Join("/home/test", ".supabase", AccessTokenKey)
+		exists, err := afero.Exists(fsys, defaultPath)
+		assert.NoError(t, err)
+		assert.False(t, exists)
 	})
 
 	t.Run("throws error on home dir failure", func(t *testing.T) {

--- a/apps/cli-go/internal/utils/deno.go
+++ b/apps/cli-go/internal/utils/deno.go
@@ -40,7 +40,7 @@ func GetDenoPath() (string, error) {
 	if len(DenoPathOverride) > 0 {
 		return DenoPathOverride, nil
 	}
-	home, err := os.UserHomeDir()
+	home, err := SupabaseHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -48,7 +48,7 @@ func GetDenoPath() (string, error) {
 	if runtime.GOOS == "windows" {
 		denoBinName = "deno.exe"
 	}
-	denoPath := filepath.Join(home, ".supabase", denoBinName)
+	denoPath := filepath.Join(home, denoBinName)
 	return denoPath, nil
 }
 

--- a/apps/cli-go/internal/utils/deno_test.go
+++ b/apps/cli-go/internal/utils/deno_test.go
@@ -64,6 +64,19 @@ func TestGetDenoPath(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, path)
 	})
+
+	t.Run("returns SUPABASE_HOME path when configured", func(t *testing.T) {
+		t.Setenv("SUPABASE_HOME", "/custom/supabase")
+		expected := filepath.Join("/custom/supabase", "deno")
+		if runtime.GOOS == "windows" {
+			expected += ".exe"
+		}
+
+		path, err := GetDenoPath()
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, path)
+	})
 }
 
 func TestIsScriptModified(t *testing.T) {

--- a/apps/cli-go/internal/utils/profile.go
+++ b/apps/cli-go/internal/utils/profile.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -136,11 +135,11 @@ func getProfileName(fsys afero.Fs) string {
 }
 
 func getProfilePath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := SupabaseHomeDir()
 	if err != nil {
-		return "", errors.Errorf("failed to get $HOME directory: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, ".supabase", "profile"), nil
+	return filepath.Join(home, "profile"), nil
 }
 
 func SaveProfileName(prof string, fsys afero.Fs) error {

--- a/apps/cli-go/internal/utils/profile_test.go
+++ b/apps/cli-go/internal/utils/profile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
@@ -74,5 +75,24 @@ func TestLoadProfile(t *testing.T) {
 		err := LoadProfile(context.Background(), fsys)
 		// Check error
 		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestSaveProfileName(t *testing.T) {
+	t.Run("saves to SUPABASE_HOME when configured", func(t *testing.T) {
+		t.Setenv("HOME", "/home/test")
+		t.Setenv("SUPABASE_HOME", "/custom/supabase")
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		// Run test
+		err := SaveProfileName("supabase-staging", fsys)
+		// Check error
+		assert.NoError(t, err)
+		contents, err := afero.ReadFile(fsys, filepath.Join("/custom/supabase", "profile"))
+		assert.NoError(t, err)
+		assert.Equal(t, "supabase-staging", string(contents))
+		exists, err := afero.Exists(fsys, filepath.Join("/home/test", ".supabase", "profile"))
+		assert.NoError(t, err)
+		assert.False(t, exists)
 	})
 }

--- a/apps/cli-go/internal/utils/supabase_home.go
+++ b/apps/cli-go/internal/utils/supabase_home.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-errors/errors"
+)
+
+// SupabaseHomeDir returns the global Supabase CLI state root. It is overridden
+// by the SUPABASE_HOME environment variable when set to a non-empty value (an
+// absolute path is expected; the value is used verbatim), otherwise it defaults
+// to ~/.supabase.
+func SupabaseHomeDir() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("SUPABASE_HOME")); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Errorf("failed to get $HOME directory: %w", err)
+	}
+	return filepath.Join(home, ".supabase"), nil
+}

--- a/apps/cli/docs/supabase-home.md
+++ b/apps/cli/docs/supabase-home.md
@@ -254,7 +254,7 @@ Not all runtime files live in the repo.
 Auth is still machine-global today:
 
 - keyring entry: `Supabase CLI/access-token`
-- filesystem fallback: `~/.supabase/access-token`
+- filesystem fallback: `<SUPABASE_HOME or ~/.supabase>/access-token`
 
 ### Telemetry and traces
 
@@ -268,7 +268,13 @@ Telemetry state remains in `SUPABASE_HOME`:
 Downloaded binaries remain shared across projects in:
 
 ```text
-~/.supabase/bin/
+<SUPABASE_HOME or ~/.supabase>/bin/
+```
+
+The legacy Go installer stores its Deno binary directly under the state root:
+
+```text
+<SUPABASE_HOME or ~/.supabase>/deno
 ```
 
 ### Live runtime sockets

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
@@ -4,6 +4,7 @@ import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { normalizeKeyringToken } from "../../shared/auth/keyring-token.ts";
 import { LegacyDebugLogger } from "../shared/legacy-debug-logger.service.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
+import { legacySupabaseHome } from "../config/legacy-profile-file.ts";
 import { LEGACY_ACCESS_TOKEN_PATTERN, validateLegacyAccessToken } from "./legacy-access-token.ts";
 import { LegacyCredentials } from "./legacy-credentials.service.ts";
 import {
@@ -318,8 +319,8 @@ const makeLegacyCredentials = Effect.gen(function* () {
   const debugLogger = yield* LegacyDebugLogger;
   const profileAccount = cliConfig.profile;
 
-  // ~/.supabase/access-token — fallback file path
-  const fallbackDir = path.join(runtimeInfo.homeDir, ".supabase");
+  // <SUPABASE_HOME or ~/.supabase>/access-token — fallback file path
+  const fallbackDir = legacySupabaseHome(runtimeInfo.homeDir);
   const fallbackPath = path.join(fallbackDir, "access-token");
 
   // `SUPABASE_NO_KEYRING=1` disables the OS keyring entirely (matches `next/`'s
@@ -379,7 +380,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
         return Option.some(Redacted.make(keyringValue.value));
       }
 
-      // Filesystem fallback at ~/.supabase/access-token.
+      // Filesystem fallback in the Supabase home directory.
       const fileValue = yield* readFile;
       if (Option.isSome(fileValue)) {
         yield* debugLogger.debug(`Using access token from file: ${fallbackPath}`);

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.unit.test.ts
@@ -256,6 +256,17 @@ describe("legacyCredentialsLayer.getAccessToken", () => {
     }).pipe(Effect.provide(makeLayer()));
   });
 
+  it.effect("falls back to SUPABASE_HOME/access-token when configured", () => {
+    const supabaseHome = join(tempHome, "custom-supabase-home");
+    mkdirSync(supabaseHome, { recursive: true });
+    writeFileSync(join(supabaseHome, "access-token"), `${VALID_TOKEN}\n`, { mode: 0o600 });
+    return Effect.gen(function* () {
+      const { getAccessToken } = yield* LegacyCredentials;
+      const token = yield* getAccessToken;
+      expectSomeToken(token, VALID_TOKEN);
+    }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_HOME: supabaseHome } })));
+  });
+
   it.effect("returns None when no source provides a token", () =>
     Effect.gen(function* () {
       const { getAccessToken } = yield* LegacyCredentials;
@@ -342,6 +353,18 @@ describe("legacyCredentialsLayer.saveAccessToken", () => {
       expect(content).toBe(VALID_TOKEN);
     }).pipe(Effect.provide(makeLayer()));
   });
+
+  it.effect("filesystem fallback honors SUPABASE_HOME when configured", () => {
+    throwOnSetPassword = true;
+    const supabaseHome = join(tempHome, "custom-supabase-home");
+    return Effect.gen(function* () {
+      const { saveAccessToken } = yield* LegacyCredentials;
+      yield* saveAccessToken(VALID_TOKEN);
+      const content = readFileSync(join(supabaseHome, "access-token"), "utf-8");
+      expect(content).toBe(VALID_TOKEN);
+      expect(existsSync(join(tempHome, ".supabase", "access-token"))).toBe(false);
+    }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_HOME: supabaseHome } })));
+  });
 });
 
 // Go's `utils.DeleteAccessToken` (`access_token.go:100-119`) collapses three
@@ -367,6 +390,19 @@ describe("legacyCredentialsLayer.deleteAccessToken", () => {
       expect(passwords.has("Supabase CLI/access-token")).toBe(false);
       expect(tokenFileExists(tempHome)).toBe(false);
     }).pipe(Effect.provide(makeLayer()));
+  });
+
+  it.effect("logged in via keyring profile entry → deletes the SUPABASE_HOME file", () => {
+    const supabaseHome = join(tempHome, "custom-supabase-home");
+    mkdirSync(supabaseHome, { recursive: true });
+    writeFileSync(join(supabaseHome, "access-token"), VALID_TOKEN, { mode: 0o600 });
+    passwords.set("Supabase CLI/supabase", VALID_TOKEN);
+    return Effect.gen(function* () {
+      const { deleteAccessToken } = yield* LegacyCredentials;
+      yield* deleteAccessToken;
+      expect(passwords.has("Supabase CLI/supabase")).toBe(false);
+      expect(existsSync(join(supabaseHome, "access-token"))).toBe(false);
+    }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_HOME: supabaseHome } })));
   });
 
   it.effect(

--- a/apps/cli/src/legacy/auth/legacy-credentials.service.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.service.ts
@@ -18,7 +18,7 @@ interface LegacyCredentialsShape {
    * Deletes the access token, reproducing Go's `utils.DeleteAccessToken`
    * (`apps/cli-go/internal/utils/access_token.go:100-119`) exactly:
    *
-   *   1. Remove `~/.supabase/access-token` first. A non-`ENOENT` removal error
+   *   1. Remove `<SUPABASE_HOME or ~/.supabase>/access-token` first. A non-`ENOENT` removal error
    *      fails `LegacyDeleteTokenError`; a missing file is ignored.
    *   2. Best-effort delete of the legacy `access-token` keyring account — any
    *      error other than not-found is swallowed and never affects the outcome.

--- a/apps/cli/src/legacy/auth/legacy-errors.ts
+++ b/apps/cli/src/legacy/auth/legacy-errors.ts
@@ -37,7 +37,7 @@ export class LegacyNotLoggedInError extends Data.TaggedError("LegacyNotLoggedInE
 
 /**
  * Raised by `deleteAccessToken` when removing the token fails for a real reason
- * — a non-`ENOENT` failure removing `~/.supabase/access-token`, or a non
+ * — a non-`ENOENT` failure removing `<SUPABASE_HOME or ~/.supabase>/access-token`, or a non
  * not-found error deleting the profile keyring entry. Mirrors Go's
  * `failed to remove access token file: …` / `failed to delete access token from
  * keyring: …` errors (`access_token.go:100-119`), which exit 1.

--- a/apps/cli/src/legacy/commands/login/login.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/login/login.e2e.test.ts
@@ -10,8 +10,9 @@ const VALID_TOKEN = "sbp_" + "a".repeat(40);
 
 describe("supabase login (legacy)", () => {
   // Golden path: --token persists the access token and reports success. The e2e
-  // harness sets SUPABASE_NO_KEYRING=1, so the token lands in the isolated
-  // HOME's ~/.supabase/access-token rather than the OS keyring.
+  // harness sets SUPABASE_NO_KEYRING=1 and points SUPABASE_HOME at the isolated
+  // home dir, so the token lands in <SUPABASE_HOME>/access-token rather than the
+  // OS keyring.
   test(
     "login --token persists the token and prints the logged-in message",
     { timeout: E2E_TIMEOUT_MS },
@@ -24,7 +25,7 @@ describe("supabase login (legacy)", () => {
       });
       expect(exitCode).toBe(0);
       expect(stdout).toContain("You are now logged in. Happy coding!");
-      expect(existsSync(join(home.dir, ".supabase", "access-token"))).toBe(true);
+      expect(existsSync(join(home.dir, "access-token"))).toBe(true);
     },
   );
 

--- a/apps/cli/src/legacy/commands/login/login.handler.ts
+++ b/apps/cli/src/legacy/commands/login/login.handler.ts
@@ -36,7 +36,7 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
 
   // Mirrors Go's login `PostRunE` (`cmd/login.go:42-48`): when a profile was
   // explicitly chosen (`--profile` over its default, else `SUPABASE_PROFILE`),
-  // persist it to `~/.supabase/profile` on success so later commands resolve the
+  // persist it to `<SUPABASE_HOME or ~/.supabase>/profile` on success so later commands resolve the
   // same profile. The raw token is written (Go's `viper.GetString("PROFILE")`),
   // so a YAML-path profile round-trips. A write failure is fatal (Go: "Failure
   // to save should block subsequent commands on CI").

--- a/apps/cli/src/legacy/commands/logout/logout.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.e2e.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, test } from "vitest";
@@ -8,10 +8,10 @@ import { makeTempHome, runSupabase } from "../../../../tests/helpers/cli.ts";
 const E2E_TIMEOUT_MS = 30_000;
 const VALID_TOKEN = "sbp_" + "a".repeat(40);
 
+// The e2e harness points SUPABASE_HOME at the isolated home dir, so the fallback
+// token file lives at <SUPABASE_HOME>/access-token.
 function seedTokenFile(home: string): string {
-  const supaDir = join(home, ".supabase");
-  mkdirSync(supaDir, { recursive: true });
-  const tokenPath = join(supaDir, "access-token");
+  const tokenPath = join(home, "access-token");
   writeFileSync(tokenPath, VALID_TOKEN, { mode: 0o600 });
   return tokenPath;
 }

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
@@ -96,6 +96,19 @@ describe("legacyCliConfigLayer", () => {
     }).pipe(Effect.provide(makeLayer({ home, cwd: tempRoot })));
   });
 
+  it.effect("reads the persisted profile file from SUPABASE_HOME when configured", () => {
+    const home = join(tempRoot, "home");
+    const supabaseHome = join(tempRoot, "custom-supabase-home");
+    mkdirSync(supabaseHome, { recursive: true });
+    writeFileSync(join(supabaseHome, "profile"), "supabase-staging\n");
+    return Effect.gen(function* () {
+      const config = yield* LegacyCliConfig;
+      expect(config.profile).toBe("supabase-staging");
+    }).pipe(
+      Effect.provide(makeLayer({ home, cwd: tempRoot, env: { SUPABASE_HOME: supabaseHome } })),
+    );
+  });
+
   it.effect("debug logs the persisted profile file source", () => {
     const home = join(tempRoot, "home");
     const profilePath = join(home, ".supabase", "profile");

--- a/apps/cli/src/legacy/config/legacy-profile-file.ts
+++ b/apps/cli/src/legacy/config/legacy-profile-file.ts
@@ -1,14 +1,28 @@
 import { Data, Effect, FileSystem, Path } from "effect";
+import { resolveSupabaseHome } from "../../shared/config/supabase-home.ts";
 
 /**
- * Helpers for the persisted profile-name file `~/.supabase/profile`, mirroring
- * Go's `getProfileName` file fallback and `SaveProfileName`
+ * Helpers for the persisted profile-name file under the global Supabase home,
+ * mirroring Go's `getProfileName` file fallback and `SaveProfileName`
  * (`apps/cli-go/internal/utils/profile.go:121-152`).
  *
  * `login` writes this file (on success, when a profile was explicitly set) so a
  * later command run without `--profile` / `SUPABASE_PROFILE` resolves the same
  * profile; `LegacyCliConfig` reads it as the lowest-precedence profile source.
  */
+
+/**
+ * Resolves the global Supabase home for the legacy shell. Delegates to the
+ * shared `resolveSupabaseHome` contract (honors `SUPABASE_HOME`, else
+ * `<homeDir>/.supabase`). The legacy shell reads ambient `process.env` directly,
+ * matching Go parity, so `env` defaults to it.
+ */
+export function legacySupabaseHome(
+  homeDir: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  return resolveSupabaseHome(env, homeDir);
+}
 
 /** Raised when persisting the profile name fails — Go's `SaveProfileName` error,
  * which `login`'s PostRunE returns to block subsequent CI commands
@@ -17,11 +31,15 @@ export class LegacyProfileSaveError extends Data.TaggedError("LegacyProfileSaveE
   readonly message: string;
 }> {}
 
-export function legacyProfileFilePath(path: Path.Path, homeDir: string): string {
-  return path.join(homeDir, ".supabase", "profile");
+export function legacyProfileFilePath(
+  path: Path.Path,
+  homeDir: string,
+  env?: Readonly<Record<string, string | undefined>>,
+): string {
+  return path.join(legacySupabaseHome(homeDir, env), "profile");
 }
 
-/** Writes the profile name to `~/.supabase/profile`. Fatal on failure (Go parity). */
+/** Writes the profile name to `<SUPABASE_HOME or ~/.supabase>/profile`. Fatal on failure (Go parity). */
 export const saveLegacyProfileName = (
   fs: FileSystem.FileSystem,
   path: Path.Path,

--- a/apps/cli/src/legacy/telemetry/legacy-telemetry-state.layer.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-telemetry-state.layer.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import { TelemetryRuntime } from "../../shared/telemetry/runtime.service.ts";
 import { isEphemeralIdentityRuntime } from "../../shared/telemetry/identity.ts";
+import { legacySupabaseHome } from "../config/legacy-profile-file.ts";
 import { LegacyTelemetryState } from "./legacy-telemetry-state.service.ts";
 
 interface State {
@@ -19,11 +20,7 @@ const SCHEMA_VERSION = 1;
 const SESSION_ROTATION_MS = 30 * 60 * 1000;
 
 function legacyTelemetryPath(env: Record<string, string | undefined>, pathSvc: Path.Path): string {
-  const supabaseHome = env["SUPABASE_HOME"]?.trim();
-  if (supabaseHome !== undefined && supabaseHome.length > 0) {
-    return pathSvc.join(supabaseHome, "telemetry.json");
-  }
-  return pathSvc.join(homedir(), ".supabase", "telemetry.json");
+  return pathSvc.join(legacySupabaseHome(homedir(), env), "telemetry.json");
 }
 
 interface PriorState {

--- a/apps/cli/src/next/commands/logout/logout.guide.md
+++ b/apps/cli/src/next/commands/logout/logout.guide.md
@@ -4,7 +4,7 @@ Log out of Supabase and remove the stored access token from your system.
 
 ## When to use
 
-Run to revoke local CLI access — for example when switching accounts, on a shared machine, or after finishing work. The stored token is deleted from your system keyring (or the fallback file `~/.supabase/access-token`). After logging out, commands that require auth will prompt you to log in again.
+Run to revoke local CLI access — for example when switching accounts, on a shared machine, or after finishing work. The stored token is deleted from your system keyring (or the fallback file `<SUPABASE_HOME or ~/.supabase>/access-token`). After logging out, commands that require auth will prompt you to log in again.
 
 <!-- USAGE:START -->
 <!-- USAGE:END -->

--- a/apps/cli/src/next/config/cli-config.layer.ts
+++ b/apps/cli/src/next/config/cli-config.layer.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer, Option, Redacted } from "effect";
+import { resolveSupabaseHome } from "../../shared/config/supabase-home.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { resolvePosthogConfig } from "../../shared/telemetry/posthog-config.ts";
 import { CliConfig } from "./cli-config.service.ts";
@@ -41,10 +42,7 @@ const makeCliConfig = Effect.gen(function* () {
       Redacted.make(token, { label: "SUPABASE_ACCESS_TOKEN" }),
     ),
     noKeyring: readEnv(effectiveEnv, "SUPABASE_NO_KEYRING"),
-    supabaseHome: Option.getOrElse(
-      readEnv(effectiveEnv, "SUPABASE_HOME"),
-      () => `${runtimeInfo.homeDir}/.supabase`,
-    ),
+    supabaseHome: resolveSupabaseHome(effectiveEnv, runtimeInfo.homeDir),
     debug: readEnv(effectiveEnv, "SUPABASE_DEBUG"),
     telemetryDebug: readEnv(effectiveEnv, "SUPABASE_TELEMETRY_DEBUG"),
     telemetryDisabled: readEnv(effectiveEnv, "SUPABASE_TELEMETRY_DISABLED"),

--- a/apps/cli/src/next/config/cli-config.layer.unit.test.ts
+++ b/apps/cli/src/next/config/cli-config.layer.unit.test.ts
@@ -189,6 +189,37 @@ describe("cliConfigLayer", () => {
     );
   });
 
+  it.live("uses SUPABASE_HOME (trimmed) when configured", () => {
+    const tempDir = makeTempDir();
+    const supabaseHome = join(tempDir, "custom-supabase-home");
+    return Effect.gen(function* () {
+      const cliConfig = yield* CliConfig;
+
+      expect(cliConfig.supabaseHome).toBe(supabaseHome);
+    }).pipe(
+      Effect.provide(buildLayer({ cwd: tempDir, env: { SUPABASE_HOME: `  ${supabaseHome}  ` } })),
+      Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+    );
+  });
+
+  for (const value of ["", "   "]) {
+    it.live(
+      `falls back to <homeDir>/.supabase when SUPABASE_HOME is ${JSON.stringify(value)}`,
+      () => {
+        const tempDir = makeTempDir();
+        const homeDir = join(tempDir, "home");
+        return Effect.gen(function* () {
+          const cliConfig = yield* CliConfig;
+
+          expect(cliConfig.supabaseHome).toBe(join(homeDir, ".supabase"));
+        }).pipe(
+          Effect.provide(buildLayer({ cwd: tempDir, homeDir, env: { SUPABASE_HOME: value } })),
+          Effect.ensuring(Effect.tryPromise(() => rm(tempDir, { recursive: true, force: true }))),
+        );
+      },
+    );
+  }
+
   it.live("uses the build-injected PostHog key and host when no runtime override is set", () => {
     const tempDir = makeTempDir();
     return Effect.gen(function* () {

--- a/apps/cli/src/shared/config/supabase-home.ts
+++ b/apps/cli/src/shared/config/supabase-home.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+
+/**
+ * Resolves the global Supabase CLI state root.
+ *
+ * `SUPABASE_HOME` overrides the location when set to a non-empty value after
+ * trimming surrounding whitespace (an absolute path is expected; the value is
+ * used verbatim). Otherwise it defaults to `<homeDir>/.supabase`.
+ *
+ * This is the single source of truth for the `SUPABASE_HOME` contract in the
+ * TypeScript CLI. It is a pure function: callers pass their own environment and
+ * home directory so it stays trivially testable and free of global state. The
+ * legacy and next shells both resolve through it; libraries such as
+ * `@supabase/stack` never read `SUPABASE_HOME` themselves and instead receive
+ * the resolved path from the CLI.
+ */
+export const resolveSupabaseHome = (
+  env: Readonly<Record<string, string | undefined>>,
+  homeDir: string,
+): string => {
+  const configured = env["SUPABASE_HOME"]?.trim();
+  return configured !== undefined && configured.length > 0
+    ? configured
+    : join(homeDir, ".supabase");
+};

--- a/apps/cli/src/shared/config/supabase-home.unit.test.ts
+++ b/apps/cli/src/shared/config/supabase-home.unit.test.ts
@@ -1,0 +1,31 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveSupabaseHome } from "./supabase-home.ts";
+
+const HOME = join("/home", "test");
+
+describe("resolveSupabaseHome", () => {
+  it("returns SUPABASE_HOME when set to a non-empty value", () => {
+    expect(resolveSupabaseHome({ SUPABASE_HOME: "/custom/supabase" }, HOME)).toBe(
+      "/custom/supabase",
+    );
+  });
+
+  it("trims surrounding whitespace from SUPABASE_HOME", () => {
+    expect(resolveSupabaseHome({ SUPABASE_HOME: "  /custom/supabase  " }, HOME)).toBe(
+      "/custom/supabase",
+    );
+  });
+
+  it("falls back to <homeDir>/.supabase when SUPABASE_HOME is unset", () => {
+    expect(resolveSupabaseHome({}, HOME)).toBe(join(HOME, ".supabase"));
+  });
+
+  it("falls back to <homeDir>/.supabase when SUPABASE_HOME is empty", () => {
+    expect(resolveSupabaseHome({ SUPABASE_HOME: "" }, HOME)).toBe(join(HOME, ".supabase"));
+  });
+
+  it("falls back to <homeDir>/.supabase when SUPABASE_HOME is whitespace only", () => {
+    expect(resolveSupabaseHome({ SUPABASE_HOME: "   " }, HOME)).toBe(join(HOME, ".supabase"));
+  });
+});

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -27,7 +27,7 @@ ADR 0001 Pillar 5 and ADR 0002 share infrastructure. No separate metrics SDK and
      ┌─────────────┼─────────────┐
      ▼             ▼             ▼
 Local file      --debug       Remote
-~/.supabase/        output        export
+state root/     output        export
 traces/         (always)      (opt-in)
 (always)           │               │
      │             │         ┌─────┴─────┐
@@ -38,6 +38,8 @@ Observability  Observability Sentry    Grafana
 ```
 
 Sentry receives every command span via its native OpenTelemetry integration and powers error diagnostics, performance monitoring, and product analytics dashboards for all 5 metric categories from ADR 0002. In Phase 2, spans will also be exported to a company-owned Grafana instance via OTLP for long-term retention and custom analytics. The CLI code does not change between phases — only the exporter configuration.
+
+In the diagram, "state root" means `<SUPABASE_HOME or ~/.supabase>`.
 
 ## Collection Architecture
 
@@ -112,7 +114,7 @@ command({
 
 **Anonymous phase** — before login:
 
-`device_id`: random UUID generated on first run, persisted in `~/.supabase/telemetry.json`. Never changes unless the file is deleted. This is the only identity before the user runs `supabase login`. It is attached to every span as the `cli.device_id` resource attribute.
+`device_id`: random UUID generated on first run, persisted in `<SUPABASE_HOME or ~/.supabase>/telemetry.json`. Never changes unless the file is deleted. This is the only identity before the user runs `supabase login`. It is attached to every span as the `cli.device_id` resource attribute.
 
 `session_id`: random UUID that rotates after 30 minutes of inactivity (no CLI commands). This defines "session" for the Engagement metrics.
 
@@ -156,7 +158,7 @@ Privacy guarantees:
 
 ## Local Storage
 
-NDJSON files in `~/.supabase/traces/`:
+NDJSON files in `<SUPABASE_HOME or ~/.supabase>/traces/`:
 
 - One file per day: `2025-01-15.ndjson`
 - 7-day automatic retention (older files deleted on CLI startup)
@@ -246,7 +248,7 @@ span.setStatus({ code: SpanStatusCode.OK });
 span.end();
 
 // 5. Always: append to local trace file
-// ~/.supabase/traces/2025-01-15.ndjson += JSON.stringify(spanData) + "\n"
+// <SUPABASE_HOME or ~/.supabase>/traces/2025-01-15.ndjson += JSON.stringify(spanData) + "\n"
 
 // 6. If consent === "granted": Sentry SDK exports the span
 // Non-blocking — SDK batches internally
@@ -334,7 +336,7 @@ rootSpan.end();
 
 ## Consent Implementation
 
-Three-state model stored in `~/.supabase/telemetry.json`:
+Three-state model stored in `<SUPABASE_HOME or ~/.supabase>/telemetry.json`:
 
 ```typescript
 type ConsentState = "pending" | "granted" | "denied";


### PR DESCRIPTION
## What changed

Routes the global CLI state root through a single `SUPABASE_HOME` resolver in each language the CLI is written in, so `SUPABASE_HOME` consistently overrides every machine-global state path instead of being honored on some paths and hard-coded to `~/.supabase` on others.

- **Go CLI** — new `utils.SupabaseHomeDir()` helper, used by the access-token, profile, telemetry, and Deno-binary paths. Previously only telemetry state honored `SUPABASE_HOME`.
- **TypeScript CLI** — new pure `resolveSupabaseHome(env, homeDir)` helper as the single source of truth, used by both the `next` and `legacy` shells for the access-token fallback file and the persisted profile file.
- **Docs** — auth, telemetry, and login/logout docs now describe the state root as `<SUPABASE_HOME or ~/.supabase>`.

## Why

`SUPABASE_HOME` is the documented global state root, but several paths bypassed it. Most concretely, the `next` shell honored `SUPABASE_HOME` for the access-token file while the Go and `legacy` shells hard-coded `~/.supabase` — so a token or profile written under a custom `SUPABASE_HOME` by one shell was not found by another. This aligns every path on the documented behavior.

## Design notes

`SUPABASE_HOME` is treated as an application (CLI) concern. The resolver lives only in the two languages the CLI is written in (Go and TypeScript). Libraries stay env-agnostic: `@supabase/stack` continues to receive its cache root from the CLI as an explicit `cacheRoot` and never reads `SUPABASE_HOME` itself, and `@supabase/config` is project-local and unaffected. This keeps `@supabase/stack` ergonomic for standalone and test use (an optional `cacheRoot` with a plain `~/.supabase` default).

This keeps a single relocatable home (no separate `SUPABASE_CACHEDIR` or XDG split), matching the `CARGO_HOME` precedent referenced in the issue. The access token's primary store is the OS keychain; the `SUPABASE_HOME` file is only the no-keyring fallback.

Closes #5214.
