### PR TITLE
chore(cli): downgrade realtime image to v2.108.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,17 @@ updates:
       - dependency-name: "axllent/mailpit"
       - dependency-name: "darthsim/imgproxy"
       - dependency-name: "timberio/vector"
+      # Held back: v2.109.0+ adds a setup_supabase_realtime_admin migration
+      # that fails against the CLI's local Postgres and breaks `supabase start`.
+      # Remove once the CLI's local stack is compatible with the new migration.
+      - dependency-name: "supabase/realtime"
+        versions:
+          - ">= 2.109.0"
+      # Held back: 1.45.0 is not mirrored to the ghcr registry CI pulls from
+      # ("manifest unknown"). Remove once a mirrored tag is available.
+      - dependency-name: "supabase/logflare"
+        versions:
+          - ">= 1.45.0"
     cooldown:
       default-days: 7
       exclude:

--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -11,7 +11,7 @@ FROM supabase/edge-runtime:v1.74.1 AS edgeruntime
 FROM timberio/vector:0.53.0-alpine AS vector
 FROM supabase/supavisor:2.9.7 AS supavisor
 FROM supabase/gotrue:v2.190.0 AS gotrue
-FROM supabase/realtime:v2.109.1 AS realtime
+FROM supabase/realtime:v2.108.0 AS realtime
 FROM supabase/storage-api:v1.60.21 AS storage
 FROM supabase/logflare:1.45.0 AS logflare
 # Append to JobImages when adding new dependencies below

--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -13,7 +13,7 @@ FROM supabase/supavisor:2.9.7 AS supavisor
 FROM supabase/gotrue:v2.190.0 AS gotrue
 FROM supabase/realtime:v2.108.0 AS realtime
 FROM supabase/storage-api:v1.60.21 AS storage
-FROM supabase/logflare:1.45.0 AS logflare
+FROM supabase/logflare:1.44.3 AS logflare
 # Append to JobImages when adding new dependencies below
 FROM supabase/pgadmin-schema-diff:cli-0.0.5 AS differ
 FROM supabase/migra:3.0.1663481299 AS migra


### PR DESCRIPTION
Downgrades the Supabase Realtime Docker image from v2.109.1 to v2.108.0 in the generated Dockerfile template.

This change updates the base image version used in the CLI's Docker configuration for local development environments.

https://claude.ai/code/session_01RLY7KJJ6So673p6ung8yFV