### PR TITLE
ci(release): register QEMU before containerd restart for arm64 smoke tests

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -116,6 +116,17 @@ jobs:
           enableCrossOsArchive: true
           fail-on-cache-miss: true
 
+      # Register the QEMU binfmt handlers BEFORE restarting Docker below.
+      # binfmt_misc registrations live in the host kernel, but containerd
+      # snapshots the set of emulated platforms at daemon startup. If QEMU is
+      # installed after the restart, containerd never sees the arm64 handler
+      # and every `docker run --platform linux/arm64` dies with
+      # "exec /bin/sh: exec format error". Installing first, restarting second
+      # guarantees the restarted daemon discovers linux/arm64.
+      - name: Setup QEMU for cross-platform Docker
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
       # Docker's classic image store keeps a single platform manifest per
       # tag, so pulling `alpine:3.21` for amd64 and again for arm64 leaves
       # only the most recent one in the local store — and `docker save`
@@ -129,10 +140,13 @@ jobs:
           echo '{"features":{"containerd-snapshotter":true}}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker info --format '{{.DriverStatus}}'
-
-      - name: Setup QEMU for cross-platform Docker
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+          # Fail fast with a clear message if the restarted daemon did not pick
+          # up the arm64 emulator, rather than surfacing later as opaque
+          # "exec format error" lines in the smoke tests. Reads the kernel
+          # binfmt_misc state directly — no image pull, no network.
+          echo "::group::Verify linux/arm64 binfmt handler is registered and enabled"
+          grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64
+          echo "::endgroup::"
 
       # Cache the smoke-test base images across runs. Without this, eight
       # parallel `docker run` calls in smoke-test-linux.ts race on first-time


### PR DESCRIPTION
## What changed

In the `smoke-test` job of `release-shared.yml`, register the QEMU binfmt handlers (`docker/setup-qemu-action`) **before** the "Enable containerd image store" step restarts Docker — previously the restart happened first. Also added a fast assertion (`grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64`) right after the restart.

## Why

containerd (the snapshotter image store) enumerates the set of emulated platforms **at daemon startup**. With the old ordering, Docker was restarted before the arm64 binfmt handler existed, so on a fresh runner the daemon never saw it and every `docker run --platform linux/arm64` died with `exec /bin/sh: exec format error`, failing all four `linux-arm64-*` package smoke tests.

This was **intermittent**, which is why it shipped unnoticed: warm/reused Blacksmith VMs already had arm64 binfmt registered from a prior job (and a warm `smoke-docker-images` cache), so the suite passed for weeks. It only failed on cold VMs, where the ordering race is exposed.

## Reviewer notes

- The failure correlates perfectly with a `smoke-docker-images-…` cache **miss** (a proxy for a cold VM) and with setup-qemu's "Extracting available platforms" reporting only native platforms (`linux/amd64,…,linux/386`) despite `--install all` printing `arm64 OK`. Verified across 6 release runs (2026-06-17 → 06-20): every green run had a cache hit + arm64 present; both 06-20 reds had a cache miss + arm64 absent.
- The ordering was introduced in #5258. It is not a code regression — the only commit between the last green and first red release run was an unrelated `supabase/postgres` bump.
- Safe because `binfmt_misc` registrations are kernel-level (registered with the `F` fix-binary flag) and survive the subsequent Docker restart.
- Reproducing requires a cold runner, so this can't be fully exercised until a real release lands on a fresh VM; the new assertion makes any future cold-VM regression fail fast with a clear message instead of opaque exec-format errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)