### PR TITLE
fix(functions): forward npm auth token to Docker bundler

### DIFF
--- a/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
@@ -1280,11 +1280,9 @@ describe("functions deploy", () => {
       );
 
       expect(forwardedEnv).toEqual(
-        expect.arrayContaining([
-          "NPM_CONFIG_REGISTRY=https://npm.pkg.github.com",
-          "NPM_AUTH_TOKEN=test-token",
-        ]),
+        expect.arrayContaining(["NPM_CONFIG_REGISTRY", "NPM_AUTH_TOKEN"]),
       );
+      expect(forwardedEnv).not.toContain("NPM_AUTH_TOKEN=test-token");
     }).pipe(Effect.ensuring(Effect.all([cleanupTempDir(tempDir), restoreEnv])));
   });
 

--- a/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
@@ -1224,6 +1224,70 @@ describe("functions deploy", () => {
     }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
   });
 
+  it.live("forwards npm auth environment to the Docker bundler", () => {
+    const tempDir = makeTempDir();
+    const previousRegistry = process.env["NPM_CONFIG_REGISTRY"];
+    const previousToken = process.env["NPM_AUTH_TOKEN"];
+    const child = mockChildProcessSpawner({
+      exitCode: 0,
+      onSpawn: (record) => {
+        if (record.command !== "docker" || record.args[0] !== "run") {
+          return;
+        }
+        const outputPath = resolveDockerOutputPath(record.args);
+        mkdirSync(dirname(outputPath), { recursive: true });
+        writeFileSync(outputPath, "eszip-test-output");
+      },
+    });
+
+    const restoreEnv = Effect.sync(() => {
+      if (previousRegistry === undefined) {
+        delete process.env["NPM_CONFIG_REGISTRY"];
+      } else {
+        process.env["NPM_CONFIG_REGISTRY"] = previousRegistry;
+      }
+      if (previousToken === undefined) {
+        delete process.env["NPM_AUTH_TOKEN"];
+      } else {
+        process.env["NPM_AUTH_TOKEN"] = previousToken;
+      }
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeProjectConfig(tempDir));
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+      yield* Effect.sync(() => {
+        process.env["NPM_CONFIG_REGISTRY"] = "https://npm.pkg.github.com";
+        process.env["NPM_AUTH_TOKEN"] = "test-token";
+      });
+
+      const { layer } = setup(tempDir, {
+        rawArgs: ["functions", "deploy", "hello-world", "--use-docker"],
+        childLayer: child.layer,
+      });
+
+      yield* functionsDeploy({
+        ...BASE_FLAGS,
+        functionNames: ["hello-world"],
+        useDocker: true,
+      }).pipe(Effect.provide(layer));
+
+      const dockerRun = child.spawned.find(
+        (record) => record.command === "docker" && record.args[0] === "run",
+      );
+      const forwardedEnv = dockerRun?.args.flatMap((arg, index, args) =>
+        args[index - 1] === "-e" ? [arg] : [],
+      );
+
+      expect(forwardedEnv).toEqual(
+        expect.arrayContaining([
+          "NPM_CONFIG_REGISTRY=https://npm.pkg.github.com",
+          "NPM_AUTH_TOKEN=test-token",
+        ]),
+      );
+    }).pipe(Effect.ensuring(Effect.all([cleanupTempDir(tempDir), restoreEnv])));
+  });
+
   it.live("rejects unsupported edge runtime Deno versions for Docker bundling", () => {
     const tempDir = makeTempDir();
 

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -269,7 +269,7 @@ function dockerBindHostPath(bind: string) {
 function dockerNpmEnv(env: NodeJS.ProcessEnv = process.env): ReadonlyArray<string> {
   return dockerNpmEnvNames.flatMap((name) => {
     const value = env[name];
-    return value === undefined || value === "" ? [] : [`${name}=${value}`];
+    return value === undefined || value === "" ? [] : [name];
   });
 }
 

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -240,6 +240,7 @@ function localDockerId(name: string, projectId: string) {
 
 const dockerCliProjectLabel = "com.supabase.cli.project";
 const dockerComposeProjectLabel = "com.docker.compose.project";
+const dockerNpmEnvNames = ["NPM_CONFIG_REGISTRY", "NPM_AUTH_TOKEN"] as const;
 
 function dockerProjectLabels(projectId: string) {
   return {
@@ -263,6 +264,13 @@ function dockerBindHostPath(bind: string) {
   const withoutMode = bind.replace(/:(?:ro|rw)$/, "");
   const separatorIndex = withoutMode.lastIndexOf(":");
   return separatorIndex === -1 ? withoutMode : withoutMode.slice(0, separatorIndex);
+}
+
+function dockerNpmEnv(env: NodeJS.ProcessEnv = process.env): ReadonlyArray<string> {
+  return dockerNpmEnvNames.flatMap((name) => {
+    const value = env[name];
+    return value === undefined || value === "" ? [] : [`${name}=${value}`];
+  });
 }
 
 function toApiRelativePath(cwd: string, hostPath: string) {
@@ -1256,8 +1264,8 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
     ) {
       command.push("-e", "DENO_NO_PACKAGE_JSON=1");
     }
-    if (process.env["NPM_CONFIG_REGISTRY"] !== undefined) {
-      command.push("-e", `NPM_CONFIG_REGISTRY=${process.env["NPM_CONFIG_REGISTRY"]}`);
+    for (const env of dockerNpmEnv()) {
+      command.push("-e", env);
     }
 
     command.push(


### PR DESCRIPTION
Ports the Docker bundler npm env forwarding from #4933 into the TypeScript functions deploy implementation.

The TS deploy path already forwarded NPM_CONFIG_REGISTRY from the host, but did not forward NPM_AUTH_TOKEN, so .npmrc entries that expand ${NPM_AUTH_TOKEN} could fail when Docker resolves private npm packages. This keeps the scope to host environment forwarding only; it does not load supabase/functions/.env during deploy.

Refs #4927.
Refs #4933.