### PR TITLE
refactor(cli-go): extract envOrDefault helper and make Kong workers configurable

### DIFF
--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -526,7 +526,11 @@ vector --config /etc/vector/vector.yaml
 					// Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126
 					"KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k",
 					"KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k",
-					"KONG_NGINX_WORKER_PROCESSES=1",
+					// Default to a single nginx worker to minimize the local stack's
+					// memory usage (Ref: #1271). Operators who need more throughput can
+					// override this from their shell, e.g. KONG_NGINX_WORKER_PROCESSES=auto
+					// for one worker per CPU core.
+					envOrDefault("KONG_NGINX_WORKER_PROCESSES", "1"),
 					// Use modern TLS certificate
 					"KONG_SSL_CERT=/home/kong/localhost.crt",
 					"KONG_SSL_CERT_KEY=/home/kong/localhost.key",
@@ -1407,6 +1411,15 @@ func appendGotrueExternalProviderEnv(env []string) []string {
 	return env
 }
 
+// envOrDefault formats a "KEY=value" container env entry, preferring the
+// operator's shell value for key when set and otherwise falling back to def.
+func envOrDefault(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return key + "=" + v
+	}
+	return key + "=" + def
+}
+
 // appendStorageVectorEnv wires the storage container with the vector-bucket
 // env contract from supabase/storage#1094. The CLI provides three CLI-owned
 // defaults that the operator can override from their shell environment:
@@ -1422,12 +1435,6 @@ func appendGotrueExternalProviderEnv(env []string) []string {
 //     credentials, but operators are expected to override this to reach an
 //     external postgres in self-hosted setups.
 func appendStorageVectorEnv(env []string, dbConfig pgconn.Config) []string {
-	envOrDefault := func(key, def string) string {
-		if v, ok := os.LookupEnv(key); ok {
-			return key + "=" + v
-		}
-		return key + "=" + def
-	}
 	defaultVectorURL := fmt.Sprintf(
 		"postgresql://postgres:%s@%s:%d/%s",
 		dbConfig.Password,


### PR DESCRIPTION
Extract the `envOrDefault` helper function to module scope so it can be reused across the codebase, and apply it to make the Kong nginx worker process count configurable while maintaining a sensible default.

**Key changes:**

- Moved `envOrDefault` from a local closure in `appendStorageVectorEnv` to a package-level function for reusability
- Applied `envOrDefault` to `KONG_NGINX_WORKER_PROCESSES` configuration, defaulting to `1` to minimize memory usage in local stacks
- Added documentation explaining the default and how operators can override it (e.g., `KONG_NGINX_WORKER_PROCESSES=auto` for one worker per CPU core)

This allows operators to tune Kong's throughput for their local development needs while keeping the default conservative for resource-constrained environments.

https://claude.ai/code/session_01CMFeivEEgffHFdpWMfawj2