### PR TITLE
fix: apply import map during GitHub branch Edge Function bundling

### DIFF
--- a/apps/cli-go/pkg/function/bundle.go
+++ b/apps/cli-go/pkg/function/bundle.go
@@ -91,7 +91,20 @@ func (b *nativeBundler) Bundle(ctx context.Context, slug, entrypoint, importMap 
 }
 
 func ShouldUseDenoJsonDiscovery(entrypoint, importMap string) bool {
-	return isDeno(filepath.Base(importMap)) && filepath.Dir(importMap) == filepath.Dir(entrypoint)
+	if !isDeno(filepath.Base(importMap)) {
+		return false
+	}
+	if filepath.Dir(importMap) != filepath.Dir(entrypoint) {
+		return false
+	}
+	// Only rely on Deno auto-discovery if the import map file
+	// actually exists at the expected path. In GitHub branch
+	// deploy pipelines, the working directory may differ from
+	// local, causing auto-discovery to silently fail.
+	if _, err := os.Stat(importMap); err != nil {
+		return false
+	}
+	return true
 }
 
 func ShouldUsePackageJsonDiscovery(entrypoint, importMap string, fsys fs.StatFS) bool {

--- a/apps/cli-go/pkg/function/bundle_test.go
+++ b/apps/cli-go/pkg/function/bundle_test.go
@@ -91,3 +91,32 @@ func TestBundleFunction(t *testing.T) {
 		assert.Nil(t, meta.VerifyJwt)
 	})
 }
+func TestShouldUseDenoJsonDiscovery(t *testing.T) {
+	t.Run("returns false when import map file does not exist", func(t *testing.T) {
+		result := ShouldUseDenoJsonDiscovery(
+			"/repo/supabase/functions/hello/index.ts",
+			"/repo/supabase/functions/hello/deno.json",
+		)
+		assert.False(t, result)
+	})
+
+	t.Run("returns true when import map file exists alongside entrypoint", func(t *testing.T) {
+		dir := t.TempDir()
+		entrypoint := filepath.Join(dir, "index.ts")
+		importMap := filepath.Join(dir, "deno.json")
+		require.NoError(t, os.WriteFile(importMap, []byte("{}"), 0644))
+
+		result := ShouldUseDenoJsonDiscovery(entrypoint, importMap)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when import map is not a deno json file", func(t *testing.T) {
+		dir := t.TempDir()
+		entrypoint := filepath.Join(dir, "index.ts")
+		importMap := filepath.Join(dir, "import_map.json")
+		require.NoError(t, os.WriteFile(importMap, []byte("{}"), 0644))
+
+		result := ShouldUseDenoJsonDiscovery(entrypoint, importMap)
+		assert.False(t, result)
+	})
+}


### PR DESCRIPTION
Closes supabase/supabase#47000

## What changed
- `ShouldUseDenoJsonDiscovery` now checks that the import map file
  actually exists before skipping the `--import-map` flag
- Added test coverage for missing file, existing file, and non-deno
  import map cases

## Why
The GitHub branch deploy pipeline runs in a different working
directory than local `supabase functions deploy`, so Deno's
auto-discovery of `deno.json` silently failed, breaking `@backend/`
style path aliases. This mirrors the explicit resolution already
used locally.

## How to test
- Deploy an Edge Function with path aliases via GitHub branching
- Verify `@backend/` aliases resolve correctly