### PR TITLE
chore(cli-go): regenerate API types for organization member avatar_url

### DIFF
--- a/apps/cli-go/pkg/api/types.gen.go
+++ b/apps/cli-go/pkg/api/types.gen.go
@@ -4857,11 +4857,12 @@ type V1ListMigrationsResponse = []struct {
 
 // V1OrganizationMemberResponse defines model for V1OrganizationMemberResponse.
 type V1OrganizationMemberResponse struct {
-	Email      *string `json:"email,omitempty"`
-	MfaEnabled bool    `json:"mfa_enabled"`
-	RoleName   string  `json:"role_name"`
-	UserId     string  `json:"user_id"`
-	UserName   string  `json:"user_name"`
+	AvatarUrl  nullable.Nullable[string] `json:"avatar_url"`
+	Email      *string                   `json:"email,omitempty"`
+	MfaEnabled bool                      `json:"mfa_enabled"`
+	RoleName   string                    `json:"role_name"`
+	UserId     string                    `json:"user_id"`
+	UserName   string                    `json:"user_name"`
 }
 
 // V1OrganizationSlugResponse defines model for V1OrganizationSlugResponse.


### PR DESCRIPTION
## What changed

Regenerates `apps/cli-go/pkg/api/types.gen.go` from the live OpenAPI spec. The only change is a new `avatar_url` field on `V1OrganizationMemberResponse`.

## Why

The upstream API spec (`https://api.supabase.green/api/v1-yaml`, the source for `go generate`) added `avatar_url` to the organization member response. The committed generated file no longer matches `go generate` output, so the **Codegen** CI check (`git diff --exit-code pkg` after `go generate`) started failing on `develop` and consequently on every open PR. Regenerating restores the check.

This is the standard generated-types drift; no hand-written code or behavior changes.