### PR TITLE
chore(ci): exclude generated API code from CODEOWNERS review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,7 @@
 /apps/cli-go/pkg/config/templates/Dockerfile
 /pnpm-lock.yaml
 /pnpm-workspace.yaml
+
+# Generated code. These ownerless rules override the catch-all above so
+# CI-green sync PRs (e.g. Management API OpenAPI spec) can be auto-merged.
+/packages/api/src/generated/


### PR DESCRIPTION
Adds an ownerless rule for `/packages/api/src/generated/` to `.github/CODEOWNERS`.

The catch-all `* @supabase/cli` requires CLI-team code-owner review on every PR. A later, more-specific rule with no owner removes that required reviewer for matching paths — the same mechanism already used for the Dependabot dependency surfaces.

This unblocks the recurring Management API OpenAPI spec sync PRs (e.g. #5662), whose entire diff lives under `packages/api/src/generated/`, so they no longer wait on code-owner review and can be auto-merged once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)