### PR TITLE
test(cli): guard config schema against inbucket name leakage

### DIFF
--- a/packages/config/src/io.unit.test.ts
+++ b/packages/config/src/io.unit.test.ts
@@ -674,7 +674,9 @@ major_version = 16
     expect(schemaString).toContain("remotes");
     expect(schemaString).toContain("static_files");
     expect(schemaString).toContain("env");
-    expect(schemaString).not.toContain("inbucket");
+    // The deprecated implementation name must not leak anywhere in the schema,
+    // including descriptions (case-insensitive guard).
+    expect(schemaString.toLowerCase()).not.toContain("inbucket");
     expect(schemaString).not.toContain("versions");
   });
 


### PR DESCRIPTION
Follow-up to #5333 (the `inbucket` → `local_smtp` config rename).

Strengthens the config-schema unit test so the deprecated implementation name cannot creep back into the published schema: the assertion now checks the generated schema case-insensitively (`schemaString.toLowerCase()`), covering descriptions as well as keys — not just the lowercase `inbucket` substring.

#5333 already removed the last user-facing `inbucket` references (the section key, plus the schema descriptions/link which now point at the actual local tool, Mailpit). This test makes that invariant durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)