### PR TITLE
ci: auto-approve and auto-merge API package sync PRs

### DIFF
--- a/.github/workflows/api-package-sync.yml
+++ b/.github/workflows/api-package-sync.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check.outputs.has_changes == 'true'
+        id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -63,3 +64,18 @@ jobs:
             Changes were detected in the upstream OpenAPI document exposed by `https://api.supabase.com/api/v1-json`.
           branch: sync/api-package
           base: develop
+
+      - name: Approve a PR
+        if: steps.check.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-operation == 'created'
+        continue-on-error: true
+        run: gh pr review --approve --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+
+      - name: Enable Pull Request Automerge
+        if: steps.check.outputs.has_changes == 'true'
+        run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Brings the `@supabase/api` package sync workflow in line with the Go CLI API sync workflow ([cli-go-api-sync.yml](.github/workflows/cli-go-api-sync.yml)), which already auto-approves and auto-merges its generated PRs.

Previously [api-package-sync.yml](.github/workflows/api-package-sync.yml) created a PR on its hourly cron but stopped there — every sync PR waited on a human even when all checks were green.

Changes:
- Add `id: cpr` to the Create Pull Request step so its outputs can be referenced.
- Add an Approve step that runs only when a PR was actually created (`pull-request-operation == 'created'`), with `continue-on-error: true` so re-runs against an existing PR don't fail the job.
- Add an Enable Pull Request Automerge step (`gh pr merge --auto --squash`) so the PR merges once required checks pass.

Note: relies on the repo's "Allow auto-merge" setting and branch protection on `develop` requiring checks — the same prerequisites the Go sync workflow already depends on.