### PR TITLE
fix(docker): bump logflare to 1.45.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,11 +71,6 @@ updates:
       - dependency-name: "supabase/realtime"
         versions:
           - ">= 2.109.0"
-      # Held back: 1.45.0 is not mirrored to the ghcr registry CI pulls from
-      # ("manifest unknown"). Remove once a mirrored tag is available.
-      - dependency-name: "supabase/logflare"
-        versions:
-          - ">= 1.45.0"
     cooldown:
       default-days: 7
       exclude:

--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -13,7 +13,7 @@ FROM supabase/supavisor:2.9.7 AS supavisor
 FROM supabase/gotrue:v2.191.0 AS gotrue
 FROM supabase/realtime:v2.108.0 AS realtime
 FROM supabase/storage-api:v1.60.29 AS storage
-FROM supabase/logflare:1.44.3 AS logflare
+FROM supabase/logflare:1.45.3 AS logflare
 # Append to JobImages when adding new dependencies below
 FROM supabase/pgadmin-schema-diff:cli-0.0.5 AS differ
 FROM supabase/migra:3.0.1663481299 AS migra


### PR DESCRIPTION
## Summary
- Bump the local stack logflare image from `1.44.3` to `1.45.3` in the CLI Dockerfile manifest.
- Remove the stale Dependabot ignore for `supabase/logflare` versions `>= 1.45.0` — those tags are now mirrored to GHCR and ECR.