### PR TITLE
fix(stack): retry edge function cold-start to avoid first-request 502

### DIFF
--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option, Context } from "effect";
+import { Effect, Layer, Option, Context, Schedule, Result } from "effect";
 import {
   Headers,
   HttpBody,
@@ -105,6 +105,13 @@ function addCorsHeaders(
   );
 }
 
+// Edge Functions cold-boot lazily: the first request to a function makes the
+// edge-runtime spin up a user worker, and it can drop the connection while it
+// does so. Its `/_internal/health` probe answers immediately, so "Healthy"
+// status does not mean a function is servable yet. Briefly retry transport
+// failures on that route so a user's first call doesn't surface as a 502.
+const COLD_START_RETRY_SCHEDULE = Schedule.spaced("250 millis").pipe(Schedule.take(8));
+
 interface ProxyHandlerOptions {
   readonly backendPort: number;
   readonly stripPrefix?: string;
@@ -112,6 +119,10 @@ interface ProxyHandlerOptions {
   readonly transformAuth?: boolean;
   readonly transformAuthCustomHeader?: boolean;
   readonly extraHeaders?: Record<string, string>;
+  // Retry transient transport failures, for backends (edge-runtime) that may
+  // refuse/reset connections while cold-starting. Buffers the request body so
+  // it can be re-sent across attempts.
+  readonly retryColdStart?: boolean;
 }
 
 function makeProxyHandler(
@@ -145,16 +156,35 @@ function makeProxyHandler(
       const backendUrl = `http://127.0.0.1:${opts.backendPort}${backendPath}`;
       const noBodyMethods = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
       const contentType = Option.getOrUndefined(Headers.get(req.headers, "content-type"));
-      const body = noBodyMethods.has(req.method)
-        ? HttpBody.empty
-        : HttpBody.stream(req.stream, contentType);
+
+      let body: HttpBody.HttpBody;
+      if (noBodyMethods.has(req.method)) {
+        body = HttpBody.empty;
+      } else if (opts.retryColdStart === true) {
+        // Buffer the body so the request can be safely re-sent if we retry.
+        const buffered = yield* Effect.result(req.arrayBuffer);
+        if (Result.isFailure(buffered)) {
+          return HttpServerResponse.text("Bad gateway: unable to read request body", {
+            status: 502,
+          });
+        }
+        body = HttpBody.uint8Array(new Uint8Array(buffered.success), contentType);
+      } else {
+        body = HttpBody.stream(req.stream, contentType);
+      }
 
       const outReq = HttpClientRequest.make(req.method)(backendUrl, {
         headers: outHeaders,
         body,
       });
 
-      const outRes = yield* client.execute(outReq);
+      const request = client.execute(outReq);
+      const outRes = yield* opts.retryColdStart === true
+        ? Effect.retry(request, {
+            while: (error) => error.reason._tag === "TransportError",
+            schedule: COLD_START_RETRY_SCHEDULE,
+          })
+        : request;
       const responseHeaders = sanitizeProxyResponseHeaders(outRes.headers);
       return HttpServerResponse.stream(outRes.stream, {
         status: outRes.status,
@@ -263,6 +293,7 @@ export class ApiProxy extends Context.Service<
               stripPrefix: "/functions/v1",
               transformAuth: true,
               transformAuthCustomHeader: true,
+              retryColdStart: true,
             }),
           ),
           HttpRouter.route(

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -58,12 +58,70 @@ function startEchoBackend(): Promise<EchoServer> {
   });
 }
 
+interface FlakyServer {
+  readonly port: number;
+  readonly attempts: () => number;
+  readonly stop: () => Promise<void>;
+}
+
+// Backend that resets the connection (transport failure) for the first
+// `failFirst` requests, then responds 200 with `body`. Mirrors an edge-runtime
+// dropping connections while it cold-boots a user worker on first request.
+function startFlakyBackend(opts: { failFirst: number; body: string }): Promise<FlakyServer> {
+  return new Promise((resolve, reject) => {
+    let attempts = 0;
+    const server = http.createServer((req, incomingRes) => {
+      attempts += 1;
+      if (attempts <= opts.failFirst) {
+        req.socket.destroy();
+        return;
+      }
+      incomingRes.writeHead(200, {
+        "Content-Type": "text/plain",
+        "Content-Length": Buffer.byteLength(opts.body),
+      });
+      incomingRes.end(opts.body);
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Unexpected server address"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        attempts: () => attempts,
+        stop: () =>
+          new Promise<void>((res, rej) => server.close((err) => (err ? rej(err) : res()))),
+      });
+    });
+
+    server.on("error", reject);
+  });
+}
+
 // Builds the full proxy layer backed by a Node HTTP server.
 function buildProxyLayer(config: ProxyConfig): Layer.Layer<ApiProxy, never, never> {
   return ApiProxy.layer(config).pipe(
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
     Layer.provide(FetchHttpClient.layer),
   ) as Layer.Layer<ApiProxy, never, never>;
+}
+
+// Spins up a proxy for an ad-hoc config and returns its URL plus a disposer.
+async function startProxy(
+  config: ProxyConfig,
+): Promise<{ url: string; dispose: () => Promise<void> }> {
+  const proxyRuntime = ManagedRuntime.make(buildProxyLayer(config));
+  const proxy = await proxyRuntime.runPromise(ApiProxy);
+  const addr = proxy.address;
+  let url = "";
+  if (addr._tag === "TcpAddress") {
+    const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
+    url = `http://${host}:${addr.port}`;
+  }
+  return { url, dispose: () => proxyRuntime.dispose() };
 }
 
 describe("ApiProxy", () => {
@@ -325,6 +383,109 @@ describe("ApiProxy", () => {
       expect(res.status).toBe(502);
     } finally {
       await deadRuntime.dispose();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge-function cold-start: retry transient connection failures
+  // ---------------------------------------------------------------------------
+
+  function configForPort(port: number): ProxyConfig {
+    return {
+      listenPort: 0,
+      gotruePort: port,
+      postgrestPort: port,
+      postgrestAdminPort: port,
+      edgeRuntimePort: port,
+      realtimePort: port,
+      storagePort: port,
+      pgmetaPort: port,
+      analyticsPort: port,
+      poolerPort: port,
+      studioPort: port,
+      publishableKey: PUBLISHABLE_KEY,
+      secretKey: SECRET_KEY,
+      anonJwt: ANON_JWT,
+      serviceRoleJwt: SERVICE_ROLE_JWT,
+    };
+  }
+
+  test("retries transient connection failures on the functions route until it is servable", async () => {
+    const backend = await startFlakyBackend({ failFirst: 1, body: "hello" });
+    const proxy = await startProxy(configForPort(backend.port));
+    try {
+      const res = await fetch(`${proxy.url}/functions/v1/hello`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello");
+      expect(backend.attempts()).toBeGreaterThanOrEqual(2);
+    } finally {
+      await proxy.dispose();
+      await backend.stop();
+    }
+  });
+
+  test("does not retry non-functions routes on a connection failure", async () => {
+    const backend = await startFlakyBackend({ failFirst: 1, body: "ok" });
+    const proxy = await startProxy(configForPort(backend.port));
+    try {
+      const res = await fetch(`${proxy.url}/rest/v1/users`);
+      expect(res.status).toBe(502);
+      expect(backend.attempts()).toBe(1);
+    } finally {
+      await proxy.dispose();
+      await backend.stop();
+    }
+  });
+
+  test("replays the request body when retrying the functions route", async () => {
+    let attempts = 0;
+    // First request: reset the connection. Second: echo the received body back,
+    // so the assertion fails unless the buffered body was re-sent on retry.
+    const echoBody = await new Promise<FlakyServer>((resolve, reject) => {
+      const server = http.createServer((req, incomingRes) => {
+        attempts += 1;
+        if (attempts === 1) {
+          req.socket.destroy();
+          return;
+        }
+        let data = "";
+        req.on("data", (chunk) => (data += chunk));
+        req.on("end", () => {
+          incomingRes.writeHead(200, {
+            "Content-Type": "text/plain",
+            "Content-Length": Buffer.byteLength(data),
+          });
+          incomingRes.end(data);
+        });
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") {
+          reject(new Error("Unexpected server address"));
+          return;
+        }
+        resolve({
+          port: addr.port,
+          attempts: () => attempts,
+          stop: () =>
+            new Promise<void>((res, rej) => server.close((err) => (err ? rej(err) : res()))),
+        });
+      });
+      server.on("error", reject);
+    });
+
+    const proxy = await startProxy(configForPort(echoBody.port));
+    try {
+      const res = await fetch(`${proxy.url}/functions/v1/hello`, {
+        method: "POST",
+        body: "payload",
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("payload");
+      expect(echoBody.attempts()).toBeGreaterThanOrEqual(2);
+    } finally {
+      await proxy.dispose();
+      await echoBody.stop();
     }
   });
 });


### PR DESCRIPTION
## What

Add a bounded, transport-level retry to the local API proxy's `/functions/v1/*` route so the first request to an Edge Function does not surface as a `502 Bad Gateway` while edge-runtime cold-boots its user worker.

## Why

The proxy forwarded function requests to edge-runtime with no retry, mapping any transport `HttpClientError` straight to a 502. Edge functions cold-boot lazily: the first request to a function makes edge-runtime spin up a user worker, and the connection can be refused/reset during that window. The runtime's `/_internal/health` probe answers immediately, so the stack reporting `edge-runtime: Healthy` does **not** mean a given function is servable yet. The result is an intermittent one-off 502 on a user's first call — and the same race made the `packages/stack` edge-function e2e test flaky.

## How

- New `retryColdStart` option on the proxy handler, enabled only on the functions route (other routes proxy to already-warm services and are unchanged).
- Retries only transient `TransportError`s, spaced 250ms, bounded to 8 attempts (~2s ceiling).
- Buffers the request body into memory on that route so the request can be safely re-sent across attempts; a body-read failure returns a 502 instead.

Covered by new `ApiProxy.unit.test.ts` cases: the functions route retries a reset connection to success, non-functions routes do **not** retry, and the buffered body is replayed on retry (the last test fails if the body is streamed instead of buffered).