### PR TITLE
fix(cli): wait for all image pulls before starting containers

### DIFF
--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -244,7 +244,14 @@ func ensureImagesCached(ctx context.Context, project types.Project) error {
 		_, err := utils.DockerResolveImageIfNotCached(ctx, image)
 		return err
 	})
-	return errors.Join(result...)
+	// Set the install hint once, sequentially, after the concurrent resolve
+	// finishes, rather than from inside DockerResolveImageIfNotCached where the
+	// WaitAll goroutines would race on the CmdSuggestion global.
+	if err := errors.Join(result...); err != nil {
+		utils.SuggestDockerInstallIfConnectionFailed(err)
+		return err
+	}
+	return nil
 }
 
 func run(ctx context.Context, fsys afero.Fs, excludedContainers []string, dbConfig pgconn.Config, ignoreHealthCheck bool, options ...func(*pgx.ConnConfig)) error {

--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -215,6 +215,38 @@ func pullImagesUsingCompose(ctx context.Context, project types.Project) error {
 	return service.Pull(ctx, &project, api.PullOptions{IgnoreFailures: true})
 }
 
+// ensureImagesCached guarantees every image required by the project is present in
+// the local Docker cache before any container is started. The compose pre-pull is
+// best effort (PullOptions.IgnoreFailures) and only targets the primary registry,
+// so any image it skips would otherwise be pulled lazily by DockerStart while
+// containers are already starting. Resolving each image here, using the same
+// multi-registry fallback as DockerStart, keeps all pulls ahead of container start.
+//
+// project.Services[*].Image is the registry-normalized URL produced by GetServices
+// (via GetRegistryImageUrl), which DockerResolveImageIfNotCached expands back into
+// the same candidate set DockerStart later resolves against. On a warm cache this
+// is one ImageInspect per image (no pull, no output); that cost is intentional and
+// bounded by the fixed service count.
+func ensureImagesCached(ctx context.Context, project types.Project) error {
+	seen := make(map[string]struct{}, len(project.Services))
+	var images []string
+	for _, service := range project.Services {
+		if service.Image == "" {
+			continue
+		}
+		if _, ok := seen[service.Image]; ok {
+			continue
+		}
+		seen[service.Image] = struct{}{}
+		images = append(images, service.Image)
+	}
+	result := utils.WaitAll(images, func(image string) error {
+		_, err := utils.DockerResolveImageIfNotCached(ctx, image)
+		return err
+	})
+	return errors.Join(result...)
+}
+
 func run(ctx context.Context, fsys afero.Fs, excludedContainers []string, dbConfig pgconn.Config, ignoreHealthCheck bool, options ...func(*pgx.ConnConfig)) error {
 	excluded := make(map[string]bool)
 	for _, name := range excludedContainers {
@@ -236,6 +268,11 @@ func run(ctx context.Context, fsys afero.Fs, excludedContainers []string, dbConf
 		Services: utils.GetServices().Filter(notExcluded),
 	}
 	if err := pullImagesUsingCompose(ctx, project); err != nil {
+		return err
+	}
+	// Pull any images the best-effort compose pre-pull skipped, so that all pulls
+	// finish before containers start (https://github.com/supabase/cli/issues/5068).
+	if err := ensureImagesCached(ctx, project); err != nil {
 		return err
 	}
 

--- a/apps/cli-go/internal/start/start_test.go
+++ b/apps/cli-go/internal/start/start_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	composeTypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -18,6 +19,7 @@ import (
 	"github.com/h2non/gock"
 	"github.com/jackc/pgconn"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	phtelemetry "github.com/supabase/cli/internal/telemetry"
@@ -146,16 +148,20 @@ func TestDatabaseStart(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/networks/create").
 			Reply(http.StatusCreated).
 			JSON(network.CreateResponse{})
-		// Caches all dependencies
+		// Caches all dependencies. Each image is inspected several times during start:
+		// the compose pre-pull, the ensureImagesCached completeness pass, and the
+		// per-container DockerStart. Persist the inspect mocks so every lookup is a hit.
 		imageUrl := utils.GetRegistryImageUrl(utils.Config.Db.Image)
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
+			Persist().
 			Reply(http.StatusOK).
 			JSON(image.InspectResponse{})
 		for _, img := range config.Images.Services() {
 			service := utils.GetRegistryImageUrl(img)
 			gock.New(utils.Docker.DaemonHost()).
 				Get("/v" + utils.Docker.ClientVersion() + "/images/" + service + "/json").
+				Persist().
 				Reply(http.StatusOK).
 				JSON(image.InspectResponse{})
 		}
@@ -274,10 +280,12 @@ func TestDatabaseStart(t *testing.T) {
 			Post("/v" + utils.Docker.ClientVersion() + "/networks/create").
 			Reply(http.StatusCreated).
 			JSON(network.CreateResponse{})
-		// Caches all dependencies
+		// Caches all dependencies. The db image is inspected by the compose pre-pull,
+		// the ensureImagesCached completeness pass, and DockerStart, so persist the mock.
 		imageUrl := utils.GetRegistryImageUrl(utils.Config.Db.Image)
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images/" + imageUrl + "/json").
+			Persist().
 			Reply(http.StatusOK).
 			JSON(image.InspectResponse{})
 		// Start postgres
@@ -304,6 +312,73 @@ func TestDatabaseStart(t *testing.T) {
 		err := run(context.Background(), fsys, exclude, pgconn.Config{Host: utils.DbId}, false)
 		// Check error
 		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+}
+
+func TestEnsureImagesCached(t *testing.T) {
+	// Force a single registry candidate per image so the resolved URL is the raw
+	// image name, keeping the mocks simple. The multi-registry fallback itself is
+	// covered by utils.TestPullImage.
+	viper.Set("INTERNAL_IMAGE_REGISTRY", "docker.io")
+	t.Cleanup(func() { viper.Set("INTERNAL_IMAGE_REGISTRY", "") })
+
+	t.Run("pulls images the best-effort pre-pull skipped", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		cached := utils.GetRegistryImageUrl("test-image-cached")
+		missing := utils.GetRegistryImageUrl("test-image-missing")
+		// Already cached locally: resolved without a pull.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/images/" + cached + "/json").
+			Reply(http.StatusOK).
+			JSON(image.InspectResponse{})
+		// Missed by the compose pre-pull: must be pulled before ensureImagesCached returns.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/images/" + missing + "/json").
+			Reply(http.StatusNotFound)
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v"+utils.Docker.ClientVersion()+"/images/create").
+			MatchParam("fromImage", missing).
+			MatchParam("tag", "latest").
+			Reply(http.StatusAccepted)
+		// Run test
+		project := composeTypes.Project{
+			Name: "supabase-cli",
+			Services: composeTypes.Services{
+				"cached":  {Name: "cached", Image: cached},
+				"missing": {Name: "missing", Image: missing},
+			},
+		}
+		err := ensureImagesCached(context.Background(), project)
+		// Check error: gock.IsDone proves the missed image's images/create mock was
+		// consumed, i.e. the pull happened before ensureImagesCached returned. A no-op
+		// completeness pass would leave it pending and fail this assertion.
+		assert.NoError(t, err)
+		assert.True(t, gock.IsDone())
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("returns an error when an image cannot be resolved", func(t *testing.T) {
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		broken := utils.GetRegistryImageUrl("test-image-broken")
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/images/" + broken + "/json").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		project := composeTypes.Project{
+			Name: "supabase-cli",
+			Services: composeTypes.Services{
+				"broken": {Name: "broken", Image: broken},
+			},
+		}
+		err := ensureImagesCached(context.Background(), project)
+		// Check error: a failed resolve must propagate so run() aborts before any
+		// container is created.
+		assert.Error(t, err)
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }

--- a/apps/cli-go/internal/utils/docker.go
+++ b/apps/cli-go/internal/utils/docker.go
@@ -329,12 +329,6 @@ func DockerResolveImageIfNotCached(ctx context.Context, imageName string) (strin
 		if _, err := Docker.ImageInspect(ctx, imageUrl); err == nil {
 			return imageUrl, nil
 		} else if !errdefs.IsNotFound(err) {
-			// Surface the install hint here too: callers like ensureImagesCached
-			// resolve images before DockerStart runs, so this is the first place a
-			// "Docker not running" failure is seen.
-			if client.IsErrConnectionFailed(err) {
-				CmdSuggestion = suggestDockerInstall
-			}
 			return "", errors.Errorf("failed to inspect docker image: %w", err)
 		}
 	}
@@ -355,13 +349,22 @@ func DockerResolveImageIfNotCached(ctx context.Context, imageName string) (strin
 
 var suggestDockerInstall = "Docker Desktop is a prerequisite for local development. Follow the official docs to install: https://docs.docker.com/desktop"
 
+// SuggestDockerInstallIfConnectionFailed sets the install hint when err is a
+// Docker daemon connection failure. Callers that resolve images before
+// DockerStart (e.g. the concurrent ensureImagesCached pre-pull) call this once
+// on the aggregated error, so the hint is surfaced without racing on the
+// CmdSuggestion global from multiple goroutines.
+func SuggestDockerInstallIfConnectionFailed(err error) {
+	if client.IsErrConnectionFailed(err) {
+		CmdSuggestion = suggestDockerInstall
+	}
+}
+
 func DockerStart(ctx context.Context, config container.Config, hostConfig container.HostConfig, networkingConfig network.NetworkingConfig, containerName string) (string, error) {
 	// Pull container image
 	imageUrl, err := DockerResolveImageIfNotCached(ctx, config.Image)
 	if err != nil {
-		if client.IsErrConnectionFailed(err) {
-			CmdSuggestion = suggestDockerInstall
-		}
+		SuggestDockerInstallIfConnectionFailed(err)
 		return "", err
 	}
 	// Setup default config

--- a/apps/cli-go/internal/utils/docker.go
+++ b/apps/cli-go/internal/utils/docker.go
@@ -329,6 +329,12 @@ func DockerResolveImageIfNotCached(ctx context.Context, imageName string) (strin
 		if _, err := Docker.ImageInspect(ctx, imageUrl); err == nil {
 			return imageUrl, nil
 		} else if !errdefs.IsNotFound(err) {
+			// Surface the install hint here too: callers like ensureImagesCached
+			// resolve images before DockerStart runs, so this is the first place a
+			// "Docker not running" failure is seen.
+			if client.IsErrConnectionFailed(err) {
+				CmdSuggestion = suggestDockerInstall
+			}
 			return "", errors.Errorf("failed to inspect docker image: %w", err)
 		}
 	}

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { createHmac } from "node:crypto";
-import { Effect, Fiber, Layer, Stream } from "effect";
+import { Effect, Exit, Fiber, Layer, Stream } from "effect";
 import { mockChildProcessSpawner } from "../../process-compose/tests/helpers/mocks.ts";
 import { mockBinaryResolver } from "../tests/helpers/mocks.ts";
 import { defaultPublishableKey, defaultSecretKey, generateJwt } from "./JwtGenerator.ts";
@@ -362,6 +362,39 @@ describe("Stack", () => {
       const exit = yield* stack.startService("nonexistent").pipe(Effect.exit);
 
       expect(exit._tag).toBe("Failure");
+    }).pipe(Effect.provide(layer));
+  });
+
+  // Regression guard for https://github.com/supabase/cli/issues/5068: image
+  // acquisition must complete during preparation, so a failed pull aborts start
+  // instead of letting containers come up before their images are ready.
+  // it.live is required because the mock spawner resolves exit codes on the real
+  // clock; it.effect's TestClock would leave those sleeps pending.
+  it.live("start fails and never starts containers when a docker image pull fails", () => {
+    // Fail binary resolution so every service falls back to Docker, then fail
+    // every spawned docker command (image inspect + pull).
+    const resolver = mockBinaryResolver({ failServices: ["postgres", "postgrest", "auth"] });
+    const spawner = mockChildProcessSpawner({ exitCode: 1 });
+    const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
+    const coordinatorLayer = StackLifecycleCoordinator.layer(defaultConfig).pipe(
+      Layer.provide(StackBuilder.layer),
+      Layer.provide(stackPreparationLayer),
+      Layer.provide(StackMetadataPersistence.noop),
+    );
+    const layer = Stack.layer(defaultConfig).pipe(
+      Layer.provide(coordinatorLayer),
+      Layer.provide(spawner.layer),
+      Layer.provide(BunServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const exit = yield* stack.start().pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      // No container was ever started: only prepare-phase docker commands ran.
+      const startedContainers = spawner.spawned.filter((record) => record.args[0] === "run");
+      expect(startedContainers).toEqual([]);
     }).pipe(Effect.provide(layer));
   });
 });

--- a/packages/stack/src/prefetch.unit.test.ts
+++ b/packages/stack/src/prefetch.unit.test.ts
@@ -3,6 +3,7 @@ import { Deferred, Effect, Layer, Sink, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { mockBinaryResolver } from "../tests/helpers/mocks.ts";
 import { BinaryResolver } from "./BinaryResolver.ts";
+import { DockerPullError } from "./errors.ts";
 import { prefetch } from "./prefetch.ts";
 import {
   ServiceDownloadFinished,
@@ -158,6 +159,38 @@ describe("prefetch", () => {
       "supabase/gotrue:v2.188.0-rc.15",
       "ghcr.io/supabase/gotrue:v2.188.0-rc.15",
     ]);
+  });
+
+  test("preparation fails with DockerPullError when all registry candidates fail", async () => {
+    const resolver = mockBinaryResolver({ failServices: ["auth"] });
+    // 3 image inspects (not cached locally) followed by a non-retryable pull for
+    // each registry candidate (ECR, Docker Hub, GHCR). "manifest unknown" is not a
+    // retryable pattern, so each candidate gets exactly one pull attempt: 3 + 3 = 6
+    // spawns. With the whole fallback chain failing, preparation must fail rather
+    // than defer the pull to startup.
+    const spawner = mockSequenceSpawner([
+      { exitCode: 1 },
+      { exitCode: 1 },
+      { exitCode: 1 },
+      { exitCode: 1, stderr: ["manifest unknown"] },
+      { exitCode: 1, stderr: ["manifest unknown"] },
+      { exitCode: 1, stderr: ["manifest unknown"] },
+    ]);
+
+    const layer = StackPreparation.layer.pipe(
+      Layer.provide(resolver.layer),
+      Layer.provide(spawner.layer),
+    );
+
+    const error = await Effect.runPromise(
+      prefetch({ mode: "docker", services: ["auth"] }).pipe(Effect.provide(layer), Effect.flip),
+    );
+
+    expect(error).toBeInstanceOf(DockerPullError);
+    // Guard the spawn-count assumption above: if the retry/candidate logic changes
+    // so more spawns occur, the mock would default the extras to success and mask
+    // the failure. Assert the exact count so that regresses loudly instead.
+    expect(spawner.spawned).toHaveLength(6);
   });
 
   test("does not report downloading when the docker image is already cached locally", async () => {


### PR DESCRIPTION
## What changed

`supabase start` could start containers before their Docker images had finished downloading.

The command ran two uncoordinated image-acquisition paths:

1. A best-effort concurrent pre-pull (`pullImagesUsingCompose`) using docker-compose's `Pull` with `PullOptions{IgnoreFailures: true}`. It only targets the primary registry and, by design, **silently swallows per-image pull failures** (the `IgnoreFailures` flag is the hook that lets the registry fallback recover).
2. An authoritative lazy per-container pull inside `utils.DockerStart` → `DockerResolveImageIfNotCached` (multi-registry fallback: ECR → GHCR → Docker Hub).

So any image the concurrent pre-pull failed to cache — a transient registry/network/rate-limit hiccup, common on a fresh machine pulling 10+ images at once — was pulled **later**, during the `Starting database… / Starting containers…` phase. That is the "start doesn't wait for pulls" behaviour from the issue. The pre-pull was added in #4394, matching the reporter's "last few versions" regression window.

## The fix

Add `ensureImagesCached`, a completeness pass that runs immediately after the best-effort pre-pull and before any container starts. It resolves every project image through the **same** multi-registry fallback resolver `DockerStart` already uses (`DockerResolveImageIfNotCached`), fanned out concurrently via the existing `utils.WaitAll` primitive.

After it returns, every required image is guaranteed present in the local cache, so the per-container `DockerStart` calls become pure cache hits and never pull mid-start. On the happy path it is just N cheap image inspects; an image that genuinely cannot be pulled from any registry now fails the start cleanly **before** any container is created, instead of limping into a half-pulled start. The compose pre-pull (and its `IgnoreFailures`) is kept as the fast concurrent progress UI — it is simply no longer relied on for completeness.

## TypeScript port

The native-TS port already pulls in a preparation phase that is awaited before startup and fails hard on pull errors, so it does not have this bug. This PR adds regression guards locking that contract in:

- `Stack.unit.test.ts`: `stack.start()` aborts and starts zero containers when a docker pull fails.
- `prefetch.unit.test.ts`: preparation fails with `DockerPullError` when the whole registry fallback chain fails.

Fixes #5068
