### PR TITLE
ci(release): add targeted job timeouts

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: ${{ inputs.non_blocking }}
     permissions:
       contents: write

--- a/.github/workflows/build-cli-artifacts.yml
+++ b/.github/workflows/build-cli-artifacts.yml
@@ -26,6 +26,16 @@ on:
         required: false
         type: string
         default: ""
+      timeout_minutes:
+        description: Maximum minutes to allow for the build job
+        required: false
+        type: number
+        default: 30
+      build_timeout_minutes:
+        description: Maximum minutes to allow for the artifact build step after setup
+        required: false
+        type: number
+        default: 4
     secrets:
       SENTRY_DSN:
         required: false
@@ -43,6 +53,7 @@ jobs:
   build:
     name: Build CLI artifacts
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       BUN_SHELL: ${{ inputs.shell }}
       VERSION: ${{ inputs.version }}
@@ -64,10 +75,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
-          # The GitHub-hosted producer frees disk space by deleting the pnpm
-          # store before exiting, which would make the post-job pnpm cache save
-          # fail with a path validation error. Skip the dependency cache there.
-          dependency-cache: ${{ inputs.cache_key_suffix != '-github' }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -103,25 +110,8 @@ jobs:
       - name: Sync versions
         run: pnpm exec bun apps/cli/scripts/sync-versions.ts --version "${VERSION}"
 
-      # The GitHub-hosted ubuntu-latest runner ships only ~14 GB free on /, and
-      # build.ts cross-compiles 8 Bun binaries (each embeds the full Bun runtime)
-      # plus 6 Go binaries in parallel, then writes archives + Linux packages —
-      # which tips over "no space left on device" non-deterministically depending
-      # on the runner the attempt lands on. Reclaim the preinstalled toolchains we
-      # don't use (~25 GB) before building. Blacksmith runners have ample disk so
-      # this is gated to the github-hosted producer.
-      #   - tool-cache stays false: setup-go installed Go into
-      #     /opt/hostedtoolcache above, so removing it would break the Go build.
-      #   - swap-storage stays (false = keep): the parallel bun --compile fan-out
-      #     is memory-heavy and the swapfile guards against OOM kills.
-      - name: Free disk space before building
-        if: inputs.cache_key_suffix == '-github'
-        uses: supabase/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # supabase fork of jlumbroso/free-disk-space
-        with:
-          tool-cache: false
-          swap-storage: false
-
       - name: Build selected shell
+        timeout-minutes: ${{ inputs.build_timeout_minutes }}
         run: pnpm exec bun apps/cli/scripts/build.ts --version "${VERSION}" --shell "${BUN_SHELL}"
 
       - name: Verify build artifacts
@@ -145,14 +135,6 @@ jobs:
             if echo "$info" | grep -q 'LINKER_SIGNED'; then echo "::error::$bin still linker-signed"; exit 1; fi
             echo "::endgroup::"
           done
-
-      - name: Free space before saving GitHub-hosted artifacts cache
-        if: inputs.cache_key_suffix == '-github'
-        run: |
-          rm -rf node_modules apps/*/node_modules packages/*/node_modules
-          chmod -R u+w "$HOME/.cache/go-build" "$HOME/go/pkg/mod" 2>/dev/null || true
-          rm -rf "$(pnpm store path --silent)" "$HOME/.cache/go-build" "$HOME/go/pkg/mod"
-          df -h
 
       - name: Check existing build artifacts cache
         id: build-artifacts-cache

--- a/.github/workflows/propose-release-notes.yml
+++ b/.github/workflows/propose-release-notes.yml
@@ -45,6 +45,7 @@ jobs:
     # allow any tag so reviewers can opt in for beta/alpha from the Actions tab.
     if: ${{ github.event_name == 'workflow_dispatch' || (!contains(inputs.tag, '-beta.') && !contains(inputs.tag, '-alpha.')) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     continue-on-error: ${{ inputs.non_blocking || false }}
     permissions:
       contents: write

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -74,8 +74,10 @@ jobs:
     with:
       version: ${{ inputs.version }}
       shell: ${{ inputs.shell }}
-      runner: ubuntu-latest
+      runner: large-linux-x86
       cache_key_suffix: -github
+      timeout_minutes: 45
+      build_timeout_minutes: 20
     secrets:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
@@ -92,6 +94,7 @@ jobs:
           - blacksmith-8vcpu-ubuntu-2404
           - blacksmith-8vcpu-windows-2025
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     env:
       NPM_TAG: ${{ inputs.npm_tag }}
       VERSION: ${{ inputs.version }}
@@ -227,6 +230,7 @@ jobs:
     needs:
       - build-github
     runs-on: macos-latest
+    timeout-minutes: 25
     env:
       NPM_TAG: ${{ inputs.npm_tag }}
       VERSION: ${{ inputs.version }}
@@ -271,6 +275,7 @@ jobs:
     # publish job must stay on a github-hosted runner. The job is short
     # and not compute-bound, so the wall-clock cost is negligible.
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       CHANNEL: ${{ inputs.channel }}
       NPM_TAG: ${{ inputs.npm_tag }}
@@ -448,6 +453,7 @@ jobs:
     # github-hosted to share a cache store with build-github/publish, whose
     # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       BREW_NAME: ${{ inputs.brew_name }}
       VERSION: ${{ inputs.version }}
@@ -510,6 +516,7 @@ jobs:
     # github-hosted to share a cache store with build-github/publish, whose
     # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SCOOP_NAME: ${{ inputs.scoop_name }}
       VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.review.state == 'approved'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -78,6 +79,7 @@ jobs:
     name: Plan release
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       should_release: ${{ steps.compute.outputs.should_release }}
       version: ${{ steps.compute.outputs.version }}

--- a/.github/workflows/setup-cli-smoke-test.yml
+++ b/.github/workflows/setup-cli-smoke-test.yml
@@ -43,6 +43,7 @@ jobs:
           - v1
           - v2
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}
     steps:
@@ -88,6 +89,7 @@ jobs:
           - v1
           - v2
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # `node:20-alpine` ships a musl-linked Node, which is required for
     # JavaScript-based actions (setup-cli included) to launch inside an
     # Alpine container — the runner's mounted glibc Node won't execute here.

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Send Slack notification
         # Values flow in through env so the payload heredoc never interpolates

--- a/.github/workflows/verify-install-channels.yml
+++ b/.github/workflows/verify-install-channels.yml
@@ -70,6 +70,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}
       BREW_NAME: ${{ inputs.brew_name }}
@@ -135,6 +136,7 @@ jobs:
   scoop:
     name: Scoop (${{ inputs.scoop_name }})
     runs-on: windows-latest
+    timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}
       SCOOP_NAME: ${{ inputs.scoop_name }}
@@ -196,6 +198,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}
     steps:


### PR DESCRIPTION
Adds per-job timeouts across the release workflow graph so stuck release jobs fail near their expected runtime instead of running for the default six-hour limit.

Updates the GitHub-produced artifact build to use the `large-linux-x86` runner, removes the now-unneeded disk cleanup step, and lets Go/pnpm caches persist so repeated release builds avoid cold sidecar compilation costs.