### PR TITLE
chore(ci): allow API sync automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,5 @@
 
 # Generated code. These ownerless rules override the catch-all above so
 # CI-green sync PRs (e.g. Management API OpenAPI spec) can be auto-merged.
+/apps/cli-go/pkg/api/*.gen.go
 /packages/api/src/generated/

--- a/.github/workflows/api-package-sync.yml
+++ b/.github/workflows/api-package-sync.yml
@@ -65,14 +65,6 @@ jobs:
           branch: sync/api-package
           base: develop
 
-      - name: Approve a PR
-        if: steps.check.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-operation == 'created'
-        continue-on-error: true
-        run: gh pr review --approve --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-
       - name: Enable Pull Request Automerge
         if: steps.check.outputs.has_changes == 'true'
         run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"

--- a/.github/workflows/cli-go-api-sync.yml
+++ b/.github/workflows/cli-go-api-sync.yml
@@ -61,14 +61,6 @@ jobs:
           branch: sync/api-types
           base: develop
 
-      - name: Approve a PR
-        if: steps.check.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-operation == 'created'
-        continue-on-error: true
-        run: gh pr review --approve --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-
       - name: Enable Pull Request Automerge
         if: steps.check.outputs.has_changes == 'true'
         run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"


### PR DESCRIPTION
Generated API sync PRs only touch generated output, but the Go API files still inherited the catch-all CODEOWNERS rule and requested CLI team review.

This adds an ownerless CODEOWNERS override for `apps/cli-go/pkg/api/*.gen.go` so green Go API sync PRs can be auto-merged by the existing app bypass.

It also removes the ignored self-approval steps from both API sync workflows. GitHub rejects those approvals for PRs created by the same app, and the workflows already enable auto-merge with the app token after opening or updating the PR.
