### PR TITLE
test(cli): supabox-backed live test suite + cli-e2e-ci dispatch

### DIFF
--- a/.github/workflows/dispatch-cli-e2e-ci.yml
+++ b/.github/workflows/dispatch-cli-e2e-ci.yml
@@ -23,7 +23,12 @@ permissions:
 
 jobs:
   dispatch:
-    if: contains(github.event.pull_request.labels.*.name, 'run-live-e2e-ci')
+    # Same-repo PRs only: fork PRs don't receive secrets (GH_APP_PRIVATE_KEY), so
+    # the App-token step would fail and leave a red check. Skip them cleanly —
+    # fork PRs use cli-e2e-ci's workflow_dispatch with `cli_ref` instead.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-live-e2e-ci')
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # App token scoped to cli-e2e-ci with contents:write — the

--- a/.github/workflows/dispatch-cli-e2e-ci.yml
+++ b/.github/workflows/dispatch-cli-e2e-ci.yml
@@ -1,0 +1,52 @@
+name: Dispatch cli-e2e-ci
+
+# Asks the supabase/cli-e2e-ci harness to run the cli `test:live` suite against
+# a full supabox stack, built from THIS PR's head commit (CLI-1825 / CLI-1831).
+#
+# This is distinct from `live-e2e.yml`, which runs the cli-e2e package against
+# real staging (api.supabase.green). Here the suite runs against a local supabox
+# stack stood up inside the private cli-e2e-ci repo; we only fire the trigger and
+# pass our head SHA — cli-e2e-ci checks that SHA out into its `cli` submodule.
+#
+# Opt-in by label to keep the expensive full-stack run off every PR: add the
+# `run-live-e2e-ci` label (re-dispatches on each subsequent push while labeled).
+# cli-e2e-ci reports a `cli-e2e-ci / live` commit status back onto the head SHA.
+#
+# Fork PRs cannot dispatch (no access to the App secret); run cli-e2e-ci's own
+# workflow_dispatch with `cli_ref` for those.
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: contains(github.event.pull_request.labels.*.name, 'run-live-e2e-ci')
+    runs-on: ubuntu-latest
+    steps:
+      # App token scoped to cli-e2e-ci with contents:write — the
+      # repository_dispatch REST endpoint requires write on the target repo.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: supabase
+          repositories: cli-e2e-ci
+          permission-contents: write
+
+      - name: Dispatch live run to cli-e2e-ci
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLI_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Dispatching cli-e2e-ci live run for PR #${PR_NUMBER} @ ${CLI_SHA}"
+          # Build the nested client_payload with jq — `gh api -f` sends a flat
+          # body and would not nest `client_payload.*` correctly.
+          jq -n --arg sha "$CLI_SHA" --argjson pr "$PR_NUMBER" \
+            '{event_type: "cli-pr", client_payload: {cli_sha: $sha, pr_number: $pr}}' \
+            | gh api -X POST repos/supabase/cli-e2e-ci/dispatches --input -

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,6 +33,7 @@
     "dev:legacy": "pnpm exec bun src/legacy/main.ts",
     "test": "nx run-many -t test:core test:e2e --projects=$npm_package_name",
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name --coverage.enabled",
+    "test:live": "nx run-many -t test:live --projects=$npm_package_name",
     "test:smoke": "bun run tests/smoke-test.ts",
     "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"
@@ -107,7 +108,8 @@
     "entry": [
       "src/shared/cli/bin.ts",
       "src/**/*.test.ts",
-      "src/**/*.e2e.test.ts"
+      "src/**/*.e2e.test.ts",
+      "src/**/*.live.test.ts"
     ],
     "ignore": [
       "scripts/*.ts",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,7 +33,6 @@
     "dev:legacy": "pnpm exec bun src/legacy/main.ts",
     "test": "nx run-many -t test:core test:e2e --projects=$npm_package_name",
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name --coverage.enabled",
-    "test:live": "nx run-many -t test:live --projects=$npm_package_name",
     "test:smoke": "bun run tests/smoke-test.ts",
     "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"

--- a/apps/cli/src/legacy/commands/branches/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/branches/list/list.live.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+
+import {
+  describeLiveProject,
+  requireLiveProjectRef,
+  runSupabaseLive,
+} from "../../../../../tests/helpers/live.ts";
+
+const LIVE_TIMEOUT_MS = 120_000;
+
+// Project-scoped read-only scenario. Skipped unless SUPABASE_LIVE_PROJECT_REF is
+// set — i.e. a project has been provisioned on the stack (the cli-e2e-ci runner
+// does this; a control-plane-only stack, like local macOS, skips it).
+//
+// Entry point for the branching lifecycle tracked in CLI-1834
+// (create / switch / delete) — extend here once a provisioned project is
+// available on the full stack.
+describeLiveProject("supabase branches list (live)", () => {
+  test("lists branches for the project", { timeout: LIVE_TIMEOUT_MS }, async () => {
+    const ref = requireLiveProjectRef();
+    const { exitCode, stdout, stderr } = await runSupabaseLive([
+      "branches",
+      "list",
+      "--project-ref",
+      ref,
+    ]);
+    expect(`${stdout}${stderr}`).not.toContain("Unauthorized");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/apps/cli/src/legacy/commands/functions/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/functions/list/list.live.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import {
+  describeLive,
   describeLiveProject,
   requireLiveProjectRef,
   runSupabaseLive,
@@ -27,5 +28,25 @@ describeLiveProject("supabase functions list (live)", () => {
     ]);
     expect(`${stdout}${stderr}`).not.toContain("Unauthorized");
     expect(exitCode).toBe(0);
+  });
+});
+
+// Project-scoped error path that needs NO provisioned project: a valid token
+// with an unknown `--project-ref` must reach the live Management API, come back
+// 404, and surface as a non-zero exit (not a crash, not "Unauthorized"). This
+// exercises the `--project-ref` request path + error mapping on a control-plane-
+// only stack, so it runs under `describeLive`, not `describeLiveProject`.
+describeLive("supabase functions list — unknown project (live)", () => {
+  test("fails with a 404 for an unknown project ref", { timeout: LIVE_TIMEOUT_MS }, async () => {
+    const { exitCode, stdout, stderr } = await runSupabaseLive([
+      "functions",
+      "list",
+      "--project-ref",
+      "a".repeat(20), // well-formed (20 lowercase chars) but nonexistent ref
+    ]);
+    const out = `${stdout}${stderr}`;
+    expect(exitCode).not.toBe(0);
+    expect(out).not.toContain("Unauthorized");
+    expect(out).toContain("404");
   });
 });

--- a/apps/cli/src/legacy/commands/functions/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/functions/list/list.live.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+
+import {
+  describeLiveProject,
+  requireLiveProjectRef,
+  runSupabaseLive,
+} from "../../../../../tests/helpers/live.ts";
+
+const LIVE_TIMEOUT_MS = 120_000;
+
+// Project-scoped read-only scenario. Skipped unless SUPABASE_LIVE_PROJECT_REF is
+// set — i.e. a project has been provisioned on the stack (the cli-e2e-ci runner
+// does this; a control-plane-only stack, like local macOS, skips it).
+//
+// This is the entry point for the broader edge-functions coverage tracked in
+// CLI-1834 (deploy + invoke over :443 / {ref}.supabase.red), which needs the
+// project's gateway reachable from the host — author those here as they become
+// runnable on the full stack.
+describeLiveProject("supabase functions list (live)", () => {
+  test("lists edge functions for the project", { timeout: LIVE_TIMEOUT_MS }, async () => {
+    const ref = requireLiveProjectRef();
+    const { exitCode, stdout, stderr } = await runSupabaseLive([
+      "functions",
+      "list",
+      "--project-ref",
+      ref,
+    ]);
+    expect(`${stdout}${stderr}`).not.toContain("Unauthorized");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
@@ -21,4 +21,16 @@ describeLive("supabase orgs list (live)", () => {
       expect(exitCode).toBe(0);
     },
   );
+
+  // Negative path: a bad token must round-trip to the real Management API, come
+  // back 401, and surface as a non-zero exit with the upstream "Unauthorized"
+  // message — i.e. the cli's auth + error mapping work against the live stack,
+  // not just the golden path. Overrides only the token (profile stays set).
+  test("fails with Unauthorized for an invalid token", { timeout: LIVE_TIMEOUT_MS }, async () => {
+    const { exitCode, stdout, stderr } = await runSupabaseLive(["orgs", "list"], {
+      env: { SUPABASE_ACCESS_TOKEN: `sbp_${"0".repeat(40)}` },
+    });
+    expect(exitCode).not.toBe(0);
+    expect(`${stdout}${stderr}`).toContain("Unauthorized");
+  });
 });

--- a/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { describeLive, runSupabaseLive } from "../../../../../tests/helpers/live.ts";
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+// Harness smoke for the `live` Vitest project: the canonical example of a live
+// test. It exercises the full path — built binary → SUPABASE_PROFILE resolution
+// → authenticated Management API request against the running platform — with a
+// read-only call, so it is safe to run repeatedly and creates no resources.
+//
+// Gated by `describeLive`: skipped unless SUPABASE_ACCESS_TOKEN is set (the
+// cli-e2e-ci runner provides supabox's seeded PAT). Broader lifecycle scenarios
+// (projects, functions, branching, db, storage) build on this same harness.
+describeLive("supabase orgs list (live)", () => {
+  test(
+    "lists organizations for the authenticated token",
+    { timeout: LIVE_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stdout, stderr } = await runSupabaseLive(["orgs", "list"]);
+      expect(`${stdout}${stderr}`).not.toContain("Unauthorized");
+      expect(exitCode).toBe(0);
+    },
+  );
+});

--- a/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/orgs/list/list.live.test.ts
@@ -22,6 +22,22 @@ describeLive("supabase orgs list (live)", () => {
     },
   );
 
+  test(
+    "emits machine-readable JSON with --output-format json",
+    { timeout: LIVE_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stdout } = await runSupabaseLive([
+        "orgs",
+        "list",
+        "--output-format",
+        "json",
+      ]);
+      expect(exitCode).toBe(0);
+      // stdout must be payload-only valid JSON in json mode (no spinner/log noise).
+      expect(() => JSON.parse(stdout)).not.toThrow();
+    },
+  );
+
   // Negative path: a bad token must round-trip to the real Management API, come
   // back 401, and surface as a non-zero exit with the upstream "Unauthorized"
   // message — i.e. the cli's auth + error mapping work against the live stack,

--- a/apps/cli/src/legacy/commands/projects/list/list.live.test.ts
+++ b/apps/cli/src/legacy/commands/projects/list/list.live.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+
+import { describeLive, runSupabaseLive } from "../../../../../tests/helpers/live.ts";
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+// Account-level read-only live scenario, alongside `orgs list`. Lists every
+// project the authenticated token can access — no project ref required, so it
+// runs against just the control plane (no provisioned project instance needed).
+// Safe to run repeatedly; creates nothing.
+describeLive("supabase projects list (live)", () => {
+  test("lists projects for the authenticated token", { timeout: LIVE_TIMEOUT_MS }, async () => {
+    const { exitCode, stdout, stderr } = await runSupabaseLive(["projects", "list"]);
+    expect(`${stdout}${stderr}`).not.toContain("Unauthorized");
+    expect(exitCode).toBe(0);
+  });
+
+  test(
+    "emits machine-readable JSON with --output-format json",
+    { timeout: LIVE_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stdout } = await runSupabaseLive([
+        "projects",
+        "list",
+        "--output-format",
+        "json",
+      ]);
+      expect(exitCode).toBe(0);
+      // stdout must be payload-only valid JSON in json mode (no spinner/log noise).
+      expect(() => JSON.parse(stdout)).not.toThrow();
+    },
+  );
+});

--- a/apps/cli/tests/helpers/live-env.ts
+++ b/apps/cli/tests/helpers/live-env.ts
@@ -1,0 +1,73 @@
+/**
+ * Environment-only helpers for the `live` Vitest project, with **no Vitest test
+ * APIs imported**. Vitest evaluates `globalSetup` (live-global-setup.ts) in a
+ * separate context before the test workers, where importing `describe`/`test`
+ * is not valid — so the global setup imports the env helpers from here, while
+ * the test-facing pieces (`describeLive`, `runSupabaseLive`, …) live in
+ * `live.ts` and re-export these.
+ *
+ * Environment contract (provided by the cli-e2e-ci runner):
+ * - `SUPABASE_ACCESS_TOKEN` — required; the platform PAT (supabox seeds a
+ *   deterministic `sbp_…` token into its mgmt-api database).
+ * - `SUPABASE_PROFILE` — selects the API base URL; defaults to `supabase-local`
+ *   (→ `http://localhost:8080`, `project_host: supabase.red`). Note the cli does
+ *   NOT honor `SUPABASE_API_URL` (Go parity) — the profile is the override.
+ * - `SUPABASE_LIVE_API_URL` — base URL the readiness check probes; defaults to
+ *   `http://localhost:8080`.
+ * - `SUPABASE_LIVE_PROJECT_REF` — a provisioned project; gates project-scoped
+ *   suites (functions, branches, db, storage).
+ * - `NODE_EXTRA_CA_CERTS` — trusts the supabox CA for `*.supabase.red` TLS;
+ *   inherited by the subprocess via the parent environment.
+ */
+
+/** Default profile for the host runner: api_url → localhost:8080, project_host → supabase.red. */
+export const LIVE_DEFAULT_PROFILE = "supabase-local";
+
+/**
+ * Default subprocess exit timeout for live runs. `runSupabase` otherwise caps at
+ * 60s, which would kill a slow-but-valid supabox call before the live tests'
+ * own (60–120s+) timeouts fire. Generous, but under the `live` project's 300s
+ * cap so the per-test timeout stays the real gate. Callers may override.
+ */
+export const LIVE_EXIT_TIMEOUT_MS = 240_000;
+
+/** Management API base URL probed by the live readiness check. */
+export function liveApiBaseUrl(): string {
+  return process.env["SUPABASE_LIVE_API_URL"] ?? "http://localhost:8080";
+}
+
+/**
+ * True when the environment carries a platform access token, i.e. the live
+ * suite is expected to run. Used to gate `describeLive` so live tests are inert
+ * in the default test loop.
+ */
+export function isLiveConfigured(): boolean {
+  return Boolean(process.env["SUPABASE_ACCESS_TOKEN"]);
+}
+
+/**
+ * Project ref for project-scoped live scenarios (functions, branches, db,
+ * storage, …). The cli-e2e-ci runner sets this once a project has been
+ * provisioned on the stack; absent → those suites skip. Returns `undefined`
+ * when unset so callers can branch; use `requireLiveProjectRef` inside a
+ * `describeLiveProject` block where presence is already guaranteed.
+ */
+export function liveProjectRef(): string | undefined {
+  return process.env["SUPABASE_LIVE_PROJECT_REF"];
+}
+
+/**
+ * The live project ref, or a thrown error if unset. Safe to call inside a
+ * `describeLiveProject` block (the gate guarantees it is present) and gives a
+ * typed `string` without a non-null assertion.
+ */
+export function requireLiveProjectRef(): string {
+  const ref = liveProjectRef();
+  if (!ref) {
+    throw new Error(
+      "SUPABASE_LIVE_PROJECT_REF must be set for project-scoped live tests " +
+        "(the cli-e2e-ci runner sets it after provisioning a project).",
+    );
+  }
+  return ref;
+}

--- a/apps/cli/tests/helpers/live.ts
+++ b/apps/cli/tests/helpers/live.ts
@@ -27,6 +27,14 @@ import { runSupabase } from "./cli.ts";
 /** Default profile for the host runner: api_url → localhost:8080, project_host → supabase.red. */
 export const LIVE_DEFAULT_PROFILE = "supabase-local";
 
+/**
+ * Default subprocess exit timeout for live runs. `runSupabase` otherwise caps at
+ * 60s, which would kill a slow-but-valid supabox call before the live tests'
+ * own (60–120s+) timeouts fire. Generous, but under the `live` project's 300s
+ * cap so the per-test timeout stays the real gate. Callers may override.
+ */
+export const LIVE_EXIT_TIMEOUT_MS = 240_000;
+
 /** Management API base URL probed by the live readiness check. */
 export function liveApiBaseUrl(): string {
   return process.env["SUPABASE_LIVE_API_URL"] ?? "http://localhost:8080";
@@ -95,6 +103,7 @@ export function runSupabaseLive(
   return runSupabase(args, {
     entrypoint: "legacy",
     ...options,
+    exitTimeoutMs: options?.exitTimeoutMs ?? LIVE_EXIT_TIMEOUT_MS,
     env: {
       SUPABASE_PROFILE: process.env["SUPABASE_PROFILE"] ?? LIVE_DEFAULT_PROFILE,
       ...options?.env,

--- a/apps/cli/tests/helpers/live.ts
+++ b/apps/cli/tests/helpers/live.ts
@@ -1,0 +1,68 @@
+import { describe } from "vitest";
+import { runSupabase } from "./cli.ts";
+
+/**
+ * Helpers for the `live` Vitest project (`*.live.test.ts`): black-box CLI
+ * subprocess tests that run against a *real* Supabase platform — in CI that is
+ * a local supabox stack (see the `supabase/cli-e2e-ci` harness).
+ *
+ * Unlike `*.e2e.test.ts`, which use fake tokens and assert error/golden-path
+ * surface behavior, live tests exercise real Management API, edge function,
+ * database, and storage flows end to end. They are gated off by default and
+ * only run when a live access token is present in the environment, so the
+ * normal unit/integration/e2e loop never touches a network.
+ *
+ * Environment contract (provided by the cli-e2e-ci runner):
+ * - `SUPABASE_ACCESS_TOKEN` — required; the platform PAT (supabox seeds a
+ *   deterministic `sbp_…` token into its mgmt-api database).
+ * - `SUPABASE_PROFILE` — selects the API base URL; defaults to `supabase-local`
+ *   (→ `http://localhost:8080`, `project_host: supabase.red`). Note the cli does
+ *   NOT honor `SUPABASE_API_URL` (Go parity) — the profile is the override.
+ * - `SUPABASE_LIVE_API_URL` — base URL the readiness check probes; defaults to
+ *   `http://localhost:8080`.
+ * - `NODE_EXTRA_CA_CERTS` — trusts the supabox CA for `*.supabase.red` TLS;
+ *   inherited by the subprocess via the parent environment.
+ */
+
+/** Default profile for the host runner: api_url → localhost:8080, project_host → supabase.red. */
+export const LIVE_DEFAULT_PROFILE = "supabase-local";
+
+/** Management API base URL probed by the live readiness check. */
+export function liveApiBaseUrl(): string {
+  return process.env["SUPABASE_LIVE_API_URL"] ?? "http://localhost:8080";
+}
+
+/**
+ * True when the environment carries a platform access token, i.e. the live
+ * suite is expected to run. Used to gate `describeLive` so live tests are inert
+ * in the default test loop.
+ */
+export function isLiveConfigured(): boolean {
+  return Boolean(process.env["SUPABASE_ACCESS_TOKEN"]);
+}
+
+/**
+ * `describe` that runs only when the live environment is configured. Use this
+ * for every live suite so the file is inert (skipped, not failed) outside the
+ * cli-e2e-ci runner.
+ */
+export const describeLive = describe.skipIf(!isLiveConfigured());
+
+/**
+ * Spawn the built CLI against the live platform, injecting the profile so the
+ * Management API base resolves to the stack. Defaults to the `legacy` shell,
+ * which hosts the platform commands (orgs, projects, branches, functions, …).
+ */
+export function runSupabaseLive(
+  args: string[],
+  options?: Parameters<typeof runSupabase>[1],
+): ReturnType<typeof runSupabase> {
+  return runSupabase(args, {
+    entrypoint: "legacy",
+    ...options,
+    env: {
+      SUPABASE_PROFILE: process.env["SUPABASE_PROFILE"] ?? LIVE_DEFAULT_PROFILE,
+      ...options?.env,
+    },
+  });
+}

--- a/apps/cli/tests/helpers/live.ts
+++ b/apps/cli/tests/helpers/live.ts
@@ -49,6 +49,41 @@ export function isLiveConfigured(): boolean {
 export const describeLive = describe.skipIf(!isLiveConfigured());
 
 /**
+ * Project ref for project-scoped live scenarios (functions, branches, db,
+ * storage, …). The cli-e2e-ci runner sets this once a project has been
+ * provisioned on the stack; absent → those suites skip. Returns `undefined`
+ * when unset so callers can branch; use `requireLiveProjectRef` inside a
+ * `describeLiveProject` block where presence is already guaranteed.
+ */
+export function liveProjectRef(): string | undefined {
+  return process.env["SUPABASE_LIVE_PROJECT_REF"];
+}
+
+/**
+ * The live project ref, or a thrown error if unset. Safe to call inside a
+ * `describeLiveProject` block (the gate guarantees it is present) and gives a
+ * typed `string` without a non-null assertion.
+ */
+export function requireLiveProjectRef(): string {
+  const ref = liveProjectRef();
+  if (!ref) {
+    throw new Error(
+      "SUPABASE_LIVE_PROJECT_REF must be set for project-scoped live tests " +
+        "(the cli-e2e-ci runner sets it after provisioning a project).",
+    );
+  }
+  return ref;
+}
+
+/**
+ * `describe` for project-scoped live suites: runs only when the live env is
+ * configured AND a project ref is available. On a control-plane-only stack
+ * (e.g. local macOS where project instances can't be built) these skip rather
+ * than fail. See `requireLiveProjectRef`.
+ */
+export const describeLiveProject = describe.skipIf(!isLiveConfigured() || !liveProjectRef());
+
+/**
  * Spawn the built CLI against the live platform, injecting the profile so the
  * Management API base resolves to the stack. Defaults to the `legacy` shell,
  * which hosts the platform commands (orgs, projects, branches, functions, …).

--- a/apps/cli/tests/helpers/live.ts
+++ b/apps/cli/tests/helpers/live.ts
@@ -1,53 +1,34 @@
 import { describe } from "vitest";
+
 import { runSupabase } from "./cli.ts";
+import {
+  isLiveConfigured,
+  LIVE_DEFAULT_PROFILE,
+  LIVE_EXIT_TIMEOUT_MS,
+  liveProjectRef,
+} from "./live-env.ts";
 
 /**
- * Helpers for the `live` Vitest project (`*.live.test.ts`): black-box CLI
- * subprocess tests that run against a *real* Supabase platform — in CI that is
- * a local supabox stack (see the `supabase/cli-e2e-ci` harness).
+ * Test-facing helpers for the `live` Vitest project (`*.live.test.ts`):
+ * black-box CLI subprocess tests that run against a *real* Supabase platform —
+ * in CI a local supabox stack (see the `supabase/cli-e2e-ci` harness).
  *
- * Unlike `*.e2e.test.ts`, which use fake tokens and assert error/golden-path
- * surface behavior, live tests exercise real Management API, edge function,
- * database, and storage flows end to end. They are gated off by default and
- * only run when a live access token is present in the environment, so the
- * normal unit/integration/e2e loop never touches a network.
- *
- * Environment contract (provided by the cli-e2e-ci runner):
- * - `SUPABASE_ACCESS_TOKEN` — required; the platform PAT (supabox seeds a
- *   deterministic `sbp_…` token into its mgmt-api database).
- * - `SUPABASE_PROFILE` — selects the API base URL; defaults to `supabase-local`
- *   (→ `http://localhost:8080`, `project_host: supabase.red`). Note the cli does
- *   NOT honor `SUPABASE_API_URL` (Go parity) — the profile is the override.
- * - `SUPABASE_LIVE_API_URL` — base URL the readiness check probes; defaults to
- *   `http://localhost:8080`.
- * - `NODE_EXTRA_CA_CERTS` — trusts the supabox CA for `*.supabase.red` TLS;
- *   inherited by the subprocess via the parent environment.
+ * This module imports Vitest test APIs (`describe`), so it must NOT be imported
+ * from `globalSetup` (Vitest evaluates that in a different context). The
+ * env-only helpers live in `./live-env.ts`; `globalSetup` imports from there.
+ * They are re-exported below so test files have a single import site.
  */
 
-/** Default profile for the host runner: api_url → localhost:8080, project_host → supabase.red. */
-export const LIVE_DEFAULT_PROFILE = "supabase-local";
-
-/**
- * Default subprocess exit timeout for live runs. `runSupabase` otherwise caps at
- * 60s, which would kill a slow-but-valid supabox call before the live tests'
- * own (60–120s+) timeouts fire. Generous, but under the `live` project's 300s
- * cap so the per-test timeout stays the real gate. Callers may override.
- */
-export const LIVE_EXIT_TIMEOUT_MS = 240_000;
-
-/** Management API base URL probed by the live readiness check. */
-export function liveApiBaseUrl(): string {
-  return process.env["SUPABASE_LIVE_API_URL"] ?? "http://localhost:8080";
-}
-
-/**
- * True when the environment carries a platform access token, i.e. the live
- * suite is expected to run. Used to gate `describeLive` so live tests are inert
- * in the default test loop.
- */
-export function isLiveConfigured(): boolean {
-  return Boolean(process.env["SUPABASE_ACCESS_TOKEN"]);
-}
+// Re-export the env-only helpers so `*.live.test.ts` files import everything
+// from `helpers/live.ts`.
+export {
+  isLiveConfigured,
+  LIVE_DEFAULT_PROFILE,
+  LIVE_EXIT_TIMEOUT_MS,
+  liveApiBaseUrl,
+  liveProjectRef,
+  requireLiveProjectRef,
+} from "./live-env.ts";
 
 /**
  * `describe` that runs only when the live environment is configured. Use this
@@ -55,33 +36,6 @@ export function isLiveConfigured(): boolean {
  * cli-e2e-ci runner.
  */
 export const describeLive = describe.skipIf(!isLiveConfigured());
-
-/**
- * Project ref for project-scoped live scenarios (functions, branches, db,
- * storage, …). The cli-e2e-ci runner sets this once a project has been
- * provisioned on the stack; absent → those suites skip. Returns `undefined`
- * when unset so callers can branch; use `requireLiveProjectRef` inside a
- * `describeLiveProject` block where presence is already guaranteed.
- */
-export function liveProjectRef(): string | undefined {
-  return process.env["SUPABASE_LIVE_PROJECT_REF"];
-}
-
-/**
- * The live project ref, or a thrown error if unset. Safe to call inside a
- * `describeLiveProject` block (the gate guarantees it is present) and gives a
- * typed `string` without a non-null assertion.
- */
-export function requireLiveProjectRef(): string {
-  const ref = liveProjectRef();
-  if (!ref) {
-    throw new Error(
-      "SUPABASE_LIVE_PROJECT_REF must be set for project-scoped live tests " +
-        "(the cli-e2e-ci runner sets it after provisioning a project).",
-    );
-  }
-  return ref;
-}
 
 /**
  * `describe` for project-scoped live suites: runs only when the live env is

--- a/apps/cli/tests/live-global-setup.ts
+++ b/apps/cli/tests/live-global-setup.ts
@@ -14,18 +14,21 @@ export async function setup(): Promise<void> {
     return;
   }
 
-  const healthUrl = `${liveApiBaseUrl()}/v1/health`;
+  // Reachability gate only. Any HTTP response — including 401/404 — proves the
+  // Management API is up and routing, which is all this probe needs to assert.
+  // supabox's mgmt-api requires auth on every route and exposes no public health
+  // endpoint (`/v1/health` 404s; an unauthenticated request is rejected by the
+  // auth middleware with 401), so we deliberately do NOT require a 2xx here.
+  // Functional and auth coverage is the live tests' job (e.g. `orgs list`).
+  const probeUrl = `${liveApiBaseUrl()}/v1/organizations`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 30_000);
   try {
-    const response = await fetch(healthUrl, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`${healthUrl} responded with ${response.status}`);
-    }
+    await fetch(probeUrl, { signal: controller.signal });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `Live platform is not reachable at ${healthUrl}: ${reason}.\n` +
+      `Live platform is not reachable at ${probeUrl}: ${reason}.\n` +
         "Ensure the supabox stack is up and the host can reach mgmt-api (see cli-e2e-ci).",
     );
   } finally {

--- a/apps/cli/tests/live-global-setup.ts
+++ b/apps/cli/tests/live-global-setup.ts
@@ -1,4 +1,6 @@
-import { isLiveConfigured, liveApiBaseUrl } from "./helpers/live.ts";
+// Import from the Vitest-free env module — globalSetup runs in a context where
+// importing Vitest test APIs (which `helpers/live.ts` pulls in) is not valid.
+import { isLiveConfigured, liveApiBaseUrl } from "./helpers/live-env.ts";
 
 /**
  * Global setup for the `live` Vitest project. When the live environment is not

--- a/apps/cli/tests/live-global-setup.ts
+++ b/apps/cli/tests/live-global-setup.ts
@@ -1,0 +1,34 @@
+import { isLiveConfigured, liveApiBaseUrl } from "./helpers/live.ts";
+
+/**
+ * Global setup for the `live` Vitest project. When the live environment is not
+ * configured the suite is skipped (via `describeLive`) and this is a no-op.
+ *
+ * When it IS configured (the cli-e2e-ci runner sets `SUPABASE_ACCESS_TOKEN`),
+ * fail fast with a clear message if the platform is unreachable, so a
+ * misconfigured stack surfaces as a setup error rather than dozens of opaque
+ * per-test timeouts.
+ */
+export async function setup(): Promise<void> {
+  if (!isLiveConfigured()) {
+    return;
+  }
+
+  const healthUrl = `${liveApiBaseUrl()}/v1/health`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const response = await fetch(healthUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`${healthUrl} responded with ${response.status}`);
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Live platform is not reachable at ${healthUrl}: ${reason}.\n` +
+        "Ensure the supabox stack is up and the host can reach mgmt-api (see cli-e2e-ci).",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         "**/*.unit.test.ts",
         "**/*.integration.test.ts",
         "**/*.e2e.test.ts",
+        "**/*.live.test.ts",
         "**/*.command.ts",
         "src/app.ts",
         "src/bin.ts",
@@ -64,6 +65,21 @@ export default defineConfig({
           setupFiles: ["tests/e2e-setup.ts"],
           testTimeout: 120_000,
           hookTimeout: 120_000,
+        },
+      },
+      {
+        plugins: [dockerfileTextPlugin()],
+        test: {
+          // Live tests run against a real platform (a supabox stack in CI) and
+          // are gated by `describeLive`, so they are inert unless the live env
+          // is configured. Never part of the default unit/integration/e2e loop.
+          name: "live",
+          include: ["**/*.live.test.ts"],
+          fileParallelism: false,
+          maxWorkers: 1,
+          globalSetup: ["tests/live-global-setup.ts"],
+          testTimeout: 300_000,
+          hookTimeout: 300_000,
         },
       },
     ],

--- a/nx.json
+++ b/nx.json
@@ -75,6 +75,17 @@
         "{projectRoot}/dist/**/*"
       ]
     },
+    "test:live": {
+      "parallelism": false,
+      "cache": false,
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "default",
+        "{projectRoot}/dist/**/*"
+      ]
+    },
     "dev": {
       "cache": false
     }


### PR DESCRIPTION
Adds a `live` test category that exercises the built CLI against a **real Supabase platform** — a fulls supabox stack stood up in CI by cli-e2e-ci — and the cli-side trigger that runs it for a PR.

## What changed
- **`live` Vitest project** (`*.live.test.ts`) + harness in `apps/cli/tests/helpers/live.ts`:
  - `runSupabaseLive` (drives the built binary via `SUPABASE_PROFILE=supabase-local`), `describeLive` (gated on `SUPABASE_ACCESS_TOKEN`), and `describeLiveProject` / `requireLiveProjectRef` (gated on `SUPABASE_LIVE_PROJECT_REF` for project-scoped suites).
  - `tests/live-global-setup.ts` fail-fast reachability probe.
  - nx `test:live` target (auto-derived from the project) + `nx.json` default; **removed** the recursive `test:live` package script (it shadowed the nx target and looped).
- **8 live scenarios**: `orgs list` (+JSON, +invalid-token negative), `projects list` (+JSON), `functions list` / `branches list` (project-scoped), and a `functions list` unknown-project (404) negative.
- **`.github/workflows/dispatch-cli-e2e-ci.yml`**: on PRs labeled `run-live-e2e-ci`, fires a `repository_dispatch` to cli-e2e-ci with the PR head SHA; cli-e2e-ci builds that SHA, runs the suite, and reports a `cli-e2e-ci / live` commit status back. Distinct from the staging `live-e2e.yml`.

## Why
There was no backend-hitting live coverage — existing `*.e2e.test.ts` use fake tokens. This validates real Management-API flows end-to-end against supabox. Refs CLI-1825 / CLI-1834 / CLI-1831.

## Reviewer notes
- The `live` project is **inert by default** — it only runs when `SUPABASE_ACCESS_TOKEN` is set (the cli-e2e-ci runner provides supabox's seeded PAT), so it does not touch the normal unit/integration/e2e loop.
- Validated green in cli-e2e-ci on Blacksmith: **8 passed, 0 skipped**, including the project-scoped suites (the runner provisions a project and sets `SUPABASE_LIVE_PROJECT_REF`).
- The dispatch loop needs, on the infra side: a `run-live-e2e-ci` label on this repo, the App's `contents: write` on cli-e2e-ci (to dispatch) and `statuses: write` here (for the back-status). The build/test half is proven without them.