### PR TITLE
fix(cli): storage config

### DIFF
--- a/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
@@ -332,7 +332,7 @@ project_id = "abcdefghijklmnopqrst"
   });
 
   it.live("pushes storage when the remote response omits databasePoolMode", () => {
-    const { layer, out } = setup({
+    const { layer, api } = setup({
       toml: `project_id = "test"
 [auth]
 enabled = false
@@ -349,7 +349,9 @@ file_size_limit = "50MiB"
     });
     return Effect.gen(function* () {
       yield* legacyConfigPush({ projectRef: Option.none() });
-      expect(out.stderrText).toContain("Remote Storage config is up to date.");
+      expect(
+        api.requests.some((r) => r.method === "GET" && r.url.includes("/config/storage")),
+      ).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.integration.test.ts
@@ -46,6 +46,8 @@ interface RouteOpts {
   readonly postgrestPatch?: { status: number; body: unknown } | "fail";
   readonly postgresGet?: { status: number; body: unknown };
   readonly postgresPut?: { status: number; body: unknown };
+  readonly storageGet?: { status: number; body: unknown };
+  readonly storagePatch?: { status: number; body: unknown };
 }
 
 function setup(opts: {
@@ -89,6 +91,14 @@ function setup(opts: {
         const p = routes.postgresPut ?? { status: 200, body: {} };
         return Effect.succeed(legacyJsonResponse(request, p.status, p.body));
       }
+      if (url.includes("/config/storage")) {
+        if (request.method === "GET") {
+          const g = routes.storageGet ?? { status: 200, body: {} };
+          return Effect.succeed(legacyJsonResponse(request, g.status, g.body));
+        }
+        const p = routes.storagePatch ?? { status: 200, body: {} };
+        return Effect.succeed(legacyJsonResponse(request, p.status, p.body));
+      }
       // Anything else (auth/storage/etc.) — succeed with empty so unconfigured
       // gated services don't hang if a test enables them.
       return Effect.succeed(legacyJsonResponse(request, 200, {}));
@@ -118,6 +128,20 @@ enabled = false
 [storage]
 enabled = false
 `;
+
+const STORAGE_CONFIG_WITHOUT_POOL_MODE = {
+  fileSizeLimit: 52428800,
+  features: {
+    imageTransformation: { enabled: false },
+    s3Protocol: { enabled: false },
+    purgeCache: { enabled: false },
+    icebergCatalog: { enabled: false, maxNamespaces: 0, maxTables: 0, maxCatalogs: 0 },
+    vectorBuckets: { enabled: false, maxBuckets: 0, maxIndexes: 0 },
+  },
+  capabilities: { list_v2: true, iceberg_catalog: false },
+  external: { upstreamTarget: "main" },
+  migrationVersion: "20240701",
+};
 
 describe("legacy config push integration", () => {
   it.live("pushes local config (text, Go parity) and surfaces a PATCH failure", () => {
@@ -304,6 +328,28 @@ project_id = "abcdefghijklmnopqrst"
       expect(success).toBeDefined();
       expect(success?.data?.project_ref).toBe("abcdefghijklmnopqrst");
       expect(Array.isArray(success?.data?.services)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("pushes storage when the remote response omits databasePoolMode", () => {
+    const { layer, out } = setup({
+      toml: `project_id = "test"
+[auth]
+enabled = false
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+`,
+      yes: true,
+      routes: {
+        postgrestGet: { status: 200, body: POSTGREST_DISABLED },
+        postgresGet: { status: 200, body: {} },
+        storageGet: { status: 200, body: STORAGE_CONFIG_WITHOUT_POOL_MODE },
+      },
+    });
+    return Effect.gen(function* () {
+      yield* legacyConfigPush({ projectRef: Option.none() });
+      expect(out.stderrText).toContain("Remote Storage config is up to date.");
     }).pipe(Effect.provide(layer));
   });
 

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -615,5 +615,22 @@
       "type": "string",
       "nullable": true
     }
+  },
+  {
+    "op": "test",
+    "path": "/components/schemas/StorageConfigResponse/required",
+    "value": [
+      "fileSizeLimit",
+      "features",
+      "capabilities",
+      "external",
+      "migrationVersion",
+      "databasePoolMode"
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/StorageConfigResponse/required",
+    "value": ["fileSizeLimit", "features", "capabilities", "external", "migrationVersion"]
   }
 ]

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -3527,7 +3527,7 @@ export const V1GetStorageConfigOutput = Schema.Struct({
   capabilities: Schema.Struct({ list_v2: Schema.Boolean, iceberg_catalog: Schema.Boolean }),
   external: Schema.Struct({ upstreamTarget: Schema.Literals(["main", "canary"]) }),
   migrationVersion: Schema.String,
-  databasePoolMode: Schema.String,
+  databasePoolMode: Schema.optionalKey(Schema.String),
 });
 export const V1GetVanitySubdomainConfigInput = Schema.Struct({
   ref: Schema.String.check(Schema.isMinLength(20))

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -18698,14 +18698,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "fileSizeLimit",
-          "features",
-          "capabilities",
-          "external",
-          "migrationVersion",
-          "databasePoolMode"
-        ]
+        "required": ["fileSizeLimit", "features", "capabilities", "external", "migrationVersion"]
       },
       "UpdateStorageConfigBody": {
         "type": "object",


### PR DESCRIPTION
## TL;DR 
Fixes `config push` failing when the remote Storage config omits `databasePoolMode`

## ref:
- closes https://github.com/supabase/cli/issues/5728
- closes https://github.com/supabase/cli/issues/5726