### PR TITLE
ci: migrate build artifact handoff from cache to artifacts

### DIFF
--- a/.github/workflows/build-cli-artifacts.yml
+++ b/.github/workflows/build-cli-artifacts.yml
@@ -21,8 +21,8 @@ on:
         required: false
         type: string
         default: blacksmith-32vcpu-ubuntu-2404
-      cache_key_suffix:
-        description: Suffix to distinguish build artifact cache producers
+      artifact_name_suffix:
+        description: Suffix to distinguish build artifact producers (e.g. -github)
         required: false
         type: string
         default: ""
@@ -124,23 +124,25 @@ jobs:
           ls -la dist/
 
 
-      - name: Check existing build artifacts cache
-        id: build-artifacts-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Hand the build off to the smoke/publish/brew/scoop jobs via a run-scoped
+      # artifact rather than a cache. Caches share a 10 GB per-repo budget and
+      # are evicted LRU, so a large build cache could vanish mid-run between the
+      # producer and a later consumer (e.g. publish), failing the restore.
+      # Artifacts have their own deterministic retention and survive job re-runs
+      # within the run, which is exactly what this handoff needs.
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.artifact_name_suffix }}
           path: |
             packages/cli-*/bin/
             dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.cache_key_suffix }}-v1
-          enableCrossOsArchive: true
-          lookup-only: true
-
-      - name: Save build artifacts cache
-        if: steps.build-artifacts-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.cache_key_suffix }}-v1
-          enableCrossOsArchive: true
+          # Intra-run handoff, not a kept deliverable — expire it the next day.
+          retention-days: 1
+          # A full re-run of this job replaces its own artifact instead of
+          # failing on the duplicate name from the previous attempt.
+          overwrite: true
+          # dist/* is already compressed (tar.gz/zip/deb/rpm/apk); a light level
+          # trims the raw bin/ binaries without burning CPU re-packing the rest.
+          compression-level: 1
+          if-no-files-found: error

--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -57,15 +57,10 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Restore preview build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download preview build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-legacy-${{ env.PREVIEW_VERSION }}-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-legacy-${{ env.PREVIEW_VERSION }}
 
       - name: Prepare package files
         run: |

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -75,7 +75,7 @@ jobs:
       version: ${{ inputs.version }}
       shell: ${{ inputs.shell }}
       runner: large-linux-x86
-      cache_key_suffix: -github
+      artifact_name_suffix: -github
       timeout_minutes: 45
       build_timeout_minutes: 20
     secrets:
@@ -109,15 +109,10 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Restore build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}
 
       # Docker's classic image store keeps a single platform manifest per
       # tag, so pulling `alpine:3.21` for amd64 and again for arm64 leaves
@@ -245,15 +240,10 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Restore build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
 
       - name: Fix binary permissions
         run: chmod +x packages/cli-*/bin/supabase || true
@@ -304,15 +294,17 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Restore build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
+
+      # Artifacts are zipped and do not carry Unix permissions, so the compiled
+      # binaries arrive without the executable bit. publish.ts ships
+      # packages/cli-*/bin/supabase to npm verbatim, so restore +x before
+      # publishing or the installed CLI would not be runnable.
+      - name: Fix binary permissions
+        run: chmod +x packages/cli-*/bin/supabase || true
 
       - name: Sync versions
         run: pnpm exec bun apps/cli/scripts/sync-versions.ts --version "${VERSION}"
@@ -450,8 +442,6 @@ jobs:
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    # github-hosted to share a cache store with build-github/publish, whose
-    # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -468,21 +458,16 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      # Must restore the github-hosted build (-github-v1), the same artifacts
-      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
-      # are not byte-for-byte reproducible across the blacksmith and github
-      # builds, so the blacksmith dist/checksums.txt does not match the released
+      # Must download the github-hosted build (-github), the same artifacts the
+      # publish job uploads to the GitHub Release. The Bun-compiled binaries are
+      # not byte-for-byte reproducible across the blacksmith and github builds,
+      # so the blacksmith dist/checksums.txt does not match the released
       # tarballs. Reading it here produced a formula whose sha256 rejected the
       # downloaded archive ("Formula reports different checksum").
-      - name: Restore build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
 
       - name: Generate Homebrew tap token
         id: app-token
@@ -513,8 +498,6 @@ jobs:
   publish-scoop:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
-    # github-hosted to share a cache store with build-github/publish, whose
-    # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -531,21 +514,16 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      # Must restore the github-hosted build (-github-v1), the same artifacts
-      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
-      # are not byte-for-byte reproducible across the blacksmith and github
-      # builds, so the blacksmith dist/checksums.txt does not match the released
+      # Must download the github-hosted build (-github), the same artifacts the
+      # publish job uploads to the GitHub Release. The Bun-compiled binaries are
+      # not byte-for-byte reproducible across the blacksmith and github builds,
+      # so the blacksmith dist/checksums.txt does not match the released
       # tarballs. Reading it here would produce a manifest whose hash rejects the
       # downloaded archive.
-      - name: Restore build artifacts cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: |
-            packages/cli-*/bin/
-            dist/
-          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
 
       - name: Generate Scoop bucket token
         id: app-token


### PR DESCRIPTION
Replace GitHub Actions cache with artifacts for passing build outputs between jobs in the release workflow. This improves reliability by using run-scoped artifacts with deterministic retention instead of a shared 10 GB cache budget that can be evicted LRU mid-run.

**Key changes:**

- **build-cli-artifacts.yml**: Replace `actions/cache/save` with `actions/upload-artifact` to hand off compiled binaries and dist files to downstream jobs. Artifacts are configured with 1-day retention, light compression (binaries already compressed), and overwrite enabled for job re-runs.

- **release-shared.yml**: Replace all `actions/cache/restore` calls with `actions/download-artifact` in publish, publish-homebrew, and publish-scoop jobs. Update artifact names to match the new naming scheme (`cli-build-{shell}-{version}{suffix}`).

- **build-cli-artifacts.yml**: Rename `cache_key_suffix` input to `artifact_name_suffix` for clarity.

- **release-shared.yml**: Add missing binary permission fix step in the npm-publish job (chmod +x on compiled binaries) to match the pattern used in other publish jobs, since artifacts don't preserve Unix permissions.

- **publish-preview-cli-packages.yml**: Update preview build artifact retrieval to use `actions/download-artifact`.

This change eliminates the risk of cache eviction between the build producer and downstream consumers while simplifying the artifact naming and handoff logic.

https://claude.ai/code/session_012AkD2XxUdcrBLH58fQr7yi