### PR TITLE
ci(release): restore action/cache release handoff

### DIFF
--- a/.github/workflows/build-cli-artifacts.yml
+++ b/.github/workflows/build-cli-artifacts.yml
@@ -21,8 +21,8 @@ on:
         required: false
         type: string
         default: blacksmith-32vcpu-ubuntu-2404
-      artifact_name_suffix:
-        description: Suffix to distinguish build artifact producers (e.g. -github)
+      cache_key_suffix:
+        description: Suffix to distinguish build artifact cache producers
         required: false
         type: string
         default: ""
@@ -123,26 +123,23 @@ jobs:
           echo "Checking dist/..."
           ls -la dist/
 
-
-      # Hand the build off to the smoke/publish/brew/scoop jobs via a run-scoped
-      # artifact rather than a cache. Caches share a 10 GB per-repo budget and
-      # are evicted LRU, so a large build cache could vanish mid-run between the
-      # producer and a later consumer (e.g. publish), failing the restore.
-      # Artifacts have their own deterministic retention and survive job re-runs
-      # within the run, which is exactly what this handoff needs.
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Check existing build artifacts cache
+        id: build-artifacts-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.artifact_name_suffix }}
           path: |
             packages/cli-*/bin/
             dist/
-          # Intra-run handoff, not a kept deliverable — expire it the next day.
-          retention-days: 1
-          # A full re-run of this job replaces its own artifact instead of
-          # failing on the duplicate name from the previous attempt.
-          overwrite: true
-          # dist/* is already compressed (tar.gz/zip/deb/rpm/apk); a light level
-          # trims the raw bin/ binaries without burning CPU re-packing the rest.
-          compression-level: 1
-          if-no-files-found: error
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.cache_key_suffix }}-v1
+          enableCrossOsArchive: true
+          lookup-only: true
+
+      - name: Save build artifacts cache
+        if: steps.build-artifacts-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}${{ inputs.cache_key_suffix }}-v1
+          enableCrossOsArchive: true

--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -57,10 +57,15 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Download preview build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore preview build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-legacy-${{ env.PREVIEW_VERSION }}
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-legacy-${{ env.PREVIEW_VERSION }}-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Prepare package files
         run: |

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -75,7 +75,7 @@ jobs:
       version: ${{ inputs.version }}
       shell: ${{ inputs.shell }}
       runner: large-linux-x86
-      artifact_name_suffix: -github
+      cache_key_suffix: -github
       timeout_minutes: 45
       build_timeout_minutes: 20
     secrets:
@@ -109,10 +109,15 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       # Docker's classic image store keeps a single platform manifest per
       # tag, so pulling `alpine:3.21` for amd64 and again for arm64 leaves
@@ -240,10 +245,15 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Fix binary permissions
         run: chmod +x packages/cli-*/bin/supabase || true
@@ -294,17 +304,15 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
-
-      # Artifacts are zipped and do not carry Unix permissions, so the compiled
-      # binaries arrive without the executable bit. publish.ts ships
-      # packages/cli-*/bin/supabase to npm verbatim, so restore +x before
-      # publishing or the installed CLI would not be runnable.
-      - name: Fix binary permissions
-        run: chmod +x packages/cli-*/bin/supabase || true
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Sync versions
         run: pnpm exec bun apps/cli/scripts/sync-versions.ts --version "${VERSION}"
@@ -442,6 +450,8 @@ jobs:
   publish-homebrew:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
+    # github-hosted to share a cache store with build-github/publish, whose
+    # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -458,16 +468,21 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      # Must download the github-hosted build (-github), the same artifacts the
-      # publish job uploads to the GitHub Release. The Bun-compiled binaries are
-      # not byte-for-byte reproducible across the blacksmith and github builds,
-      # so the blacksmith dist/checksums.txt does not match the released
+      # Must restore the github-hosted build (-github-v1), the same artifacts
+      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
+      # are not byte-for-byte reproducible across the blacksmith and github
+      # builds, so the blacksmith dist/checksums.txt does not match the released
       # tarballs. Reading it here produced a formula whose sha256 rejected the
       # downloaded archive ("Formula reports different checksum").
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Generate Homebrew tap token
         id: app-token
@@ -498,6 +513,8 @@ jobs:
   publish-scoop:
     needs: publish
     if: ${{ !inputs.dry_run && inputs.publish_brew_scoop }}
+    # github-hosted to share a cache store with build-github/publish, whose
+    # -github-v1 artifacts this job's checksums must match.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -514,16 +531,21 @@ jobs:
         with:
           dependency-firewall-token: ${{ secrets.DF_FIREWALL_TOKEN }}
 
-      # Must download the github-hosted build (-github), the same artifacts the
-      # publish job uploads to the GitHub Release. The Bun-compiled binaries are
-      # not byte-for-byte reproducible across the blacksmith and github builds,
-      # so the blacksmith dist/checksums.txt does not match the released
+      # Must restore the github-hosted build (-github-v1), the same artifacts
+      # the publish job uploads to the GitHub Release. The Bun-compiled binaries
+      # are not byte-for-byte reproducible across the blacksmith and github
+      # builds, so the blacksmith dist/checksums.txt does not match the released
       # tarballs. Reading it here would produce a manifest whose hash rejects the
       # downloaded archive.
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: cli-build-${{ inputs.shell }}-${{ inputs.version }}-github
+          path: |
+            packages/cli-*/bin/
+            dist/
+          key: cli-build-${{ github.run_id }}-${{ inputs.shell }}-${{ inputs.version }}-github-v1
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Generate Scoop bucket token
         id: app-token


### PR DESCRIPTION
## Summary

Reverts the release workflow handoff from uploaded artifacts back to `actions/cache` now that the repository has more GitHub cache capacity.

This restores the previous run-scoped cache keys for CLI build outputs across smoke, publish, Homebrew, Scoop, and preview-package jobs while keeping the newer pinned `actions/cache` version from the dependency bump.

Reverts #5740
