### PR TITLE
ci: auto approve API sync PRs

### DIFF
--- a/.github/workflows/cli-go-api-sync.yml
+++ b/.github/workflows/cli-go-api-sync.yml
@@ -61,6 +61,13 @@ jobs:
           branch: sync/api-types
           base: develop
 
+      - name: Approve Pull Request
+        if: steps.check.outputs.has_changes == 'true'
+        run: gh pr review --approve --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_PR_PAT }}
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+
       - name: Enable Pull Request Automerge
         if: steps.check.outputs.has_changes == 'true'
         run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"


### PR DESCRIPTION
Follows up on #5753 by letting API sync PRs satisfy the approval requirement automatically.

This adds a dedicated approval step after the generated API sync PR is created. The step uses the shared account PAT stored in `AUTO_APPROVE_PR_PAT`, while the existing GitHub App token continues to own PR creation and auto-merge setup.