### PR TITLE
fix(cli): query output

### DIFF
--- a/apps/cli/src/legacy/commands/db/query/query.handler.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.handler.ts
@@ -356,9 +356,10 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
     // 2. Agent mode + the resolved payload format, mirroring Go's resolution
     //    (`cmd/db.go:316-325`): an explicit `-o json|table|csv` always wins;
     //    otherwise default to JSON for agents and a table for humans. The global
-    //    `-o` choice is a union (see `query.command.ts`), so values outside Go's
-    //    `json|table|csv` enum (`pretty|yaml|toml|env`) fall through to the
-    //    agent-mode default rather than erroring.
+    //    `-o` choice is a union (see `query.command.ts`), while TS
+    //    `--output-format json|stream-json` must also resolve to JSON here, so
+    //    values outside Go's `json|table|csv` enum (`pretty|yaml|toml|env`)
+    //    fall through to the agent/machine default rather than erroring.
     const agentMode = legacyResolveAgentMode(agentFlag, aiTool.name);
     const explicit = Option.getOrUndefined(outputFlag);
     const format: LegacyResolvedFormat =
@@ -368,7 +369,7 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
           ? "csv"
           : explicit === "table"
             ? "table"
-            : agentMode
+            : output.format !== "text" || agentMode
               ? "json"
               : "table";
 

--- a/apps/cli/src/legacy/commands/db/query/query.handler.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.handler.ts
@@ -121,7 +121,14 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
       const jsonData =
         fieldTypeIds === undefined ? data : legacyCoerceLocalJsonRows(data, fieldTypeIds);
       const boundary = agentMode ? yield* random.randomHex(BOUNDARY_BYTES) : "";
-      yield* output.raw(legacyRenderJson(cols, jsonData, agentMode, boundary, advisory));
+      const rendered = legacyRenderJson(cols, jsonData, agentMode, boundary, advisory);
+      if (output.format === "stream-json" && Option.getOrUndefined(outputFlag) !== "json") {
+        yield* output.raw(
+          `{"type":"result","data":${rendered.trimEnd()},"timestamp":${JSON.stringify(new Date().toISOString())}}\n`,
+        );
+        return;
+      }
+      yield* output.raw(rendered);
     });
 
   const runLocal = (

--- a/apps/cli/src/legacy/commands/db/query/query.handler.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.handler.ts
@@ -123,8 +123,9 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
       const boundary = agentMode ? yield* random.randomHex(BOUNDARY_BYTES) : "";
       const rendered = legacyRenderJson(cols, jsonData, agentMode, boundary, advisory);
       if (output.format === "stream-json" && Option.getOrUndefined(outputFlag) !== "json") {
+        const compactRendered = rendered.trimEnd().replaceAll("\n", "");
         yield* output.raw(
-          `{"type":"result","data":${rendered.trimEnd()},"timestamp":${JSON.stringify(new Date().toISOString())}}\n`,
+          `{"type":"result","data":${compactRendered},"timestamp":${JSON.stringify(new Date().toISOString())}}\n`,
         );
         return;
       }
@@ -374,9 +375,9 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
         ? "json"
         : explicit === "csv"
           ? "csv"
-          : explicit === "table"
+          : explicit === "table" || explicit === "pretty"
             ? "table"
-            : output.format !== "text" || agentMode
+            : explicit === undefined && (output.format !== "text" || agentMode)
               ? "json"
               : "table";
 

--- a/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
@@ -447,6 +447,7 @@ describe("legacy db query integration", () => {
     const { layer, out } = setup({ result: SELECT_RESULT, agent: "no", format: "stream-json" });
     return Effect.gen(function* () {
       yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
+      expect(out.stdoutText.trimEnd().split("\n")).toHaveLength(1);
       expect(JSON.parse(out.stdoutText)).toEqual(
         expect.objectContaining({
           type: "result",
@@ -472,7 +473,22 @@ describe("legacy db query integration", () => {
     });
     return Effect.gen(function* () {
       yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
-      expect(out.stdoutText).toContain('"data":[\n  {\n    "n": 9223372036854775807\n  }\n]');
+      expect(out.stdoutText.trimEnd().split("\n")).toHaveLength(1);
+      expect(out.stdoutText).toContain('"n": 9223372036854775807');
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("lets --output pretty win over --output-format json", () => {
+    const { layer, out } = setup({
+      result: SELECT_RESULT,
+      agent: "no",
+      format: "json",
+      goOutput: "pretty",
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
+      expect(out.stdoutText).toContain("│ id │ name  │");
+      expect(out.messages.find((message) => message.type === "success")).toBeUndefined();
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
@@ -443,14 +443,36 @@ describe("legacy db query integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("renders plain JSON for --output-format stream-json with --agent no", () => {
+  it.live("emits a result event for --output-format stream-json with --agent no", () => {
     const { layer, out } = setup({ result: SELECT_RESULT, agent: "no", format: "stream-json" });
     return Effect.gen(function* () {
       yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
-      expect(JSON.parse(out.stdoutText)).toEqual([
-        { id: 1, name: "alice" },
-        { id: 2, name: "bob" },
-      ]);
+      expect(JSON.parse(out.stdoutText)).toEqual(
+        expect.objectContaining({
+          type: "result",
+          data: [
+            { id: 1, name: "alice" },
+            { id: 2, name: "bob" },
+          ],
+        }),
+      );
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("preserves exact bigint tokens in --output-format stream-json", () => {
+    const { layer, out } = setup({
+      result: {
+        fields: ["n"],
+        fieldTypeIds: [20],
+        rows: [["9223372036854775807"]],
+        commandTag: "SELECT 1",
+      },
+      agent: "no",
+      format: "stream-json",
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
+      expect(out.stdoutText).toContain('"data":[\n  {\n    "n": 9223372036854775807\n  }\n]');
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.integration.test.ts
@@ -432,6 +432,28 @@ describe("legacy db query integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.live("renders plain JSON for --output-format json with --agent no", () => {
+    const { layer, out } = setup({ result: SELECT_RESULT, agent: "no", format: "json" });
+    return Effect.gen(function* () {
+      yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
+      expect(JSON.parse(out.stdoutText)).toEqual([
+        { id: 1, name: "alice" },
+        { id: 2, name: "bob" },
+      ]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("renders plain JSON for --output-format stream-json with --agent no", () => {
+    const { layer, out } = setup({ result: SELECT_RESULT, agent: "no", format: "stream-json" });
+    return Effect.gen(function* () {
+      yield* legacyDbQuery(flags({ sql: Option.some("select 1"), local: Option.some(true) }));
+      expect(JSON.parse(out.stdoutText)).toEqual([
+        { id: 1, name: "alice" },
+        { id: 2, name: "bob" },
+      ]);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.live("fails JSON output on a non-finite float (Go's json.Encoder error), no stdout", () => {
     // select 'NaN'::float8 -o json — Go fails to encode and exits non-zero with empty
     // stdout, rather than emitting `null` like JSON.stringify.


### PR DESCRIPTION

## TL;DR 
makes `db query --output-format json` resolve to JSON even when `--agent no` is used

## ref:
- Closes https://github.com/supabase/cli/issues/5762