### PR TITLE
fix(cli): CSV-split sso and postgres-config StringSlice flags

### DIFF
--- a/apps/cli/src/legacy/commands/postgres-config/delete/delete.command.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/delete/delete.command.ts
@@ -3,18 +3,25 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { legacyParseStringSliceFlag } from "../../../shared/legacy-string-slice-flag.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyPostgresConfigDelete } from "./delete.handler.ts";
+
+export const legacyPostgresConfigDeleteConfigFlag = Flag.string("config").pipe(
+  Flag.withDescription("Config keys to delete (comma-separated)"),
+  Flag.atLeast(0),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+);
 
 const config = {
   projectRef: Flag.string("project-ref").pipe(
     Flag.withDescription("Project ref of the Supabase project."),
     Flag.optional,
   ),
-  config: Flag.string("config").pipe(
-    Flag.withDescription("Config keys to delete (comma-separated)"),
-    Flag.atLeast(0),
-  ),
+  config: legacyPostgresConfigDeleteConfigFlag,
   noRestart: Flag.boolean("no-restart").pipe(
     Flag.withDescription("Do not restart the database after deleting config."),
   ),

--- a/apps/cli/src/legacy/commands/postgres-config/delete/delete.command.unit.test.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/delete/delete.command.unit.test.ts
@@ -1,0 +1,46 @@
+import { BunServices } from "@effect/platform-bun";
+import { Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+import { legacyPostgresConfigDeleteConfigFlag } from "./delete.command.ts";
+
+describe("legacy postgres-config delete --config flag (pflag StringSlice parity)", () => {
+  test("splits a comma-separated value into multiple keys", async () => {
+    const [, values] = await Effect.runPromise(
+      legacyPostgresConfigDeleteConfigFlag
+        .parse({
+          flags: { config: ["max_connections,statement_timeout"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(values).toEqual(["max_connections", "statement_timeout"]);
+  });
+
+  test("accumulates repeated occurrences, each CSV-split", async () => {
+    const [, values] = await Effect.runPromise(
+      legacyPostgresConfigDeleteConfigFlag
+        .parse({
+          flags: { config: ["max_connections,statement_timeout", "custom_key"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(values).toEqual(["max_connections", "statement_timeout", "custom_key"]);
+  });
+
+  test("rejects malformed CSV (bare quote)", async () => {
+    const exit = await Effect.runPromise(
+      legacyPostgresConfigDeleteConfigFlag
+        .parse({
+          flags: { config: ['max"connections'] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer))
+        .pipe(Effect.exit),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/apps/cli/src/legacy/commands/postgres-config/update/update.command.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/update/update.command.ts
@@ -3,18 +3,25 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { legacyParseStringSliceFlag } from "../../../shared/legacy-string-slice-flag.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyPostgresConfigUpdate } from "./update.handler.ts";
+
+export const legacyPostgresConfigUpdateConfigFlag = Flag.string("config").pipe(
+  Flag.withDescription("Config overrides specified as a 'key=value' pair"),
+  Flag.atLeast(0),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+);
 
 const config = {
   projectRef: Flag.string("project-ref").pipe(
     Flag.withDescription("Project ref of the Supabase project."),
     Flag.optional,
   ),
-  config: Flag.string("config").pipe(
-    Flag.withDescription("Config overrides specified as a 'key=value' pair"),
-    Flag.atLeast(0),
-  ),
+  config: legacyPostgresConfigUpdateConfigFlag,
   replaceExistingOverrides: Flag.boolean("replace-existing-overrides").pipe(
     Flag.withDescription(
       "If true, replaces all existing overrides with the ones provided. If false (default), merges existing overrides with the ones provided.",

--- a/apps/cli/src/legacy/commands/postgres-config/update/update.command.unit.test.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/update/update.command.unit.test.ts
@@ -1,0 +1,46 @@
+import { BunServices } from "@effect/platform-bun";
+import { Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+import { legacyPostgresConfigUpdateConfigFlag } from "./update.command.ts";
+
+describe("legacy postgres-config update --config flag (pflag StringSlice parity)", () => {
+  test("splits a comma-separated value into multiple key=value pairs", async () => {
+    const [, values] = await Effect.runPromise(
+      legacyPostgresConfigUpdateConfigFlag
+        .parse({
+          flags: { config: ["max_connections=100,statement_timeout=600"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(values).toEqual(["max_connections=100", "statement_timeout=600"]);
+  });
+
+  test("accumulates repeated occurrences, each CSV-split", async () => {
+    const [, values] = await Effect.runPromise(
+      legacyPostgresConfigUpdateConfigFlag
+        .parse({
+          flags: { config: ["max_connections=100,statement_timeout=600", "custom_key=alpha"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(values).toEqual(["max_connections=100", "statement_timeout=600", "custom_key=alpha"]);
+  });
+
+  test("rejects malformed CSV (unterminated quote)", async () => {
+    const exit = await Effect.runPromise(
+      legacyPostgresConfigUpdateConfigFlag
+        .parse({
+          flags: { config: ['"max_connections=100'] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer))
+        .pipe(Effect.exit),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/apps/cli/src/legacy/commands/sso/add/add.command.ts
+++ b/apps/cli/src/legacy/commands/sso/add/add.command.ts
@@ -3,6 +3,7 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { legacyParseStringSliceFlag } from "../../../shared/legacy-string-slice-flag.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySsoAdd } from "./add.handler.ts";
 
@@ -12,6 +13,18 @@ const NAME_ID_FORMATS = [
   "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
   "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
 ] as const;
+
+export const legacySsoAddDomainsFlag = Flag.string("domains").pipe(
+  Flag.atLeast(0),
+  Flag.withDescription(
+    "Comma separated list of email domains to associate with the added identity provider.",
+  ),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+  Flag.withDefault([] as ReadonlyArray<string>),
+);
 
 const config = {
   projectRef: Flag.string("project-ref").pipe(
@@ -24,13 +37,7 @@ const config = {
     Flag.withAlias("t"),
     Flag.withDescription("Type of identity provider (according to supported protocol)."),
   ),
-  domains: Flag.string("domains").pipe(
-    Flag.atLeast(0),
-    Flag.withDescription(
-      "Comma separated list of email domains to associate with the added identity provider.",
-    ),
-    Flag.withDefault([] as ReadonlyArray<string>),
-  ),
+  domains: legacySsoAddDomainsFlag,
   metadataFile: Flag.string("metadata-file").pipe(
     Flag.withDescription(
       "File containing a SAML 2.0 Metadata XML document describing the identity provider.",

--- a/apps/cli/src/legacy/commands/sso/add/add.command.unit.test.ts
+++ b/apps/cli/src/legacy/commands/sso/add/add.command.unit.test.ts
@@ -1,0 +1,59 @@
+import { BunServices } from "@effect/platform-bun";
+import { Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+import { legacySsoAddDomainsFlag } from "./add.command.ts";
+
+describe("legacy sso add --domains flag (pflag StringSlice parity)", () => {
+  test("splits a comma-separated value into multiple domains", async () => {
+    const [, domains] = await Effect.runPromise(
+      legacySsoAddDomainsFlag
+        .parse({
+          flags: { domains: ["example.com,example.org"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(domains).toEqual(["example.com", "example.org"]);
+  });
+
+  test("accumulates repeated occurrences, each CSV-split", async () => {
+    const [, domains] = await Effect.runPromise(
+      legacySsoAddDomainsFlag
+        .parse({
+          flags: { domains: ["example.com,example.org", "example.net"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(domains).toEqual(["example.com", "example.org", "example.net"]);
+  });
+
+  test("defaults to an empty array when unset", async () => {
+    const [, domains] = await Effect.runPromise(
+      legacySsoAddDomainsFlag
+        .parse({
+          flags: {},
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(domains).toEqual([]);
+  });
+
+  test("rejects malformed CSV (unterminated quote)", async () => {
+    const exit = await Effect.runPromise(
+      legacySsoAddDomainsFlag
+        .parse({
+          flags: { domains: ['"example.com'] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer))
+        .pipe(Effect.exit),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/apps/cli/src/legacy/commands/sso/update/update.command.ts
+++ b/apps/cli/src/legacy/commands/sso/update/update.command.ts
@@ -3,6 +3,7 @@ import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
+import { legacyParseStringSliceFlag } from "../../../shared/legacy-string-slice-flag.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacySsoUpdate } from "./update.handler.ts";
 
@@ -13,30 +14,46 @@ const NAME_ID_FORMATS = [
   "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
 ] as const;
 
+export const legacySsoUpdateDomainsFlag = Flag.string("domains").pipe(
+  Flag.atLeast(0),
+  Flag.withDescription("Replace domains with this comma separated list of email domains."),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+  Flag.withDefault([] as ReadonlyArray<string>),
+);
+
+export const legacySsoUpdateAddDomainsFlag = Flag.string("add-domains").pipe(
+  Flag.atLeast(0),
+  Flag.withDescription("Add this comma separated list of email domains to the identity provider."),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+  Flag.withDefault([] as ReadonlyArray<string>),
+);
+
+export const legacySsoUpdateRemoveDomainsFlag = Flag.string("remove-domains").pipe(
+  Flag.atLeast(0),
+  Flag.withDescription(
+    "Remove this comma separated list of email domains from the identity provider.",
+  ),
+  Flag.mapTryCatch(
+    (rawValues) => legacyParseStringSliceFlag(rawValues),
+    (err) => (err instanceof Error ? err.message : String(err)),
+  ),
+  Flag.withDefault([] as ReadonlyArray<string>),
+);
+
 const config = {
   projectRef: Flag.string("project-ref").pipe(
     Flag.withDescription("Project ref of the Supabase project."),
     Flag.optional,
   ),
-  domains: Flag.string("domains").pipe(
-    Flag.atLeast(0),
-    Flag.withDescription("Replace domains with this comma separated list of email domains."),
-    Flag.withDefault([] as ReadonlyArray<string>),
-  ),
-  addDomains: Flag.string("add-domains").pipe(
-    Flag.atLeast(0),
-    Flag.withDescription(
-      "Add this comma separated list of email domains to the identity provider.",
-    ),
-    Flag.withDefault([] as ReadonlyArray<string>),
-  ),
-  removeDomains: Flag.string("remove-domains").pipe(
-    Flag.atLeast(0),
-    Flag.withDescription(
-      "Remove this comma separated list of email domains from the identity provider.",
-    ),
-    Flag.withDefault([] as ReadonlyArray<string>),
-  ),
+  domains: legacySsoUpdateDomainsFlag,
+  addDomains: legacySsoUpdateAddDomainsFlag,
+  removeDomains: legacySsoUpdateRemoveDomainsFlag,
   metadataFile: Flag.string("metadata-file").pipe(
     Flag.withDescription(
       "File containing a SAML 2.0 Metadata XML document describing the identity provider.",

--- a/apps/cli/src/legacy/commands/sso/update/update.command.unit.test.ts
+++ b/apps/cli/src/legacy/commands/sso/update/update.command.unit.test.ts
@@ -1,0 +1,63 @@
+import { BunServices } from "@effect/platform-bun";
+import { Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+import {
+  legacySsoUpdateAddDomainsFlag,
+  legacySsoUpdateDomainsFlag,
+  legacySsoUpdateRemoveDomainsFlag,
+} from "./update.command.ts";
+
+describe("legacy sso update domain flags (pflag StringSlice parity)", () => {
+  test("--domains splits a comma-separated value into multiple domains", async () => {
+    const [, domains] = await Effect.runPromise(
+      legacySsoUpdateDomainsFlag
+        .parse({
+          flags: { domains: ["example.com,example.org"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(domains).toEqual(["example.com", "example.org"]);
+  });
+
+  test("--add-domains splits a comma-separated value into multiple domains", async () => {
+    const [, addDomains] = await Effect.runPromise(
+      legacySsoUpdateAddDomainsFlag
+        .parse({
+          flags: { "add-domains": ["example.com,example.org"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(addDomains).toEqual(["example.com", "example.org"]);
+  });
+
+  test("--remove-domains splits a comma-separated value into multiple domains", async () => {
+    const [, removeDomains] = await Effect.runPromise(
+      legacySsoUpdateRemoveDomainsFlag
+        .parse({
+          flags: { "remove-domains": ["example.com,example.org"] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(removeDomains).toEqual(["example.com", "example.org"]);
+  });
+
+  test("rejects malformed CSV (bare quote)", async () => {
+    const exit = await Effect.runPromise(
+      legacySsoUpdateDomainsFlag
+        .parse({
+          flags: { domains: ['example"com'] },
+          arguments: [],
+        })
+        .pipe(Effect.provide(BunServices.layer))
+        .pipe(Effect.exit),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/apps/cli/src/legacy/shared/legacy-schema-flags.ts
+++ b/apps/cli/src/legacy/shared/legacy-schema-flags.ts
@@ -3,119 +3,23 @@
  *
  * Go defines `--schema` as a Cobra `StringSliceVarP` on both `gen types`
  * (`apps/cli-go/cmd/gen.go:155`) and `db lint` (`apps/cli-go/cmd/db.go:506`).
- * pflag's `StringSlice.Set` parses each value via `encoding/csv` (`readAsCSV`
- * → `csv.NewReader`), so a quoted value like `"tenant,one"` is ONE element
- * (`tenant,one`) while `public,private` is two elements. Plain `split(",")` wrongly
- * breaks quoted commas.
+ * The CSV-per-occurrence parsing itself lives in `legacy-string-slice-flag.ts`
+ * (shared with every other Go `StringSliceVar` flag ported to the legacy
+ * shell); this module re-exports it under the `--schema`-specific names and
+ * adds `legacySchemaToCsvField`, the CSV re-encoder used when forwarding
+ * `--schema` back to a delegated Go subprocess.
  *
- * Whitespace is NOT trimmed and empty fields are NOT dropped: Go's csv.Reader
- * returns raw field values; pflag appends them directly to the slice.
- *
- * Shared by `gen types` and `db lint` (two command families).
+ * Shared by `gen types`, `db lint`, `db dump`, `db pull`, `db diff`, and
+ * `db schema {generate,sync}`.
  */
+import {
+  legacyParseStringSliceFlag,
+  LegacyStringSliceFlagParseError,
+} from "./legacy-string-slice-flag.ts";
 
-/** Thrown by `legacyParseSchemaFlags` when a `--schema` value is not valid CSV. */
-export class LegacySchemaFlagParseError extends Error {
-  readonly value: string;
-  readonly detail: string;
-  constructor(value: string, detail: string) {
-    super(`parse error on line 1, column 0: ${detail}`);
-    this.name = "LegacySchemaFlagParseError";
-    this.value = value;
-    this.detail = detail;
-  }
-}
+export { LegacyStringSliceFlagParseError as LegacySchemaFlagParseError };
 
-/**
- * Parses one CSV record from `val`, matching Go's `encoding/csv` defaults used by
- * pflag's `StringSlice.Set` (`readAsCSV` → `csv.NewReader`).
- *
- * Rules: comma delimiter, double-quote quoting, `""` escapes a literal quote.
- * Whitespace is preserved (Go does not trim). An empty string returns `[]`.
- *
- * **Throws `LegacySchemaFlagParseError`** on any of the three malformed-CSV conditions
- * that Go's `csv.Reader` rejects:
- *   - Quoted field with no closing quote (`"tenant`) → "extraneous or missing \" in quoted-field"
- *   - Extra non-comma bytes after a closing quote (`"a"b`) → "extraneous or missing \" in quoted-field"
- *   - A bare `"` inside an unquoted field (`a"b`) → "bare \" in non-quoted-field"
- */
-function readAsCSVStrict(val: string): string[] {
-  if (val === "") return [];
-  const fields: string[] = [];
-  let i = 0;
-  while (i < val.length) {
-    if (val[i] === '"') {
-      // Quoted field: accumulate until the closing (unescaped) quote.
-      i++; // skip opening quote
-      let field = "";
-      let closed = false;
-      while (i < val.length) {
-        if (val[i] === '"') {
-          if (i + 1 < val.length && val[i + 1] === '"') {
-            field += '"';
-            i += 2; // "" → single "
-          } else {
-            i++; // skip closing quote
-            closed = true;
-            break;
-          }
-        } else {
-          field += val[i++];
-        }
-      }
-      if (!closed) {
-        // Ran off the end without finding a closing quote.
-        throw new LegacySchemaFlagParseError(val, `extraneous or missing " in quoted-field`);
-      }
-      // After the closing quote only a comma or end-of-string is allowed.
-      if (i < val.length && val[i] !== ",") {
-        throw new LegacySchemaFlagParseError(val, `extraneous or missing " in quoted-field`);
-      }
-      fields.push(field);
-    } else {
-      // Unquoted field: a bare `"` anywhere inside is illegal.
-      const start = i;
-      while (i < val.length && val[i] !== ",") {
-        if (val[i] === '"') {
-          throw new LegacySchemaFlagParseError(val, `bare " in non-quoted-field`);
-        }
-        i++;
-      }
-      fields.push(val.slice(start, i));
-    }
-    // Consume the delimiter; a trailing comma produces one more empty field.
-    if (i < val.length && val[i] === ",") {
-      i++;
-      if (i === val.length) {
-        fields.push(""); // trailing comma → empty trailing field
-      }
-    }
-  }
-  return fields;
-}
-
-/**
- * CSV-parses and flattens all raw `--schema` occurrences.
- *
- * **Throws `LegacySchemaFlagParseError`** on the first malformed value, matching
- * Go's pflag parse-time behaviour where a bad `--schema` value fails the command
- * before it runs (Go: `invalid argument "..." for "-s, --schema" flag: parse error ...`).
- *
- * Valid behaviour:
- *   - `"tenant,one"` → `["tenant,one"]` (quoted comma stays one field)
- *   - `public,private` → `["public", "private"]`
- *   - no trimming, `""` escapes a literal quote inside a quoted field
- *   - empty string → no field
- */
-export function legacyParseSchemaFlags(rawValues: ReadonlyArray<string>): ReadonlyArray<string> {
-  const schemas: string[] = [];
-  for (const value of rawValues) {
-    for (const field of readAsCSVStrict(value)) {
-      schemas.push(field);
-    }
-  }
-  return schemas;
-}
+export const legacyParseSchemaFlags = legacyParseStringSliceFlag;
 
 /**
  * Whether a CSV field must be quoted. Mirrors Go's `encoding/csv`

--- a/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
+++ b/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
@@ -1,0 +1,116 @@
+/**
+ * Parses a pflag `StringSliceVar` flag: CSV-splits each occurrence via
+ * `encoding/csv` and accumulates across repeats, matching `readAsCSV` in
+ * `github.com/spf13/pflag/string_slice.go`'s `stringSliceValue.Set`. A naive
+ * `.split(",")` diverges on quoted/embedded commas (`'"a,b",c'`). Effect V4
+ * CLI has no CSV/list primitive, so every Go `StringSliceVar` flag ported to
+ * the legacy shell needs this (e.g. `--domains`, `--config`).
+ *
+ * Whitespace is NOT trimmed and empty fields are NOT dropped: Go's csv.Reader
+ * returns raw field values; pflag appends them directly to the slice.
+ */
+
+/** Thrown by `legacyParseStringSliceFlag` when a value is not valid CSV. */
+export class LegacyStringSliceFlagParseError extends Error {
+  readonly value: string;
+  readonly detail: string;
+  constructor(value: string, detail: string) {
+    super(`parse error on line 1, column 0: ${detail}`);
+    this.name = "LegacyStringSliceFlagParseError";
+    this.value = value;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Parses one CSV record from `val`, matching Go's `encoding/csv` defaults used by
+ * pflag's `StringSlice.Set` (`readAsCSV` → `csv.NewReader`).
+ *
+ * Rules: comma delimiter, double-quote quoting, `""` escapes a literal quote.
+ * Whitespace is preserved (Go does not trim). An empty string returns `[]`.
+ *
+ * **Throws `LegacyStringSliceFlagParseError`** on any of the three malformed-CSV
+ * conditions that Go's `csv.Reader` rejects:
+ *   - Quoted field with no closing quote (`"tenant`) → "extraneous or missing \" in quoted-field"
+ *   - Extra non-comma bytes after a closing quote (`"a"b`) → "extraneous or missing \" in quoted-field"
+ *   - A bare `"` inside an unquoted field (`a"b`) → "bare \" in non-quoted-field"
+ */
+function readAsCSVStrict(val: string): string[] {
+  if (val === "") return [];
+  const fields: string[] = [];
+  let i = 0;
+  while (i < val.length) {
+    if (val[i] === '"') {
+      // Quoted field: accumulate until the closing (unescaped) quote.
+      i++; // skip opening quote
+      let field = "";
+      let closed = false;
+      while (i < val.length) {
+        if (val[i] === '"') {
+          if (i + 1 < val.length && val[i + 1] === '"') {
+            field += '"';
+            i += 2; // "" → single "
+          } else {
+            i++; // skip closing quote
+            closed = true;
+            break;
+          }
+        } else {
+          field += val[i++];
+        }
+      }
+      if (!closed) {
+        // Ran off the end without finding a closing quote.
+        throw new LegacyStringSliceFlagParseError(val, `extraneous or missing " in quoted-field`);
+      }
+      // After the closing quote only a comma or end-of-string is allowed.
+      if (i < val.length && val[i] !== ",") {
+        throw new LegacyStringSliceFlagParseError(val, `extraneous or missing " in quoted-field`);
+      }
+      fields.push(field);
+    } else {
+      // Unquoted field: a bare `"` anywhere inside is illegal.
+      const start = i;
+      while (i < val.length && val[i] !== ",") {
+        if (val[i] === '"') {
+          throw new LegacyStringSliceFlagParseError(val, `bare " in non-quoted-field`);
+        }
+        i++;
+      }
+      fields.push(val.slice(start, i));
+    }
+    // Consume the delimiter; a trailing comma produces one more empty field.
+    if (i < val.length && val[i] === ",") {
+      i++;
+      if (i === val.length) {
+        fields.push(""); // trailing comma → empty trailing field
+      }
+    }
+  }
+  return fields;
+}
+
+/**
+ * CSV-parses and flattens all raw occurrences of a repeated pflag `StringSlice` flag.
+ *
+ * **Throws `LegacyStringSliceFlagParseError`** on the first malformed value, matching
+ * Go's pflag parse-time behaviour where a bad value fails the command before it
+ * runs (Go: `invalid argument "..." for "--<flag>" flag: parse error ...`).
+ *
+ * Valid behaviour:
+ *   - `"tenant,one"` → `["tenant,one"]` (quoted comma stays one field)
+ *   - `public,private` → `["public", "private"]`
+ *   - no trimming, `""` escapes a literal quote inside a quoted field
+ *   - empty string → no field
+ */
+export function legacyParseStringSliceFlag(
+  rawValues: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const values: string[] = [];
+  for (const value of rawValues) {
+    for (const field of readAsCSVStrict(value)) {
+      values.push(field);
+    }
+  }
+  return values;
+}

--- a/apps/cli/src/legacy/shared/legacy-string-slice-flag.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-string-slice-flag.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  legacyParseStringSliceFlag,
+  LegacyStringSliceFlagParseError,
+} from "./legacy-string-slice-flag.ts";
+
+describe("legacyParseStringSliceFlag (pflag StringSlice CSV parity)", () => {
+  it("splits unquoted comma-separated values", () => {
+    expect(legacyParseStringSliceFlag(["public,private"])).toEqual(["public", "private"]);
+  });
+
+  it("keeps a quoted value with embedded comma as a single element", () => {
+    // pflag TestSSWithComma: `"tenant,one"` → one element "tenant,one"
+    expect(legacyParseStringSliceFlag(['"tenant,one"'])).toEqual(["tenant,one"]);
+  });
+
+  it("single value with no comma", () => {
+    expect(legacyParseStringSliceFlag(["public"])).toEqual(["public"]);
+  });
+
+  it("accumulates repeated flags", () => {
+    expect(legacyParseStringSliceFlag(["public", "private"])).toEqual(["public", "private"]);
+  });
+
+  it("accumulates repeated flags mixed with csv", () => {
+    expect(legacyParseStringSliceFlag(["public,private", "staging"])).toEqual([
+      "public",
+      "private",
+      "staging",
+    ]);
+  });
+
+  it("unescapes doubled double-quote inside quoted field", () => {
+    // Go csv: `"a""b"` → field is `a"b`
+    expect(legacyParseStringSliceFlag(['"a""b"'])).toEqual(['a"b']);
+  });
+
+  it("empty input returns empty array", () => {
+    expect(legacyParseStringSliceFlag([])).toEqual([]);
+  });
+
+  it("preserves whitespace (Go does not trim)", () => {
+    // Go csv passes raw field values; pflag does not trim
+    expect(legacyParseStringSliceFlag([" public , private "])).toEqual([" public ", " private "]);
+  });
+
+  // --- malformed inputs: must THROW ---
+
+  it("throws on an unterminated quoted field", () => {
+    // `"tenant` — opening quote but no closing quote
+    expect(() => legacyParseStringSliceFlag(['"tenant'])).toThrow(LegacyStringSliceFlagParseError);
+    expect(() => legacyParseStringSliceFlag(['"tenant'])).toThrow(
+      /extraneous or missing " in quoted-field/,
+    );
+  });
+
+  it("throws on extra bytes after a closing quote", () => {
+    // `"a"b` — closing quote followed by a non-comma character
+    expect(() => legacyParseStringSliceFlag(['"a"b'])).toThrow(LegacyStringSliceFlagParseError);
+    expect(() => legacyParseStringSliceFlag(['"a"b'])).toThrow(
+      /extraneous or missing " in quoted-field/,
+    );
+  });
+
+  it("throws on a bare quote inside an unquoted field", () => {
+    // `a"b` — bare " in a field that did not start with a quote
+    expect(() => legacyParseStringSliceFlag(['a"b'])).toThrow(LegacyStringSliceFlagParseError);
+    expect(() => legacyParseStringSliceFlag(['a"b'])).toThrow(/bare " in non-quoted-field/);
+  });
+
+  it("throws on the first malformed value in a multi-value list", () => {
+    // The valid "public" comes before the malformed one; the error is still thrown
+    expect(() => legacyParseStringSliceFlag(["public", '"broken'])).toThrow(
+      LegacyStringSliceFlagParseError,
+    );
+  });
+});


### PR DESCRIPTION
## Current Behavior

Go registers `sso add/update --domains/--add-domains/--remove-domains` and `postgres-config update/delete --config` as pflag `StringSliceVar`, which CSV-splits each occurrence (via `encoding/csv`) and accumulates across repeats. The legacy TS port only supported flag repetition (`Flag.atLeast(0)`), so a single comma-separated value like `--domains a.com,b.com` produced one malformed string (`"a.com,b.com"`) instead of two domains — sent to the API as-is, or (for `postgres-config`) failing the `key=value` split validation.

Fixes #CLI-1853

## Expected Behavior

`--domains a.com,b.com` (and `--config foo=bar,baz=qux`) now CSV-split per-occurrence and accumulate across repeats, matching Go's `pflag.StringSliceVar`/`encoding/csv` semantics exactly — including quoted-comma handling (`'"a,b",c'` → `["a,b", "c"]`) and Go's `csv.Reader` malformed-input error messages.

The CSV-parsing algorithm already existed for `--schema` flags (`gen types`, `db lint`, `db dump`, `db pull`, `db diff`, `db schema {generate,sync}`) in `legacy-schema-flags.ts`. This extracts the generic algorithm into a new shared `legacy-string-slice-flag.ts` module (`legacyParseStringSliceFlag`) so the four newly-fixed flags reuse it instead of duplicating it; `legacy-schema-flags.ts` now delegates to the shared module while keeping its schema-specific CSV re-encoder (`legacySchemaToCsvField`) untouched.

Out of scope: the ticket's "bonus" item (aligning `sso update`'s domains mutex error message with cobra's group-error template) is deferred — it depends on the separate functions-mutex-template fix (CLI-1860), which hasn't landed yet.

CLOSES CLI-1853