### PR TITLE
chore(deps): bump effect to 4.0.0-beta.93 and update effect submodule

### DIFF
--- a/apps/cli/src/next/commands/login/login.handler.ts
+++ b/apps/cli/src/next/commands/login/login.handler.ts
@@ -1,5 +1,5 @@
 import { Data, Effect, Exit, Option, Redacted } from "effect";
-import { UrlParams } from "effect/unstable/http";
+import { Url, UrlParams } from "effect/unstable/http";
 import { validateToken } from "../../auth/token.ts";
 import { CliConfig } from "../../config/cli-config.service.ts";
 import { Output } from "../../../shared/output/output.service.ts";
@@ -151,7 +151,7 @@ const browserOAuthFlow = Effect.fnUntraced(function* (flags: LoginFlags) {
   const sessionId = yield* crypto.generateSessionId;
   const tokenName = Option.isSome(flags.name) ? flags.name.value : yield* crypto.defaultTokenName;
 
-  const loginUrl = yield* UrlParams.makeUrl(
+  const loginUrl = yield* Url.make(
     `${dashboardUrl}/cli/login`,
     UrlParams.fromInput({
       session_id: sessionId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@effect/atom-react':
-      specifier: 4.0.0-beta.88
-      version: 4.0.0-beta.88
+      specifier: 4.0.0-beta.93
+      version: 4.0.0-beta.93
     '@effect/platform-bun':
-      specifier: 4.0.0-beta.88
-      version: 4.0.0-beta.88
+      specifier: 4.0.0-beta.93
+      version: 4.0.0-beta.93
     '@effect/platform-node':
-      specifier: 4.0.0-beta.88
-      version: 4.0.0-beta.88
+      specifier: 4.0.0-beta.93
+      version: 4.0.0-beta.93
     '@effect/sql-pg':
-      specifier: 4.0.0-beta.88
-      version: 4.0.0-beta.88
+      specifier: 4.0.0-beta.93
+      version: 4.0.0-beta.93
     '@effect/vitest':
-      specifier: ^4.0.0-beta.85
-      version: 4.0.0-beta.91
+      specifier: ^4.0.0-beta.93
+      version: 4.0.0-beta.93
     '@nx/devkit':
       specifier: ^23.0.0
       version: 23.0.1
@@ -43,8 +43,8 @@ catalogs:
       specifier: ^4.1.9
       version: 4.1.9
     effect:
-      specifier: 4.0.0-beta.88
-      version: 4.0.0-beta.88
+      specifier: 4.0.0-beta.93
+      version: 4.0.0-beta.93
     knip:
       specifier: ^6.17.1
       version: 6.23.0
@@ -107,16 +107,16 @@ importers:
         version: 1.6.0
       '@effect/atom-react':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(react@19.2.7)(scheduler@0.27.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.88)(vitest@4.1.9)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@4.1.9)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -167,7 +167,7 @@ importers:
         version: 17.4.2
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.88
+        version: 4.0.0-beta.93
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -320,13 +320,13 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(ioredis@5.11.0)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.11.0)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.88
+        version: 4.0.0-beta.93
       undici:
         specifier: ^8.5.0
         version: 8.5.0
@@ -409,16 +409,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(ioredis@5.11.0)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.11.0)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.88
+        version: 4.0.0-beta.93
       smol-toml:
         specifier: ^1.7.0
         version: 1.7.0
@@ -455,14 +455,14 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.88
+        version: 4.0.0-beta.93
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.88)(vitest@4.1.9)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@4.1.9)
       '@tsconfig/bun':
         specifier: 'catalog:'
         version: 1.0.10
@@ -495,10 +495,10 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(ioredis@5.11.0)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.11.0)
       '@supabase/config':
         specifier: workspace:*
         version: link:../config
@@ -507,11 +507,11 @@ importers:
         version: link:../process-compose
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.88
+        version: 4.0.0-beta.93
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.88)(vitest@4.1.9)
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@4.1.9)
       '@supabase/supabase-js':
         specifier: ^2.108.2
         version: 2.108.2
@@ -724,40 +724,40 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
-  '@effect/atom-react@4.0.0-beta.88':
-    resolution: {integrity: sha512-uHzeUaW1jQNdMXs7qOGW5/PF6UthQzIF5I3IkmlTjUM+1+dSX0oM3Bwy4nIh5UnZQr7sSKw1JE1Zy/8fwiBsIg==}
+  '@effect/atom-react@4.0.0-beta.93':
+    resolution: {integrity: sha512-43FOYozhZT+VIQBH5LVAbabhdjGCuxGKdVTeUnkMp5NY+/g3nDLcAyAkNYn99G3+XDbqFvJaqmNJP7NLF5+WFg==}
     peerDependencies:
-      effect: ^4.0.0-beta.88
+      effect: ^4.0.0-beta.93
       react: ^19.2.4
       scheduler: '*'
 
-  '@effect/platform-bun@4.0.0-beta.88':
-    resolution: {integrity: sha512-BS0s9ecvPcAM6XjVutXb+eYoejepk3gr+G6GoT8vRqxSrhFrdDIY1hTPb4XyvkP9acm4ubIOm3+SSjgtRCLmCw==}
+  '@effect/platform-bun@4.0.0-beta.93':
+    resolution: {integrity: sha512-pny29d1NhJ7XLv19as7A0pIZr+QFi5KejnwB/lLW1c8P63t+PDMPEn21toy2vx2yzl9xRTo8heyiXPXRsqPN5w==}
     peerDependencies:
-      effect: ^4.0.0-beta.88
+      effect: ^4.0.0-beta.93
 
-  '@effect/platform-node-shared@4.0.0-beta.91':
-    resolution: {integrity: sha512-JX++yhomaOEpQmnTYuhn+pKAgKg5MQvycAf1rXGtyVKi202Nc5nK37xbywDcugfwrc1FrPxrxa3BY3lbSc74cw==}
+  '@effect/platform-node-shared@4.0.0-beta.93':
+    resolution: {integrity: sha512-XUqZ2u5GglBqY8q2jj4Q7GjN5K/enedk8auZM9rY/l5a/myaQTrQp3QnvpIK4/Yg0WFjLGuctGPMKWRk3OLIrA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.93
 
-  '@effect/platform-node@4.0.0-beta.88':
-    resolution: {integrity: sha512-k05jVJ8uYFm5VNfFFndM0kePKz9+RNW1r4ofiTMRadWzH6YqlJcuAU7Gj6RXCg2cKV+Ad/CsDqBD6QTi44ZKow==}
+  '@effect/platform-node@4.0.0-beta.93':
+    resolution: {integrity: sha512-QagsCGR0ZOXaCQqS5qGR2mcDng4LiP2bYhiiX1D6UC8cT9vsusVVOHiJWn8CupeDx+yVnPcu81QmA/SDt6GM1w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.88
+      effect: ^4.0.0-beta.93
       ioredis: ^5.7.0
 
-  '@effect/sql-pg@4.0.0-beta.88':
-    resolution: {integrity: sha512-aZNElnvf/RUU7wavt21tOGcqlaSYHdltcam5B4tSIA2Indq0wTnIvTEaKcwoFocFcwE23CxR59a7o3zmUQ+u/Q==}
+  '@effect/sql-pg@4.0.0-beta.93':
+    resolution: {integrity: sha512-wpoGGezcmMVGG9p9vumFTR42+LPE2PaaUZ+vTcpo0hyc4TvChSRZiv4uZafrXEnDdYgdUFw7UQzrEO8+pa5crg==}
     peerDependencies:
-      effect: ^4.0.0-beta.88
+      effect: ^4.0.0-beta.93
 
-  '@effect/vitest@4.0.0-beta.91':
-    resolution: {integrity: sha512-RTowh92EawJWk+PewFrbqmPSOjbJ9xcq4BcWGV4t0aaYIvZj5g5dubXUvCioh6aq4lkOnTEJmC6seGZjDFO/MQ==}
+  '@effect/vitest@4.0.0-beta.93':
+    resolution: {integrity: sha512-gMAnZ9PiMeJMDED9s0jWgCOhc2JccrTCxowhur/KriImsHnHIRj4VG/vK0xLw0Axe4AkTWzXNdRsFrYOjBTl3A==}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.93
       vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
@@ -3670,8 +3670,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.88:
-    resolution: {integrity: sha512-ml7Xr2BhU12RnNk5xX0lPqHv5pIXg7E161ooGlYncFd17Z5NKXL26DnfvwZsNBxYLS0ToGVMhb4Em7Z0A4dTDA==}
+  effect@4.0.0-beta.93:
+    resolution: {integrity: sha512-wNS5MKFa3C42uBfIDik2oJ78lhpoYz2hN4oBR0229BeeDCIrkg/FiOvoiPGdCVlWa7MEKxEL5I0f8AILVHSD9A==}
 
   ejs@5.0.1:
     resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
@@ -7037,33 +7037,33 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@effect/atom-react@4.0.0-beta.88(effect@4.0.0-beta.88)(react@19.2.7)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.93(effect@4.0.0-beta.93)(react@19.2.7)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.88
+      effect: 4.0.0-beta.93
       react: 19.2.7
       scheduler: 0.27.0
 
-  '@effect/platform-bun@4.0.0-beta.88(effect@4.0.0-beta.88)':
+  '@effect/platform-bun@4.0.0-beta.93(effect@4.0.0-beta.93)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.91(effect@4.0.0-beta.88)
-      effect: 4.0.0-beta.88
+      '@effect/platform-node-shared': 4.0.0-beta.93(effect@4.0.0-beta.93)
+      effect: 4.0.0-beta.93
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.91(effect@4.0.0-beta.88)':
+  '@effect/platform-node-shared@4.0.0-beta.93(effect@4.0.0-beta.93)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.88
+      effect: 4.0.0-beta.93
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.88(effect@4.0.0-beta.88)(ioredis@5.11.0)':
+  '@effect/platform-node@4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.11.0)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.91(effect@4.0.0-beta.88)
-      effect: 4.0.0-beta.88
+      '@effect/platform-node-shared': 4.0.0-beta.93(effect@4.0.0-beta.93)
+      effect: 4.0.0-beta.93
       ioredis: 5.11.0
       mime: 4.1.0
       undici: 8.5.0
@@ -7071,9 +7071,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-pg@4.0.0-beta.88(effect@4.0.0-beta.88)':
+  '@effect/sql-pg@4.0.0-beta.93(effect@4.0.0-beta.93)':
     dependencies:
-      effect: 4.0.0-beta.88
+      effect: 4.0.0-beta.93
       pg: 8.22.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.22.0)
@@ -7082,9 +7082,9 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  '@effect/vitest@4.0.0-beta.91(effect@4.0.0-beta.88)(vitest@4.1.9)':
+  '@effect/vitest@4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@4.1.9)':
     dependencies:
-      effect: 4.0.0-beta.88
+      effect: 4.0.0-beta.93
       vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -9587,7 +9587,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.88:
+  effect@4.0.0-beta.93:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,11 +12,11 @@ allowBuilds:
   sharp: true
 
 catalog:
-  "@effect/atom-react": "4.0.0-beta.88"
-  "@effect/platform-bun": "4.0.0-beta.88"
-  "@effect/platform-node": "4.0.0-beta.88"
-  "@effect/sql-pg": "4.0.0-beta.88"
-  "@effect/vitest": "^4.0.0-beta.85"
+  "@effect/atom-react": "4.0.0-beta.93"
+  "@effect/platform-bun": "4.0.0-beta.93"
+  "@effect/platform-node": "4.0.0-beta.93"
+  "@effect/sql-pg": "4.0.0-beta.93"
+  "@effect/vitest": "^4.0.0-beta.93"
   "@nx/devkit": "^23.0.0"
   "@swc-node/register": "^1.10.9"
   "@swc/core": "^1.15.43"
@@ -24,7 +24,7 @@ catalog:
   "@types/bun": "^1.3.14"
   "@typescript/native-preview": "7.0.0-dev.20260624.1"
   "@vitest/coverage-istanbul": "^4.1.9"
-  "effect": "4.0.0-beta.88"
+  "effect": "4.0.0-beta.93"
   "knip": "^6.17.1"
   "nx": "^23.0.0"
   "oxfmt": "^0.56.0"


### PR DESCRIPTION
## Summary
- Bump the effect catalog entries (`effect`, `@effect/atom-react`, `@effect/platform-bun`, `@effect/platform-node`, `@effect/sql-pg`, `@effect/vitest`) in `pnpm-workspace.yaml` from `4.0.0-beta.88` to `4.0.0-beta.93`, matching the latest published `beta` dist-tag
- Fast-forward the `.repos/effect` submodule from `49b5a569` to latest `main` (`455ecc9a`)
- Fix `apps/cli` login handler for the upstream `UrlParams.makeUrl` -> `Url.make` rename (effect-smol#2518)