### PR TITLE
fix(cli): resolve network-bans project ref before validating --db-unban-ip

### DIFF
--- a/apps/cli/src/legacy/commands/network-bans/remove/remove.handler.ts
+++ b/apps/cli/src/legacy/commands/network-bans/remove/remove.handler.ts
@@ -33,15 +33,18 @@ export const legacyNetworkBansRemove = Effect.fn("legacy.network-bans.remove")(f
   const telemetryState = yield* LegacyTelemetryState;
 
   yield* Effect.gen(function* () {
-    for (const ip of flags.dbUnbanIp) {
-      if (isIP(ip) === 0) {
-        return yield* new LegacyNetworkBansInvalidIpError({ input: ip });
-      }
-    }
-
+    // Go resolves the project ref in `PersistentPreRunE` (`cmd/root.go:108-114`),
+    // before `RunE`'s `--db-unban-ip` validation (`internal/bans/update/update.go:12-25`)
+    // ever runs — so a bad ref must surface before a bad IP, not after.
     const ref = yield* resolver.resolve(flags.projectRef);
 
     yield* Effect.gen(function* () {
+      for (const ip of flags.dbUnbanIp) {
+        if (isIP(ip) === 0) {
+          return yield* new LegacyNetworkBansInvalidIpError({ input: ip });
+        }
+      }
+
       yield* api.v1
         .deleteNetworkBans({
           ref,

--- a/apps/cli/src/legacy/commands/network-bans/remove/remove.integration.test.ts
+++ b/apps/cli/src/legacy/commands/network-bans/remove/remove.integration.test.ts
@@ -165,6 +165,60 @@ describe("legacy network-bans remove integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.live(
+    "surfaces the unresolved-ref error, not the invalid-IP error, when both are wrong",
+    () => {
+      // Go resolves the project ref in PersistentPreRunE, before RunE's IP
+      // validation ever runs (cmd/root.go:108-114 vs internal/bans/update/update.go:12-25),
+      // so a bad ref must win over a bad IP — this is the regression CLI-1856 guards.
+      const out = mockOutput({ format: "text" });
+      const api = mockLegacyPlatformApi({ response: { status: 200, body: null } });
+      const cliConfig = mockLegacyCliConfig({
+        workdir: tempRoot.current,
+        projectId: Option.none(),
+      });
+      const layer = buildLegacyTestRuntime({ out, api, cliConfig });
+
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyNetworkBansRemove({
+            projectRef: Option.none(),
+            dbUnbanIp: ["12.3.4"],
+          }),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(api.requests).toHaveLength(0);
+        if (Exit.isFailure(exit)) {
+          const errJson = JSON.stringify(exit.cause);
+          expect(errJson).toContain("LegacyProjectNotLinkedError");
+          expect(errJson).not.toContain("LegacyNetworkBansInvalidIpError");
+        }
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.live(
+    "surfaces the invalid-project-ref error, not the invalid-IP error, when both are wrong",
+    () => {
+      const { layer, api } = setup();
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyNetworkBansRemove({
+            projectRef: Option.some("BADREF"),
+            dbUnbanIp: ["12.3.4"],
+          }),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(api.requests).toHaveLength(0);
+        if (Exit.isFailure(exit)) {
+          const errJson = JSON.stringify(exit.cause);
+          expect(errJson).toContain("LegacyInvalidProjectRefError");
+          expect(errJson).not.toContain("LegacyNetworkBansInvalidIpError");
+        }
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
   it.live("fails with LegacyNetworkBansRemoveUnexpectedStatusError on HTTP 503", () => {
     const { layer } = setup({ status: 503 });
     return Effect.gen(function* () {


### PR DESCRIPTION
## Current Behavior

`supabase network-bans remove --project-ref <bad-ref> --db-unban-ip <bad-ip>` surfaces the invalid-IP error first, because the TS handler validated `--db-unban-ip` before resolving the project ref.

## Expected Behavior

Go resolves the project ref in `PersistentPreRunE`, which cobra always runs before `RunE`'s IP validation (`cmd/root.go:108-114` vs `internal/bans/update/update.go:12-25`). So an invalid ref must surface before an invalid IP, matching Go. The handler now resolves the ref first, and the IP validation loop runs inside the same `Effect.ensuring(linkedProjectCache.cache(ref))` scope that Go's `ensureProjectGroupsCached` mirrors.

Added regression tests covering both the unresolved-ref (no linked project) and invalid-ref (`--project-ref BADREF`) cases combined with an invalid `--db-unban-ip`, asserting the ref error wins and no API call is made.

Fixes CLI-1856