### PR TITLE
fix(cli): add hidden --exclude and --ignore-health-check flags to status

### DIFF
--- a/apps/cli/src/legacy/commands/status/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/status/SIDE_EFFECTS.md
@@ -80,3 +80,5 @@ Not applicable.
 - `-o env` output format uses KEY=VALUE pairs.
 - `-o json` output format uses a JSON object.
 - `-o pretty` (default) uses the human-readable table format.
+- `--exclude` (hidden, repeatable) omits named containers from the output; matches Go's `cmd/status.go:39-40`.
+- `--ignore-health-check` (hidden, boolean) exits `0` even when a service is unhealthy; matches Go's `cmd/status.go:41-42`.

--- a/apps/cli/src/legacy/commands/status/status.command.ts
+++ b/apps/cli/src/legacy/commands/status/status.command.ts
@@ -8,6 +8,16 @@ const config = {
     Flag.withDescription("Override specific variable names."),
     Flag.withDefault([] as ReadonlyArray<string>),
   ),
+  exclude: Flag.string("exclude").pipe(
+    Flag.atLeast(0),
+    Flag.withDescription("Names of containers to omit from output."),
+    Flag.withDefault([] as ReadonlyArray<string>),
+    Flag.withHidden,
+  ),
+  ignoreHealthCheck: Flag.boolean("ignore-health-check").pipe(
+    Flag.withDescription("Ignore unhealthy services and exit 0"),
+    Flag.withHidden,
+  ),
 } as const;
 
 export type LegacyStatusFlags = CliCommand.Command.Config.Infer<typeof config>;

--- a/apps/cli/src/legacy/commands/status/status.handler.ts
+++ b/apps/cli/src/legacy/commands/status/status.handler.ts
@@ -6,5 +6,7 @@ export const legacyStatus = Effect.fn("legacy.status")(function* (flags: LegacyS
   const proxy = yield* LegacyGoProxy;
   const args: string[] = ["status"];
   for (const override of flags.overrideName) args.push("--override-name", override);
+  for (const name of flags.exclude) args.push("--exclude", name);
+  if (flags.ignoreHealthCheck) args.push("--ignore-health-check");
   yield* proxy.exec(args);
 });

--- a/apps/cli/src/legacy/commands/status/status.integration.test.ts
+++ b/apps/cli/src/legacy/commands/status/status.integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
+import { legacyStatus } from "./status.handler.ts";
+import type { LegacyStatusFlags } from "./status.command.ts";
+
+function setupLegacyStatus() {
+  const calls: Array<ReadonlyArray<string>> = [];
+  const layer = Layer.succeed(LegacyGoProxy, {
+    exec: (args) =>
+      Effect.sync(() => {
+        calls.push(args);
+      }),
+    execCapture: () => Effect.succeed(""),
+  });
+  return { layer, calls };
+}
+
+const baseFlags: LegacyStatusFlags = {
+  overrideName: [],
+  exclude: [],
+  ignoreHealthCheck: false,
+};
+
+describe("legacy status", () => {
+  it.live("forwards no extra flags when defaults are used", () => {
+    const { layer, calls } = setupLegacyStatus();
+    return Effect.gen(function* () {
+      yield* legacyStatus(baseFlags);
+      expect(calls).toEqual([["status"]]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards --override-name for each provided override", () => {
+    const { layer, calls } = setupLegacyStatus();
+    return Effect.gen(function* () {
+      yield* legacyStatus({
+        ...baseFlags,
+        overrideName: ["api.url=NEXT_PUBLIC_SUPABASE_URL"],
+      });
+      expect(calls).toEqual([["status", "--override-name", "api.url=NEXT_PUBLIC_SUPABASE_URL"]]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards the hidden --exclude and --ignore-health-check flags", () => {
+    const { layer, calls } = setupLegacyStatus();
+    return Effect.gen(function* () {
+      yield* legacyStatus({
+        overrideName: [],
+        exclude: ["db", "kong"],
+        ignoreHealthCheck: true,
+      });
+      expect(calls).toEqual([
+        ["status", "--exclude", "db", "--exclude", "kong", "--ignore-health-check"],
+      ]);
+    }).pipe(Effect.provide(layer));
+  });
+});


### PR DESCRIPTION
## Current Behavior

The TS `status` command only declares `--override-name`. Go's `status` also registers two hidden flags, `--exclude` and `--ignore-health-check` (`cmd/status.go:38-42`). Because the Effect CLI parser rejects undeclared flags before the command proxies to the Go binary, `supabase status --exclude db` and `supabase status --ignore-health-check` fail with an UnrecognizedOption error in TS while working fine in Go.

## Expected Behavior

Both flags are now declared as hidden (matching Go's `MarkHidden`) and forwarded verbatim to the Go binary proxy, following the same pattern already used for `--override-name` and for `start`'s hidden flags. `SIDE_EFFECTS.md` documents the new flags with references to the Go source lines they mirror.

Fixes CLI-1857