### PR TITLE
fix(migration): improve gap detection error message

### DIFF
--- a/apps/cli-go/internal/migration/up/up.go
+++ b/apps/cli-go/internal/migration/up/up.go
@@ -47,7 +47,7 @@ func GetPendingMigrations(ctx context.Context, includeAll bool, conn *pgx.Conn, 
 			pending := localMigrations[len(remoteMigrations)+len(diff):]
 			return append(diff, pending...), nil
 		}
-		utils.CmdSuggestion = suggestIgnoreFlag(diff)
+		return diff, fmt.Errorf("%w\n%s", err, suggestIgnoreFlag(diff))
 	}
 	return diff, err
 }

--- a/apps/cli-go/internal/migration/up/up_test.go
+++ b/apps/cli-go/internal/migration/up/up_test.go
@@ -86,6 +86,7 @@ func TestPendingMigrations(t *testing.T) {
 		_, err := GetPendingMigrations(context.Background(), false, conn.MockClient(t), fsys)
 		// Check error
 		assert.ErrorIs(t, err, migration.ErrMissingRemote)
+		assert.ErrorContains(t, err, "--include-all")
 	})
 }
 


### PR DESCRIPTION
**Fixes supabase/supabase#45124**

**Background**
When pushing migrations to a remote preview branch, users encountered a failure when there is a multi-migration gap. The underlying error scenario is `"Found local migration files to be inserted before the last migration on remote database."`

This function currently signals the resolution hint (`--include-all`) via a global variable (`utils.CmdSuggestion`) read only by the CLI's own root command. If the hint is consumed differently downstream — e.g., by a non-interactive caller reading the error value — it would be lost. This PR removes that dependency.

**Potential Cloud Fix**
Our theory is that returning a wrapped error containing the hint natively from `GetPendingMigrations`—instead of sidestepping it into a global variable—will likely resolve the issue for preview branch pushes. If the overarching cloud orchestrator surfaces the raw error text — whether by capturing CLI stdout/stderr or reading a returned error object — this ensures the `--include-all` hint travels with it intact.

**Changes**
- Removed global `utils.CmdSuggestion` mutation for missing remote migrations.
- Updated `GetPendingMigrations` to return `fmt.Errorf("%w\n%s", err, suggestIgnoreFlag(diff))`.
- Updated `TestPendingMigrations` to explicitly assert `assert.ErrorContains(t, err, "--include-all")`.

> [!WARNING]
> **E2E Suite Verification Required**
> The local `test:core` suite could not be run locally in this environment due to missing Docker/OrbStack daemon connectivity (`connection refused`). This fix has been fully verified via unit tests in `internal/migration/up` only.
> **Requesting CI/maintainer confirmation that the e2e suite passes cleanly and exercises this path correctly.**