### PR TITLE
test: trim low-value unit coverage

### DIFF
--- a/packages/config/src/tls.unit.test.ts
+++ b/packages/config/src/tls.unit.test.ts
@@ -6,6 +6,5 @@ describe("KONG_LOCAL_CA_CERT", () => {
   it("is a non-empty PEM certificate", () => {
     expect(KONG_LOCAL_CA_CERT).toContain("BEGIN CERTIFICATE");
     expect(KONG_LOCAL_CA_CERT).toContain("END CERTIFICATE");
-    expect(KONG_LOCAL_CA_CERT.length).toBeGreaterThan(0);
   });
 });

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -16,8 +16,7 @@
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name",
     "test:e2e:warmup": "bun run tests/warmup-e2e.ts",
     "sync:versions": "bun run scripts/sync-versions-from-dockerfile.ts",
-    "sync:versions:check": "bun run scripts/sync-versions-from-dockerfile.ts --check",
-    "check:all": "nx run-many -t types:check lint:check fmt:check knip:check sync:versions:check --projects=$npm_package_name",
+    "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"
   },
   "dependencies": {

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -16,7 +16,8 @@
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name",
     "test:e2e:warmup": "bun run tests/warmup-e2e.ts",
     "sync:versions": "bun run scripts/sync-versions-from-dockerfile.ts",
-    "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",
+    "sync:versions:check": "bun run scripts/sync-versions-from-dockerfile.ts --check",
+    "check:all": "nx run-many -t types:check lint:check fmt:check knip:check sync:versions:check --projects=$npm_package_name",
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"
   },
   "dependencies": {

--- a/packages/stack/src/JwtGenerator.unit.test.ts
+++ b/packages/stack/src/JwtGenerator.unit.test.ts
@@ -1,14 +1,36 @@
+import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { defaultJwtSecret, generateJwks, generateJwt } from "./JwtGenerator.ts";
 
 describe("JwtGenerator", () => {
   it("generates HS256 JWTs", () => {
-    const jwt = generateJwt(defaultJwtSecret, "anon");
+    const before = Math.floor(Date.now() / 1000);
+    const role = "anon";
+    const jwt = generateJwt(defaultJwtSecret, role);
+    const after = Math.floor(Date.now() / 1000);
     const [header, payload, signature] = jwt.split(".");
 
-    expect(header).toBeDefined();
-    expect(payload).toBeDefined();
-    expect(signature).toBeDefined();
+    expect(JSON.parse(Buffer.from(header!, "base64url").toString("utf8"))).toEqual({
+      alg: "HS256",
+      typ: "JWT",
+    });
+    expect(JSON.parse(Buffer.from(payload!, "base64url").toString("utf8"))).toEqual({
+      role,
+      iss: "supabase",
+      iat: expect.any(Number),
+      exp: expect.any(Number),
+    });
+
+    const decodedPayload = JSON.parse(Buffer.from(payload!, "base64url").toString("utf8")) as {
+      readonly iat: number;
+      readonly exp: number;
+    };
+    expect(decodedPayload.iat).toBeGreaterThanOrEqual(before);
+    expect(decodedPayload.iat).toBeLessThanOrEqual(after);
+    expect(decodedPayload.exp).toBe(decodedPayload.iat + 60 * 60 * 24 * 365 * 10);
+    expect(signature).toBe(
+      createHmac("sha256", defaultJwtSecret).update(`${header}.${payload}`).digest("base64url"),
+    );
   });
 
   it("generates an oct JWKS from the local JWT secret", () => {

--- a/packages/stack/src/entrypoints.unit.test.ts
+++ b/packages/stack/src/entrypoints.unit.test.ts
@@ -4,44 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import {
-  daemonEntryPoint as bunDaemonEntryPoint,
-  createStack as createBunStack,
-  unixHttpClientLayer as bunUnixHttpClientLayer,
-} from "./bun.ts";
-import {
-  DEFAULT_VERSIONS,
-  Stack,
-  StackError,
-  StackServiceState,
-  connectLayer,
-  projectDaemonLayer,
-} from "./effect.ts";
-import {
-  daemonEntryPoint as nodeDaemonEntryPoint,
-  createStack as createNodeStack,
-  unixHttpClientLayer as nodeUnixHttpClientLayer,
-} from "./node.ts";
-
 describe("@supabase/stack entrypoints", () => {
-  it("exports runtime-specific stack builders", () => {
-    expect(typeof createBunStack).toBe("function");
-    expect(typeof createNodeStack).toBe("function");
-    expect(typeof bunDaemonEntryPoint).toBe("string");
-    expect(typeof nodeDaemonEntryPoint).toBe("string");
-    expect(bunUnixHttpClientLayer).toBeDefined();
-    expect(nodeUnixHttpClientLayer).toBeDefined();
-  });
-
-  it("consolidates advanced and internal APIs under effect", () => {
-    expect(Stack).toBeDefined();
-    expect(typeof connectLayer).toBe("function");
-    expect(typeof projectDaemonLayer).toBe("function");
-    expect(StackServiceState).toBeDefined();
-    expect(StackError).toBeDefined();
-    expect(DEFAULT_VERSIONS.postgres).toBeDefined();
-  });
-
   it("ships conditional root exports and keeps only the effect subpath", () => {
     const srcDir = dirname(fileURLToPath(import.meta.url));
     const packageJson = JSON.parse(readFileSync(join(srcDir, "../package.json"), "utf8")) as {

--- a/packages/stack/src/versions.unit.test.ts
+++ b/packages/stack/src/versions.unit.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   readVersionManifestFromDockerfile,
@@ -13,11 +12,6 @@ import {
   normalizeServiceVersion,
   type VersionManifest,
 } from "./versions.ts";
-
-const dockerfile = readFileSync(
-  new URL("../../../apps/cli-go/pkg/config/templates/Dockerfile", import.meta.url),
-  "utf8",
-);
 
 const sampleDockerfile = `
 FROM supabase/postgres:17.0.0.1 AS pg
@@ -36,30 +30,6 @@ FROM supabase/storage-api:v1.50.0 AS storage
 FROM supabase/logflare:1.40.0 AS logflare
 FROM supabase/migra:3.0.1663481299 AS migra
 `;
-
-describe("DEFAULT_VERSIONS", () => {
-  it("has all required services", () => {
-    expect(DEFAULT_VERSIONS).toHaveProperty("postgres");
-    expect(DEFAULT_VERSIONS).toHaveProperty("postgrest");
-    expect(DEFAULT_VERSIONS).toHaveProperty("auth");
-    expect(DEFAULT_VERSIONS).toHaveProperty("edge-runtime");
-  });
-
-  it("versions are non-empty strings", () => {
-    expect(typeof DEFAULT_VERSIONS.postgres).toBe("string");
-    expect(DEFAULT_VERSIONS.postgres.length).toBeGreaterThan(0);
-    expect(typeof DEFAULT_VERSIONS.postgrest).toBe("string");
-    expect(DEFAULT_VERSIONS.postgrest.length).toBeGreaterThan(0);
-    expect(typeof DEFAULT_VERSIONS.auth).toBe("string");
-    expect(DEFAULT_VERSIONS.auth.length).toBeGreaterThan(0);
-    expect(typeof DEFAULT_VERSIONS["edge-runtime"]).toBe("string");
-    expect(DEFAULT_VERSIONS["edge-runtime"].length).toBeGreaterThan(0);
-  });
-
-  it("matches the Dockerfile manifest exposed to Dependabot", () => {
-    expect(readVersionManifestFromDockerfile(dockerfile)).toEqual(DEFAULT_VERSIONS);
-  });
-});
 
 describe("syncDefaultVersionsSource", () => {
   it("rewrites the DEFAULT_VERSIONS block from Dockerfile versions", () => {
@@ -111,7 +81,9 @@ after`;
 
   it("fails when the Dockerfile contains an unexpected image alias", () => {
     expect(() =>
-      readVersionManifestFromDockerfile(`${dockerfile}\nFROM supabase/example:1.0.0 AS example\n`),
+      readVersionManifestFromDockerfile(
+        `${sampleDockerfile}\nFROM supabase/example:1.0.0 AS example\n`,
+      ),
     ).toThrow("Unknown Dockerfile image alias 'example'.");
   });
 });


### PR DESCRIPTION
Trims unit tests that only asserted exported symbols, object shape, or redundant constant properties, while keeping package export contracts that guard real behavior.

Removes low-value literal default-version assertions from the stack unit tests without adding new CI surface area.

Strengthens JWT generation coverage by checking the decoded header and payload plus the HMAC signature instead of only checking that the token has three segments.