### PR TITLE
fix(cli): remove "nano" from projects/branches create --size enum

### DIFF
--- a/apps/cli/src/legacy/commands/branches/create/create.command.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.command.ts
@@ -44,7 +44,6 @@ const BRANCH_SIZES = [
   "48xlarge_optimized_memory",
   "4xlarge",
   "8xlarge",
-  "nano",
   "small",
   "xlarge",
 ] as const;

--- a/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
@@ -1,8 +1,10 @@
 import type { V1CreateABranchOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, Option } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
+import { Command } from "effect/unstable/cli";
 
 import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
+import { LEGACY_GLOBAL_FLAGS } from "../../../../shared/legacy/global-flags.ts";
 import {
   LEGACY_VALID_REF,
   buildLegacyTestRuntime,
@@ -13,7 +15,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
-import type { LegacyBranchesCreateFlags } from "./create.command.ts";
+import { legacyBranchesCreateCommand, type LegacyBranchesCreateFlags } from "./create.command.ts";
 import { legacyBranchesCreate } from "./create.handler.ts";
 
 type CreatedBranch = typeof V1CreateABranchOutput.Type;
@@ -282,4 +284,44 @@ describe("legacy branches create integration", () => {
       expect(cache.cached).toBe(true);
     }).pipe(Effect.provide(layer));
   });
+
+  // Go parity (`apps/cli-go/cmd/projects.go:34-55`, reused by `branches create`
+  // at `apps/cli-go/cmd/branches.go:212`): Go's --size EnumFlag is an 18-value
+  // list that does not include "nano" (or "pico") and rejects any other value
+  // at flag-parse time. TS previously listed "nano" as a valid choice, silently
+  // succeeding where Go errors.
+  it.live("rejects --size nano at flag-parse time, matching Go's 18-value enum", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withGlobalFlags(LEGACY_GLOBAL_FLAGS),
+      Command.withSubcommands([legacyBranchesCreateCommand]),
+    );
+
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        Command.runWith(root, { version: "0.0.0-test" })(["create", "--size", "nano"]),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(rejectsInvalidSizeChoice(Cause.squash(exit.cause))).toBe(true);
+      }
+    }) as Effect.Effect<void>;
+  });
 });
+
+// Distinguishes "the --size flag itself was rejected at parse time" from any
+// other failure (e.g. a missing runtime service in this minimal test setup),
+// so the regression test above can't pass for the wrong reason.
+function rejectsInvalidSizeChoice(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("errors" in error)) return false;
+  const { errors } = error;
+  if (!Array.isArray(errors)) return false;
+  return errors.some(
+    (candidate: unknown) =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      "_tag" in candidate &&
+      candidate._tag === "InvalidValue" &&
+      "option" in candidate &&
+      candidate.option === "size",
+  );
+}

--- a/apps/cli/src/legacy/commands/projects/create/create.command.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.command.ts
@@ -27,24 +27,24 @@ const AWS_REGIONS = [
 ] as const;
 
 const INSTANCE_SIZES = [
-  "micro",
-  "small",
-  "medium",
   "large",
-  "xlarge",
-  "2xlarge",
-  "4xlarge",
-  "8xlarge",
+  "medium",
+  "micro",
   "12xlarge",
   "16xlarge",
   "24xlarge",
   "24xlarge_high_memory",
   "24xlarge_optimized_cpu",
   "24xlarge_optimized_memory",
+  "2xlarge",
   "48xlarge",
   "48xlarge_high_memory",
   "48xlarge_optimized_cpu",
   "48xlarge_optimized_memory",
+  "4xlarge",
+  "8xlarge",
+  "small",
+  "xlarge",
 ] as const;
 
 const config = {

--- a/apps/cli/src/legacy/commands/projects/create/create.command.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.command.ts
@@ -27,7 +27,6 @@ const AWS_REGIONS = [
 ] as const;
 
 const INSTANCE_SIZES = [
-  "nano",
   "micro",
   "small",
   "medium",

--- a/apps/cli/src/legacy/commands/projects/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/projects/create/create.integration.test.ts
@@ -1,8 +1,10 @@
 import type { OrganizationResponseV1, V1CreateAProjectOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, Option } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
+import { Command } from "effect/unstable/cli";
 
 import { mockOutput, mockTty } from "../../../../../tests/helpers/mocks.ts";
+import { LEGACY_GLOBAL_FLAGS } from "../../../../shared/legacy/global-flags.ts";
 import {
   type LegacyApiResponse,
   type LegacyHttpMethod,
@@ -13,7 +15,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
-import type { LegacyProjectsCreateFlags } from "./create.command.ts";
+import { legacyProjectsCreateCommand, type LegacyProjectsCreateFlags } from "./create.command.ts";
 import { legacyProjectsCreate } from "./create.handler.ts";
 
 const CREATED: typeof V1CreateAProjectOutput.Type = {
@@ -451,4 +453,54 @@ describe("legacy projects create integration", () => {
       expect(cache.cached).toBe(false);
     }).pipe(Effect.provide(layer));
   });
+
+  // Go parity (`apps/cli-go/cmd/projects.go:34-55`): Go's --size EnumFlag is an
+  // 18-value list that does not include "nano" (or "pico") and rejects any other
+  // value at flag-parse time. TS previously listed "nano" as a valid choice,
+  // silently succeeding where Go errors.
+  it.live("rejects --size nano at flag-parse time, matching Go's 18-value enum", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withGlobalFlags(LEGACY_GLOBAL_FLAGS),
+      Command.withSubcommands([legacyProjectsCreateCommand]),
+    );
+
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        Command.runWith(root, { version: "0.0.0-test" })([
+          "create",
+          "alpha",
+          "--org-id",
+          "acme",
+          "--db-password",
+          "s3cret-pass",
+          "--region",
+          "us-east-1",
+          "--size",
+          "nano",
+        ]),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(rejectsInvalidSizeChoice(Cause.squash(exit.cause))).toBe(true);
+      }
+    }) as Effect.Effect<void>;
+  });
 });
+
+// Distinguishes "the --size flag itself was rejected at parse time" from any
+// other failure (e.g. a missing runtime service in this minimal test setup),
+// so the regression test above can't pass for the wrong reason.
+function rejectsInvalidSizeChoice(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("errors" in error)) return false;
+  const { errors } = error;
+  if (!Array.isArray(errors)) return false;
+  return errors.some(
+    (candidate: unknown) =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      "_tag" in candidate &&
+      candidate._tag === "InvalidValue" &&
+      "option" in candidate &&
+      candidate.option === "size",
+  );
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (Go parity).

## What is the current behavior?

Go's `--size` flag on `projects create` (`apps/cli-go/cmd/projects.go:34-55`) is a single shared 18-value `EnumFlag` reused by `branches create` (`apps/cli-go/cmd/branches.go:212`), and does not include `"nano"` (or `"pico"`). The TS legacy port's `INSTANCE_SIZES` (`projects/create/create.command.ts`) and `BRANCH_SIZES` (`branches/create/create.command.ts`) both included `"nano"` as a valid `Flag.choice` value, so `--size nano` silently succeeded in TS while Go rejects it.

Verified directly against the real, compiled Go binary (`apps/cli-go`) rather than just reading source — `projects create --size nano` genuinely errors with `invalid argument "nano" for "--size" flag: must be one of [...]`, confirming this is current, shipped Go behavior and not a stale enum.

Note: the live Management API contract (`packages/api/src/generated/contracts.ts`) does list `"nano"`/`"pico"` as accepted `desired_instance_size` values, and `next/`'s independently-authored `branches create` already exposes both. Neither the Go CLI nor this legacy port surfaces them as CLI options, though — that's a separate product question (filed as CLI-1897) about whether these tiers should eventually be CLI-selectable, not a reason to keep an option the legacy shell's own Go-parity contract says should be rejected.

## What is the new behavior?

`--size nano` is now rejected identically on both `projects create` and `branches create`, matching Go's 18-value enum exactly.

Fixes CLI-1869. See also CLI-1897 (product decision on nano/pico) and CLI-1898 (unrelated pre-existing bug in `effect`'s `Flag.choice` error-message formatting, found during this PR's review).