### PR TITLE
fix(stack): echo requested headers on CORS preflight

### DIFF
--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -98,9 +98,23 @@ const CORS_HEADERS: ReadonlyArray<readonly [string, string]> = [
 
 function addCorsHeaders(
   response: HttpServerResponse.HttpServerResponse,
+  requestedHeaders?: string,
 ): HttpServerResponse.HttpServerResponse {
+  // On a preflight, echo the requested headers: browser clients evolve
+  // faster than any static list (supabase-js added x-supabase-api-version;
+  // PostgREST reads Prefer and the profile headers), and echoing is what
+  // Kong's cors plugin — the classic CLI's proxy — does when no header
+  // list is configured. The static list stays as the fallback for
+  // preflights that name no headers and for non-preflight responses.
   return CORS_HEADERS.reduce(
-    (res, [name, value]) => HttpServerResponse.setHeader(res, name, value),
+    (res, [name, value]) =>
+      HttpServerResponse.setHeader(
+        res,
+        name,
+        name === "access-control-allow-headers" && requestedHeaders !== undefined
+          ? requestedHeaders
+          : value,
+      ),
     response,
   );
 }
@@ -370,7 +384,10 @@ export class ApiProxy extends Context.Service<
           const req = yield* HttpServerRequest.HttpServerRequest;
 
           if (req.method === "OPTIONS") {
-            return addCorsHeaders(HttpServerResponse.empty({ status: 204 }));
+            return addCorsHeaders(
+              HttpServerResponse.empty({ status: 204 }),
+              req.headers["access-control-request-headers"],
+            );
           }
 
           const response = yield* httpEffect;

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -205,6 +205,33 @@ describe("ApiProxy", () => {
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
+  test("preflight echoes the requested headers", async () => {
+    // Browser clients evolve faster than any static allow list
+    // (supabase-js's x-supabase-api-version, PostgREST's Prefer); the
+    // preflight reflects what was asked for — the same default Kong's cors
+    // plugin gives the classic CLI's proxy.
+    const res = await fetch(`${proxyUrl}/rest/v1/users`, {
+      method: "OPTIONS",
+      headers: {
+        "access-control-request-headers": "authorization,prefer,x-supabase-api-version",
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-headers")).toBe(
+      "authorization,prefer,x-supabase-api-version",
+    );
+  });
+
+  test("the echo is preflight-only: non-OPTIONS requests keep the static list", async () => {
+    const res = await fetch(`${proxyUrl}/health`, {
+      headers: {
+        "access-control-request-headers": "x-arbitrary-header",
+      },
+    });
+    expect(res.headers.get("access-control-allow-headers")).toContain("apikey");
+    expect(res.headers.get("access-control-allow-headers")).not.toContain("x-arbitrary-header");
+  });
+
   // ---------------------------------------------------------------------------
   // Auth transformation — publishableKey → anonJwt
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The API proxy short-circuits every `OPTIONS` with 204 and a static `access-control-allow-headers` list, so the backing services' own CORS handling is never consulted. The static list predates headers today's browser clients send — supabase-js 2.x adds `x-supabase-api-version` (the same skew class as supabase/auth#1589, fixed service-side in supabase/auth#1612, but the proxy's short-circuit masks that fix), and postgrest-js writes send `Prefer`. Result: credentialless browser calls through the proxy fail CORS preflight (`net::ERR_FAILED`; hit in a real web e2e suite).

## Fix

Preflights echo the request's `Access-Control-Request-Headers`. That is also what the classic CLI's proxy already does: its `kong.yml` ships the bare `cors` plugin, and Kong's handler reflects `Access-Control-Request-Headers` when no header list is configured — so this restores parity with the Go CLI's behavior rather than inventing policy. Echo over a wildcard because `*` is literal (not a wildcard) for credentialed requests. The echo is preflight-only; the static list stays for preflights naming no headers and for non-`OPTIONS` responses.

## Tests

- preflight echoes the requested headers
- the echo is preflight-only: non-OPTIONS requests keep the static list

🤖 Generated with [Claude Code](https://claude.com/claude-code)