### PR TITLE
feat(stack): typed external OAuth providers and redirect allow list

### DIFF
--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -108,13 +108,15 @@ Optional. Omit to include with defaults, set to `false` to exclude.
 
 Optional. Omit to include with defaults, set to `false` to exclude.
 
-| Field         | Type     | Default                    | Description                        |
-| ------------- | -------- | -------------------------- | ---------------------------------- |
-| `port`        | `number` | auto                       | Auth service port                  |
-| `siteUrl`     | `string` | `http://localhost:3000`    | Auth redirect URL (your app's URL) |
-| `jwtExpiry`   | `number` | `3600`                     | JWT expiry in seconds              |
-| `externalUrl` | `string` | `http://127.0.0.1:${port}` | Auth external URL                  |
-| `version`     | `string` | `2.188.0-rc.15`            | Auth version                       |
+| Field                    | Type       | Default                            | Description                                              |
+| ------------------------ | ---------- | ---------------------------------- | -------------------------------------------------------- |
+| `port`                   | `number`   | auto                               | Auth service port                                         |
+| `siteUrl`                | `string`   | `http://localhost:3000`            | Auth redirect URL (your app's URL)                        |
+| `jwtExpiry`              | `number`   | `3600`                             | JWT expiry in seconds                                     |
+| `externalUrl`            | `string`   | `http://127.0.0.1:${port}/auth/v1` | Auth external URL (through the API gateway, path included) |
+| `version`                | `string`   | `2.188.0-rc.15`                    | Auth version                                              |
+| `external`               | `object`   | `{}`                               | External OAuth providers by GoTrue provider id            |
+| `additionalRedirectUrls` | `string[]` | `[]`                               | Extra allowed redirect URLs (`GOTRUE_URI_ALLOW_LIST`)     |
 
 ### Full config example
 

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -71,7 +71,7 @@ const defaultConfig: ResolvedStackConfig = {
     port: 9999,
     siteUrl: "http://localhost:3000",
     jwtExpiry: 3600,
-    externalUrl: "http://127.0.0.1:54321",
+    externalUrl: "http://127.0.0.1:54321/auth/v1",
     version: DEFAULT_VERSIONS.auth,
     external: {},
     additionalRedirectUrls: [],

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -73,6 +73,8 @@ const defaultConfig: ResolvedStackConfig = {
     jwtExpiry: 3600,
     externalUrl: "http://127.0.0.1:54321",
     version: DEFAULT_VERSIONS.auth,
+    external: {},
+    additionalRedirectUrls: [],
   },
   edgeRuntime: false,
   realtime: false,

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -74,9 +74,13 @@ export interface AuthExternalProviderConfig {
    * google one-tap); emitted empty when absent, like the classic CLI. */
   readonly secret?: string;
   /** Defaults to `<externalUrl>/auth/v1/callback`, the classic CLI's
-   * issuer-derived default. */
+   * issuer-derived default. Empty means unset, like the classic surface
+   * (TOML strings can't be absent). */
   readonly redirectUri?: string;
-  /** Base URL for self-hosted providers (gitlab, azure, keycloak). */
+  /** Base URL for self-hosted providers (gitlab, azure, keycloak).
+   * Empty means unset, like the classic surface — GoTrue falls back to
+   * the provider's default; always emitted (empty included) so a shell
+   * variable can never supply it. */
   readonly url?: string;
   /** Default false — emitted explicitly so a shell variable can never
    * override the typed config (native spawns extend the parent env). */

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -70,10 +70,12 @@ export interface AuthExternalProviderConfig {
    * credentials wired but inactive with an explicit false. */
   readonly enabled?: boolean;
   readonly clientId: string;
-  /** Optional for providers GoTrue accepts without one (e.g. apple,
-   * google one-tap); emitted empty when absent, like the classic CLI. */
+  /** Optional: the id-token flow (google one-tap, apple sign-in)
+   * reads provider config without a secret; the /authorize OAuth flow
+   * still requires one and GoTrue refuses it at request time. Emitted
+   * empty when absent, like the classic CLI. */
   readonly secret?: string;
-  /** Defaults to `<externalUrl>/auth/v1/callback`, the classic CLI's
+  /** Defaults to `<externalUrl>/callback`, the classic CLI's
    * issuer-derived default. Empty means unset, like the classic surface
    * (TOML strings can't be absent). */
   readonly redirectUri?: string;
@@ -93,6 +95,11 @@ export interface AuthConfig {
   readonly port?: number;
   readonly siteUrl?: string;
   readonly jwtExpiry?: number;
+  /** The auth service's public URL through the API gateway, path
+   * included — the classic CLI's auth.external_url. Defaults to
+   * `http://127.0.0.1:<apiPort>/auth/v1`, matching the proxy's
+   * /auth/v1 routing; GoTrue receives it as API_EXTERNAL_URL and
+   * builds outgoing URLs (mail links, OAuth callbacks) against it. */
   readonly externalUrl?: string;
   readonly version?: string;
   readonly external?: Readonly<Record<string, AuthExternalProviderConfig>>;

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -60,12 +60,43 @@ export interface PostgrestConfig {
   readonly version?: string;
 }
 
+/** One external OAuth provider for the auth (GoTrue) member, keyed in
+ * `AuthConfig.external` by the provider id GoTrue knows (google, github,
+ * azure, …) — the same set the classic CLI's `[auth.external.*]` config
+ * drives, translated to `GOTRUE_EXTERNAL_<ID>_*` env the same way.
+ * Provider ids are validated by GoTrue itself. */
+export interface AuthExternalProviderConfig {
+  /** Default true: a declared provider is one you mean to use; keep
+   * credentials wired but inactive with an explicit false. */
+  readonly enabled?: boolean;
+  readonly clientId: string;
+  /** Optional for providers GoTrue accepts without one (e.g. apple,
+   * google one-tap); emitted empty when absent, like the classic CLI. */
+  readonly secret?: string;
+  /** Defaults to `<externalUrl>/auth/v1/callback`, the classic CLI's
+   * issuer-derived default. */
+  readonly redirectUri?: string;
+  /** Base URL for self-hosted providers (gitlab, azure, keycloak). */
+  readonly url?: string;
+  /** Default false — emitted explicitly so a shell variable can never
+   * override the typed config (native spawns extend the parent env). */
+  readonly skipNonceCheck?: boolean;
+  /** Default false — emitted explicitly, like skipNonceCheck. */
+  readonly emailOptional?: boolean;
+}
+
 export interface AuthConfig {
   readonly port?: number;
   readonly siteUrl?: string;
   readonly jwtExpiry?: number;
   readonly externalUrl?: string;
   readonly version?: string;
+  readonly external?: Readonly<Record<string, AuthExternalProviderConfig>>;
+  /** Extra redirect targets GoTrue accepts beyond siteUrl — the classic
+   * CLI's [auth] additional_redirect_urls, translated to
+   * GOTRUE_URI_ALLOW_LIST the same way (always emitted, empty when none,
+   * so a shell variable can never supply the allow list). */
+  readonly additionalRedirectUrls?: ReadonlyArray<string>;
 }
 
 export interface RealtimeConfig {
@@ -190,6 +221,8 @@ export interface ResolvedAuthConfig {
   readonly jwtExpiry: number;
   readonly externalUrl: string;
   readonly version: string;
+  readonly external: Readonly<Record<string, AuthExternalProviderConfig>>;
+  readonly additionalRedirectUrls: ReadonlyArray<string>;
 }
 
 export interface ResolvedRealtimeConfig {
@@ -640,6 +673,8 @@ export class StackBuilder extends Context.Service<
                   smtpPort: config.mailpit !== false ? config.mailpit.smtpPort : undefined,
                   smtpAdminEmail: config.mailpit !== false ? config.mailpit.adminEmail : undefined,
                   smtpSenderName: config.mailpit !== false ? config.mailpit.senderName : undefined,
+                  external: config.auth.external,
+                  additionalRedirectUrls: config.auth.additionalRedirectUrls,
                   dependencies: postgresDeps,
                 })
               : makeAuthServiceDocker({
@@ -655,6 +690,8 @@ export class StackBuilder extends Context.Service<
                   smtpPort: config.mailpit !== false ? config.mailpit.smtpPort : undefined,
                   smtpAdminEmail: config.mailpit !== false ? config.mailpit.adminEmail : undefined,
                   smtpSenderName: config.mailpit !== false ? config.mailpit.senderName : undefined,
+                  external: config.auth.external,
+                  additionalRedirectUrls: config.auth.additionalRedirectUrls,
                   networkArgs: dockerNetworkArgs(platform.os, [config.auth.port]),
                   apiPort: config.apiPort,
                   dependencies: postgresDeps,

--- a/packages/stack/src/StackBuilder.unit.test.ts
+++ b/packages/stack/src/StackBuilder.unit.test.ts
@@ -70,7 +70,7 @@ const baseConfig: ResolvedStackConfig = {
     port: 9999,
     siteUrl: "http://localhost:3000",
     jwtExpiry: 3600,
-    externalUrl: "http://localhost:9999",
+    externalUrl: "http://localhost:9999/auth/v1",
     version: DEFAULT_VERSIONS.auth,
     external: {},
     additionalRedirectUrls: [],

--- a/packages/stack/src/StackBuilder.unit.test.ts
+++ b/packages/stack/src/StackBuilder.unit.test.ts
@@ -72,6 +72,8 @@ const baseConfig: ResolvedStackConfig = {
     jwtExpiry: 3600,
     externalUrl: "http://localhost:9999",
     version: DEFAULT_VERSIONS.auth,
+    external: {},
+    additionalRedirectUrls: [],
   },
   edgeRuntime: false,
   realtime: false,

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -297,7 +297,7 @@ function resolveAuthConfig(
     port: ports.authPort,
     siteUrl: cfg.siteUrl ?? "http://localhost:3000",
     jwtExpiry: cfg.jwtExpiry ?? 3600,
-    externalUrl: cfg.externalUrl ?? `http://127.0.0.1:${apiPort}`,
+    externalUrl: cfg.externalUrl ?? `http://127.0.0.1:${apiPort}/auth/v1`,
     version: cfg.version ?? DEFAULT_VERSIONS.auth,
     external: cfg.external ?? {},
     additionalRedirectUrls: cfg.additionalRedirectUrls ?? [],

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -299,6 +299,8 @@ function resolveAuthConfig(
     jwtExpiry: cfg.jwtExpiry ?? 3600,
     externalUrl: cfg.externalUrl ?? `http://127.0.0.1:${apiPort}`,
     version: cfg.version ?? DEFAULT_VERSIONS.auth,
+    external: cfg.external ?? {},
+    additionalRedirectUrls: cfg.additionalRedirectUrls ?? [],
   };
 }
 

--- a/packages/stack/src/services/auth.ts
+++ b/packages/stack/src/services/auth.ts
@@ -8,6 +8,11 @@ interface AuthServiceOptions {
   readonly siteUrl: string;
   readonly jwtSecret: string;
   readonly jwtExpiry: number;
+  /** The auth service's public URL through the API gateway, path
+   * included (`<api-root>/auth/v1`) — the classic CLI's
+   * auth.external_url. Emitted as API_EXTERNAL_URL (GoTrue builds
+   * outgoing URLs against it) and the base for the derived provider
+   * callback. */
   readonly externalUrl: string;
   readonly smtpHost?: string;
   readonly smtpPort?: number;
@@ -57,7 +62,7 @@ const externalProviderEnv = (opts: AuthServiceOptions): Record<string, string> =
     env[`${prefix}_ENABLED`] = String(provider.enabled ?? true);
     env[`${prefix}_CLIENT_ID`] = provider.clientId;
     env[`${prefix}_SECRET`] = provider.secret ?? "";
-    env[`${prefix}_REDIRECT_URI`] = provider.redirectUri || `${opts.externalUrl}/auth/v1/callback`;
+    env[`${prefix}_REDIRECT_URI`] = provider.redirectUri || `${opts.externalUrl}/callback`;
     env[`${prefix}_SKIP_NONCE_CHECK`] = String(provider.skipNonceCheck ?? false);
     env[`${prefix}_EMAIL_OPTIONAL`] = String(provider.emailOptional ?? false);
     env[`${prefix}_URL`] = provider.url ?? "";

--- a/packages/stack/src/services/auth.ts
+++ b/packages/stack/src/services/auth.ts
@@ -38,11 +38,18 @@ interface DockerAuthOptions extends AuthServiceOptions {
 }
 
 /** Mirrors the classic CLI's [auth.external.*] → GOTRUE_EXTERNAL_* env
- * translation. Every field except url emits explicitly, defaults
- * included: native-mode spawns extend the parent environment, so an
- * unset variable would inherit whatever the shell carries — the classic
- * CLI shadows the same way (start.go emits the booleans with %t). url
- * stays conditional, matching start.go. */
+ * translation. Every field emits explicitly, defaults included:
+ * native-mode spawns extend the parent environment, so an unset
+ * variable would inherit whatever the shell carries — the classic CLI
+ * shadows the same way (start.go emits the booleans with %t). The
+ * empty string is the classic surface's unset (TOML strings can't be
+ * absent; the generated template ships redirect_uri = "" and
+ * url = ""), so an empty redirectUri falls back to the derived
+ * callback like start.go. url emits even when empty — GoTrue reads an
+ * empty URL as unset (chooseHost falls back to each provider's
+ * default), so this matches start.go's skip-when-empty behaviorally
+ * while still shadowing the parent env; start.go can afford to skip
+ * because its containers never inherit a shell. */
 const externalProviderEnv = (opts: AuthServiceOptions): Record<string, string> => {
   const env: Record<string, string> = {};
   for (const [id, provider] of Object.entries(opts.external ?? {})) {
@@ -50,12 +57,10 @@ const externalProviderEnv = (opts: AuthServiceOptions): Record<string, string> =
     env[`${prefix}_ENABLED`] = String(provider.enabled ?? true);
     env[`${prefix}_CLIENT_ID`] = provider.clientId;
     env[`${prefix}_SECRET`] = provider.secret ?? "";
-    env[`${prefix}_REDIRECT_URI`] = provider.redirectUri ?? `${opts.externalUrl}/auth/v1/callback`;
+    env[`${prefix}_REDIRECT_URI`] = provider.redirectUri || `${opts.externalUrl}/auth/v1/callback`;
     env[`${prefix}_SKIP_NONCE_CHECK`] = String(provider.skipNonceCheck ?? false);
     env[`${prefix}_EMAIL_OPTIONAL`] = String(provider.emailOptional ?? false);
-    if (provider.url !== undefined) {
-      env[`${prefix}_URL`] = provider.url;
-    }
+    env[`${prefix}_URL`] = provider.url ?? "";
   }
   return env;
 };

--- a/packages/stack/src/services/auth.ts
+++ b/packages/stack/src/services/auth.ts
@@ -1,4 +1,5 @@
 import type { ServiceDef } from "@supabase/process-compose";
+import type { AuthExternalProviderConfig } from "../StackBuilder.ts";
 import { dockerServiceCleanup, dockerServiceOrphanCleanup } from "./docker-cleanup.ts";
 
 interface AuthServiceOptions {
@@ -12,6 +13,13 @@ interface AuthServiceOptions {
   readonly smtpPort?: number;
   readonly smtpAdminEmail?: string;
   readonly smtpSenderName?: string;
+  /** External OAuth providers by GoTrue provider id, translated to
+   * `GOTRUE_EXTERNAL_<ID>_*` env the way the classic CLI translates
+   * `[auth.external.*]`. */
+  readonly external?: Readonly<Record<string, AuthExternalProviderConfig>>;
+  /** Extra allowed redirect targets, translated to GOTRUE_URI_ALLOW_LIST
+   * like the classic CLI's [auth] additional_redirect_urls. */
+  readonly additionalRedirectUrls?: ReadonlyArray<string>;
   readonly dependencies: ReadonlyArray<{
     readonly service: string;
     readonly condition: "healthy" | "completed";
@@ -28,6 +36,29 @@ interface DockerAuthOptions extends AuthServiceOptions {
   readonly networkArgs: readonly string[];
   readonly apiPort: number;
 }
+
+/** Mirrors the classic CLI's [auth.external.*] → GOTRUE_EXTERNAL_* env
+ * translation. Every field except url emits explicitly, defaults
+ * included: native-mode spawns extend the parent environment, so an
+ * unset variable would inherit whatever the shell carries — the classic
+ * CLI shadows the same way (start.go emits the booleans with %t). url
+ * stays conditional, matching start.go. */
+const externalProviderEnv = (opts: AuthServiceOptions): Record<string, string> => {
+  const env: Record<string, string> = {};
+  for (const [id, provider] of Object.entries(opts.external ?? {})) {
+    const prefix = `GOTRUE_EXTERNAL_${id.toUpperCase()}`;
+    env[`${prefix}_ENABLED`] = String(provider.enabled ?? true);
+    env[`${prefix}_CLIENT_ID`] = provider.clientId;
+    env[`${prefix}_SECRET`] = provider.secret ?? "";
+    env[`${prefix}_REDIRECT_URI`] = provider.redirectUri ?? `${opts.externalUrl}/auth/v1/callback`;
+    env[`${prefix}_SKIP_NONCE_CHECK`] = String(provider.skipNonceCheck ?? false);
+    env[`${prefix}_EMAIL_OPTIONAL`] = String(provider.emailOptional ?? false);
+    if (provider.url !== undefined) {
+      env[`${prefix}_URL`] = provider.url;
+    }
+  }
+  return env;
+};
 
 const authEnv = (opts: AuthServiceOptions, dbHost = "127.0.0.1"): Record<string, string> => ({
   GOTRUE_DB_DATABASE_URL: `postgresql://supabase_auth_admin:postgres@${dbHost}:${opts.dbPort}/postgres`,
@@ -56,6 +87,11 @@ const authEnv = (opts: AuthServiceOptions, dbHost = "127.0.0.1"): Record<string,
           ? {}
           : { GOTRUE_SMTP_SENDER_NAME: opts.smtpSenderName }),
       }),
+  // Always emitted, empty when none: native spawns extend the parent env,
+  // so omission would let a shell GOTRUE_URI_ALLOW_LIST become the allow
+  // list (start.go always appends it, empty included).
+  GOTRUE_URI_ALLOW_LIST: (opts.additionalRedirectUrls ?? []).join(","),
+  ...externalProviderEnv(opts),
 });
 
 const authHealthCheck = (port: number) => ({

--- a/packages/stack/src/services/auth.unit.test.ts
+++ b/packages/stack/src/services/auth.unit.test.ts
@@ -30,10 +30,11 @@ describe("auth external providers", () => {
       // Defaults survive beside the provider translation.
       GOTRUE_SITE_URL: "http://localhost:3000",
     });
-    expect(def.env).not.toHaveProperty("GOTRUE_EXTERNAL_GOOGLE_URL");
-    // Boolean defaults emit explicitly: native spawns extend the parent
-    // env, so an omitted var would inherit the shell's value.
+    // Defaults emit explicitly, url's empty string included: native
+    // spawns extend the parent env, so an omitted var would inherit the
+    // shell's value (GoTrue reads an empty URL as its provider default).
     expect(def.env).toMatchObject({
+      GOTRUE_EXTERNAL_GOOGLE_URL: "",
       GOTRUE_EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: "false",
       GOTRUE_EXTERNAL_GOOGLE_EMAIL_OPTIONAL: "false",
     });
@@ -77,6 +78,26 @@ describe("auth external providers", () => {
     expect(def.env).toMatchObject({
       GOTRUE_EXTERNAL_APPLE_ENABLED: "true",
       GOTRUE_EXTERNAL_APPLE_SECRET: "",
+    });
+  });
+
+  test("empty redirectUri and url mean unset, like the classic surface", () => {
+    // The generated config.toml template ships redirect_uri = "" and
+    // url = "" — TOML strings can't be absent — and start.go substitutes
+    // the derived callback for an empty redirect_uri. The URL var still
+    // emits (empty = GoTrue's provider default) so a shell variable can
+    // never supply it under native-mode env extension.
+    const def = makeAuthServiceNative({
+      ...baseOptions,
+      binPath: "/opt/supabase",
+      external: {
+        gitlab: { clientId: "gl-id", secret: "gl-secret", redirectUri: "", url: "" },
+      },
+    });
+
+    expect(def.env).toMatchObject({
+      GOTRUE_EXTERNAL_GITLAB_REDIRECT_URI: "http://127.0.0.1:54321/auth/v1/callback",
+      GOTRUE_EXTERNAL_GITLAB_URL: "",
     });
   });
 

--- a/packages/stack/src/services/auth.unit.test.ts
+++ b/packages/stack/src/services/auth.unit.test.ts
@@ -7,7 +7,7 @@ const baseOptions = {
   siteUrl: "http://localhost:3000",
   jwtSecret: "super-secret-jwt-token-with-at-least-32-characters-long",
   jwtExpiry: 3600,
-  externalUrl: "http://127.0.0.1:54321",
+  externalUrl: "http://127.0.0.1:54321/auth/v1",
   dependencies: [],
 };
 

--- a/packages/stack/src/services/auth.unit.test.ts
+++ b/packages/stack/src/services/auth.unit.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { makeAuthServiceDocker, makeAuthServiceNative } from "./auth.ts";
+
+const baseOptions = {
+  dbPort: 54322,
+  authPort: 54324,
+  siteUrl: "http://localhost:3000",
+  jwtSecret: "super-secret-jwt-token-with-at-least-32-characters-long",
+  jwtExpiry: 3600,
+  externalUrl: "http://127.0.0.1:54321",
+  dependencies: [],
+};
+
+describe("auth external providers", () => {
+  // The contract: `external` is the typed surface for GoTrue OAuth
+  // providers, translated to GOTRUE_EXTERNAL_<ID>_* env the way the
+  // classic CLI translates [auth.external.*].
+  test("native: a declared provider enables with the issuer-derived redirect", () => {
+    const def = makeAuthServiceNative({
+      ...baseOptions,
+      binPath: "/opt/supabase",
+      external: { google: { clientId: "client-id", secret: "client-secret" } },
+    });
+
+    expect(def.env).toMatchObject({
+      GOTRUE_EXTERNAL_GOOGLE_ENABLED: "true",
+      GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: "client-id",
+      GOTRUE_EXTERNAL_GOOGLE_SECRET: "client-secret",
+      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: "http://127.0.0.1:54321/auth/v1/callback",
+      // Defaults survive beside the provider translation.
+      GOTRUE_SITE_URL: "http://localhost:3000",
+    });
+    expect(def.env).not.toHaveProperty("GOTRUE_EXTERNAL_GOOGLE_URL");
+    // Boolean defaults emit explicitly: native spawns extend the parent
+    // env, so an omitted var would inherit the shell's value.
+    expect(def.env).toMatchObject({
+      GOTRUE_EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: "false",
+      GOTRUE_EXTERNAL_GOOGLE_EMAIL_OPTIONAL: "false",
+    });
+  });
+
+  test("docker: explicit fields reach the container args; enabled=false stays declared", () => {
+    const def = makeAuthServiceDocker({
+      ...baseOptions,
+      image: "supabase/gotrue:test",
+      dbHost: "127.0.0.1",
+      networkArgs: [],
+      apiPort: 54321,
+      external: {
+        github: {
+          enabled: false,
+          clientId: "gh-id",
+          secret: "gh-secret",
+          redirectUri: "http://example.test/cb",
+          url: "https://ghe.example.test",
+          skipNonceCheck: true,
+        },
+      },
+    });
+
+    const args = def.args ?? [];
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_ENABLED=false");
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=gh-id");
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_SECRET=gh-secret");
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=http://example.test/cb");
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_URL=https://ghe.example.test");
+    expect(args).toContain("GOTRUE_EXTERNAL_GITHUB_SKIP_NONCE_CHECK=true");
+  });
+
+  test("a secretless provider emits an empty secret, like the classic CLI", () => {
+    const def = makeAuthServiceNative({
+      ...baseOptions,
+      binPath: "/opt/supabase",
+      external: { apple: { clientId: "apple-id" } },
+    });
+
+    expect(def.env).toMatchObject({
+      GOTRUE_EXTERNAL_APPLE_ENABLED: "true",
+      GOTRUE_EXTERNAL_APPLE_SECRET: "",
+    });
+  });
+
+  test("no external config adds no provider env", () => {
+    const def = makeAuthServiceNative({ ...baseOptions, binPath: "/opt/supabase" });
+    const providerKeys = Object.keys(def.env ?? {}).filter(
+      (key) => key.startsWith("GOTRUE_EXTERNAL_") && key !== "GOTRUE_EXTERNAL_EMAIL_ENABLED",
+    );
+    expect(providerKeys).toEqual([]);
+    // Empty but present: [] must mean "no extra redirects", not "whatever
+    // the parent shell says".
+    expect(def.env).toMatchObject({ GOTRUE_URI_ALLOW_LIST: "" });
+  });
+
+  test("additional redirect urls translate to the comma-joined allow list", () => {
+    const def = makeAuthServiceNative({
+      ...baseOptions,
+      binPath: "/opt/supabase",
+      additionalRedirectUrls: ["http://localhost:3000", "https://app.example.test"],
+    });
+    expect(def.env).toMatchObject({
+      GOTRUE_URI_ALLOW_LIST: "http://localhost:3000,https://app.example.test",
+    });
+  });
+});

--- a/packages/stack/src/services/services.unit.test.ts
+++ b/packages/stack/src/services/services.unit.test.ts
@@ -267,7 +267,7 @@ describe("makeAuthServiceNative", () => {
       siteUrl: "http://localhost:3000",
       jwtSecret: JWT_SECRET,
       jwtExpiry: 3600,
-      externalUrl: `http://127.0.0.1:${API_PORT}`,
+      externalUrl: `http://127.0.0.1:${API_PORT}/auth/v1`,
       dependencies: [{ service: "postgres-init", condition: "completed" }],
     });
 
@@ -297,7 +297,7 @@ describe("makeAuthServiceDocker", () => {
       siteUrl: "http://localhost:3000",
       jwtSecret: JWT_SECRET,
       jwtExpiry: 3600,
-      externalUrl: `http://127.0.0.1:${API_PORT}`,
+      externalUrl: `http://127.0.0.1:${API_PORT}/auth/v1`,
       dbHost: "127.0.0.1",
       networkArgs: [...LINUX_HOST_GATEWAY_ARGS, "-p", "9999:9999"],
       apiPort: API_PORT,


### PR DESCRIPTION
## Problem

The stack has no surface for GoTrue's external OAuth providers or extra redirect URLs — the `[auth.external.*]` and `additional_redirect_urls` config the classic CLI translates into `GOTRUE_EXTERNAL_*`/`GOTRUE_URI_ALLOW_LIST` env (`start.go`) has no equivalent on `AuthConfig`, so a programmatic embedder can't wire e.g. Google login. (Use case: a dev-environment supervisor embedding the stack, with Google OAuth in its dev profile.)

## Change

`AuthConfig` gains:

- `external` — a record of typed per-provider configs keyed by GoTrue provider id (`enabled` default-true, `clientId`, optional `secret`, `redirectUri` defaulting to the issuer-derived `<externalUrl>/auth/v1/callback`, `url`, `skipNonceCheck`, `emailOptional`), translated to `GOTRUE_EXTERNAL_<ID>_*` in the auth member exactly like the classic CLI's start path; GoTrue itself validates provider ids.
- `additionalRedirectUrls` — translated to `GOTRUE_URI_ALLOW_LIST` the same way.

The booleans and the allow list emit explicitly, defaults included: native-mode spawns extend the parent environment (`extendEnv: true`), so an omitted variable would let a same-named shell variable override the typed config — `start.go` shadows the same way (`%t` booleans, always-appended allow list).

## Considered and rejected

- A raw `auth.env` passthrough: caller-wins env could silently override core wiring (`GOTRUE_DB_DATABASE_URL`, `GOTRUE_JWT_SECRET`), and the stack's config surfaces are typed camelCase interfaces.
- Reusing `@supabase/config`'s provider schema types directly: those are the toml layer's snake_case shapes; the stack keeps its own camelCase config interfaces like the rest of `AuthConfig`.

## Tests

Contract tests on both factory shapes: the issuer-derived redirect default, explicit fields reaching docker args, the secretless-provider case (empty emit), the allow-list translation and its empty-but-present baseline, and explicit boolean defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)