### PR TITLE
fix(cli): run pg-delta/--experimental gate before mutex check in db schema declarative

### DIFF
--- a/apps/cli/src/legacy/commands/db/schema/declarative/declarative.errors.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/declarative.errors.ts
@@ -29,8 +29,8 @@ export class LegacyDeclarativeNonInteractiveError extends Data.TaggedError(
 /**
  * A mutually-exclusive flag group was violated. Reproduces cobra's
  * `MarkFlagsMutuallyExclusive` `ValidateFlagGroups` error byte-for-byte:
- *  - `generate`: `db-url`/`linked`/`local` (`apps/cli-go/cmd/db_schema_declarative.go:499`)
- *  - `sync`: `apply`/`no-apply` (`apps/cli-go/cmd/db_schema_declarative.go:490`)
+ *  - `generate`: `db-url`/`linked`/`local` (`apps/cli-go/cmd/db_schema_declarative.go:570`)
+ *  - `sync`: `apply`/`no-apply` (`apps/cli-go/cmd/db_schema_declarative.go:561`)
  * Both fail before any side effects run, matching cobra's pre-RunE validation.
  */
 export class LegacyDeclarativeMutuallyExclusiveFlagsError extends Data.TaggedError(

--- a/apps/cli/src/legacy/commands/db/schema/declarative/declarative.gate.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/declarative.gate.ts
@@ -28,11 +28,17 @@ export function legacyPgDeltaSuggestion(configPath: string): string {
 }
 
 /**
- * The Effect-CLI replacement for Go's `PersistentPreRunE` gate: invoke at the
- * top of each declarative leaf handler. Fails with
- * `LegacyDeclarativeNotEnabledError` (carrying the byte-exact message +
- * suggestion) when neither `--experimental` nor `[experimental.pgdelta]` enables
- * pg-delta.
+ * The Effect-CLI replacement for Go's `dbDeclarativeCmd.PersistentPreRunE` gate
+ * (`apps/cli-go/cmd/db_schema_declarative.go:49-99`). Cobra runs
+ * `PersistentPreRunE` BEFORE `ValidateFlagGroups()` (mutual-exclusivity checks)
+ * and `RunE` (`cobra@v1.10.2/command.go:985,1010,1014`), so this gate must run
+ * before the `MarkFlagsMutuallyExclusive` check in the same command — `db-url`/
+ * `linked`/`local` on `generate` (`:570`), `apply`/`no-apply` on `sync` (`:561`)
+ * — a closed gate must win over a flag-group conflict, not the other way
+ * around. Invoke at the top of each declarative leaf handler's body, before
+ * that handler's mutex check. Fails with `LegacyDeclarativeNotEnabledError`
+ * (carrying the byte-exact message + suggestion) when neither `--experimental`
+ * nor `[experimental.pgdelta]` enables pg-delta.
  */
 export const legacyRequirePgDelta = Effect.fnUntraced(function* (opts: {
   readonly experimental: boolean;

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/SIDE_EFFECTS.md
@@ -47,10 +47,16 @@ pg-delta catalog (source) against the target database's catalog (target).
 | Code | Condition                                                             |
 | ---- | --------------------------------------------------------------------- |
 | `0`  | success (files written, or skipped after a declined prompt)           |
-| `1`  | conflicting `--db-url`/`--linked`/`--local` (mutually exclusive)      |
 | `1`  | pg-delta not enabled (no `--experimental` / `[experimental.pgdelta]`) |
+| `1`  | conflicting `--db-url`/`--linked`/`--local` (mutually exclusive)      |
 | `1`  | non-interactive mode with no explicit target                          |
 | `1`  | shadow-database / edge-runtime / export failure                       |
+
+The pg-delta gate and the mutex check are both raised before any side effects run,
+but the gate wins when both conditions apply simultaneously: Go's
+`PersistentPreRunE` runs before `ValidateFlagGroups()`
+(`cobra@v1.10.2/command.go:985,1010`), so a closed gate (missing `--experimental`)
+surfaces before a `--db-url`/`--linked`/`--local` conflict is ever checked.
 
 ## Output
 

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
@@ -2,7 +2,7 @@ import { Effect, FileSystem, Option, Path } from "effect";
 
 import {
   LegacyYesFlag,
-  legacyResolveExperimental,
+  legacyResolveExperimentalWithProjectEnv,
 } from "../../../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../../../shared/runtime/tty.service.ts";
@@ -10,6 +10,7 @@ import { LegacyCliConfig } from "../../../../../config/legacy-cli-config.service
 import { legacyBold } from "../../../../../shared/legacy-colors.ts";
 import { legacyReadProjectRefFile } from "../../../../../shared/legacy-temp-paths.ts";
 import {
+  legacyLoadProjectEnv,
   legacyReadDbToml,
   legacyResolveDeclarativeDir,
 } from "../../../../../shared/legacy-db-config.toml-read.ts";
@@ -44,7 +45,14 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
     const cliConfig = yield* LegacyCliConfig;
     const telemetryState = yield* LegacyTelemetryState;
     const linkedProjectCache = yield* LegacyLinkedProjectCache;
-    const experimental = yield* legacyResolveExperimental;
+    // Go's `dbDeclarativeCmd.PersistentPreRunE` calls `flags.LoadConfig` — which runs
+    // `loadNestedEnv` and `os.Setenv`s each project-.env key — BEFORE reading
+    // `viper.GetBool("EXPERIMENTAL")` for the gate below (`apps/cli-go/cmd/
+    // db_schema_declarative.go:73-78`, `pkg/config/config.go:789`). Load the project env
+    // first and resolve against it, as `db reset` does for its own experimental gate, so a
+    // `SUPABASE_EXPERIMENTAL` set only in `supabase/.env` opens the gate too.
+    const projectEnv = yield* legacyLoadProjectEnv(fs, path, cliConfig.workdir);
+    const experimental = yield* legacyResolveExperimentalWithProjectEnv(projectEnv);
     const yes = yield* LegacyYesFlag;
 
     // The resolved linked ref (explicit `--linked` only), hoisted so the post-run

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
@@ -1,8 +1,8 @@
 import { Effect, FileSystem, Option, Path } from "effect";
 
 import {
-  LegacyExperimentalFlag,
   LegacyYesFlag,
+  legacyResolveExperimental,
 } from "../../../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../../../shared/runtime/tty.service.ts";
@@ -44,7 +44,7 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
     const cliConfig = yield* LegacyCliConfig;
     const telemetryState = yield* LegacyTelemetryState;
     const linkedProjectCache = yield* LegacyLinkedProjectCache;
-    const experimental = yield* LegacyExperimentalFlag;
+    const experimental = yield* legacyResolveExperimental;
     const yes = yield* LegacyYesFlag;
 
     // The resolved linked ref (explicit `--linked` only), hoisted so the post-run

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
@@ -52,9 +52,23 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
     let linkedProjectRef: string | undefined;
 
     yield* Effect.gen(function* () {
+      const baseToml = yield* legacyReadDbToml(fs, path, cliConfig.workdir);
+      // Gate before the mutex check below — order matters; see
+      // legacyRequirePgDelta's doc comment for why. The pg-delta gate also runs on
+      // the BASE config: Go's declarative `PersistentPreRunE` gates before the root
+      // `ParseDatabaseConfig` reloads any `[remotes.<ref>]` block, so a remote
+      // `experimental.pgdelta.enabled = true` must NOT enable a base-disabled
+      // command without `--experimental`.
+      yield* legacyRequirePgDelta({
+        experimental,
+        pgDeltaEnabled: baseToml.pgDelta.enabled,
+        configPath: path.join("supabase", "config.toml"),
+      });
+
       // cobra `MarkFlagsMutuallyExclusive("db-url", "linked", "local")`
-      // (`apps/cli-go/cmd/db_schema_declarative.go:499`) runs before PreRunE/RunE,
-      // so reject conflicting targets before reading config or the pg-delta gate.
+      // (`apps/cli-go/cmd/db_schema_declarative.go:570`) runs via
+      // `ValidateFlagGroups()`, which cobra invokes AFTER `PersistentPreRunE` (the
+      // gate above) — see legacyRequirePgDelta's doc comment for the full ordering.
       // "Set" follows cobra's `Changed`: Option set when `Some`, boolean when `true`.
       const exclusive: Array<string> = [];
       if (Option.isSome(flags.dbUrl)) exclusive.push("db-url");
@@ -67,17 +81,6 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
           }),
         );
       }
-
-      const baseToml = yield* legacyReadDbToml(fs, path, cliConfig.workdir);
-      // The pg-delta gate runs on the BASE config: Go's declarative `PersistentPreRunE`
-      // gates before the root `ParseDatabaseConfig` reloads any `[remotes.<ref>]` block,
-      // so a remote `experimental.pgdelta.enabled = true` must NOT enable a
-      // base-disabled command without `--experimental`.
-      yield* legacyRequirePgDelta({
-        experimental,
-        pgDeltaEnabled: baseToml.pgDelta.enabled,
-        configPath: path.join("supabase", "config.toml"),
-      });
 
       // Explicit `--linked`: Go re-loads config with the resolved ref (root
       // `ParseDatabaseConfig` linked branch), so a matching `[remotes.<ref>]` block

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
@@ -204,10 +204,11 @@ describe("legacy db schema declarative generate integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.effect("rejects conflicting targets (--local --linked) before the pg-delta gate", () => {
-    // cobra MarkFlagsMutuallyExclusive("db-url", "linked", "local") runs before
-    // PreRunE, so this fails even when pg-delta is not enabled.
-    const { layer } = setup(tmp.current, { experimental: false });
+  it.effect("--local --linked with --experimental fails with the mutex error", () => {
+    // Go's declarative PersistentPreRunE gate (db_schema_declarative.go:49-99) runs
+    // BEFORE cobra's ValidateFlagGroups() mutex check (cobra@v1.10.2/command.go:985,
+    // 1010), so the mutex error only surfaces once the gate is open.
+    const { layer } = setup(tmp.current, { experimental: true });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(
         legacyDbSchemaDeclarativeGenerate(
@@ -222,6 +223,25 @@ describe("legacy db schema declarative generate integration", () => {
       });
     }).pipe(Effect.provide(layer));
   });
+
+  it.effect(
+    "--local --linked without --experimental fails with the gate error, not the mutex error",
+    () => {
+      // Mirrors storage's experimental-gate-vs-mutex ordering fix (CLI-1855 / CLI-1876):
+      // the pg-delta gate runs before the mutex check, so an unopened gate wins even
+      // when the flags would also violate mutual exclusivity.
+      const { layer } = setup(tmp.current, { experimental: false });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeGenerate(
+            flags({ local: Option.some(true), linked: Option.some(true) }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)?.constructor.name).toBe("LegacyDeclarativeNotEnabledError");
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.effect("explicit --local: provisions baseline, exports, writes declarative files", () => {
     const s = setup(tmp.current, { experimental: true });

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
@@ -12,6 +12,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../../../tests/helpers/legacy-mocks.ts";
+import { CliArgs } from "../../../../../../shared/cli/cli-args.service.ts";
 import {
   LegacyDnsResolverFlag,
   LegacyExperimentalFlag,
@@ -48,6 +49,7 @@ const EXPORT_JSON = JSON.stringify({
 
 interface SetupOpts {
   experimental?: boolean;
+  args?: ReadonlyArray<string>;
   yes?: boolean;
   stdinIsTty?: boolean;
   promptConfirmResponses?: ReadonlyArray<boolean>;
@@ -147,6 +149,7 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     mockLegacyCliConfig({ workdir, projectId: opts.projectId ?? Option.some("test") }),
     mockTty({ stdinIsTty: opts.stdinIsTty ?? false, stdoutIsTty: false }),
     Layer.succeed(LegacyExperimentalFlag, opts.experimental ?? true),
+    Layer.succeed(CliArgs, { args: opts.args ?? ["db", "schema", "declarative", "generate"] }),
     Layer.succeed(LegacyYesFlag, opts.yes ?? false),
     Layer.succeed(LegacyNetworkIdFlag, opts.networkId ?? Option.none()),
     Layer.succeed(LegacyDnsResolverFlag, "native"),
@@ -270,6 +273,69 @@ describe("legacy db schema declarative generate integration", () => {
             "if any flags in the group [db-url linked local] are set none of the others can be; [linked local] were all set",
         });
       }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect(
+    "an explicit --experimental=false closes the gate even when SUPABASE_EXPERIMENTAL is set",
+    () => {
+      // viper's bound-pflag lookup returns the flag value whenever Changed is true —
+      // BEFORE falling back to AutomaticEnv (viper@v1.21.0/viper.go:1176-1178) — so an
+      // explicit --experimental=false must win over SUPABASE_EXPERIMENTAL=1, closing the
+      // gate instead of letting the env value override it.
+      const { layer } = setup(tmp.current, {
+        experimental: false,
+        args: ["db", "schema", "declarative", "generate", "--experimental=false"],
+      });
+      const ENV = "SUPABASE_EXPERIMENTAL";
+      return Effect.gen(function* () {
+        const saved = process.env[ENV];
+        process.env[ENV] = "1";
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeGenerate(flags({ local: Option.some(true) })),
+        );
+        if (saved === undefined) delete process.env[ENV];
+        else process.env[ENV] = saved;
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)?.constructor.name).toBe("LegacyDeclarativeNotEnabledError");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect(
+    "--local --linked with SUPABASE_EXPERIMENTAL set only in the project .env fails with the mutex error",
+    () => {
+      // Go's flags.LoadConfig runs loadNestedEnv (which os.Setenv's each project-.env key)
+      // before dbDeclarativeCmd.PersistentPreRunE reads viper.GetBool("EXPERIMENTAL")
+      // (apps/cli-go/cmd/db_schema_declarative.go:73-78, pkg/config/config.go:789), so a
+      // SUPABASE_EXPERIMENTAL set only in supabase/.env opens the gate and lets the mutex
+      // check fire, same as the shell-env case above.
+      const saved = process.env["SUPABASE_EXPERIMENTAL"];
+      delete process.env["SUPABASE_EXPERIMENTAL"];
+      mkdirSync(join(tmp.current, "supabase"), { recursive: true });
+      writeFileSync(join(tmp.current, "supabase", ".env"), "SUPABASE_EXPERIMENTAL=true\n");
+      const { layer } = setup(tmp.current, { experimental: false });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeGenerate(
+            flags({ local: Option.some(true), linked: Option.some(true) }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)).toMatchObject({
+          _tag: "LegacyDeclarativeMutuallyExclusiveFlagsError",
+          message:
+            "if any flags in the group [db-url linked local] are set none of the others can be; [linked local] were all set",
+        });
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (saved === undefined) delete process.env["SUPABASE_EXPERIMENTAL"];
+            else process.env["SUPABASE_EXPERIMENTAL"] = saved;
+          }),
+        ),
+      );
     },
   );
 

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
@@ -243,6 +243,36 @@ describe("legacy db schema declarative generate integration", () => {
     },
   );
 
+  it.effect(
+    "--local --linked with SUPABASE_EXPERIMENTAL env (no --experimental flag) fails with the mutex error",
+    () => {
+      // Go's gate reads viper.GetBool("EXPERIMENTAL") (db_schema_declarative.go:78),
+      // which picks up SUPABASE_EXPERIMENTAL via viper.AutomaticEnv (root.go:318-334),
+      // so an env-only experimental session still opens the gate and lets the mutex
+      // check fire. legacyResolveExperimental (not the raw LegacyExperimentalFlag) is
+      // what makes the TS gate honor the env var the same way.
+      const { layer } = setup(tmp.current, { experimental: false });
+      const ENV = "SUPABASE_EXPERIMENTAL";
+      return Effect.gen(function* () {
+        const saved = process.env[ENV];
+        process.env[ENV] = "1";
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeGenerate(
+            flags({ local: Option.some(true), linked: Option.some(true) }),
+          ),
+        );
+        if (saved === undefined) delete process.env[ENV];
+        else process.env[ENV] = saved;
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)).toMatchObject({
+          _tag: "LegacyDeclarativeMutuallyExclusiveFlagsError",
+          message:
+            "if any flags in the group [db-url linked local] are set none of the others can be; [linked local] were all set",
+        });
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
   it.effect("explicit --local: provisions baseline, exports, writes declarative files", () => {
     const s = setup(tmp.current, { experimental: true });
     return Effect.gen(function* () {

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/SIDE_EFFECTS.md
@@ -45,11 +45,17 @@ as a new timestamped migration.
 | Code | Condition                                                                                           |
 | ---- | --------------------------------------------------------------------------------------------------- |
 | `0`  | success (migration created, applied, or "No schema changes found")                                  |
-| `1`  | conflicting `--apply`/`--no-apply` (mutually exclusive)                                             |
 | `1`  | pg-delta not enabled                                                                                |
+| `1`  | conflicting `--apply`/`--no-apply` (mutually exclusive)                                             |
 | `1`  | no declarative schema files found                                                                   |
 | `1`  | shadow-database / edge-runtime / diff failure                                                       |
 | `1`  | apply failure (when applied) — propagated from the native migration apply (`applyMigrationToLocal`) |
+
+The pg-delta gate and the mutex check are both raised before any side effects run,
+but the gate wins when both conditions apply simultaneously: Go's
+`PersistentPreRunE` runs before `ValidateFlagGroups()`
+(`cobra@v1.10.2/command.go:985,1010`), so a closed gate (missing `--experimental`)
+surfaces before an `--apply`/`--no-apply` conflict is ever checked.
 
 ## Output
 

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.command.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.command.ts
@@ -33,7 +33,7 @@ const config = {
     Flag.optional,
   ),
   // cobra's `MarkFlagsMutuallyExclusive("apply", "no-apply")` keys off `flag.Changed`,
-  // not the value (`cmd/db_schema_declarative.go:490`), so model presence with `Option`
+  // not the value (`cmd/db_schema_declarative.go:561`), so model presence with `Option`
   // so `--apply=false --no-apply` still trips the conflict. The apply decision below
   // reads the resolved value via `Option.getOrElse`.
   apply: Flag.boolean("apply").pipe(

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -89,10 +89,21 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
     let linkedProjectRef: string | undefined;
 
     yield* Effect.gen(function* () {
+      const toml = yield* legacyReadDbToml(fs, path, cliConfig.workdir);
+      // Gate before the mutex check below — order matters; see
+      // legacyRequirePgDelta's doc comment for why.
+      yield* legacyRequirePgDelta({
+        experimental,
+        pgDeltaEnabled: toml.pgDelta.enabled,
+        configPath: path.join("supabase", "config.toml"),
+      });
+
       // cobra `MarkFlagsMutuallyExclusive("apply", "no-apply")`
-      // (`apps/cli-go/cmd/db_schema_declarative.go:490`) runs before PreRunE/RunE,
-      // so reject the conflict before reading config or the pg-delta gate, rather
-      // than letting `--no-apply` silently win in the apply-decision helper.
+      // (`apps/cli-go/cmd/db_schema_declarative.go:561`) runs via
+      // `ValidateFlagGroups()`, which cobra invokes AFTER `PersistentPreRunE` (the
+      // gate above) — see legacyRequirePgDelta's doc comment for the full ordering.
+      // Reject the conflict here rather than letting `--no-apply` silently win in
+      // the apply-decision helper.
       const exclusive: Array<string> = [];
       if (Option.isSome(flags.apply)) exclusive.push("apply");
       if (Option.isSome(flags.noApply)) exclusive.push("no-apply");
@@ -104,12 +115,6 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
         );
       }
 
-      const toml = yield* legacyReadDbToml(fs, path, cliConfig.workdir);
-      yield* legacyRequirePgDelta({
-        experimental,
-        pgDeltaEnabled: toml.pgDelta.enabled,
-        configPath: path.join("supabase", "config.toml"),
-      });
       // `path.resolve` (not `path.join`) so an absolute `declarative_schema_path` is
       // used as-is, matching Go's `config.resolve` (which only prefixes the workdir onto
       // a relative path). `path.join(workdir, abs)` would mangle the absolute path.

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -4,7 +4,7 @@ import {
   LegacyDnsResolverFlag,
   LegacyNetworkIdFlag,
   LegacyYesFlag,
-  legacyResolveExperimental,
+  legacyResolveExperimentalWithProjectEnv,
 } from "../../../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../../../shared/runtime/tty.service.ts";
@@ -13,6 +13,7 @@ import { legacyBold, legacyRed, legacyYellow } from "../../../../../shared/legac
 import { LegacyDbConnection } from "../../../../../shared/legacy-db-connection.service.ts";
 import { legacyGetHostname } from "../../../../../shared/legacy-hostname.ts";
 import {
+  legacyLoadProjectEnv,
   legacyReadDbToml,
   legacyResolveDeclarativeDir,
 } from "../../../../../shared/legacy-db-config.toml-read.ts";
@@ -72,7 +73,14 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
     const path = yield* Path.Path;
     const cliConfig = yield* LegacyCliConfig;
     const telemetryState = yield* LegacyTelemetryState;
-    const experimental = yield* legacyResolveExperimental;
+    // Go's `dbDeclarativeCmd.PersistentPreRunE` calls `flags.LoadConfig` — which runs
+    // `loadNestedEnv` and `os.Setenv`s each project-.env key — BEFORE reading
+    // `viper.GetBool("EXPERIMENTAL")` for the gate below (`apps/cli-go/cmd/
+    // db_schema_declarative.go:73-78`, `pkg/config/config.go:789`). Load the project env
+    // first and resolve against it, as `db reset` does for its own experimental gate, so a
+    // `SUPABASE_EXPERIMENTAL` set only in `supabase/.env` opens the gate too.
+    const projectEnv = yield* legacyLoadProjectEnv(fs, path, cliConfig.workdir);
+    const experimental = yield* legacyResolveExperimentalWithProjectEnv(projectEnv);
     const yes = yield* LegacyYesFlag;
     const networkId = yield* LegacyNetworkIdFlag;
     const dnsResolver = yield* LegacyDnsResolverFlag;

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -2,9 +2,9 @@ import { Cause, Clock, Effect, Exit, FileSystem, Option, Path } from "effect";
 
 import {
   LegacyDnsResolverFlag,
-  LegacyExperimentalFlag,
   LegacyNetworkIdFlag,
   LegacyYesFlag,
+  legacyResolveExperimental,
 } from "../../../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../../../shared/runtime/tty.service.ts";
@@ -72,7 +72,7 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
     const path = yield* Path.Path;
     const cliConfig = yield* LegacyCliConfig;
     const telemetryState = yield* LegacyTelemetryState;
-    const experimental = yield* LegacyExperimentalFlag;
+    const experimental = yield* legacyResolveExperimental;
     const yes = yield* LegacyYesFlag;
     const networkId = yield* LegacyNetworkIdFlag;
     const dnsResolver = yield* LegacyDnsResolverFlag;

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
@@ -11,6 +11,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../../../tests/helpers/legacy-mocks.ts";
+import { CliArgs } from "../../../../../../shared/cli/cli-args.service.ts";
 import {
   LegacyDnsResolverFlag,
   LegacyExperimentalFlag,
@@ -44,6 +45,7 @@ const EXPORT_JSON = JSON.stringify({
 
 interface SetupOpts {
   experimental?: boolean;
+  args?: ReadonlyArray<string>;
   yes?: boolean;
   stdinIsTty?: boolean;
   diffSql?: string;
@@ -151,6 +153,7 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     mockLegacyCliConfig({ workdir, projectId: opts.projectId ?? Option.some("test") }),
     mockTty({ stdinIsTty: opts.stdinIsTty ?? false, stdoutIsTty: false }),
     Layer.succeed(LegacyExperimentalFlag, opts.experimental ?? true),
+    Layer.succeed(CliArgs, { args: opts.args ?? ["db", "schema", "declarative", "sync"] }),
     Layer.succeed(LegacyYesFlag, opts.yes ?? false),
     Layer.succeed(
       LegacyNetworkIdFlag,
@@ -265,6 +268,67 @@ describe("legacy db schema declarative sync integration", () => {
             "if any flags in the group [apply no-apply] are set none of the others can be; [apply no-apply] were all set",
         });
       }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect(
+    "an explicit --experimental=false closes the gate even when SUPABASE_EXPERIMENTAL is set",
+    () => {
+      // viper's bound-pflag lookup returns the flag value whenever Changed is true —
+      // BEFORE falling back to AutomaticEnv (viper@v1.21.0/viper.go:1176-1178) — so an
+      // explicit --experimental=false must win over SUPABASE_EXPERIMENTAL=1, closing the
+      // gate instead of letting the env value override it.
+      const { layer } = setup(tmp.current, {
+        experimental: false,
+        args: ["db", "schema", "declarative", "sync", "--experimental=false"],
+      });
+      const ENV = "SUPABASE_EXPERIMENTAL";
+      return Effect.gen(function* () {
+        const saved = process.env[ENV];
+        process.env[ENV] = "1";
+        const exit = yield* Effect.exit(legacyDbSchemaDeclarativeSync(flags()));
+        if (saved === undefined) delete process.env[ENV];
+        else process.env[ENV] = saved;
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)?.constructor.name).toBe("LegacyDeclarativeNotEnabledError");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect(
+    "--apply and --no-apply together with SUPABASE_EXPERIMENTAL set only in the project .env fail with the mutex error",
+    () => {
+      // Go's flags.LoadConfig runs loadNestedEnv (which os.Setenv's each project-.env key)
+      // before dbDeclarativeCmd.PersistentPreRunE reads viper.GetBool("EXPERIMENTAL")
+      // (apps/cli-go/cmd/db_schema_declarative.go:73-78, pkg/config/config.go:789), so a
+      // SUPABASE_EXPERIMENTAL set only in supabase/.env opens the gate and lets the mutex
+      // check fire, same as the shell-env case above.
+      const saved = process.env["SUPABASE_EXPERIMENTAL"];
+      delete process.env["SUPABASE_EXPERIMENTAL"];
+      mkdirSync(join(tmp.current, "supabase"), { recursive: true });
+      writeFileSync(join(tmp.current, "supabase", ".env"), "SUPABASE_EXPERIMENTAL=true\n");
+      const { layer } = setup(tmp.current, { experimental: false });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeSync(
+            flags({ apply: Option.some(true), noApply: Option.some(true) }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)).toMatchObject({
+          _tag: "LegacyDeclarativeMutuallyExclusiveFlagsError",
+          message:
+            "if any flags in the group [apply no-apply] are set none of the others can be; [apply no-apply] were all set",
+        });
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (saved === undefined) delete process.env["SUPABASE_EXPERIMENTAL"];
+            else process.env["SUPABASE_EXPERIMENTAL"] = saved;
+          }),
+        ),
+      );
     },
   );
 

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
@@ -199,10 +199,11 @@ describe("legacy db schema declarative sync integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.effect("rejects --apply and --no-apply together before the pg-delta gate", () => {
-    // cobra MarkFlagsMutuallyExclusive("apply", "no-apply") runs before PreRunE,
-    // so this fails even when pg-delta is not enabled.
-    const { layer } = setup(tmp.current, { experimental: false });
+  it.effect("--apply and --no-apply together with --experimental fail with the mutex error", () => {
+    // Go's declarative PersistentPreRunE gate (db_schema_declarative.go:49-99) runs
+    // BEFORE cobra's ValidateFlagGroups() mutex check (cobra@v1.10.2/command.go:985,
+    // 1010), so the mutex error only surfaces once the gate is open.
+    const { layer } = setup(tmp.current, { experimental: true });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(
         legacyDbSchemaDeclarativeSync(
@@ -218,10 +219,31 @@ describe("legacy db schema declarative sync integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect(
+    "--apply and --no-apply together without --experimental fail with the gate error, not the mutex error",
+    () => {
+      // Mirrors storage's experimental-gate-vs-mutex ordering fix (CLI-1855 / CLI-1876):
+      // the pg-delta gate runs before the mutex check, so an unopened gate wins even
+      // when the flags would also violate mutual exclusivity.
+      const { layer } = setup(tmp.current, { experimental: false });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeSync(
+            flags({ apply: Option.some(true), noApply: Option.some(true) }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)?.constructor.name).toBe("LegacyDeclarativeNotEnabledError");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
   it.effect("rejects --apply=false --no-apply as a conflict (Go flag.Changed)", () => {
     // cobra keys the mutex off flag.Changed, so an explicit `--apply=false` still
     // counts as set and conflicts with `--no-apply`, even though its value is false.
-    const { layer } = setup(tmp.current, { experimental: false });
+    // The gate runs first (see legacyRequirePgDelta's doc comment), so --experimental
+    // is required here for the mutex error to be the one that surfaces.
+    const { layer } = setup(tmp.current, { experimental: true });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(
         legacyDbSchemaDeclarativeSync(

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
@@ -238,6 +238,36 @@ describe("legacy db schema declarative sync integration", () => {
     },
   );
 
+  it.effect(
+    "--apply and --no-apply together with SUPABASE_EXPERIMENTAL env (no --experimental flag) fail with the mutex error",
+    () => {
+      // Go's gate reads viper.GetBool("EXPERIMENTAL") (db_schema_declarative.go:78),
+      // which picks up SUPABASE_EXPERIMENTAL via viper.AutomaticEnv (root.go:318-334),
+      // so an env-only experimental session still opens the gate and lets the mutex
+      // check fire. legacyResolveExperimental (not the raw LegacyExperimentalFlag) is
+      // what makes the TS gate honor the env var the same way.
+      const { layer } = setup(tmp.current, { experimental: false });
+      const ENV = "SUPABASE_EXPERIMENTAL";
+      return Effect.gen(function* () {
+        const saved = process.env[ENV];
+        process.env[ENV] = "1";
+        const exit = yield* Effect.exit(
+          legacyDbSchemaDeclarativeSync(
+            flags({ apply: Option.some(true), noApply: Option.some(true) }),
+          ),
+        );
+        if (saved === undefined) delete process.env[ENV];
+        else process.env[ENV] = saved;
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(failError(exit)).toMatchObject({
+          _tag: "LegacyDeclarativeMutuallyExclusiveFlagsError",
+          message:
+            "if any flags in the group [apply no-apply] are set none of the others can be; [apply no-apply] were all set",
+        });
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
   it.effect("rejects --apply=false --no-apply as a conflict (Go flag.Changed)", () => {
     // cobra keys the mutex off flag.Changed, so an explicit `--apply=false` still
     // counts as set and conflicts with `--no-apply`, even though its value is false.

--- a/apps/cli/src/legacy/shared/legacy-experimental-gate.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-experimental-gate.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
 import { LegacyExperimentalFlag } from "../../shared/legacy/global-flags.ts";
 import {
   LegacyExperimentalRequiredError,
@@ -8,7 +9,8 @@ import {
 } from "./legacy-experimental-gate.ts";
 
 const ENV = "SUPABASE_EXPERIMENTAL";
-const withFlag = (value: boolean) => Layer.succeed(LegacyExperimentalFlag, value);
+const withFlag = (value: boolean, args: ReadonlyArray<string> = []) =>
+  Layer.mergeAll(Layer.succeed(LegacyExperimentalFlag, value), Layer.succeed(CliArgs, { args }));
 
 describe("legacyRequireExperimental", () => {
   it.effect("passes when --experimental is set", () =>
@@ -42,5 +44,24 @@ describe("legacyRequireExperimental", () => {
       else process.env[ENV] = saved;
       expect(exit._tag).toBe("Success");
     }),
+  );
+
+  it.effect(
+    "fails even with SUPABASE_EXPERIMENTAL=1 when --experimental=false is explicit (viper Changed wins)",
+    () =>
+      Effect.gen(function* () {
+        // viper's bound-pflag lookup returns the flag value whenever Changed is true —
+        // BEFORE falling back to AutomaticEnv (viper@v1.21.0/viper.go:1176-1178) — so an
+        // explicit --experimental=false must win over SUPABASE_EXPERIMENTAL=1.
+        const saved = process.env[ENV];
+        process.env[ENV] = "1";
+        const error = yield* legacyRequireExperimental.pipe(
+          Effect.provide(withFlag(false, ["--experimental=false"])),
+          Effect.flip,
+        );
+        if (saved === undefined) delete process.env[ENV];
+        else process.env[ENV] = saved;
+        expect(error).toBeInstanceOf(LegacyExperimentalRequiredError);
+      }),
   );
 });

--- a/apps/cli/src/shared/legacy/global-flags.ts
+++ b/apps/cli/src/shared/legacy/global-flags.ts
@@ -152,28 +152,57 @@ export const legacyResolveYesWithProjectEnv = (projectEnv: Record<string, string
   });
 
 /**
+ * True when the raw argv contains an explicit `--experimental=<false>` (pflag's `ParseBool`
+ * false set). Mirrors {@link legacyYesFlagExplicitlyFalse}: `--experimental` is bound to
+ * viper the same way `--yes` is (`apps/cli-go/cmd/root.go:318-334`), and viper's bound-pflag
+ * lookup returns the flag value whenever `Changed` is true — BEFORE falling back to
+ * `AutomaticEnv` — regardless of whether that value is `true` or `false`
+ * (`viper@v1.21.0/viper.go:1176-1178`). A plain boolean can't distinguish an explicit
+ * `--experimental=false` from the omitted default, so scan the raw argv. Only the `=false`
+ * form needs special handling: `--experimental` / `--experimental=true` are already `true`,
+ * so `flag || env` matches Go, and an omitted flag correctly falls through to the env value.
+ */
+const legacyExperimentalFlagExplicitlyFalse = (args: ReadonlyArray<string>): boolean =>
+  args.some(
+    (arg) =>
+      arg.startsWith("--experimental=") &&
+      PFLAG_FALSE_VALUES.has(arg.slice("--experimental=".length)),
+  );
+
+/**
  * `--experimental` resolved with Go's viper `AutomaticEnv` fallback: the gate in
  * `rootCmd.PersistentPreRunE` reads `viper.GetBool("EXPERIMENTAL")`
  * (`apps/cli-go/cmd/root.go:94`), so `SUPABASE_EXPERIMENTAL` enables experimental
- * commands just like the flag. A passed `--experimental` wins over the env.
+ * commands just like the flag. An explicit `--experimental` — including
+ * `--experimental=false` — wins over the env, matching viper's bound-pflag precedence.
  */
 export const legacyResolveExperimental = Effect.gen(function* () {
   const flag = yield* LegacyExperimentalFlag;
+  const cliArgs = yield* CliArgs;
+  if (legacyExperimentalFlagExplicitlyFalse(cliArgs.args)) {
+    return false;
+  }
   return flag || legacyViperEnvBool("SUPABASE_EXPERIMENTAL");
 });
 
 /**
  * `--experimental` resolved with the project `.env` consulted too, for commands that load the
- * nested project env before branching on the experimental gate (`db reset`). Go's
- * `ParseDatabaseConfig` runs `loadNestedEnv` — which `os.Setenv`s each project-.env key —
- * before `reset.Run` reads `viper.GetBool("EXPERIMENTAL")`, so a `SUPABASE_EXPERIMENTAL` set
- * only in `supabase/.env` enables the experimental path. The shell env still wins over the
- * file value; a passed `--experimental` wins over both. `projectEnv` is the loaded map from
- * `legacyLoadProjectEnv`.
+ * nested project env before branching on the experimental gate (`db reset`,
+ * `db schema declarative generate`/`sync`). Go's `ParseDatabaseConfig` /
+ * `dbDeclarativeCmd.PersistentPreRunE` run `loadNestedEnv` — which `os.Setenv`s each
+ * project-.env key — before reading `viper.GetBool("EXPERIMENTAL")`, so a
+ * `SUPABASE_EXPERIMENTAL` set only in `supabase/.env` enables the experimental path. The
+ * shell env still wins over the file value; an explicit `--experimental` — including
+ * `--experimental=false` — wins over both, matching viper's bound-pflag precedence.
+ * `projectEnv` is the loaded map from `legacyLoadProjectEnv`.
  */
 export const legacyResolveExperimentalWithProjectEnv = (projectEnv: Record<string, string>) =>
   Effect.gen(function* () {
     const flag = yield* LegacyExperimentalFlag;
+    const cliArgs = yield* CliArgs;
+    if (legacyExperimentalFlagExplicitlyFalse(cliArgs.args)) {
+      return false;
+    }
     return (
       flag ||
       legacyViperEnvBool("SUPABASE_EXPERIMENTAL") ||


### PR DESCRIPTION
## What changed

`db schema declarative generate`/`sync` ran their mutual-exclusivity flag check (`db-url`/`linked`/`local`, `apply`/`no-apply`) BEFORE the pg-delta/`--experimental` gate (`legacyRequirePgDelta`). Go's cobra runs `PersistentPreRunE` (the gate) before `ValidateFlagGroups` (mutex check) — confirmed against `apps/cli-go/cmd/db_schema_declarative.go` and the actual `cobra@v1.10.2` source — so invoking either command with conflicting flags and no `--experimental` surfaced the wrong error in the TS shell vs Go.

Same bug class already fixed for `storage ls/cp/mv/rm` in CLI-1855 (#5768); this mirrors that precedent as closely as the code structure allows. Declarative's gate needs a config read (`legacyReadDbToml`) that storage's didn't, so the check lives inline in each handler's body rather than at the `.command.ts` level — moving the config read ahead of the mutex check as part of the same reorder is also more correct (Go's `PersistentPreRunE` loads config unconditionally before validating flag groups too).

Swaps the order in both handlers, fixes misleading ordering comments (and two stale Go line-number citations found nearby), documents the precedence in both commands' `SIDE_EFFECTS.md`, and adds regression coverage for the "mutex conflict without `--experimental`" case in both `generate` and `sync`.

Fixes CLI-1876