### PR TITLE
docs(cli): link Effect-TS upstream issue for doubled-Expected workaround

### DIFF
--- a/apps/cli/src/shared/cli/invalid-value-message.ts
+++ b/apps/cli/src/shared/cli/invalid-value-message.ts
@@ -19,6 +19,9 @@
 // scanning `error.value`. Remove once upstream `effect` fixes this (see
 // CLI-1898).
 //
+// TODO: remove once Effect-TS/effect#6312 is fixed upstream.
+// https://github.com/Effect-TS/effect/issues/6312
+//
 // Shared by two call sites that each see `InvalidValue` failures at a
 // different point in `effect`'s CLI runtime:
 // - `subcommand-flag-suggestions.ts` formats errors that reach the


### PR DESCRIPTION
## What changed

Files [Effect-TS/effect#6312](https://github.com/Effect-TS/effect/issues/6312) for the doubled `"Expected: Expected ..."` prefix bug in `effect@4.0.0-beta.93`'s CLI primitive parsers (`Primitive.choice`/schema-backed `integer`/`float`/`boolean`/`date`), per [review feedback on #5831](https://github.com/supabase/cli/pull/5831#pullrequestreview-4661453095), and adds a `TODO` in `invalid-value-message.ts` linking to it, so the workaround is easy to find and remove once upstream fixes the underlying bug.