### PR TITLE
fix(cli): validate config before the destructive db reset --local recreate

### DIFF
--- a/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
@@ -14,7 +14,7 @@ primitives run behind the hidden Go `db __db-bootstrap` seam. Only the niche
 | Path                                                   | Format     | When                                                                      |
 | ------------------------------------------------------ | ---------- | ------------------------------------------------------------------------- |
 | `<workdir>/supabase/migrations/`                       | directory  | to validate `--version` / resolve `--last`, and to load migrations        |
-| `<workdir>/supabase/config.toml`                       | TOML       | remote path + local bucket seeding (embedded defaults when absent)        |
+| `<workdir>/supabase/config.toml`                       | TOML       | always, parsed up front before any destructive work (embedded defaults when absent); re-read for local bucket seeding |
 | `<workdir>/.git/HEAD` (walked upward)                  | plain text | local path, for the `Finished … on branch <branch>.` line                 |
 | `~/.supabase/<hash>/project-ref`                       | plain text | `--linked`, to resolve the ref                                            |
 | `~/.supabase/access-token`                             | plain text | `--linked`, when `SUPABASE_ACCESS_TOKEN` unset and a temp role is minted  |

--- a/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
@@ -11,15 +11,15 @@ primitives run behind the hidden Go `db __db-bootstrap` seam. Only the niche
 
 ## Files Read
 
-| Path                                                   | Format     | When                                                                      |
-| ------------------------------------------------------ | ---------- | ------------------------------------------------------------------------- |
-| `<workdir>/supabase/migrations/`                       | directory  | to validate `--version` / resolve `--last`, and to load migrations        |
+| Path                                                   | Format     | When                                                                                                                  |
+| ------------------------------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| `<workdir>/supabase/migrations/`                       | directory  | to validate `--version` / resolve `--last`, and to load migrations                                                    |
 | `<workdir>/supabase/config.toml`                       | TOML       | always, parsed up front before any destructive work (embedded defaults when absent); re-read for local bucket seeding |
-| `<workdir>/.git/HEAD` (walked upward)                  | plain text | local path, for the `Finished … on branch <branch>.` line                 |
-| `~/.supabase/<hash>/project-ref`                       | plain text | `--linked`, to resolve the ref                                            |
-| `~/.supabase/access-token`                             | plain text | `--linked`, when `SUPABASE_ACCESS_TOKEN` unset and a temp role is minted  |
-| seed files from `--sql-paths` or `[db.seed].sql_paths` | SQL        | when seeding is enabled (not `--no-seed`); `--sql-paths` overrides config |
-| `<workdir>/supabase/buckets/`                          | files      | local path, when storage is up and `[storage.buckets]` configure objects  |
+| `<workdir>/.git/HEAD` (walked upward)                  | plain text | local path, for the `Finished … on branch <branch>.` line                                                             |
+| `~/.supabase/<hash>/project-ref`                       | plain text | `--linked`, to resolve the ref                                                                                        |
+| `~/.supabase/access-token`                             | plain text | `--linked`, when `SUPABASE_ACCESS_TOKEN` unset and a temp role is minted                                              |
+| seed files from `--sql-paths` or `[db.seed].sql_paths` | SQL        | when seeding is enabled (not `--no-seed`); `--sql-paths` overrides config                                             |
+| `<workdir>/supabase/buckets/`                          | files      | local path, when storage is up and `[storage.buckets]` configure objects                                              |
 
 ## Files Written
 

--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -247,13 +247,14 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       // per-connType `LoadConfig`, `internal/utils/flags/db_url.go:77-80`) runs full
       // config validation before `reset.Run` ever reaches `AssertSupabaseDbIsRunning`
       // / the destructive `resetDatabase` (`internal/db/reset/reset.go:57-61`). The
-      // resolver's own local read (above) already performs that same validation
-      // internally, but repeat it here as an explicit, independent gate — the same
-      // pattern `db start` and `db push` use for their own pre-destructive-work
-      // checks — so a malformed config.toml (bad bucket name, undecryptable secret,
-      // empty project_id) is guaranteed to abort before the local database is
-      // recreated, and that guarantee stays covered by a handler-level test even if
-      // the resolver's own internal read is ever mocked, relaxed, or refactored.
+      // resolver's own local read (above, line 239) already performs the identical
+      // validation and would already reject a broken config before this point is
+      // reached — so today this re-validates for its own sake. Repeat it here anyway,
+      // as an explicit, independent gate (the same pattern `db start` and `db push`
+      // use), so the "malformed config aborts before the local database is recreated"
+      // guarantee is enforced by this handler directly and stays covered by a
+      // handler-level test even if the resolver's own internal read is ever mocked,
+      // relaxed, or refactored to stop validating.
       yield* legacyCheckDbToml(fs, path, workdir);
 
       // AssertSupabaseDbIsRunning — error if the local db container is down.
@@ -279,18 +280,15 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       const storageReady = yield* seam.awaitStorageReady();
       if (storageReady) {
         // Go's `buckets.Run(ctx, "", false, fsys)` — non-interactive: overwrite/prune
-        // confirmations take their defaults instead of blocking on input.
-        //
-        // Bucket seeding re-loads config.toml through the strict `@supabase/config` loader
-        // (in `goViperCompat` mode), which is usually in lockstep with the Go-parity
-        // reader used earlier in reset (both now resolve `env(VAR)` booleans via Go's
-        // `strconv.ParseBool` acceptance set) — but a genuinely invalid config would
-        // already have failed the earlier `legacyCheckDbToml` gate before the destructive
-        // recreate. A parse failure reaching HERE means the two loaders have drifted out
-        // of lockstep for some config shape, not that the config is invalid: the seam's Go
-        // `recreate` has already run Go's full `LoadConfig`+`Validate` on this same config.
-        // Recreate already dropped/rebuilt the DB, so aborting now would leave the reset
-        // half-done; warn and skip buckets so `db reset` finishes like Go instead.
+        // confirmations take their defaults instead of blocking on input. Go's own
+        // `resetDatabase` (`internal/db/reset/reset.go:66-68`) propagates ANY
+        // `buckets.Run` error as a full command failure (no "Finished ..." line,
+        // non-zero exit) — Go loads `config.toml` exactly once into memory, so it can
+        // never reach "recreate succeeded, then a later reload of the same file fails."
+        // Match that contract here: a `LegacySeedConfigLoadError` from this reload is
+        // not swallowed. `config push` hard-fails on the identical `@supabase/config`
+        // strictness gap (CLI-1489) rather than warning-and-continuing; do the same here
+        // for consistency, instead of carving out a reset-only exception.
         yield* legacySeedBucketsRun({
           projectRef: "",
           emitSummary: false,
@@ -299,14 +297,7 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
           // auto-confirms bucket/vector/analytics prune prompts. Pass the project-env-resolved
           // `yes` (the shared runner's own `legacyResolveYes` only sees the shell env).
           yes,
-        }).pipe(
-          Effect.catchTag("LegacySeedConfigLoadError", (error) =>
-            output.raw(
-              `${legacyYellow("WARNING:")} skipped seeding storage buckets: ${error.message}\n`,
-              "stderr",
-            ),
-          ),
-        );
+        });
       }
 
       // "Finished supabase db reset on branch <branch>." (both Aqua).

--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -280,15 +280,24 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       const storageReady = yield* seam.awaitStorageReady();
       if (storageReady) {
         // Go's `buckets.Run(ctx, "", false, fsys)` — non-interactive: overwrite/prune
-        // confirmations take their defaults instead of blocking on input. Go's own
-        // `resetDatabase` (`internal/db/reset/reset.go:66-68`) propagates ANY
-        // `buckets.Run` error as a full command failure (no "Finished ..." line,
-        // non-zero exit) — Go loads `config.toml` exactly once into memory, so it can
-        // never reach "recreate succeeded, then a later reload of the same file fails."
-        // Match that contract here: a `LegacySeedConfigLoadError` from this reload is
-        // not swallowed. `config push` hard-fails on the identical `@supabase/config`
-        // strictness gap (CLI-1489) rather than warning-and-continuing; do the same here
-        // for consistency, instead of carving out a reset-only exception.
+        // confirmations take their defaults instead of blocking on input.
+        //
+        // `legacyCheckDbToml` above resolves `env(VAR)` via `legacyLoadProjectEnv`,
+        // which mirrors Go's full nested-env walk (`.env.<SUPABASE_ENV>.local`,
+        // `.env.local`, `.env.<SUPABASE_ENV>`, `.env`, across both `supabase/` and the
+        // project root — `pkg/config/config.go:1220-1257`). This reload instead goes
+        // through `@supabase/config`'s `loadProjectConfig` → `loadProjectEnvironment`,
+        // which only ever reads `supabase/.env`/`.env.local` plus ambient env
+        // (`packages/config/src/project.ts:209-245`) — regardless of `goViperCompat`,
+        // which only widens `env(VAR)` matching, not the file set consulted. So a
+        // config whose `env(VAR)` reference is backed by e.g. `supabase/.env.development`
+        // is genuinely Go-valid (Go's `godotenv.Load` calls `os.Setenv`, so the value is
+        // real ambient env by the time Go resolves it — `config.go:1260-1261`) and
+        // already passed `legacyCheckDbToml` and the real recreate above, but this
+        // narrower reload can still reject it. A `LegacySeedConfigLoadError` here is
+        // that env-file-set gap, not a genuinely invalid config — and recreate already
+        // dropped/rebuilt the DB, so aborting now would leave the reset half-done; warn
+        // and skip buckets so `db reset` finishes like Go instead.
         yield* legacySeedBucketsRun({
           projectRef: "",
           emitSummary: false,
@@ -297,7 +306,14 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
           // auto-confirms bucket/vector/analytics prune prompts. Pass the project-env-resolved
           // `yes` (the shared runner's own `legacyResolveYes` only sees the shell env).
           yes,
-        });
+        }).pipe(
+          Effect.catchTag("LegacySeedConfigLoadError", (error) =>
+            output.raw(
+              `${legacyYellow("WARNING:")} skipped seeding storage buckets: ${error.message}\n`,
+              "stderr",
+            ),
+          ),
+        );
       }
 
       // "Finished supabase db reset on branch <branch>." (both Aqua).

--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -243,6 +243,19 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
     // (running check, messages, bucket seeding, git-branch line, output shaping).
     // Mirrors `internal/db/reset/reset.go:57-77`.
     if (cfg.isLocal) {
+      // Go's `flags.LoadConfig` (root `PersistentPreRunE` → the local target's
+      // per-connType `LoadConfig`, `internal/utils/flags/db_url.go:77-80`) runs full
+      // config validation before `reset.Run` ever reaches `AssertSupabaseDbIsRunning`
+      // / the destructive `resetDatabase` (`internal/db/reset/reset.go:57-61`). The
+      // resolver's own local read (above) already performs that same validation
+      // internally, but repeat it here as an explicit, independent gate — the same
+      // pattern `db start` and `db push` use for their own pre-destructive-work
+      // checks — so a malformed config.toml (bad bucket name, undecryptable secret,
+      // empty project_id) is guaranteed to abort before the local database is
+      // recreated, and that guarantee stays covered by a handler-level test even if
+      // the resolver's own internal read is ever mocked, relaxed, or refactored.
+      yield* legacyCheckDbToml(fs, path, workdir);
+
       // AssertSupabaseDbIsRunning — error if the local db container is down.
       const running = yield* seam.isDbRunning();
       if (!running) {
@@ -268,13 +281,16 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
         // Go's `buckets.Run(ctx, "", false, fsys)` — non-interactive: overwrite/prune
         // confirmations take their defaults instead of blocking on input.
         //
-        // Bucket seeding re-loads config.toml through the strict `@supabase/config`
-        // loader, which (unlike the Go-parity reader used elsewhere in reset) rejects some
-        // Go-valid configs — e.g. `[db.seed] enabled = "env(SEED_ENABLED)"`. The seam's Go
-        // `recreate` has already run Go's full `LoadConfig`+`Validate` on this same config,
-        // so a parse failure HERE is that loader-strictness gap, not a genuinely invalid
-        // config. Recreate already dropped/rebuilt the DB, so aborting now would leave the
-        // reset half-done; warn and skip buckets so `db reset` finishes like Go instead.
+        // Bucket seeding re-loads config.toml through the strict `@supabase/config` loader
+        // (in `goViperCompat` mode), which is usually in lockstep with the Go-parity
+        // reader used earlier in reset (both now resolve `env(VAR)` booleans via Go's
+        // `strconv.ParseBool` acceptance set) — but a genuinely invalid config would
+        // already have failed the earlier `legacyCheckDbToml` gate before the destructive
+        // recreate. A parse failure reaching HERE means the two loaders have drifted out
+        // of lockstep for some config shape, not that the config is invalid: the seam's Go
+        // `recreate` has already run Go's full `LoadConfig`+`Validate` on this same config.
+        // Recreate already dropped/rebuilt the DB, so aborting now would leave the reset
+        // half-done; warn and skip buckets so `db reset` finishes like Go instead.
         yield* legacySeedBucketsRun({
           projectRef: "",
           emitSummary: false,

--- a/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
@@ -367,6 +367,33 @@ describe("legacy db reset", () => {
     });
   });
 
+  it.live(
+    "fails a local reset on a malformed config.toml even when the database is not running",
+    () => {
+      // Pins Go's exact ordering: `flags.LoadConfig` runs in the root `PersistentPreRunE`,
+      // strictly before `reset.Run` ever calls `AssertSupabaseDbIsRunning`
+      // (`internal/db/reset/reset.go:57`). So a broken config must surface as a config
+      // error even when the local database is ALSO not running — the config check must
+      // win the race, not the "is not running" check.
+      const { layer, seam } = setup(tmp.current, {
+        toml: 'project_id = "unterminated\n',
+        args: ["db", "reset"],
+        isLocal: true,
+        running: false,
+      });
+      return Effect.gen(function* () {
+        const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const cause = JSON.stringify(exit.cause);
+          expect(cause).toContain("failed to load config");
+          expect(cause).not.toContain("is not running.");
+        }
+        expect(seam.recreateCalls).toHaveLength(0);
+      });
+    },
+  );
+
   it.live("fails a local reset before the destructive recreate on an undecryptable secret", () => {
     // Regression: Go's `flags.LoadConfig` decrypts every `encrypted:` secret before
     // `reset.Run` recreates the local database, so an undecryptable secret must abort
@@ -381,8 +408,12 @@ describe("legacy db reset", () => {
     return Effect.gen(function* () {
       const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
       expect(Exit.isFailure(exit)).toBe(true);
+      // Assert on the stable "failed to parse config:" prefix rather than the exact
+      // decrypt-failure tail, which depends on whether an ambient `DOTENV_PRIVATE_KEY*`
+      // is set (missing key vs. a base64/decrypt failure) — either way, the config
+      // load must fail before the destructive recreate.
       if (Exit.isFailure(exit)) {
-        expect(JSON.stringify(exit.cause)).toContain("failed to parse config: missing private key");
+        expect(JSON.stringify(exit.cause)).toContain("failed to parse config:");
       }
       expect(seam.recreateCalls).toHaveLength(0);
     });

--- a/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
@@ -490,6 +490,38 @@ describe("legacy db reset", () => {
     );
   });
 
+  it.live(
+    "finishes a local reset when bucket seeding can't see an env(VAR) value the pre-recreate gate saw",
+    () => {
+      // `legacyCheckDbToml` (the pre-recreate gate) resolves `env(VAR)` via
+      // `legacyLoadProjectEnv`, which mirrors Go's full nested-env walk and sees
+      // `supabase/.env.development` — a real, Go-valid env source
+      // (`pkg/config/config.go:1220-1257`; `godotenv.Load` calls `os.Setenv`, so this
+      // is genuinely ambient env by the time Go itself resolves `env(VAR)`,
+      // `config.go:1260-1261`). The post-recreate bucket-seed reload instead goes
+      // through `@supabase/config`'s `loadProjectEnvironment`, which only ever reads
+      // `supabase/.env`/`.env.local` + ambient env (`packages/config/src/project.ts:
+      // 209-245) — it can't see `.env.development` at all. So this Go-valid config
+      // passes the gate and the real recreate, then can't be re-resolved by the
+      // reload; the reset must still finish (warn-and-skip), not hard-fail after the
+      // local database has already been dropped and rebuilt.
+      const { layer, out, seam } = setup(tmp.current, {
+        toml: 'project_id = "test"\n\n[db.seed]\nenabled = "env(SEED_ENABLED)"\n',
+        files: { "supabase/.env.development": "SEED_ENABLED=true\n" },
+        args: ["db", "reset"],
+        isLocal: true,
+        running: true,
+        storageReady: true,
+      });
+      return Effect.gen(function* () {
+        yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer));
+        expect(seam.recreateCalls).toHaveLength(1);
+        expect(out.stderrText).toContain("skipped seeding storage buckets");
+        expect(out.stderrText).toContain("Finished ");
+      });
+    },
+  );
+
   it.live("uses the detected git branch in the Finished line", () => {
     const { layer, out } = setup(tmp.current, {
       toml: 'project_id = "test"\n',

--- a/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
@@ -329,6 +329,86 @@ describe("legacy db reset", () => {
     });
   });
 
+  it.live("proceeds with a local reset when no config file is present", () => {
+    // Go's `Config.Load` tolerates a missing `config.toml`: `Eject` defaults an empty
+    // `project_id` to the cwd basename (`pkg/config/config.go:563-570`), so `Validate`
+    // never sees an empty required field and the CLI proceeds — exactly the mechanism
+    // the cli-e2e parity suite relies on when it runs `db reset --local` from a project
+    // with no config.toml. A missing config must not become a hard failure here.
+    const { layer, seam } = setup(tmp.current, {
+      args: ["db", "reset"],
+      isLocal: true,
+      running: true,
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer));
+      expect(seam.recreateCalls).toHaveLength(1);
+    });
+  });
+
+  it.live("fails a local reset before the destructive recreate on a malformed config.toml", () => {
+    // Go's `flags.LoadConfig` (the local target's `LoadConfig`, `db_url.go:77-80`) runs
+    // full config validation before `reset.Run` reaches `AssertSupabaseDbIsRunning` /
+    // `resetDatabase` (`internal/db/reset/reset.go:57-61`). A broken config.toml must
+    // abort before the local database is ever recreated.
+    const { layer, seam } = setup(tmp.current, {
+      toml: 'project_id = "unterminated\n',
+      args: ["db", "reset"],
+      isLocal: true,
+      running: true,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("failed to load config");
+      }
+      expect(seam.recreateCalls).toHaveLength(0);
+    });
+  });
+
+  it.live("fails a local reset before the destructive recreate on an undecryptable secret", () => {
+    // Regression: Go's `flags.LoadConfig` decrypts every `encrypted:` secret before
+    // `reset.Run` recreates the local database, so an undecryptable secret must abort
+    // before the destructive recreate, not surface later (or never) during bucket
+    // seeding.
+    const { layer, seam } = setup(tmp.current, {
+      toml: 'project_id = "test"\n\n[db.vault]\nmy_secret = "encrypted:anything"\n',
+      args: ["db", "reset"],
+      isLocal: true,
+      running: true,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("failed to parse config: missing private key");
+      }
+      expect(seam.recreateCalls).toHaveLength(0);
+    });
+  });
+
+  it.live("fails a local reset before the destructive recreate on an empty project_id", () => {
+    // Go's `config.Validate` rejects an explicit `project_id = ""` (a present override
+    // that resolved to empty, unlike an absent field) before the local recreate.
+    const { layer, seam } = setup(tmp.current, {
+      toml: 'project_id = ""\n',
+      args: ["db", "reset"],
+      isLocal: true,
+      running: true,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain(
+          "Missing required field in config: project_id",
+        );
+      }
+      expect(seam.recreateCalls).toHaveLength(0);
+    });
+  });
+
   it.live("seeds buckets after a local reset when storage is ready", () => {
     const { layer, seam } = setup(tmp.current, {
       toml: 'project_id = "test"\n',
@@ -346,16 +426,16 @@ describe("legacy db reset", () => {
     });
   });
 
-  it.live("finishes a local reset when bucket seeding hits a strict-loader-rejected config", () => {
-    // The bucket-seeding core re-loads config via the strict `@supabase/config` loader.
-    // `SEED_ENABLED=maybe` is invalid for both Go's `strconv.ParseBool` and the TS
-    // loader's coercion, so the reload fails during decode (unlike e.g. `1`/`true`,
-    // which both now accept). The seam's Go recreate already validated + rebuilt the
-    // DB, so aborting here would leave the reset half-done — warn and skip buckets so
-    // reset finishes like Go.
+  it.live("fails a local reset before the destructive recreate on an unparseable boolean", () => {
+    // `SEED_ENABLED=maybe` cannot be resolved by Go's `strconv.ParseBool`, so
+    // `flags.LoadConfig` aborts on this config before `reset.Run` ever reaches
+    // `AssertSupabaseDbIsRunning`/`resetDatabase`. Previously this surfaced only much
+    // later (if at all) via the bucket-seeding core's own reload, AFTER the local
+    // database had already been recreated — this must now abort up front instead,
+    // via the pre-recreate `legacyCheckDbToml` gate.
     const previous = process.env["SEED_ENABLED"];
     process.env["SEED_ENABLED"] = "maybe";
-    const { layer, out, seam } = setup(tmp.current, {
+    const { layer, seam } = setup(tmp.current, {
       toml: 'project_id = "test"\n\n[db.seed]\nenabled = "env(SEED_ENABLED)"\n',
       args: ["db", "reset"],
       isLocal: true,
@@ -363,10 +443,12 @@ describe("legacy db reset", () => {
       storageReady: true,
     });
     return Effect.gen(function* () {
-      yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer));
-      expect(out.stderrText).toContain("skipped seeding storage buckets");
-      expect(out.stderrText).toContain("Finished ");
-      expect(seam.recreateCalls).toHaveLength(1);
+      const exit = yield* legacyDbReset(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("invalid db.seed.enabled");
+      }
+      expect(seam.recreateCalls).toHaveLength(0);
     }).pipe(
       Effect.ensuring(
         Effect.sync(() => {


### PR DESCRIPTION
## What changed

`supabase db reset --local` now runs full Go-parity config validation (`legacyCheckDbToml`, matching Go's `flags.LoadConfig`) at the top of its local branch, before `AssertSupabaseDbIsRunning`/the destructive container recreate — the same pre-destructive-work gate `db start` and `db push` already have. A broken `supabase/config.toml` (unterminated TOML, an undecryptable `encrypted:` vault secret, an unparseable `env(VAR)` boolean, an explicit empty `project_id`) now aborts before the local database is ever recreated, instead of only surfacing later (or never) during bucket seeding.

A genuinely **missing** `config.toml` is still tolerated, unchanged: Go's `Config.Load` defaults `project_id` to the current directory's basename when no config file exists, so `Validate` never rejects it — this is exactly the mechanism the `cli-e2e` parity suite relies on when it runs `db push --local` / `db reset --local` from a project with no `config.toml`. Only a config file that is *present but broken* is now caught earlier.

`db reset --local`'s post-recreate bucket-seeding step catches a `LegacySeedConfigLoadError` from its own config reload and warns-and-continues rather than failing the command. An earlier version of this PR removed that fallback (reasoning: Go loads `config.toml` exactly once into memory, so it can never reach "recreate succeeded, then a later reload of the same file fails"). A Codex review on this PR caught that this doesn't transfer to the TS port: the new pre-recreate gate resolves `env(VAR)` via the Go-parity nested-env reader (sees `supabase/.env.development`, the project root, etc.), but the post-recreate reload goes through `@supabase/config`'s narrower loader (`supabase/.env`/`.env.local` only) — so a genuinely Go-valid config can pass the gate and the real recreate, then hard-fail only at the later, narrower reload, after the local database has already been dropped and rebuilt. The fallback is restored, with a comment naming the actual env-file-set gap instead of generic "loader strictness."

## Why

Linear [CLI-1877](https://linear.app/supabase/issue/CLI-1877/reject-directlocal-db-push-db-reset-without-project-config-go): a Codex P1 finding on #5715 flagged that the native `db reset`/`db push`/`db start` port tolerates a missing project config more broadly than Go, and that `db reset --local`'s config validation happened too late relative to the destructive recreate.

Investigation (via `go-parity-auditor`, cross-checked against the compiled Go binary) found the issue's literal premise — "reject direct/local db push + db reset without project config" — does **not** match current Go behavior: Go tolerates a missing config file by defaulting `project_id` to the cwd basename, and the TS port already matches that. Implementing a hard reject-on-missing-config would have been a *new* divergence from Go and would have broken the currently-green `cli-e2e` parity tests (exactly the regression risk the issue's own "deferred from #5715" note called out). `db start`'s and `db push`'s validation-ordering guarantees were also found to already be correct and already covered by existing tests. The one real, narrow gap was `db reset --local`'s ordering guarantee being implicit — buried inside a config resolver whose test double bypasses it entirely — rather than explicit and independently testable. This PR closes that gap.

## Test plan

- Added regression tests in `reset.integration.test.ts` for a local reset: malformed config.toml, an unparseable boolean, an undecryptable vault secret, and an explicit empty `project_id`, all asserting the destructive recreate never runs; a test pinning that a broken config wins over the "not running" error; and a test confirming a genuinely missing config.toml is still tolerated.
- `pnpm check:all` and the full `apps/cli` unit + integration suite (4758 tests) pass.
- Ran the 4-agent `review-changes` procedure (architect/engineer/security/DX) against the diff and worked every finding; see "Judgement calls" below for what a `review-adjudicator` settled and what remains a documented, deliberate trade-off.

## Judgement calls / open notes

- The `review-changes` engineer pass flagged that rewriting a pre-existing test orphaned the bucket-seed warn-and-skip branch, regressing coverage. A `review-adjudicator` pass at the time concluded there was no Go-parity reason to keep that fallback and recommended deleting it (done in the second commit) — a subsequent Codex review on the open PR found a concrete Go-valid config shape (an `env(VAR)` value sourced from `supabase/.env.development`) that the deletion broke, so the fallback was restored with an accurate comment (see "What changed" above).
- The new pre-recreate gate is currently unreachable in production (the resolver's own internal read already validates first and would already reject a broken config identically) — it exists for defense-in-depth and so the "validate before destroy" guarantee is enforced directly by the handler and stays covered by a test even if the resolver is ever mocked or refactored to stop validating. Both the architect and DX review passes flagged this as worth calling out explicitly rather than as a blocking issue.
- Not addressed here (flagged by review but out of scope): `LegacyDbConfigResolver.resolve` could return the validated config it already reads, so callers stop re-parsing `config.toml` up to 2-3 times on the local reset path. This is a pre-existing, codebase-wide pattern (`db push` does the same double-read), not something introduced by this PR, and is better done as its own resolver-contract refactor.

Fixes CLI-1877.
