### PR TITLE
ci: add contribution gate workflow for external PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,11 +2,14 @@ name: Bug report
 description: Report a reproducible problem with the Supabase CLI.
 labels:
   - 🐛 Bug
+  - needs-triage
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for helping improve the Supabase CLI. Please include the exact command and output whenever possible so maintainers can reproduce the issue quickly.
+
+        Open this issue **before** starting work — a maintainer will add the `open-for-contribution` label once it is triaged and ready. Pull requests from external contributors that don't link an open, `open-for-contribution` issue are closed automatically. See [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md).
 
   - type: dropdown
     id: affected-area

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,6 @@ name: Bug report
 description: Report a reproducible problem with the Supabase CLI.
 labels:
   - 🐛 Bug
-  - needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 📖 Contribution workflow
+    url: https://github.com/supabase/cli/blob/develop/CONTRIBUTING.md
+    about: Read this before opening an issue or pull request — PRs must link a labeled, open issue.
   - name: Supabase support
     url: https://supabase.com/support
     about: Get help with your Supabase project, account, billing, or hosted services.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -2,7 +2,6 @@ name: Documentation
 description: Suggest an improvement to Supabase CLI documentation.
 labels:
   - 📘 Docs
-  - needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -2,7 +2,13 @@ name: Documentation
 description: Suggest an improvement to Supabase CLI documentation.
 labels:
   - 📘 Docs
+  - needs-triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs! Open this issue **before** starting work — a maintainer will add the `open-for-contribution` label once it is triaged and ready. Pull requests from external contributors that don't link an open, `open-for-contribution` issue are closed automatically. See [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md).
+
   - type: input
     id: link
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,13 @@ name: Feature request
 description: Suggest an improvement or new capability for the Supabase CLI.
 labels:
   - ✨ Feature
+  - needs-triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Open this issue **before** starting work — a maintainer will add the `open-for-contribution` label once it is triaged and ready. Pull requests from external contributors that don't link an open, `open-for-contribution` issue are closed automatically. See [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md).
+
   - type: checkboxes
     id: existing-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,6 @@ name: Feature request
 description: Suggest an improvement or new capability for the Supabase CLI.
 labels:
   - ✨ Feature
-  - needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -10,12 +10,9 @@ that carries the **`open-for-contribution`** label. This is enforced by the
 [`Contribution Gate`](./workflows/contribution-gate.yml) workflow, whose decision logic
 lives in [`scripts/contribution-gate.ts`](./scripts/contribution-gate.ts).
 
-The gate runs **reactively on each PR** via `pull_request_target`
-(`opened`/`reopened`/`edited`) so a non-conforming PR is closed right away, and can also
-be **swept across every open PR on demand** via the workflow's *Run workflow* button
-(`workflow_dispatch`). Both paths only ever run trusted base-branch code with the
-repository token: `pull_request_target` checks out the base branch (not the PR head), and
-the script only makes GitHub API calls — it never checks out or executes a fork's code.
+The gate runs **reactively on each PR** so a non-conforming PR is closed right away, and
+can also be **swept across every open PR on demand** via the workflow's *Run workflow*
+button.
 
 A pull request is **auto-closed with an explanatory comment** when the author is external
 and any of these is true:

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -42,12 +42,11 @@ closing anything; run again with `dry_run` unchecked to apply the decisions.
 During triage:
 
 1. Categorize the issue with one of `✨ Feature`, `🐛 Bug`, or `📘 Docs`. Issues opened
-   via the templates start with both their category label and `needs-triage`.
-2. When the issue is ready to be worked on, add the **`open-for-contribution`** label and
-   remove `needs-triage`.
+   via the templates start with their category label already applied.
+2. When the issue is ready to be worked on, add the **`open-for-contribution`** label.
 
-Both `needs-triage` and `open-for-contribution` must exist as repository labels for this
-workflow to function; create them once from **Issues → Labels** if they are missing.
+The `open-for-contribution` label must exist as a repository label for this workflow to
+function; create it once from **Issues → Labels** if it is missing.
 
 Applying `open-for-contribution` is currently a **manual step** — do it on the GitHub
 issue directly (from the GitHub UI, or from the Linear-linked issue).

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -1,0 +1,62 @@
+# Maintainers guide
+
+Internal notes for maintaining the Supabase CLI contribution workflow. See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) for the contributor-facing version.
+
+## The `open-for-contribution` gate
+
+External pull requests are only accepted when they link to an **open** GitHub issue
+that carries the **`open-for-contribution`** label. This is enforced by the
+[`Contribution Gate`](./workflows/contribution-gate.yml) workflow, whose decision logic
+lives in [`scripts/contribution-gate.ts`](./scripts/contribution-gate.ts).
+
+The gate runs **reactively on each PR** via `pull_request_target`
+(`opened`/`reopened`/`edited`) so a non-conforming PR is closed right away, and can also
+be **swept across every open PR on demand** via the workflow's *Run workflow* button
+(`workflow_dispatch`). Both paths only ever run trusted base-branch code with the
+repository token: `pull_request_target` checks out the base branch (not the PR head), and
+the script only makes GitHub API calls — it never checks out or executes a fork's code.
+
+A pull request is **auto-closed with an explanatory comment** when the author is external
+and any of these is true:
+
+- no issue is linked (via a closing keyword such as `Closes #123`, or the PR's
+  Development sidebar), or
+- the linked issue is closed, or
+- the linked issue is missing the `open-for-contribution` label.
+
+Authors whose `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, and bot
+accounts, are **exempt** — Supabase maintainers can keep working from Linear tickets that
+aren't public on GitHub.
+
+### Running the gate manually
+
+Use **Actions → Contribution Gate → Run workflow** to sweep all open PRs on demand — for
+example right after bulk-applying `open-for-contribution` labels, so the whole backlog is
+re-evaluated at once instead of waiting for each PR's next edit. Set the **`dry_run`**
+input to `true` first to log each PR's decision in the run output without commenting on or
+closing anything; run again with `dry_run` unchecked to apply the decisions.
+
+## Triage: applying the label (manual)
+
+During triage:
+
+1. Categorize the issue with one of `✨ Feature`, `🐛 Bug`, or `📘 Docs`. Issues opened
+   via the templates start with both their category label and `needs-triage`.
+2. When the issue is ready to be worked on, add the **`open-for-contribution`** label and
+   remove `needs-triage`.
+
+Both `needs-triage` and `open-for-contribution` must exist as repository labels for this
+workflow to function; create them once from **Issues → Labels** if they are missing.
+
+Applying `open-for-contribution` is currently a **manual step** — do it on the GitHub
+issue directly (from the GitHub UI, or from the Linear-linked issue).
+
+## Deferred: automatic Linear → GitHub label sync
+
+We considered auto-applying `open-for-contribution` when a Linear issue moves out of
+Triage/Backlog (e.g. to Todo). Linear's native GitHub automations are one-directional
+(GitHub events update Linear status) and cannot push a GitHub label, so this would need an
+external bridge (a scheduled job polling the Linear API, a Zapier/Make zap, or a Linear
+webhook → relay). It is **out of scope for now** and tracked separately; until then, apply
+the label manually as above.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Before opening this PR, confirm the linked issue is open and carries the
+`open-for-contribution` label. PRs from external contributors that don't follow
+the workflow in CONTRIBUTING.md are closed automatically.
+@supabase members working from Linear tickets are exempt.
+-->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Linked issue
+
+Closes #
+
+- [ ] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).
+
+## Checklist
+
+- [ ] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(cli): …`).
+- [ ] Tests added or updated for the change.
+- [ ] `pnpm check:all` and `pnpm test` pass for the workspace(s) I touched.

--- a/.github/scripts/contribution-gate.test.ts
+++ b/.github/scripts/contribution-gate.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateAllOpenPrs,
+  evaluateGate,
+  GATE_LABEL,
+  type GateIo,
+  type LinkedIssue,
+  type OpenPr,
+} from "./contribution-gate.ts";
+
+const REPO = "supabase/cli";
+
+describe("evaluateGate", () => {
+  test("skips bot authors", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: true,
+      linkedIssues: [],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("bot");
+  });
+
+  test.each(["OWNER", "MEMBER", "COLLABORATOR"])(
+    "skips internal author association %s",
+    (authorAssociation) => {
+      const result = evaluateGate({
+        repository: REPO,
+        authorAssociation,
+        isBot: false,
+        linkedIssues: [],
+      });
+      expect(result.pass).toBe(true);
+      expect(result.reason).toBe("internal");
+    },
+  );
+
+  test("fails when no issue is linked", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("no-linked-issue");
+    expect(result.message).toContain(GATE_LABEL);
+    expect(result.message).toContain("CONTRIBUTING.md");
+  });
+
+  test("fails when the linked issue is open but not labeled", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "CONTRIBUTOR",
+      isBot: false,
+      linkedIssues: [
+        { repository: REPO, number: 12, state: "OPEN", labels: ["🐛 Bug"] },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("missing-label");
+    expect(result.message).toContain(GATE_LABEL);
+  });
+
+  test("fails when the only labeled issue is closed", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        { repository: REPO, number: 7, state: "CLOSED", labels: [GATE_LABEL] },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("issue-closed");
+  });
+
+  test("passes when a linked issue is open and carries the gate label", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        {
+          repository: REPO,
+          number: 42,
+          state: "OPEN",
+          labels: [GATE_LABEL, "🐛 Bug"],
+        },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+
+  test("passes when any one of several linked issues qualifies", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "FIRST_TIME_CONTRIBUTOR",
+      isBot: false,
+      linkedIssues: [
+        { repository: REPO, number: 1, state: "CLOSED", labels: [GATE_LABEL] },
+        { repository: REPO, number: 2, state: "OPEN", labels: ["✨ Feature"] },
+        { repository: REPO, number: 3, state: "OPEN", labels: [GATE_LABEL] },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+
+  test("ignores an open, labeled issue from a different repository", () => {
+    // Cross-repo closing keyword (e.g. `Closes attacker/repo#1`): the issue is
+    // controlled by the contributor, so it must not satisfy the gate.
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        {
+          repository: "attacker/repo",
+          number: 1,
+          state: "OPEN",
+          labels: [GATE_LABEL],
+        },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("no-linked-issue");
+  });
+
+  test("matches the repository case-insensitively", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        {
+          repository: "Supabase/CLI",
+          number: 5,
+          state: "OPEN",
+          labels: [GATE_LABEL],
+        },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+});
+
+describe("evaluateAllOpenPrs", () => {
+  function makeIo(
+    openPrs: OpenPr[],
+    linkedByPr: Record<number, LinkedIssue[]>,
+  ): { io: GateIo; closed: Array<{ number: number; message: string }> } {
+    const closed: Array<{ number: number; message: string }> = [];
+    const io: GateIo = {
+      listOpenPrs: () => Promise.resolve(openPrs),
+      fetchLinkedIssues: (prNumber) =>
+        Promise.resolve(linkedByPr[prNumber] ?? []),
+      closePr: (prNumber, message) => {
+        closed.push({ number: prNumber, message });
+        return Promise.resolve();
+      },
+    };
+    return { io, closed };
+  }
+
+  test("closes only non-conforming external PRs and leaves the rest", async () => {
+    const { io, closed } = makeIo(
+      [
+        { number: 1, authorAssociation: "NONE", isBot: false }, // no issue -> close
+        { number: 2, authorAssociation: "MEMBER", isBot: false }, // internal -> skip
+        { number: 3, authorAssociation: "NONE", isBot: true }, // bot -> skip
+        { number: 4, authorAssociation: "CONTRIBUTOR", isBot: false }, // conforming -> keep
+        { number: 5, authorAssociation: "NONE", isBot: false }, // missing label -> close
+      ],
+      {
+        4: [
+          { repository: REPO, number: 40, state: "OPEN", labels: [GATE_LABEL] },
+        ],
+        5: [
+          { repository: REPO, number: 50, state: "OPEN", labels: ["🐛 Bug"] },
+        ],
+      },
+    );
+
+    const entries = await evaluateAllOpenPrs(io, REPO);
+
+    expect(closed.map((c) => c.number).sort((a, b) => a - b)).toEqual([1, 5]);
+    const byNumber = Object.fromEntries(
+      entries.map((entry) => [entry.number, entry.result]),
+    );
+    expect(byNumber[1]?.reason).toBe("no-linked-issue");
+    expect(byNumber[2]?.pass).toBe(true);
+    expect(byNumber[2]?.reason).toBe("internal");
+    expect(byNumber[3]?.reason).toBe("bot");
+    expect(byNumber[4]?.pass).toBe(true);
+    expect(byNumber[5]?.reason).toBe("missing-label");
+    expect(closed.find((c) => c.number === 1)?.message).toContain(GATE_LABEL);
+  });
+
+  test("returns an entry per PR and closes none when all conform", async () => {
+    const { io, closed } = makeIo(
+      [{ number: 9, authorAssociation: "NONE", isBot: false }],
+      {
+        9: [
+          { repository: REPO, number: 90, state: "OPEN", labels: [GATE_LABEL] },
+        ],
+      },
+    );
+
+    const entries = await evaluateAllOpenPrs(io, REPO);
+
+    expect(entries).toHaveLength(1);
+    expect(closed).toHaveLength(0);
+    expect(entries[0]?.result.pass).toBe(true);
+  });
+});

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -1,0 +1,418 @@
+/**
+ * Contribution gate: enforces the Supabase CLI contribution workflow across all
+ * OPEN pull requests opened by external contributors.
+ *
+ * A PR passes only when it links to an OPEN GitHub issue that carries the
+ * `open-for-contribution` label. Members/collaborators/owners and bots are
+ * exempt (they work from Linear tickets or automation). PRs that do not follow
+ * the process are commented on and closed.
+ *
+ * Two modes, both driven from `main()`:
+ *   - single-PR (default): reacts to one PR on `pull_request_target`
+ *     (`opened`/`reopened`/`edited`), using the PR_* env vars from the event.
+ *   - all-PRs sweep (`GATE_MODE=all`, or the `--all` flag): evaluates every
+ *     open PR, for on-demand `workflow_dispatch` runs. Set `DRY_RUN=true` to
+ *     log decisions without commenting/closing.
+ *
+ * In both modes the workflow checks out the base branch, so this only ever
+ * executes trusted repository code — it never runs a fork's code.
+ *
+ * Run in CI as: `bun .github/scripts/contribution-gate.ts`.
+ * The pure `evaluateGate` decision and the `evaluateAllOpenPrs` orchestrator
+ * (I/O injected) are unit-tested in `contribution-gate.test.ts`; `main()` wires
+ * up the real GitHub I/O.
+ */
+
+export const GATE_LABEL = "open-for-contribution";
+
+/** Author associations treated as internal (exempt from the gate). */
+const INTERNAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+export interface LinkedIssue {
+  /** `owner/name` of the repo the issue lives in (from GraphQL nameWithOwner). */
+  repository: string;
+  number: number;
+  state: "OPEN" | "CLOSED";
+  labels: string[];
+}
+
+export interface GateInput {
+  /** `owner/name` of this repository (from GITHUB_REPOSITORY). */
+  repository: string;
+  authorAssociation: string;
+  isBot: boolean;
+  linkedIssues: LinkedIssue[];
+}
+
+export type GateReason =
+  | "bot"
+  | "internal"
+  | "ok"
+  | "no-linked-issue"
+  | "missing-label"
+  | "issue-closed";
+
+export interface GateResult {
+  pass: boolean;
+  reason: GateReason;
+  /** Explanatory comment body, present only when `pass` is false. */
+  message?: string;
+}
+
+const DOCS_FOOTER =
+  `\nSee [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md) for the full workflow. ` +
+  `Once a maintainer adds the \`${GATE_LABEL}\` label to a linked open issue, ` +
+  `reopen or open a new pull request and it will be accepted.`;
+
+function buildMessage(reason: GateReason): string {
+  switch (reason) {
+    case "no-linked-issue":
+      return (
+        `👋 Thanks for the contribution! This pull request isn't linked to a ` +
+        `tracked issue, so it's being closed automatically.\n\n` +
+        `Please open an issue first, wait for a maintainer to add the ` +
+        `\`${GATE_LABEL}\` label, then open a pull request that links the issue ` +
+        `with a closing keyword (e.g. \`Closes #123\`).${DOCS_FOOTER}`
+      );
+    case "missing-label":
+      return (
+        `👋 Thanks! The linked issue hasn't been marked \`${GATE_LABEL}\` yet, ` +
+        `so this pull request is being closed automatically.\n\n` +
+        `A maintainer adds that label once an issue is triaged and ready to be ` +
+        `worked on. Please wait for the label before opening a pull ` +
+        `request.${DOCS_FOOTER}`
+      );
+    case "issue-closed":
+      return (
+        `👋 The issue linked to this pull request is closed, so it's being ` +
+        `closed automatically.\n\n` +
+        `Please link an open issue that carries the \`${GATE_LABEL}\` ` +
+        `label.${DOCS_FOOTER}`
+      );
+    default:
+      return "";
+  }
+}
+
+/**
+ * Pure decision function for the contribution gate. Given the PR author context
+ * and its linked issues, returns whether the PR is allowed and why.
+ */
+export function evaluateGate(input: GateInput): GateResult {
+  if (input.isBot) {
+    return { pass: true, reason: "bot" };
+  }
+  if (INTERNAL_ASSOCIATIONS.has(input.authorAssociation)) {
+    return { pass: true, reason: "internal" };
+  }
+
+  // Only issues in THIS repository count. A cross-repository closing keyword
+  // (e.g. `Closes attacker/repo#1`) links an issue the contributor controls,
+  // so it must never satisfy the gate.
+  const repo = input.repository.toLowerCase();
+  const repoIssues = input.linkedIssues.filter(
+    (issue) => issue.repository.toLowerCase() === repo,
+  );
+
+  if (repoIssues.length === 0) {
+    return {
+      pass: false,
+      reason: "no-linked-issue",
+      message: buildMessage("no-linked-issue"),
+    };
+  }
+
+  const qualifies = repoIssues.some(
+    (issue) => issue.state === "OPEN" && issue.labels.includes(GATE_LABEL),
+  );
+  if (qualifies) {
+    return { pass: true, reason: "ok" };
+  }
+
+  const hasOpenIssue = repoIssues.some((issue) => issue.state === "OPEN");
+  const reason: GateReason = hasOpenIssue ? "missing-label" : "issue-closed";
+  return { pass: false, reason, message: buildMessage(reason) };
+}
+
+/** Minimal open-PR shape the gate needs to decide exemption. */
+export interface OpenPr {
+  number: number;
+  authorAssociation: string;
+  isBot: boolean;
+}
+
+/** Injected GitHub I/O so the sweep can be unit-tested without the network. */
+export interface GateIo {
+  /** List every open pull request in the repository. */
+  listOpenPrs: () => Promise<OpenPr[]>;
+  /** Fetch the issues a PR closes (via `closingIssuesReferences`). */
+  fetchLinkedIssues: (prNumber: number) => Promise<LinkedIssue[]>;
+  /** Comment with `message` then close the PR. Called only for failing PRs. */
+  closePr: (prNumber: number, message: string) => Promise<void>;
+}
+
+export interface SweepEntry {
+  number: number;
+  result: GateResult;
+}
+
+/**
+ * Evaluate the gate against every open PR, closing the ones that fail. Pure
+ * orchestration over the injected `io`; returns each PR's decision so the
+ * caller can log a summary.
+ */
+export async function evaluateAllOpenPrs(
+  io: GateIo,
+  repository: string,
+): Promise<SweepEntry[]> {
+  const openPrs = await io.listOpenPrs();
+  const entries: SweepEntry[] = [];
+  for (const pr of openPrs) {
+    const linkedIssues = await io.fetchLinkedIssues(pr.number);
+    const result = evaluateGate({
+      repository,
+      authorAssociation: pr.authorAssociation,
+      isBot: pr.isBot,
+      linkedIssues,
+    });
+    if (!result.pass && result.message) {
+      await io.closePr(pr.number, result.message);
+    }
+    entries.push({ number: pr.number, result });
+  }
+  return entries;
+}
+
+// --- GitHub I/O (only runs when executed directly) ---
+
+interface GraphQLIssueNode {
+  number: number;
+  state: "OPEN" | "CLOSED";
+  repository: { nameWithOwner: string };
+  labels: { nodes: Array<{ name: string }> };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function githubFetch(
+  url: string,
+  token: string,
+  init: Omit<RequestInit, "headers"> = {},
+): Promise<Response> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub request failed (${response.status}) for ${url}: ${body}`,
+    );
+  }
+  return response;
+}
+
+async function fetchLinkedIssues(
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<LinkedIssue[]> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 20) {
+            nodes {
+              number
+              state
+              repository { nameWithOwner }
+              labels(first: 50) { nodes { name } }
+            }
+          }
+        }
+      }
+    }`;
+  const response = await githubFetch("https://api.github.com/graphql", token, {
+    method: "POST",
+    body: JSON.stringify({
+      query,
+      variables: { owner, repo, number: prNumber },
+    }),
+  });
+  const payload = (await response.json()) as {
+    errors?: Array<{ message: string }>;
+    data?: {
+      repository?: {
+        pullRequest?: {
+          closingIssuesReferences?: { nodes?: GraphQLIssueNode[] };
+        };
+      };
+    };
+  };
+  if (payload.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  const nodes =
+    payload.data?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
+  return nodes.map((node) => ({
+    repository: node.repository.nameWithOwner,
+    number: node.number,
+    state: node.state,
+    labels: node.labels.nodes.map((label) => label.name),
+  }));
+}
+
+interface RestPullRequest {
+  number: number;
+  author_association: string;
+  user: { type: string } | null;
+}
+
+async function fetchOpenPullRequests(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<OpenPr[]> {
+  const prs: OpenPr[] = [];
+  for (let page = 1; ; page++) {
+    const url =
+      `https://api.github.com/repos/${owner}/${repo}/pulls` +
+      `?state=open&per_page=100&page=${page}`;
+    const response = await githubFetch(url, token);
+    const batch = (await response.json()) as RestPullRequest[];
+    for (const pr of batch) {
+      prs.push({
+        number: pr.number,
+        authorAssociation: pr.author_association,
+        isBot: pr.user?.type === "Bot",
+      });
+    }
+    if (batch.length < 100) {
+      break;
+    }
+  }
+  return prs;
+}
+
+/**
+ * Build the "comment then close" action for a repo. In dry-run mode it logs the
+ * intended action instead of mutating the PR.
+ */
+function makeCloser(
+  token: string,
+  base: string,
+  dryRun: boolean,
+): (prNumber: number, message: string) => Promise<void> {
+  return async (prNumber, message) => {
+    if (dryRun) {
+      console.log(`[dry-run] would comment on and close PR #${prNumber}`);
+      return;
+    }
+    await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
+      method: "POST",
+      body: JSON.stringify({ body: message }),
+    });
+    await githubFetch(`${base}/issues/${prNumber}`, token, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
+    });
+  };
+}
+
+/** Single-PR mode: react to the PR carried by a `pull_request_target` event. */
+async function runSinglePr(
+  token: string,
+  owner: string,
+  repo: string,
+  repository: string,
+): Promise<void> {
+  const prNumber = Number(requireEnv("PR_NUMBER"));
+  const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
+  const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
+
+  const linkedIssues = await fetchLinkedIssues(token, owner, repo, prNumber);
+  const result = evaluateGate({
+    repository,
+    authorAssociation,
+    isBot,
+    linkedIssues,
+  });
+
+  console.log(
+    `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +
+      `(author_association=${authorAssociation}, bot=${isBot}, linked_issues=${linkedIssues.length})`,
+  );
+
+  if (result.pass || !result.message) {
+    return;
+  }
+
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  await makeCloser(token, base, false)(prNumber, result.message);
+  console.log(`Closed PR #${prNumber} (reason=${result.reason}).`);
+}
+
+/** All-PRs mode: sweep every open PR, for on-demand `workflow_dispatch` runs. */
+async function runSweep(
+  token: string,
+  owner: string,
+  repo: string,
+  repository: string,
+  dryRun: boolean,
+): Promise<void> {
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  const io: GateIo = {
+    listOpenPrs: () => fetchOpenPullRequests(token, owner, repo),
+    fetchLinkedIssues: (prNumber) =>
+      fetchLinkedIssues(token, owner, repo, prNumber),
+    closePr: makeCloser(token, base, dryRun),
+  };
+
+  const entries = await evaluateAllOpenPrs(io, repository);
+  const failing = entries.filter((entry) => !entry.result.pass);
+  console.log(
+    `Contribution gate sweep: ${entries.length} open PR(s) evaluated, ` +
+      `${failing.length} ${dryRun ? "would be " : ""}closed.`,
+  );
+  for (const entry of entries) {
+    console.log(
+      `  PR #${entry.number}: pass=${entry.result.pass} reason=${entry.result.reason}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const token = requireEnv("GITHUB_TOKEN");
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const [owner, repo] = repository.split("/");
+
+  const allMode =
+    process.env.GATE_MODE === "all" || process.argv.includes("--all");
+  if (allMode) {
+    const dryRun = /^(1|true)$/i.test(process.env.DRY_RUN ?? "");
+    await runSweep(token, owner!, repo!, repository, dryRun);
+  } else {
+    await runSinglePr(token, owner!, repo!, repository);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/workflows/contribution-gate.yml
+++ b/.github/workflows/contribution-gate.yml
@@ -1,0 +1,74 @@
+name: Contribution Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+  # Manual sweep over every open PR — e.g. after bulk-applying the
+  # `open-for-contribution` label. Set `dry_run` to log decisions without
+  # commenting or closing.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Evaluate and log decisions only; do not comment or close"
+        type: boolean
+        default: false
+
+permissions:
+  pull-requests: write
+  issues: read
+  contents: read
+
+concurrency:
+  # Per-PR for pull_request_target; unique per run for manual sweeps (which
+  # carry no pull_request payload) so two sweeps never cancel each other.
+  group: contribution-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gate-single:
+    name: Contribution Gate
+    runs-on: ubuntu-latest
+    # Exempt maintainers/collaborators and bots. External contributors are gated.
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      # Checks out the base repo (default for pull_request_target), so the gate
+      # runs trusted code from the base branch, never the untrusted PR head.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.13"
+      - name: Evaluate contribution gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: bun .github/scripts/contribution-gate.ts
+
+  gate-all:
+    name: Contribution Gate (all open PRs)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      # Base-branch checkout only — the sweep makes API calls and never runs
+      # any PR's code.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.13"
+      - name: Evaluate contribution gate across all open PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GATE_MODE: all
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bun .github/scripts/contribution-gate.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Bun monorepo for exploring the next generation of the Supabase CLI and local dev
 Before you open a pull request:
 
 1. **Open an issue first**, using one of the [issue templates](https://github.com/supabase/cli/issues/new/choose).
-2. **Wait for maintainer triage.** A maintainer categorizes the issue (`✨ Feature`, `🐛 Bug`, or `📘 Docs`) and adds the **`open-for-contribution`** label once it is ready to be worked on. New issues start with `needs-triage`.
+2. **Wait for maintainer triage.** A maintainer categorizes the issue (`✨ Feature`, `🐛 Bug`, or `📘 Docs`) and adds the **`open-for-contribution`** label once it is ready to be worked on.
 3. **Open a pull request only after the `open-for-contribution` label is set**, and link the issue with a closing keyword (for example `Closes #123`).
 
 Until the `open-for-contribution` label is present, the issue is still in triage, so work should not start and a pull request should not be opened.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Bun monorepo for exploring the next generation of the Supabase CLI and local development stack.
 
+## Contribution workflow
+
+Before you open a pull request:
+
+1. **Open an issue first**, using one of the [issue templates](https://github.com/supabase/cli/issues/new/choose).
+2. **Wait for maintainer triage.** A maintainer categorizes the issue (`✨ Feature`, `🐛 Bug`, or `📘 Docs`) and adds the **`open-for-contribution`** label once it is ready to be worked on. New issues start with `needs-triage`.
+3. **Open a pull request only after the `open-for-contribution` label is set**, and link the issue with a closing keyword (for example `Closes #123`).
+
+Until the `open-for-contribution` label is present, the issue is still in triage, so work should not start and a pull request should not be opened.
+
+Pull requests from external contributors that do not follow this workflow are commented on and closed automatically by the [Contribution Gate](.github/workflows/contribution-gate.yml). Supabase members are exempt, so they can work from Linear tickets that are not public on GitHub. Maintainers: see [`.github/MAINTAINERS.md`](.github/MAINTAINERS.md).
+
 ## Setup
 
 ### Tool versions

--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ pnpm repos:install
 
 ## Contributing
 
-We love focused pull requests with a clear problem, a small surface area, and tests that match the user-facing behavior. Before opening a PR, run the checks for the workspace you touched.
+We love focused pull requests with a clear problem, a small surface area, and tests that match the user-facing behavior.
+
+Open an issue first and wait for a maintainer to add the `open-for-contribution` label before starting work — external pull requests that don't link a labeled, open issue are closed automatically. See [CONTRIBUTING.md](./CONTRIBUTING.md#contribution-workflow) for the full workflow.
+
+Before opening a PR, run the checks for the workspace you touched.
 
 ```sh
 pnpm check:all


### PR DESCRIPTION
Implement an automated contribution gate that enforces the Supabase CLI contribution workflow for external pull requests. The gate requires PRs from external contributors to link to an open GitHub issue carrying the `open-for-contribution` label, while exempting maintainers and bots.

## Changes

- **Contribution gate script** (`contribution-gate.ts`): Pure decision logic and GitHub I/O for evaluating PRs against the gate policy. Supports two modes:
  - Single-PR mode: reacts to individual PRs on `pull_request_target` events
  - All-PRs sweep mode: evaluates every open PR on-demand via `workflow_dispatch`
  
- **Gate tests** (`contribution-gate.test.ts`): Comprehensive unit tests for the decision logic and orchestration, with injected I/O for network-free testing

- **Workflow** (`contribution-gate.yml`): GitHub Actions workflow that runs the gate reactively on PR open/reopen/edit and supports manual sweeps with dry-run capability

- **Documentation**:
  - `MAINTAINERS.md`: Internal guide for maintainers on applying the `open-for-contribution` label and running manual sweeps
  - Updated `CONTRIBUTING.md`: Contributor-facing workflow requiring issues to be opened first and labeled before PR submission
  - Updated issue templates and PR template: Guidance on the new workflow
  - Updated issue config: Link to contribution workflow

## Implementation details

- Non-conforming PRs are auto-closed with explanatory comments directing contributors to the workflow
- Cross-repository closing keywords are rejected as a security measure (contributors cannot control external repos)
- Repository name matching is case-insensitive
- Internal authors (OWNER, MEMBER, COLLABORATOR) and bots are exempt from the gate
- The workflow checks out the base branch, ensuring only trusted code executes

https://claude.ai/code/session_01YY1sNQLXPxaeN6JX1NFSWj