### PR TITLE
fix(cli): suppress vendored effect CLI's stdout help-dump and duplicate error on parse failures (CLI-1901)

### DIFF
--- a/apps/cli-e2e/src/tests/migrations.e2e.test.ts
+++ b/apps/cli-e2e/src/tests/migrations.e2e.test.ts
@@ -45,7 +45,10 @@ describe("migrations", () => {
     testBehaviour("exits non-zero without name argument", async ({ run }) => {
       const result = await run(["migration", "new"]);
       expect(result.exitCode).not.toBe(0);
-      expect(result.stdout).toContain("migration name");
+      // CLI-1901: a missing positional argument's usage block now prints to
+      // stderr (never stdout) instead of being duplicated across both.
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("migration name");
     });
   });
 
@@ -90,7 +93,11 @@ describe("migrations", () => {
     testBehaviour("exits non-zero when --status flag is missing", async ({ run }) => {
       const result = await run(["migration", "repair", "--local", "20230101000000"]);
       expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain("--status");
+      // CLI-1901: a missing required flag now drops the vendored library's
+      // duplicate usage dump entirely (Go's cobra suppresses usage for this
+      // case too), leaving only this repo's existing Go-parity error line,
+      // which spells the flag name without its `--` prefix.
+      expect(result.stderr).toContain('"status" not set');
     });
 
     testBehaviour("exits non-zero on connection refused", async ({ run }) => {

--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -38,19 +38,18 @@ describe("legacy CLI agent output", () => {
     });
 
     expect(exitCode).toBe(1);
+    // CLI-1901: the vendored effect CLI library's own duplicate JSON render
+    // (the old `{_tag:"Help"}` + `{_tag:"Error", error:{code:"ShowHelp"}}`
+    // pair on stdout, `{_tag:"Errors"}` on stderr) is gone. stdout carries
+    // exactly this repo's single Go-parity error line; the library's help
+    // doc is redirected to stderr instead of being dropped or duplicated.
     expect(parseJsonLines(stdout)).toEqual([
-      expect.objectContaining({ _tag: "Help" }),
       expect.objectContaining({
         _tag: "Error",
-        error: expect.objectContaining({ code: "ShowHelp" }),
+        error: expect.objectContaining({ code: "UnknownSubcommand" }),
       }),
     ]);
-    expect(parseJsonLines(stderr)).toEqual([
-      expect.objectContaining({
-        _tag: "Errors",
-        errors: [expect.objectContaining({ code: "UnknownSubcommand" })],
-      }),
-    ]);
+    expect(parseJsonLines(stderr)).toEqual([expect.objectContaining({ _tag: "Help" })]);
   });
 
   test("keeps parse errors in text mode when --output-format=text is explicit", async () => {
@@ -63,7 +62,9 @@ describe("legacy CLI agent output", () => {
     );
 
     expect(exitCode).toBe(1);
-    expect(stdout).toContain("DESCRIPTION");
+    // CLI-1901: the help doc no longer prints to stdout at all.
+    expect(stdout).toBe("");
+    expect(stderr).toContain("DESCRIPTION");
     expect(stderr).toContain('Unknown subcommand "definitely-not-a-command"');
   });
 
@@ -77,7 +78,8 @@ describe("legacy CLI agent output", () => {
     );
 
     expect(exitCode).toBe(1);
-    expect(stdout).toContain("DESCRIPTION");
+    expect(stdout).toBe("");
+    expect(stderr).toContain("DESCRIPTION");
     expect(stderr).toContain('Unknown subcommand "definitely-not-a-command"');
   });
 
@@ -92,18 +94,12 @@ describe("legacy CLI agent output", () => {
 
     expect(exitCode).toBe(1);
     expect(parseJsonLines(stdout)).toEqual([
-      expect.objectContaining({ _tag: "Help" }),
       expect.objectContaining({
         _tag: "Error",
-        error: expect.objectContaining({ code: "ShowHelp" }),
+        error: expect.objectContaining({ code: "UnknownSubcommand" }),
       }),
     ]);
-    expect(parseJsonLines(stderr)).toEqual([
-      expect.objectContaining({
-        _tag: "Errors",
-        errors: [expect.objectContaining({ code: "UnknownSubcommand" })],
-      }),
-    ]);
+    expect(parseJsonLines(stderr)).toEqual([expect.objectContaining({ _tag: "Help" })]);
   });
 
   test("keeps built-in version and help in text mode for detected coding agents", async () => {

--- a/apps/cli/src/legacy/commands/sso/sso.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.e2e.test.ts
@@ -69,4 +69,39 @@ describe("supabase sso (legacy)", () => {
       expect(`${stdout}${stderr}`).toContain(`identity provider ID "not-a-uuid" is not a UUID`);
     },
   );
+
+  // CLI-1901: `add`'s `--type` has no `Flag.optional` (see `add.command.ts`)
+  // — Go marks it required via `MarkFlagRequired("type")` (`cmd/sso.go:65`)
+  // — so a missing/invalid `--type` used to dump the full help doc to
+  // stdout AND print the error twice on stderr. No auth/network call ever
+  // happens for either case: flag parsing fails before the handler runs.
+  test(
+    "add without --type: stdout stays clean, stderr is a single Go-parity line",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stdout, stderr } = await runSupabase(
+        ["sso", "add", "--project-ref", TEST_PROJECT_REF],
+        { entrypoint: "legacy" },
+      );
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toContain(`required flag(s) "type" not set`);
+      expect(stderr.trim().split("\n")).toHaveLength(2);
+    },
+  );
+
+  test(
+    "add with an invalid --type value: stdout stays clean, stderr is a single Go-parity line",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stdout, stderr } = await runSupabase(
+        ["sso", "add", "--type", "bogus", "--project-ref", TEST_PROJECT_REF],
+        { entrypoint: "legacy" },
+      );
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toContain(`Invalid value for flag --type: "bogus"`);
+      expect(stderr.trim().split("\n")).toHaveLength(2);
+    },
+  );
 });

--- a/apps/cli/src/legacy/commands/sso/sso.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.e2e.test.ts
@@ -75,8 +75,17 @@ describe("supabase sso (legacy)", () => {
   // — so a missing/invalid `--type` used to dump the full help doc to
   // stdout AND print the error twice on stderr. No auth/network call ever
   // happens for either case: flag parsing fails before the handler runs.
+  //
+  // A missing required flag and an invalid choice value get different
+  // treatment, matching the real `apps/cli-go/supabase-go` binary (verified
+  // directly against it): Go's `PersistentPreRunE` sets `SilenceUsage = true`
+  // (`cmd/root.go:97`) BEFORE `ValidateRequiredFlags` runs, so a missing
+  // `--type` is a single clean stderr line with no usage block — but
+  // `Flag.choice` validation happens during `ParseFlags`, BEFORE that point,
+  // so Go still shows a usage block for an invalid `--type` value, always on
+  // stderr, never stdout.
   test(
-    "add without --type: stdout stays clean, stderr is a single Go-parity line",
+    "add without --type: stdout stays clean, stderr is a single Go-parity line (no usage block)",
     { timeout: E2E_TIMEOUT_MS },
     async () => {
       const { exitCode, stdout, stderr } = await runSupabase(
@@ -86,12 +95,13 @@ describe("supabase sso (legacy)", () => {
       expect(exitCode).toBe(1);
       expect(stdout).toBe("");
       expect(stderr).toContain(`required flag(s) "type" not set`);
+      expect(stderr).not.toContain("USAGE");
       expect(stderr.trim().split("\n")).toHaveLength(2);
     },
   );
 
   test(
-    "add with an invalid --type value: stdout stays clean, stderr is a single Go-parity line",
+    "add with an invalid --type value: stdout stays clean, the usage content and the single error line land on stderr with no duplicate",
     { timeout: E2E_TIMEOUT_MS },
     async () => {
       const { exitCode, stdout, stderr } = await runSupabase(
@@ -100,8 +110,12 @@ describe("supabase sso (legacy)", () => {
       );
       expect(exitCode).toBe(1);
       expect(stdout).toBe("");
-      expect(stderr).toContain(`Invalid value for flag --type: "bogus"`);
-      expect(stderr.trim().split("\n")).toHaveLength(2);
+      expect(stderr).toContain("USAGE");
+      const occurrences = stderr.split(`Invalid value for flag --type: "bogus"`).length - 1;
+      expect(occurrences).toBe(1);
+      expect(
+        stderr.trim().endsWith("Try rerunning the command with --debug to troubleshoot the error."),
+      ).toBe(true);
     },
   );
 });

--- a/apps/cli/src/shared/cli/run.e2e.test.ts
+++ b/apps/cli/src/shared/cli/run.e2e.test.ts
@@ -22,3 +22,29 @@ describe("legacy CLI process exit codes (CLI-1906)", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+/**
+ * CLI-1901: a required-flag/choice parse failure used to dump the full help
+ * doc to **stdout** and print the error **twice** on stderr. The buffering
+ * mechanism that fixes this (`withoutParseErrorHelpDump` in `run.ts`) is
+ * already covered against a real command definition, in-process, by
+ * `run.integration.test.ts` — this is the one minimal case that observes the
+ * real subprocess boundary: whether the actual `stdout`/`stderr` streams of
+ * the shipped binary stay separated, matching Go cobra's `SilenceUsage`
+ * behavior (`apps/cli-go/cmd/root.go:97`) for the same failure.
+ */
+describe("legacy CLI required-flag/choice parse errors (CLI-1901)", () => {
+  test("an unrecognized flag: stdout stays clean, stderr is a single Go-parity line (no help dump, no duplicate)", async () => {
+    const { exitCode, stdout, stderr } = await runSupabase(
+      ["branches", "--this-flag-does-not-exist"],
+      { entrypoint: "legacy" },
+    );
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Unrecognized flag: --this-flag-does-not-exist");
+    // The library's own duplicate print plus the debug suggestion would be
+    // 3+ lines; the fix leaves exactly the one error line and the
+    // suggestion line.
+    expect(stderr.trim().split("\n")).toHaveLength(2);
+  });
+});

--- a/apps/cli/src/shared/cli/run.e2e.test.ts
+++ b/apps/cli/src/shared/cli/run.e2e.test.ts
@@ -30,21 +30,33 @@ describe("legacy CLI process exit codes (CLI-1906)", () => {
  * already covered against a real command definition, in-process, by
  * `run.integration.test.ts` — this is the one minimal case that observes the
  * real subprocess boundary: whether the actual `stdout`/`stderr` streams of
- * the shipped binary stay separated, matching Go cobra's `SilenceUsage`
- * behavior (`apps/cli-go/cmd/root.go:97`) for the same failure.
+ * the shipped binary stay separated, and whether the error text is
+ * de-duplicated, matching the real `apps/cli-go/supabase-go` binary (Go
+ * still shows a usage block for an unrecognized flag — raised during
+ * `ParseFlags`, before `PersistentPreRunE` sets `SilenceUsage`
+ * (`apps/cli-go/cmd/root.go:97`) — always on stderr, never stdout;
+ * verified directly against the built Go binary).
  */
 describe("legacy CLI required-flag/choice parse errors (CLI-1901)", () => {
-  test("an unrecognized flag: stdout stays clean, stderr is a single Go-parity line (no help dump, no duplicate)", async () => {
+  test("an unrecognized flag: stdout stays clean, the help/usage content and the single error line land on stderr with no duplicate", async () => {
     const { exitCode, stdout, stderr } = await runSupabase(
       ["branches", "--this-flag-does-not-exist"],
       { entrypoint: "legacy" },
     );
     expect(exitCode).toBe(1);
     expect(stdout).toBe("");
-    expect(stderr).toContain("Unrecognized flag: --this-flag-does-not-exist");
-    // The library's own duplicate print plus the debug suggestion would be
-    // 3+ lines; the fix leaves exactly the one error line and the
-    // suggestion line.
-    expect(stderr.trim().split("\n")).toHaveLength(2);
+    // Matches Go's still-shown usage block for this error class (see the
+    // describe-level comment) — this library's help doc isn't byte-identical
+    // to cobra's shorter usage template, but it's on the right stream now.
+    expect(stderr).toContain("USAGE");
+    // The error text appears exactly once — before the fix, the library's own
+    // duplicate render put it on stderr a second time (on top of the stdout
+    // help dump this test doesn't even need to check for, since stdout is
+    // asserted empty above).
+    const occurrences = stderr.split("Unrecognized flag: --this-flag-does-not-exist").length - 1;
+    expect(occurrences).toBe(1);
+    expect(
+      stderr.trim().endsWith("Try rerunning the command with --debug to troubleshoot the error."),
+    ).toBe(true);
   });
 });

--- a/apps/cli/src/shared/cli/run.integration.test.ts
+++ b/apps/cli/src/shared/cli/run.integration.test.ts
@@ -1,11 +1,54 @@
 import { describe, expect, test } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
-import { Effect, Exit, Layer } from "effect";
-import { CliOutput, Command } from "effect/unstable/cli";
+import { Console, Effect, Exit, Layer } from "effect";
+import { CliOutput, Command, Flag } from "effect/unstable/cli";
 import { legacyBranchesCommand } from "../../legacy/commands/branches/branches.command.ts";
 import { textCliOutputFormatter } from "../output/text-formatter.ts";
 import { CliArgs } from "./cli-args.service.ts";
-import { exitCodeForFailure } from "./run.ts";
+import { exitCodeForFailure, withoutParseErrorHelpDump } from "./run.ts";
+
+/**
+ * A `Console.Console` test double that records `log`/`error` calls into
+ * `calls` instead of writing anywhere, for asserting on writes through the
+ * `Console.Console` Effect service directly. Deliberately NOT `vi.spyOn`ing
+ * the global `console` object: under this repo's Bun + Vitest combination,
+ * spying on `console.log` and `console.error` in the SAME test reliably
+ * breaks call detection on both (reproduced in isolation, unrelated to this
+ * fix) — observing the `Console.Console` service `withoutParseErrorHelpDump`
+ * itself reads and overrides is both more precise and immune to that quirk.
+ */
+function fakeConsole(): { readonly console: Console.Console; readonly calls: Array<string> } {
+  const calls: Array<string> = [];
+  const unused = () => {};
+  return {
+    calls,
+    console: {
+      assert: unused,
+      clear: unused,
+      count: unused,
+      countReset: unused,
+      debug: unused,
+      dir: unused,
+      dirxml: unused,
+      error: (...args: ReadonlyArray<unknown>) => {
+        calls.push(`error:${args.join(" ")}`);
+      },
+      group: unused,
+      groupCollapsed: unused,
+      groupEnd: unused,
+      info: unused,
+      log: (...args: ReadonlyArray<unknown>) => {
+        calls.push(`log:${args.join(" ")}`);
+      },
+      table: unused,
+      time: unused,
+      timeEnd: unused,
+      timeLog: unused,
+      trace: unused,
+      warn: unused,
+    },
+  };
+}
 
 /**
  * CLI-1906: `supabase branches` (a legacy "group" command — subcommands, no
@@ -62,5 +105,114 @@ describe("legacy group command exit codes (CLI-1906)", () => {
     if (!Exit.isFailure(exit)) return;
 
     expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+});
+
+/**
+ * CLI-1901: a required-flag/choice parse failure used to dump the full help
+ * doc to stdout (`console.log`) AND print the error twice — once from the
+ * vendored `effect` CLI library's own `showHelp()` (`console.error`), once
+ * from this repo's own Go-parity renderer (`handledProgram` +
+ * `normalizeCause` in `run.ts`, exercised downstream of this test, not
+ * here). These tests run real commands through `Command.runWith`, wrapped in
+ * `withoutParseErrorHelpDump`, and assert on the calls recorded by a fake
+ * `Console.Console` (see `fakeConsole` above) provided in place of the real
+ * one — that's the exact service `withoutParseErrorHelpDump` overrides and
+ * later replays through, so it's what actually matters here.
+ *
+ * `legacyBranchesCommand` (no `Command.provide` of its own — see the
+ * sibling CLI-1906 suite above for why that matters) covers the
+ * `UnrecognizedOption` shape and proves the buffering/conditional-flush
+ * wiring end to end. `MissingOption`/`InvalidValue` specifically need a
+ * genuinely required flag / `Flag.choice`, which every shipped native
+ * command with one (e.g. `sso add`'s `--type`, see `add.command.ts`) also
+ * wraps in its own `Command.provide`d management-API runtime layer —
+ * exercising those tags against a real shipped command would mean
+ * providing or mocking that whole layer graph for services this parse-error
+ * path never consumes (same friction the CLI-1906 suite's own comment
+ * describes and avoids). A minimal `Command.make` with a required
+ * `Flag.string`/`Flag.choice` still runs through the exact same vendored
+ * `Command.runWith`/`showHelp()` machinery that produces the bug — the
+ * command is synthetic, but the `ShowHelp` cause shape it produces is not; a
+ * real subprocess run against `sso add` itself (the issue's own named
+ * repro target) is covered end to end by `sso.e2e.test.ts`.
+ */
+describe("withoutParseErrorHelpDump (CLI-1901)", () => {
+  const layerFor = (args: ReadonlyArray<string>, console: Console.Console) =>
+    Layer.mergeAll(
+      CliOutput.layer(textCliOutputFormatter()),
+      Layer.succeed(CliArgs, { args }),
+      Layer.succeed(Console.Console, console),
+      BunServices.layer,
+    );
+
+  const runBranches = (args: ReadonlyArray<string>, console: Console.Console) =>
+    withoutParseErrorHelpDump(
+      Command.runWith(legacyBranchesCommand, { version: "0.0.0-test" })(args),
+    ).pipe(Effect.provide(layerFor(args, console)));
+
+  const requiredFlagCommand = Command.make("test-required-flag", {
+    type: Flag.choice("type", ["saml"] as const),
+  });
+
+  const runRequiredFlagCommand = (args: ReadonlyArray<string>, console: Console.Console) =>
+    withoutParseErrorHelpDump(
+      Command.runWith(requiredFlagCommand, { version: "0.0.0-test" })(args),
+    ).pipe(Effect.provide(layerFor(args, console)));
+
+  test("an unrecognized flag: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runBranches(["--this-flag-does-not-exist"], console));
+
+    // The vendored library's own showHelp() writes are gone entirely — no
+    // stdout help dump, no duplicate stderr error.
+    expect(calls).toEqual([]);
+
+    // The original ShowHelp/UnrecognizedOption failure still propagates —
+    // the fix only suppresses the library's own console writes, it must not
+    // swallow or reshape the failure this repo's own `handledProgram` +
+    // `normalizeCause` still needs to render the single Go-parity line.
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+
+  test("`branches` bare (clean ShowHelp) still flushes its help dump and exits 0 (untouched)", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runBranches([], console));
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("log:"))).toBe(true);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(0);
+  });
+
+  test("missing a required flag: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runRequiredFlagCommand([], console));
+
+    expect(calls).toEqual([]);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+
+  test("an invalid Flag.choice value: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--type", "bogus"], console));
+
+    expect(calls).toEqual([]);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+
+  test("`--help` on a command with a required flag still prints the full help doc and exits 0 (untouched)", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--help"], console));
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(Exit.isSuccess(exit)).toBe(true);
   });
 });

--- a/apps/cli/src/shared/cli/run.integration.test.ts
+++ b/apps/cli/src/shared/cli/run.integration.test.ts
@@ -158,17 +158,23 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
   const runBranches = (args: ReadonlyArray<string>, console: Console.Console) =>
     withoutParseErrorHelpDump(
       Command.runWith(legacyBranchesCommand, { version: "0.0.0-test" })(args),
-      args,
+      { rootCommand: legacyBranchesCommand, args },
     ).pipe(Effect.provide(layerFor(args, console)));
 
+  // `type`'s `-t` alias mirrors the real `sso add --type`/`-t` flag
+  // (`add.command.ts`) so the short-alias "present but missing its value"
+  // case below (Codex review finding, CLI-1901 follow-up) exercises the same
+  // shape end to end, without pulling in `sso add`'s own management-API
+  // runtime layer graph (see the suite-level comment above for why that's
+  // avoided here).
   const requiredFlagCommand = Command.make("test-required-flag", {
-    type: Flag.choice("type", ["saml"] as const),
+    type: Flag.choice("type", ["saml"] as const).pipe(Flag.withAlias("t")),
   });
 
   const runRequiredFlagCommand = (args: ReadonlyArray<string>, console: Console.Console) =>
     withoutParseErrorHelpDump(
       Command.runWith(requiredFlagCommand, { version: "0.0.0-test" })(args),
-      args,
+      { rootCommand: requiredFlagCommand, args },
     ).pipe(Effect.provide(layerFor(args, console)));
 
   test("an unrecognized flag: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
@@ -233,6 +239,27 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     expect(exitCodeForFailure(exit.cause)).toBe(1);
   });
 
+  // Codex review finding (CLI-1901 follow-up): the same "present but missing
+  // its value" case, but supplied via the flag's SHORT ALIAS (`-t`) instead of
+  // its canonical long form. Go's pflag treats a present-but-valueless
+  // shorthand exactly like the long form (`parseSingleShortArg` raises the
+  // same `ValueRequiredError` as `parseLongArg`, same pre-`SilenceUsage`
+  // timing) — verified against the real `apps/cli-go/supabase-go` binary
+  // (`sso add -t`: full usage block on stderr, byte-parallel to `sso add
+  // --type`). Before this fix, `isMissingFlagTokenPresent` only recognized
+  // the canonical `--type` token and misclassified `-t` as absent, silently
+  // dropping the help dump instead.
+  test("a required flag present on argv by its short alias but missing its value: replays the help dump to stderr instead of dropping it", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["-t"], console));
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("error:"))).toBe(true);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+
   test("an invalid Flag.choice value: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--type", "bogus"], console));
@@ -268,7 +295,7 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     });
 
     const result = await Effect.runPromise(
-      withoutParseErrorHelpDump(program, []).pipe(
+      withoutParseErrorHelpDump(program, { rootCommand: requiredFlagCommand, args: [] }).pipe(
         Effect.provide(Layer.succeed(Console.Console, console)),
       ),
     );

--- a/apps/cli/src/shared/cli/run.integration.test.ts
+++ b/apps/cli/src/shared/cli/run.integration.test.ts
@@ -158,6 +158,7 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
   const runBranches = (args: ReadonlyArray<string>, console: Console.Console) =>
     withoutParseErrorHelpDump(
       Command.runWith(legacyBranchesCommand, { version: "0.0.0-test" })(args),
+      args,
     ).pipe(Effect.provide(layerFor(args, console)));
 
   const requiredFlagCommand = Command.make("test-required-flag", {
@@ -167,6 +168,7 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
   const runRequiredFlagCommand = (args: ReadonlyArray<string>, console: Console.Console) =>
     withoutParseErrorHelpDump(
       Command.runWith(requiredFlagCommand, { version: "0.0.0-test" })(args),
+      args,
     ).pipe(Effect.provide(layerFor(args, console)));
 
   test("an unrecognized flag: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
@@ -213,6 +215,24 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     expect(exitCodeForFailure(exit.cause)).toBe(1);
   });
 
+  // CLI-1901 (Codex review finding): the vendored library can't tell "flag
+  // never given" apart from "flag given with no value following it" — both
+  // raise `MissingOption`. Go's pflag DOES distinguish these (a present-but-
+  // valueless flag is a `ParseFlags`-time error, before `SilenceUsage` is
+  // set) — verified against the real `apps/cli-go/supabase-go` binary, which
+  // still prints its usage block for this input. `--type` as the LAST token
+  // (no value token follows it) reproduces that "present but valueless" case.
+  test("a required flag present on argv but missing its value: replays the help dump to stderr instead of dropping it", async () => {
+    const { console, calls } = fakeConsole();
+    const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--type"], console));
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("error:"))).toBe(true);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    expect(exitCodeForFailure(exit.cause)).toBe(1);
+  });
+
   test("an invalid Flag.choice value: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--type", "bogus"], console));
@@ -248,7 +268,7 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     });
 
     const result = await Effect.runPromise(
-      withoutParseErrorHelpDump(program).pipe(
+      withoutParseErrorHelpDump(program, []).pipe(
         Effect.provide(Layer.succeed(Console.Console, console)),
       ),
     );

--- a/apps/cli/src/shared/cli/run.integration.test.ts
+++ b/apps/cli/src/shared/cli/run.integration.test.ts
@@ -120,6 +120,15 @@ describe("legacy group command exit codes (CLI-1906)", () => {
  * one — that's the exact service `withoutParseErrorHelpDump` overrides and
  * later replays through, so it's what actually matters here.
  *
+ * Go only suppresses its own usage block for a MISSING REQUIRED FLAG
+ * (`ValidateRequiredFlags`, post-`PersistentPreRunE`) — verified against the
+ * real `apps/cli-go/supabase-go` binary. Every other parse-error tag
+ * (`UnrecognizedOption`, `InvalidValue`, `MissingArgument`,
+ * `UnknownSubcommand`) is raised during `ParseFlags`/`ValidateArgs`, BEFORE
+ * `PersistentPreRunE` sets `SilenceUsage` — Go still shows a usage block for
+ * those, always on stderr, never stdout. `classifyParseErrorConsoleOutput`
+ * (see `run.ts`) mirrors that split; these tests cover both branches.
+ *
  * `legacyBranchesCommand` (no `Command.provide` of its own — see the
  * sibling CLI-1906 suite above for why that matters) covers the
  * `UnrecognizedOption` shape and proves the buffering/conditional-flush
@@ -160,13 +169,17 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
       Command.runWith(requiredFlagCommand, { version: "0.0.0-test" })(args),
     ).pipe(Effect.provide(layerFor(args, console)));
 
-  test("an unrecognized flag: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+  test("an unrecognized flag: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runBranches(["--this-flag-does-not-exist"], console));
 
-    // The vendored library's own showHelp() writes are gone entirely — no
-    // stdout help dump, no duplicate stderr error.
-    expect(calls).toEqual([]);
+    // The library's own duplicate `Console.error` write is gone. Its help
+    // doc survives, but redirected to stderr (`error:`), never stdout
+    // (`log:`) — matching Go, which still shows usage for an unrecognized
+    // flag (raised during `ParseFlags`, before `SilenceUsage` is set), just
+    // on stderr.
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("error:"))).toBe(true);
 
     // The original ShowHelp/UnrecognizedOption failure still propagates —
     // the fix only suppresses the library's own console writes, it must not
@@ -177,7 +190,7 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     expect(exitCodeForFailure(exit.cause)).toBe(1);
   });
 
-  test("`branches` bare (clean ShowHelp) still flushes its help dump and exits 0 (untouched)", async () => {
+  test("`branches` bare (clean ShowHelp) still flushes its help dump to stdout and exits 0 (untouched)", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runBranches([], console));
 
@@ -188,31 +201,60 @@ describe("withoutParseErrorHelpDump (CLI-1901)", () => {
     expect(exitCodeForFailure(exit.cause)).toBe(0);
   });
 
-  test("missing a required flag: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+  test("missing a required flag: drops the help dump entirely and the duplicate error, but still fails with the original cause", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runRequiredFlagCommand([], console));
 
+    // Go's `SilenceUsage` is already active for a missing required flag
+    // (post-`PersistentPreRunE`) — nothing survives, not even on stderr.
     expect(calls).toEqual([]);
     expect(Exit.isFailure(exit)).toBe(true);
     if (!Exit.isFailure(exit)) return;
     expect(exitCodeForFailure(exit.cause)).toBe(1);
   });
 
-  test("an invalid Flag.choice value: suppresses the help dump and the duplicate error, but still fails with the original cause", async () => {
+  test("an invalid Flag.choice value: replays the help dump to stderr (never stdout) and drops the duplicate error, but still fails with the original cause", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--type", "bogus"], console));
 
-    expect(calls).toEqual([]);
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("error:"))).toBe(true);
     expect(Exit.isFailure(exit)).toBe(true);
     if (!Exit.isFailure(exit)) return;
     expect(exitCodeForFailure(exit.cause)).toBe(1);
   });
 
-  test("`--help` on a command with a required flag still prints the full help doc and exits 0 (untouched)", async () => {
+  test("`--help` on a command with a required flag still prints the full help doc to stdout and exits 0 (untouched)", async () => {
     const { console, calls } = fakeConsole();
     const exit = await Effect.runPromiseExit(runRequiredFlagCommand(["--help"], console));
 
     expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.startsWith("log:"))).toBe(true);
     expect(Exit.isSuccess(exit)).toBe(true);
+  });
+
+  // Effect's default logger (`Effect.log*`) resolves through this same
+  // `Console.Console` reference (`Logger.withConsoleLog`/`withConsoleError`
+  // in the vendored library) — see the "buffering scope" note on
+  // `withoutParseErrorHelpDump` in `run.ts`. No command handler in this
+  // codebase uses `Effect.log*` today, but this pins the invariant the doc
+  // comment describes: on a successful run, buffered logger output still
+  // reaches the user (deferred to end-of-run, not dropped).
+  test("Effect.log* output during a successful run is still flushed, not lost", async () => {
+    const { console, calls } = fakeConsole();
+    const program = Effect.gen(function* () {
+      yield* Effect.logInfo("hello from a handler");
+      return "done" as const;
+    });
+
+    const result = await Effect.runPromise(
+      withoutParseErrorHelpDump(program).pipe(
+        Effect.provide(Layer.succeed(Console.Console, console)),
+      ),
+    );
+
+    expect(result).toBe("done");
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.some((call) => call.includes("hello from a handler"))).toBe(true);
   });
 });

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -305,14 +305,24 @@ export function classifyParseErrorConsoleOutput(
  * Safe to wrap the entire `runWith` call — parsing AND the eventual command
  * handler, not just the parse phase that can actually raise `ShowHelp`: no
  * command handler in this codebase writes through `effect`'s `Console`
- * service directly (they go through the `Output` service instead), so
- * buffering here never delays or drops real command output. Note that
- * Effect's OWN default logger (`Effect.log*`) DOES resolve through this same
- * `Console` reference (`Logger.withConsoleLog`/`withConsoleError`) — this
- * codebase has no `Effect.log*` call sites today, but if one is ever added
- * to a handler, its output would be buffered too (deferred to end-of-run on
- * the "flush unchanged" path, or dropped on a genuine parse failure — which
- * never runs a handler in the first place, so that half is moot).
+ * service directly (they go through the `Output` service instead). One
+ * indirect exception is known — `@supabase/config`'s `loadProjectConfigFile`
+ * emits its deprecated-config-section warnings via `Console.error`, and is
+ * reachable from handlers through `ProjectConfigStore`/`loadProjectConfig` —
+ * so it pins itself to the real console (`Effect.provideService(Console.Console,
+ * globalThis.console)`) rather than relying on whatever `Console.Console` is
+ * ambient here; see CLI-1901 and that package's `io.ts` for why (a
+ * long-running command like `functions serve` would otherwise have the
+ * warning buffered for its entire session instead of shown at startup).
+ * Any other handler writing through `Console` directly would need the same
+ * treatment — buffering here never delays or drops real command output
+ * ONLY as long as that invariant holds. Note that Effect's OWN default
+ * logger (`Effect.log*`) DOES resolve through this same `Console` reference
+ * (`Logger.withConsoleLog`/`withConsoleError`) — this codebase has no
+ * `Effect.log*` call sites today, but if one is ever added to a handler, its
+ * output would be buffered too (deferred to end-of-run on the "flush
+ * unchanged" path, or dropped on a genuine parse failure — which never runs
+ * a handler in the first place, so that half is moot).
  */
 export function withoutParseErrorHelpDump<A, E, R>(
   effect: Effect.Effect<A, E, R>,

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -253,9 +253,26 @@ export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-h
  * shown) into a "present but missing its value" one (Go: usage shown) — see
  * CLI-1901.
  *
- * `isValueTakingToken` (from `isValueTakingFlagTokenFor`) lets the scan skip
- * a token immediately consumed as the VALUE of a preceding value-taking
- * flag, instead of mistaking that consumed token for `option`'s own
+ * That `--` cutoff is only genuine when the scan reaches `--` as a LIVE
+ * token, not when it was itself consumed as the VALUE of an immediately
+ * preceding value-taking flag. Go/pflag's `parseArgs` (`flag.go`) only
+ * recognizes `--` as the terminator when it's at the FRONT of the remaining
+ * args on a fresh iteration; `parseLongArg`'s value branch pops the very
+ * next raw token with no shape check at all, so a literal `--` right after a
+ * value-taking flag gets swallowed as that flag's value and never reaches
+ * the terminator check — e.g. `sso add --project-ref -- --type` hands the
+ * literal string `--` to `--project-ref`, and parsing resumes normally on
+ * `--type` (which then fails with pflag's OWN `ValueRequiredError` — a
+ * `ParseFlags`-time error, usage still shown — since nothing follows it).
+ * The scan below therefore folds the terminator check into the very same
+ * loop that already skips consumed-value tokens, rather than precomputing
+ * `args.indexOf("--")` up front — a Codex review finding on CLI-1901.
+ *
+ * `isValueTakingToken` (from `isValueTakingFlagTokenFor`, OR'd with
+ * `globalFlagsWithValues` at the `classifyParseErrorConsoleOutput` call site
+ * below) lets the scan skip a token immediately consumed as the VALUE of a
+ * preceding value-taking flag — local OR global — instead of mistaking that
+ * consumed token (or a consumed literal `--`, per above) for `option`'s own
  * occurrence. Go/pflag's `parseLongArg` (`flag.go`) unconditionally consumes
  * the very next argv entry as a value-taking flag's value, even when that
  * entry itself looks like another flag — e.g. `sso add --project-ref --type`
@@ -276,18 +293,21 @@ function isMissingFlagTokenPresent(
   isValueTakingToken: (token: string) => boolean = () => false,
 ): boolean {
   const tokens = [`--${option}`, ...aliases];
-  const terminatorIndex = args.indexOf("--");
-  const scannedArgs = terminatorIndex === -1 ? args : args.slice(0, terminatorIndex);
-  for (let index = 0; index < scannedArgs.length; index++) {
-    const arg = scannedArgs[index];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
     if (arg === undefined) continue;
+    // A literal "--" only terminates flag parsing when reached as a LIVE
+    // token here — if the previous iteration already skipped it as a
+    // value-taking flag's consumed value (below), this line never runs for
+    // it, matching pflag's own ordering (see the doc comment above).
+    if (arg === "--") break;
     if (tokens.some((token) => arg === token || arg.startsWith(`${token}=`))) return true;
     const equalIndex = arg.indexOf("=");
     const bareToken = equalIndex === -1 ? arg : arg.slice(0, equalIndex);
     if (equalIndex === -1 && isValueTakingToken(bareToken)) {
       // Go/pflag consumes the following argv entry as `bareToken`'s value
-      // unconditionally — skip it so it can't be mistaken for `option` being
-      // present.
+      // unconditionally — even a literal "--" — so skip it here too, before
+      // the next iteration's terminator check ever sees it.
       index++;
     }
   }
@@ -302,7 +322,18 @@ export function classifyParseErrorConsoleOutput(
   if (!CliError.isCliError(error) || error._tag !== "ShowHelp" || error.errors.length === 0) {
     return "flush-unchanged";
   }
-  const isValueTakingToken = isValueTakingFlagTokenFor(context.rootCommand, error.commandPath);
+  // `isValueTakingFlagTokenFor` only inspects the resolved LEAF command's own
+  // flags, so it has no visibility into value-taking GLOBAL flags (`--network-id`,
+  // `--profile`, etc. — see `globalFlagsWithValues` above). Without OR-ing those
+  // in, a global value flag consuming the very next token (e.g.
+  // `migration repair --network-id --status --local <version>` handing the
+  // literal `--status` to `--network-id`, per pflag's `parseLongArg`) would
+  // leave the required `status` flag looking "present" to the scan below, even
+  // though Go/pflag never sees it as its own occurrence and suppresses usage
+  // for it (`SilenceUsage`) — a Codex review finding on CLI-1901.
+  const isLeafValueTakingToken = isValueTakingFlagTokenFor(context.rootCommand, error.commandPath);
+  const isValueTakingToken = (token: string) =>
+    globalFlagsWithValues.has(token) || isLeafValueTakingToken(token);
   const isSuppressedMissingFlag = (inner: (typeof error.errors)[number]) =>
     inner._tag === "MissingOption" &&
     !isMissingFlagTokenPresent(

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -359,6 +359,12 @@ export function classifyParseErrorConsoleOutput(
  * error line) from this one call site, without patching the vendored
  * library itself.
  *
+ * TODO: remove this whole buffering/classification dance once upstream
+ * Effect-TS/effect#6313 is fixed — https://github.com/Effect-TS/effect/issues/6313.
+ * `runWith` has no supported way to opt out of, or redirect, its own
+ * `showHelp` console writes; everything below exists only to work around
+ * that gap from the outside.
+ *
  * The "flush unchanged" outcome covers success, `--help`, `--version`,
  * `--completions`, and the bare-group-command help dump, all of which stay
  * untouched.

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -185,53 +185,78 @@ function bufferingConsole(sink: Array<BufferedConsoleWrite>): Console.Console {
 }
 
 /**
- * Whether `withoutParseErrorHelpDump`'s buffered `Console.log`/`Console.error`
- * writes should be dropped rather than flushed, given how the wrapped effect
- * failed.
+ * How `withoutParseErrorHelpDump` should dispose of its buffered
+ * `Console.log`/`Console.error` writes, given how the wrapped effect failed:
  *
- * True only for a genuine parse/validation failure: `CliError.ShowHelp`
- * carrying a non-empty `errors` array. That is the ONLY shape whose buffered
- * writes are the CLI-1901 bug — the vendored `effect` CLI library's own
- * `showHelp()` (the single `catchFilter` in `Command.ts`'s `runWith`) always
- * `Console.log`s the full help doc and, when `errors.length > 0`, ALSO
- * `Console.error`s the same errors this repo's own `normalizeCause` already
- * renders correctly afterward (`handledProgram` below). Go cobra never shows
- * this dump for the equivalent case: `PersistentPreRunE` sets
- * `SilenceUsage = true` (`apps/cli-go/cmd/root.go:97`) before
- * `ValidateRequiredFlags` (cobra `command.go:1007`), so a missing required
- * flag is a single clean stderr line with nothing on stdout — see CLI-1901.
+ * - `"flush-unchanged"` — success, or a "clean" `ShowHelp` (`errors: []` —
+ *   an explicit `--help` or a bare group command with no subcommand, both
+ *   of which map to exit `0` per `exitCodeForFailure` above), or any other
+ *   failure. Those buffered writes (if any, there normally are none outside
+ *   the two `ShowHelp` cases) are the actual intended output.
+ * - `"drop"` — a genuine parse/validation failure Go cobra's
+ *   `PersistentPreRunE` already suppresses usage for: `ValidateRequiredFlags`
+ *   (cobra `command.go:1007`), which sets `cmd.SilenceUsage = true`
+ *   (`apps/cli-go/cmd/root.go:97`) BEFORE it runs. This library's
+ *   `MissingOption` is the one tag that maps to that stage — see CLI-1901.
+ * - `"flush-help-doc-to-stderr"` — every other genuine parse/validation
+ *   failure (`UnrecognizedOption`, `InvalidValue`, `MissingArgument`,
+ *   `UnknownSubcommand`; multiple simultaneous errors also lands here).
+ *   These map to cobra's `ParseFlags`/`ValidateArgs` (`command.go:919,968`),
+ *   which run BEFORE `PersistentPreRunE` — Go still shows a usage block for
+ *   these, just on stderr, never stdout (verified against the real
+ *   `apps/cli-go/supabase-go` binary, e.g. `branches --bogus-flag` and
+ *   `sso add --type bogus`). The help doc this library renders isn't
+ *   byte-identical to cobra's shorter usage template (that would need a
+ *   second formatter, out of scope for CLI-1901), but showing SOME usage
+ *   content on the RIGHT stream is closer to Go than showing none at all.
  *
- * False for success, for a "clean" `ShowHelp` (`errors: []` — an explicit
- * `--help` or a bare group command with no subcommand, both of which map to
- * exit `0` per `exitCodeForFailure` above), and for any other failure —
- * those buffered writes (if any, there normally are none) are the actual
- * intended output and must reach the user.
+ * In every "genuine failure" case, the buffered `Console.error` write (the
+ * library's own duplicate render of the errors) is always dropped — this
+ * repo's own `handledProgram` + `normalizeCause` already render the single
+ * Go-parity line for it (see `withoutParseErrorHelpDump` below).
  */
-export function shouldSuppressShowHelpConsoleOutput(cause: Cause.Cause<unknown>): boolean {
+export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-help-doc-to-stderr";
+
+export function classifyParseErrorConsoleOutput(
+  cause: Cause.Cause<unknown>,
+): ParseErrorConsoleDisposition {
   const error = Cause.squash(cause);
-  return CliError.isCliError(error) && error._tag === "ShowHelp" && error.errors.length > 0;
+  if (!CliError.isCliError(error) || error._tag !== "ShowHelp" || error.errors.length === 0) {
+    return "flush-unchanged";
+  }
+  const isMissingRequiredFlag = error.errors.every((inner) => inner._tag === "MissingOption");
+  return isMissingRequiredFlag ? "drop" : "flush-help-doc-to-stderr";
 }
 
 /**
  * Wraps `Command.runWith(rootCommand, ...)(args)` so the vendored `effect`
- * CLI library's OWN `Console.log`/`Console.error` writes (see
- * `shouldSuppressShowHelpConsoleOutput`) are captured instead of reaching the
- * real console, and are dropped entirely for a genuine parse-error failure.
- * This repo's own `handledProgram` + `normalizeCause` already render the
- * single Go-parity line for that case, so dropping the library's writes
+ * CLI library's OWN `Console.log`/`Console.error` writes are captured
+ * instead of reaching the real console, then disposed of per
+ * `classifyParseErrorConsoleOutput` once the run's outcome is known:
+ * dropped entirely for a missing-required-flag failure, replayed to stderr
+ * (never stdout) for every other genuine parse/validation failure, and
+ * replayed unchanged for everything else. Either way, the library's own
+ * duplicate error render never survives — this repo's own `handledProgram`
+ * + `normalizeCause` already render the single Go-parity line for it. That
  * fixes both halves of CLI-1901 (the stdout help dump and the duplicate
  * error line) from this one call site, without patching the vendored
  * library itself.
  *
- * Every other outcome (success, or a "clean" `errors: []` `ShowHelp`) flushes
- * the buffered writes unchanged, so `--help`, `--version`, `--completions`,
- * and the bare-group-command help dump are all untouched.
+ * The "flush unchanged" outcome covers success, `--help`, `--version`,
+ * `--completions`, and the bare-group-command help dump, all of which stay
+ * untouched.
  *
  * Safe to wrap the entire `runWith` call — parsing AND the eventual command
  * handler, not just the parse phase that can actually raise `ShowHelp`: no
  * command handler in this codebase writes through `effect`'s `Console`
  * service directly (they go through the `Output` service instead), so
- * buffering here never delays or drops real command output.
+ * buffering here never delays or drops real command output. Note that
+ * Effect's OWN default logger (`Effect.log*`) DOES resolve through this same
+ * `Console` reference (`Logger.withConsoleLog`/`withConsoleError`) — this
+ * codebase has no `Effect.log*` call sites today, but if one is ever added
+ * to a handler, its output would be buffered too (deferred to end-of-run on
+ * the "flush unchanged" path, or dropped on a genuine parse failure — which
+ * never runs a handler in the first place, so that half is moot).
  */
 export function withoutParseErrorHelpDump<A, E, R>(
   effect: Effect.Effect<A, E, R>,
@@ -242,13 +267,21 @@ export function withoutParseErrorHelpDump<A, E, R>(
       Effect.provideService(Console.Console, bufferingConsole(sink)),
       Effect.exit,
     );
-    if (Exit.isFailure(exit) && shouldSuppressShowHelpConsoleOutput(exit.cause)) {
+    const disposition = Exit.isFailure(exit)
+      ? classifyParseErrorConsoleOutput(exit.cause)
+      : "flush-unchanged";
+    if (disposition === "drop") {
       return yield* exit;
     }
     for (const write of sink) {
+      // The library's own duplicate error render never survives a genuine
+      // parse failure — only its help-doc `log` write gets a second look,
+      // redirected to stderr instead of its original stdout-bound method.
+      if (disposition === "flush-help-doc-to-stderr" && write.method === "error") continue;
+      const method = disposition === "flush-help-doc-to-stderr" ? "error" : write.method;
       yield* Console.consoleWith((console) =>
         Effect.sync(() => {
-          console[write.method](...write.args);
+          console[method](...write.args);
         }),
       );
     }

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -30,7 +30,7 @@ import { tracingLayer } from "../telemetry/tracing.layer.ts";
 import { CliArgs } from "./cli-args.service.ts";
 import { resolveAgentOutputFormatFromArgs } from "./agent-output.ts";
 import type { CliErrorSuggestionContext } from "./subcommand-flag-suggestions.ts";
-import { flagAliasesFor } from "./subcommand-flag-suggestions.ts";
+import { flagAliasesFor, isValueTakingFlagTokenFor } from "./subcommand-flag-suggestions.ts";
 
 // Global flags that consume the following argv token as their value. Keep this in
 // sync with the value-taking global flags defined in `shared/cli/global-flags.ts`
@@ -252,18 +252,46 @@ export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-h
  * flag was given, flipping a genuinely-absent-flag failure (Go: no usage
  * shown) into a "present but missing its value" one (Go: usage shown) — see
  * CLI-1901.
+ *
+ * `isValueTakingToken` (from `isValueTakingFlagTokenFor`) lets the scan skip
+ * a token immediately consumed as the VALUE of a preceding value-taking
+ * flag, instead of mistaking that consumed token for `option`'s own
+ * occurrence. Go/pflag's `parseLongArg` (`flag.go`) unconditionally consumes
+ * the very next argv entry as a value-taking flag's value, even when that
+ * entry itself looks like another flag — e.g. `sso add --project-ref --type`
+ * hands the literal string `--type` to `--project-ref`, so `--type` is never
+ * seen as its own occurrence in Go, and its `MissingOption` failure keeps
+ * Go's `SilenceUsage` treatment (no usage shown). The vendored `effect`
+ * parser does NOT replicate that eager consumption (it only treats a
+ * following token as a value when the lexer tags it `Value`, never a
+ * flag-shaped token — `internal/parser.ts`'s `consumeFlagValueWithTokens`),
+ * so without this skip the raw scan would find the literal `--type` token
+ * and wrongly flush the help doc for an input Go shows no usage for — a
+ * Codex review finding on CLI-1901.
  */
 function isMissingFlagTokenPresent(
   option: string,
   args: ReadonlyArray<string>,
   aliases: ReadonlyArray<string> = [],
+  isValueTakingToken: (token: string) => boolean = () => false,
 ): boolean {
   const tokens = [`--${option}`, ...aliases];
   const terminatorIndex = args.indexOf("--");
   const scannedArgs = terminatorIndex === -1 ? args : args.slice(0, terminatorIndex);
-  return scannedArgs.some((arg) =>
-    tokens.some((token) => arg === token || arg.startsWith(`${token}=`)),
-  );
+  for (let index = 0; index < scannedArgs.length; index++) {
+    const arg = scannedArgs[index];
+    if (arg === undefined) continue;
+    if (tokens.some((token) => arg === token || arg.startsWith(`${token}=`))) return true;
+    const equalIndex = arg.indexOf("=");
+    const bareToken = equalIndex === -1 ? arg : arg.slice(0, equalIndex);
+    if (equalIndex === -1 && isValueTakingToken(bareToken)) {
+      // Go/pflag consumes the following argv entry as `bareToken`'s value
+      // unconditionally — skip it so it can't be mistaken for `option` being
+      // present.
+      index++;
+    }
+  }
+  return false;
 }
 
 export function classifyParseErrorConsoleOutput(
@@ -274,12 +302,14 @@ export function classifyParseErrorConsoleOutput(
   if (!CliError.isCliError(error) || error._tag !== "ShowHelp" || error.errors.length === 0) {
     return "flush-unchanged";
   }
+  const isValueTakingToken = isValueTakingFlagTokenFor(context.rootCommand, error.commandPath);
   const isSuppressedMissingFlag = (inner: (typeof error.errors)[number]) =>
     inner._tag === "MissingOption" &&
     !isMissingFlagTokenPresent(
       inner.option,
       context.args,
       flagAliasesFor(context.rootCommand, error.commandPath, inner.option),
+      isValueTakingToken,
     );
   return error.errors.every(isSuppressedMissingFlag) ? "drop" : "flush-help-doc-to-stderr";
 }

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -29,6 +29,8 @@ import { telemetryRuntimeLayer } from "../telemetry/runtime.layer.ts";
 import { tracingLayer } from "../telemetry/tracing.layer.ts";
 import { CliArgs } from "./cli-args.service.ts";
 import { resolveAgentOutputFormatFromArgs } from "./agent-output.ts";
+import type { CliErrorSuggestionContext } from "./subcommand-flag-suggestions.ts";
+import { flagAliasesFor } from "./subcommand-flag-suggestions.ts";
 
 // Global flags that consume the following argv token as their value. Keep this in
 // sync with the value-taking global flags defined in `shared/cli/global-flags.ts`
@@ -229,35 +231,40 @@ function bufferingConsole(sink: Array<BufferedConsoleWrite>): Console.Console {
 export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-help-doc-to-stderr";
 
 /**
- * Whether `option`'s long-form flag token (`--option` or `--option=...`)
- * appears anywhere in the raw argv this run was invoked with — used to tell
- * a genuinely-absent required flag (Go: `SilenceUsage`-suppressed) apart from
+ * Whether `option`'s canonical long-form flag token (`--option` or
+ * `--option=...`), or one of its short/long `aliases` (e.g. `-t`), appears
+ * anywhere in the raw argv this run was invoked with — used to tell a
+ * genuinely-absent required flag (Go: `SilenceUsage`-suppressed) apart from
  * one that's present but missing its value (Go: a `ParseFlags`-time error,
  * usage still shown). See the `"drop"` case on `ParseErrorConsoleDisposition`
- * above for the full rationale.
- *
- * Known gap: this only recognizes the flag's canonical long-form name, not a
- * short alias (e.g. `sso add -t` with no value would still be misclassified
- * as "absent"). Resolving aliases requires walking the command tree for the
- * failing `commandPath` (the same lookup `subcommand-flag-suggestions.ts`
- * does for hint placement) — left as a follow-up rather than threading a
- * `rootCommand`/`CliErrorSuggestionContext` into this call site too.
+ * above for the full rationale. `aliases` come from `flagAliasesFor` (see
+ * `classifyParseErrorConsoleOutput` below), already formatted with their
+ * leading dash(es).
  */
-function isMissingFlagTokenPresent(option: string, args: ReadonlyArray<string>): boolean {
-  const token = `--${option}`;
-  return args.some((arg) => arg === token || arg.startsWith(`${token}=`));
+function isMissingFlagTokenPresent(
+  option: string,
+  args: ReadonlyArray<string>,
+  aliases: ReadonlyArray<string> = [],
+): boolean {
+  const tokens = [`--${option}`, ...aliases];
+  return args.some((arg) => tokens.some((token) => arg === token || arg.startsWith(`${token}=`)));
 }
 
 export function classifyParseErrorConsoleOutput(
   cause: Cause.Cause<unknown>,
-  args: ReadonlyArray<string>,
+  context: CliErrorSuggestionContext,
 ): ParseErrorConsoleDisposition {
   const error = Cause.squash(cause);
   if (!CliError.isCliError(error) || error._tag !== "ShowHelp" || error.errors.length === 0) {
     return "flush-unchanged";
   }
   const isSuppressedMissingFlag = (inner: (typeof error.errors)[number]) =>
-    inner._tag === "MissingOption" && !isMissingFlagTokenPresent(inner.option, args);
+    inner._tag === "MissingOption" &&
+    !isMissingFlagTokenPresent(
+      inner.option,
+      context.args,
+      flagAliasesFor(context.rootCommand, error.commandPath, inner.option),
+    );
   return error.errors.every(isSuppressedMissingFlag) ? "drop" : "flush-help-doc-to-stderr";
 }
 
@@ -293,7 +300,7 @@ export function classifyParseErrorConsoleOutput(
  */
 export function withoutParseErrorHelpDump<A, E, R>(
   effect: Effect.Effect<A, E, R>,
-  args: ReadonlyArray<string>,
+  context: CliErrorSuggestionContext,
 ): Effect.Effect<A, E, R> {
   return Effect.gen(function* () {
     const sink: Array<BufferedConsoleWrite> = [];
@@ -302,7 +309,7 @@ export function withoutParseErrorHelpDump<A, E, R>(
       Effect.exit,
     );
     const disposition = Exit.isFailure(exit)
-      ? classifyParseErrorConsoleOutput(exit.cause, args)
+      ? classifyParseErrorConsoleOutput(exit.cause, context)
       : "flush-unchanged";
     if (disposition === "drop") {
       return yield* exit;
@@ -379,10 +386,10 @@ function cliProgramFor(
       }),
     ),
   );
-  return withoutParseErrorHelpDump(
-    Command.runWith(rootCommand, { version: CLI_VERSION })(args),
+  return withoutParseErrorHelpDump(Command.runWith(rootCommand, { version: CLI_VERSION })(args), {
+    rootCommand,
     args,
-  ).pipe(
+  }).pipe(
     Effect.provide(formatterLayerFor(rootCommand, args, outputFormat)),
     Effect.provide(options.analyticsLayer),
     Effect.provide(tracingLayer),

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -197,7 +197,18 @@ function bufferingConsole(sink: Array<BufferedConsoleWrite>): Console.Console {
  *   `PersistentPreRunE` already suppresses usage for: `ValidateRequiredFlags`
  *   (cobra `command.go:1007`), which sets `cmd.SilenceUsage = true`
  *   (`apps/cli-go/cmd/root.go:97`) BEFORE it runs. This library's
- *   `MissingOption` is the one tag that maps to that stage — see CLI-1901.
+ *   `MissingOption` is the one tag that maps to that stage — see CLI-1901 —
+ *   but ONLY when the flag was never given at all. A required flag that IS
+ *   present on argv but missing its value (e.g. `sso add --type` with
+ *   nothing after it) also raises `MissingOption` in this library (it has no
+ *   distinct "value required" tag), yet Go's own pflag raises a DIFFERENT,
+ *   earlier `ParseFlags`-time error for that input (`flag needs an
+ *   argument: --type`) which does NOT get `SilenceUsage` treatment — verified
+ *   against the real binary (`apps/cli-go/supabase-go sso add --type`: full
+ *   usage block on stderr, vs `sso add --project-ref x` with `--type` never
+ *   mentioned at all: bare `required flag(s) "type" not set`, no usage). See
+ *   `isMissingFlagTokenPresent` below for how this case is distinguished from
+ *   a genuinely-absent flag.
  * - `"flush-help-doc-to-stderr"` — every other genuine parse/validation
  *   failure (`UnrecognizedOption`, `InvalidValue`, `MissingArgument`,
  *   `UnknownSubcommand`; multiple simultaneous errors also lands here).
@@ -217,15 +228,37 @@ function bufferingConsole(sink: Array<BufferedConsoleWrite>): Console.Console {
  */
 export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-help-doc-to-stderr";
 
+/**
+ * Whether `option`'s long-form flag token (`--option` or `--option=...`)
+ * appears anywhere in the raw argv this run was invoked with — used to tell
+ * a genuinely-absent required flag (Go: `SilenceUsage`-suppressed) apart from
+ * one that's present but missing its value (Go: a `ParseFlags`-time error,
+ * usage still shown). See the `"drop"` case on `ParseErrorConsoleDisposition`
+ * above for the full rationale.
+ *
+ * Known gap: this only recognizes the flag's canonical long-form name, not a
+ * short alias (e.g. `sso add -t` with no value would still be misclassified
+ * as "absent"). Resolving aliases requires walking the command tree for the
+ * failing `commandPath` (the same lookup `subcommand-flag-suggestions.ts`
+ * does for hint placement) — left as a follow-up rather than threading a
+ * `rootCommand`/`CliErrorSuggestionContext` into this call site too.
+ */
+function isMissingFlagTokenPresent(option: string, args: ReadonlyArray<string>): boolean {
+  const token = `--${option}`;
+  return args.some((arg) => arg === token || arg.startsWith(`${token}=`));
+}
+
 export function classifyParseErrorConsoleOutput(
   cause: Cause.Cause<unknown>,
+  args: ReadonlyArray<string>,
 ): ParseErrorConsoleDisposition {
   const error = Cause.squash(cause);
   if (!CliError.isCliError(error) || error._tag !== "ShowHelp" || error.errors.length === 0) {
     return "flush-unchanged";
   }
-  const isMissingRequiredFlag = error.errors.every((inner) => inner._tag === "MissingOption");
-  return isMissingRequiredFlag ? "drop" : "flush-help-doc-to-stderr";
+  const isSuppressedMissingFlag = (inner: (typeof error.errors)[number]) =>
+    inner._tag === "MissingOption" && !isMissingFlagTokenPresent(inner.option, args);
+  return error.errors.every(isSuppressedMissingFlag) ? "drop" : "flush-help-doc-to-stderr";
 }
 
 /**
@@ -260,6 +293,7 @@ export function classifyParseErrorConsoleOutput(
  */
 export function withoutParseErrorHelpDump<A, E, R>(
   effect: Effect.Effect<A, E, R>,
+  args: ReadonlyArray<string>,
 ): Effect.Effect<A, E, R> {
   return Effect.gen(function* () {
     const sink: Array<BufferedConsoleWrite> = [];
@@ -268,7 +302,7 @@ export function withoutParseErrorHelpDump<A, E, R>(
       Effect.exit,
     );
     const disposition = Exit.isFailure(exit)
-      ? classifyParseErrorConsoleOutput(exit.cause)
+      ? classifyParseErrorConsoleOutput(exit.cause, args)
       : "flush-unchanged";
     if (disposition === "drop") {
       return yield* exit;
@@ -347,6 +381,7 @@ function cliProgramFor(
   );
   return withoutParseErrorHelpDump(
     Command.runWith(rootCommand, { version: CLI_VERSION })(args),
+    args,
   ).pipe(
     Effect.provide(formatterLayerFor(rootCommand, args, outputFormat)),
     Effect.provide(options.analyticsLayer),

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -372,6 +372,12 @@ export async function runCli(rootCommand: Command.Command.Any, options: RunCliOp
     }).pipe(Effect.provide(BunServices.layer)),
   );
 
+  // Same `{ rootCommand, args }` shape `formatterLayerFor` builds below, so
+  // `normalizeCause`'s single-render fallback path (CLI-1901) can reuse
+  // `formatCliErrorsForDisplay` and surface the same subcommand-flag hint the
+  // text/json formatters would have shown before the vendored library's own
+  // duplicate render was suppressed.
+  const suggestionContext = { rootCommand, args };
   const useGlobalSignalInterrupt = shouldUseGlobalSignalInterrupt(args);
   const outputFormat = await Effect.runPromise(
     Effect.gen(function* () {
@@ -425,7 +431,7 @@ export async function runCli(rootCommand: Command.Command.Any, options: RunCliOp
         // below. See `exitCodeForFailure` for why a "clean" ShowHelp failure
         // (e.g. a bare group command with no subcommand) also maps to exit 0.
         if (shouldReportFailure(exit.cause, exitCode)) {
-          yield* output.fail(normalizeCause(exit.cause));
+          yield* output.fail(normalizeCause(exit.cause, suggestionContext));
         }
         return yield* processControl.exit(exitCode);
       }

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -233,13 +233,25 @@ export type ParseErrorConsoleDisposition = "flush-unchanged" | "drop" | "flush-h
 /**
  * Whether `option`'s canonical long-form flag token (`--option` or
  * `--option=...`), or one of its short/long `aliases` (e.g. `-t`), appears
- * anywhere in the raw argv this run was invoked with — used to tell a
- * genuinely-absent required flag (Go: `SilenceUsage`-suppressed) apart from
- * one that's present but missing its value (Go: a `ParseFlags`-time error,
- * usage still shown). See the `"drop"` case on `ParseErrorConsoleDisposition`
- * above for the full rationale. `aliases` come from `flagAliasesFor` (see
+ * anywhere in the raw argv this run was invoked with BEFORE the `--`
+ * operand terminator (if any) — used to tell a genuinely-absent required
+ * flag (Go: `SilenceUsage`-suppressed) apart from one that's present but
+ * missing its value (Go: a `ParseFlags`-time error, usage still shown). See
+ * the `"drop"` case on `ParseErrorConsoleDisposition` above for the full
+ * rationale. `aliases` come from `flagAliasesFor` (see
  * `classifyParseErrorConsoleOutput` below), already formatted with their
  * leading dash(es).
+ *
+ * Tokens after a literal `--` are always positional operands, never a flag
+ * occurrence for ANY option — this mirrors the vendored `effect` CLI
+ * library's own lexer, which treats `--` the same way (`internal/lexer.ts`,
+ * `argv.indexOf("--")`). Without this cutoff, a command like
+ * `migration repair -- 20230101000000 --status` (a required `Flag.choice`,
+ * `legacy/commands/migration/repair/repair.command.ts`) would have its
+ * trailing `--status` positional argument misread as evidence the `--status`
+ * flag was given, flipping a genuinely-absent-flag failure (Go: no usage
+ * shown) into a "present but missing its value" one (Go: usage shown) — see
+ * CLI-1901.
  */
 function isMissingFlagTokenPresent(
   option: string,
@@ -247,7 +259,11 @@ function isMissingFlagTokenPresent(
   aliases: ReadonlyArray<string> = [],
 ): boolean {
   const tokens = [`--${option}`, ...aliases];
-  return args.some((arg) => tokens.some((token) => arg === token || arg.startsWith(`${token}=`)));
+  const terminatorIndex = args.indexOf("--");
+  const scannedArgs = terminatorIndex === -1 ? args : args.slice(0, terminatorIndex);
+  return scannedArgs.some((arg) =>
+    tokens.some((token) => arg === token || arg.startsWith(`${token}=`)),
+  );
 }
 
 export function classifyParseErrorConsoleOutput(

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -1,8 +1,8 @@
 import { BunServices } from "@effect/platform-bun";
 import { ProjectConfigStore } from "@supabase/config";
 import { unixHttpClientLayer } from "@supabase/stack";
-import { Cause, Effect, Exit, Fiber, Layer, Runtime, Stdio } from "effect";
-import { CliOutput, Command } from "effect/unstable/cli";
+import { Cause, Console, Effect, Exit, Fiber, Layer, Runtime, Stdio } from "effect";
+import { CliError, CliOutput, Command } from "effect/unstable/cli";
 import { CLI_VERSION } from "./version.ts";
 import { Credentials } from "../../next/auth/credentials.service.ts";
 import { jsonCliOutputFormatter } from "../output/json-formatter.ts";
@@ -137,6 +137,125 @@ export function shouldReportFailure(cause: Cause.Cause<unknown>, exitCode: numbe
   return !(Cause.squash(cause) instanceof LegacyGoChildExitError);
 }
 
+/**
+ * A single `Console.log`/`Console.error` call captured while
+ * `withoutParseErrorHelpDump` runs, so it can be replayed once the run's
+ * outcome is known instead of being written immediately.
+ */
+interface BufferedConsoleWrite {
+  readonly method: "log" | "error";
+  readonly args: ReadonlyArray<unknown>;
+}
+
+/**
+ * A `Console.Console` that captures `log`/`error` calls into `sink` instead
+ * of writing them, and forwards every other method straight through to the
+ * real console. The vendored `effect` CLI library's parser only ever calls
+ * `log`/`error` (`showHelp()` and the `Help`/`Version`/`Completions`
+ * `GlobalFlag.Action`s in `Command.ts`) — the rest are implemented so this
+ * stays a faithful `Console.Console` rather than a partial stand-in.
+ */
+function bufferingConsole(sink: Array<BufferedConsoleWrite>): Console.Console {
+  const real = globalThis.console;
+  return {
+    assert: real.assert.bind(real),
+    clear: real.clear.bind(real),
+    count: real.count.bind(real),
+    countReset: real.countReset.bind(real),
+    debug: real.debug.bind(real),
+    dir: real.dir.bind(real),
+    dirxml: real.dirxml.bind(real),
+    error: (...args: ReadonlyArray<unknown>) => {
+      sink.push({ method: "error", args });
+    },
+    group: real.group.bind(real),
+    groupCollapsed: real.groupCollapsed.bind(real),
+    groupEnd: real.groupEnd.bind(real),
+    info: real.info.bind(real),
+    log: (...args: ReadonlyArray<unknown>) => {
+      sink.push({ method: "log", args });
+    },
+    table: real.table.bind(real),
+    time: real.time.bind(real),
+    timeEnd: real.timeEnd.bind(real),
+    timeLog: real.timeLog.bind(real),
+    trace: real.trace.bind(real),
+    warn: real.warn.bind(real),
+  };
+}
+
+/**
+ * Whether `withoutParseErrorHelpDump`'s buffered `Console.log`/`Console.error`
+ * writes should be dropped rather than flushed, given how the wrapped effect
+ * failed.
+ *
+ * True only for a genuine parse/validation failure: `CliError.ShowHelp`
+ * carrying a non-empty `errors` array. That is the ONLY shape whose buffered
+ * writes are the CLI-1901 bug — the vendored `effect` CLI library's own
+ * `showHelp()` (the single `catchFilter` in `Command.ts`'s `runWith`) always
+ * `Console.log`s the full help doc and, when `errors.length > 0`, ALSO
+ * `Console.error`s the same errors this repo's own `normalizeCause` already
+ * renders correctly afterward (`handledProgram` below). Go cobra never shows
+ * this dump for the equivalent case: `PersistentPreRunE` sets
+ * `SilenceUsage = true` (`apps/cli-go/cmd/root.go:97`) before
+ * `ValidateRequiredFlags` (cobra `command.go:1007`), so a missing required
+ * flag is a single clean stderr line with nothing on stdout — see CLI-1901.
+ *
+ * False for success, for a "clean" `ShowHelp` (`errors: []` — an explicit
+ * `--help` or a bare group command with no subcommand, both of which map to
+ * exit `0` per `exitCodeForFailure` above), and for any other failure —
+ * those buffered writes (if any, there normally are none) are the actual
+ * intended output and must reach the user.
+ */
+export function shouldSuppressShowHelpConsoleOutput(cause: Cause.Cause<unknown>): boolean {
+  const error = Cause.squash(cause);
+  return CliError.isCliError(error) && error._tag === "ShowHelp" && error.errors.length > 0;
+}
+
+/**
+ * Wraps `Command.runWith(rootCommand, ...)(args)` so the vendored `effect`
+ * CLI library's OWN `Console.log`/`Console.error` writes (see
+ * `shouldSuppressShowHelpConsoleOutput`) are captured instead of reaching the
+ * real console, and are dropped entirely for a genuine parse-error failure.
+ * This repo's own `handledProgram` + `normalizeCause` already render the
+ * single Go-parity line for that case, so dropping the library's writes
+ * fixes both halves of CLI-1901 (the stdout help dump and the duplicate
+ * error line) from this one call site, without patching the vendored
+ * library itself.
+ *
+ * Every other outcome (success, or a "clean" `errors: []` `ShowHelp`) flushes
+ * the buffered writes unchanged, so `--help`, `--version`, `--completions`,
+ * and the bare-group-command help dump are all untouched.
+ *
+ * Safe to wrap the entire `runWith` call — parsing AND the eventual command
+ * handler, not just the parse phase that can actually raise `ShowHelp`: no
+ * command handler in this codebase writes through `effect`'s `Console`
+ * service directly (they go through the `Output` service instead), so
+ * buffering here never delays or drops real command output.
+ */
+export function withoutParseErrorHelpDump<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.gen(function* () {
+    const sink: Array<BufferedConsoleWrite> = [];
+    const exit = yield* effect.pipe(
+      Effect.provideService(Console.Console, bufferingConsole(sink)),
+      Effect.exit,
+    );
+    if (Exit.isFailure(exit) && shouldSuppressShowHelpConsoleOutput(exit.cause)) {
+      return yield* exit;
+    }
+    for (const write of sink) {
+      yield* Console.consoleWith((console) =>
+        Effect.sync(() => {
+          console[write.method](...write.args);
+        }),
+      );
+    }
+    return yield* exit;
+  });
+}
+
 function projectContextLayerFor(runtimeLayer: Layer.Layer<never>) {
   return projectContextLayer.pipe(Layer.provide(runtimeLayer), Layer.provide(BunServices.layer));
 }
@@ -193,7 +312,9 @@ function cliProgramFor(
       }),
     ),
   );
-  return Command.runWith(rootCommand, { version: CLI_VERSION })(args).pipe(
+  return withoutParseErrorHelpDump(
+    Command.runWith(rootCommand, { version: CLI_VERSION })(args),
+  ).pipe(
     Effect.provide(formatterLayerFor(rootCommand, args, outputFormat)),
     Effect.provide(options.analyticsLayer),
     Effect.provide(tracingLayer),

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -280,6 +280,36 @@ describe("classifyParseErrorConsoleOutput", () => {
     ).toBe("flush-help-doc-to-stderr");
   });
 
+  // Codex review finding (CLI-1901 follow-up): `sso add --project-ref --type`
+  // omits `--type`'s value, but `--type` immediately follows `--project-ref`
+  // (a value-taking `Flag.string`, `add.command.ts`). Verified against the
+  // real `apps/cli-go/supabase-go` binary: pflag's `parseLongArg`
+  // (`flag.go`) unconditionally consumes the very next argv entry as
+  // `--project-ref`'s value, even though it looks like another flag — so
+  // `--type` is never seen as its own occurrence, and Go shows no usage at
+  // all (only its own "type" required-flag error, `SilenceUsage`-suppressed).
+  // The vendored `effect` parser does NOT eagerly consume a flag-shaped
+  // token as a value (`internal/parser.ts`'s `consumeFlagValueWithTokens`
+  // only consumes a following `Value`-tagged token), so `--type` remains its
+  // own token and raises its own `MissingOption` here too — but the raw scan
+  // must still recognize that `--type` was effectively consumed as
+  // `--project-ref`'s value, matching Go, instead of concluding `--type` is
+  // present but missing its value (which would wrongly flush the help doc).
+  it("drops the help dump when a required flag's own token is consumed as a preceding value-taking flag's value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["supabase", "sso", "add"],
+        errors: [new CliError.MissingOption({ option: "type" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--project-ref", "--type"],
+      }),
+    ).toBe("drop");
+  });
+
   it("still drops the help dump for a missing required flag even when an unrelated flag shares a substring of its name", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -231,6 +231,33 @@ describe("classifyParseErrorConsoleOutput", () => {
     ).toBe("flush-help-doc-to-stderr");
   });
 
+  // Codex review finding (CLI-1901 follow-up): `--` is the standard operand
+  // terminator — everything after it is positional, never a flag occurrence,
+  // for ANY option (mirrors the vendored `effect` lexer's own
+  // `argv.indexOf("--")` cutoff, `internal/lexer.ts`). Verified against the
+  // real `apps/cli-go/supabase-go` binary:
+  // `migration repair --local -- 20230101000000 --status` prints a bare
+  // `required flag(s) "status" not set`, no usage block — Go correctly parses
+  // the literal `--status` string as a second positional `version`, leaving
+  // the real `--status` flag genuinely unset. Without the `--` cutoff,
+  // `isMissingFlagTokenPresent` would find that trailing `--status` string
+  // anywhere in argv and wrongly conclude the flag was given but missing its
+  // value.
+  it("drops the help dump for a missing required flag whose token only appears after the -- terminator", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["supabase", "migration", "repair"],
+        errors: [new CliError.MissingOption({ option: "status" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["migration", "repair", "--", "20230101000000", "--status"],
+      }),
+    ).toBe("drop");
+  });
+
   // Codex review finding (CLI-1901 follow-up): `sso add`'s `type` flag also has
   // a short alias, `-t` (`add.command.ts`). Go's pflag treats a present-but-
   // valueless SHORT flag exactly like the long form — `parseSingleShortArg`

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 
 import { LegacyGoChildExitError } from "../legacy/legacy-go-child-exit.error.ts";
 import {
+  classifyParseErrorConsoleOutput,
   exitCodeForFailure,
   extractCommandPath,
   shouldReportFailure,
-  shouldSuppressShowHelpConsoleOutput,
   shouldUseGlobalSignalInterrupt,
 } from "./run.ts";
 
@@ -151,22 +151,47 @@ describe("shouldReportFailure", () => {
 // doc to stdout AND print the error twice (once from the vendored `effect`
 // CLI library's own `showHelp()`, once from this repo's own Go-parity
 // renderer). `withoutParseErrorHelpDump` fixes this by buffering the
-// library's own `Console.log`/`Console.error` writes and dropping them
-// entirely for exactly this cause shape — this suite covers that predicate;
-// `run.integration.test.ts` covers the end-to-end buffering/suppression
-// behavior against a real command definition.
-describe("shouldSuppressShowHelpConsoleOutput", () => {
-  it("suppresses a ShowHelp failure carrying a genuine validation error (missing required flag)", () => {
+// library's own `Console.log`/`Console.error` writes and disposing of them
+// per this classifier's verdict — this suite covers the classifier;
+// `run.integration.test.ts` covers the end-to-end buffering/flush behavior
+// against real command definitions, and `run.e2e.test.ts` /
+// `sso.e2e.test.ts` cover the real subprocess stdout/stderr streams.
+describe("classifyParseErrorConsoleOutput", () => {
+  // Go cobra's `PersistentPreRunE` sets `SilenceUsage = true`
+  // (`apps/cli-go/cmd/root.go:97`) BEFORE `ValidateRequiredFlags`
+  // (`command.go:1007`) runs — verified against the real `supabase-go`
+  // binary (`sso add` without `--type`): a single clean stderr line, no
+  // usage block. `MissingOption` is the one tag that maps to that stage.
+  it("drops the help dump for a missing required flag", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
         commandPath: ["sso", "add"],
         errors: [new CliError.MissingOption({ option: "type" })],
       }),
     );
-    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("drop");
   });
 
-  it("suppresses a ShowHelp failure carrying an invalid Flag.choice value", () => {
+  // Multiple simultaneously-missing required flags: still `ValidateRequiredFlags`,
+  // still post-`PersistentPreRunE` in Go — must still drop, not just for a lone error.
+  it("drops the help dump when every error is a missing required flag", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "add"],
+        errors: [
+          new CliError.MissingOption({ option: "type" }),
+          new CliError.MissingOption({ option: "project-ref" }),
+        ],
+      }),
+    );
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("drop");
+  });
+
+  // Go's `ParseFlags` (`command.go:919`) validates `Flag.choice` values BEFORE
+  // `PersistentPreRunE` runs — verified against the real binary (`sso add --type
+  // bogus`): Go still shows its usage block, on stderr. Same for an unrecognized
+  // flag and a missing positional argument (both also pre-`PersistentPreRunE`).
+  it("flushes the help dump to stderr for an invalid Flag.choice value", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
         commandPath: ["sso", "add"],
@@ -180,35 +205,62 @@ describe("shouldSuppressShowHelpConsoleOutput", () => {
         ],
       }),
     );
-    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
   });
 
-  it("suppresses a ShowHelp failure carrying an unrecognized flag", () => {
+  it("flushes the help dump to stderr for an unrecognized flag", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
         commandPath: ["branches"],
         errors: [new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] })],
       }),
     );
-    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
   });
 
-  it("does not suppress a clean ShowHelp failure (bare group command / explicit --help)", () => {
+  it("flushes the help dump to stderr for a missing positional argument", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "show"],
+        errors: [new CliError.MissingArgument({ argument: "id" })],
+      }),
+    );
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+  });
+
+  // A mix (e.g. a missing required flag alongside an unrecognized flag) can't
+  // actually occur in practice — the library fails fast on the earlier
+  // `ParseFlags`-class error before `MissingOption` is ever checked — but the
+  // classifier must still not mistake a mix for the all-`MissingOption` case.
+  it("flushes the help dump to stderr for a mix of error tags", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "add"],
+        errors: [
+          new CliError.MissingOption({ option: "type" }),
+          new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] }),
+        ],
+      }),
+    );
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+  });
+
+  it("flushes unchanged for a clean ShowHelp failure (bare group command / explicit --help)", () => {
     const cause = Cause.fail(new CliError.ShowHelp({ commandPath: ["branches"], errors: [] }));
-    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(false);
+    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-unchanged");
   });
 
-  it("does not suppress a non-ShowHelp failure", () => {
-    expect(shouldSuppressShowHelpConsoleOutput(Cause.fail(new Error("boom")))).toBe(false);
+  it("flushes unchanged for a non-ShowHelp failure", () => {
+    expect(classifyParseErrorConsoleOutput(Cause.fail(new Error("boom")))).toBe("flush-unchanged");
   });
 
-  it("does not suppress an interrupt", () => {
-    expect(shouldSuppressShowHelpConsoleOutput(Cause.interrupt())).toBe(false);
+  it("flushes unchanged for an interrupt", () => {
+    expect(classifyParseErrorConsoleOutput(Cause.interrupt())).toBe("flush-unchanged");
   });
 
-  it("does not suppress a defect with no typed failure", () => {
-    expect(shouldSuppressShowHelpConsoleOutput(Cause.die(new Error("unexpected crash")))).toBe(
-      false,
+  it("flushes unchanged for a defect with no typed failure", () => {
+    expect(classifyParseErrorConsoleOutput(Cause.die(new Error("unexpected crash")))).toBe(
+      "flush-unchanged",
     );
   });
 });

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -310,6 +310,58 @@ describe("classifyParseErrorConsoleOutput", () => {
     ).toBe("drop");
   });
 
+  // Codex review finding (CLI-1901 follow-up): `isValueTakingFlagTokenFor`
+  // only inspects the resolved LEAF command's own flags, so it doesn't know
+  // `--network-id` (a value-taking GLOBAL flag, `globalFlagsWithValues` in
+  // `run.ts`) consumes the very next argv entry. Verified against pflag's
+  // `parseLongArg` (`flag.go`): `--network-id --status` hands the literal
+  // string `--status` to `--network-id` as its value, so the required
+  // `status` flag (`migration repair`, `Flag.choice`) is never seen as its
+  // own occurrence and keeps Go's `SilenceUsage` treatment (no usage shown).
+  // Without OR-ing `globalFlagsWithValues` into the scan's value-taking
+  // predicate, the raw `--status` token would be found anyway and wrongly
+  // flush the help doc.
+  it("drops the help dump when a required flag's own token is consumed as a global value-taking flag's value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["supabase", "migration", "repair"],
+        errors: [new CliError.MissingOption({ option: "status" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["migration", "repair", "--network-id", "--status", "--local", "20230101000000"],
+      }),
+    ).toBe("drop");
+  });
+
+  // Codex review finding (CLI-1901 follow-up): a literal `--` immediately
+  // after a value-taking flag is NOT a genuine operand terminator in Go —
+  // pflag's `parseLongArg` (`flag.go`) pops the very next raw token as the
+  // flag's value with no shape check at all, so `--project-ref --` hands the
+  // literal string `--` to `--project-ref`. Parsing then resumes normally on
+  // `--type`, which (nothing follows it) raises pflag's own
+  // `ValueRequiredError` — a `ParseFlags`-time error, usage still shown, NOT
+  // `SilenceUsage`-suppressed. Precomputing `args.indexOf("--")` before the
+  // value-consumption scan would wrongly treat that consumed `--` as the
+  // terminator and drop `--type` from the scan entirely, misclassifying
+  // `type` as genuinely absent.
+  it("flushes the help dump to stderr for a required flag whose own token follows a -- consumed as a preceding value-taking flag's value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["supabase", "sso", "add"],
+        errors: [new CliError.MissingOption({ option: "type" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--project-ref", "--", "--type"],
+      }),
+    ).toBe("flush-help-doc-to-stderr");
+  });
+
   it("still drops the help dump for a missing required flag even when an unrelated flag shares a substring of its name", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -7,6 +7,7 @@ import {
   exitCodeForFailure,
   extractCommandPath,
   shouldReportFailure,
+  shouldSuppressShowHelpConsoleOutput,
   shouldUseGlobalSignalInterrupt,
 } from "./run.ts";
 
@@ -143,5 +144,71 @@ describe("shouldReportFailure", () => {
       }),
     );
     expect(shouldReportFailure(cause, 1)).toBe(true);
+  });
+});
+
+// CLI-1901: a required-flag/choice parse failure used to dump the full help
+// doc to stdout AND print the error twice (once from the vendored `effect`
+// CLI library's own `showHelp()`, once from this repo's own Go-parity
+// renderer). `withoutParseErrorHelpDump` fixes this by buffering the
+// library's own `Console.log`/`Console.error` writes and dropping them
+// entirely for exactly this cause shape — this suite covers that predicate;
+// `run.integration.test.ts` covers the end-to-end buffering/suppression
+// behavior against a real command definition.
+describe("shouldSuppressShowHelpConsoleOutput", () => {
+  it("suppresses a ShowHelp failure carrying a genuine validation error (missing required flag)", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "add"],
+        errors: [new CliError.MissingOption({ option: "type" })],
+      }),
+    );
+    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+  });
+
+  it("suppresses a ShowHelp failure carrying an invalid Flag.choice value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "add"],
+        errors: [
+          new CliError.InvalidValue({
+            option: "type",
+            value: "bogus",
+            expected: 'Expected "saml", got "bogus"',
+            kind: "flag",
+          }),
+        ],
+      }),
+    );
+    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+  });
+
+  it("suppresses a ShowHelp failure carrying an unrecognized flag", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["branches"],
+        errors: [new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] })],
+      }),
+    );
+    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(true);
+  });
+
+  it("does not suppress a clean ShowHelp failure (bare group command / explicit --help)", () => {
+    const cause = Cause.fail(new CliError.ShowHelp({ commandPath: ["branches"], errors: [] }));
+    expect(shouldSuppressShowHelpConsoleOutput(cause)).toBe(false);
+  });
+
+  it("does not suppress a non-ShowHelp failure", () => {
+    expect(shouldSuppressShowHelpConsoleOutput(Cause.fail(new Error("boom")))).toBe(false);
+  });
+
+  it("does not suppress an interrupt", () => {
+    expect(shouldSuppressShowHelpConsoleOutput(Cause.interrupt())).toBe(false);
+  });
+
+  it("does not suppress a defect with no typed failure", () => {
+    expect(shouldSuppressShowHelpConsoleOutput(Cause.die(new Error("unexpected crash")))).toBe(
+      false,
+    );
   });
 });

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -1,7 +1,10 @@
 import { Cause } from "effect";
-import { CliError } from "effect/unstable/cli";
+import { CliError, Command } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 
+import { legacyBranchesCommand } from "../../legacy/commands/branches/branches.command.ts";
+import { legacyMigrationCommand } from "../../legacy/commands/migration/migration.command.ts";
+import { legacySsoCommand } from "../../legacy/commands/sso/sso.command.ts";
 import { LegacyGoChildExitError } from "../legacy/legacy-go-child-exit.error.ts";
 import {
   classifyParseErrorConsoleOutput,
@@ -10,6 +13,13 @@ import {
   shouldReportFailure,
   shouldUseGlobalSignalInterrupt,
 } from "./run.ts";
+
+// Real command tree (not a hand-rolled stand-in) so `classifyParseErrorConsoleOutput`'s
+// alias resolution (`flagAliasesFor`, via `context.rootCommand`) has real `Flag.withAlias`
+// declarations to walk — e.g. `sso add`'s `type` flag aliases to `-t` (`add.command.ts`).
+const testRoot = Command.make("supabase").pipe(
+  Command.withSubcommands([legacyBranchesCommand, legacyMigrationCommand, legacySsoCommand]),
+);
 
 describe("extractCommandPath", () => {
   it("returns positional command-path tokens", () => {
@@ -165,14 +175,17 @@ describe("classifyParseErrorConsoleOutput", () => {
   it("drops the help dump for a missing required flag", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "add"],
+        commandPath: ["supabase", "sso", "add"],
         errors: [new CliError.MissingOption({ option: "type" })],
       }),
     );
-    // `--type` never appears on argv at all — genuinely absent.
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--project-ref", "x"])).toBe(
-      "drop",
-    );
+    // `--type` (nor its `-t` alias) never appears on argv at all — genuinely absent.
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--project-ref", "x"],
+      }),
+    ).toBe("drop");
   });
 
   // Multiple simultaneously-missing required flags: still `ValidateRequiredFlags`,
@@ -180,14 +193,16 @@ describe("classifyParseErrorConsoleOutput", () => {
   it("drops the help dump when every error is a missing required flag", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "add"],
+        commandPath: ["supabase", "sso", "add"],
         errors: [
           new CliError.MissingOption({ option: "type" }),
           new CliError.MissingOption({ option: "project-ref" }),
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add"])).toBe("drop");
+    expect(
+      classifyParseErrorConsoleOutput(cause, { rootCommand: testRoot, args: ["sso", "add"] }),
+    ).toBe("drop");
   });
 
   // CLI-1901 (Codex review finding): the vendored library raises the SAME
@@ -204,24 +219,54 @@ describe("classifyParseErrorConsoleOutput", () => {
   it("flushes the help dump to stderr for a required flag present on argv but missing its value", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["migration", "repair"],
+        commandPath: ["supabase", "migration", "repair"],
         errors: [new CliError.MissingOption({ option: "status" })],
       }),
     );
     expect(
-      classifyParseErrorConsoleOutput(cause, ["migration", "repair", "20230101000000", "--status"]),
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["migration", "repair", "20230101000000", "--status"],
+      }),
+    ).toBe("flush-help-doc-to-stderr");
+  });
+
+  // Codex review finding (CLI-1901 follow-up): `sso add`'s `type` flag also has
+  // a short alias, `-t` (`add.command.ts`). Go's pflag treats a present-but-
+  // valueless SHORT flag exactly like the long form — `parseSingleShortArg`
+  // raises the same `ValueRequiredError` as `parseLongArg`, same timing, same
+  // "usage still shown" outcome — verified against the real
+  // `apps/cli-go/supabase-go` binary (`sso add -t`: full usage block on
+  // stderr, byte-parallel to `sso add --type`). `flagAliasesFor` resolves
+  // `type`'s aliases from the real command tree (via `context.rootCommand`)
+  // so `isMissingFlagTokenPresent` recognizes `-t` here too, instead of
+  // misclassifying it as a genuinely-absent flag.
+  it("flushes the help dump to stderr for a required flag present on argv by its short alias but missing its value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["supabase", "sso", "add"],
+        errors: [new CliError.MissingOption({ option: "type" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, { rootCommand: testRoot, args: ["sso", "add", "-t"] }),
     ).toBe("flush-help-doc-to-stderr");
   });
 
   it("still drops the help dump for a missing required flag even when an unrelated flag shares a substring of its name", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "add"],
+        commandPath: ["supabase", "sso", "add"],
         errors: [new CliError.MissingOption({ option: "type" })],
       }),
     );
     // `--type-hint` is a different flag token — must not false-positive-match `--type`.
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--type-hint", "x"])).toBe("drop");
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--type-hint", "x"],
+      }),
+    ).toBe("drop");
   });
 
   // Go's `ParseFlags` (`command.go:919`) validates `Flag.choice` values BEFORE
@@ -231,7 +276,7 @@ describe("classifyParseErrorConsoleOutput", () => {
   it("flushes the help dump to stderr for an invalid Flag.choice value", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "add"],
+        commandPath: ["supabase", "sso", "add"],
         errors: [
           new CliError.InvalidValue({
             option: "type",
@@ -242,33 +287,39 @@ describe("classifyParseErrorConsoleOutput", () => {
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--type", "bogus"])).toBe(
-      "flush-help-doc-to-stderr",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--type", "bogus"],
+      }),
+    ).toBe("flush-help-doc-to-stderr");
   });
 
   it("flushes the help dump to stderr for an unrecognized flag", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["branches"],
+        commandPath: ["supabase", "branches"],
         errors: [new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] })],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause, ["branches", "--bogus"])).toBe(
-      "flush-help-doc-to-stderr",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["branches", "--bogus"],
+      }),
+    ).toBe("flush-help-doc-to-stderr");
   });
 
   it("flushes the help dump to stderr for a missing positional argument", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "show"],
+        commandPath: ["supabase", "sso", "show"],
         errors: [new CliError.MissingArgument({ argument: "id" })],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "show"])).toBe(
-      "flush-help-doc-to-stderr",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, { rootCommand: testRoot, args: ["sso", "show"] }),
+    ).toBe("flush-help-doc-to-stderr");
   });
 
   // A mix (e.g. a missing required flag alongside an unrecognized flag) can't
@@ -278,36 +329,51 @@ describe("classifyParseErrorConsoleOutput", () => {
   it("flushes the help dump to stderr for a mix of error tags", () => {
     const cause = Cause.fail(
       new CliError.ShowHelp({
-        commandPath: ["sso", "add"],
+        commandPath: ["supabase", "sso", "add"],
         errors: [
           new CliError.MissingOption({ option: "type" }),
           new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] }),
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--bogus"])).toBe(
-      "flush-help-doc-to-stderr",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, {
+        rootCommand: testRoot,
+        args: ["sso", "add", "--bogus"],
+      }),
+    ).toBe("flush-help-doc-to-stderr");
   });
 
   it("flushes unchanged for a clean ShowHelp failure (bare group command / explicit --help)", () => {
-    const cause = Cause.fail(new CliError.ShowHelp({ commandPath: ["branches"], errors: [] }));
-    expect(classifyParseErrorConsoleOutput(cause, ["branches"])).toBe("flush-unchanged");
+    const cause = Cause.fail(
+      new CliError.ShowHelp({ commandPath: ["supabase", "branches"], errors: [] }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, { rootCommand: testRoot, args: ["branches"] }),
+    ).toBe("flush-unchanged");
   });
 
   it("flushes unchanged for a non-ShowHelp failure", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.fail(new Error("boom")), [])).toBe(
-      "flush-unchanged",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(Cause.fail(new Error("boom")), {
+        rootCommand: testRoot,
+        args: [],
+      }),
+    ).toBe("flush-unchanged");
   });
 
   it("flushes unchanged for an interrupt", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.interrupt(), [])).toBe("flush-unchanged");
+    expect(
+      classifyParseErrorConsoleOutput(Cause.interrupt(), { rootCommand: testRoot, args: [] }),
+    ).toBe("flush-unchanged");
   });
 
   it("flushes unchanged for a defect with no typed failure", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.die(new Error("unexpected crash")), [])).toBe(
-      "flush-unchanged",
-    );
+    expect(
+      classifyParseErrorConsoleOutput(Cause.die(new Error("unexpected crash")), {
+        rootCommand: testRoot,
+        args: [],
+      }),
+    ).toBe("flush-unchanged");
   });
 });

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -169,7 +169,10 @@ describe("classifyParseErrorConsoleOutput", () => {
         errors: [new CliError.MissingOption({ option: "type" })],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("drop");
+    // `--type` never appears on argv at all — genuinely absent.
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--project-ref", "x"])).toBe(
+      "drop",
+    );
   });
 
   // Multiple simultaneously-missing required flags: still `ValidateRequiredFlags`,
@@ -184,7 +187,41 @@ describe("classifyParseErrorConsoleOutput", () => {
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("drop");
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add"])).toBe("drop");
+  });
+
+  // CLI-1901 (Codex review finding): the vendored library raises the SAME
+  // `MissingOption` tag whether a required flag was never given at all, or
+  // given with no value following it (e.g. `sso add --type` as the last
+  // token) — it has no distinct "value required" error. Go's own pflag does
+  // distinguish these: a present-but-valueless flag is a `ParseFlags`-time
+  // error (`flag needs an argument: --type`), raised BEFORE
+  // `PersistentPreRunE` sets `SilenceUsage` — verified against the real
+  // `apps/cli-go/supabase-go` binary, which still prints its full usage block
+  // to stderr for this input. `isMissingFlagTokenPresent` recovers this
+  // distinction from raw argv so this case flushes the help doc instead of
+  // silently dropping it like a genuinely-absent flag.
+  it("flushes the help dump to stderr for a required flag present on argv but missing its value", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["migration", "repair"],
+        errors: [new CliError.MissingOption({ option: "status" })],
+      }),
+    );
+    expect(
+      classifyParseErrorConsoleOutput(cause, ["migration", "repair", "20230101000000", "--status"]),
+    ).toBe("flush-help-doc-to-stderr");
+  });
+
+  it("still drops the help dump for a missing required flag even when an unrelated flag shares a substring of its name", () => {
+    const cause = Cause.fail(
+      new CliError.ShowHelp({
+        commandPath: ["sso", "add"],
+        errors: [new CliError.MissingOption({ option: "type" })],
+      }),
+    );
+    // `--type-hint` is a different flag token — must not false-positive-match `--type`.
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--type-hint", "x"])).toBe("drop");
   });
 
   // Go's `ParseFlags` (`command.go:919`) validates `Flag.choice` values BEFORE
@@ -205,7 +242,9 @@ describe("classifyParseErrorConsoleOutput", () => {
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--type", "bogus"])).toBe(
+      "flush-help-doc-to-stderr",
+    );
   });
 
   it("flushes the help dump to stderr for an unrecognized flag", () => {
@@ -215,7 +254,9 @@ describe("classifyParseErrorConsoleOutput", () => {
         errors: [new CliError.UnrecognizedOption({ option: "--bogus", suggestions: [] })],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+    expect(classifyParseErrorConsoleOutput(cause, ["branches", "--bogus"])).toBe(
+      "flush-help-doc-to-stderr",
+    );
   });
 
   it("flushes the help dump to stderr for a missing positional argument", () => {
@@ -225,7 +266,9 @@ describe("classifyParseErrorConsoleOutput", () => {
         errors: [new CliError.MissingArgument({ argument: "id" })],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "show"])).toBe(
+      "flush-help-doc-to-stderr",
+    );
   });
 
   // A mix (e.g. a missing required flag alongside an unrecognized flag) can't
@@ -242,24 +285,28 @@ describe("classifyParseErrorConsoleOutput", () => {
         ],
       }),
     );
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-help-doc-to-stderr");
+    expect(classifyParseErrorConsoleOutput(cause, ["sso", "add", "--bogus"])).toBe(
+      "flush-help-doc-to-stderr",
+    );
   });
 
   it("flushes unchanged for a clean ShowHelp failure (bare group command / explicit --help)", () => {
     const cause = Cause.fail(new CliError.ShowHelp({ commandPath: ["branches"], errors: [] }));
-    expect(classifyParseErrorConsoleOutput(cause)).toBe("flush-unchanged");
+    expect(classifyParseErrorConsoleOutput(cause, ["branches"])).toBe("flush-unchanged");
   });
 
   it("flushes unchanged for a non-ShowHelp failure", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.fail(new Error("boom")))).toBe("flush-unchanged");
+    expect(classifyParseErrorConsoleOutput(Cause.fail(new Error("boom")), [])).toBe(
+      "flush-unchanged",
+    );
   });
 
   it("flushes unchanged for an interrupt", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.interrupt())).toBe("flush-unchanged");
+    expect(classifyParseErrorConsoleOutput(Cause.interrupt(), [])).toBe("flush-unchanged");
   });
 
   it("flushes unchanged for a defect with no typed failure", () => {
-    expect(classifyParseErrorConsoleOutput(Cause.die(new Error("unexpected crash")))).toBe(
+    expect(classifyParseErrorConsoleOutput(Cause.die(new Error("unexpected crash")), [])).toBe(
       "flush-unchanged",
     );
   });

--- a/apps/cli/src/shared/cli/subcommand-flag-suggestions.ts
+++ b/apps/cli/src/shared/cli/subcommand-flag-suggestions.ts
@@ -128,6 +128,45 @@ export function flagAliasesFor(
   return flag?.aliases ?? [];
 }
 
+/**
+ * Builds a lookup for whether an argv token (a canonical `--name` or one of
+ * its aliases, e.g. `-t`) at `commandPath` belongs to a *value-taking* flag
+ * (any flag whose `HelpDoc.FlagDoc.type !== "boolean"`) on the command
+ * resolved the same way `flagAliasesFor` does. Returns a function that
+ * answers `false` for every token when `commandPath` doesn't resolve to a
+ * real command, mirroring `flagAliasesFor`'s "no aliases" fallback.
+ *
+ * Used by `run.ts`'s `isMissingFlagTokenPresent` to recognize when a
+ * DIFFERENT flag's value-consumption ate the very token being scanned for.
+ * Go/pflag's `parseLongArg` (`flag.go`) unconditionally consumes the next
+ * argv entry as a value-taking flag's value, even when that entry itself
+ * looks like another flag — e.g. `sso add --project-ref --type` hands the
+ * literal string `--type` to `--project-ref`, so `--type` is never seen as
+ * its own occurrence and its `MissingOption` failure gets Go's
+ * `SilenceUsage` treatment (no usage shown). The vendored `effect` CLI
+ * library's own parser does NOT replicate that (`internal/parser.ts`'s
+ * `consumeFlagValueWithTokens` only consumes a following token when it's
+ * lexed as a plain `Value`, never a flag-shaped token), so without this
+ * lookup the raw argv scan in `isMissingFlagTokenPresent` would find the
+ * literal `--type` token and wrongly conclude the flag is present but
+ * missing its value — reintroducing the usage dump CLI-1901 suppresses.
+ */
+export function isValueTakingFlagTokenFor(
+  rootCommand: Command.Command.Any,
+  commandPath: ReadonlyArray<string>,
+): (token: string) => boolean {
+  const command = findCommand(rootCommand, commandPath.slice(1));
+  const flags = command && helpDocFor(command, commandPath)?.flags;
+  if (!flags) return () => false;
+  const valueTakingTokens = new Set<string>();
+  for (const flag of flags) {
+    if (flag.type === "boolean") continue;
+    valueTakingTokens.add(`--${flag.name}`);
+    for (const alias of flag.aliases) valueTakingTokens.add(alias);
+  }
+  return (token: string) => valueTakingTokens.has(token);
+}
+
 function findPathEndIndex(
   args: ReadonlyArray<string>,
   pathWithoutRoot: ReadonlyArray<string>,

--- a/apps/cli/src/shared/cli/subcommand-flag-suggestions.ts
+++ b/apps/cli/src/shared/cli/subcommand-flag-suggestions.ts
@@ -102,6 +102,32 @@ function flagMatchesOption(flag: HelpDoc.FlagDoc, option: string): boolean {
   return flag.aliases.includes(option);
 }
 
+/**
+ * Every argv token (e.g. `-t`, alongside the canonical `--type`) that also
+ * resolves to `option` for the command at `commandPath`, by walking the
+ * command tree the same way `buildSubcommandFlagHint` does. Returns `[]` if
+ * `commandPath` doesn't resolve to a real command or that command has no
+ * flag named `option` — callers should treat that as "no aliases", not an
+ * error, since a synthetic/test command path is a legitimate input.
+ *
+ * Used by `run.ts`'s `isMissingFlagTokenPresent` to recognize a required
+ * flag supplied by its short alias but missing its value (Go/pflag still
+ * shows usage for that case — see CLI-1901) instead of misclassifying it as
+ * genuinely absent (Go: `SilenceUsage`-suppressed, no usage shown).
+ */
+export function flagAliasesFor(
+  rootCommand: Command.Command.Any,
+  commandPath: ReadonlyArray<string>,
+  option: string,
+): ReadonlyArray<string> {
+  const command = findCommand(rootCommand, commandPath.slice(1));
+  if (!command) return [];
+  const flag = helpDocFor(command, commandPath)?.flags.find(
+    (candidate) => candidate.name === option,
+  );
+  return flag?.aliases ?? [];
+}
+
 function findPathEndIndex(
   args: ReadonlyArray<string>,
   pathWithoutRoot: ReadonlyArray<string>,

--- a/apps/cli/src/shared/output/normalize-error.ts
+++ b/apps/cli/src/shared/output/normalize-error.ts
@@ -129,29 +129,48 @@ const mappedError = (
       // message — otherwise the user sees a useless top-line above the real
       // problem.
       const errors = error["errors"];
-      if (Array.isArray(errors) && errors.length === 1) {
+      if (!Array.isArray(errors) || errors.length === 0) return undefined;
+
+      if (errors.length === 1) {
         const inner = errors[0];
         if (isErrorRecord(inner)) {
           const innerMapped = mappedError(inner, context);
           if (innerMapped) return innerMapped;
-          // No Go-parity-specific mapping exists for this inner tag (e.g.
-          // UnrecognizedOption, DuplicateOption, MissingArgument,
-          // UnknownSubcommand, UserError — or an InvalidValue that doesn't
-          // hit CLI-1898's doubled-"Expected"-prefix bug). Surface the inner
-          // error's own message rather than falling through to ShowHelp's
-          // useless "Help requested": since CLI-1901 (`run.ts`'s
-          // `withoutParseErrorHelpDump`) stopped the vendored library from
-          // also `Console.error`-ing this same text, this is now the ONLY
-          // place it reaches the user. Reuse the same `formatCliErrorsForDisplay`
-          // the text/json formatters use (rather than the raw `.message`
-          // getter) so a subcommand-flag hint (e.g. "Hint: --foo is available
-          // on `branches create`. Pass it after the subcommand") that used to
-          // reach the user via the library's now-suppressed duplicate render
-          // still survives through this single-render path.
-          if (CliError.isCliError(inner)) {
-            const [formatted] = formatCliErrorsForDisplay([inner], context).errors;
-            if (formatted) return { code: formatted._tag, message: formatted.message };
-          }
+        }
+      }
+
+      // No Go-parity-specific single-error mapping applies (either more than
+      // one simultaneous error, e.g. a child flag placed before its
+      // subcommand — `UnrecognizedOption` plus the `UnknownSubcommand` its
+      // misplaced value gets parsed as — or a lone error with no known
+      // mapping: UnrecognizedOption, DuplicateOption, MissingArgument,
+      // UnknownSubcommand, UserError, or an InvalidValue that doesn't hit
+      // CLI-1898's doubled-"Expected"-prefix bug). Surface every inner
+      // error's own message — reusing the same `formatCliErrorsForDisplay`
+      // the text/json formatters use, so a subcommand-flag hint (e.g. "Hint:
+      // --foo is available on `branches create`. Pass it after the
+      // subcommand") survives — rather than falling through to ShowHelp's
+      // useless "Help requested" envelope message: since CLI-1901 (`run.ts`'s
+      // `withoutParseErrorHelpDump`) stopped the vendored library from also
+      // `Console.error`-ing this same text, this is now the ONLY place any
+      // of it reaches the user, for one error or many.
+      if (errors.every(CliError.isCliError)) {
+        const formatted = formatCliErrorsForDisplay(errors, context);
+        if (formatted.errors.length > 0) {
+          const [only] = formatted.errors;
+          return {
+            code: formatted.errors.length === 1 && only ? only._tag : "ShowHelp",
+            message: formatted.errors.map((formattedError) => formattedError.message).join("\n\n"),
+          };
+        }
+      }
+
+      // Defensive fallback for a single inner value that carries a usable
+      // `_tag`/`message` pair but isn't a real `CliError` instance (e.g. a
+      // hand-rolled test double) — real `ShowHelp.errors` entries always are.
+      if (errors.length === 1) {
+        const inner = errors[0];
+        if (isErrorRecord(inner)) {
           const code = readString(inner, "_tag");
           const message = readString(inner, "message");
           if (code && message) return { code, message };

--- a/apps/cli/src/shared/output/normalize-error.ts
+++ b/apps/cli/src/shared/output/normalize-error.ts
@@ -128,6 +128,18 @@ const mappedError = (error: ErrorRecord): NormalizedCliError | undefined => {
         if (isErrorRecord(inner)) {
           const innerMapped = mappedError(inner);
           if (innerMapped) return innerMapped;
+          // No Go-parity-specific mapping exists for this inner tag (e.g.
+          // UnrecognizedOption, DuplicateOption, MissingArgument,
+          // UnknownSubcommand, UserError — or an InvalidValue that doesn't
+          // hit CLI-1898's doubled-"Expected"-prefix bug). Surface the inner
+          // error's own message rather than falling through to ShowHelp's
+          // useless "Help requested": since CLI-1901 (`run.ts`'s
+          // `withoutParseErrorHelpDump`) stopped the vendored library from
+          // also `Console.error`-ing this same text, this is now the ONLY
+          // place it reaches the user.
+          const code = readString(inner, "_tag");
+          const message = readString(inner, "message");
+          if (code && message) return { code, message };
         }
       }
       return undefined;

--- a/apps/cli/src/shared/output/normalize-error.ts
+++ b/apps/cli/src/shared/output/normalize-error.ts
@@ -1,5 +1,8 @@
 import { Cause, Option } from "effect";
+import { CliError } from "effect/unstable/cli";
 import { formatInvalidValueMessage } from "../cli/invalid-value-message.ts";
+import type { CliErrorSuggestionContext } from "../cli/subcommand-flag-suggestions.ts";
+import { formatCliErrorsForDisplay } from "../cli/subcommand-flag-suggestions.ts";
 
 type NormalizedCliError = {
   readonly code: string;
@@ -28,7 +31,10 @@ const readRawString = (value: ErrorRecord, key: string): string | undefined => {
   return typeof field === "string" ? field : undefined;
 };
 
-const mappedError = (error: ErrorRecord): NormalizedCliError | undefined => {
+const mappedError = (
+  error: ErrorRecord,
+  context?: CliErrorSuggestionContext,
+): NormalizedCliError | undefined => {
   const tag = readString(error, "_tag");
   switch (tag) {
     case "NoRunningStackError":
@@ -126,7 +132,7 @@ const mappedError = (error: ErrorRecord): NormalizedCliError | undefined => {
       if (Array.isArray(errors) && errors.length === 1) {
         const inner = errors[0];
         if (isErrorRecord(inner)) {
-          const innerMapped = mappedError(inner);
+          const innerMapped = mappedError(inner, context);
           if (innerMapped) return innerMapped;
           // No Go-parity-specific mapping exists for this inner tag (e.g.
           // UnrecognizedOption, DuplicateOption, MissingArgument,
@@ -136,7 +142,16 @@ const mappedError = (error: ErrorRecord): NormalizedCliError | undefined => {
           // useless "Help requested": since CLI-1901 (`run.ts`'s
           // `withoutParseErrorHelpDump`) stopped the vendored library from
           // also `Console.error`-ing this same text, this is now the ONLY
-          // place it reaches the user.
+          // place it reaches the user. Reuse the same `formatCliErrorsForDisplay`
+          // the text/json formatters use (rather than the raw `.message`
+          // getter) so a subcommand-flag hint (e.g. "Hint: --foo is available
+          // on `branches create`. Pass it after the subcommand") that used to
+          // reach the user via the library's now-suppressed duplicate render
+          // still survives through this single-render path.
+          if (CliError.isCliError(inner)) {
+            const [formatted] = formatCliErrorsForDisplay([inner], context).errors;
+            if (formatted) return { code: formatted._tag, message: formatted.message };
+          }
           const code = readString(inner, "_tag");
           const message = readString(inner, "message");
           if (code && message) return { code, message };
@@ -147,9 +162,12 @@ const mappedError = (error: ErrorRecord): NormalizedCliError | undefined => {
   }
 };
 
-export function normalizeCliError(error: unknown): NormalizedCliError {
+export function normalizeCliError(
+  error: unknown,
+  context?: CliErrorSuggestionContext,
+): NormalizedCliError {
   if (isErrorRecord(error)) {
-    const mapped = mappedError(error);
+    const mapped = mappedError(error, context);
     if (mapped) {
       return mapped;
     }
@@ -186,9 +204,15 @@ export function normalizeCliError(error: unknown): NormalizedCliError {
   };
 }
 
-export function normalizeCause(cause: Cause.Cause<unknown>): NormalizedCliError {
+export function normalizeCause(
+  cause: Cause.Cause<unknown>,
+  context?: CliErrorSuggestionContext,
+): NormalizedCliError {
   const errorOption = Cause.findErrorOption(cause);
-  return normalizeCliError(Option.getOrElse(errorOption, () => Cause.squash(cause)));
+  return normalizeCliError(
+    Option.getOrElse(errorOption, () => Cause.squash(cause)),
+    context,
+  );
 }
 
 export function formatCliError(error: NormalizedCliError): string {

--- a/apps/cli/src/shared/output/normalize-error.unit.test.ts
+++ b/apps/cli/src/shared/output/normalize-error.unit.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "vitest";
 import { Cause } from "effect";
 import { CliError, Command } from "effect/unstable/cli";
 import { legacyBranchesCommand } from "../../legacy/commands/branches/branches.command.ts";
+import { legacyNetworkRestrictionsCommand } from "../../legacy/commands/network-restrictions/network-restrictions.command.ts";
 import { formatCliError, normalizeCause, normalizeCliError } from "./normalize-error.ts";
 
-const testRoot = Command.make("supabase").pipe(Command.withSubcommands([legacyBranchesCommand]));
+const testRoot = Command.make("supabase").pipe(
+  Command.withSubcommands([legacyBranchesCommand, legacyNetworkRestrictionsCommand]),
+);
 
 describe("normalizeCliError", () => {
   test("maps NoRunningStackError to a user-facing message", () => {
@@ -219,6 +222,77 @@ describe("normalizeCliError", () => {
     expect(result.message).toContain(
       "Hint: --persistent is available on `supabase branches create` and `supabase branches update`. Pass it after the subcommand",
     );
+  });
+
+  // Regression test for a second Codex review finding on CLI-1901: a child
+  // flag placed before its subcommand, WITH a value (e.g. `network-restrictions
+  // --project-ref <ref> get`), makes Effect raise TWO simultaneous errors —
+  // `UnrecognizedOption` for the flag, plus `UnknownSubcommand` for the
+  // flag's own value being misread as the subcommand name. Before this fix,
+  // `mappedError`'s ShowHelp unwrap only ever looked at `errors.length === 1`,
+  // so a real two-error ShowHelp fell straight through to the generic
+  // "Help requested" envelope message — losing the hint (and the specific
+  // error) entirely now that CLI-1901 also suppresses the vendored library's
+  // own duplicate render for this case.
+  test("ShowHelp envelope unwraps multiple simultaneous errors and preserves the subcommand-flag hint (child flag with a value, before its subcommand)", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["network-restrictions"],
+      errors: [
+        new CliError.UnrecognizedOption({
+          option: "--project-ref",
+          command: ["supabase", "network-restrictions"],
+          suggestions: [],
+        }),
+        new CliError.UnknownSubcommand({
+          subcommand: "jacraenyzrorgjhsdvvf",
+          parent: ["supabase", "network-restrictions"],
+          suggestions: [],
+        }),
+      ],
+    };
+
+    const result = normalizeCliError(error, {
+      rootCommand: testRoot,
+      args: ["network-restrictions", "--project-ref", "jacraenyzrorgjhsdvvf", "get"],
+    });
+
+    expect(result.code).toBe("UnrecognizedOption");
+    expect(result.message).toContain(
+      "Unrecognized flag: --project-ref in command supabase network-restrictions",
+    );
+    expect(result.message).toContain(
+      "Hint: --project-ref is available on `supabase network-restrictions get` and `supabase network-restrictions update`.",
+    );
+    expect(result.message).not.toContain("Help requested");
+  });
+
+  // A genuine, unrelated multi-error case (no shared hint to collapse them
+  // into one) must still surface every error's own message, not just the
+  // first — and must not crash trying to pick a single `code`.
+  test("ShowHelp envelope unwraps multiple unrelated simultaneous errors into a joined message", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["branches"],
+      errors: [
+        new CliError.UnrecognizedOption({
+          option: "--bogus-one",
+          command: ["supabase", "branches"],
+          suggestions: [],
+        }),
+        new CliError.UnrecognizedOption({
+          option: "--bogus-two",
+          command: ["supabase", "branches"],
+          suggestions: [],
+        }),
+      ],
+    };
+
+    const result = normalizeCliError(error, { rootCommand: testRoot, args: ["branches"] });
+
+    expect(result.code).toBe("ShowHelp");
+    expect(result.message).toContain("Unrecognized flag: --bogus-one in command supabase branches");
+    expect(result.message).toContain("Unrecognized flag: --bogus-two in command supabase branches");
   });
 
   // The same fallback also covers an InvalidValue that does NOT have the

--- a/apps/cli/src/shared/output/normalize-error.unit.test.ts
+++ b/apps/cli/src/shared/output/normalize-error.unit.test.ts
@@ -183,6 +183,46 @@ describe("normalizeCliError", () => {
     });
   });
 
+  // The same fallback also covers an InvalidValue that does NOT have the
+  // CLI-1898 doubled-"Expected"-prefix bug (e.g. a custom `Flag.mapTryCatch`
+  // validator like `sso add --domains`, whose `expected` text is already
+  // clean) — `mappedError`'s own InvalidValue case returns `undefined` for
+  // those (nothing to fix), so this generic fallback is what surfaces the
+  // message, not CLI-1898's specific rebuild.
+  test("ShowHelp envelope unwraps a single InvalidValue with an already-clean expected message (not the CLI-1898 doubled-prefix bug)", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["sso", "add"],
+      errors: [
+        new CliError.InvalidValue({
+          option: "domains",
+          value: "unterminated-quote.com",
+          expected: "a comma-separated list (unterminated quote)",
+          kind: "flag",
+        }),
+      ],
+    };
+    expect(normalizeCliError(error)).toEqual({
+      code: "InvalidValue",
+      message:
+        'Invalid value for flag --domains: "unterminated-quote.com". Expected: a comma-separated list (unterminated quote)',
+    });
+  });
+
+  // If the single inner error has a `_tag` but no usable `message` (neither a
+  // string via its own getter nor otherwise), the fallback must not surface a
+  // blank/garbage message — it should fall through to ShowHelp's own generic
+  // handling, same as the pre-existing multiple-errors case below.
+  test("ShowHelp envelope with a single inner error carrying no message falls back to generic", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["branches"],
+      errors: [{ _tag: "SomeUnmappedTag" }],
+    };
+    const result = normalizeCliError(error);
+    expect(result.code).toBe("ShowHelp");
+  });
+
   test("ShowHelp with multiple errors does not unwrap (falls back to generic)", () => {
     const error = {
       _tag: "ShowHelp",

--- a/apps/cli/src/shared/output/normalize-error.unit.test.ts
+++ b/apps/cli/src/shared/output/normalize-error.unit.test.ts
@@ -157,6 +157,32 @@ describe("normalizeCliError", () => {
     });
   });
 
+  // CLI-1901: before this fix, the vendored `effect` CLI library's own
+  // `showHelp()` also printed this same message (via `Console.error`) as a
+  // duplicate of whatever `normalizeCause` rendered here — so a tag with no
+  // Go-parity-specific mapping (e.g. UnrecognizedOption) still had SOME
+  // informative text visible, just twice. Now that CLI-1901's `run.ts` fix
+  // suppresses the library's own duplicate print entirely, this generic
+  // fallback is the ONLY place the message reaches the user — it must not
+  // regress to the useless "Help requested" envelope message.
+  test("ShowHelp envelope unwraps a single UnrecognizedOption to its own message (no Go-parity mapping exists yet)", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["branches"],
+      errors: [
+        new CliError.UnrecognizedOption({
+          option: "--bogus",
+          command: ["branches"],
+          suggestions: [],
+        }),
+      ],
+    };
+    expect(normalizeCliError(error)).toEqual({
+      code: "UnrecognizedOption",
+      message: "Unrecognized flag: --bogus in command branches",
+    });
+  });
+
   test("ShowHelp with multiple errors does not unwrap (falls back to generic)", () => {
     const error = {
       _tag: "ShowHelp",

--- a/apps/cli/src/shared/output/normalize-error.unit.test.ts
+++ b/apps/cli/src/shared/output/normalize-error.unit.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { Cause } from "effect";
-import { CliError } from "effect/unstable/cli";
+import { CliError, Command } from "effect/unstable/cli";
+import { legacyBranchesCommand } from "../../legacy/commands/branches/branches.command.ts";
 import { formatCliError, normalizeCause, normalizeCliError } from "./normalize-error.ts";
+
+const testRoot = Command.make("supabase").pipe(Command.withSubcommands([legacyBranchesCommand]));
 
 describe("normalizeCliError", () => {
   test("maps NoRunningStackError to a user-facing message", () => {
@@ -181,6 +184,41 @@ describe("normalizeCliError", () => {
       code: "UnrecognizedOption",
       message: "Unrecognized flag: --bogus in command branches",
     });
+  });
+
+  // Regression test for a Codex review finding on CLI-1901: `run.ts`'s
+  // `withoutParseErrorHelpDump` suppresses the vendored library's own
+  // `Console.error` render, which used to be the only place a subcommand-flag
+  // placement hint (`buildSubcommandFlagHint` /
+  // `subcommand-flag-suggestions.ts`) reached the user. When a
+  // `CliErrorSuggestionContext` is supplied, this fallback must reuse
+  // `formatCliErrorsForDisplay` — the same helper the text/json formatters
+  // use — so that hint still survives through the single-render path.
+  test("ShowHelp envelope unwraps a single UnrecognizedOption and preserves its subcommand-flag hint when a suggestion context is supplied", () => {
+    const error = {
+      _tag: "ShowHelp",
+      commandPath: ["branches"],
+      errors: [
+        new CliError.UnrecognizedOption({
+          option: "--persistent",
+          command: ["supabase", "branches"],
+          suggestions: [],
+        }),
+      ],
+    };
+
+    const result = normalizeCliError(error, {
+      rootCommand: testRoot,
+      args: ["branches", "--persistent", "create"],
+    });
+
+    expect(result.code).toBe("UnrecognizedOption");
+    expect(result.message).toContain(
+      "Unrecognized flag: --persistent in command supabase branches",
+    );
+    expect(result.message).toContain(
+      "Hint: --persistent is available on `supabase branches create` and `supabase branches update`. Pass it after the subcommand",
+    );
   });
 
   // The same fallback also covers an InvalidValue that does NOT have the

--- a/packages/config/src/io.ts
+++ b/packages/config/src/io.ts
@@ -667,12 +667,19 @@ export const loadProjectConfigFile = Effect.fnUntraced(function* (
   });
   const { document: normalized, deprecatedSections } = normalizeDeprecatedSMTPSections(document);
   // Warn on stderr (matching Go's normalizeDeprecatedSMTPConfig) so the notice
-  // never pollutes machine-readable stdout payloads.
+  // never pollutes machine-readable stdout payloads. Pinned to the real
+  // console (bypassing whatever `Console.Console` is ambient) so this always
+  // writes immediately, matching Go's synchronous `fmt.Fprintln(os.Stderr, ...)`
+  // (config.go:618,630) — a caller wrapping this in a deferred/buffered
+  // `Console.Console` (e.g. `apps/cli/src/shared/cli/run.ts`'s
+  // `withoutParseErrorHelpDump`, which only buffers the CLI parser's own
+  // duplicate-render writes and must never delay a handler's real output; see
+  // CLI-1901) must not silently swallow or delay it.
   for (const section of deprecatedSections) {
     const replacement = section.replace(/inbucket$/, "local_smtp");
     yield* Console.error(
       `WARN: config section [${section}] is deprecated. Please use [${replacement}] instead.`,
-    );
+    ).pipe(Effect.provideService(Console.Console, globalThis.console));
   }
 
   // Substitute `env(VAR)` references against `.env`/`.env.local`/ambient env
@@ -750,11 +757,13 @@ export const loadProjectConfigFile = Effect.fnUntraced(function* (
   // artifact, not the parity-relevant part, same call already made for
   // `LegacyInvalidPortEnvOverrideError` in the legacy shell. Not reproduced
   // byte-for-byte; `Console.error` supplies a normal trailing newline instead.
+  // Pinned to the real console for the same reason as the `[inbucket]`
+  // warning above — see that comment.
   if (goViperCompat) {
     for (const ext of deprecatedProviders) {
       yield* Console.error(
         `WARN: disabling deprecated "${ext}" provider. Please use [auth.external.${ext}_oidc] instead`,
-      );
+      ).pipe(Effect.provideService(Console.Console, globalThis.console));
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (legacy shell shared CLI runtime).

## What is the current behavior?

Fixes [CLI-1901](https://linear.app/supabase/issue/CLI-1901/legacy-cli-required-flagchoice-parse-errors-double-print-and-dump-help), originally surfaced as a side-finding during #5803's review (CLI-1859, `gen bearer-jwt --role required`).

Any legacy command whose flag parsing fails with a `CliError.ShowHelp`-wrapped error carrying a non-empty `errors` array (missing required flag, invalid `Flag.choice` value, unrecognized flag, etc.) printed a broken, non-Go-parity error:

```
$ supabase sso add --project-ref <ref>
DESCRIPTION
  Add and configure a new connection to a SSO identity provider...
USAGE
  supabase sso add [flags]
FLAGS
  ...
[... 20-30 line help doc, printed to STDOUT ...]

ERROR
  Missing required flag: --type
Error: required flag(s) "type" not set
Try rerunning the command with --debug to troubleshoot the error.
```

Root cause: the vendored `effect@4.0.0-beta.93` CLI library's `Command.runWith` (`.repos/effect/packages/effect/src/unstable/cli/Command.ts`) always dumps the full help doc via `Console.log` and, when `errors.length > 0`, also `Console.error`s the same errors — before this repo's own Go-parity renderer (`normalize-error.ts` + `run.ts`'s `handledProgram`) renders its own line for the same failure. This breaks stdout-piping scripts (e.g. `TOKEN=$(supabase gen bearer-jwt --role "$ROLE")` with an empty `$ROLE`) and violates this repo's own Go-parity contract (`apps/cli/CLAUDE.md`).

## What is the new behavior?

`run.ts` gains `withoutParseErrorHelpDump`, which wraps `Command.runWith(rootCommand, ...)(args)` with a buffering `Console.Console` and, once the run's outcome is known, disposes of the buffered writes per `classifyParseErrorConsoleOutput` — a three-way split that mirrors Go cobra's *actual* behavior (verified directly against the built `apps/cli-go/supabase-go` binary, not just assumed):

- **`drop`** — a missing required flag (`MissingOption`). Go's `PersistentPreRunE` sets `SilenceUsage = true` (`cmd/root.go:97`) *before* `ValidateRequiredFlags` runs, so this is a single clean stderr line, nothing on stdout.
- **`flush-help-doc-to-stderr`** — every other genuine parse/validation failure (unrecognized flag, invalid `Flag.choice` value, missing positional argument, unknown subcommand). These are raised during `ParseFlags`/`ValidateArgs`, *before* `SilenceUsage` is set — Go still shows a usage block for these, always on stderr, never stdout. The library's help doc isn't byte-identical to cobra's shorter usage template (see judgement calls below), but it's now on the right stream with no duplicate.
- **`flush-unchanged`** — success, `--help`, `--version`, `--completions`, and the bare-group-command help dump (`errors: []`, exit 0) — all untouched.

In every genuine-failure case, the library's own duplicate `Console.error` render is dropped; this repo's own `handledProgram` + `normalizeCause` render the single Go-parity line instead.

`normalize-error.ts`'s `ShowHelp`-envelope unwrap was also extended: since the library's duplicate render is now gone, a wrapped inner error with no Go-parity-specific mapping (`UnrecognizedOption`, `DuplicateOption`, `MissingArgument`, `UnknownSubcommand`, or a non-doubled-prefix `InvalidValue`) now falls back to that inner error's own `.message` instead of the useless generic "Help requested" envelope text — otherwise removing the duplicate would have silently regressed those tags from "informative, but printed twice" to "printed once, uselessly."

Tests: pure-predicate unit tests for the three-way classifier (`run.unit.test.ts`), integration tests exercising the real buffering/flush wiring against `legacyBranchesCommand` and a synthetic required-flag command via a `Console.Console` test double (`run.integration.test.ts` — not `vi.spyOn`, which reliably breaks call detection when spying `console.log` and `console.error` in the same test under this repo's Bun+Vitest combination), and e2e tests proving the real subprocess stdout/stderr streams against `branches --bogus-flag` and `sso add` (missing/invalid `--type`, the issue's own named repro target).

### Judgement calls left open

- **Wording, not structure**: some of this repo's existing error wording still differs from Go's exact text for these paths (e.g. Go's bare `required flag(s) "type" not set` vs this repo's `Error: required flag(s) "type" not set` with an extra `Error: ` prefix; Go's `invalid argument "bogus" for "-t, --type" flag: must be one of [ saml ]` vs this repo's `Invalid value for flag --type: "bogus". Expected "saml", got "bogus"`). Both pre-date this fix and are unrelated to the stdout-pollution/duplicate-print bug it targets — flagged by review as a possible follow-up, not fixed here to keep this PR's diff focused.
- **Usage-block content, not stream**: the help/usage text now correctly lands on stderr (never stdout) for the `flush-help-doc-to-stderr` class, but its *content* is this library's own (longer) help doc, not cobra's shorter usage template. True byte-parity there would need a second, purpose-built "usage-only" formatter — out of scope for this fix.
- **Pre-existing terminal-escape echo**: user-supplied argv tokens (e.g. an unrecognized flag name) are echoed verbatim into error messages with no control-character stripping. Unaffected in kind by this change (just relocated/de-duplicated); flagged by security review as low-priority and better suited to its own issue if the team wants to harden it.
- The issue's secondary, explicitly-optional finding (`internal/command.ts:243` misreporting `Flag.optional` status in `--output-format json` help docs) is a separate, unrelated code path in the same vendored module — deliberately left unaddressed here to keep this PR scoped to the double-print/stdout-dump bug.