### PR TITLE
fix(cli): match Go path.Match character-class negation in legacy seed globbing

### DIFF
--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -30,11 +30,8 @@ import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.
 import { legacyDropUserSchemas } from "../shared/legacy-drop-schemas.ts";
 import { LegacyDbBootstrapSeam } from "../shared/legacy-db-bootstrap.seam.service.ts";
 import { legacyListLocalMigrations } from "../shared/legacy-pgdelta.cache.ts";
-import {
-  legacyGetPendingSeeds,
-  legacyMatchPattern,
-  legacySeedData,
-} from "../shared/legacy-seed-ops.ts";
+import { legacyGetPendingSeeds, legacySeedData } from "../shared/legacy-seed-ops.ts";
+import { legacyPathMatch } from "../../../shared/legacy-path-match.ts";
 import { legacyUpsertVaultSecrets } from "../../../shared/legacy-vault.ts";
 import { legacySeedBucketsRun } from "../../../shared/legacy-seed-buckets.ts";
 import type { LegacyDbResetFlags } from "./reset.command.ts";
@@ -206,7 +203,9 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       const entries = yield* fs
         .readDirectory(migrationsDir)
         .pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>));
-      const found = entries.some((name) => legacyMatchPattern(`${v}_*.sql`, path.basename(name)));
+      const found = entries.some(
+        (name) => legacyPathMatch(`${v}_*.sql`, path.basename(name)).matched,
+      );
       if (!found) {
         return yield* Effect.fail(
           new LegacyDbResetMigrationFileError({

--- a/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.ts
@@ -5,6 +5,7 @@ import { Output } from "../../../../shared/output/output.service.ts";
 import type { LegacyDbExecError } from "../../../shared/legacy-db-connection.errors.ts";
 import type { LegacyDbSession } from "../../../shared/legacy-db-connection.service.ts";
 import { legacyCreateSeedTable } from "../../../shared/legacy-migration-history.ts";
+import { legacyPathMatch } from "../../../shared/legacy-path-match.ts";
 import { legacySplitAndTrim } from "../../../shared/legacy-sql-split.ts";
 
 /**
@@ -26,74 +27,6 @@ export interface LegacySeedFile {
 }
 
 const META_CHARS = /[*?[\\]/u;
-
-/**
- * Go's `path.Match` for a single filename (no `/`). Supports `*` (any run of
- * non-separator chars), `?` (one char), `[...]` classes with ranges and a
- * leading `^`/`!` negation, and `\` escapes. Filenames never contain `/`, so the
- * separator subtlety in Go's matcher does not apply here.
- */
-export function legacyMatchPattern(pattern: string, name: string): boolean {
-  const matchClass = (cls: string, ch: string): boolean => {
-    let negated = false;
-    let body = cls;
-    if (body.startsWith("^") || body.startsWith("!")) {
-      negated = true;
-      body = body.slice(1);
-    }
-    let matched = false;
-    for (let k = 0; k < body.length; k++) {
-      if (body[k + 1] === "-" && k + 2 < body.length) {
-        if (ch >= body[k]! && ch <= body[k + 2]!) matched = true;
-        k += 2;
-      } else if (body[k] === ch) {
-        matched = true;
-      }
-    }
-    return matched !== negated;
-  };
-
-  const match = (p: number, n: number): boolean => {
-    while (p < pattern.length) {
-      const pc = pattern[p]!;
-      if (pc === "*") {
-        // Collapse consecutive stars, then try to match the rest at every offset.
-        while (pattern[p] === "*") p++;
-        if (p === pattern.length) return true;
-        for (let k = n; k <= name.length; k++) {
-          if (match(p, k)) return true;
-        }
-        return false;
-      }
-      if (n >= name.length) return false;
-      if (pc === "?") {
-        p++;
-        n++;
-        continue;
-      }
-      if (pc === "[") {
-        const end = pattern.indexOf("]", p + 1);
-        if (end === -1) return false;
-        if (!matchClass(pattern.slice(p + 1, end), name[n]!)) return false;
-        p = end + 1;
-        n++;
-        continue;
-      }
-      if (pc === "\\" && p + 1 < pattern.length) {
-        if (pattern[p + 1] !== name[n]) return false;
-        p += 2;
-        n++;
-        continue;
-      }
-      if (pc !== name[n]) return false;
-      p++;
-      n++;
-    }
-    return n === name.length;
-  };
-
-  return match(0, 0);
-}
 
 /** Result of resolving `[db.seed].sql_paths` against the workspace. */
 interface LegacyGlobResult {
@@ -202,7 +135,7 @@ const globOne = (
         .readDirectory(absDir)
         .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
       for (const name of names) {
-        if (legacyMatchPattern(file, name)) {
+        if (legacyPathMatch(file, name).matched) {
           result.push(d === "" ? name : `${d}/${name}`);
         }
       }

--- a/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.ts
@@ -5,7 +5,7 @@ import { Output } from "../../../../shared/output/output.service.ts";
 import type { LegacyDbExecError } from "../../../shared/legacy-db-connection.errors.ts";
 import type { LegacyDbSession } from "../../../shared/legacy-db-connection.service.ts";
 import { legacyCreateSeedTable } from "../../../shared/legacy-migration-history.ts";
-import { legacyPathMatch } from "../../../shared/legacy-path-match.ts";
+import { LEGACY_BAD_PATTERN_MESSAGE, legacyPathMatch } from "../../../shared/legacy-path-match.ts";
 import { legacySplitAndTrim } from "../../../shared/legacy-sql-split.ts";
 
 /**
@@ -41,8 +41,10 @@ interface LegacyGlobResult {
  * over `fs.Glob` (`pkg/config/config.go:102-124`). Each pattern is first joined
  * under the `supabase/` directory (Go resolves `sql_paths` at config load,
  * `config.go:884`). Matches per pattern are sorted; the overall result preserves
- * first-seen order across patterns. A pattern that matches nothing contributes a
- * `no files matched pattern: <pattern>` warning but is not fatal.
+ * first-seen order across patterns. A pattern that matches nothing, or is malformed
+ * (Go's `path.ErrBadPattern`, e.g. an unterminated `[` class), contributes a warning
+ * but is not fatal — mirroring `fs.Glob`'s up-front `Match(pattern, "")` validation
+ * (`io/fs/glob.go`) and the sibling seed pipeline's `legacy-seed.ts:resolveSeedFiles`.
  */
 const legacyGlobSeedFiles = Effect.fnUntraced(function* (
   fs: FileSystem.FileSystem,
@@ -61,6 +63,13 @@ const legacyGlobSeedFiles = Effect.fnUntraced(function* (
     // globs those resolved paths without re-prefixing (`config.go:102-124`), so only
     // normalize separators here; re-joining `supabase/` would double-prefix.
     const pattern = toSlash(rawPattern);
+    // Go's `fs.Glob` validates the whole pattern up front (`Match(pattern, "")`); a
+    // malformed glob is reported as `failed to glob files: <ErrBadPattern>` and
+    // contributes no matches, rather than the misleading "no files matched" below.
+    if (legacyPathMatch(pattern, "").badPattern) {
+      errors.push(`failed to glob files: ${LEGACY_BAD_PATTERN_MESSAGE}`);
+      continue;
+    }
     const matches = yield* globOne(fs, path, workdir, pattern);
     if (matches.length === 0) {
       errors.push(`no files matched pattern: ${pattern}`);

--- a/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.unit.test.ts
@@ -7,7 +7,7 @@ import { Data, Effect, Exit, FileSystem, Path } from "effect";
 
 import { mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import type { LegacyDbSession } from "../../../shared/legacy-db-connection.service.ts";
-import { legacyMatchPattern, legacySeedData } from "./legacy-seed-ops.ts";
+import { legacyGetPendingSeeds, legacySeedData } from "./legacy-seed-ops.ts";
 
 class TestError extends Data.TaggedError("TestError")<{ readonly message: string }> {}
 
@@ -29,40 +29,35 @@ function fakeSeedSession() {
   return { session, calls };
 }
 
-describe("legacyMatchPattern", () => {
-  it("matches a literal filename", () => {
-    expect(legacyMatchPattern("seed.sql", "seed.sql")).toBe(true);
-    expect(legacyMatchPattern("seed.sql", "other.sql")).toBe(false);
-  });
-
-  it("matches `*` against any run of characters", () => {
-    expect(legacyMatchPattern("*.sql", "seed.sql")).toBe(true);
-    expect(legacyMatchPattern("*.sql", "0001_init.sql")).toBe(true);
-    expect(legacyMatchPattern("*.sql", "seed.txt")).toBe(false);
-    expect(legacyMatchPattern("seed.*", "seed.sql")).toBe(true);
-  });
-
-  it("matches `?` against exactly one character", () => {
-    expect(legacyMatchPattern("seed?.sql", "seed1.sql")).toBe(true);
-    expect(legacyMatchPattern("seed?.sql", "seed12.sql")).toBe(false);
-    expect(legacyMatchPattern("seed?.sql", "seed.sql")).toBe(false);
-  });
-
-  it("matches character classes with ranges and negation", () => {
-    expect(legacyMatchPattern("seed[0-9].sql", "seed5.sql")).toBe(true);
-    expect(legacyMatchPattern("seed[0-9].sql", "seedx.sql")).toBe(false);
-    expect(legacyMatchPattern("seed[!0-9].sql", "seedx.sql")).toBe(true);
-    expect(legacyMatchPattern("seed[!0-9].sql", "seed5.sql")).toBe(false);
-  });
-
-  it("honors backslash escapes", () => {
-    expect(legacyMatchPattern("seed\\*.sql", "seed*.sql")).toBe(true);
-    expect(legacyMatchPattern("seed\\*.sql", "seedx.sql")).toBe(false);
-  });
-
-  it("collapses consecutive stars", () => {
-    expect(legacyMatchPattern("**.sql", "seed.sql")).toBe(true);
-  });
+// Glob matching itself is `legacyPathMatch` (`../../../shared/legacy-path-match.ts`),
+// a faithful port of Go's `path.Match` already covered by
+// `legacy-path-match.unit.test.ts` (including the `^`-only negation / `!`-is-literal
+// rule this file used to duplicate — and get wrong — in a local `legacyMatchPattern`).
+// This exercises that the seed pipeline's own glob resolution (`legacyGetPendingSeeds`)
+// actually uses it end to end, per Go's `config.Glob.Files` → `fs.Glob` → `path.Match`.
+describe("legacyGetPendingSeeds (glob character classes)", () => {
+  it.effect(
+    "treats a leading `!` in a bracket class as literal, not negation (Go path.Match parity)",
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), "legacy-seed-glob-"));
+      writeFileSync(join(dir, "a.sql"), "select 1;");
+      writeFileSync(join(dir, "b.sql"), "select 2;");
+      const { session } = fakeSeedSession();
+      return Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        // Go's `[!a]` is a positive class of the literal members `!` and `a` — only a
+        // leading `^` negates. So this pattern matches `a.sql`, not `b.sql` (the old
+        // shell-style bug negated on `!` too, and would have matched `b.sql` instead).
+        const pending = yield* legacyGetPendingSeeds(session, fs, path, ["[!a].sql"], dir);
+        expect(pending.map((seed) => seed.path)).toEqual(["a.sql"]);
+        rmSync(dir, { recursive: true, force: true });
+      }).pipe(
+        Effect.provide(mockOutput({ format: "text" }).layer),
+        Effect.provide(BunServices.layer),
+      );
+    },
+  );
 });
 
 const runSeed = (

--- a/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-seed-ops.unit.test.ts
@@ -58,6 +58,28 @@ describe("legacyGetPendingSeeds (glob character classes)", () => {
       );
     },
   );
+
+  it.effect(
+    "warns Go's bad-pattern message for an unterminated bracket class, not a bogus no-match",
+    () => {
+      // An unclosed `[` is malformed per Go's `path.Match` grammar (`ErrBadPattern`), which
+      // `fs.Glob` reports as `failed to glob files: syntax error in pattern` — not the
+      // generic `no files matched pattern` a same-shaped but well-formed glob would get.
+      const dir = mkdtempSync(join(tmpdir(), "legacy-seed-glob-"));
+      const { session } = fakeSeedSession();
+      const out = mockOutput({ format: "text" });
+      return Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const pending = yield* legacyGetPendingSeeds(session, fs, path, ["seed[.sql"], dir);
+        expect(pending).toEqual([]);
+        expect(out.rawChunks.map((c) => c.text).join("")).toContain(
+          "failed to glob files: syntax error in pattern",
+        );
+        rmSync(dir, { recursive: true, force: true });
+      }).pipe(Effect.provide(out.layer), Effect.provide(BunServices.layer));
+    },
+  );
 });
 
 const runSeed = (


### PR DESCRIPTION
## Current Behavior

`legacyMatchPattern` (the glob matcher backing `[db.seed].sql_paths` and `db reset --version`) treated a leading `!` inside a `[...]` bracket class the same as `^` — shell/fnmatch-style negation. Go's `path.Match` (which `apps/cli-go`'s `fs.Glob`/`afero.Glob` actually use for this) only negates on `^`; `!` is an ordinary literal class member. So a pattern like `[!a].sql` matched `b.sql` in the TS port where the Go CLI would not, meaning `db push --include-seed` / `db reset` could read, hash, and execute seed SQL outside the set the user's Go-compatible config intended.

Verified directly against the real Go stdlib source (`$GOROOT/src/path/match.go`) available on this machine, and against `apps/cli-go/pkg/config/config.go` (`fs.Glob`) and `apps/cli-go/internal/migration/repair/repair.go` (`GetMigrationFile` / `afero.Glob`) — both go through the same `path.Match` grammar.

## New Behavior

Rather than patching the bug in place, this fixes it by deleting the duplicate: `apps/cli/src/legacy/shared/legacy-path-match.ts` (`legacyPathMatch`) is already a byte-faithful, already-tested port of Go's `path.Match` — introduced earlier for the sibling `db new`/migration seed pipeline (`legacy-seed.ts`) — with correct `^`-only negation, escapes, and malformed-pattern (`ErrBadPattern`) detection. `legacyMatchPattern` and its `matchClass`/`match` helpers are removed, and both call sites are rewired onto `legacyPathMatch`:

- `legacy-seed-ops.ts`'s own seed glob (`globOne`)
- `reset.handler.ts`'s `--version` migration-file glob (behavior-identical here — `v` is validated as digits-only before the glob ever runs, so no bracket syntax is reachable on this path)

A follow-up commit closes a related gap all four `review-changes` reviewers independently flagged: `legacyGlobSeedFiles` was discarding `legacyPathMatch`'s `badPattern` signal, so a malformed pattern (e.g. an unterminated `[` class) fell through to the generic `no files matched pattern` warning instead of Go's `failed to glob files: syntax error in pattern` (`fs.Glob`'s up-front `Match(pattern, "")` validation). The sibling pipeline (`legacy-seed.ts:resolveSeedFiles`) already did this correctly — mirrored it here now that both pipelines share `legacyPathMatch`.

**Behavior change worth calling out for release notes:** any existing `[db.seed].sql_paths` config relying on `[!x]` as shell-style negation will now select a different (Go-correct) set of seed files with no error — e.g. `[!0-9]` now means "the literal characters `!`, `0`-`9`", not "not a digit". Use `[^x]` for negation, matching Go/the real Go CLI. This is a correctness fix (the legacy shell's contract is strict Go parity), but it is a silent behavior change for anyone who had unknowingly depended on the old, non-Go-compatible negation.

## Related Issue(s)

Fixes https://linear.app/supabase/issue/CLI-1880

## Notes for reviewers

`review-changes` (architect/engineer/security/DX, run against the first commit) all returned APPROVE/SHIP IT. Judgement calls deliberately left open rather than expanded into this PR:

- The two seed pipelines (`legacy-seed-ops.ts` and `legacy-seed.ts`) still duplicate the outer `fs.Glob`-style directory-walk/dedup logic (both now delegate the leaf matcher to `legacyPathMatch`, but the surrounding glob-resolution code is still two separate ports). Flagged by the architect reviewer as a good candidate for a follow-up consolidation, out of scope for this fix.
- `sql_paths`' glob dialect (Go `path.Match` semantics, `^`-only negation, no POSIX classes) isn't documented anywhere user-facing (`packages/config/src/db.ts`). Flagged by the DX reviewer as worth a docs follow-up, not blocking.