### PR TITLE
fix(stack): Pin realtime database connection to IPv4 in docker mode

### DIFF
--- a/packages/stack/src/services/realtime.ts
+++ b/packages/stack/src/services/realtime.ts
@@ -45,6 +45,10 @@ export const makeRealtimeServiceDocker = (opts: DockerRealtimeOptions): ServiceD
     env: {
       PORT: String(opts.port),
       DB_HOST: opts.dbHost,
+      // In docker mode DB_HOST is host.docker.internal, which resolves to IPv4
+      // only on Docker Desktop; pin IPv4 so realtime doesn't hang trying to
+      // reach the database over IPv6 (#5788).
+      DB_IP_VERSION: "ipv4",
       DB_PORT: String(opts.dbPort),
       DB_USER: "postgres",
       DB_PASSWORD: "postgres",

--- a/packages/stack/src/services/services.unit.test.ts
+++ b/packages/stack/src/services/services.unit.test.ts
@@ -14,6 +14,7 @@ import {
 import { makePostgresService, makePostgresServiceDocker } from "./postgres.ts";
 import { makePostgrestService } from "./postgrest.ts";
 import { makePoolerServiceDocker, poolerContainerPorts } from "./pooler.ts";
+import { makeRealtimeServiceDocker } from "./realtime.ts";
 import { LOCAL_S3_PROTOCOL_ACCESS_KEY_ID, LOCAL_S3_PROTOCOL_ACCESS_KEY_SECRET } from "./storage.ts";
 import { makeStudioServiceDocker } from "./studio.ts";
 import { makeVectorServiceDocker } from "./vector.ts";
@@ -315,6 +316,31 @@ describe("makeAuthServiceDocker", () => {
     expect(def.supervision).toEqual({
       orphanCleanup: [{ _tag: "DockerRemove", containerName: `supabase-auth-${API_PORT}` }],
     });
+  });
+});
+
+describe("makeRealtimeServiceDocker", () => {
+  it("pins the database connection to IPv4 so realtime doesn't hang over IPv6 (#5788)", () => {
+    const def = makeRealtimeServiceDocker({
+      image: dockerImageForService("realtime", DEFAULT_VERSIONS.realtime),
+      port: 4000,
+      apiPort: API_PORT,
+      dbHost: "host.docker.internal",
+      dbPort: DB_PORT,
+      jwtSecret: JWT_SECRET,
+      jwtJwks: "{}",
+      tenantId: "realtime-dev",
+      encryptionKey: "supabaserealtime",
+      secretKeyBase: "0".repeat(64),
+      maxHeaderLength: 4096,
+      networkArgs: [...LINUX_HOST_GATEWAY_ARGS],
+      dependencies: [{ service: "postgres", condition: "healthy" }],
+    });
+
+    expect(def.name).toBe("realtime");
+    expect(def.command).toBe("docker");
+    expect(def.args).toContain("DB_IP_VERSION=ipv4");
+    expect(def.dependencies).toEqual([{ service: "postgres", condition: "healthy" }]);
   });
 });
 


### PR DESCRIPTION
In docker mode the realtime service connects to the database via `host.docker.internal`, which resolves to IPv4 only on Docker Desktop. Without `DB_IP_VERSION` set, realtime attempts IPv6 first and hangs, so `stack.start()` never completes.

This sets `DB_IP_VERSION=ipv4` on the docker realtime service so it connects over IPv4.

Fixes #5788.
