### PR TITLE
fix(cli): restore Edge Function docker bundling

### DIFF
--- a/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
@@ -1549,6 +1549,44 @@ describe("functions deploy", () => {
     }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
   });
 
+  it.live("bundles when Docker only shares the project directory", () => {
+    const tempDir = makeTempDir();
+    const sharedOutputRoot = join(tempDir, "supabase", ".temp");
+    let outputPath = "";
+    const child = mockChildProcessSpawner({
+      exitCode: 0,
+      onSpawn: (record) => {
+        if (record.command !== "docker" || record.args[0] !== "run") {
+          return;
+        }
+        outputPath = resolveDockerOutputPath(record.args);
+        if (!outputPath.startsWith(`${sharedOutputRoot}${sep}`)) {
+          return;
+        }
+        mkdirSync(dirname(outputPath), { recursive: true });
+        writeFileSync(outputPath, "eszip-test-output");
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => writeProjectConfig(tempDir));
+      yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+
+      const { layer } = setup(tempDir, {
+        rawArgs: ["functions", "deploy", "hello-world", "--use-docker"],
+        childLayer: child.layer,
+      });
+
+      yield* functionsDeploy({
+        ...BASE_FLAGS,
+        functionNames: ["hello-world"],
+        useDocker: true,
+      }).pipe(Effect.provide(layer));
+
+      expect(outputPath.startsWith(`${sharedOutputRoot}${sep}`)).toBe(true);
+    }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
+  });
+
   it.live("forwards npm auth environment to the Docker bundler", () => {
     const tempDir = makeTempDir();
     const previousRegistry = process.env["NPM_CONFIG_REGISTRY"];

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -1,7 +1,6 @@
 import { brotliCompressSync, constants as zlibConstants } from "node:zlib";
-import { chmod, mkdtemp, readFile, readdir, realpath, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { tmpdir } from "node:os";
 import { URL } from "node:url";
 import { FunctionResponse, operationDefinitions, type ApiClient } from "@supabase/api/effect";
 import {
@@ -1334,8 +1333,10 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
   const output = yield* Output;
   yield* output.raw(`Bundling Function: ${config.slug}\n`, "stderr");
 
+  const outputRoot = resolve(functionsDir, "..", ".temp");
+  yield* Effect.tryPromise(() => mkdir(outputRoot, { recursive: true }));
   const outputDir = yield* Effect.tryPromise(() =>
-    mkdtemp(join(tmpdir(), `.supabase-output-${config.slug}-`)),
+    mkdtemp(join(outputRoot, `.output_${config.slug}-`)),
   );
   try {
     yield* Effect.tryPromise(() => chmod(outputDir, 0o777));

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -1336,7 +1336,7 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
   const outputRoot = resolve(functionsDir, "..", ".temp");
   yield* Effect.tryPromise(() => mkdir(outputRoot, { recursive: true }));
   const outputDir = yield* Effect.tryPromise(() =>
-    mkdtemp(join(outputRoot, `.output_${config.slug}-`)),
+    mkdtemp(join(outputRoot, `.supabase-output-${config.slug}-`)),
   );
   try {
     yield* Effect.tryPromise(() => chmod(outputDir, 0o777));


### PR DESCRIPTION
## TL;DR

docker-based deploys could finish bundling and then fail with `failed to open eszip: ENOENT ... output.eszip`  <br>the [Go CLI wrote bundle output to project-local `supabase/.temp`](<https://github.com/supabase/cli/blob/249b9ec577f178350c686e1a581469d680e054ba/apps/cli-go/internal/functions/deploy/bundle.go#L36>)

but the [TypeScript port moved it to the host OS temporary directory](<https://github.com/supabase/cli/blob/249b9ec577f178350c686e1a581469d680e054ba/apps/cli/src/shared/functions/deploy.ts#L1337-L1340>)  <br>typically under `/var/folders/...`, which may not be shared with Docker Desktop's VM

this restores the Go CLI's project local output behavior while retaining unique bundle directories & cleanup...

## ref:

* towards: supabase/cli#5735
* follow up to:  <br>[https://github.com/supabase/cli/pull/5755](<https://github.com/supabase/cli/pull/5755>)  <br>[https://github.com/supabase/cli/pull/5747](<https://github.com/supabase/cli/pull/5747>)