### PR TITLE
fix(cli): redact API keys

### DIFF
--- a/apps/cli/src/shared/telemetry/tracing.layer.ts
+++ b/apps/cli/src/shared/telemetry/tracing.layer.ts
@@ -76,6 +76,7 @@ class ExportableSpan implements Tracer.Span {
   }
 
   attribute(key: string, value: unknown): void {
+    if (key.endsWith(".header.apikey")) return;
     this.attributes.set(key, value);
   }
 

--- a/apps/cli/src/shared/telemetry/tracing.layer.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/tracing.layer.unit.test.ts
@@ -242,6 +242,33 @@ describe("tracingLayer – span behaviour", () => {
     );
   });
 
+  it.live("does not write API keys to trace files", () => {
+    const home = makeTempDir();
+    const tracesDir = path.join(home, ".supabase", "traces");
+    const secretKey = `sb_secret_${"a".repeat(40)}`;
+    return Effect.gen(function* () {
+      const tracer = yield* Tracer.Tracer;
+      const span = tracer.span(makeSpanOptions());
+      span.attribute("http.request.header.apikey", secretKey);
+      span.end(BigInt(Date.now() + 100) * 1_000_000n, Exit.void);
+    }).pipe(
+      Effect.provide(buildTracingLayer({ home })),
+      Effect.ensuring(
+        Effect.sync(() => {
+          try {
+            const traceFile = readdirSync(tracesDir).find((file) => file.endsWith(".ndjson"));
+            expect(traceFile).toBeDefined();
+            const trace = readFileSync(path.join(tracesDir, traceFile!), "utf8");
+            expect(trace).not.toContain(secretKey);
+            expect(trace).not.toContain("http.request.header.apikey");
+          } finally {
+            rmSync(home, { recursive: true, force: true });
+          }
+        }),
+      ),
+    );
+  });
+
   it.live("span end does NOT export to NDJSON when SUPABASE_TELEMETRY_DISABLED=1", () => {
     const home = makeTempDir();
     const configDir = path.join(home, ".supabase");


### PR DESCRIPTION
## TL;DR

fixes project keys being written to CLI traces, matching the Go cli's behavior...

## Problem

The Go-cli use to send keys through the `apikey` header:

[https://github.com/supabase/cli/blob/2cb2d6e83a3f7d65ebdab905c35b8f8257e685dc/apps/cli-go/pkg/fetcher/gateway.go#L22-L33](<https://github.com/supabase/cli/blob/2cb2d6e83a3f7d65ebdab905c35b8f8257e685dc/apps/cli-go/pkg/fetcher/gateway.go#L22-L33>)

Its debug transport only logs the request method and URL:

[https://github.com/supabase/cli/blob/2cb2d6e83a3f7d65ebdab905c35b8f8257e685dc/apps/cli-go/internal/debug/http.go#L14-L16](<https://github.com/supabase/cli/blob/2cb2d6e83a3f7d65ebdab905c35b8f8257e685dc/apps/cli-go/internal/debug/http.go#L14-L16>)

Effect tracing captures request headers, but `apikey` is not included in its default redaction list...<br>this allowed values to be written to local traces...

## sol

exclude `apikey` header attributes at the tracing boundary....<br>requests and all other telemetry remain unchanged, while NDJSON and debug output no longer contain project keys....

## ref:

* reported in: supabase/cli#5890