### PR TITLE
Fix for supabase start reports "already running" when all local conta…

### DIFF
--- a/apps/cli-go/internal/db/lint/lint_test.go
+++ b/apps/cli-go/internal/db/lint/lint_test.go
@@ -38,7 +38,9 @@ func TestLintCommand(t *testing.T) {
 	gock.New(utils.Docker.DaemonHost()).
 		Get("/v" + utils.Docker.ClientVersion() + "/containers").
 		Reply(http.StatusOK).
-		JSON(container.InspectResponse{})
+		JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+			State: &container.State{Running: true},
+		}})
 	// Setup db response
 	expected := Result{
 		Function: "22751",

--- a/apps/cli-go/internal/db/reset/reset_test.go
+++ b/apps/cli-go/internal/db/reset/reset_test.go
@@ -46,7 +46,9 @@ func TestResetCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		gock.New(utils.Docker.DaemonHost()).
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK)
@@ -145,7 +147,9 @@ func TestResetCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		gock.New(utils.Docker.DaemonHost()).
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			ReplyError(errors.New("network error"))

--- a/apps/cli-go/internal/db/start/start_test.go
+++ b/apps/cli-go/internal/db/start/start_test.go
@@ -196,7 +196,9 @@ func TestStartCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Run test
 		err := Run(context.Background(), "", fsys)
 		// Check error

--- a/apps/cli-go/internal/functions/serve/serve_test.go
+++ b/apps/cli-go/internal/functions/serve/serve_test.go
@@ -38,7 +38,9 @@ func TestServeCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		containerId := "supabase_edge_runtime_test"
 		gock.New(utils.Docker.DaemonHost()).
 			Delete("/v" + utils.Docker.ClientVersion() + "/containers/" + containerId).
@@ -100,7 +102,9 @@ func TestServeCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Run test
 		err := Run(context.Background(), ".env", nil, "", RuntimeOption{}, fsys)
 		// Check error
@@ -120,7 +124,9 @@ func TestServeCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_test/json").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Run test
 		err := Run(context.Background(), ".env", cast.Ptr(true), "import_map.json", RuntimeOption{}, fsys)
 		// Check error

--- a/apps/cli-go/internal/gen/types/types_test.go
+++ b/apps/cli-go/internal/gen/types/types_test.go
@@ -42,7 +42,9 @@ func TestGenLocalCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world\n"))
 		// Setup mock postgres
@@ -79,7 +81,9 @@ func TestGenLocalCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/images").
 			Reply(http.StatusServiceUnavailable)
@@ -100,7 +104,9 @@ func TestGenLocalCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId).
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		apitest.MockDockerStart(utils.Docker, imageUrl, containerId)
 		require.NoError(t, apitest.MockDockerLogs(utils.Docker, containerId, "hello world\n"))
 		// Setup mock postgres

--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -58,6 +58,20 @@ func Run(ctx context.Context, fsys afero.Fs, excludedContainers []string, ignore
 		} else if !errors.Is(err, utils.ErrNotRunning) {
 			return err
 		}
+		// The project's containers may exist but be stopped rather than
+		// missing entirely, e.g. when Docker Desktop restarts without
+		// honouring container restart policies. Clear out any leftover
+		// containers from a previous session so the ContainerCreate calls
+		// below don't collide on name, while preserving named volumes so
+		// local data survives the restart.
+		if exists, err := utils.HasProjectContainers(ctx, utils.Config.ProjectId); err != nil {
+			return err
+		} else if exists {
+			fmt.Fprintln(os.Stderr, "Found stopped containers from a previous session, cleaning up before restart...")
+			if err := utils.DockerRemoveAll(ctx, os.Stderr, utils.Config.ProjectId); err != nil {
+				return err
+			}
+		}
 		if err := flags.LoadProjectRef(fsys); err == nil {
 			_ = services.CheckVersions(ctx, fsys)
 		}

--- a/apps/cli-go/internal/start/start_test.go
+++ b/apps/cli-go/internal/start/start_test.go
@@ -100,7 +100,9 @@ func TestStartCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_start/json").
@@ -121,6 +123,55 @@ func TestStartCommand(t *testing.T) {
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
+	t.Run("cleans up stopped containers before restarting", func(t *testing.T) {
+		// Setup in-memory fs
+		fsys := afero.NewMemMapFs()
+		require.NoError(t, utils.WriteConfig(fsys, false))
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		// Db container exists but exited, e.g. after Docker Desktop restarts
+		// without honouring restart policies.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_start/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: false, Status: "exited"},
+			}})
+		// HasProjectContainers finds leftover containers from a previous session.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON([]container.Summary{{ID: "supabase_db_start"}})
+		// DockerRemoveAll re-lists, stops, and prunes them.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON([]container.Summary{{ID: "supabase_db_start"}})
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_start/stop").
+			Reply(http.StatusNoContent)
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/prune").
+			Reply(http.StatusOK).
+			JSON(container.PruneReport{})
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/networks/prune").
+			Reply(http.StatusOK).
+			JSON(network.PruneReport{})
+		// Let the flow fail deterministically once it reaches image pulling,
+		// well past the recovery logic under test.
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/images/").
+			ReplyError(errors.New("network error"))
+		// Run test
+		err := Run(context.Background(), fsys, []string{}, false)
+		// Check error
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, utils.ErrNotRunning)
+		assert.NotContains(t, err.Error(), "already running")
+	})
+
 	t.Run("show status without health check if database is already running and ignored", func(t *testing.T) {
 		var running []container.Summary
 		for _, name := range utils.GetDockerIds() {
@@ -137,7 +188,9 @@ func TestStartCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/supabase_db_start/json").

--- a/apps/cli-go/internal/utils/docker.go
+++ b/apps/cli-go/internal/utils/docker.go
@@ -145,6 +145,22 @@ func DockerRemoveAll(ctx context.Context, w io.Writer, projectId string) error {
 	return nil
 }
 
+// HasProjectContainers returns true if any docker containers exist for the
+// given project, running or not. Used to distinguish a project that was
+// never started (nothing to recover) from one whose containers exist but
+// exited, e.g. after Docker Desktop restarts without honouring restart
+// policies.
+func HasProjectContainers(ctx context.Context, projectId string) (bool, error) {
+	containers, err := Docker.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: CliProjectFilter(projectId),
+	})
+	if err != nil {
+		return false, errors.Errorf("failed to list containers: %w", err)
+	}
+	return len(containers) > 0, nil
+}
+
 func CliProjectFilter(projectId string) filters.Args {
 	if len(projectId) == 0 {
 		return filters.NewArgs(

--- a/apps/cli-go/internal/utils/docker_test.go
+++ b/apps/cli-go/internal/utils/docker_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -383,4 +384,51 @@ func TestExecOnce(t *testing.T) {
 	})
 
 	// TODO: mock tcp hijack
+}
+
+func TestHasProjectContainers(t *testing.T) {
+	t.Run("returns true when containers exist", func(t *testing.T) {
+		// Setup mock server
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON([]container.Summary{{ID: "supabase_db_test"}})
+		// Run test
+		exists, err := HasProjectContainers(context.Background(), "test")
+		// Check error
+		assert.NoError(t, err)
+		assert.True(t, exists)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("returns false when no containers exist", func(t *testing.T) {
+		// Setup mock server
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/json").
+			Reply(http.StatusOK).
+			JSON([]container.Summary{})
+		// Run test
+		exists, err := HasProjectContainers(context.Background(), "test")
+		// Check error
+		assert.NoError(t, err)
+		assert.False(t, exists)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on failure to list containers", func(t *testing.T) {
+		// Setup mock server
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/json").
+			ReplyError(errors.New("network error"))
+		// Run test
+		_, err := HasProjectContainers(context.Background(), "test")
+		// Check error
+		assert.ErrorContains(t, err, "failed to list containers")
+	})
 }

--- a/apps/cli-go/internal/utils/misc.go
+++ b/apps/cli-go/internal/utils/misc.go
@@ -146,7 +146,8 @@ func AssertSupabaseDbIsRunning() error {
 }
 
 func AssertServiceIsRunning(ctx context.Context, containerId string) error {
-	if _, err := Docker.ContainerInspect(ctx, containerId); err != nil {
+	resp, err := Docker.ContainerInspect(ctx, containerId)
+	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return errors.New(ErrNotRunning)
 		}
@@ -154,6 +155,12 @@ func AssertServiceIsRunning(ctx context.Context, containerId string) error {
 			CmdSuggestion = suggestDockerInstall
 		}
 		return errors.Errorf("failed to inspect service: %w", err)
+	}
+	// A container that exists but has exited (e.g. Docker Desktop restarted
+	// without honouring restart policies) is not running, even though
+	// ContainerInspect succeeds.
+	if resp.ContainerJSONBase == nil || resp.State == nil || !resp.State.Running {
+		return errors.New(ErrNotRunning)
 	}
 	return nil
 }

--- a/apps/cli-go/internal/utils/misc_test.go
+++ b/apps/cli-go/internal/utils/misc_test.go
@@ -1,15 +1,20 @@
 package utils
 
 import (
+	"context"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/h2non/gock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/cli/internal/testing/apitest"
 	"github.com/supabase/cli/pkg/config"
 )
 
@@ -197,6 +202,53 @@ func TestWriteFile(t *testing.T) {
 		written, err := afero.ReadFile(fsys, path)
 		assert.NoError(t, err)
 		assert.Equal(t, updated, written)
+	})
+}
+
+func TestAssertServiceIsRunning(t *testing.T) {
+	t.Run("returns nil when container is running", func(t *testing.T) {
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/" + containerId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
+
+		err := AssertServiceIsRunning(context.Background(), containerId)
+
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("returns ErrNotRunning when container exists but exited", func(t *testing.T) {
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/" + containerId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: false, Status: "exited"},
+			}})
+
+		err := AssertServiceIsRunning(context.Background(), containerId)
+
+		assert.ErrorIs(t, err, ErrNotRunning)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("returns ErrNotRunning when container does not exist", func(t *testing.T) {
+		require.NoError(t, apitest.MockDocker(Docker))
+		defer gock.OffAll()
+		gock.New(Docker.DaemonHost()).
+			Get("/v" + Docker.ClientVersion() + "/containers/" + containerId + "/json").
+			Reply(http.StatusNotFound)
+
+		err := AssertServiceIsRunning(context.Background(), containerId)
+
+		assert.ErrorIs(t, err, ErrNotRunning)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 }
 

--- a/apps/cli-go/legacy/branch/switch_/switch__test.go
+++ b/apps/cli-go/legacy/branch/switch_/switch__test.go
@@ -34,7 +34,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		gock.New(utils.Docker.DaemonHost()).
 			Post("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusServiceUnavailable)
@@ -99,7 +101,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Run test
 		err := Run(context.Background(), "postgres", fsys)
 		// Check error
@@ -117,7 +121,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Run test
 		err := Run(context.Background(), "main", fsys)
 		// Check error
@@ -135,7 +141,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Setup target branch
 		branch := "main"
 		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
@@ -159,7 +167,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Setup target branch
 		branch := "target"
 		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)
@@ -183,7 +193,9 @@ func TestSwitchCommand(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers").
 			Reply(http.StatusOK).
-			JSON(container.InspectResponse{})
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
 		// Setup target branch
 		branch := "main"
 		branchPath := filepath.Join(filepath.Dir(utils.CurrBranchPath), branch)


### PR DESCRIPTION
upabase start only checked whether the db container existed (via ContainerInspect), never whether it was actually in the running state. After Docker Desktop restarts (observed on Windows with Docker Desktop 4.81.0) without honouring container restart policies, the supabase_db_* container is left Exited but still exists — so the CLI reported "already running" and never attempted to recover, forcing users to manually docker start the containers or run supabase stop && supabase start.

This change:

Fixes AssertServiceIsRunning to check the container's actual .State.Running, not just its existence.
Adds a HasProjectContainers helper to detect leftover (stopped) containers for the current project.
Updates start.Run() so that when the db isn't running but the project's containers still exist, it cleans up the stale containers (preserving named volumes, so local data survives) before recreating them, instead of just reporting "already running".
Linked issue
Closes [#47816](https://github.com/supabase/cli/issues/5917)

not done
The linked issue is open and carries the open-for-contribution label (or I'm a Supabase maintainer).