### PR TITLE
feat(cli): allow suppressing update notifier via SUPABASE_NO_UPDATE_NOTIFIER

### DIFF
--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -188,15 +189,17 @@ func Execute() {
 	if executedCmd != nil {
 		ctx = executedCmd.Context()
 	}
-	version, err := checkUpgrade(ctx, afero.NewOsFs())
-	if err != nil {
-		fmt.Fprintln(utils.GetDebugLogger(), err)
-	}
 	if hint := utils.SuggestClaudePlugin(); hint != "" {
 		fmt.Fprintln(os.Stderr, hint)
 	}
-	if semver.Compare(version, "v"+utils.Version) > 0 {
-		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
+	if updateNotifierEnabled() {
+		version, err := checkUpgrade(ctx, afero.NewOsFs())
+		if err != nil {
+			fmt.Fprintln(utils.GetDebugLogger(), err)
+		}
+		if semver.Compare(version, "v"+utils.Version) > 0 {
+			fmt.Fprintln(os.Stderr, suggestUpgrade(version))
+		}
 	}
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
@@ -237,6 +240,13 @@ func exitCode(err error) int {
 		return 1
 	}
 	return 0
+}
+
+func updateNotifierEnabled() bool {
+	// Read the env directly instead of viper: the upgrade check also runs for
+	// --help and --version, which skip the cobra initializer that binds env vars.
+	disabled, _ := strconv.ParseBool(os.Getenv("SUPABASE_NO_UPDATE_NOTIFIER"))
+	return !disabled
 }
 
 func checkUpgrade(ctx context.Context, fsys afero.Fs) (string, error) {

--- a/apps/cli-go/cmd/root_test.go
+++ b/apps/cli-go/cmd/root_test.go
@@ -61,6 +61,25 @@ func TestCommandAnalyticsContext(t *testing.T) {
 	assert.NotEmpty(t, ctx.RunID)
 }
 
+func TestUpdateNotifierEnabled(t *testing.T) {
+	for value, wantEnabled := range map[string]bool{
+		"":      true,
+		"0":     true,
+		"false": true,
+		"1":     false,
+		"true":  false,
+		"t":     false,
+		"TRUE":  false,
+		"yes":   true,
+	} {
+		t.Run("value "+value, func(t *testing.T) {
+			t.Setenv("SUPABASE_NO_UPDATE_NOTIFIER", value)
+
+			assert.Equal(t, wantEnabled, updateNotifierEnabled())
+		})
+	}
+}
+
 func TestCommandName(t *testing.T) {
 	root := &cobra.Command{Use: "supabase"}
 	parent := &cobra.Command{Use: "db"}


### PR DESCRIPTION
## What

Adds a `SUPABASE_NO_UPDATE_NOTIFIER` environment variable that suppresses the "A new version of Supabase CLI is available" upgrade notifier. When set to a truthy value (`1`, `true`, …), the CLI skips both the GitHub release check and the stderr suggestion.

## Why

Closes #5853. Users who pin the CLI version through a package manager such as Nix are intentionally on a fixed version and have no way to opt out of the periodic upgrade check and its message. This gives them a standard, npm-style env var (`NO_UPDATE_NOTIFIER`, prefixed with `SUPABASE_` to match the CLI's other environment variables) to turn it off.

## Notes

- The variable is read directly from the environment (`os.Getenv` + `strconv.ParseBool`) rather than through viper, because the upgrade check in `Execute()` also runs for `--help` and `--version`, which bypass the `cobra.OnInitialize` hook that configures viper's automatic env binding. Reading it directly makes suppression work consistently across every invocation. Boolean semantics match `viper.GetBool` (used by `SUPABASE_DEBUG` etc.).
- When disabled, the network call to GitHub is skipped entirely, not just the message — so pinned installs make no release request at all.
- Behavior unchanged when the variable is unset or falsy (`0`/`false`).