### PR TITLE
fix(cli): preserve auth templates

### DIFF
--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -508,6 +508,19 @@ describe("legacy functions serve integration", () => {
           },
         });
 
+        expect(deployMockState.runCalls).toContainEqual({
+          command: "docker",
+          args: [
+            "exec",
+            "supabase_kong_test-project",
+            "kong",
+            "reload",
+            "--nginx-conf",
+            "/home/kong/custom_nginx.template",
+          ],
+          options: { stdout: "ignore", stderr: "pipe" },
+        });
+
         expect(childSpawner.spawned).toEqual([
           {
             command: "docker",

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -1225,10 +1225,11 @@ const bestEffortRemoveContainer = Effect.fnUntraced(function* (containerId: stri
 const reloadKong = Effect.fnUntraced(function* (projectId: string) {
   const output = yield* Output;
   const kongId = localDockerId("kong", projectId);
-  const result = yield* runChildProcess("docker", ["exec", kongId, "kong", "reload"], {
-    stdout: "ignore",
-    stderr: "pipe",
-  }).pipe(Effect.catch(() => Effect.succeed({ exitCode: 1, stdout: "", stderr: "" })));
+  const result = yield* runChildProcess(
+    "docker",
+    ["exec", kongId, "kong", "reload", "--nginx-conf", "/home/kong/custom_nginx.template"],
+    { stdout: "ignore", stderr: "pipe" },
+  ).pipe(Effect.catch(() => Effect.succeed({ exitCode: 1, stdout: "", stderr: "" })));
 
   if (result.exitCode !== 0) {
     const suffix = result.stderr.trim().length > 0 ? ` ${result.stderr.trim()}` : "";


### PR DESCRIPTION
## TL;DR

Fixes Kong reloads dropping the custom nginx configuration,<br> so custom Auth email templates no longer silently fall back to GoTrue defaults

adds the configured nginx template to the reload command w focused coverage...

## Ref

* closes supabase/cli#5905