### PR TITLE
Fix for Expose GoTrue UpdatePasswordRequireCurrentPassword toggle in …

### DIFF
--- a/apps/cli-go/internal/start/start.go
+++ b/apps/cli-go/internal/start/start.go
@@ -1404,6 +1404,7 @@ func buildGotrueEnv(dbConfig pgconn.Config) []string {
 		fmt.Sprintf("GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=%v", utils.Config.Auth.RefreshTokenReuseInterval),
 		fmt.Sprintf("GOTRUE_SECURITY_MANUAL_LINKING_ENABLED=%v", utils.Config.Auth.EnableManualLinking),
 		fmt.Sprintf("GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION=%v", utils.Config.Auth.Email.SecurePasswordChange),
+		fmt.Sprintf("GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD=%v", utils.Config.Auth.Email.RequireCurrentPassword),
 		fmt.Sprintf("GOTRUE_MFA_PHONE_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.Phone.EnrollEnabled),
 		fmt.Sprintf("GOTRUE_MFA_PHONE_VERIFY_ENABLED=%v", utils.Config.Auth.MFA.Phone.VerifyEnabled),
 		fmt.Sprintf("GOTRUE_MFA_TOTP_ENROLL_ENABLED=%v", utils.Config.Auth.MFA.TOTP.EnrollEnabled),

--- a/apps/cli-go/internal/start/start_test.go
+++ b/apps/cli-go/internal/start/start_test.go
@@ -517,6 +517,23 @@ func TestBuildGotrueEnv(t *testing.T) {
 		assert.False(t, hasPasskey)
 		assert.False(t, hasRpId)
 	})
+
+	t.Run("maps require current password setting", func(t *testing.T) {
+		utils.Config = config.NewConfig()
+		utils.Config.Auth.Email.RequireCurrentPassword = true
+
+		env := envToMap(buildGotrueEnv(pgconn.Config{}))
+
+		assert.Equal(t, "true", env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD"])
+	})
+
+	t.Run("omits require current password setting by default", func(t *testing.T) {
+		utils.Config = config.NewConfig()
+
+		env := envToMap(buildGotrueEnv(pgconn.Config{}))
+
+		assert.Equal(t, "false", env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD"])
+	})
 }
 
 func TestBuildStudioEnv(t *testing.T) {

--- a/apps/cli-go/pkg/config/auth.go
+++ b/apps/cli-go/pkg/config/auth.go
@@ -240,16 +240,17 @@ type (
 	}
 
 	email struct {
-		EnableSignup         bool                     `toml:"enable_signup" json:"enable_signup"`
-		DoubleConfirmChanges bool                     `toml:"double_confirm_changes" json:"double_confirm_changes"`
-		EnableConfirmations  bool                     `toml:"enable_confirmations" json:"enable_confirmations"`
-		SecurePasswordChange bool                     `toml:"secure_password_change" json:"secure_password_change"`
-		Template             map[string]emailTemplate `toml:"template" json:"template"`
-		Notification         map[string]notification  `toml:"notification" json:"notification"`
-		Smtp                 *smtp                    `toml:"smtp" json:"smtp"`
-		MaxFrequency         time.Duration            `toml:"max_frequency" json:"max_frequency"`
-		OtpLength            uint                     `toml:"otp_length" json:"otp_length"`
-		OtpExpiry            uint                     `toml:"otp_expiry" json:"otp_expiry"`
+		EnableSignup           bool                     `toml:"enable_signup" json:"enable_signup"`
+		DoubleConfirmChanges   bool                     `toml:"double_confirm_changes" json:"double_confirm_changes"`
+		EnableConfirmations    bool                     `toml:"enable_confirmations" json:"enable_confirmations"`
+		SecurePasswordChange   bool                     `toml:"secure_password_change" json:"secure_password_change"`
+		RequireCurrentPassword bool                     `toml:"require_current_password" json:"require_current_password"`
+		Template               map[string]emailTemplate `toml:"template" json:"template"`
+		Notification           map[string]notification  `toml:"notification" json:"notification"`
+		Smtp                   *smtp                    `toml:"smtp" json:"smtp"`
+		MaxFrequency           time.Duration            `toml:"max_frequency" json:"max_frequency"`
+		OtpLength              uint                     `toml:"otp_length" json:"otp_length"`
+		OtpExpiry              uint                     `toml:"otp_expiry" json:"otp_expiry"`
 	}
 
 	smtp struct {

--- a/apps/cli-go/pkg/config/templates/config.toml
+++ b/apps/cli-go/pkg/config/templates/config.toml
@@ -226,6 +226,8 @@ double_confirm_changes = true
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
+# If enabled, users must supply their current password when changing their password.
+require_current_password = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.

--- a/apps/docs/public/cli/config.schema.json
+++ b/apps/docs/public/cli/config.schema.json
@@ -862,6 +862,11 @@
               "description": "If enabled, users will need to reauthenticate or have logged in recently to change their password.",
               "default": false
             },
+            "require_current_password": {
+              "type": "boolean",
+              "description": "If enabled, users must supply their current password when changing their password.",
+              "default": false
+            },
             "max_frequency": {
               "type": "string",
               "description": "Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.",
@@ -4385,6 +4390,11 @@
                           "secure_password_change": {
                             "type": "boolean",
                             "description": "If enabled, users will need to reauthenticate or have logged in recently to change their password.",
+                            "default": false
+                          },
+                          "require_current_password": {
+                            "type": "boolean",
+                            "description": "If enabled, users must supply their current password when changing their password.",
                             "default": false
                           },
                           "max_frequency": {


### PR DESCRIPTION
## Summary

Exposes GoTrue's `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` setting in `config.toml` as `require_current_password` under `[auth.email]`, mirroring the existing `secure_password_change` toggle. Previously there was no way to enable this locally even though GoTrue supports it, so local dev stacks couldn't reproduce the server-side "require current password on change" behavior that's configurable on hosted projects.

This change:
- Adds `RequireCurrentPassword bool` to the `email` config struct (`pkg/config/auth.go`).
- Maps it to `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD` in `buildGotrueEnv()` (`internal/start/start.go`), next to the existing `secure_password_change` mapping.
- Adds the field with a doc comment to the default `config.toml` template.
- Adds the corresponding `config.schema.json` entries.
- Adds test coverage in `TestBuildGotrueEnv` for both the enabled and default-disabled cases.

Verified end-to-end against a live local stack, not just unit tests: with `require_current_password = true`, the running GoTrue container correctly rejects a password update missing the current password (`400 current_password_required`) and accepts it once the current password is supplied (`200`).

## Linked issue

Closes #5846

- [ ] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(cli): …`).
- [x] Tests added or updated for the change.
- [ ] `pnpm check:all` and `pnpm test` pass for the workspace(s) I touched.