### PR TITLE
chore(release): stop mutating global registry config in local-registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,7 +270,7 @@ Test a real end-to-end publish and install of the CLI against a local npm regist
 pnpm local-registry
 ```
 
-This starts Verdaccio on `http://localhost:4873`, creates a publish user, and redirects the global `npm` and `pnpm` registry config to `localhost`. Press **Ctrl+C** when done — the original registry settings are restored automatically.
+This starts Verdaccio on `http://localhost:4873` and creates a publish user. Your global `npm` and `pnpm` registry config is never modified — every command that talks to the local registry passes `--registry` explicitly. Press **Ctrl+C** when done.
 
 **Terminal 2 — build and publish:**
 
@@ -310,7 +310,7 @@ supabase --version
 | `Error: Something is already running on port 4873` | Kill the leftover Verdaccio process (`lsof -ti:4873 \| xargs kill`) and retry |
 | `go not found in PATH` (legacy only) | Install Go from https://go.dev/dl/ |
 | `Error: Go CLI source not found` (legacy only) | Run `pnpm repos:install` to clone `apps/cli-go` |
-| Registry not restored after crash | Run `npm config set registry https://registry.npmjs.org/` and `pnpm config set registry https://registry.npmjs.org/` |
+| `npm` / `pnpm` tries to fetch from `localhost:4873` when no registry is running | Stale global registry override left behind by an older version of `local-registry.ts` (the current script never modifies global config). Run `npm config delete registry` and `pnpm config delete registry`. Note that pnpm stores the override in its own global config (`~/Library/Preferences/pnpm/auth.ini` on macOS, `~/.config/pnpm/` on Linux), not `~/.npmrc` — check there if the delete command fails |
 | `npx` resolves from npm instead of local | Pass `--registry http://localhost:4873` explicitly to `npx` / `npm install` |
 
 ## Using Nx

--- a/tools/release/local-registry.ts
+++ b/tools/release/local-registry.ts
@@ -5,11 +5,13 @@
  *
  * - Starts Verdaccio on http://localhost:4873
  * - Creates a local publish user and stores the auth token in tmp/verdaccio-token
- * - Redirects the global npm and pnpm registry config to the local registry
- * - Restores the original registry config and kills Verdaccio on Ctrl+C / SIGTERM
+ * - Kills Verdaccio on Ctrl+C / SIGTERM / SIGHUP
+ *
+ * Global npm/pnpm registry config is never modified — everything that talks to
+ * the local registry passes --registry explicitly (see local-release.ts), so a
+ * crash or hard kill cannot leave the developer's machine pointed at localhost.
  */
 
-import { $ } from "bun";
 import { openSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -80,15 +82,6 @@ async function createUser(): Promise<string> {
 	return body.token;
 }
 
-async function getRegistryConfig(tool: "npm" | "pnpm"): Promise<string> {
-	try {
-		const value = (await $`${tool} config get registry`.quiet().text()).trim();
-		return value === "undefined" ? "https://registry.npmjs.org/" : value;
-	} catch {
-		return "https://registry.npmjs.org/";
-	}
-}
-
 async function main() {
 	if (await isPortInUse()) {
 		console.error(`\nError: Something is already running on port ${PORT}.`);
@@ -134,13 +127,6 @@ async function main() {
 	const token = await createUser();
 	await writeFile(tokenPath, token, "utf-8");
 
-	// Capture current global registry settings so we can restore them on exit.
-	const origNpm = await getRegistryConfig("npm");
-	const origPnpm = await getRegistryConfig("pnpm");
-
-	await $`npm config set registry ${REGISTRY}`.quiet();
-	await $`pnpm config set registry ${REGISTRY}`.quiet();
-
 	console.log(`
   Registry : ${REGISTRY}
   Token    : ${tokenPath}
@@ -150,28 +136,21 @@ async function main() {
     pnpm cli-release --next
     pnpm cli-release --legacy
 
-  Press Ctrl+C to stop and restore the original registry settings.
+  Global npm/pnpm registry config is untouched — pass --registry ${REGISTRY}
+  to npx / npm install when testing the published package.
+
+  Press Ctrl+C to stop.
 `);
 
-	const cleanup = async () => {
-		process.stdout.write("\nShutting down local registry...");
-		try {
-			await $`npm config set registry ${origNpm}`.quiet();
-			await $`pnpm config set registry ${origPnpm}`.quiet();
-			process.stdout.write(" registry restored.\n");
-		} catch {
-			process.stdout.write(
-				"\nWarning: could not restore registry config — run:\n" +
-					`  npm config set registry ${origNpm}\n` +
-					`  pnpm config set registry ${origPnpm}\n`,
-			);
-		}
+	const cleanup = () => {
+		process.stdout.write("\nShutting down local registry...\n");
 		proc.kill();
 		process.exit(0);
 	};
 
 	process.on("SIGINT", cleanup);
 	process.on("SIGTERM", cleanup);
+	process.on("SIGHUP", cleanup);
 
 	// Block until a signal is received.
 	await new Promise<never>(() => {});


### PR DESCRIPTION
## What

`pnpm local-registry` (the local Verdaccio helper for release testing) no longer redirects the global `npm` and `pnpm` registry config to `localhost:4873` on startup, and no longer needs to restore it on shutdown. The cleanup handler now just kills Verdaccio, and additionally handles `SIGHUP` so closing the terminal window doesn't orphan the server. `CONTRIBUTING.md` is updated to match, and the troubleshooting table now covers recovering from the stale override left behind by older versions of the script.

## Why

The restore path had holes that could leave a developer's machine pointed at a dead localhost registry, making every subsequent `pnpm i` fail:

- The Verdaccio-crash path called `process.exit(1)` without restoring the registry.
- `SIGHUP` (closing the terminal) wasn't handled, so no cleanup ran at all.
- A partial restore failure only printed a warning, right as the terminal session was being torn down.

This bit for real: pnpm persists the override in its own global config (`~/Library/Preferences/pnpm/auth.ini` on macOS) rather than `~/.npmrc`, so an `~/.npmrc`-focused manual cleanup makes npm look healthy while pnpm silently keeps resolving from `localhost:4873`.

The global redirect was also unnecessary: `local-release.ts` already passes `--registry` explicitly to every publish command and writes a scoped `.npmrc` (with the auth token) into its temp publish dir, and the suggested `npx` / `npm install -g` smoke-test commands carry the flag too. With the redirect gone, there is no cleanup left to get wrong — a crash or hard kill can no longer corrupt the developer's registry config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)