### PR TITLE
fix(cli): pg-delta workspace mount

### DIFF
--- a/apps/cli-go/internal/db/pgcache/cache.go
+++ b/apps/cli-go/internal/db/pgcache/cache.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -261,6 +262,9 @@ func exportCatalog(ctx context.Context, targetRef string, options ...func(*pgx.C
 	}
 	env := append([]string{"TARGET=" + preparedRef, "ROLE=postgres"}, sslEnv...)
 	binds := []string{utils.EdgeRuntimeId + ":/root/.cache/deno:rw"}
+	if cwd, err := os.Getwd(); err == nil {
+		binds = append(binds, cwd+":/workspace")
+	}
 	var stdout, stderr bytes.Buffer
 	script := config.InterpolatePgDeltaScript(config.Config(&utils.Config), pgDeltaCatalogExportTS)
 	if err := utils.RunEdgeRuntimeScript(ctx, env, script, binds, "error exporting pg-delta catalog", &stdout, &stderr, utils.PgDeltaNpmRegistryOption()); err != nil {


### PR DESCRIPTION
## TL;DR: 

`db push` crashes with `ENOENT` reading the `pg-delta` CA cert on every push against a hosted/TLS target,
missing Docker mount

## Prob

 exportCatalog writes the CA bundle to `<cwd>/supabase/.temp/pgdelta/` and points `sslrootcert` at `/workspace/... `inside the container, but never mounted `cwd `to /workspace like every other pg-delta call site does. 
Container looks for a file that was never shared with it.

## Sol: 

(pragmatic fix)
adds the same `cwd:/workspace` bind the sibling functions in `internal/db/diff/pgdelta.go` already has. that's it..

## Ref:
- towards #5921

