### PR TITLE
fix(cli): skip OS junk files when seeding storage buckets

### DIFF
--- a/apps/cli/src/legacy/commands/seed/buckets/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/seed/buckets/SIDE_EFFECTS.md
@@ -116,6 +116,7 @@ Creating vector bucket: <name>
 Pruning vector bucket: <name>
 Uploading: <objects_path>/<rel> => <bucket>/<rel>
 Skipping non-regular file: <path>
+Skipping OS metadata file: <path>
 WARNING: Vector buckets are not available in this project's region yet. Skipping vector bucket seeding.
 WARNING: Vector buckets are not available in the local storage service. If this project is linked, run `supabase link` to update service versions, then restart the local stack. Skipping vector bucket seeding.
 ```

--- a/apps/cli/src/legacy/commands/seed/buckets/buckets.integration.test.ts
+++ b/apps/cli/src/legacy/commands/seed/buckets/buckets.integration.test.ts
@@ -1285,6 +1285,95 @@ describe("legacy seed buckets", () => {
     });
   });
 
+  it.live("skips OS metadata files during the object walk (CLI-1950)", () => {
+    // .DS_Store (macOS Finder), Thumbs.db and desktop.ini (Windows Explorer)
+    // must never be uploaded as seeded objects — they are never even attempted,
+    // covering the "silently becomes a public object" failure mode, not just
+    // an upload-time abort.
+    mkdirSync(join(tmp.current, "supabase", "assets"), { recursive: true });
+    writeFileSync(join(tmp.current, "supabase", "assets", "a.txt"), "hello");
+    writeFileSync(join(tmp.current, "supabase", "assets", ".DS_Store"), "junk");
+    writeFileSync(join(tmp.current, "supabase", "assets", "Thumbs.db"), "junk");
+    writeFileSync(join(tmp.current, "supabase", "assets", "desktop.ini"), "junk");
+    const { layer, out, requests } = setupLegacySeedBuckets(tmp.current, {
+      toml: '[storage.buckets.images]\npublic = true\nobjects_path = "./assets"\n',
+      routes: [
+        { method: "GET", match: "/storage/v1/bucket", body: [] },
+        { method: "POST", match: "/storage/v1/object/", body: {} },
+        { method: "POST", match: "/storage/v1/bucket", body: { name: "images" } },
+      ],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacySeedBuckets(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(out.stderrText).toContain("Skipping OS metadata file: supabase/assets/.DS_Store");
+      expect(out.stderrText).toContain("Skipping OS metadata file: supabase/assets/Thumbs.db");
+      expect(out.stderrText).toContain("Skipping OS metadata file: supabase/assets/desktop.ini");
+      expect(out.stderrText).toContain("Uploading: supabase/assets/a.txt => images/a.txt");
+      const uploads = requests.filter((r) => r.url.includes("/storage/v1/object/"));
+      expect(uploads).toHaveLength(1);
+    });
+  });
+
+  it.live(
+    "skips a .DS_Store file in a MIME-restricted bucket instead of uploading it (CLI-1950)",
+    () => {
+      // Reproduces the original bug report shape: a bucket with allowed_mime_types
+      // restricted to images. The test harness's mock HTTP route doesn't enforce
+      // allowed_mime_types server-side (that's real Storage-service behavior), so
+      // this doesn't simulate the 415 abort itself — it asserts the junk file is
+      // skipped and never uploaded, while the real image file still uploads.
+      mkdirSync(join(tmp.current, "supabase", "assets"), { recursive: true });
+      writeFileSync(join(tmp.current, "supabase", "assets", "logo.png"), "fake-png-bytes");
+      writeFileSync(join(tmp.current, "supabase", "assets", ".DS_Store"), "junk");
+      const { layer, out, requests } = setupLegacySeedBuckets(tmp.current, {
+        toml: [
+          "[storage.buckets.images]",
+          "public = true",
+          'allowed_mime_types = ["image/png"]',
+          'objects_path = "./assets"',
+        ].join("\n"),
+        routes: [
+          { method: "GET", match: "/storage/v1/bucket", body: [] },
+          { method: "POST", match: "/storage/v1/object/", body: {} },
+          { method: "POST", match: "/storage/v1/bucket", body: { name: "images" } },
+        ],
+      });
+      return Effect.gen(function* () {
+        const exit = yield* legacySeedBuckets(DEFAULT_FLAGS).pipe(
+          Effect.provide(layer),
+          Effect.exit,
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(out.stderrText).toContain("Skipping OS metadata file: supabase/assets/.DS_Store");
+        expect(out.stderrText).toContain("Uploading: supabase/assets/logo.png => images/logo.png");
+        const uploads = requests.filter((r) => r.url.includes("/storage/v1/object/"));
+        expect(uploads).toHaveLength(1);
+      });
+    },
+  );
+
+  it.live("skips a .DS_Store file when objects_path points directly at it (CLI-1950)", () => {
+    // Covers collectFiles' single-file branch: objects_path resolves directly to
+    // a junk-named file rather than a directory.
+    mkdirSync(join(tmp.current, "supabase"), { recursive: true });
+    writeFileSync(join(tmp.current, "supabase", ".DS_Store"), "junk");
+    const { layer, out, requests } = setupLegacySeedBuckets(tmp.current, {
+      toml: '[storage.buckets.images]\npublic = true\nobjects_path = "./.DS_Store"\n',
+      routes: [
+        { method: "GET", match: "/storage/v1/bucket", body: [] },
+        { method: "POST", match: "/storage/v1/bucket", body: { name: "images" } },
+      ],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacySeedBuckets(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(out.stderrText).toContain("Skipping OS metadata file: supabase/.DS_Store");
+      const uploads = requests.filter((r) => r.url.includes("/storage/v1/object/"));
+      expect(uploads).toHaveLength(0);
+    });
+  });
+
   // Root bypasses POSIX permission bits, so chmod 000 wouldn't block open() there
   // and the open-vs-stat distinction this test relies on would vanish.
   const isRoot = typeof process.getuid === "function" && process.getuid() === 0;

--- a/apps/cli/src/legacy/shared/legacy-seed-buckets.ts
+++ b/apps/cli/src/legacy/shared/legacy-seed-buckets.ts
@@ -39,6 +39,14 @@ const CONFIG_PATH = "supabase/config.toml";
 const UPLOAD_CONCURRENCY = 5;
 
 /**
+ * Well-known OS metadata files (macOS Finder, Windows Explorer) that must
+ * never be uploaded as seeded objects — see CLI-1950. Go has no equivalent
+ * skip; this is an intentional TS-only improvement over Go's current (also
+ * buggy) behavior.
+ */
+const osJunkFileNames = new Set([".DS_Store", "Thumbs.db", "desktop.ini"]);
+
+/**
  * Mirrors Go's `ValidateBucketName` regex (`apps/cli-go/pkg/config/config.go:1382`).
  * Used to validate `[storage.buckets]` names before any Storage API call, matching
  * Go's config-load-time check (`config.go:899-903`). Vector and analytics names are
@@ -537,6 +545,10 @@ const collectFiles = (
       return yield* collectDir(fs, path, output, absRoot, displayRoot);
     }
     if (info.type === "File") {
+      if (osJunkFileNames.has(path.basename(displayRoot))) {
+        yield* output.raw(`Skipping OS metadata file: ${displayRoot}\n`, "stderr");
+        return [];
+      }
       return [{ absPath: absRoot, displayPath: displayRoot }];
     }
     yield* output.raw(`Skipping non-regular file: ${displayRoot}\n`, "stderr");
@@ -556,6 +568,10 @@ const collectDir = (
     for (const name of names) {
       const absChild = path.join(absDir, name);
       const displayChild = path.join(displayDir, name);
+      if (osJunkFileNames.has(name)) {
+        yield* output.raw(`Skipping OS metadata file: ${displayChild}\n`, "stderr");
+        continue;
+      }
       // `readLink` succeeds only on a symlink — our no-follow detector (Effect's
       // `stat` follows symlinks and has no `lstat`).
       const isSymlink = yield* fs.readLink(absChild).pipe(


### PR DESCRIPTION
## Summary

* Skip `.DS_Store`, `Thumbs.db`, and `desktop.ini` when walking a bucket's `objects_path` during `supabase seed buckets`, logging `Skipping OS metadata file: <path>` instead of uploading them
* Previously these OS-generated files either aborted the whole seed run (415 invalid_mime_type on MIME-restricted buckets) or silently became public objects
* TS-only fix (legacy port); `apps/cli-go` is left untouched as it's the frozen Go reference

Fixes supabase/cli#5931, closes supabase/cli#5931