### PR TITLE
fix(cli): render SMS/MFA config templates instead of emitting the raw text/template escape

### DIFF
--- a/apps/cli/src/shared/init/project-init.templates.ts
+++ b/apps/cli/src/shared/init/project-init.templates.ts
@@ -260,7 +260,7 @@ enable_signup = false
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
-template = "Your code is {{ \`{{ .Code }}\` }}"
+template = "Your code is {{ .Code }}"
 # Controls the minimum amount of time that must pass before sending another sms otp.
 max_frequency = "5s"
 
@@ -308,7 +308,7 @@ verify_enabled = false
 enroll_enabled = false
 verify_enabled = false
 otp_length = 6
-template = "Your code is {{ \`{{ .Code }}\` }}"
+template = "Your code is {{ .Code }}"
 max_frequency = "5s"
 
 # Configure MFA via WebAuthn

--- a/apps/cli/src/shared/init/project-init.templates.unit.test.ts
+++ b/apps/cli/src/shared/init/project-init.templates.unit.test.ts
@@ -24,22 +24,39 @@ function readGoTemplate(...segments: ReadonlyArray<string>): string {
 // Go renders its config.toml scaffold through text/template (config.Eject), so an action
 // containing a backtick raw string — {{ (backtick){{ .Code }}(backtick) }} in the template
 // source — is rendered to the literal string it quotes: {{ .Code }} in the ejected file.
+// This is the only text/template construct emulated here beyond the substituted fields;
+// the "models every template action" test below fails loudly if the Go scaffold ever
+// gains a construct this suite does not resolve.
 function resolveGoTemplateEscapes(template: string): string {
   return template.replace(/\{\{\s*`([^`]*)`\s*\}\}/g, "$1");
 }
 
-describe("project init templates", () => {
-  it("renders config.toml with the same content as the Go CLI ejects", () => {
-    const expected = resolveGoTemplateEscapes(
-      readGoTemplate("pkg", "config", "templates", "config.toml"),
-    )
+// Emulates what Go's config.Eject writes to disk for a fresh `supabase init` project.
+function renderExpectedGoEject(): string {
+  return (
+    resolveGoTemplateEscapes(readGoTemplate("pkg", "config", "templates", "config.toml"))
       .replace("{{ .ProjectId }}", "demo-project")
       .replace("{{ .Experimental.OrioleDBVersion }}", "15.1.0.150")
       // supabase init always opts new projects into pg-delta; the Go template renders
       // this from a flag set only on the init path (false when deriving defaults).
-      .replace("{{ .Experimental.PgDeltaInitEnabled }}", "true");
+      .replace("{{ .Experimental.PgDeltaInitEnabled }}", "true")
+  );
+}
 
-    expect(normalizeNewlines(renderProjectConfigTemplate("demo-project", true))).toBe(expected);
+describe("project init templates", () => {
+  it("renders config.toml with the same content as the Go CLI ejects", () => {
+    expect(normalizeNewlines(renderProjectConfigTemplate("demo-project", true))).toBe(
+      renderExpectedGoEject(),
+    );
+  });
+
+  it("models every template action in the Go scaffold, so parity cannot silently drift", () => {
+    // After escape resolution and field substitution, the only {{ ... }} occurrences left
+    // must be the GoTrue OTP placeholders quoted by the backtick escapes. Anything else
+    // means the Go template gained a construct this suite does not emulate yet — update
+    // resolveGoTemplateEscapes/renderExpectedGoEject to match config.Eject before shipping.
+    const unresolvedActions = renderExpectedGoEject().match(/\{\{[^}]*\}\}/g) ?? [];
+    expect(new Set(unresolvedActions)).toEqual(new Set(["{{ .Code }}"]));
   });
 
   it("renders the SMS and MFA phone OTP templates as GoTrue templates, not raw Go escapes", () => {

--- a/apps/cli/src/shared/init/project-init.templates.unit.test.ts
+++ b/apps/cli/src/shared/init/project-init.templates.unit.test.ts
@@ -21,9 +21,18 @@ function readGoTemplate(...segments: ReadonlyArray<string>): string {
   return normalizeNewlines(readFileSync(join(goCliRoot, ...segments), "utf8"));
 }
 
+// Go renders its config.toml scaffold through text/template (config.Eject), so an action
+// containing a backtick raw string — {{ (backtick){{ .Code }}(backtick) }} in the template
+// source — is rendered to the literal string it quotes: {{ .Code }} in the ejected file.
+function resolveGoTemplateEscapes(template: string): string {
+  return template.replace(/\{\{\s*`([^`]*)`\s*\}\}/g, "$1");
+}
+
 describe("project init templates", () => {
-  it("renders config.toml with the same content as the Go scaffold", () => {
-    const expected = readGoTemplate("pkg", "config", "templates", "config.toml")
+  it("renders config.toml with the same content as the Go CLI ejects", () => {
+    const expected = resolveGoTemplateEscapes(
+      readGoTemplate("pkg", "config", "templates", "config.toml"),
+    )
       .replace("{{ .ProjectId }}", "demo-project")
       .replace("{{ .Experimental.OrioleDBVersion }}", "15.1.0.150")
       // supabase init always opts new projects into pg-delta; the Go template renders
@@ -31,6 +40,15 @@ describe("project init templates", () => {
       .replace("{{ .Experimental.PgDeltaInitEnabled }}", "true");
 
     expect(normalizeNewlines(renderProjectConfigTemplate("demo-project", true))).toBe(expected);
+  });
+
+  it("renders the SMS and MFA phone OTP templates as GoTrue templates, not raw Go escapes", () => {
+    const rendered = renderProjectConfigTemplate("demo-project", false);
+    const otpTemplateLines = rendered.split("\n").filter((line) => line.startsWith("template = "));
+    expect(otpTemplateLines).toEqual([
+      'template = "Your code is {{ .Code }}"',
+      'template = "Your code is {{ .Code }}"',
+    ]);
   });
 
   it("enables pg-delta by default in the generated config", () => {


### PR DESCRIPTION
## What changed

`supabase init` (and the `bootstrap` scratch-project path — both go through the shared `renderProjectConfigTemplate` in `apps/cli/src/shared/init/project-init.templates.ts`) wrote two broken lines into the generated `supabase/config.toml`:

```toml
template = "Your code is {{ `{{ .Code }}` }}"
```

for both `[auth.sms]` and `[auth.mfa.phone]`. The Go CLI's template source contains that `text/template` self-escape, but Go renders the scaffold through `text/template` (`config.Eject`, `pkg/config/config.go:555,572`), which resolves the backtick raw-string action to the literal GoTrue template. The TS renderer copied the escape verbatim and runs no template engine, so the raw escape landed in users' configs — a functionally broken SMS/MFA OTP template (GoTrue would send the literal text instead of substituting the code).

The fix pre-renders the two lines in the TS template constant:

```toml
template = "Your code is {{ .Code }}"
```

Verified byte-identical against the Go CLI's actual `config.Eject` output (dumped via a throwaway Go test harness): these two lines were the only divergence, and after the fix the full generated file matches Go's eject byte-for-byte, including the trailing newline.

## Test changes

The existing byte-parity test compared the TS render against the **raw Go template source**, so both sides carried the unresolved escape and the test passed while the shipped output was broken. It now emulates Go's eject-time rendering (`resolveGoTemplateEscapes`) before comparing, so it would have caught this bug. Also added:

- a dedicated regression test asserting the two generated `template =` lines are the rendered GoTrue templates, not raw Go escapes;
- a guard test that fails loudly if the Go scaffold ever gains a `{{ ... }}` construct the suite does not model, so this class of parity drift cannot silently return (raised by review).

## Deliberately out of scope (from review)

- **Configs already generated with the broken lines are not auto-migrated.** Users who ran `init`/`bootstrap` with an affected build keep the raw escape in their `config.toml`; the manual fix is replacing the two `template =` lines under `[auth.sms]` and `[auth.mfa.phone]` with `"Your code is {{ .Code }}"`. A detect-and-warn on config load (particularly on the `config push` path, which can carry the broken template to hosted GoTrue) was suggested in review as a possible fast-follow, but auto-editing or warning about user-owned config is a scope/UX decision beyond this parity fix.

Fixes CLI-1971

Linear: https://linear.app/supabase/issue/CLI-1971/initbootstrap-write-broken-smsmfa-template-lines-into-configtoml
