### PR TITLE
fix(cli): suppress the --debug hint when a confirmation prompt is declined

### DIFF
--- a/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/agent-output.e2e.test.ts
@@ -1,26 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { runSupabase } from "../../../tests/helpers/cli.ts";
-
-function stripAnsi(output: string): string {
-  let stripped = "";
-  for (let i = 0; i < output.length; i++) {
-    const charCode = output.charCodeAt(i);
-    if (charCode !== 0x1b || output[i + 1] !== "[") {
-      stripped += output[i];
-      continue;
-    }
-
-    i += 2;
-    while (i < output.length) {
-      const code = output.charCodeAt(i);
-      if (code >= 0x40 && code <= 0x7e) {
-        break;
-      }
-      i++;
-    }
-  }
-  return stripped;
-}
+import { runSupabase, stripAnsi } from "../../../tests/helpers/cli.ts";
 
 function parseJsonLines(output: string): Array<unknown> {
   return stripAnsi(output)

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
@@ -6,6 +6,7 @@ import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
 import { LegacyLinkedProjectCache } from "../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
 import { LegacyWorkdirFlag, legacyResolveYes } from "../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../shared/output/errors.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { LegacyGoProxy } from "../../../shared/legacy/go-proxy.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
@@ -135,7 +136,9 @@ export const legacyBootstrap = Effect.fn("legacy.bootstrap")(function* (
             { defaultValue: true },
           );
       if (!overwrite) {
-        return yield* new LegacyBootstrapOverwriteDeclinedError({ message: "context canceled" });
+        return yield* new LegacyBootstrapOverwriteDeclinedError({
+          message: CONTEXT_CANCELED_MESSAGE,
+        });
       }
     }
 

--- a/apps/cli/src/legacy/commands/branches/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.handler.ts
@@ -7,6 +7,7 @@ import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.ser
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { LegacyOutputFlag } from "../../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { detectGitBranch } from "../../../../shared/git/git-branch.ts";
 import {
@@ -68,7 +69,7 @@ export const legacyBranchesCreate = Effect.fn("legacy.branches.create")(function
         .promptConfirm(`Do you want to create a branch named ${gitBranch.value}?`)
         .pipe(Effect.orElseSucceed(() => true));
       if (!confirmed) {
-        return yield* new LegacyBranchesCreateCancelledError({ message: "context canceled" });
+        return yield* new LegacyBranchesCreateCancelledError({ message: CONTEXT_CANCELED_MESSAGE });
       }
       branchName = gitBranch.value;
       if (gitBranchForBody === undefined) {

--- a/apps/cli/src/legacy/commands/db/diff/diff.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   legacyFailWriteStringOnNthCallFsLayer,
   mockLegacyCliConfig,
@@ -230,10 +231,6 @@ const flags = (over: Partial<LegacyDbDiffFlags> = {}): LegacyDbDiffFlags => ({
   schema: over.schema ?? [],
 });
 
-// Strip ANSI so assertions are colour-independent: `legacyAqua`/`legacyYellow`
-// emit colour only when the test runner's stderr is a TTY.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 const stdout = (out: ReturnType<typeof mockOutput>) =>
   stripAnsi(
     out.rawChunks

--- a/apps/cli/src/legacy/commands/db/pull/pull.debug.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.debug.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   legacyFormatByteSize,
   legacyFormatCatalogSummary,
@@ -8,10 +9,6 @@ import {
   legacyRedactPostgresURL,
   legacySummarizeCatalogJson,
 } from "./pull.debug.ts";
-
-// ANSI may wrap the bold debugDir; strip for assertions.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("legacyRedactPostgresURL", () => {
   it("replaces the password but keeps the username", () => {

--- a/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   legacyFailWriteStringOnNthCallFsLayer,
   mockLegacyCliConfig,
@@ -304,8 +305,6 @@ const flags = (over: Partial<LegacyDbPullFlags> = {}): LegacyDbPullFlags => ({
   password: over.password ?? Option.none(),
 });
 
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 const streamText = (out: ReturnType<typeof mockOutput>, stream: "stdout" | "stderr") =>
   stripAnsi(
     out.rawChunks

--- a/apps/cli/src/legacy/commands/db/push/push.handler.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.handler.ts
@@ -3,6 +3,7 @@ import { Clock, Effect, FileSystem, Option, Path } from "effect";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
 import { LegacyDnsResolverFlag } from "../../../../shared/legacy/global-flags.ts";
 import { legacyResolveYesWithProjectEnv } from "../../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
@@ -268,7 +269,7 @@ export const legacyDbPush = Effect.fn("legacy.db.push")(function* (flags: Legacy
             );
             if (!ok) {
               return yield* Effect.fail(
-                new LegacyDbPushCancelledError({ message: "context canceled" }),
+                new LegacyDbPushCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
               );
             }
             yield* legacySeedGlobals(
@@ -290,7 +291,7 @@ export const legacyDbPush = Effect.fn("legacy.db.push")(function* (flags: Legacy
             );
             if (!ok) {
               return yield* Effect.fail(
-                new LegacyDbPushCancelledError({ message: "context canceled" }),
+                new LegacyDbPushCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
               );
             }
             yield* legacyUpsertVaultSecrets(session, vaultSecrets);
@@ -333,7 +334,7 @@ export const legacyDbPush = Effect.fn("legacy.db.push")(function* (flags: Legacy
             );
             if (!ok) {
               return yield* Effect.fail(
-                new LegacyDbPushCancelledError({ message: "context canceled" }),
+                new LegacyDbPushCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
               );
             }
             yield* legacySeedData(session, fs, workdir, path, seeds, applyError);

--- a/apps/cli/src/legacy/commands/db/reset/reset.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.e2e.test.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { runSupabase, stripAnsi } from "../../../../../tests/helpers/cli.ts";
+
+const E2E_TIMEOUT_MS = 30_000;
+
+describe("supabase db reset (legacy)", () => {
+  let workdir: string;
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), "sb-db-reset-e2e-"));
+    mkdirSync(join(workdir, "supabase"), { recursive: true });
+    writeFileSync(join(workdir, "supabase", "config.toml"), "[db]\nport = 54322\n");
+  });
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  // Docker-free: the destructive remote-reset confirmation fires after the config
+  // load and BEFORE any connection is dialed, so a piped decline exits without a
+  // database. Declining must byte-match Go: a single `context canceled` line on
+  // stderr and exit 1, with NO `--debug` troubleshooting hint — `recoverAndExit`
+  // skips `SuggestDebugFlag` for `context.Canceled` (apps/cli-go/cmd/root.go:287-303).
+  // CLI-1973.
+  test(
+    "declining the remote reset prompt prints only context canceled, no --debug hint",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      const { exitCode, stderr } = await runSupabase(
+        ["db", "reset", "--db-url", "postgresql://postgres:postgres@127.0.0.1:9999/postgres"],
+        { entrypoint: "legacy", cwd: workdir, stdin: "n\n" },
+      );
+      expect(exitCode).toBe(1);
+      // The destructive confirmation (default No → `[y/N]`) actually rendered and
+      // was answered — the cancellation didn't come from some other failure path.
+      expect(stripAnsi(stderr)).toContain("[y/N]");
+      const lines = stripAnsi(stderr).trimEnd().split("\n");
+      expect(lines.at(-1)).toBe("context canceled");
+      expect(stderr).not.toContain("Try rerunning the command with --debug");
+    },
+  );
+});

--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -8,6 +8,7 @@ import {
   legacyResolveYesWithProjectEnv,
 } from "../../../../shared/legacy/global-flags.ts";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { legacyAqua, legacyYellow } from "../../../shared/legacy-colors.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
@@ -415,7 +416,9 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       false,
     );
     if (!shouldReset) {
-      return yield* Effect.fail(new LegacyDbResetCancelledError({ message: "context canceled" }));
+      return yield* Effect.fail(
+        new LegacyDbResetCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
+      );
     }
     yield* output.raw(`Resetting remote database${toLogMessage(resolvedVersion)}\n`, "stderr");
 

--- a/apps/cli/src/legacy/commands/db/schema/declarative/declarative.gate.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/declarative.gate.unit.test.ts
@@ -1,18 +1,13 @@
 import { Cause, Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../../../../tests/helpers/ansi.ts";
 import { LegacyDeclarativeNotEnabledError } from "./declarative.errors.ts";
 import {
   legacyIsPgDeltaEnabled,
   legacyPgDeltaSuggestion,
   legacyRequirePgDelta,
 } from "./declarative.gate.ts";
-
-// `legacyAqua`/`legacyBold` colour their tokens when stderr is a TTY (matching
-// Go's lipgloss). Strip ANSI so the assertions validate text content exactly,
-// independent of the runner's colour profile.
-const stripAnsi = (text: string) =>
-  text.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
 
 const EXPECTED_SUGGESTION =
   "Either pass --experimental or add [experimental.pgdelta] with enabled = true to supabase/config.toml";

--- a/apps/cli/src/legacy/commands/gen/signing-key/signing-key.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/signing-key/signing-key.e2e.test.ts
@@ -43,6 +43,8 @@ describe("supabase gen signing-key (legacy)", () => {
       });
       expect(exitCode).toBe(1);
       expect(stderr).toContain("context canceled");
+      // No SuggestDebugFlag fallback for context.Canceled (cmd/root.go:287-303, CLI-1973).
+      expect(stderr).not.toContain("Try rerunning the command with --debug");
       expect(stderr).not.toContain("Service not found");
       const saved = readFileSync(join(projectDir, "supabase", "signing_keys.json"), "utf8");
       expect(JSON.parse(saved)).toEqual([]);

--- a/apps/cli/src/legacy/commands/gen/signing-key/signing-key.handler.ts
+++ b/apps/cli/src/legacy/commands/gen/signing-key/signing-key.handler.ts
@@ -11,6 +11,7 @@ import { LegacyDebugLogger } from "../../../shared/legacy-debug-logger.service.t
 import { legacyPromptYesNo } from "../../../shared/legacy-prompt-yes-no.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { legacyResolveYesWithProjectEnv } from "../../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../shared/runtime/tty.service.ts";
 import type { LegacyGenSigningKeyFlags } from "./signing-key.command.ts";
@@ -316,7 +317,7 @@ export const legacyGenSigningKey = Effect.fn("legacy.gen.signing-key")(function*
                 );
           if (!confirmed) {
             return yield* Effect.fail(
-              new LegacyGenSigningKeyCancelledError({ message: "context canceled" }),
+              new LegacyGenSigningKeyCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
             );
           }
           return [key];

--- a/apps/cli/src/legacy/commands/logout/logout.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.e2e.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "vitest";
 
-import { makeTempHome, runSupabase } from "../../../../tests/helpers/cli.ts";
+import { makeTempHome, runSupabase, stripAnsi } from "../../../../tests/helpers/cli.ts";
 
 const E2E_TIMEOUT_MS = 30_000;
 const VALID_TOKEN = "sbp_" + "a".repeat(40);
@@ -34,6 +34,29 @@ describe("supabase logout (legacy)", () => {
       expect(exitCode).toBe(0);
       expect(stderr).toContain("You were not logged in, nothing to do.");
       expect(existsSync(tokenPath)).toBe(false);
+    },
+  );
+
+  // Declining the confirmation must byte-match Go: a single `context canceled`
+  // line on stderr and exit 1, with NO `--debug` troubleshooting hint —
+  // `recoverAndExit` skips `SuggestDebugFlag` for `context.Canceled`
+  // (apps/cli-go/cmd/root.go:287-303). CLI-1973.
+  test(
+    "declining the logout prompt prints only context canceled, no --debug hint",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      using home = makeTempHome();
+      seedTokenFile(home.dir);
+      const { exitCode, stderr } = await runSupabase(["logout"], {
+        entrypoint: "legacy",
+        home: home.dir,
+        env: { HOME: home.dir },
+        stdin: "n\n",
+      });
+      expect(exitCode).toBe(1);
+      const lines = stripAnsi(stderr).trimEnd().split("\n");
+      expect(lines.at(-1)).toBe("context canceled");
+      expect(stderr).not.toContain("Try rerunning the command with --debug");
     },
   );
 

--- a/apps/cli/src/legacy/commands/logout/logout.errors.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.errors.ts
@@ -2,13 +2,14 @@ import { Data } from "effect";
 
 /**
  * Raised when the user declines the logout confirmation prompt. Go returns
- * `errors.New(context.Canceled)` (`apps/cli-go/internal/logout/logout.go:18`),
+ * `errors.New(context.Canceled)` (`apps/cli-go/internal/logout/logout.go:19`),
  * which the root error handler renders as `context canceled` on stderr with
- * exit code 1 (`cmd/root.go:288-301` skips the debug suggestion for
- * `context.Canceled`).
+ * exit code 1 and no `--debug` suggestion (`cmd/root.go:287-303` skips
+ * `SuggestDebugFlag` for `context.Canceled`). The TS renderer mirrors that:
+ * constructing this error with `CONTEXT_CANCELED_MESSAGE`
+ * (`shared/output/errors.ts`) is what makes the text `Output.fail` withhold
+ * the debug hint (CLI-1973).
  */
 export class LegacyLogoutCancelledError extends Data.TaggedError("LegacyLogoutCancelledError")<{
   readonly message: string;
 }> {}
-
-export const LEGACY_LOGOUT_CANCELLED_MESSAGE = "context canceled";

--- a/apps/cli/src/legacy/commands/logout/logout.handler.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.handler.ts
@@ -3,9 +3,10 @@ import { Effect } from "effect";
 import { LegacyCredentials } from "../../auth/legacy-credentials.service.ts";
 import { LegacyTelemetryState } from "../../telemetry/legacy-telemetry-state.service.ts";
 import { legacyResolveYes } from "../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../shared/output/errors.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { legacyPromptYesNo } from "../../shared/legacy-prompt-yes-no.ts";
-import { LegacyLogoutCancelledError, LEGACY_LOGOUT_CANCELLED_MESSAGE } from "./logout.errors.ts";
+import { LegacyLogoutCancelledError } from "./logout.errors.ts";
 
 const LOGGED_OUT_MSG = "Access token deleted successfully. You are now logged out.";
 
@@ -37,7 +38,7 @@ export const legacyLogout = Effect.fn("legacy.logout")(function* () {
     });
     if (!confirmed) {
       return yield* Effect.fail(
-        new LegacyLogoutCancelledError({ message: LEGACY_LOGOUT_CANCELLED_MESSAGE }),
+        new LegacyLogoutCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
       );
     }
 

--- a/apps/cli/src/legacy/commands/migration/down/down.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/down/down.handler.ts
@@ -5,6 +5,7 @@ import {
   legacyResolveYesWithProjectEnv,
 } from "../../../../shared/legacy/global-flags.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
@@ -138,7 +139,7 @@ const runDown = Effect.fnUntraced(function* (
         );
         if (!confirmed) {
           return yield* Effect.fail(
-            new LegacyOperationCanceledError({ message: "context canceled" }),
+            new LegacyOperationCanceledError({ message: CONTEXT_CANCELED_MESSAGE }),
           );
         }
 

--- a/apps/cli/src/legacy/commands/migration/down/down.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/down/down.integration.test.ts
@@ -5,6 +5,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   LEGACY_VALID_REF,
   mockLegacyCliConfig,
@@ -151,8 +152,6 @@ const flags = (over: Partial<LegacyMigrationDownFlags> = {}): LegacyMigrationDow
   local: over.local ?? true,
 });
 
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 const seed = (workdir: string, name: string, body = "create table a;\n") => {
   const dir = join(workdir, "supabase", "migrations");
   mkdirSync(dir, { recursive: true });

--- a/apps/cli/src/legacy/commands/migration/fetch/fetch.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/migration/fetch/fetch.e2e.test.ts
@@ -3,12 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { runSupabase } from "../../../../../tests/helpers/cli.ts";
+import { runSupabase, stripAnsi } from "../../../../../tests/helpers/cli.ts";
 
 const E2E_TIMEOUT_MS = 30_000;
-
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("supabase migration fetch (legacy)", () => {
   let workdir: string;
@@ -40,9 +37,15 @@ describe("supabase migration fetch (legacy)", () => {
         stdin: "n\n",
       });
 
-      // Declined → cancelled (non-zero), and the Go-style prompt label reached stderr.
-      expect(exitCode).not.toBe(0);
+      // Declined → cancelled (exit 1), and the Go-style prompt label reached stderr.
+      expect(exitCode).toBe(1);
       expect(stripAnsi(stderr)).toContain("[Y/n]");
+      // Byte-parity with Go's `recoverAndExit` (apps/cli-go/cmd/root.go:287-303):
+      // a declined prompt renders a lone `context canceled` line, with NO
+      // `SuggestDebugFlag` troubleshooting hint appended. CLI-1973.
+      const lines = stripAnsi(stderr).trimEnd().split("\n");
+      expect(lines.at(-1)).toBe("context canceled");
+      expect(stderr).not.toContain("Try rerunning the command with --debug");
       // The existing file was NOT overwritten — the piped answer was honored.
       expect(readdirSync(join(workdir, "supabase", "migrations"))).toEqual([
         "20240101000000_existing.sql",

--- a/apps/cli/src/legacy/commands/migration/fetch/fetch.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/fetch/fetch.handler.ts
@@ -5,6 +5,7 @@ import {
   legacyResolveYesWithProjectEnv,
 } from "../../../../shared/legacy/global-flags.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
@@ -114,7 +115,7 @@ const runFetch = Effect.fnUntraced(function* (
       const overwrite = yield* legacyMigrationConfirm(title, { defaultValue: true, yes });
       if (!overwrite) {
         return yield* Effect.fail(
-          new LegacyOperationCanceledError({ message: "context canceled" }),
+          new LegacyOperationCanceledError({ message: CONTEXT_CANCELED_MESSAGE }),
         );
       }
     }

--- a/apps/cli/src/legacy/commands/migration/list/list.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/list/list.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   LEGACY_VALID_REF,
   mockLegacyCliConfig,
@@ -107,9 +108,6 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     resolverCalls,
   };
 }
-
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 const flags = (over: Partial<LegacyMigrationListFlags> = {}): LegacyMigrationListFlags => ({
   dbUrl: over.dbUrl ?? Option.none(),

--- a/apps/cli/src/legacy/commands/migration/new/new.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/migration/new/new.e2e.test.ts
@@ -3,16 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { runSupabase } from "../../../../../tests/helpers/cli.ts";
+import { runSupabase, stripAnsi } from "../../../../../tests/helpers/cli.ts";
 
 const E2E_TIMEOUT_MS = 30_000;
-
-// Strip ANSI so the assertion is colour-independent: the handler prints the path
-// via `legacyBold`, which emits bold escapes under CI's `FORCE_COLOR` even on a
-// piped stdout. The text content is the parity contract, not the colour. Mirrors
-// `new.integration.test.ts`.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("supabase migration new (legacy)", () => {
   let workdir: string;

--- a/apps/cli/src/legacy/commands/migration/new/new.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/new/new.integration.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option, Stream } from "effect";
 import { badArgument } from "effect/PlatformError";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   mockLegacyCliConfig,
   mockLegacyTelemetryStateTracked,
@@ -34,10 +35,6 @@ function setup(workdir: string, opts: SetupOpts = {}) {
   );
   return { layer, out, telemetry };
 }
-
-// Strip ANSI so assertions are colour-independent (`legacyBold` emits colour on a TTY).
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 const tmp = useLegacyTempWorkdir();
 

--- a/apps/cli/src/legacy/commands/migration/repair/repair.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/repair/repair.handler.ts
@@ -5,6 +5,7 @@ import {
   legacyResolveYesWithProjectEnv,
 } from "../../../../shared/legacy/global-flags.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
@@ -200,7 +201,7 @@ const runRepair = Effect.fnUntraced(function* (
       );
       if (!confirmed) {
         return yield* Effect.fail(
-          new LegacyOperationCanceledError({ message: "context canceled" }),
+          new LegacyOperationCanceledError({ message: CONTEXT_CANCELED_MESSAGE }),
         );
       }
       versions = yield* legacyLoadLocalVersions(fs, path, migrationsDir);

--- a/apps/cli/src/legacy/commands/migration/repair/repair.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/repair/repair.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   LEGACY_VALID_REF,
   mockLegacyCliConfig,
@@ -133,8 +134,6 @@ const input = (over: Partial<LegacyMigrationRepairInput> = {}): LegacyMigrationR
   password: over.password ?? Option.none(),
 });
 
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 const seedMigration = (workdir: string, name: string, body: string) => {
   const dir = join(workdir, "supabase", "migrations");
   mkdirSync(dir, { recursive: true });

--- a/apps/cli/src/legacy/commands/migration/up/up.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
 import {
   LEGACY_VALID_REF,
   mockLegacyCliConfig,
@@ -126,8 +127,6 @@ const flags = (over: Partial<LegacyMigrationUpFlags> = {}): LegacyMigrationUpFla
   local: over.local ?? true,
 });
 
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 const seed = (workdir: string, name: string, body = "create table a;\n") => {
   const dir = join(workdir, "supabase", "migrations");
   mkdirSync(dir, { recursive: true });

--- a/apps/cli/src/legacy/commands/projects/delete/delete.handler.ts
+++ b/apps/cli/src/legacy/commands/projects/delete/delete.handler.ts
@@ -13,6 +13,7 @@ import {
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { LegacyYesFlag } from "../../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../shared/runtime/tty.service.ts";
 import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
@@ -81,7 +82,7 @@ export const legacyProjectsDelete = Effect.fn("legacy.projects.delete")(function
       confirmed = yield* output.promptConfirm(title).pipe(Effect.orElseSucceed(() => false));
     }
     if (!confirmed) {
-      return yield* new LegacyProjectsDeleteCancelledError({ message: "context canceled" });
+      return yield* new LegacyProjectsDeleteCancelledError({ message: CONTEXT_CANCELED_MESSAGE });
     }
 
     const mapDeleteError = mapLegacyHttpError({

--- a/apps/cli/src/legacy/commands/secrets/unset/unset.handler.ts
+++ b/apps/cli/src/legacy/commands/secrets/unset/unset.handler.ts
@@ -6,6 +6,7 @@ import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.ser
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { legacyResolveYes } from "../../../../shared/legacy/global-flags.ts";
+import { CONTEXT_CANCELED_MESSAGE } from "../../../../shared/output/errors.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { Tty } from "../../../../shared/runtime/tty.service.ts";
 import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
@@ -87,7 +88,7 @@ export const legacySecretsUnset = Effect.fn("legacy.secrets.unset")(function* (
 
     if (!confirmed) {
       return yield* Effect.fail(
-        new LegacySecretsUnsetCancelledError({ message: "context canceled" }),
+        new LegacySecretsUnsetCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
       );
     }
 

--- a/apps/cli/src/legacy/commands/start/start.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.e2e.test.ts
@@ -3,15 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { runSupabase } from "../../../../tests/helpers/cli.ts";
+import { runSupabase, stripAnsi } from "../../../../tests/helpers/cli.ts";
 
 const E2E_TIMEOUT_MS = 30_000;
-
-// Strip ANSI so the assertion is colour-independent — `legacyPartitionStartExcludeFlags`
-// styles the warning via `legacy-colors.ts`, matching `start.exclude.unit.test.ts`'s
-// own convention for the same text.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("supabase start (legacy)", () => {
   let projectDir: string;

--- a/apps/cli/src/legacy/commands/start/start.exclude.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.exclude.unit.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../../tests/helpers/ansi.ts";
 import { LEGACY_START_EXCLUDABLE_KEYS, legacyPartitionStartExcludeFlags } from "./start.exclude.ts";
-
-// The warning applies Go-parity ANSI styling via `legacy-colors.ts`, which
-// no-ops on a real non-TTY stream but the vitest process presents its stderr
-// as color-capable. Strip escapes so these assertions target the plain text
-// content — matching `status.pretty.unit.test.ts`'s convention.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 // Go's `ExcludableContainers()` order (`apps/cli-go/internal/start/start.go:
 // 1297-1303` walking `config.Images.Services()`,

--- a/apps/cli/src/legacy/commands/start/start.format.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.format.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../../tests/helpers/ansi.ts";
 import {
   LEGACY_START_STARTING_CONTAINERS_MESSAGE,
   LEGACY_START_STARTING_DATABASE_FROM_BACKUP_MESSAGE,
@@ -9,13 +10,6 @@ import {
   legacyStartCompletedMessage,
   legacyStartSecurityNotice,
 } from "./start.format.ts";
-
-// The formatters apply Go-parity ANSI styling via `legacy-colors.ts`, which
-// no-ops on a real non-TTY stream but the vitest process presents its stderr
-// as color-capable. Strip escapes so these assertions target the plain text
-// content — matching `status.pretty.unit.test.ts`'s convention.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("legacyStartAlreadyRunningMessage", () => {
   it("matches Go's exact stderr line, with a single trailing newline", () => {

--- a/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
@@ -1,6 +1,7 @@
 import { Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../tests/helpers/ansi.ts";
 import { LegacyDbExecError } from "./legacy-db-connection.errors.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
@@ -20,10 +21,6 @@ const failingSession = (error: LegacyDbExecError): LegacyDbSession => ({
   copyToCsv: () => Effect.die("unused"),
   queryRaw: () => Effect.die("unused"),
 });
-
-// Strip ANSI so the bold repair suggestions compare regardless of TTY colour.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 describe("legacyReconcileMigrations", () => {
   it("reports in-sync when remote and local match", () => {

--- a/apps/cli/src/legacy/shared/legacy-status-pretty.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-status-pretty.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "../../../tests/helpers/ansi.ts";
 import {
   legacyRenderStatusPretty,
   legacyStatusColumnLayout,
@@ -7,14 +8,6 @@ import {
   legacyWrapStatusLabel,
 } from "./legacy-status-pretty.ts";
 import type { LegacyStatusOutputNames } from "./legacy-status-values.ts";
-
-// The renderer applies Go-parity ANSI styling via `legacy-colors.ts`, which
-// no-ops on a real non-TTY stream but the vitest process presents its stderr
-// as color-capable. Strip escapes so these assertions target the plain
-// structural output — the golden contract per the port plan — not whichever
-// TTY heuristic the test runner happens to report.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/gu, "");
 
 // Default (un-overridden) output names, matching `legacy-status-values.ts`'s
 // `resolveOutputNames` with an empty override map — the KEYs the pretty

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -11,6 +11,7 @@ import {
 import { Duration, Effect, Option, Schema, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import { CONTEXT_CANCELED_MESSAGE } from "../output/errors.ts";
 import { Output } from "../output/output.service.ts";
 import { spawnContainerCli } from "../../legacy/shared/legacy-container-cli.ts";
 import { legacyGetRegistryImageUrl } from "../../legacy/shared/legacy-docker-registry.ts";
@@ -2084,7 +2085,9 @@ const pruneFunctions = Effect.fnUntraced(function* (
   ].join("\n");
   const confirmed = yes || (yield* output.promptConfirm(`${prompt}\n`, { defaultValue: false }));
   if (!confirmed) {
-    return yield* Effect.fail(new FunctionDeployCancelledError({ message: "context canceled" }));
+    return yield* Effect.fail(
+      new FunctionDeployCancelledError({ message: CONTEXT_CANCELED_MESSAGE }),
+    );
   }
 
   for (const slug of toDelete) {

--- a/apps/cli/src/shared/output/errors.ts
+++ b/apps/cli/src/shared/output/errors.ts
@@ -1,5 +1,31 @@
 import { Data } from "effect";
 
+/**
+ * Byte-for-byte render of Go's `context.Canceled` sentinel.
+ *
+ * Every declined confirmation prompt in the Go CLI surfaces as a bare
+ * `context.Canceled` (e.g. `errors.New(context.Canceled)` in
+ * `apps/cli-go/internal/logout/logout.go:19`), and `recoverAndExit`
+ * (`apps/cli-go/cmd/root.go:287-303`) deliberately skips the
+ * `SuggestDebugFlag` hint for it — declining a prompt is a user decision,
+ * not an error worth troubleshooting. Handlers that port those decline
+ * paths construct their cancellation errors with this exact message, and
+ * the text `Output.fail` renderer keys on it to suppress the `--debug`
+ * hint, mirroring Go's `!errors.Is(err, context.Canceled)` guard.
+ *
+ * Two invariants of that renderer check:
+ * - The value must stay trim-invariant: it round-trips through
+ *   `normalizeCliError`'s trimming `readString` before reaching the
+ *   renderer's equality check (`shared/output/normalize-error.ts`).
+ * - The check is exact-match, narrower than Go's chain-walking
+ *   `errors.Is`: a future producer surfacing a WRAPPED cancellation
+ *   (`"...: context canceled"`) through `Output.fail` would keep the hint
+ *   where Go suppresses it — no such producer exists today (mid-flight
+ *   Ctrl-C takes the interrupt/exit-130 path and never reaches
+ *   `Output.fail`), but widen the check if one ever appears.
+ */
+export const CONTEXT_CANCELED_MESSAGE = "context canceled";
+
 export class NonInteractiveError extends Data.TaggedError("NonInteractiveError")<{
   readonly detail: string;
   readonly suggestion: string;

--- a/apps/cli/src/shared/output/output.layer.ts
+++ b/apps/cli/src/shared/output/output.layer.ts
@@ -17,7 +17,7 @@ import { styleText } from "node:util";
 import { Effect, Layer, Stdio, Stream } from "effect";
 
 import { Tty } from "../runtime/tty.service.ts";
-import { NonInteractiveError } from "./errors.ts";
+import { CONTEXT_CANCELED_MESSAGE, NonInteractiveError } from "./errors.ts";
 import { Output } from "./output.service.ts";
 import type { OutputFormat, StreamEvent } from "./types.ts";
 
@@ -346,8 +346,15 @@ export const textOutputLayer = Layer.effect(
           }
           if (err.suggestion !== undefined) {
             process.stderr.write(err.suggestion + "\n");
-          } else if (!process.argv.includes("--debug")) {
-            // Go's `utils.SuggestDebugFlag` (apps/cli-go/internal/utils/misc.go:41).
+          } else if (
+            err.message !== CONTEXT_CANCELED_MESSAGE &&
+            !process.argv.includes("--debug")
+          ) {
+            // Go's `utils.SuggestDebugFlag` (apps/cli-go/internal/utils/misc.go:41),
+            // withheld for the canceled sentinel exactly like `recoverAndExit`'s
+            // `!errors.Is(err, context.Canceled)` guard (apps/cli-go/cmd/root.go:287-292):
+            // a declined confirmation prompt is a user decision, so Go prints only
+            // the red `context canceled` line with no troubleshooting hint (CLI-1973).
             process.stderr.write(
               "Try rerunning the command with --debug to troubleshoot the error.\n",
             );

--- a/apps/cli/src/shared/output/output.layer.unit.test.ts
+++ b/apps/cli/src/shared/output/output.layer.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { afterEach, beforeEach, vi } from "vitest";
 import { Cause, Effect, Exit, Layer, Sink, Stdio, Stream } from "effect";
-import { NonInteractiveError } from "./errors.ts";
+import { CONTEXT_CANCELED_MESSAGE, NonInteractiveError } from "./errors.ts";
 import { mockTty } from "../../../tests/helpers/mocks.ts";
 import { Output } from "./output.service.ts";
 import {
@@ -245,6 +245,62 @@ describe("Output", () => {
           Effect.sync(() => {
             process.stderr.write = originalWrite;
             process.argv = originalArgv;
+          }),
+        ),
+      );
+    });
+
+    it.effect("fail withholds the --debug fallback for a declined-prompt cancellation", () => {
+      const writes: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      const originalArgv = process.argv;
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+      // Strip --debug from argv so only the canceled-sentinel check can suppress the hint.
+      process.argv = originalArgv.filter((arg) => arg !== "--debug");
+      return Effect.gen(function* () {
+        const out = yield* Output;
+        // Same shape `normalizeCause` produces for any declined confirmation prompt
+        // (logout, migration fetch/repair/down, db push/reset, functions deploy
+        // --prune, ...): Go's `recoverAndExit` prints only the red `context canceled`
+        // line for `context.Canceled` (apps/cli-go/cmd/root.go:287-303) — CLI-1973.
+        yield* out.fail({ code: "LegacyLogoutCancelledError", message: CONTEXT_CANCELED_MESSAGE });
+        expect(writes).toEqual(["\x1B[31mcontext canceled\x1B[39m\n"]);
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.sync(() => {
+            process.stderr.write = originalWrite;
+            process.argv = originalArgv;
+          }),
+        ),
+      );
+    });
+
+    it.effect("fail still prints an explicit caller suggestion for a cancellation", () => {
+      const writes: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+      return Effect.gen(function* () {
+        const out = yield* Output;
+        // Go prints a pre-set `utils.CmdSuggestion` even for `context.Canceled` —
+        // only the `SuggestDebugFlag` fallback is withheld (cmd/root.go:287-292).
+        yield* out.fail({
+          code: "E_TEST",
+          message: CONTEXT_CANCELED_MESSAGE,
+          suggestion: "custom hint",
+        });
+        expect(writes).toEqual(["\x1B[31mcontext canceled\x1B[39m\n", "custom hint\n"]);
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.sync(() => {
+            process.stderr.write = originalWrite;
           }),
         ),
       );

--- a/apps/cli/tests/helpers/ansi.ts
+++ b/apps/cli/tests/helpers/ansi.ts
@@ -1,0 +1,21 @@
+/** Strip ANSI CSI escape sequences (colors, styles, cursor codes) from captured CLI output. */
+export function stripAnsi(output: string): string {
+  let stripped = "";
+  for (let i = 0; i < output.length; i++) {
+    const charCode = output.charCodeAt(i);
+    if (charCode !== 0x1b || output[i + 1] !== "[") {
+      stripped += output[i];
+      continue;
+    }
+
+    i += 2;
+    while (i < output.length) {
+      const code = output.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        break;
+      }
+      i++;
+    }
+  }
+  return stripped;
+}

--- a/apps/cli/tests/helpers/cli.ts
+++ b/apps/cli/tests/helpers/cli.ts
@@ -13,9 +13,7 @@ import {
   registerTempStackProject,
 } from "./stack-e2e-cleanup.ts";
 
-/** Strip ANSI SGR escape sequences (colors/styles) from captured CLI output. */
-// eslint-disable-next-line no-control-regex
-export const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/gu, "");
+export { stripAnsi } from "./ansi.ts";
 
 const BINARY_EXT = process.platform === "win32" ? ".exe" : "";
 const SHIM_PATH = fileURLToPath(new URL("../../dist/supabase.js", import.meta.url));

--- a/apps/cli/tests/helpers/cli.ts
+++ b/apps/cli/tests/helpers/cli.ts
@@ -13,6 +13,10 @@ import {
   registerTempStackProject,
 } from "./stack-e2e-cleanup.ts";
 
+/** Strip ANSI SGR escape sequences (colors/styles) from captured CLI output. */
+// eslint-disable-next-line no-control-regex
+export const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/gu, "");
+
 const BINARY_EXT = process.platform === "win32" ? ".exe" : "";
 const SHIM_PATH = fileURLToPath(new URL("../../dist/supabase.js", import.meta.url));
 const LEGACY_BINARY_PATH = fileURLToPath(


### PR DESCRIPTION
## What changed

When a confirmation prompt is declined, the Go CLI prints only a red `context canceled` on stderr and exits 1 — `recoverAndExit` (`apps/cli-go/cmd/root.go:287-303`) explicitly skips the `SuggestDebugFlag` fallback for `errors.Is(err, context.Canceled)`. The TS text `Output.fail` renderer appended the fallback hint for every suggestion-less error, including cancellations, so every prompting command (`logout`, `db push` (3 prompts), `db reset`, `migration fetch`/`repair`/`down`, `functions deploy --prune`, `gen signing-key`, `secrets unset`, `projects delete`, `branches create`, `bootstrap`) printed:

```
context canceled
Try rerunning the command with --debug to troubleshoot the error.   ← spurious
```

This PR mirrors Go's guard at the render boundary:

- New shared sentinel `CONTEXT_CANCELED_MESSAGE` in `apps/cli/src/shared/output/errors.ts` — the byte-for-byte render of Go's `context.Canceled`.
- The text-layer `fail` (`apps/cli/src/shared/output/output.layer.ts`) skips the debug-hint fallback when the normalized message equals the sentinel. The explicit-suggestion branch stays first, matching Go printing a pre-set `utils.CmdSuggestion` even for canceled errors.
- All 14 cancellation construction sites (12 files: the legacy decline paths above plus `shared/functions/deploy.ts`) now reference the constant instead of an inline literal, so the sentinel is single-sourced like Go's.
- `LEGACY_LOGOUT_CANCELLED_MESSAGE` is folded into the shared constant, and the documented intent in `logout.errors.ts` (which already described the Go behavior this PR implements) now matches reality.

## Why the fix is shared rather than legacy-scoped

The failure-rendering seam (`shared/cli/run.ts` `handledProgram` → `Output.fail`) is shell-agnostic, and `next/` genuinely shares a cancellation producer: `shared/functions/deploy.ts` (used by `next functions deploy --prune`) fails with the same `context canceled` message on a declined prune prompt. Suppressing a troubleshooting hint for a user-declined prompt is the correct behavior in both shells, so the fix lives in the shared layer instead of forking the renderer per shell. Aside from that, `next/` handlers treat declines gracefully (no `context canceled` error), so next-shell text rendering is otherwise unchanged. This is deliberate and reviewed against the CLI-1546 invariant (no spinner/stream routing was touched).

## Tests

- Unit (`output.layer.unit.test.ts`): byte assertions that the sentinel message renders as exactly the red `context canceled` line with no hint (fails without the fix), and that an explicit caller suggestion still prints for a cancellation (Go ordering).
- Declined-prompt stderr-byte e2e per affected family, each asserting exit code 1, last stderr line exactly `context canceled`, and no debug-hint line: `logout` (new), `migration fetch` (extended), `db reset` (new file — Docker-free, the destructive prompt fires before any connection is dialed), `gen signing-key` (extended).
- The existing non-canceled guards stay: a generic error still gets the hint (unit + `run.e2e.test.ts` asserts stderr ends with the hint for an unrecognized flag).
- `stripAnsi` hoisted to `tests/helpers/cli.ts` for the files this PR touches.

## Deliberately-open judgement calls

- **Exact-match vs `errors.Is`:** the TS check is message equality, narrower than Go's chain-walking `errors.Is`. A future producer surfacing a *wrapped* cancellation (`"...: context canceled"`) through `Output.fail` would keep the hint where Go suppresses it. No such producer exists today (mid-flight Ctrl-C takes the interrupt/exit-130 path and never reaches `Output.fail`); the invariant is documented on the constant. Reviewers (architect/engineer/parity passes) agreed a tag-registry or normalized-error flag isn't warranted for a single Go sentinel.
- **Pre-existing divergences noted during the parity audit, out of scope here:** (a) Ctrl-C *at* a prompt → TS clack `Operation cancelled.`/exit 130 vs Go `context canceled`/exit 1; (b) the hint's `--debug` detection uses `process.argv` vs Go's `viper.GetBool("DEBUG")` (which also honors `SUPABASE_DEBUG`) — affects only the non-canceled branch.

Fixes CLI-1973

https://linear.app/supabase/issue/CLI-1973/declined-confirmation-prompts-print-a-spurious-debug-hint-context
