### PR TITLE
fix(cli): surface db connection-failure detail and fix connect suggestion classifiers

### DIFF
--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -1,8 +1,10 @@
 /**
- * Connection-error classification ported from Go's `internal/utils/connect.go`.
+ * Connection-error classification and rendering ported from Go's
+ * `internal/utils/connect.go` and pgconn's `connectError` (`errors.go:60-77`).
  * Used by the container-level pooler fallback (`db dump --linked`) to decide
  * whether a failed pg_dump/pg container was an IPv6 connectivity failure that
- * warrants retrying through the IPv4 transaction pooler.
+ * warrants retrying through the IPv4 transaction pooler, and by the connection
+ * layer to render connect failures with Go's `host=… user=… database=…` detail.
  */
 
 import { isIPv6 } from "node:net";
@@ -29,7 +31,10 @@ export function legacyIpv6Suggestion(): string {
 // Go's `ipv6LiteralPattern` (`connect.go:181`): an IPv6 address in brackets
 // (Go dial form) or parens (libpq form). Run against the original-case message.
 const IPV6_LITERAL_PATTERN = /(?:\[[0-9a-fA-F:]+\]|\([0-9a-fA-F:]+\))/;
-const NODE_ENETUNREACH_PATTERN = /\benetunreach\s+([0-9a-fA-F:]+):\d+(?:\s|$)/i;
+// Node's dial-failure shape (`connect ENETUNREACH 2600:…:5432`). The port may be
+// followed by whitespace, end-of-string, or a closing paren — the connect-failure
+// message renders the driver cause parenthesized (pgconn `dial error (…)` form).
+const NODE_ENETUNREACH_PATTERN = /\benetunreach\s+([0-9a-fA-F:]+):\d+(?:[\s)]|$)/i;
 
 /**
  * Port of Go's `isIPv6ConnectivityError` (`connect.go:189-208`). Lower-cases the
@@ -97,6 +102,182 @@ function legacyCollectConnectErrorText(error: unknown): string {
 }
 
 /**
+ * The connection identity pgconn embeds in its `connectError` text
+ * (`errors.go:66-68`): the config-level (primary) host, user, and database —
+ * never the password.
+ */
+export interface LegacyConnectFailureTarget {
+  readonly host: string;
+  readonly user: string;
+  readonly database: string;
+}
+
+/**
+ * Walk to the deepest underlying driver error: unwrap `cause` chains (the
+ * `@effect/sql` `SqlError` exposes its `ConnectionError` reason as `cause`, and
+ * the reason exposes the node-postgres error the same way) and descend into the
+ * LAST entry of an `AggregateError`'s `errors[]` — pgconn's multi-address
+ * fallback loop likewise surfaces the last attempt's error
+ * (`pgconn.go:159-192`).
+ */
+function legacyDeepestConnectCause(error: unknown): unknown {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8; depth++) {
+    if (typeof current !== "object" || current === null || seen.has(current)) break;
+    seen.add(current);
+    const errors = Reflect.get(current, "errors");
+    if (Array.isArray(errors) && errors.length > 0) {
+      current = errors[errors.length - 1];
+      continue;
+    }
+    const cause = Reflect.get(current, "cause");
+    if (typeof cause !== "object" || cause === null) break;
+    current = cause;
+  }
+  return current;
+}
+
+// Node/Bun errno codes raised while dialing the server — pgconn wraps the
+// equivalent net.Dial failures as `dial error (…)` (`pgconn.go:276`).
+const LEGACY_DIAL_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "EADDRNOTAVAIL",
+]);
+// Node/OpenSSL certificate-verification codes plus node's ERR_TLS_*/ERR_SSL_*
+// families — pgconn wraps TLS negotiation failures as `tls error (…)`
+// (`pgconn.go:288`).
+const LEGACY_TLS_ERROR_CODES = new Set([
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "CERT_HAS_EXPIRED",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "HOSTNAME_MISMATCH",
+]);
+// node-postgres' own message when the server answers `N` to SSLRequest
+// (`pg/lib/connection.js`); pgconn: `tls error (server refused TLS connection)`.
+const LEGACY_SERVER_REFUSED_SSL = "The server does not support SSL connections";
+// A Postgres SQLSTATE is exactly five uppercase alphanumerics. Combined with the
+// `severity` field this identifies a node-postgres `DatabaseError` (a server
+// ErrorResponse), never a node system error (whose codes are longer `E…` names).
+const SQLSTATE_PATTERN = /^[0-9A-Z]{5}$/;
+
+/**
+ * Render the underlying driver failure the way pgconn stages its
+ * `connectError.msg` (`server error` / `hostname resolving error` /
+ * `dial error` / `tls error`, each with the cause parenthesized —
+ * `errors.go:66-72`). A server ErrorResponse reproduces pgconn's `PgError`
+ * rendering byte-for-byte (`Severity: Message (SQLSTATE Code)`, `errors.go:51`);
+ * for the other stages the parenthesized text is the node driver's own message,
+ * which cannot byte-match libpq/pgconn wording (e.g. node's
+ * `connect ECONNREFUSED 1.2.3.4:5432` vs Go's
+ * `dial tcp 1.2.3.4:5432: connect: connection refused`). An unrecognized cause
+ * (e.g. node-postgres' `Connection terminated unexpectedly`, where pgconn would
+ * say `failed to receive message (unexpected EOF)`) is rendered verbatim rather
+ * than guessing a stage.
+ *
+ * Known stage-label caveat: pgconn labels by auth PHASE, which node-postgres
+ * does not expose — a wrong password over SCRAM arrives mid-SASL, so Go renders
+ * `failed SASL auth (FATAL: password authentication failed … (SQLSTATE 28P01))`
+ * (`pgconn.go:359`) where this renders `server error (…)` with the identical
+ * inner `PgError` bytes. The suggestion classifier keys off the inner text, so
+ * the `SUPABASE_DB_PASSWORD` hint fires identically either way.
+ */
+function legacyConnectCauseDetail(cause: unknown): string {
+  if (typeof cause !== "object" || cause === null) return String(cause);
+  const message = Reflect.get(cause, "message");
+  const code = Reflect.get(cause, "code");
+  const severity = Reflect.get(cause, "severity");
+  const syscall = Reflect.get(cause, "syscall");
+  const text =
+    typeof message === "string" && message.length > 0
+      ? message
+      : typeof code === "string"
+        ? code
+        : String(cause);
+  if (typeof severity === "string" && typeof code === "string" && SQLSTATE_PATTERN.test(code)) {
+    return `server error (${severity}: ${text} (SQLSTATE ${code}))`;
+  }
+  if (syscall === "getaddrinfo" || code === "ENOTFOUND" || code === "EAI_AGAIN") {
+    return `hostname resolving error (${text})`;
+  }
+  if (syscall === "connect" || (typeof code === "string" && LEGACY_DIAL_ERROR_CODES.has(code))) {
+    return `dial error (${text})`;
+  }
+  if (
+    text === LEGACY_SERVER_REFUSED_SSL ||
+    (typeof code === "string" &&
+      (LEGACY_TLS_ERROR_CODES.has(code) ||
+        code.startsWith("ERR_TLS") ||
+        code.startsWith("ERR_SSL")))
+  ) {
+    return `tls error (${text})`;
+  }
+  return text;
+}
+
+/**
+ * Port of pgconn's `connectError.Error()` (`errors.go:66-72`), the inner text of
+ * Go's `failed to connect to postgres: %w` wrap (`pkg/pgxv5/connect.go:33`):
+ * `` failed to connect to `host=… user=… database=…`: <staged driver cause> ``.
+ * Callers pass the connection config (pgconn embeds the config-level identity,
+ * `errors.go:66-68`) and the raw failure — either the `@effect/sql` `SqlError`
+ * from the pooled connect probe or the bare node-postgres error from the raw
+ * client, both unwrapped by {@link legacyDeepestConnectCause}.
+ */
+export function legacyConnectFailureMessage(
+  target: LegacyConnectFailureTarget,
+  error: unknown,
+): string {
+  const detail = legacyConnectCauseDetail(legacyDeepestConnectCause(error));
+  return `failed to connect to \`host=${target.host} user=${target.user} database=${target.database}\`: ${detail}`;
+}
+
+// Dial errno codes that mean the target address itself is unreachable. Combined
+// with an IPv6 `address` they are node's equivalents of Go's IPv6-connectivity
+// texts: ENETUNREACH → `network is unreachable`, EHOSTUNREACH → `no route to
+// host`, EADDRNOTAVAIL → `cannot assign requested address` (`connect.go:204-223`).
+const LEGACY_IPV6_DIAL_CODES = new Set(["ENETUNREACH", "EHOSTUNREACH", "EADDRNOTAVAIL"]);
+
+/**
+ * Whether the error chain carries a node dial failure whose errno + `address`
+ * fields identify an unreachable IPv6 target. This is the structured complement
+ * to {@link legacyIsIPv6ConnectivityError}: node system errors carry the dialed
+ * address as a field (`connect EHOSTUNREACH 2600:…:5432` has `code` and
+ * `address`), whereas Go's classifier reads the same facts out of pgconn's
+ * message text. Narrower than `legacyIsIPv6ConnectivityErrorCause` — it never
+ * treats `ENOTFOUND` (a plain DNS miss, e.g. a typo'd host) as IPv6, matching
+ * Go, where a failed lookup renders `hostname resolving error` and sets no
+ * suggestion. Use THIS one for the connect suggestion; the container-level
+ * pooler fallback keeps the broader `legacyIsIPv6ConnectivityErrorCause`.
+ * Depth-bounded recursion (no `seen` set): a pathological cause cycle re-walks
+ * at most 8 levels, which is cheap and cannot loop.
+ */
+function legacyHasIPv6DialCause(error: unknown, depth = 0): boolean {
+  if (depth > 8 || typeof error !== "object" || error === null) return false;
+  const code = Reflect.get(error, "code");
+  const address = Reflect.get(error, "address");
+  if (
+    typeof code === "string" &&
+    LEGACY_IPV6_DIAL_CODES.has(code) &&
+    typeof address === "string" &&
+    isIPv6(address)
+  ) {
+    return true;
+  }
+  const errors = Reflect.get(error, "errors");
+  if (Array.isArray(errors) && errors.some((child) => legacyHasIPv6DialCause(child, depth + 1))) {
+    return true;
+  }
+  return legacyHasIPv6DialCause(Reflect.get(error, "cause"), depth + 1);
+}
+
+/**
  * Port of Go's `SetConnectSuggestion` (`internal/utils/connect.go:313-335`): map a
  * Postgres connect failure to an actionable hint that replaces the generic
  * "Try rerunning the command with --debug" suggestion. Go matches `pgconn`'s
@@ -105,6 +286,12 @@ function legacyCollectConnectErrorText(error: unknown): string {
  * the `SqlError` cause/aggregate chain. The branch order mirrors Go's `if/else if`.
  * Returns `undefined` when no specific suggestion applies (the caller then falls
  * back to the generic suggestion, like Go leaving `CmdSuggestion` empty).
+ *
+ * Sourcing note: the rendered message ({@link legacyConnectFailureMessage})
+ * surfaces only the LAST fallback attempt (pgconn parity), while this classifier
+ * deliberately scans the WHOLE chain — do not "align" one to the other. Real
+ * Supabase aggregates are single-family (direct = IPv6-only, pooler = IPv4-only),
+ * so the two never disagree in practice.
  */
 export function legacyConnectSuggestion(
   error: unknown,
@@ -132,11 +319,21 @@ export function legacyConnectSuggestion(
   ) {
     return LEGACY_SUGGEST_ENV_VAR;
   }
-  if (legacyIsIPv6ConnectivityError(text)) {
+  // Go: `isIPv6ConnectivityError` on the pgconn text. node system errors carry
+  // the dialed address as a structured field instead of libpq's parenthesized
+  // literal, so also consult the errno + `address` classifier.
+  if (legacyIsIPv6ConnectivityError(text) || legacyHasIPv6DialCause(error)) {
     return legacyIpv6Suggestion();
   }
-  // no route to host / Tenant or user not found → wrong profile.
-  if (text.includes("no route to host") || text.includes("Tenant or user not found")) {
+  // connect: no route to host / Tenant or user not found → wrong profile.
+  // node's "no route to host" is `connect EHOSTUNREACH <ip>:<port>`; an IPv6
+  // EHOSTUNREACH was already captured by the IPv6 branch above, mirroring Go's
+  // branch order ("Assumes IPv6 check has been performed before this").
+  if (
+    text.includes("no route to host") ||
+    text.includes("EHOSTUNREACH") ||
+    text.includes("Tenant or user not found")
+  ) {
     return `Make sure your project exists on profile: ${ctx.profileName}`;
   }
   return undefined;
@@ -155,6 +352,9 @@ function hasStringCode(error: unknown): error is {
  * Classifies Node socket/getaddrinfo causes that carry errno-style `code` fields.
  * `ENOTFOUND` is intentionally broader than Go's text classifier (it can include
  * typo'd hosts); callers must combine this with a direct `db.<ref>` host gate.
+ * Used by the container-level pooler fallback (`gen types` / `db dump`); the
+ * connect-suggestion path uses the narrower `legacyHasIPv6DialCause` instead,
+ * which must not treat a DNS miss as IPv6.
  */
 export function legacyIsIPv6ConnectivityErrorCause(error: unknown): boolean {
   if (error instanceof AggregateError) {

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -198,6 +198,15 @@ const LEGACY_TLS_ERROR_CODES = new Set([
 // node-postgres' own message when the server answers `N` to SSLRequest
 // (`pg/lib/connection.js`); pgconn: `tls error (server refused TLS connection)`.
 const LEGACY_SERVER_REFUSED_SSL = "The server does not support SSL connections";
+// Node/Bun's TLS-socket message when the server accepts SSLRequest but closes
+// the socket before the handshake completes (node `lib/_tls_wrap.js`
+// `onConnectEnd`; Bun emits the same text for both FIN and RST). Phase-specific
+// by construction — only ever raised pre-secure-connection — so it maps to
+// pgconn's startTLS stage (`tls error (…)`, `pgconn.go:283-289`). Its code is
+// ECONNRESET, deliberately absent from LEGACY_DIAL_ERROR_CODES: a raw
+// post-handshake `read ECONNRESET` is not phase-specific and stays verbatim.
+const LEGACY_TLS_DISCONNECT_MESSAGE =
+  "Client network socket disconnected before secure TLS connection was established";
 // A Postgres SQLSTATE is exactly five uppercase alphanumerics. Combined with the
 // `severity` field this identifies a node-postgres `DatabaseError` (a server
 // ErrorResponse), never a node system error (whose codes are longer `E…` names).
@@ -247,6 +256,7 @@ function legacyConnectCauseDetail(cause: unknown): string {
   }
   if (
     text === LEGACY_SERVER_REFUSED_SSL ||
+    text === LEGACY_TLS_DISCONNECT_MESSAGE ||
     (typeof code === "string" &&
       (LEGACY_TLS_ERROR_CODES.has(code) ||
         code.startsWith("ERR_TLS") ||

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -151,16 +151,42 @@ const LEGACY_DIAL_ERROR_CODES = new Set([
   "EHOSTUNREACH",
   "EADDRNOTAVAIL",
 ]);
-// Node/OpenSSL certificate-verification codes plus node's ERR_TLS_*/ERR_SSL_*
-// families — pgconn wraps TLS negotiation failures as `tls error (…)`
-// (`pgconn.go:288`).
+// The complete documented Node/OpenSSL X509 certificate-verification code
+// family (Node tls docs "X509 certificate error codes", OpenSSL's
+// `X509_verify_cert_error` set), complemented by node's ERR_TLS_*/ERR_SSL_*
+// prefixes at the use site. pgconn stages by connection PHASE — ANY `startTLS`
+// failure becomes `tls error (…)` (`pgconn.go:283-289`) — but node exposes no
+// phase marker, so the full code family is the proxy. These strings are unique
+// to TLS-layer verification: server SQLSTATEs and dial/DNS `E…` errnos are
+// classified by earlier branches.
 const LEGACY_TLS_ERROR_CODES = new Set([
-  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-  "SELF_SIGNED_CERT_IN_CHAIN",
-  "DEPTH_ZERO_SELF_SIGNED_CERT",
-  "CERT_HAS_EXPIRED",
   "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_CRL",
+  "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+  "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+  "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+  "CERT_SIGNATURE_FAILURE",
+  "CRL_SIGNATURE_FAILURE",
+  "CERT_NOT_YET_VALID",
+  "CERT_HAS_EXPIRED",
+  "CRL_NOT_YET_VALID",
+  "CRL_HAS_EXPIRED",
+  "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+  "ERROR_IN_CERT_NOT_AFTER_FIELD",
+  "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+  "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+  "OUT_OF_MEM",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
   "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "CERT_CHAIN_TOO_LONG",
+  "CERT_REVOKED",
+  "INVALID_CA",
+  "PATH_LENGTH_EXCEEDED",
+  "INVALID_PURPOSE",
+  "CERT_UNTRUSTED",
+  "CERT_REJECTED",
   "HOSTNAME_MISMATCH",
 ]);
 // node-postgres' own message when the server answers `N` to SSLRequest

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -79,13 +79,16 @@ export interface LegacyConnectSuggestionContext {
  * nested `message` and `code`. The `@effect/sql` `SqlError` wraps the
  * node-postgres / node `net` driver error on its `cause`; a multi-address dial
  * wraps an `AggregateError` whose `errors[]` carry the per-IP `ECONNREFUSED` /
- * `ENETUNREACH` system errors — only the LAST child is visited, because that is
- * the attempt pgconn surfaces: its fallback loop overwrites the error on every
- * attempt so only the last one survives (`pgconn.go:171-203`), and Go's
- * `SetConnectSuggestion` classifies exactly that `err.Error()` string
- * (`connect.go:317`). Including the `code` strings lets the matcher key off
- * node's `ECONNREFUSED` the way Go keys off pgconn's `connect: connection
- * refused`.
+ * `ENETUNREACH` system errors — an aggregate node contributes NOTHING itself
+ * and only its LAST child is visited, because that is the attempt pgconn
+ * surfaces: its fallback loop overwrites the error on every attempt so only the
+ * last one survives (`pgconn.go:171-203`), and Go's `SetConnectSuggestion`
+ * classifies exactly that `err.Error()` string (`connect.go:317`). The parent's
+ * own fields must be skipped: node's `aggregateErrors` copies `errors[0].code`
+ * onto the aggregate itself (`lib/internal/errors.js`, Bun matches), so reading
+ * them would blame an abandoned first attempt. Including the `code` strings of
+ * the visited nodes lets the matcher key off node's `ECONNREFUSED` the way Go
+ * keys off pgconn's `connect: connection refused`.
  */
 function legacyCollectConnectErrorText(error: unknown): string {
   const parts: string[] = [];
@@ -93,13 +96,16 @@ function legacyCollectConnectErrorText(error: unknown): string {
   const visit = (node: unknown, depth: number): void => {
     if (depth > 8 || typeof node !== "object" || node === null || seen.has(node)) return;
     seen.add(node);
+    const errors = Reflect.get(node, "errors");
+    if (Array.isArray(errors) && errors.length > 0) {
+      visit(errors[errors.length - 1], depth + 1);
+      return;
+    }
     const message = Reflect.get(node, "message");
     if (typeof message === "string") parts.push(message);
     const code = Reflect.get(node, "code");
     if (typeof code === "string") parts.push(code);
     visit(Reflect.get(node, "cause"), depth + 1);
-    const errors = Reflect.get(node, "errors");
-    if (Array.isArray(errors) && errors.length > 0) visit(errors[errors.length - 1], depth + 1);
   };
   visit(error, 0);
   return parts.join("\n");

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -75,13 +75,17 @@ export interface LegacyConnectSuggestionContext {
 }
 
 /**
- * Flatten an error's `cause` chain and any `AggregateError.errors` into a single
- * searchable string of every nested `message` and `code`. The `@effect/sql`
- * `SqlError` wraps the node-postgres / node `net` driver error on its `cause`; a
- * multi-address dial wraps an `AggregateError` whose `errors[]` carry the per-IP
- * `ECONNREFUSED` / `ENETUNREACH` system errors. Including the `code` strings lets
- * the matcher key off node's `ECONNREFUSED` the way Go keys off pgconn's
- * `connect: connection refused`.
+ * Flatten an error's `cause` chain into a single searchable string of every
+ * nested `message` and `code`. The `@effect/sql` `SqlError` wraps the
+ * node-postgres / node `net` driver error on its `cause`; a multi-address dial
+ * wraps an `AggregateError` whose `errors[]` carry the per-IP `ECONNREFUSED` /
+ * `ENETUNREACH` system errors — only the LAST child is visited, because that is
+ * the attempt pgconn surfaces: its fallback loop overwrites the error on every
+ * attempt so only the last one survives (`pgconn.go:171-203`), and Go's
+ * `SetConnectSuggestion` classifies exactly that `err.Error()` string
+ * (`connect.go:317`). Including the `code` strings lets the matcher key off
+ * node's `ECONNREFUSED` the way Go keys off pgconn's `connect: connection
+ * refused`.
  */
 function legacyCollectConnectErrorText(error: unknown): string {
   const parts: string[] = [];
@@ -95,7 +99,7 @@ function legacyCollectConnectErrorText(error: unknown): string {
     if (typeof code === "string") parts.push(code);
     visit(Reflect.get(node, "cause"), depth + 1);
     const errors = Reflect.get(node, "errors");
-    if (Array.isArray(errors)) for (const child of errors) visit(child, depth + 1);
+    if (Array.isArray(errors) && errors.length > 0) visit(errors[errors.length - 1], depth + 1);
   };
   visit(error, 0);
   return parts.join("\n");
@@ -255,8 +259,11 @@ const LEGACY_IPV6_DIAL_CODES = new Set(["ENETUNREACH", "EHOSTUNREACH", "EADDRNOT
  * Go, where a failed lookup renders `hostname resolving error` and sets no
  * suggestion. Use THIS one for the connect suggestion; the container-level
  * pooler fallback keeps the broader `legacyIsIPv6ConnectivityErrorCause`.
- * Depth-bounded recursion (no `seen` set): a pathological cause cycle re-walks
- * at most 8 levels, which is cheap and cannot loop.
+ * Like {@link legacyDeepestConnectCause}, an `AggregateError` descends into its
+ * LAST child only — the attempt pgconn surfaces (`pgconn.go:171-203`) and the
+ * one Go's classifier reads (`connect.go:317`). Depth-bounded recursion (no
+ * `seen` set): a pathological cause cycle re-walks at most 8 levels, which is
+ * cheap and cannot loop.
  */
 function legacyHasIPv6DialCause(error: unknown, depth = 0): boolean {
   if (depth > 8 || typeof error !== "object" || error === null) return false;
@@ -271,8 +278,8 @@ function legacyHasIPv6DialCause(error: unknown, depth = 0): boolean {
     return true;
   }
   const errors = Reflect.get(error, "errors");
-  if (Array.isArray(errors) && errors.some((child) => legacyHasIPv6DialCause(child, depth + 1))) {
-    return true;
+  if (Array.isArray(errors) && errors.length > 0) {
+    return legacyHasIPv6DialCause(errors[errors.length - 1], depth + 1);
   }
   return legacyHasIPv6DialCause(Reflect.get(error, "cause"), depth + 1);
 }
@@ -287,11 +294,14 @@ function legacyHasIPv6DialCause(error: unknown, depth = 0): boolean {
  * Returns `undefined` when no specific suggestion applies (the caller then falls
  * back to the generic suggestion, like Go leaving `CmdSuggestion` empty).
  *
- * Sourcing note: the rendered message ({@link legacyConnectFailureMessage})
- * surfaces only the LAST fallback attempt (pgconn parity), while this classifier
- * deliberately scans the WHOLE chain — do not "align" one to the other. Real
- * Supabase aggregates are single-family (direct = IPv6-only, pooler = IPv4-only),
- * so the two never disagree in practice.
+ * Sourcing note: the rendered message ({@link legacyConnectFailureMessage}) and
+ * this classifier inspect the SAME surfaced attempt, as Go guarantees by
+ * construction — pgconn's fallback loop overwrites its error on every attempt so
+ * only the last one survives (`pgconn.go:171-203`), and `SetConnectSuggestion`
+ * classifies exactly that rendered `err.Error()` string (`connect.go:317`). The
+ * collectors above therefore descend into only the LAST aggregate child, the
+ * same attempt {@link legacyDeepestConnectCause} surfaces for rendering, so the
+ * displayed cause and the suggestion can never disagree.
  */
 export function legacyConnectSuggestion(
   error: unknown,

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -346,7 +346,10 @@ describe("legacyConnectSuggestion", () => {
     // the last error (`pgconn.go:171-203`) and `SetConnectSuggestion` classifies
     // that same rendered string (`connect.go:317`). An earlier IPv6 EHOSTUNREACH
     // followed by a final unclassified IPv4 timeout must NOT fire the IPv6 hint.
+    // The parent carries `code` copied from errors[0] (node's `aggregateErrors`),
+    // which must not leak into the wrong-profile branch either.
     const aggregate = Object.assign(new AggregateError([], ""), {
+      code: "EHOSTUNREACH",
       errors: [
         dialError("EHOSTUNREACH", "2600:1f18::1", 5432),
         dialError("ETIMEDOUT", "10.0.0.9", 5432),
@@ -357,8 +360,10 @@ describe("legacyConnectSuggestion", () => {
 
   it("fires the IPv6 pooler suggestion when the LAST aggregate attempt is the IPv6 dial failure", () => {
     // The surfaced (last) attempt drives both the rendered cause and the
-    // suggestion — an earlier refused IPv4 attempt is ignored, like Go.
+    // suggestion — an earlier refused IPv4 attempt is ignored, like Go, even
+    // though node copies its `code` onto the aggregate parent.
     const aggregate = Object.assign(new AggregateError([], ""), {
+      code: "ECONNREFUSED",
       errors: [
         dialError("ECONNREFUSED", "10.0.0.9", 5432),
         dialError("EHOSTUNREACH", "2600:1f18::1", 5432),
@@ -366,6 +371,41 @@ describe("legacyConnectSuggestion", () => {
     });
     expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toBe(
       legacyIpv6Suggestion(),
+    );
+  });
+
+  it("ignores the parent aggregate's copied first-attempt code (node aggregateErrors shape)", () => {
+    // Node's `aggregateErrors` (`lib/internal/errors.js`, Bun matches) copies
+    // `errors[0].code` onto the AggregateError itself. A refused first attempt
+    // followed by a final unreachable-IPv6 attempt must classify the LAST
+    // attempt (IPv6 pooler hint), not the parent's copied ECONNREFUSED —
+    // otherwise the suggestion disagrees with the rendered cause, which Go
+    // makes impossible (`pgconn.go:171-203`, `connect.go:317`).
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      code: "ECONNREFUSED",
+      errors: [
+        dialError("ECONNREFUSED", "10.0.0.9", 5432),
+        dialError("ENETUNREACH", "2600:1f18::1", 5432),
+      ],
+    });
+    expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toBe(
+      legacyIpv6Suggestion(),
+    );
+  });
+
+  it("classifies a refused LAST attempt as network restrictions despite an IPv6 first attempt", () => {
+    // Reverse direction: the parent's copied ENETUNREACH (from the abandoned
+    // IPv6 first attempt) must not fabricate the IPv6 hint when the surfaced
+    // last attempt is a plain refusal.
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      code: "ENETUNREACH",
+      errors: [
+        dialError("ENETUNREACH", "2600:1f18::1", 5432),
+        dialError("ECONNREFUSED", "10.0.0.9", 5432),
+      ],
+    });
+    expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toContain(
+      "Network Restrictions and Network Bans",
     );
   });
 

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -295,6 +295,34 @@ describe("legacyConnectSuggestion", () => {
     );
   });
 
+  it("classifies only the LAST attempt of a mixed-family aggregate (pgconn last-fallback parity)", () => {
+    // Go can never blame an abandoned attempt: pgconn's fallback loop keeps only
+    // the last error (`pgconn.go:171-203`) and `SetConnectSuggestion` classifies
+    // that same rendered string (`connect.go:317`). An earlier IPv6 EHOSTUNREACH
+    // followed by a final unclassified IPv4 timeout must NOT fire the IPv6 hint.
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      errors: [
+        dialError("EHOSTUNREACH", "2600:1f18::1", 5432),
+        dialError("ETIMEDOUT", "10.0.0.9", 5432),
+      ],
+    });
+    expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toBeUndefined();
+  });
+
+  it("fires the IPv6 pooler suggestion when the LAST aggregate attempt is the IPv6 dial failure", () => {
+    // The surfaced (last) attempt drives both the rendered cause and the
+    // suggestion — an earlier refused IPv4 attempt is ignored, like Go.
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      errors: [
+        dialError("ECONNREFUSED", "10.0.0.9", 5432),
+        dialError("EHOSTUNREACH", "2600:1f18::1", 5432),
+      ],
+    });
+    expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toBe(
+      legacyIpv6Suggestion(),
+    );
+  });
+
   it("keeps an IPv4 EADDRNOTAVAIL unclassified, like Go without an IPv6 literal", () => {
     const err = realSqlConnectError(dialError("EADDRNOTAVAIL", "10.1.2.3", 5432));
     expect(legacyConnectSuggestion(err, ctx)).toBeUndefined();

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -174,6 +174,52 @@ describe("legacyConnectFailureMessage", () => {
     );
   });
 
+  it("stages every documented X509 certificate-verification code as tls error", () => {
+    // pgconn stages by connection phase — ANY startTLS failure is `tls error (…)`
+    // (`pgconn.go:283-289`) — so the complete Node/OpenSSL verification family
+    // (Node tls docs "X509 certificate error codes") must keep the staged
+    // rendering under sslmode=verify-ca / verify-full. Pinned code-by-code so a
+    // future trim of the allowlist regresses loudly.
+    const x509Codes = [
+      "UNABLE_TO_GET_ISSUER_CERT",
+      "UNABLE_TO_GET_CRL",
+      "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+      "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+      "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+      "CERT_SIGNATURE_FAILURE",
+      "CRL_SIGNATURE_FAILURE",
+      "CERT_NOT_YET_VALID",
+      "CERT_HAS_EXPIRED",
+      "CRL_NOT_YET_VALID",
+      "CRL_HAS_EXPIRED",
+      "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+      "ERROR_IN_CERT_NOT_AFTER_FIELD",
+      "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+      "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+      "OUT_OF_MEM",
+      "DEPTH_ZERO_SELF_SIGNED_CERT",
+      "SELF_SIGNED_CERT_IN_CHAIN",
+      "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+      "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+      "CERT_CHAIN_TOO_LONG",
+      "CERT_REVOKED",
+      "INVALID_CA",
+      "PATH_LENGTH_EXCEEDED",
+      "INVALID_PURPOSE",
+      "CERT_UNTRUSTED",
+      "CERT_REJECTED",
+      "HOSTNAME_MISMATCH",
+    ] as const;
+    for (const code of x509Codes) {
+      const failure = Object.assign(new Error(`certificate verification failed: ${code}`), {
+        code,
+      });
+      expect(legacyConnectFailureMessage(target, realSqlConnectError(failure))).toBe(
+        `${prefix} tls error (certificate verification failed: ${code})`,
+      );
+    }
+  });
+
   it("renders an unrecognized cause verbatim (CLI-1942 session-pooler EOF shape)", () => {
     // node-postgres raises `Connection terminated unexpectedly` where pgconn
     // says `failed to receive message (unexpected EOF)` — no stage is guessed.

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -1,12 +1,46 @@
+import { ConnectionError, SqlError } from "effect/unstable/sql/SqlError";
+import * as Pg from "pg";
 import { describe, expect, it } from "vitest";
 
 import {
   LEGACY_SUGGEST_ENV_VAR,
+  legacyConnectFailureMessage,
   legacyConnectSuggestion,
   legacyIpv6Suggestion,
   legacyIsIPv6ConnectivityError,
   legacyIsIPv6ConnectivityErrorCause,
 } from "./legacy-connect-errors.ts";
+
+// The real `@effect/sql` wrapper produced by the connect probe
+// (`legacyAcquireProbedPool`): a `SqlError` whose `ConnectionError` reason carries
+// the node-postgres driver error as its `cause`.
+const realSqlConnectError = (cause: unknown) =>
+  new SqlError({
+    reason: new ConnectionError({
+      cause,
+      message: "PgClient: Failed to connect",
+      operation: "connect",
+    }),
+  });
+
+// A node/Bun system error exactly as the `net` stack raises it while dialing:
+// `connect ECONNREFUSED 127.0.0.1:5432` with errno-style fields attached.
+const dialError = (code: string, address: string, port: number) =>
+  Object.assign(new Error(`connect ${code} ${address}:${port}`), {
+    code,
+    errno: -61,
+    syscall: "connect",
+    address,
+    port,
+  });
+
+// A real node-postgres server ErrorResponse (`DatabaseError` from pg-protocol),
+// with the fields a live Postgres attaches for a failed password authentication.
+const authFailedError = () =>
+  Object.assign(
+    new Pg.DatabaseError('password authentication failed for user "postgres"', 104, "error"),
+    { severity: "FATAL", code: "28P01", file: "auth.c", line: "326", routine: "auth_failed" },
+  );
 
 describe("legacyIsIPv6ConnectivityError", () => {
   it("classifies the getaddrinfo IPv6-only failures (case-insensitive)", () => {
@@ -41,9 +75,127 @@ describe("legacyIsIPv6ConnectivityError", () => {
     expect(legacyIsIPv6ConnectivityError("connect ENETUNREACH 10.0.0.1:5432")).toBe(false);
   });
 
+  it("classifies Node ENETUNREACH inside the parenthesized connect-failure rendering", () => {
+    expect(
+      legacyIsIPv6ConnectivityError(
+        "failed to connect to `host=db.x.supabase.co user=postgres database=postgres`: dial error (connect ENETUNREACH 2600:1f18::1:5432)",
+      ),
+    ).toBe(true);
+  });
+
   it("does not classify unrelated errors", () => {
     expect(legacyIsIPv6ConnectivityError("permission denied for schema public")).toBe(false);
     expect(legacyIsIPv6ConnectivityError("")).toBe(false);
+  });
+});
+
+describe("legacyConnectFailureMessage", () => {
+  const target = { host: "db.abcdefghij.supabase.co", user: "postgres", database: "postgres" };
+  const prefix =
+    "failed to connect to `host=db.abcdefghij.supabase.co user=postgres database=postgres`:";
+
+  it("renders host/user/database and the staged dial cause through the real SqlError chain", () => {
+    const error = realSqlConnectError(dialError("ECONNREFUSED", "127.0.0.1", 5432));
+    expect(legacyConnectFailureMessage(target, error)).toBe(
+      `${prefix} dial error (connect ECONNREFUSED 127.0.0.1:5432)`,
+    );
+  });
+
+  it("surfaces the last dial attempt of a dual-stack AggregateError (pgconn last-fallback parity)", () => {
+    // node dials ::1 then 127.0.0.1 for `localhost` and aggregates both failures
+    // into an AggregateError with an EMPTY message; pgconn's fallback loop
+    // likewise surfaces the last attempt's error.
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      code: "ECONNREFUSED",
+      errors: [
+        dialError("ECONNREFUSED", "::1", 5432),
+        dialError("ECONNREFUSED", "127.0.0.1", 5432),
+      ],
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(aggregate))).toBe(
+      `${prefix} dial error (connect ECONNREFUSED 127.0.0.1:5432)`,
+    );
+  });
+
+  it("reproduces pgconn's server-error rendering byte-for-byte for a server ErrorResponse", () => {
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(authFailedError()))).toBe(
+      `${prefix} server error (FATAL: password authentication failed for user "postgres" (SQLSTATE 28P01))`,
+    );
+  });
+
+  it("stages a DNS failure as hostname resolving error (Bun getaddrinfo shape)", () => {
+    // Bun's getaddrinfo failure omits the hostname from the message; the host is
+    // already carried by the `host=…` identity.
+    const dns = Object.assign(new Error("getaddrinfo ENOTFOUND"), {
+      code: "ENOTFOUND",
+      syscall: "getaddrinfo",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(dns))).toBe(
+      `${prefix} hostname resolving error (getaddrinfo ENOTFOUND)`,
+    );
+    // A transient resolver failure classifies by code alone (no syscall field).
+    const eaiAgain = Object.assign(new Error("getaddrinfo EAI_AGAIN db.x.supabase.co"), {
+      code: "EAI_AGAIN",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(eaiAgain))).toBe(
+      `${prefix} hostname resolving error (getaddrinfo EAI_AGAIN db.x.supabase.co)`,
+    );
+  });
+
+  it("stages a dial errno by code alone when the syscall field is absent", () => {
+    const timedOut = Object.assign(new Error("connect ETIMEDOUT 10.0.0.9:5432"), {
+      code: "ETIMEDOUT",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(timedOut))).toBe(
+      `${prefix} dial error (connect ETIMEDOUT 10.0.0.9:5432)`,
+    );
+  });
+
+  it("stages TLS failures as tls error", () => {
+    // node-postgres' own refusal message carries no code.
+    expect(
+      legacyConnectFailureMessage(
+        target,
+        realSqlConnectError(new Error("The server does not support SSL connections")),
+      ),
+    ).toBe(`${prefix} tls error (The server does not support SSL connections)`);
+    const selfSigned = Object.assign(new Error("self-signed certificate in certificate chain"), {
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(selfSigned))).toBe(
+      `${prefix} tls error (self-signed certificate in certificate chain)`,
+    );
+    // node's ERR_TLS_* family (e.g. a hostname mismatch under verify-full).
+    const altname = Object.assign(new Error("Hostname/IP does not match certificate's altnames"), {
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(altname))).toBe(
+      `${prefix} tls error (Hostname/IP does not match certificate's altnames)`,
+    );
+  });
+
+  it("renders an unrecognized cause verbatim (CLI-1942 session-pooler EOF shape)", () => {
+    // node-postgres raises `Connection terminated unexpectedly` where pgconn
+    // says `failed to receive message (unexpected EOF)` — no stage is guessed.
+    const eof = new Error("Connection terminated unexpectedly");
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(eof))).toBe(
+      `${prefix} Connection terminated unexpectedly`,
+    );
+  });
+
+  it("handles a bare driver error (raw-client path) and non-object failures", () => {
+    // `acquireRawClient` maps the node-postgres rejection without a SqlError wrapper.
+    expect(legacyConnectFailureMessage(target, dialError("ECONNREFUSED", "127.0.0.1", 6543))).toBe(
+      `${prefix} dial error (connect ECONNREFUSED 127.0.0.1:6543)`,
+    );
+    expect(legacyConnectFailureMessage(target, "boom")).toBe(`${prefix} boom`);
+  });
+
+  it("falls back to the code when the cause carries an empty message", () => {
+    const bare = Object.assign(new Error(), { code: "ECONNREFUSED" });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(bare))).toBe(
+      `${prefix} dial error (ECONNREFUSED)`,
+    );
   });
 });
 
@@ -111,6 +263,60 @@ describe("legacyConnectSuggestion", () => {
     expect(legacyConnectSuggestion(err, ctx)).toBe(
       "Make sure your project exists on profile: supabase",
     );
+  });
+
+  it("maps node's no-route-to-host (EHOSTUNREACH over IPv4) to the wrong-profile hint", () => {
+    // Go matches pgconn's `connect: no route to host`; node renders the same
+    // failure as `connect EHOSTUNREACH <ip>:<port>` with errno fields.
+    const err = realSqlConnectError(dialError("EHOSTUNREACH", "10.1.2.3", 5432));
+    expect(legacyConnectSuggestion(err, ctx)).toBe(
+      "Make sure your project exists on profile: supabase",
+    );
+  });
+
+  it("maps an IPv6 no-route-to-host (EHOSTUNREACH) to the IPv6 pooler suggestion", () => {
+    // Go's `no route to host` counts as IPv6 when the message carries an IPv6
+    // literal; node carries the dialed address as a structured field instead.
+    const err = realSqlConnectError(dialError("EHOSTUNREACH", "2600:1f18::1", 5432));
+    expect(legacyConnectSuggestion(err, ctx)).toBe(legacyIpv6Suggestion());
+  });
+
+  it("maps an IPv6 cannot-assign-address (EADDRNOTAVAIL) to the IPv6 pooler suggestion", () => {
+    const err = realSqlConnectError(dialError("EADDRNOTAVAIL", "2a05:d014::1", 5432));
+    expect(legacyConnectSuggestion(err, ctx)).toBe(legacyIpv6Suggestion());
+  });
+
+  it("maps an aggregate of IPv6 dial failures to the IPv6 pooler suggestion", () => {
+    const aggregate = Object.assign(new AggregateError([], ""), {
+      errors: [dialError("EHOSTUNREACH", "2600:1f18::1", 5432)],
+    });
+    expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toBe(
+      legacyIpv6Suggestion(),
+    );
+  });
+
+  it("keeps an IPv4 EADDRNOTAVAIL unclassified, like Go without an IPv6 literal", () => {
+    const err = realSqlConnectError(dialError("EADDRNOTAVAIL", "10.1.2.3", 5432));
+    expect(legacyConnectSuggestion(err, ctx)).toBeUndefined();
+  });
+
+  it("fires the refused hint through the real SqlError chain, not just the test double", () => {
+    const err = realSqlConnectError(dialError("ECONNREFUSED", "127.0.0.1", 54322));
+    expect(legacyConnectSuggestion(err, ctx)).toContain("Network Restrictions and Network Bans");
+  });
+
+  it("fires the env-var hint for a real node-postgres 28P01 DatabaseError", () => {
+    expect(legacyConnectSuggestion(realSqlConnectError(authFailedError()), ctx)).toBe(
+      LEGACY_SUGGEST_ENV_VAR,
+    );
+  });
+
+  it("keeps the CLI-1942 session-pooler EOF unclassified so the generic --debug suggestion applies", () => {
+    // Go's SetConnectSuggestion has no branch for pgconn's `unexpected EOF`
+    // (the session-pooler drop in CLI-1942); node-postgres' equivalent
+    // `Connection terminated unexpectedly` must stay unclassified too.
+    const err = realSqlConnectError(new Error("Connection terminated unexpectedly"));
+    expect(legacyConnectSuggestion(err, ctx)).toBeUndefined();
   });
 
   it("returns undefined for an unrecognized connect error", () => {

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -220,6 +220,33 @@ describe("legacyConnectFailureMessage", () => {
     }
   });
 
+  it("stages a mid-handshake TLS disconnect as tls error despite its ECONNRESET code", () => {
+    // Node/Bun's `_tls_wrap.js` onConnectEnd shape: the server accepted
+    // SSLRequest but closed the socket before the handshake completed. The
+    // message is phase-specific (only ever raised pre-secure-connection), so it
+    // stages like pgconn's startTLS wrap (`tls error (…)`, pgconn.go:283-289).
+    const midHandshake = Object.assign(
+      new Error("Client network socket disconnected before secure TLS connection was established"),
+      { code: "ECONNRESET" },
+    );
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(midHandshake))).toBe(
+      `${prefix} tls error (Client network socket disconnected before secure TLS connection was established)`,
+    );
+  });
+
+  it("renders a raw socket reset verbatim — not phase-specific, so no stage is guessed", () => {
+    // Node's hard-RST shape (`read ECONNRESET`, syscall "read") is identical
+    // before and after the handshake, so unlike the message above it must NOT
+    // be staged as tls error.
+    const rawReset = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+      syscall: "read",
+    });
+    expect(legacyConnectFailureMessage(target, realSqlConnectError(rawReset))).toBe(
+      `${prefix} read ECONNRESET`,
+    );
+  });
+
   it("renders an unrecognized cause verbatim (CLI-1942 session-pooler EOF shape)", () => {
     // node-postgres raises `Connection terminated unexpectedly` where pgconn
     // says `failed to receive message (unexpected EOF)` — no stage is guessed.
@@ -407,6 +434,17 @@ describe("legacyConnectSuggestion", () => {
     expect(legacyConnectSuggestion(realSqlConnectError(aggregate), ctx)).toContain(
       "Network Restrictions and Network Bans",
     );
+  });
+
+  it("sets no suggestion for a mid-handshake TLS disconnect, like Go", () => {
+    // Go's `SetConnectSuggestion` (`connect.go:313-335`) has no branch matching
+    // resets or TLS failures — the staged `tls error (…)` rendering must not
+    // change that.
+    const midHandshake = Object.assign(
+      new Error("Client network socket disconnected before secure TLS connection was established"),
+      { code: "ECONNRESET" },
+    );
+    expect(legacyConnectSuggestion(realSqlConnectError(midHandshake), ctx)).toBeUndefined();
   });
 
   it("keeps an IPv4 EADDRNOTAVAIL unclassified, like Go without an IPv6 literal", () => {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Connection-failure behavior of the real `@effect/sql-pg` driver layer against
+ * real sockets: the `LegacyDbConnectError` message must carry Go's
+ * `failed to connect to postgres: failed to connect to
+ * `host=… user=… database=…`: <cause>` structure (pgconn `errors.go:66-72`,
+ * `pkg/pgxv5/connect.go:33`), and the connect suggestion must classify real
+ * node-postgres error shapes, not libpq wording.
+ */
+import * as net from "node:net";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { LEGACY_SUGGEST_ENV_VAR } from "./legacy-connect-errors.ts";
+import type { LegacyDbConnectError } from "./legacy-db-connection.errors.ts";
+import { type LegacyPgConnInput, LegacyDbConnection } from "./legacy-db-connection.service.ts";
+import { legacyDbConnectionSqlPgLayer } from "./legacy-db-connection.sql-pg.layer.ts";
+
+const SUGGESTION_CONTEXT = {
+  dashboardUrl: "https://supabase.com/dashboard",
+  profileName: "supabase",
+  debug: false,
+} as const;
+
+// A distinctive sentinel so a regression that leaks the password into the
+// rendered message or suggestion fails the assertions below (pgconn embeds only
+// host/user/database — never the password).
+const SENTINEL_PASSWORD = "s3cr3t-pw-do-not-leak";
+
+/** Connect through the real layer and flip the expected failure into the value. */
+const connectFailure = (
+  cfg: Partial<LegacyPgConnInput> & { readonly port: number },
+): Effect.Effect<LegacyDbConnectError> =>
+  Effect.gen(function* () {
+    const conn = yield* LegacyDbConnection;
+    return yield* conn
+      .connect(
+        {
+          host: "127.0.0.1",
+          user: "postgres",
+          password: SENTINEL_PASSWORD,
+          database: "postgres",
+          suggestionContext: SUGGESTION_CONTEXT,
+          ...cfg,
+        },
+        { isLocal: true, dnsResolver: "native" },
+      )
+      .pipe(
+        Effect.scoped,
+        Effect.flip,
+        Effect.mapError(() => new Error("expected the connection to fail")),
+        Effect.orDie,
+      );
+  }).pipe(Effect.provide(legacyDbConnectionSqlPgLayer));
+
+/** A TCP port that is guaranteed closed: bind an ephemeral port, then release it. */
+const acquireClosedPort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      server.close((error) => (error === undefined ? resolve(address.port) : reject(error)));
+    });
+  });
+
+/** Encode a Postgres wire-protocol ErrorResponse ('E') message. */
+const errorResponse = (fields: Record<string, string>): Buffer => {
+  const parts: Array<Buffer> = [];
+  for (const [key, value] of Object.entries(fields)) {
+    parts.push(Buffer.from(key, "ascii"), Buffer.from(value, "utf8"), Buffer.from([0]));
+  }
+  parts.push(Buffer.from([0]));
+  const body = Buffer.concat(parts);
+  const head = Buffer.alloc(5);
+  head.write("E", 0, "ascii");
+  head.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([head, body]);
+};
+
+/**
+ * A minimal fake Postgres server: answers `N` to an SSLRequest and hands the
+ * first startup message to `onStartup`, so tests can drive the real driver
+ * through real server-side failure shapes.
+ */
+const fakePostgresServer = (
+  onStartup: (socket: net.Socket) => void,
+): Promise<{ readonly port: number; readonly close: () => void }> =>
+  new Promise((resolve) => {
+    const server = net.createServer((socket) => {
+      let sawStartup = false;
+      socket.on("data", (data: Buffer) => {
+        // SSLRequest: 8-byte message with request code 80877103.
+        if (!sawStartup && data.length >= 8 && data.readInt32BE(4) === 80877103) {
+          socket.write("N");
+          return;
+        }
+        if (!sawStartup) {
+          sawStartup = true;
+          onStartup(socket);
+        }
+      });
+      socket.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({ port: address.port, close: () => server.close() });
+    });
+  });
+
+describe("legacyDbConnectionSqlPgLayer connect failures", () => {
+  it.live(
+    "surfaces host, user, database, and the driver cause when the connection is refused",
+    () =>
+      Effect.gen(function* () {
+        const port = yield* Effect.promise(acquireClosedPort);
+        const error = yield* connectFailure({ port });
+        expect(error._tag).toBe("LegacyDbConnectError");
+        expect(error.message).toBe(
+          "failed to connect to postgres: failed to connect to `host=127.0.0.1 user=postgres database=postgres`: " +
+            `dial error (connect ECONNREFUSED 127.0.0.1:${port})`,
+        );
+        expect(error.suggestion).toBe(
+          "Make sure your local IP is allowed in Network Restrictions and Network Bans.\n" +
+            "https://supabase.com/dashboard/project/_/database/settings",
+        );
+        expect(error.message).not.toContain(SENTINEL_PASSWORD);
+      }),
+  );
+
+  it.live(
+    "reproduces pgconn's server-error rendering for an auth failure and suggests SUPABASE_DB_PASSWORD",
+    () =>
+      Effect.gen(function* () {
+        const server = yield* Effect.promise(() =>
+          fakePostgresServer((socket) => {
+            socket.write(
+              errorResponse({
+                S: "FATAL",
+                V: "FATAL",
+                C: "28P01",
+                M: 'password authentication failed for user "postgres"',
+                F: "auth.c",
+                L: "326",
+                R: "auth_failed",
+              }),
+            );
+            socket.end();
+          }),
+        );
+        const error = yield* connectFailure({ port: server.port }).pipe(
+          Effect.ensuring(Effect.sync(server.close)),
+        );
+        expect(error.message).toBe(
+          "failed to connect to postgres: failed to connect to `host=127.0.0.1 user=postgres database=postgres`: " +
+            'server error (FATAL: password authentication failed for user "postgres" (SQLSTATE 28P01))',
+        );
+        expect(error.suggestion).toBe(LEGACY_SUGGEST_ENV_VAR);
+        expect(error.message).not.toContain(SENTINEL_PASSWORD);
+      }),
+  );
+
+  it.live(
+    "keeps the CLI-1942 session-pooler EOF shape unclassified while surfacing the cause",
+    () =>
+      Effect.gen(function* () {
+        // The session pooler dropping the connection (CLI-1942) surfaces as
+        // node-postgres' `Connection terminated unexpectedly`. Go has no
+        // suggestion branch for the equivalent `unexpected EOF`, so no
+        // suggestion may fire — the generic --debug fallback applies.
+        const server = yield* Effect.promise(() =>
+          fakePostgresServer((socket) => socket.destroy()),
+        );
+        const error = yield* connectFailure({
+          port: server.port,
+          user: "postgres.abcdefghijklmnopqrst",
+        }).pipe(Effect.ensuring(Effect.sync(server.close)));
+        expect(error.message).toBe(
+          "failed to connect to postgres: failed to connect to " +
+            "`host=127.0.0.1 user=postgres.abcdefghijklmnopqrst database=postgres`: " +
+            "Connection terminated unexpectedly",
+        );
+        expect(error.suggestion).toBeUndefined();
+      }),
+  );
+});

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -11,7 +11,7 @@ import { ConnectionError, SqlError } from "effect/unstable/sql/SqlError";
 // resolves, so the COPY path and the pooled path use the same driver.
 import * as Pg from "pg";
 import { to as pgCopyTo } from "pg-copy-streams";
-import { legacyConnectSuggestion } from "./legacy-connect-errors.ts";
+import { legacyConnectFailureMessage, legacyConnectSuggestion } from "./legacy-connect-errors.ts";
 import {
   LegacyDbConnectError,
   LegacyDbCopyError,
@@ -584,13 +584,18 @@ const connect = (
     // (`connect.go:187`), mapping the driver error to an actionable hint that replaces
     // the generic "--debug" suggestion. The resolver attaches the profile context to
     // `cfg.suggestionContext`; map it here so the suggestion travels on the error.
+    // The message mirrors Go's `pgxv5.Connect` wrap of pgconn's `connectError`
+    // (`pkg/pgxv5/connect.go:33`, pgconn `errors.go:66-72`): the `failed to connect
+    // to postgres:` prefix plus the `host=… user=… database=…` identity and the
+    // underlying driver cause — not the bare `SqlError` toString, which drops all
+    // of that detail.
     const toConnectError = (error: unknown) => {
       const suggestion =
         cfg.suggestionContext === undefined
           ? undefined
           : legacyConnectSuggestion(error, cfg.suggestionContext);
       return new LegacyDbConnectError({
-        message: `failed to connect to postgres: ${error}`,
+        message: `failed to connect to postgres: ${legacyConnectFailureMessage(cfg, error)}`,
         ...(suggestion === undefined ? {} : { suggestion }),
       });
     };


### PR DESCRIPTION
## What changed

Every legacy db command's connection failure previously rendered as

```
failed to connect to postgres: effect/sql/SqlError: PgClient: Failed to connect
```

— host, user, database, and the underlying driver cause were all lost, on every `db push` / `db pull` / `db reset` / `db diff --linked` / `inspect` / `migration` connection failure. The Go CLI renders pgconn's full detail:

```
failed to connect to postgres: failed to connect to `host=… user=… database=…`: dial error (dial tcp …: connect: connection refused)
```

This PR ports pgconn's `connectError` rendering (`errors.go:66-72`, wrapped by `pkg/pgxv5/connect.go:33`) into the legacy connection layer, and fixes the `legacyConnectSuggestion` classifier branches that could never fire on real node-postgres error shapes.

### Message rendering (`legacyConnectFailureMessage`)

- `toConnectError` in `legacy-db-connection.sql-pg.layer.ts` now renders `failed to connect to postgres: failed to connect to \`host=… user=… database=…\`: <staged cause>` using the config-level identity (host/user/database — never the password), exactly like pgconn.
- The cause is unwrapped through the real `SqlError → ConnectionError → driver error` chain (and through `AggregateError.errors[]`, taking the LAST attempt — pgconn's fallback loop also surfaces the last attempt's error).
- Stage labels mirror pgconn where the node error identifies the stage unambiguously: `server error (SEVERITY: message (SQLSTATE code))` (byte-parity with pgconn's `PgError` rendering), `hostname resolving error (…)`, `dial error (…)`, `tls error (…)`.

### Classifier fixes (`legacyConnectSuggestion`)

Branch-by-branch verification against real driver shapes (captured empirically under Bun, the CLI's runtime):

| Go branch | node-postgres shape | Before | After |
|---|---|---|---|
| `connect: connection refused` / allow_list → network-restrictions hint | `ECONNREFUSED` code / server text | fired | fires (unchanged, now also covered by real-`SqlError` tests) |
| `SSL connection is required` + `--debug` | server error text | fired | fires (unchanged) |
| `SCRAM exchange: Wrong password` / `failed SASL auth` → `SUPABASE_DB_PASSWORD` hint | `DatabaseError` 28P01 `password authentication failed` | fired | fires (unchanged, proven against a real wire-protocol ErrorResponse) |
| IPv6-only host → IPv6 pooler hint | `EHOSTUNREACH`/`EADDRNOTAVAIL`/`ENETUNREACH` with an IPv6 `address` field | **dead** for EHOSTUNREACH/EADDRNOTAVAIL (node puts the address in a structured field, not libpq's parenthesized literal) | fires via new structured errno+address check (`legacyHasIPv6DialCause`) |
| `connect: no route to host` → wrong-profile hint | `connect EHOSTUNREACH <ip>:<port>` | **dead** (node never emits "no route to host") | fires via `EHOSTUNREACH`, after the IPv6 branch, matching Go's branch order |
| `Tenant or user not found` → wrong-profile hint | Supavisor server error text | fired | fires (unchanged) |

`NODE_ENETUNREACH_PATTERN` now also tolerates a closing paren after the port, since the new message format parenthesizes the driver cause.

### CLI-1942 guard (no accidental divergence)

Go has **no** suggestion branch for the session-pooler EOF drop (`unexpected EOF`); node-postgres' equivalent is `Connection terminated unexpectedly`. Tests pin that this shape stays unclassified (generic `--debug` fallback) and that the message still carries the full `host=… user=…` identity plus the cause verbatim.

## Residual driver-text differences (impossible to byte-match)

The inner cause text comes from the driver, so exact byte parity with Go is impossible where the drivers word things differently — the **structure** (`failed to connect to postgres:` prefix + `host=… user=… database=…` + cause) and the stage labels match:

- Dial errors: node `connect ECONNREFUSED 1.2.3.4:5432` vs Go `dial tcp 1.2.3.4:5432: connect: connection refused`.
- Wrong password over SCRAM: pgconn labels by auth phase (`failed SASL auth (…)`), which node-postgres does not expose, so TS renders `server error (…)` — the inner `FATAL: password authentication failed for user "postgres" (SQLSTATE 28P01)` bytes and the fired hint are identical.
- Unrecognized causes (e.g. the CLI-1942 EOF, connect timeout) render verbatim with no stage word, where pgconn would say `failed to receive message (unexpected EOF)` — no stage is guessed rather than fabricating a wrong one.
- Server-side failures (`server error (SEVERITY: message (SQLSTATE code))`) are byte-identical to Go given the same server bytes.

## Review findings deliberately left open

Five-perspective review (architect / engineer / security / DX / go-parity-auditor) all approved. Non-blocking items noted for follow-up rather than churned here:

- Consolidating the module's four error-chain traversals (collector / deepest-path / two any-match predicates) into one walk primitive — they have genuinely different semantics and predate this PR; cross-referencing doc comments were added instead.
- Pre-existing, negligible divergence: an IPv4 `ENETUNREACH` gets no suggestion in TS while Go's over-broad `network is unreachable` text match would show the IPv6 hint even for IPv4 — the TS IPv6-literal gate is deliberate and pre-existing.
- Pre-existing: `password authentication failed` as a wrong-password disjunct would also classify a theoretical non-SCRAM 28P01 that Go leaves unclassified; Supabase auth is always SCRAM.

Related: this PR does not touch `output.layer.ts` (PR #5946 / CLI-1973 territory) — the change is confined to the SqlError mapping and the classifier module.

Fixes [CLI-1976](https://linear.app/supabase/issue/CLI-1976/db-connection-failure-errors-lose-all-detail-connect-suggestions-may)
