### PR TITLE
fix(cli): keep migration recovery local

### DIFF
--- a/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
@@ -422,7 +422,7 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
           path,
           path.join(cliConfig.workdir, "supabase", "migrations"),
         );
-        const sync = legacyReconcileMigrations(remote, local);
+        const sync = legacyReconcileMigrations(remote, local, connType === "local");
         if (sync.kind === "conflict") {
           return yield* Effect.fail(
             new LegacyDbPullMigrationConflictError({

--- a/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
@@ -1239,6 +1239,16 @@ describe("legacy db pull", () => {
     }).pipe(Effect.provide(s.layer));
   });
 
+  it.effect("db pull --local keeps migration repair suggestions local", () => {
+    seedMigration(tmp.current, "20240102000000");
+    const s = setup(tmp.current, { remoteVersions: ["20240101000000"] });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPull(flags({ local: Option.some(true) })).pipe(Effect.exit);
+      expect(JSON.stringify(exit)).toContain("migration repair --local --status reverted");
+      expect(JSON.stringify(exit)).toContain("migration repair --local --status applied");
+    }).pipe(Effect.provide(s.layer));
+  });
+
   it.effect(
     "a migration name with a path separator fails instead of an empty-version repair",
     () => {

--- a/apps/cli/src/legacy/commands/db/push/push.handler.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.handler.ts
@@ -178,7 +178,7 @@ export const legacyDbPush = Effect.fn("legacy.db.push")(function* (flags: Legacy
             return yield* Effect.fail(
               new LegacyDbPushMissingLocalError({
                 message: LEGACY_ERR_MISSING_LOCAL,
-                suggestion: legacySuggestRevertHistory(result.versions),
+                suggestion: legacySuggestRevertHistory(result.versions, connType === "local"),
               }),
             );
           }

--- a/apps/cli/src/legacy/commands/db/push/push.handler.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.handler.ts
@@ -36,7 +36,6 @@ import {
   legacyFindPendingMigrations,
   legacyIncludeAllPending,
   legacySuggestIgnoreFlag,
-  legacySuggestRevertHistory,
 } from "../shared/legacy-migration-pending.ts";
 import {
   type LegacySeedFile,
@@ -46,7 +45,10 @@ import {
 import { legacyUpsertVaultSecrets } from "../../../shared/legacy-vault.ts";
 // Listing the remote `schema_migrations` history (with the 42P01 → empty rule)
 // lives in the shared migration-history module (Go's `migration.ListRemoteMigrations`).
-import { legacyListRemoteMigrations } from "../../../shared/legacy-migration-history.ts";
+import {
+  legacyListRemoteMigrations,
+  legacySuggestRevertHistory,
+} from "../../../shared/legacy-migration-history.ts";
 import type { LegacyDbPushFlags } from "./push.command.ts";
 import {
   LegacyDbPushApplyError,

--- a/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
@@ -458,9 +458,28 @@ describe("legacy db push", () => {
         expect(JSON.stringify(exit.cause)).toContain(
           "Remote migration versions not found in local migrations directory.",
         );
-        expect(JSON.stringify(exit.cause)).toContain("migration repair --status reverted");
+        expect(JSON.stringify(exit.cause)).toContain("migration repair --local --status reverted");
+        expect(JSON.stringify(exit.cause)).toContain("supabase db pull --local");
       }
       expect(out).toBeDefined();
+    });
+  });
+
+  it.live("keeps repair suggestions targetless for an explicit local database URL", () => {
+    const dbUrl = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+    const { layer } = setup(tmp.current, {
+      toml: 'project_id = "test"\n',
+      args: ["db", "push", "--db-url", dbUrl],
+      remoteMigrations: ["20240101000000"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPush({
+        ...DEFAULT_FLAGS,
+        dbUrl: Option.some(dbUrl),
+        local: false,
+      }).pipe(Effect.provide(layer), Effect.exit);
+      expect(JSON.stringify(exit)).toContain("migration repair --status reverted");
+      expect(JSON.stringify(exit)).not.toContain("migration repair --local");
     });
   });
 

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
@@ -105,12 +105,16 @@ export function legacyIncludeAllPending(
  * Go's `suggestRevertHistory` (`internal/migration/up/up.go:55-61`). `fmt.Sprintln`
  * appends a trailing newline to each line, so the suggestion ends with `\n`.
  */
-export function legacySuggestRevertHistory(versions: ReadonlyArray<string>): string {
+export function legacySuggestRevertHistory(
+  versions: ReadonlyArray<string>,
+  isLocal = false,
+): string {
+  const localFlag = isLocal ? " --local" : "";
   return (
     "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
-    `${legacyBold(`supabase migration repair --status reverted ${versions.join(" ")}`)}\n` +
+    `${legacyBold(`supabase migration repair${localFlag} --status reverted ${versions.join(" ")}`)}\n` +
     "\nAnd update local migrations to match remote database:\n" +
-    `${legacyBold("supabase db pull")}\n`
+    `${legacyBold(`supabase db pull${localFlag}`)}\n`
   );
 }
 

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
@@ -101,23 +101,6 @@ export function legacyIncludeAllPending(
   return [...diff, ...localMigrations.slice(remoteCount + diff.length)];
 }
 
-/**
- * Go's `suggestRevertHistory` (`internal/migration/up/up.go:55-61`). `fmt.Sprintln`
- * appends a trailing newline to each line, so the suggestion ends with `\n`.
- */
-export function legacySuggestRevertHistory(
-  versions: ReadonlyArray<string>,
-  isLocal = false,
-): string {
-  const localFlag = isLocal ? " --local" : "";
-  return (
-    "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
-    `${legacyBold(`supabase migration repair${localFlag} --status reverted ${versions.join(" ")}`)}\n` +
-    "\nAnd update local migrations to match remote database:\n" +
-    `${legacyBold(`supabase db pull${localFlag}`)}\n`
-  );
-}
-
 /** Go's `suggestIgnoreFlag` (`internal/migration/up/up.go:63-67`). */
 export function legacySuggestIgnoreFlag(paths: ReadonlyArray<string>): string {
   return (

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.unit.test.ts
@@ -4,7 +4,6 @@ import {
   legacyFindPendingMigrations,
   legacyIncludeAllPending,
   legacySuggestIgnoreFlag,
-  legacySuggestRevertHistory,
 } from "./legacy-migration-pending.ts";
 
 const local = (...versions: ReadonlyArray<string>) =>
@@ -64,14 +63,6 @@ describe("legacyIncludeAllPending", () => {
 });
 
 describe("suggestion strings", () => {
-  it("builds the revert-history suggestion with a trailing newline per line", () => {
-    expect(legacySuggestRevertHistory(["0002", "0003"])).toContain(
-      "supabase migration repair --status reverted 0002 0003",
-    );
-    expect(legacySuggestRevertHistory(["0002"])).toMatch(/\n$/u);
-    expect(legacySuggestRevertHistory(["0002"])).toContain("supabase db pull");
-  });
-
   it("builds the include-all suggestion listing each path on its own line", () => {
     const suggestion = legacySuggestIgnoreFlag([
       "supabase/migrations/0001_a.sql",

--- a/apps/cli/src/legacy/commands/migration/up/up.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.handler.ts
@@ -30,11 +30,15 @@ import {
 } from "./up.errors.ts";
 
 /** Go's `suggestRevertHistory` (`internal/migration/up/up.go:55`). */
-const suggestRevertHistory = (versions: ReadonlyArray<string>): string =>
-  "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
-  `${legacyBold(`supabase migration repair --status reverted ${versions.join(" ")}`)}\n` +
-  "\nAnd update local migrations to match remote database:\n" +
-  `${legacyBold("supabase db pull")}\n`;
+const suggestRevertHistory = (versions: ReadonlyArray<string>, isLocal: boolean): string => {
+  const localFlag = isLocal ? " --local" : "";
+  return (
+    "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
+    `${legacyBold(`supabase migration repair${localFlag} --status reverted ${versions.join(" ")}`)}\n` +
+    "\nAnd update local migrations to match remote database:\n" +
+    `${legacyBold(`supabase db pull${localFlag}`)}\n`
+  );
+};
 
 /** Go's `suggestIgnoreFlag` (`internal/migration/up/up.go:63`). */
 const suggestIgnoreFlag = (paths: ReadonlyArray<string>): string =>
@@ -95,7 +99,10 @@ const runUp = Effect.fnUntraced(function* (
           return yield* Effect.fail(
             new LegacyMigrationMissingLocalError({
               message: "Remote migration versions not found in local migrations directory.",
-              suggestion: suggestRevertHistory(result.versions),
+              suggestion: suggestRevertHistory(
+                result.versions,
+                (target.connType ?? "local") === "local",
+              ),
             }),
           );
         } else if (result.kind === "missing-remote") {

--- a/apps/cli/src/legacy/commands/migration/up/up.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.handler.ts
@@ -18,6 +18,7 @@ import {
   legacyFindPendingMigrations,
   legacyListLocalMigrationPaths,
   legacyListRemoteMigrations,
+  legacySuggestRevertHistory,
 } from "../../../shared/legacy-migration-history.ts";
 import { legacyUpsertVaultSecrets } from "../../../shared/legacy-vault.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
@@ -28,17 +29,6 @@ import {
   LegacyMigrationMissingLocalError,
   LegacyMigrationMissingRemoteError,
 } from "./up.errors.ts";
-
-/** Go's `suggestRevertHistory` (`internal/migration/up/up.go:55`). */
-const suggestRevertHistory = (versions: ReadonlyArray<string>, isLocal: boolean): string => {
-  const localFlag = isLocal ? " --local" : "";
-  return (
-    "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
-    `${legacyBold(`supabase migration repair${localFlag} --status reverted ${versions.join(" ")}`)}\n` +
-    "\nAnd update local migrations to match remote database:\n" +
-    `${legacyBold(`supabase db pull${localFlag}`)}\n`
-  );
-};
 
 /** Go's `suggestIgnoreFlag` (`internal/migration/up/up.go:63`). */
 const suggestIgnoreFlag = (paths: ReadonlyArray<string>): string =>
@@ -99,7 +89,7 @@ const runUp = Effect.fnUntraced(function* (
           return yield* Effect.fail(
             new LegacyMigrationMissingLocalError({
               message: "Remote migration versions not found in local migrations directory.",
-              suggestion: suggestRevertHistory(
+              suggestion: legacySuggestRevertHistory(
                 result.versions,
                 (target.connType ?? "local") === "local",
               ),

--- a/apps/cli/src/legacy/commands/migration/up/up.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.integration.test.ts
@@ -174,6 +174,8 @@ describe("legacy migration up", () => {
         expect(Option.isSome(failure) && failure.value._tag).toBe(
           "LegacyMigrationMissingLocalError",
         );
+        expect(JSON.stringify(exit.cause)).toContain("migration repair --local --status reverted");
+        expect(JSON.stringify(exit.cause)).toContain("supabase db pull --local");
       }
     }).pipe(Effect.provide(layer));
   });

--- a/apps/cli/src/legacy/shared/legacy-migration-history.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.ts
@@ -213,6 +213,23 @@ export function legacySuggestMigrationRepair(
 }
 
 /**
+ * Go's `suggestRevertHistory` (`internal/migration/up/up.go:55-61`). `fmt.Sprintln`
+ * appends a trailing newline to each line, so the suggestion ends with `\n`.
+ */
+export function legacySuggestRevertHistory(
+  versions: ReadonlyArray<string>,
+  isLocal = false,
+): string {
+  const localFlag = isLocal ? " --local" : "";
+  return (
+    "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n" +
+    `${legacyBold(`supabase migration repair${localFlag} --status reverted ${versions.join(" ")}`)}\n` +
+    "\nAnd update local migrations to match remote database:\n" +
+    `${legacyBold(`supabase db pull${localFlag}`)}\n`
+  );
+}
+
+/**
  * Lists the remote project's applied migration versions. Mirrors Go's
  * `migration.ListRemoteMigrations` (`pkg/migration/list.go:18-31`): ONLY a missing
  * history table (`pgerrcode.UndefinedTable` = `42P01`) means the remote has no

--- a/apps/cli/src/legacy/shared/legacy-migration-history.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.ts
@@ -142,6 +142,7 @@ export type LegacyMigrationSync =
 export function legacyReconcileMigrations(
   remote: ReadonlyArray<string>,
   local: ReadonlyArray<string>,
+  isLocal = false,
 ): LegacyMigrationSync {
   // `LEGACY_MIGRATION_VERSION_MAX` is Go's `math.MaxInt` (int64 max) and pins the
   // exhausted side; `legacyParseMigrationVersion` mirrors Go's `strconv.Atoi`
@@ -182,7 +183,10 @@ export function legacyReconcileMigrations(
     }
   }
   if (extraRemote.length + extraLocal.length > 0) {
-    return { kind: "conflict", suggestion: legacySuggestMigrationRepair(extraRemote, extraLocal) };
+    return {
+      kind: "conflict",
+      suggestion: legacySuggestMigrationRepair(extraRemote, extraLocal, isLocal),
+    };
   }
   if (local.length === 0) {
     return { kind: "missing" };
@@ -194,14 +198,16 @@ export function legacyReconcileMigrations(
 export function legacySuggestMigrationRepair(
   extraRemote: ReadonlyArray<string>,
   extraLocal: ReadonlyArray<string>,
+  isLocal = false,
 ): string {
+  const localFlag = isLocal ? " --local" : "";
   let result =
     "\nMake sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:\n";
   for (const version of extraRemote) {
-    result += `${legacyBold(`supabase migration repair --status reverted ${version}`)}\n`;
+    result += `${legacyBold(`supabase migration repair${localFlag} --status reverted ${version}`)}\n`;
   }
   for (const version of extraLocal) {
-    result += `${legacyBold(`supabase migration repair --status applied ${version}`)}\n`;
+    result += `${legacyBold(`supabase migration repair${localFlag} --status applied ${version}`)}\n`;
   }
   return result;
 }

--- a/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
@@ -8,6 +8,7 @@ import {
   legacyListRemoteMigrations,
   legacyReconcileMigrations,
   legacySuggestMigrationRepair,
+  legacySuggestRevertHistory,
 } from "./legacy-migration-history.ts";
 
 const mig = (version: string) => `supabase/migrations/${version}_test.sql`;
@@ -169,5 +170,15 @@ describe("legacySuggestMigrationRepair", () => {
     expect(out).toContain("try repairing the migration history table:");
     expect(out).toContain("supabase migration repair --status reverted 111");
     expect(out).toContain("supabase migration repair --status applied 222");
+  });
+});
+
+describe("legacySuggestRevertHistory", () => {
+  it("builds the revert-history suggestion with a trailing newline per line", () => {
+    expect(legacySuggestRevertHistory(["0002", "0003"])).toContain(
+      "supabase migration repair --status reverted 0002 0003",
+    );
+    expect(legacySuggestRevertHistory(["0002"])).toMatch(/\n$/u);
+    expect(legacySuggestRevertHistory(["0002"])).toContain("supabase db pull");
   });
 });


### PR DESCRIPTION
## TL;DR 
Local migration flows can emit recovery commands without `--local`. 
copying those suggestions makes `migration repair` and `db pull` fall back to their linked defaults, which can modify remote....

basically now it,
Preserves `--local` in recovery suggestions from local `migration up`, `db push`, and `db pull` flows. Target selection and execution are unchanged, while linked and explicit `--db-url` flows retain their existing behavior....

## ref:
- towards #3493