### PR TITLE
feat: support suppressing update notification via SUPABASE_NO_UPDATE_NOTIFIER

### DIFF
--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -184,6 +185,9 @@ func Execute() {
 		panic(err)
 	}
 	// Check upgrade last because --version flag is initialised after execute
+	if shouldSkipUpdateNotifier() {
+		return
+	}
 	ctx := rootCmd.Context()
 	if executedCmd != nil {
 		ctx = executedCmd.Context()
@@ -201,6 +205,15 @@ func Execute() {
 	if len(utils.CmdSuggestion) > 0 {
 		fmt.Fprintln(os.Stderr, utils.CmdSuggestion)
 	}
+}
+
+func shouldSkipUpdateNotifier() bool {
+	val := os.Getenv("SUPABASE_NO_UPDATE_NOTIFIER")
+	if len(val) == 0 {
+		return false
+	}
+	enabled, err := strconv.ParseBool(val)
+	return err == nil && enabled
 }
 
 // ensureProjectGroupsCached populates the telemetry linked-project cache when

--- a/apps/cli-go/cmd/root_test.go
+++ b/apps/cli-go/cmd/root_test.go
@@ -119,3 +119,26 @@ func TestEnvSignals(t *testing.T) {
 	assert.Equal(t, strings.Repeat("x", 80), signals["TERM"])
 	assert.NotContains(t, signals, "AI_AGENT")
 }
+
+func TestShouldSkipUpdateNotifier(t *testing.T) {
+	t.Run("returns true when SUPABASE_NO_UPDATE_NOTIFIER is true", func(t *testing.T) {
+		t.Setenv("SUPABASE_NO_UPDATE_NOTIFIER", "true")
+		assert.True(t, shouldSkipUpdateNotifier())
+	})
+
+	t.Run("returns true when SUPABASE_NO_UPDATE_NOTIFIER is 1", func(t *testing.T) {
+		t.Setenv("SUPABASE_NO_UPDATE_NOTIFIER", "1")
+		assert.True(t, shouldSkipUpdateNotifier())
+	})
+
+	t.Run("returns false when SUPABASE_NO_UPDATE_NOTIFIER is false", func(t *testing.T) {
+		t.Setenv("SUPABASE_NO_UPDATE_NOTIFIER", "false")
+		assert.False(t, shouldSkipUpdateNotifier())
+	})
+
+	t.Run("returns false when SUPABASE_NO_UPDATE_NOTIFIER is unset", func(t *testing.T) {
+		t.Setenv("SUPABASE_NO_UPDATE_NOTIFIER", "")
+		assert.False(t, shouldSkipUpdateNotifier())
+	})
+}
+


### PR DESCRIPTION
Fixes #5853

### Summary
Adds support for the `SUPABASE_NO_UPDATE_NOTIFIER` environment variable to suppress the "A new version of Supabase CLI is available" update notification and skip the release check.

When `SUPABASE_NO_UPDATE_NOTIFIER` is set to a truthy value (`1`, `true`, etc.), `Execute()` skips checking GitHub for latest releases and suppresses the upgrade message on stderr.

### Testing
- Added unit tests `TestShouldSkipUpdateNotifier` in `apps/cli-go/cmd/root_test.go` covering truthy (`true`, `1`), falsy (`false`), and unset environment variable states.
- Ran `go test -v ./cmd -run TestShouldSkipUpdateNotifier`.