### PR TITLE
fix(cli): diagnose unrunnable images

### DIFF
--- a/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
@@ -226,15 +226,31 @@ output modes.
   volume) → Postgres create+start+health-wait → `Starting containers...` → (image
   pre-pull) → per-container create+start → `Waiting for health checks...` → `Started
 supabase local development setup.`
+- stderr (conditional, health-check timeout): per unhealthy container, a
+  `<container> container logs:` header and that container's `docker logs` output, then one
+  `<container>: <reason>` line each. Containers are named `supabase_<service>_<project id>`
+  throughout, matching Go's `started = append(started, utils.InbucketId)` rather than the
+  id `docker create` returns.
 - stdout: the `status` pretty table (rounded box, same renderer `supabase status` uses).
 - stderr: the local-dev security notice block (bind-to-`0.0.0.0` / shared-default-keys /
   no-auth-on-Studio-pgMeta-analytics warning).
+
+**Cached-image recovery advice — TS-port-only, beyond Go parity.** If an unhealthy
+container's logs contained `exec format error`, the timeout carries a `suggestion` printed
+after the reasons above, naming each affected container **with** its image (they can be
+named after different things — `supabase_inbucket_*` runs `mailpit`) plus a
+`docker image rm -f` command. It states both possible causes — a corrupt cached copy, or no
+build for the host architecture — without claiming which applies, since re-pulling only
+fixes the first. Go prints no such guidance. Being a `suggestion` also replaces the usual
+"rerun with --debug" line, which cannot help here. Nothing is ever removed automatically.
 
 ### `--output-format json` / `--output-format stream-json`
 
 A single JSON object (or a `result` NDJSON event) carrying the same value shape
 `supabase status --output json` produces. All the progress/warning/banner/security-notice
-text above is suppressed in these modes — stdout stays payload-only.
+text above is suppressed in these modes — stdout stays payload-only. On a health-check
+timeout the error payload carries the advice above as a discrete `error.suggestion` string
+alongside `error.message`, so it stays machine-readable rather than prose.
 
 ## Notes
 

--- a/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
@@ -238,7 +238,9 @@ supabase local development setup.`
   `supabase start` sequence, then a closing line for the case re-pulling cannot fix. The
   runtime named is whichever of `docker`/`podman` actually answered. `supabase stop` leads
   because `--ignore-health-check` leaves the stack up, so a bare restart would hit the
-  already-running short-circuit and never recreate the broken container. Being a
+  already-running short-circuit and never recreate the broken container. The sequence tells
+  the reader to run it from the project directory or with the same `--workdir`, rather than
+  embedding the resolved path, which would need shell quoting that differs per platform. Being a
   `suggestion` also replaces the usual "rerun with --debug" line, which cannot help here.
   Nothing is ever removed automatically, and Go prints no such guidance.
 - stdout: the `status` pretty table (rounded box, same renderer `supabase status` uses).

--- a/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
@@ -231,18 +231,19 @@ supabase local development setup.`
   `<container>: <reason>` line each. Containers are named `supabase_<service>_<project id>`
   throughout, matching Go's `started = append(started, utils.InbucketId)` rather than the
   id `docker create` returns.
+- stderr (conditional, `exec format error` in those logs) — **TS-port-only, beyond Go
+  parity**: a recovery `suggestion` printed after the reasons, naming each affected
+  container **with** its image (they can be named after different things —
+  `supabase_inbucket_*` runs `mailpit`), then a `supabase stop` / `<runtime> image rm -f` /
+  `supabase start` sequence, then a closing line for the case re-pulling cannot fix. The
+  runtime named is whichever of `docker`/`podman` actually answered. `supabase stop` leads
+  because `--ignore-health-check` leaves the stack up, so a bare restart would hit the
+  already-running short-circuit and never recreate the broken container. Being a
+  `suggestion` also replaces the usual "rerun with --debug" line, which cannot help here.
+  Nothing is ever removed automatically, and Go prints no such guidance.
 - stdout: the `status` pretty table (rounded box, same renderer `supabase status` uses).
 - stderr: the local-dev security notice block (bind-to-`0.0.0.0` / shared-default-keys /
   no-auth-on-Studio-pgMeta-analytics warning).
-
-**Cached-image recovery advice — TS-port-only, beyond Go parity.** If an unhealthy
-container's logs contained `exec format error`, the timeout carries a `suggestion` printed
-after the reasons above, naming each affected container **with** its image (they can be
-named after different things — `supabase_inbucket_*` runs `mailpit`) plus a
-`docker image rm -f` command. It states both possible causes — a corrupt cached copy, or no
-build for the host architecture — without claiming which applies, since re-pulling only
-fixes the first. Go prints no such guidance. Being a `suggestion` also replaces the usual
-"rerun with --debug" line, which cannot help here. Nothing is ever removed automatically.
 
 ### `--output-format json` / `--output-format stream-json`
 
@@ -250,7 +251,8 @@ A single JSON object (or a `result` NDJSON event) carrying the same value shape
 `supabase status --output json` produces. All the progress/warning/banner/security-notice
 text above is suppressed in these modes — stdout stays payload-only. On a health-check
 timeout the error payload carries the advice above as a discrete `error.suggestion` string
-alongside `error.message`, so it stays machine-readable rather than prose.
+alongside `error.message`, so a caller can surface it without re-parsing the message. It is
+prose, not structured data.
 
 ## Notes
 

--- a/apps/cli/src/legacy/commands/start/lib/health-check.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.ts
@@ -16,7 +16,7 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
 import {
-  spawnContainerCliWithRuntime,
+  legacySpawnContainerCliWithRuntime,
   type LegacyContainerRuntime,
 } from "../../../shared/legacy-container-cli.ts";
 import { legacyInspectContainerState } from "../../../shared/legacy-docker-lifecycle.ts";
@@ -262,7 +262,7 @@ function legacyStreamContainerLogsOnce(
   let runtime: LegacyContainerRuntime | undefined;
   return Effect.scoped(
     Effect.gen(function* () {
-      const spawned = yield* spawnContainerCliWithRuntime(spawner, ["logs", containerId], {
+      const spawned = yield* legacySpawnContainerCliWithRuntime(spawner, ["logs", containerId], {
         stdin: "ignore",
         stdout: "pipe",
         stderr: "pipe",

--- a/apps/cli/src/legacy/commands/start/lib/health-check.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.ts
@@ -163,6 +163,11 @@ function legacyMakeExecFormatScanner() {
  * recreates the broken container. `stop` without `--no-backup` preserves the
  * database volume, and is harmless after the hard-fail path's own rollback.
  *
+ * Both `supabase` steps resolve their own project the way this run did, so the
+ * sequence names that requirement rather than embedding the resolved workdir:
+ * a path rendered into a copy-pasteable command needs shell quoting, and the
+ * correct quoting differs between POSIX shells and `cmd.exe`.
+ *
  * `-f` because the container may still reference the image, and `runtime`
  * rather than a hardcoded `docker` because `spawnContainerCli` falls back to
  * Podman on hosts without Docker. The closing line covers the case re-pulling
@@ -186,7 +191,7 @@ function legacyExecFormatRecoveryHint(
   return [
     `${affected.map((entry) => `${entry.containerId}'s image ${entry.image}`).join(", ")} could not be executed ("${LEGACY_EXEC_FORMAT_ERROR}").`,
     "Either the cached copy is corrupt, or it was built for a different architecture.",
-    "Remove the cached copy and start again:",
+    "Remove the cached copy and start again, from this project directory or with the same --workdir:",
     `\n  supabase stop\n  ${runtime} image rm -f ${uniqueImages.join(" ")}\n  supabase start\n`,
     "If it fails the same way, that image has no build for this machine's architecture.",
   ].join("\n");

--- a/apps/cli/src/legacy/commands/start/lib/health-check.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.ts
@@ -50,6 +50,11 @@ const LEGACY_EDGE_RUNTIME_READY_PATH = "/functions/v1/_internal/health";
 
 /** Identifies a single container's readiness failure this round. */
 export interface LegacyHealthCheckFailure {
+  /**
+   * The container NAME (`supabase_<service>_<project id>`), not the opaque id
+   * `docker create` returns — both work with `docker container inspect`/`docker
+   * logs`, but only the name tells a user which service failed.
+   */
   readonly containerId: string;
   readonly reason: string;
 }
@@ -69,7 +74,22 @@ export class LegacyHealthCheckTimeoutError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly unhealthy: ReadonlyArray<LegacyHealthCheckFailure>;
-}> {}
+  /**
+   * Kept out of {@link message} so `Output.fail` renders it unstyled and drops
+   * the generic "rerun with --debug" line: once an exact command is named,
+   * pointing at an HTTP request logger is a non-sequitur (as in CLI-1973).
+   */
+  readonly suggestion?: string;
+}> {
+  /**
+   * What `--ignore-health-check` prints when it downgrades this to a warning.
+   * That path writes to stderr directly, so it never reaches the
+   * `Output.fail` renderer that would otherwise append {@link suggestion}.
+   */
+  get warningText(): string {
+    return this.suggestion === undefined ? this.message : `${this.message}\n${this.suggestion}`;
+  }
+}
 
 /**
  * PostgREST's local Kong gateway coordinates, mirroring Go's
@@ -110,6 +130,65 @@ export interface LegacyWaitForHealthyServicesOptions {
   readonly postgrest?: LegacyHealthCheckPostgrestGateway;
   /** See {@link LEGACY_EDGE_RUNTIME_READY_PATH}'s doc comment for why this reuses the same gateway shape as {@link postgrest}. */
   readonly edgeRuntime?: LegacyHealthCheckPostgrestGateway;
+  /** Each watched container's already-resolved image, keyed by container name. */
+  readonly images?: ReadonlyMap<string, string>;
+}
+
+/** The container runtime's message when an image cannot be executed by the host kernel. */
+const LEGACY_EXEC_FORMAT_ERROR = "exec format error";
+
+/**
+ * Scans a byte stream for {@link LEGACY_EXEC_FORMAT_ERROR} in constant memory:
+ * retaining the trailing marker-length window is exactly enough to match a
+ * marker split across a chunk boundary. One scanner per stream, so stdout and
+ * stderr bytes cannot splice into a marker neither stream contains.
+ */
+function legacyMakeExecFormatScanner() {
+  const decoder = new TextDecoder();
+  let tail = "";
+  let found = false;
+  return {
+    scan(chunk: Uint8Array): void {
+      const text = tail + decoder.decode(chunk, { stream: true });
+      found ||= text.includes(LEGACY_EXEC_FORMAT_ERROR);
+      tail = text.slice(-LEGACY_EXEC_FORMAT_ERROR.length);
+    },
+    get found(): boolean {
+      return found;
+    },
+  };
+}
+
+/**
+ * Recovery advice for a timeout whose logs showed {@link LEGACY_EXEC_FORMAT_ERROR},
+ * or `undefined` when no affected image can be named.
+ *
+ * Deliberately states the cause without promising a remedy. Re-pulling fixes a
+ * corrupt cache (supabase/cli#5952) and a wrong-architecture copy, but not a
+ * pinned version with no build for this host at all (supabase/cli#3718, #4674),
+ * where the same image comes back. `-f` because the container may still reference it —
+ * `--ignore-health-check` leaves the stack up, and a failed rollback only logs.
+ * Forcing untags one resolved image and never touches containers or volumes.
+ */
+function legacyExecFormatRecoveryHint(
+  containerIds: ReadonlyArray<string>,
+  images: ReadonlyMap<string, string> | undefined,
+): string | undefined {
+  // Both names, always: a container and its image can be named after different
+  // things (`supabase_inbucket_*` runs `mailpit`), so naming only one leaves
+  // the reader guessing whether this is the same failure as the reason above.
+  const affected = containerIds.flatMap((containerId) => {
+    const image = images?.get(containerId);
+    return image === undefined ? [] : [{ containerId, image }];
+  });
+  if (affected.length === 0) return undefined;
+  const uniqueImages = [...new Set(affected.map((entry) => entry.image))];
+  return [
+    `${affected.map((entry) => `${entry.containerId}'s image ${entry.image}`).join(", ")} could not be executed ("${LEGACY_EXEC_FORMAT_ERROR}").`,
+    "Either the cached copy is corrupt, or it was built for a different architecture.",
+    "Remove the cached copy with docker (or podman), then run supabase start again:",
+    `\n  docker image rm -f ${uniqueImages.join(" ")}`,
+  ].join("\n");
 }
 
 /**
@@ -165,8 +244,18 @@ function legacyCheckHttpReady(
  * via `docker logs <id>`, teed to this process's stderr — best-effort: a
  * failure to stream logs must never mask the timeout error it was printed
  * alongside, so every failure here is swallowed.
+ *
+ * Resolves to whether the logs contained {@link LEGACY_EXEC_FORMAT_ERROR},
+ * scanned off the bytes already being teed — no extra Docker call, no buffer.
  */
-function legacyStreamContainerLogsOnce(spawner: Spawner, containerId: string): Effect.Effect<void> {
+function legacyStreamContainerLogsOnce(
+  spawner: Spawner,
+  containerId: string,
+): Effect.Effect<boolean> {
+  // Outside the effect that can fail, so a stream breaking mid-dump cannot
+  // discard a marker the scanner has already seen.
+  const stdoutScanner = legacyMakeExecFormatScanner();
+  const stderrScanner = legacyMakeExecFormatScanner();
   return Effect.scoped(
     Effect.gen(function* () {
       const handle = yield* spawnContainerCli(spawner, ["logs", containerId], {
@@ -179,11 +268,13 @@ function legacyStreamContainerLogsOnce(spawner: Spawner, containerId: string): E
           Stream.runForEach(handle.stdout, (chunk) =>
             Effect.sync(() => {
               globalThis.process.stderr.write(chunk);
+              stdoutScanner.scan(chunk);
             }),
           ),
           Stream.runForEach(handle.stderr, (chunk) =>
             Effect.sync(() => {
               globalThis.process.stderr.write(chunk);
+              stderrScanner.scan(chunk);
             }),
           ),
         ],
@@ -191,16 +282,19 @@ function legacyStreamContainerLogsOnce(spawner: Spawner, containerId: string): E
       );
       yield* handle.exitCode;
     }),
-  ).pipe(Effect.orElseSucceed(() => undefined));
+  ).pipe(
+    Effect.orElseSucceed(() => undefined),
+    Effect.map(() => stdoutScanner.found || stderrScanner.found),
+  );
 }
 
 /** Go's `fmt.Fprintln(os.Stderr, containerId, "container logs:")` (`start.go:218`) + the log dump itself. */
-function legacyDumpContainerLogs(spawner: Spawner, containerId: string): Effect.Effect<void> {
+function legacyDumpContainerLogs(spawner: Spawner, containerId: string): Effect.Effect<boolean> {
   return Effect.gen(function* () {
     yield* Effect.sync(() => {
       globalThis.process.stderr.write(`${containerId} container logs:\n`);
     });
-    yield* legacyStreamContainerLogsOnce(spawner, containerId);
+    return yield* legacyStreamContainerLogsOnce(spawner, containerId);
   });
 }
 
@@ -278,15 +372,19 @@ export function legacyWaitForHealthyServices(
           // `!errors.Is(err, context.Canceled)`) — an interrupted fiber never
           // reaches this `Effect.catch` handler at all, so no separate check
           // is needed here.
-          yield* Effect.forEach(probeError.failures, (failure) =>
-            legacyDumpContainerLogs(spawner, failure.containerId),
-          );
+          const execFormatErrors = yield* Effect.forEach(probeError.failures, (failure) =>
+            legacyDumpContainerLogs(spawner, failure.containerId).pipe(
+              Effect.map((found) => (found ? [failure.containerId] : [])),
+            ),
+          ).pipe(Effect.map((matches) => matches.flat()));
+          const suggestion = legacyExecFormatRecoveryHint(execFormatErrors, opts.images);
           return yield* Effect.fail(
             new LegacyHealthCheckTimeoutError({
               message: probeError.failures
                 .map((failure) => `${failure.containerId}: ${failure.reason}`)
                 .join("\n"),
               unhealthy: probeError.failures,
+              ...(suggestion === undefined ? {} : { suggestion }),
             }),
           );
         }),

--- a/apps/cli/src/legacy/commands/start/lib/health-check.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.ts
@@ -15,7 +15,10 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
-import { spawnContainerCli } from "../../../shared/legacy-container-cli.ts";
+import {
+  spawnContainerCliWithRuntime,
+  type LegacyContainerRuntime,
+} from "../../../shared/legacy-container-cli.ts";
 import { legacyInspectContainerState } from "../../../shared/legacy-docker-lifecycle.ts";
 import { legacyKongAuthHeaders } from "../../../shared/legacy-kong-auth.ts";
 
@@ -80,16 +83,7 @@ export class LegacyHealthCheckTimeoutError extends Data.TaggedError(
    * pointing at an HTTP request logger is a non-sequitur (as in CLI-1973).
    */
   readonly suggestion?: string;
-}> {
-  /**
-   * What `--ignore-health-check` prints when it downgrades this to a warning.
-   * That path writes to stderr directly, so it never reaches the
-   * `Output.fail` renderer that would otherwise append {@link suggestion}.
-   */
-  get warningText(): string {
-    return this.suggestion === undefined ? this.message : `${this.message}\n${this.suggestion}`;
-  }
-}
+}> {}
 
 /**
  * PostgREST's local Kong gateway coordinates, mirroring Go's
@@ -163,16 +157,22 @@ function legacyMakeExecFormatScanner() {
  * Recovery advice for a timeout whose logs showed {@link LEGACY_EXEC_FORMAT_ERROR},
  * or `undefined` when no affected image can be named.
  *
- * Deliberately states the cause without promising a remedy. Re-pulling fixes a
- * corrupt cache (supabase/cli#5952) and a wrong-architecture copy, but not a
- * pinned version with no build for this host at all (supabase/cli#3718, #4674),
- * where the same image comes back. `-f` because the container may still reference it —
- * `--ignore-health-check` leaves the stack up, and a failed rollback only logs.
- * Forcing untags one resolved image and never touches containers or volumes.
+ * `supabase stop` leads the sequence because a bare restart is a no-op on the
+ * `--ignore-health-check` path: that path leaves the stack up by design, so the
+ * next `supabase start` takes the already-running short-circuit and never
+ * recreates the broken container. `stop` without `--no-backup` preserves the
+ * database volume, and is harmless after the hard-fail path's own rollback.
+ *
+ * `-f` because the container may still reference the image, and `runtime`
+ * rather than a hardcoded `docker` because `spawnContainerCli` falls back to
+ * Podman on hosts without Docker. The closing line covers the case re-pulling
+ * cannot fix: a pinned version with no build for this host (supabase/cli#3718,
+ * #4674), where the same image comes straight back.
  */
 function legacyExecFormatRecoveryHint(
   containerIds: ReadonlyArray<string>,
   images: ReadonlyMap<string, string> | undefined,
+  runtime: LegacyContainerRuntime,
 ): string | undefined {
   // Both names, always: a container and its image can be named after different
   // things (`supabase_inbucket_*` runs `mailpit`), so naming only one leaves
@@ -186,8 +186,9 @@ function legacyExecFormatRecoveryHint(
   return [
     `${affected.map((entry) => `${entry.containerId}'s image ${entry.image}`).join(", ")} could not be executed ("${LEGACY_EXEC_FORMAT_ERROR}").`,
     "Either the cached copy is corrupt, or it was built for a different architecture.",
-    "Remove the cached copy with docker (or podman), then run supabase start again:",
-    `\n  docker image rm -f ${uniqueImages.join(" ")}`,
+    "Remove the cached copy and start again:",
+    `\n  supabase stop\n  ${runtime} image rm -f ${uniqueImages.join(" ")}\n  supabase start\n`,
+    "If it fails the same way, that image has no build for this machine's architecture.",
   ].join("\n");
 }
 
@@ -246,23 +247,28 @@ function legacyCheckHttpReady(
  * alongside, so every failure here is swallowed.
  *
  * Resolves to whether the logs contained {@link LEGACY_EXEC_FORMAT_ERROR},
- * scanned off the bytes already being teed — no extra Docker call, no buffer.
+ * scanned off the bytes already being teed — no extra Docker call, no buffer —
+ * and to the runtime that answered, so recovery advice can name the binary the
+ * user actually has.
  */
 function legacyStreamContainerLogsOnce(
   spawner: Spawner,
   containerId: string,
-): Effect.Effect<boolean> {
+): Effect.Effect<LegacyExecFormatScanResult> {
   // Outside the effect that can fail, so a stream breaking mid-dump cannot
   // discard a marker the scanner has already seen.
   const stdoutScanner = legacyMakeExecFormatScanner();
   const stderrScanner = legacyMakeExecFormatScanner();
+  let runtime: LegacyContainerRuntime | undefined;
   return Effect.scoped(
     Effect.gen(function* () {
-      const handle = yield* spawnContainerCli(spawner, ["logs", containerId], {
+      const spawned = yield* spawnContainerCliWithRuntime(spawner, ["logs", containerId], {
         stdin: "ignore",
         stdout: "pipe",
         stderr: "pipe",
       });
+      runtime = spawned.runtime;
+      const handle = spawned.handle;
       yield* Effect.all(
         [
           Stream.runForEach(handle.stdout, (chunk) =>
@@ -284,12 +290,22 @@ function legacyStreamContainerLogsOnce(
     }),
   ).pipe(
     Effect.orElseSucceed(() => undefined),
-    Effect.map(() => stdoutScanner.found || stderrScanner.found),
+    Effect.map(() => ({ found: stdoutScanner.found || stderrScanner.found, runtime })),
   );
 }
 
+/** What one container's log dump learned, beyond the bytes it teed to stderr. */
+interface LegacyExecFormatScanResult {
+  readonly found: boolean;
+  /** `undefined` only when neither runtime could be spawned at all. */
+  readonly runtime: LegacyContainerRuntime | undefined;
+}
+
 /** Go's `fmt.Fprintln(os.Stderr, containerId, "container logs:")` (`start.go:218`) + the log dump itself. */
-function legacyDumpContainerLogs(spawner: Spawner, containerId: string): Effect.Effect<boolean> {
+function legacyDumpContainerLogs(
+  spawner: Spawner,
+  containerId: string,
+): Effect.Effect<LegacyExecFormatScanResult> {
   return Effect.gen(function* () {
     yield* Effect.sync(() => {
       globalThis.process.stderr.write(`${containerId} container logs:\n`);
@@ -372,12 +388,19 @@ export function legacyWaitForHealthyServices(
           // `!errors.Is(err, context.Canceled)`) — an interrupted fiber never
           // reaches this `Effect.catch` handler at all, so no separate check
           // is needed here.
-          const execFormatErrors = yield* Effect.forEach(probeError.failures, (failure) =>
+          const scans = yield* Effect.forEach(probeError.failures, (failure) =>
             legacyDumpContainerLogs(spawner, failure.containerId).pipe(
-              Effect.map((found) => (found ? [failure.containerId] : [])),
+              Effect.map((scan) => ({ ...scan, containerId: failure.containerId })),
             ),
-          ).pipe(Effect.map((matches) => matches.flat()));
-          const suggestion = legacyExecFormatRecoveryHint(execFormatErrors, opts.images);
+          );
+          const execFormatErrors = scans
+            .filter((scan) => scan.found)
+            .map((scan) => scan.containerId);
+          const suggestion = legacyExecFormatRecoveryHint(
+            execFormatErrors,
+            opts.images,
+            scans.find((scan) => scan.runtime !== undefined)?.runtime ?? "docker",
+          );
           return yield* Effect.fail(
             new LegacyHealthCheckTimeoutError({
               message: probeError.failures

--- a/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Layer, Sink, Stream } from "effect";
+import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
@@ -12,13 +13,24 @@ import {
 } from "./health-check.ts";
 
 /**
+ * Ends a scripted `logs` script, failing the stream after the chunks before it
+ * have already been emitted — the real "daemon dropped the pipe mid-dump" case.
+ */
+const LOG_STREAM_FAILS = Symbol("log stream fails");
+
+/**
  * A spawner that answers `docker container inspect`/`docker logs` calls.
  * `inspectResponse` is called once per `(containerId, callIndex)` pair — the
  * `callIndex` (0-based, per container) lets a test script a container's
  * health across successive polling rounds. `docker logs` calls (the
- * timeout-path debug dump) always succeed with empty output.
+ * timeout-path debug dump) succeed with whatever `logs` scripts for that
+ * container — an array so a test can script chunk boundaries, optionally
+ * terminated by {@link LOG_STREAM_FAILS} — and with empty output otherwise.
  */
-function mockHealthSpawner(inspectResponse: (containerId: string, callIndex: number) => string) {
+function mockHealthSpawner(
+  inspectResponse: (containerId: string, callIndex: number) => string,
+  logs: Readonly<Record<string, ReadonlyArray<string | typeof LOG_STREAM_FAILS>>> = {},
+) {
   const counts = new Map<string, number>();
   const encoder = new TextEncoder();
   const spawned: Array<ReadonlyArray<string>> = [];
@@ -28,19 +40,40 @@ function mockHealthSpawner(inspectResponse: (containerId: string, callIndex: num
       const args = command._tag === "StandardCommand" ? command.args : [];
       spawned.push(args);
 
-      let stdout = "";
+      let chunks: ReadonlyArray<string | typeof LOG_STREAM_FAILS> = [];
       if (args[0] === "container" && args[1] === "inspect") {
         const containerId = args[2] ?? "";
         const callIndex = counts.get(containerId) ?? 0;
         counts.set(containerId, callIndex + 1);
-        stdout = inspectResponse(containerId, callIndex);
+        chunks = [inspectResponse(containerId, callIndex)];
+      } else if (args[0] === "logs") {
+        chunks = logs[args[1] ?? ""] ?? [];
       }
+
+      const emitted = Stream.fromIterable(
+        chunks
+          .filter((chunk): chunk is string => typeof chunk === "string" && chunk.length > 0)
+          .map((chunk) => encoder.encode(chunk)),
+      );
+      const stdout = chunks.includes(LOG_STREAM_FAILS)
+        ? Stream.concat(
+            emitted,
+            Stream.fail(
+              PlatformError.systemError({
+                _tag: "BadResource",
+                module: "ChildProcess",
+                method: "stdout",
+                description: "broken pipe",
+              }),
+            ),
+          )
+        : emitted;
 
       const exitDeferred = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
       yield* Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(0));
       return ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(1),
-        stdout: Stream.fromIterable(stdout.length > 0 ? [encoder.encode(stdout)] : []),
+        stdout,
         stderr: Stream.empty,
         all: Stream.empty,
         exitCode: Deferred.await(exitDeferred),
@@ -204,6 +237,204 @@ describe("legacyWaitForHealthyServices", () => {
       ).toBe(true);
     }),
   );
+
+  describe("exec format error recovery advice", () => {
+    /**
+     * The dumped logs are teed to the real `process.stderr`; swallow them so
+     * a scenario that scripts a failing container does not spray the reporter.
+     */
+    function timeoutError(
+      mock: ReturnType<typeof mockHealthSpawner>,
+      containerIds: ReadonlyArray<string>,
+      images?: ReadonlyMap<string, string>,
+    ) {
+      return Effect.gen(function* () {
+        const originalWrite = globalThis.process.stderr.write.bind(globalThis.process.stderr);
+        globalThis.process.stderr.write = (() => true) as typeof globalThis.process.stderr.write;
+        const fiber = yield* legacyWaitForHealthyServices(mock.spawner, containerIds, {
+          timeoutSeconds: 1,
+          images,
+        }).pipe(
+          Effect.provide(unusedHttpClientLayer),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust("1 seconds");
+        return yield* Fiber.join(fiber).pipe(
+          Effect.flip,
+          Effect.ensuring(
+            Effect.sync(() => {
+              globalThis.process.stderr.write = originalWrite;
+            }),
+          ),
+        );
+      });
+    }
+
+    it.effect("names the exact image to remove when a container cannot execute its image", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_inbucket_proj: ["exec /mailpit: exec format error\n"],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj"],
+          new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
+        );
+
+        // Reasons unchanged; the advice rides on `suggestion`, which is what
+        // suppresses the unhelpful "--debug" hint downstream.
+        expect(error.message).toBe("supabase_inbucket_proj: container is not running: exited");
+        expect(error.unhealthy).toEqual([
+          { containerId: "supabase_inbucket_proj", reason: "container is not running: exited" },
+        ]);
+        // Container and image named together: they can be named after different
+        // things, so either alone leaves the reader guessing.
+        expect(error.suggestion).toContain(
+          "supabase_inbucket_proj's image public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+        // Names the cause without promising a remedy: re-pulling fixes a corrupt
+        // or wrong-architecture copy, but not a version with no build at all.
+        expect(error.suggestion).toContain("built for a different architecture");
+        expect(error.suggestion).toContain(
+          "docker image rm -f public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+      }),
+    );
+
+    it.effect("matches the marker when Docker splits it across log chunks", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_studio_proj: ["exec /docker-entrypoint.sh: exec for", "mat error\n"],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_studio_proj"],
+          new Map([["supabase_studio_proj", "public.ecr.aws/supabase/studio:2026.07.13"]]),
+        );
+
+        expect(error.suggestion).toContain(
+          "docker image rm -f public.ecr.aws/supabase/studio:2026.07.13",
+        );
+      }),
+    );
+
+    it.effect("keeps a marker already seen when the log stream breaks mid-dump", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_inbucket_proj: ["exec /mailpit: exec format error\n", LOG_STREAM_FAILS],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj"],
+          new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
+        );
+
+        // A dropped pipe part-way through the dump must not discard a marker the
+        // scanner already matched — that is exactly when this bug class shows up.
+        expect(error.suggestion).toContain(
+          "docker image rm -f public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+      }),
+    );
+
+    it.effect("stays silent for an ordinary unhealthy container", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_storage_proj: ['{"msg":"Server not started with error"}\n'],
+        });
+
+        const error = yield* timeoutError(mock, ["supabase_storage_proj"]);
+
+        expect(error.message).toBe("supabase_storage_proj: container is not running: exited");
+        expect(error.suggestion).toBeUndefined();
+        // `--ignore-health-check` prints the reasons alone, with no dangling blank line.
+        expect(error.warningText).toBe(error.message);
+      }),
+    );
+
+    it.effect("carries both halves into the --ignore-health-check warning", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_inbucket_proj: ["exec format error\n"],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj"],
+          new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
+        );
+
+        // Both downgrade sites print `warningText`, so this covers the reason
+        // block and the advice arriving together on the warning path.
+        expect(error.warningText).toBe(`${error.message}\n${error.suggestion}`);
+        expect(error.warningText).toContain("supabase_inbucket_proj: container is not running");
+        expect(error.warningText).toContain("docker image rm -f");
+      }),
+    );
+
+    it.effect("lists every distinct broken image", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_inbucket_proj: ["exec format error\n"],
+          supabase_studio_proj: ["exec format error\n"],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj", "supabase_studio_proj"],
+          new Map([
+            ["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"],
+            ["supabase_studio_proj", "public.ecr.aws/supabase/studio:2026.07.13"],
+          ]),
+        );
+
+        expect(error.suggestion).toContain(
+          "supabase_inbucket_proj's image public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+        expect(error.suggestion).toContain(
+          "supabase_studio_proj's image public.ecr.aws/supabase/studio:2026.07.13",
+        );
+        expect(error.suggestion).toContain(
+          "docker image rm -f public.ecr.aws/supabase/mailpit:v1.30.2 public.ecr.aws/supabase/studio:2026.07.13",
+        );
+      }),
+    );
+
+    it.effect("dedupes an image shared by two broken containers", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_rest_proj: ["exec format error\n"],
+          supabase_realtime_proj: ["exec format error\n"],
+          supabase_storage_proj: ["listening on :5000\n"],
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_rest_proj", "supabase_realtime_proj", "supabase_storage_proj"],
+          new Map([
+            ["supabase_rest_proj", "public.ecr.aws/supabase/postgrest:v14.15"],
+            ["supabase_realtime_proj", "public.ecr.aws/supabase/postgrest:v14.15"],
+            ["supabase_storage_proj", "public.ecr.aws/supabase/storage-api:v1.66.4"],
+          ]),
+        );
+
+        // Both containers are named against the shared image, which the removal
+        // command lists once; the healthy-logged container is never mentioned.
+        expect(error.suggestion).toContain(
+          "supabase_rest_proj's image public.ecr.aws/supabase/postgrest:v14.15, supabase_realtime_proj's image public.ecr.aws/supabase/postgrest:v14.15",
+        );
+        expect(
+          error.suggestion?.endsWith(
+            "  docker image rm -f public.ecr.aws/supabase/postgrest:v14.15",
+          ),
+        ).toBe(true);
+        expect(error.suggestion).not.toContain("storage-api");
+      }),
+    );
+  });
 
   describe("PostgREST HTTP-HEAD readiness", () => {
     function postgrestGateway(secretKey: string): LegacyHealthCheckPostgrestGateway {

--- a/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
@@ -449,6 +449,9 @@ describe("legacyWaitForHealthyServices", () => {
         expect(suggestion.indexOf("image rm -f")).toBeLessThan(
           suggestion.indexOf("supabase start"),
         );
+        // Both `supabase` steps resolve their own project, so a run made with
+        // `--workdir` has to repeat it rather than rely on the current directory.
+        expect(suggestion).toContain("--workdir");
         // And a next step for the cause re-pulling cannot fix.
         expect(suggestion).toContain("no build for this machine's architecture");
       }),

--- a/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/health-check.unit.test.ts
@@ -27,54 +27,86 @@ const LOG_STREAM_FAILS = Symbol("log stream fails");
  * container — an array so a test can script chunk boundaries, optionally
  * terminated by {@link LOG_STREAM_FAILS} — and with empty output otherwise.
  */
+type LogChunks = ReadonlyArray<string | typeof LOG_STREAM_FAILS>;
+
+/** A container's scripted `docker logs` output; a bare array targets stdout. */
+type LogScript = LogChunks | { readonly stdout?: LogChunks; readonly stderr?: LogChunks };
+
+const isLogChunks = (script: LogScript): script is LogChunks => Array.isArray(script);
+
 function mockHealthSpawner(
   inspectResponse: (containerId: string, callIndex: number) => string,
-  logs: Readonly<Record<string, ReadonlyArray<string | typeof LOG_STREAM_FAILS>>> = {},
+  logs: Readonly<Record<string, LogScript>> = {},
+  opts: { readonly runtime?: "docker" | "podman" } = {},
 ) {
   const counts = new Map<string, number>();
   const encoder = new TextEncoder();
   const spawned: Array<ReadonlyArray<string>> = [];
 
+  const toStream = (chunks: LogChunks) => {
+    const emitted = Stream.fromIterable(
+      chunks
+        .filter((chunk): chunk is string => typeof chunk === "string" && chunk.length > 0)
+        .map((chunk) => encoder.encode(chunk)),
+    );
+    return chunks.includes(LOG_STREAM_FAILS)
+      ? Stream.concat(
+          emitted,
+          Stream.fail(
+            PlatformError.systemError({
+              _tag: "BadResource",
+              module: "ChildProcess",
+              method: "stdout",
+              description: "broken pipe",
+            }),
+          ),
+        )
+      : emitted;
+  };
+
   const spawner = ChildProcessSpawner.make((command) =>
     Effect.gen(function* () {
       const args = command._tag === "StandardCommand" ? command.args : [];
+      const binary = command._tag === "StandardCommand" ? command.command : "";
+      // Mirrors a host where only one runtime is installed: `spawnContainerCli`
+      // tries `docker` first and falls back to `podman` when the spawn fails.
+      if (opts.runtime !== undefined && binary !== opts.runtime) {
+        return yield* Effect.fail(
+          PlatformError.systemError({
+            _tag: "NotFound",
+            module: "ChildProcess",
+            method: "spawn",
+            description: `${binary}: command not found`,
+          }),
+        );
+      }
       spawned.push(args);
 
-      let chunks: ReadonlyArray<string | typeof LOG_STREAM_FAILS> = [];
+      let stdoutChunks: LogChunks = [];
+      let stderrChunks: LogChunks = [];
       if (args[0] === "container" && args[1] === "inspect") {
         const containerId = args[2] ?? "";
         const callIndex = counts.get(containerId) ?? 0;
         counts.set(containerId, callIndex + 1);
-        chunks = [inspectResponse(containerId, callIndex)];
+        stdoutChunks = [inspectResponse(containerId, callIndex)];
       } else if (args[0] === "logs") {
-        chunks = logs[args[1] ?? ""] ?? [];
+        const script = logs[args[1] ?? ""];
+        if (script !== undefined) {
+          if (isLogChunks(script)) {
+            stdoutChunks = script;
+          } else {
+            stdoutChunks = script.stdout ?? [];
+            stderrChunks = script.stderr ?? [];
+          }
+        }
       }
-
-      const emitted = Stream.fromIterable(
-        chunks
-          .filter((chunk): chunk is string => typeof chunk === "string" && chunk.length > 0)
-          .map((chunk) => encoder.encode(chunk)),
-      );
-      const stdout = chunks.includes(LOG_STREAM_FAILS)
-        ? Stream.concat(
-            emitted,
-            Stream.fail(
-              PlatformError.systemError({
-                _tag: "BadResource",
-                module: "ChildProcess",
-                method: "stdout",
-                description: "broken pipe",
-              }),
-            ),
-          )
-        : emitted;
 
       const exitDeferred = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
       yield* Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(0));
       return ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(1),
-        stdout,
-        stderr: Stream.empty,
+        stdout: toStream(stdoutChunks),
+        stderr: toStream(stderrChunks),
         all: Stream.empty,
         exitCode: Deferred.await(exitDeferred),
         isRunning: Effect.succeed(false),
@@ -350,12 +382,53 @@ describe("legacyWaitForHealthyServices", () => {
 
         expect(error.message).toBe("supabase_storage_proj: container is not running: exited");
         expect(error.suggestion).toBeUndefined();
-        // `--ignore-health-check` prints the reasons alone, with no dangling blank line.
-        expect(error.warningText).toBe(error.message);
       }),
     );
 
-    it.effect("carries both halves into the --ignore-health-check warning", () =>
+    it.effect("detects the marker when it arrives on the container's stderr stream", () =>
+      Effect.gen(function* () {
+        // Where the container runtime actually writes it: `docker logs` demuxes
+        // the container's stderr onto its own stderr pipe, so this is the real
+        // path, not the stdout one every other scenario here scripts.
+        const mock = mockHealthSpawner(() => notRunning, {
+          supabase_inbucket_proj: { stderr: ["exec /mailpit: exec format error\n"] },
+        });
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj"],
+          new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
+        );
+
+        expect(error.suggestion).toContain(
+          "docker image rm -f public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+      }),
+    );
+
+    it.effect("names podman in the recovery command on a Podman-only host", () =>
+      Effect.gen(function* () {
+        const mock = mockHealthSpawner(
+          () => notRunning,
+          { supabase_inbucket_proj: { stderr: ["exec format error\n"] } },
+          { runtime: "podman" },
+        );
+
+        const error = yield* timeoutError(
+          mock,
+          ["supabase_inbucket_proj"],
+          new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
+        );
+
+        // A `docker ...` line would be uncopyable on a host without Docker.
+        expect(error.suggestion).toContain(
+          "podman image rm -f public.ecr.aws/supabase/mailpit:v1.30.2",
+        );
+        expect(error.suggestion).not.toContain("docker image rm");
+      }),
+    );
+
+    it.effect("leads the recovery sequence with supabase stop", () =>
       Effect.gen(function* () {
         const mock = mockHealthSpawner(() => notRunning, {
           supabase_inbucket_proj: ["exec format error\n"],
@@ -367,11 +440,17 @@ describe("legacyWaitForHealthyServices", () => {
           new Map([["supabase_inbucket_proj", "public.ecr.aws/supabase/mailpit:v1.30.2"]]),
         );
 
-        // Both downgrade sites print `warningText`, so this covers the reason
-        // block and the advice arriving together on the warning path.
-        expect(error.warningText).toBe(`${error.message}\n${error.suggestion}`);
-        expect(error.warningText).toContain("supabase_inbucket_proj: container is not running");
-        expect(error.warningText).toContain("docker image rm -f");
+        // Without `supabase stop`, the `--ignore-health-check` path leaves the
+        // stack up and the next `supabase start` short-circuits on
+        // already-running, never recreating the broken container.
+        const suggestion = error.suggestion ?? "";
+        expect(suggestion).toContain("supabase stop");
+        expect(suggestion.indexOf("supabase stop")).toBeLessThan(suggestion.indexOf("image rm -f"));
+        expect(suggestion.indexOf("image rm -f")).toBeLessThan(
+          suggestion.indexOf("supabase start"),
+        );
+        // And a next step for the cause re-pulling cannot fix.
+        expect(suggestion).toContain("no build for this machine's architecture");
       }),
     );
 
@@ -421,16 +500,17 @@ describe("legacyWaitForHealthyServices", () => {
           ]),
         );
 
-        // Both containers are named against the shared image, which the removal
-        // command lists once; the healthy-logged container is never mentioned.
+        // Both containers are named against the shared image...
+        expect(error.suggestion).toContain("supabase_rest_proj's image");
+        expect(error.suggestion).toContain("supabase_realtime_proj's image");
+        // ...which the removal command lists once, not twice.
         expect(error.suggestion).toContain(
-          "supabase_rest_proj's image public.ecr.aws/supabase/postgrest:v14.15, supabase_realtime_proj's image public.ecr.aws/supabase/postgrest:v14.15",
+          "docker image rm -f public.ecr.aws/supabase/postgrest:v14.15",
         );
-        expect(
-          error.suggestion?.endsWith(
-            "  docker image rm -f public.ecr.aws/supabase/postgrest:v14.15",
-          ),
-        ).toBe(true);
+        expect(error.suggestion).not.toContain(
+          "postgrest:v14.15 public.ecr.aws/supabase/postgrest:v14.15",
+        );
+        // The healthy-logged container's own image is never suggested.
         expect(error.suggestion).not.toContain("storage-api");
       }),
     );

--- a/apps/cli/src/legacy/commands/start/start.handler.ts
+++ b/apps/cli/src/legacy/commands/start/start.handler.ts
@@ -2007,13 +2007,17 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
         configImage: postgresImage,
         rootKey: values.rootKey,
       });
-      const postgresContainerId = yield* legacyStartContainer(spawner, postgresSpec, startOpts);
+      yield* legacyStartContainer(spawner, postgresSpec, startOpts);
       // `dbHealthTimeoutSeconds` is resolved eagerly, before any Docker work — see its
       // definition above, alongside the other eagerly-validated config-override fields.
+      // Watched by container name, matching Go's `utils.DbId`.
       const postgresHealthResult = yield* legacyWaitForHealthyServices(
         spawner,
-        [postgresContainerId],
-        { timeoutSeconds: dbHealthTimeoutSeconds },
+        [postgresSpec.containerName],
+        {
+          timeoutSeconds: dbHealthTimeoutSeconds,
+          images: new Map([[postgresSpec.containerName, postgresSpec.image]]),
+        },
       ).pipe(Effect.result);
       if (Result.isFailure(postgresHealthResult)) {
         const error = postgresHealthResult.failure;
@@ -2030,7 +2034,7 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
           // falls through to the SAME unconditional tail every other path
           // reaches (`start.go:84-87`), not an early return from the whole
           // command.
-          yield* output.raw(`${error.message}\n`, "stderr");
+          yield* output.raw(`${error.warningText}\n`, "stderr");
           return { kind: "postgresUnhealthyIgnored" as const };
         }
         return yield* Effect.fail(error);
@@ -2162,7 +2166,13 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
         yield* output.raw(LEGACY_START_STARTING_CONTAINERS_MESSAGE, "stderr");
       }
 
-      const started: Array<string> = [];
+      // Go's `started` slice, as an insertion-ordered container NAME -> resolved
+      // image map. Go watches container names (`started = append(started,
+      // utils.XxxId)`, `start.go:393-1267`), not the ids `docker create`
+      // returns, so an unhealthy container reports as `supabase_auth_demo`
+      // rather than 64 hex characters. Keying the images by that same name
+      // keeps the watch list and its images from drifting apart.
+      const started = new Map<string, string>();
       let postgrestGateway: LegacyHealthCheckPostgrestGateway | undefined;
       let edgeRuntimeGateway: LegacyHealthCheckPostgrestGateway | undefined;
       let storageContainerId: string | undefined;
@@ -2259,7 +2269,7 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
           // EdgeRuntimeContainer` already runs `cleanup` on a failed or
           // interrupted bring-up internally, so only the success path must
           // leave it alone.
-          started.push(runtime.containerId);
+          started.set(runtime.containerId, edgeRuntimeInput.image);
           edgeRuntimeGateway = {
             containerId: runtime.containerId,
             apiExternalUrl: values.apiUrl,
@@ -2295,19 +2305,19 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
             ),
           ),
         );
-        const containerId = yield* legacyStartContainer(spawner, spec, startOpts);
+        yield* legacyStartContainer(spawner, spec, startOpts);
         if (excludeFromHealthWatch !== true) {
-          started.push(containerId);
+          started.set(spec.containerName, spec.image);
         }
         if (entry.service === "postgrest") {
           postgrestGateway = {
-            containerId,
+            containerId: spec.containerName,
             apiExternalUrl: values.apiUrl,
             secretKey: values.secretKey,
           };
         }
         if (entry.service === "storage") {
-          storageContainerId = containerId;
+          storageContainerId = spec.containerName;
         }
       }
 
@@ -2473,9 +2483,10 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
           projectRef: "",
           config: effectiveLocalStorageConfig,
         });
-        const healthResult = yield* legacyWaitForHealthyServices(spawner, started, {
+        const healthResult = yield* legacyWaitForHealthyServices(spawner, [...started.keys()], {
           postgrest: postgrestGateway,
           edgeRuntime: edgeRuntimeGateway,
+          images: started,
         }).pipe(
           Effect.result,
           localKongCa !== undefined
@@ -2499,9 +2510,11 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
             // the same downgrade-to-warning as every other ignored-unhealthy
             // failure.
             if (isFreshVolume && storageContainerId !== undefined) {
-              const storageHealthResult = yield* legacyWaitForHealthyServices(spawner, [
-                storageContainerId,
-              ]).pipe(Effect.result);
+              const storageHealthResult = yield* legacyWaitForHealthyServices(
+                spawner,
+                [storageContainerId],
+                { images: started },
+              ).pipe(Effect.result);
               if (Result.isSuccess(storageHealthResult)) {
                 const seedResult = yield* legacySeedBucketsRun({
                   projectRef: "",
@@ -2521,7 +2534,7 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
               }
             }
             // Downgrade to a warning and fall through to the success path, no rollback.
-            yield* output.raw(`${error.message}\n`, "stderr");
+            yield* output.raw(`${error.warningText}\n`, "stderr");
           } else {
             // No manual `legacyRollbackStart` here — the outer `Effect.onError`
             // below rolls back on this failure too.

--- a/apps/cli/src/legacy/commands/start/start.handler.ts
+++ b/apps/cli/src/legacy/commands/start/start.handler.ts
@@ -153,6 +153,7 @@ import { legacyEnsureImagesCached } from "./lib/image-prepull.ts";
 import {
   legacyWaitForHealthyServices,
   type LegacyHealthCheckPostgrestGateway,
+  type LegacyHealthCheckTimeoutError,
 } from "./lib/health-check.ts";
 import {
   legacyStartInternalDbPassword,
@@ -685,6 +686,17 @@ function buildKongEmailTemplateMounts(
           }) ?? "",
       })),
   ];
+}
+
+/**
+ * What `--ignore-health-check` prints when it downgrades a health-check timeout
+ * to a warning. That decision belongs to this caller, not `lib/health-check.ts`
+ * (which only implements the polling contract), and it writes straight to
+ * stderr — bypassing the `Output.fail` renderer that would otherwise append the
+ * error's `suggestion` for it.
+ */
+function legacyHealthWarningText(error: LegacyHealthCheckTimeoutError): string {
+  return error.suggestion === undefined ? error.message : `${error.message}\n${error.suggestion}`;
 }
 
 export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacyStartFlags) {
@@ -2034,7 +2046,7 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
           // falls through to the SAME unconditional tail every other path
           // reaches (`start.go:84-87`), not an early return from the whole
           // command.
-          yield* output.raw(`${error.warningText}\n`, "stderr");
+          yield* output.raw(`${legacyHealthWarningText(error)}\n`, "stderr");
           return { kind: "postgresUnhealthyIgnored" as const };
         }
         return yield* Effect.fail(error);
@@ -2510,6 +2522,9 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
             // the same downgrade-to-warning as every other ignored-unhealthy
             // failure.
             if (isFreshVolume && storageContainerId !== undefined) {
+              // `images` is intentionally the whole run's registry, not scoped to
+              // this one-container watch list — the hint can only ever key off
+              // containers that actually appear in this call's own failures.
               const storageHealthResult = yield* legacyWaitForHealthyServices(
                 spawner,
                 [storageContainerId],
@@ -2534,7 +2549,7 @@ export const legacyStart = Effect.fn("legacy.start")(function* (flags: LegacySta
               }
             }
             // Downgrade to a warning and fall through to the success path, no rollback.
-            yield* output.raw(`${error.warningText}\n`, "stderr");
+            yield* output.raw(`${legacyHealthWarningText(error)}\n`, "stderr");
           } else {
             // No manual `legacyRollbackStart` here — the outer `Effect.onError`
             // below rolls back on this failure too.

--- a/apps/cli/src/legacy/commands/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.integration.test.ts
@@ -181,6 +181,19 @@ function containerNameFromCreateArgs(args: ReadonlyArray<string>): string {
   return nameIndex !== -1 ? (args[nameIndex + 1] ?? "unknown") : "unknown";
 }
 
+/**
+ * Real `docker create` prints a 64-hex id, never the `--name`. The mock does
+ * too, so a caller that carries that opaque id into the health watch fails the
+ * assertions here instead of shipping unreadable output to users.
+ */
+function fakeContainerId(name: string): string {
+  return [...name]
+    .map((char) => (char.codePointAt(0) ?? 0).toString(16).padStart(2, "0"))
+    .join("")
+    .padEnd(64, "0")
+    .slice(0, 64);
+}
+
 function createdContainerNames(spawned: ReadonlyArray<SpawnRecord>): ReadonlyArray<string> {
   return spawned
     .filter((s) => s.args[0] === "create")
@@ -205,7 +218,7 @@ function defaultRoute(opts: { readonly neverHealthy?: ReadonlySet<string> } = {}
     if (args[0] === "create") {
       const name = containerNameFromCreateArgs(args);
       created.add(name);
-      return { stdout: [name] };
+      return { stdout: [fakeContainerId(name)] };
     }
     if (args[0] === "start") return { exitCode: 0 };
     if (args[0] === "container" && args[1] === "inspect") {
@@ -3190,6 +3203,12 @@ content_path = "./templates/custom_notice.html"
             const name = containerNameFromCreateArgs(args);
             if (name.includes("_auth_")) neverHealthy.add(name);
           }
+          // The timeout path dumps this container's logs; scripting the
+          // `exec format error` signature into them exercises the whole
+          // recovery-advice wiring (name -> resolved image -> rendered hint).
+          if (args[0] === "logs" && (args[1] ?? "").includes("_auth_")) {
+            return { stdout: ["exec /usr/local/bin/auth: exec format error\n"] };
+          }
           return route(args);
         },
         // Sidesteps the PostgREST/Edge Runtime HTTP-HEAD readiness probes
@@ -3205,6 +3224,10 @@ content_path = "./templates/custom_notice.html"
         expect(out.stderrText).toContain("is not ready");
         expect(out.stderrText).toContain("Started");
         expect(rollbackWasAttempted(child.spawned)).toBe(false);
+        // Reported by container name, not `docker create`'s opaque id, and the
+        // advice names the image actually resolved for that container.
+        expect(out.stderrText).toContain("supabase_auth_demo: container is not ready");
+        expect(out.stderrText).toContain("docker image rm -f public.ecr.aws/supabase/gotrue:");
         // Go never fires `cli_stack_started` on the ignored-unhealthy
         // fallthrough (`start.go:1287` sits after the `if err != nil` block) —
         // only a genuine bulk health-check SUCCESS reaches that capture.

--- a/apps/cli/src/legacy/commands/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.integration.test.ts
@@ -3115,6 +3115,12 @@ content_path = "./templates/custom_notice.html"
             const name = containerNameFromCreateArgs(args);
             if (name.includes("_db_")) neverHealthy.add(name);
           }
+          // Postgres's own health wait builds its `images` map separately from the
+          // bulk one, so this scripts the marker here too rather than assuming the
+          // two call sites are wired the same way.
+          if (args[0] === "logs" && (args[1] ?? "").includes("_db_")) {
+            return { stdout: ["exec /usr/local/bin/docker-entrypoint.sh: exec format error\n"] };
+          }
           return base(args);
         };
         const { layer, out, child, analytics } = setup({
@@ -3126,6 +3132,14 @@ content_path = "./templates/custom_notice.html"
           expect(out.stderrText).toContain("is not ready");
           expect(out.stderrText).toContain("Started");
           expect(rollbackWasAttempted(child.spawned)).toBe(false);
+          // Reported by container name, with the recovery advice naming the image
+          // Postgres's own health wait resolved for it.
+          expect(out.stderrText).toContain("supabase_db_demo: container is not ready");
+          expect(out.stderrText).toContain("supabase_db_demo's image");
+          expect(out.stderrText).toContain("image rm -f public.ecr.aws/supabase/postgres:");
+          // `--ignore-health-check` leaves the stack up, so a bare restart would be a
+          // no-op — the sequence must stop first.
+          expect(out.stderrText).toContain("supabase stop");
           // No other service's container is ever created — Go's `StartDatabase`
           // returns before `run()`'s "Starting containers..." message or any other
           // service's bring-up even begins.

--- a/apps/cli/src/legacy/commands/start/start.live.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.live.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,7 +11,9 @@ import {
   legacyServiceContainerName,
   localDbContainerId,
 } from "../../shared/legacy-docker-ids.ts";
+import { legacyGetRegistryImageUrl } from "../../shared/legacy-docker-registry.ts";
 import { LEGACY_SERVICE_CATALOG } from "../../shared/legacy-service-catalog.ts";
+import { dockerfileServiceImage } from "../../../shared/services/dockerfile-images.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -200,6 +202,65 @@ describeLive("supabase start (live)", () => {
         exitTimeoutMs: SHORT_LIVE_TIMEOUT_MS,
       });
       expect(status.exitCode, `stdout:\n${status.stdout}\nstderr:\n${status.stderr}`).toBe(0);
+    },
+  );
+
+  // The health watch inspects and dumps logs by container NAME against a real
+  // daemon, and derives recovery advice from a real container's real log bytes.
+  // Neither is observable through the in-process mocks, so this reproduces
+  // supabase/cli#5952 for real: a locally cached image that cannot be executed.
+  test(
+    "names the container and its image when a cached image cannot be executed",
+    { timeout: START_TIMEOUT_MS + LIFECYCLE_OVERHEAD_MS },
+    async () => {
+      projectDir = await mkdtemp(path.join(tmpdir(), "sb-start-live-exec-"));
+      const projectId = legacySanitizeProjectId(path.basename(projectDir));
+      const mailpitContainer = legacyServiceContainerName("inbucket", projectId);
+      // The exact tag `start` resolves for Mailpit, so its already-cached check
+      // finds this deliberately broken build and never reaches a registry.
+      const mailpitImage = legacyGetRegistryImageUrl(dockerfileServiceImage("mailpit"));
+
+      const init = await runSupabaseLive(["init"], {
+        cwd: projectDir,
+        exitTimeoutMs: SHORT_LIVE_TIMEOUT_MS,
+      });
+      expect(init.exitCode, `stdout:\n${init.stdout}\nstderr:\n${init.stderr}`).toBe(0);
+
+      // A `scratch` image whose entrypoint is not an executable binary — the
+      // kernel refuses it with exactly the "exec format error" this diagnoses.
+      const buildDir = path.join(projectDir, "broken-image");
+      await mkdir(buildDir, { recursive: true });
+      await writeFile(path.join(buildDir, "mailpit"), "not an executable\n", { mode: 0o755 });
+      await writeFile(
+        path.join(buildDir, "Dockerfile"),
+        'FROM scratch\nCOPY mailpit /mailpit\nENTRYPOINT ["/mailpit"]\n',
+      );
+      await execFileAsync("docker", ["build", "-q", "-t", mailpitImage, buildDir]);
+
+      try {
+        // Everything except Postgres and Mailpit is excluded: this scenario only
+        // needs one container that cannot start.
+        const excludeArgs = LEGACY_SERVICE_CATALOG.flatMap((entry) =>
+          entry.excludeKey === undefined || entry.excludeKey === "mailpit"
+            ? []
+            : ["--exclude", entry.excludeKey],
+        );
+        const start = await runSupabaseLive(["start", ...excludeArgs], {
+          cwd: projectDir,
+          exitTimeoutMs: START_TIMEOUT_MS,
+        });
+
+        expect(start.exitCode, `stdout:\n${start.stdout}\nstderr:\n${start.stderr}`).not.toBe(0);
+        // Go reports `utils.InbucketId`, not the id `docker create` returns.
+        expect(start.stderr).toContain(`${mailpitContainer} container logs:`);
+        expect(start.stderr).toContain(`${mailpitContainer}: container is not ready`);
+        // ...and the advice names that container's actual resolved image.
+        expect(start.stderr).toContain(`${mailpitContainer}'s image ${mailpitImage}`);
+        expect(start.stderr).toContain(`image rm -f ${mailpitImage}`);
+      } finally {
+        // Never leave a poisoned tag behind for later jobs on this runner.
+        await execFileAsync("docker", ["image", "rm", "-f", mailpitImage]).catch(() => undefined);
+      }
     },
   );
 });

--- a/apps/cli/src/legacy/shared/legacy-container-cli.ts
+++ b/apps/cli/src/legacy/shared/legacy-container-cli.ts
@@ -44,6 +44,36 @@ export function legacyDescribeContainerCliFailure(cause: unknown): string {
   return String(cause);
 }
 
+/** Which of the two supported container CLIs actually answered a spawn. */
+export type LegacyContainerRuntime = "docker" | "podman";
+
+/**
+ * {@link spawnContainerCli}, but also reporting which runtime answered — for
+ * callers that print a command for the user to run themselves, where naming
+ * `docker` on a Podman-only host would be uncopyable advice.
+ */
+export const spawnContainerCliWithRuntime = (
+  spawner: Spawner,
+  args: ReadonlyArray<string>,
+  options?: ChildProcess.CommandOptions,
+) =>
+  spawner.spawn(ChildProcess.make("docker", args, options)).pipe(
+    Effect.map((handle) => ({ handle, runtime: dockerRuntime })),
+    Effect.catch(() =>
+      spawner.spawn(ChildProcess.make("podman", args, options)).pipe(
+        Effect.map((handle) => ({ handle, runtime: podmanRuntime })),
+        Effect.catch(() =>
+          Effect.fail(
+            new LegacyContainerRuntimeNotFoundError({ message: RUNTIME_NOT_FOUND_MESSAGE }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+const dockerRuntime: LegacyContainerRuntime = "docker";
+const podmanRuntime: LegacyContainerRuntime = "podman";
+
 /**
  * Spawn a container-CLI command and return the process handle. Use when the
  * caller needs to read stdout/stderr or await the exit code itself.
@@ -52,22 +82,7 @@ export const spawnContainerCli = (
   spawner: Spawner,
   args: ReadonlyArray<string>,
   options?: ChildProcess.CommandOptions,
-) =>
-  spawner
-    .spawn(ChildProcess.make("docker", args, options))
-    .pipe(
-      Effect.catch(() =>
-        spawner
-          .spawn(ChildProcess.make("podman", args, options))
-          .pipe(
-            Effect.catch(() =>
-              Effect.fail(
-                new LegacyContainerRuntimeNotFoundError({ message: RUNTIME_NOT_FOUND_MESSAGE }),
-              ),
-            ),
-          ),
-      ),
-    );
+) => spawnContainerCliWithRuntime(spawner, args, options).pipe(Effect.map((it) => it.handle));
 
 /**
  * Run a container-CLI command and resolve to its exit code, mirroring the

--- a/apps/cli/src/legacy/shared/legacy-container-cli.ts
+++ b/apps/cli/src/legacy/shared/legacy-container-cli.ts
@@ -52,7 +52,7 @@ export type LegacyContainerRuntime = "docker" | "podman";
  * callers that print a command for the user to run themselves, where naming
  * `docker` on a Podman-only host would be uncopyable advice.
  */
-export const spawnContainerCliWithRuntime = (
+export const legacySpawnContainerCliWithRuntime = (
   spawner: Spawner,
   args: ReadonlyArray<string>,
   options?: ChildProcess.CommandOptions,
@@ -82,7 +82,7 @@ export const spawnContainerCli = (
   spawner: Spawner,
   args: ReadonlyArray<string>,
   options?: ChildProcess.CommandOptions,
-) => spawnContainerCliWithRuntime(spawner, args, options).pipe(Effect.map((it) => it.handle));
+) => legacySpawnContainerCliWithRuntime(spawner, args, options).pipe(Effect.map((it) => it.handle));
 
 /**
  * Run a container-CLI command and resolve to its exit code, mirroring the


### PR DESCRIPTION
## TL;DR

`supabase start` reported health-check failures by raw Docker id with no way forward — it
now names the container, its image, and the command to fix it.

## Prob

When a container's cached image can't be executed:

```
99a635a072a8e0b2d7e56f9a619a5b4027bdeef702102508383900b78b8cc18b container logs:
exec /mailpit: exec format error
99a635a072a8e0b2d7e56f9a619a5b4027bdeef702102508383900b78b8cc18b: container is not ready: unhealthy
Try rerunning the command with --debug to troubleshoot the error.
```

You can't tell which service died, and `--debug` only logs HTTP requests.

## Sol

```
supabase_inbucket_bredbox container logs:
exec /mailpit: exec format error
supabase_inbucket_bredbox: container is not ready: unhealthy
supabase_inbucket_bredbox's image public.ecr.aws/supabase/mailpit:v1.30.2 could not be executed ("exec format error").
Either the cached copy is corrupt, or it was built for a different architecture.
Remove the cached copy with docker (or podman), then run supabase start again:

  docker image rm -f public.ecr.aws/supabase/mailpit:v1.30.2
```

Containers are watched by name, and `exec format error` attaches the affected
image and the command to remove it.

## Ref

- closes #5952