### PR TITLE
fix(cli): render Go's caret, Detail, and 42704 hint in migration-apply errors

### DIFF
--- a/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
@@ -79,6 +79,7 @@ function mockConnection(opts: {
   vaultRows?: ReadonlyArray<{ id: string; name: string }>;
   noSeedTable?: boolean;
   failExec?: string;
+  failExecWith?: { message: string; code?: string; detail?: string; position?: number };
 }) {
   const execs: Array<string> = [];
   const queries: Array<{ sql: string; params?: ReadonlyArray<unknown> }> = [];
@@ -93,7 +94,9 @@ function mockConnection(opts: {
             execs.push(sql);
             if (opts.failExec !== undefined && sql === opts.failExec) {
               return Effect.fail(
-                new LegacyDbExecError({ message: "ERROR: boom (SQLSTATE 42601)" }),
+                new LegacyDbExecError(
+                  opts.failExecWith ?? { message: "ERROR: boom (SQLSTATE 42601)" },
+                ),
               );
             }
             return Effect.void;
@@ -159,6 +162,7 @@ function setup(
     vaultRows?: ReadonlyArray<{ id: string; name: string }>;
     noSeedTable?: boolean;
     failExec?: string;
+    failExecWith?: { message: string; code?: string; detail?: string; position?: number };
     catalogStdout?: string;
     catalogExportFailWith?: string;
     noProjectId?: boolean;
@@ -813,11 +817,45 @@ describe("legacy db push", () => {
       confirm: [true],
     });
     return Effect.gen(function* () {
-      const exit = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
-      expect(Exit.isFailure(exit)).toBe(true);
-      if (Exit.isFailure(exit)) {
-        expect(JSON.stringify(exit.cause)).toContain("At statement: 0");
-      }
+      const error = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.flip);
+      // A server error without position/detail keeps Go's plain ExecBatch layout.
+      expect(error._tag).toBe("LegacyDbPushApplyError");
+      expect(error.message).toBe("ERROR: boom (SQLSTATE 42601)\nAt statement: 0\nBOOM");
+    });
+  });
+
+  it.live("renders Go's caret, Detail line, and 42704 extension hint on a failed migration", () => {
+    // Byte-match of Go's `(*MigrationFile).ExecBatch` failure rendering
+    // (`pkg/migration/file.go:88-113`): the `^` caret under the server-reported
+    // error position, the `Detail` line, and the undefined-object extension hint.
+    const stat = "CREATE TABLE test (path ltree NOT NULL)";
+    const { layer } = setup(tmp.current, {
+      toml: 'project_id = "test"\n',
+      files: migrationFile("20240101000000", `${stat};`),
+      failExec: stat,
+      failExecWith: {
+        message: 'ERROR: type "ltree" does not exist (SQLSTATE 42704)',
+        code: "42704",
+        detail: "Detail from the server.",
+        position: 25,
+      },
+      confirm: [true],
+    });
+    return Effect.gen(function* () {
+      const error = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.flip);
+      expect(error._tag).toBe("LegacyDbPushApplyError");
+      expect(error.message).toBe(
+        'ERROR: type "ltree" does not exist (SQLSTATE 42704)\n' +
+          "Detail from the server.\n" +
+          "\n" +
+          "Hint: This type may be defined in a schema that's not in your search_path.\n" +
+          "      Use schema-qualified type references to avoid this error:\n" +
+          "        CREATE TABLE example (col extensions.ltree);\n" +
+          "      Learn more: supabase migration new --help\n" +
+          "At statement: 0\n" +
+          "CREATE TABLE test (path ltree NOT NULL)\n" +
+          "                        ^",
+      );
     });
   });
 

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -213,6 +213,14 @@ const LEGACY_TLS_DISCONNECT_MESSAGE =
 const SQLSTATE_PATTERN = /^[0-9A-Z]{5}$/;
 
 /**
+ * Whether a driver error `code` is a Postgres SQLSTATE (a server ErrorResponse)
+ * rather than a node system errno (`ECONNRESET`, …). Shared by the connect-cause
+ * renderer below and the driver layer's exec-error mapping, which both need to
+ * distinguish server errors from socket/driver failures.
+ */
+export const legacyIsSqlState = (code: string): boolean => SQLSTATE_PATTERN.test(code);
+
+/**
  * Render the underlying driver failure the way pgconn stages its
  * `connectError.msg` (`server error` / `hostname resolving error` /
  * `dial error` / `tls error`, each with the cause parenthesized —
@@ -245,7 +253,7 @@ function legacyConnectCauseDetail(cause: unknown): string {
       : typeof code === "string"
         ? code
         : String(cause);
-  if (typeof severity === "string" && typeof code === "string" && SQLSTATE_PATTERN.test(code)) {
+  if (typeof severity === "string" && typeof code === "string" && legacyIsSqlState(code)) {
     return `server error (${severity}: ${text} (SQLSTATE ${code}))`;
   }
   if (syscall === "getaddrinfo" || code === "ENOTFOUND" || code === "EAI_AGAIN") {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
@@ -24,6 +24,20 @@ export class LegacyDbExecError extends Data.TaggedError("LegacyDbExecError")<{
    * missing migration-history table, not an undefined column.
    */
   readonly code?: string;
+  /**
+   * Postgres `Detail` field of a server ErrorResponse (Go's `pgErr.Detail`).
+   * Only set for server errors that carry a non-empty detail; the migration-apply
+   * error context renders it on its own line, matching Go's `ExecBatch`
+   * (`pkg/migration/file.go:99-101`).
+   */
+  readonly detail?: string;
+  /**
+   * Postgres error cursor of a server ErrorResponse (Go's `pgErr.Position`): a
+   * 1-based index into the failing statement. Only set when the server reported a
+   * position > 0. The migration-apply error context uses it to render Go's `^`
+   * caret under the error position (`pkg/migration/file.go:98`, `markError`).
+   */
+  readonly position?: number;
 }> {}
 
 /**

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -266,8 +266,15 @@ describe("legacyDbConnectionSqlPgLayer exec failures", () => {
           fakeQueryServer((sql) =>
             sql === failing
               ? Buffer.concat([
+                  // `S` (localized) and `V` (unlocalized) are deliberately distinct:
+                  // Go renders pgconn's `PgError.Severity`, populated from the wire
+                  // `S` field (pgproto3 `error_response.go` maps 'S'→Severity,
+                  // 'V'→SeverityUnlocalized), so a localized server prints e.g.
+                  // `FEHLER: …`. pg-protocol likewise assigns `severity = fields.S`
+                  // (`parser.js` parseErrorMessage); asserting `FEHLER` below fails
+                  // the tripwire if a dependency bump ever renders `V` instead.
                   errorResponse({
-                    S: "ERROR",
+                    S: "FEHLER",
                     V: "ERROR",
                     C: "42704",
                     M: 'type "ltree" does not exist',
@@ -307,7 +314,7 @@ describe("legacyDbConnectionSqlPgLayer exec failures", () => {
           Effect.ensuring(Effect.sync(server.close)),
         );
         expect(error._tag).toBe("LegacyDbExecError");
-        expect(error.message).toBe('ERROR: type "ltree" does not exist (SQLSTATE 42704)');
+        expect(error.message).toBe('FEHLER: type "ltree" does not exist (SQLSTATE 42704)');
         if (error._tag === "LegacyDbExecError") {
           expect(error.code).toBe("42704");
           expect(error.detail).toBe("Detail from the server.");

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { LEGACY_SUGGEST_ENV_VAR } from "./legacy-connect-errors.ts";
-import type { LegacyDbConnectError } from "./legacy-db-connection.errors.ts";
+import type { LegacyDbConnectError, LegacyDbExecError } from "./legacy-db-connection.errors.ts";
 import { type LegacyPgConnInput, LegacyDbConnection } from "./legacy-db-connection.service.ts";
 import { legacyDbConnectionSqlPgLayer } from "./legacy-db-connection.sql-pg.layer.ts";
 
@@ -106,6 +106,74 @@ const fakePostgresServer = (
     });
   });
 
+/** Encode a Postgres wire-protocol message with a 1-byte type + int32 length + body. */
+const wireMessage = (type: string, body: Buffer): Buffer => {
+  const head = Buffer.alloc(5);
+  head.write(type, 0, "ascii");
+  head.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([head, body]);
+};
+
+// AuthenticationOk ('R', code 0) + ReadyForQuery ('Z', idle).
+const AUTHENTICATION_OK = wireMessage("R", Buffer.from([0, 0, 0, 0]));
+const READY_FOR_QUERY = wireMessage("Z", Buffer.from("I", "ascii"));
+const commandComplete = (tag: string): Buffer =>
+  wireMessage("C", Buffer.concat([Buffer.from(tag, "utf8"), Buffer.from([0])]));
+
+/**
+ * A fake Postgres server that completes the startup handshake (no auth) and
+ * answers every simple-protocol query ('Q') via `onQuery`, so tests can drive
+ * the REAL driver stack — node-postgres wire parsing → `DatabaseError` →
+ * `@effect/sql-pg`'s `SqlError` wrapping → `legacyToExecError` — through real
+ * server-side statement failures.
+ */
+const fakeQueryServer = (
+  onQuery: (sql: string) => Buffer,
+): Promise<{ readonly port: number; readonly close: () => void }> =>
+  new Promise((resolve) => {
+    const server = net.createServer((socket) => {
+      let sawStartup = false;
+      let pending = Buffer.alloc(0);
+      socket.on("data", (data: Buffer) => {
+        pending = Buffer.concat([pending, data]);
+        for (;;) {
+          if (!sawStartup) {
+            if (pending.length < 8) return;
+            const length = pending.readInt32BE(0);
+            if (pending.length < length) return;
+            // SSLRequest: request code 80877103 → answer `N` (no TLS).
+            if (pending.readInt32BE(4) === 80877103) {
+              socket.write("N");
+            } else {
+              sawStartup = true;
+              socket.write(Buffer.concat([AUTHENTICATION_OK, READY_FOR_QUERY]));
+            }
+            pending = pending.subarray(length);
+            continue;
+          }
+          // Regular frames: [type:1][length:4][body:length-4].
+          if (pending.length < 5) return;
+          const length = pending.readInt32BE(1);
+          if (pending.length < length + 1) return;
+          const type = String.fromCharCode(pending[0] ?? 0);
+          const body = pending.subarray(5, length + 1);
+          pending = pending.subarray(length + 1);
+          if (type === "Q") {
+            // Query body is a NUL-terminated SQL string.
+            const sql = body.toString("utf8", 0, body.length - 1);
+            socket.write(onQuery(sql));
+          }
+          // Ignore Terminate ('X') and anything else.
+        }
+      });
+      socket.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({ port: address.port, close: () => server.close() });
+    });
+  });
+
 describe("legacyDbConnectionSqlPgLayer connect failures", () => {
   it.live(
     "surfaces host, user, database, and the driver cause when the connection is refused",
@@ -179,6 +247,72 @@ describe("legacyDbConnectionSqlPgLayer connect failures", () => {
             "Connection terminated unexpectedly",
         );
         expect(error.suggestion).toBeUndefined();
+      }),
+  );
+});
+
+describe("legacyDbConnectionSqlPgLayer exec failures", () => {
+  it.live(
+    "maps a real wire ErrorResponse to pgconn's PgError rendering with detail and position",
+    () =>
+      // Tripwire for the server-error extraction: drives the REAL driver stack
+      // (node-postgres wire parsing → `DatabaseError` → `@effect/sql-pg`'s
+      // `SqlError` cause chain → `legacyToExecError`), so a dependency bump that
+      // changes the error wrapping fails here instead of silently degrading
+      // migration-apply failures back to the opaque driver text.
+      Effect.gen(function* () {
+        const failing = "CREATE TABLE test (path ltree NOT NULL)";
+        const server = yield* Effect.promise(() =>
+          fakeQueryServer((sql) =>
+            sql === failing
+              ? Buffer.concat([
+                  errorResponse({
+                    S: "ERROR",
+                    V: "ERROR",
+                    C: "42704",
+                    M: 'type "ltree" does not exist',
+                    D: "Detail from the server.",
+                    P: "25",
+                    F: "parse_type.c",
+                    L: "270",
+                    R: "typenameType",
+                  }),
+                  READY_FOR_QUERY,
+                ])
+              : Buffer.concat([commandComplete("SELECT 1"), READY_FOR_QUERY]),
+          ),
+        );
+        const error: LegacyDbConnectError | LegacyDbExecError = yield* Effect.gen(function* () {
+          const conn = yield* LegacyDbConnection;
+          return yield* conn
+            .connect(
+              {
+                host: "127.0.0.1",
+                port: server.port,
+                user: "postgres",
+                password: "postgres",
+                database: "postgres",
+              },
+              { isLocal: true, dnsResolver: "native" },
+            )
+            .pipe(
+              Effect.flatMap((session) => session.exec(failing)),
+              Effect.scoped,
+              Effect.flip,
+              Effect.mapError(() => new Error("expected the statement to fail")),
+              Effect.orDie,
+            );
+        }).pipe(
+          Effect.provide(legacyDbConnectionSqlPgLayer),
+          Effect.ensuring(Effect.sync(server.close)),
+        );
+        expect(error._tag).toBe("LegacyDbExecError");
+        expect(error.message).toBe('ERROR: type "ltree" does not exist (SQLSTATE 42704)');
+        if (error._tag === "LegacyDbExecError") {
+          expect(error.code).toBe("42704");
+          expect(error.detail).toBe("Detail from the server.");
+          expect(error.position).toBe(25);
+        }
       }),
   );
 });

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -11,7 +11,11 @@ import { ConnectionError, SqlError } from "effect/unstable/sql/SqlError";
 // resolves, so the COPY path and the pooled path use the same driver.
 import * as Pg from "pg";
 import { to as pgCopyTo } from "pg-copy-streams";
-import { legacyConnectFailureMessage, legacyConnectSuggestion } from "./legacy-connect-errors.ts";
+import {
+  legacyConnectFailureMessage,
+  legacyConnectSuggestion,
+  legacyIsSqlState,
+} from "./legacy-connect-errors.ts";
 import {
   LegacyDbConnectError,
   LegacyDbCopyError,
@@ -122,6 +126,70 @@ function legacyExtractSqlState(error: unknown): string | undefined {
     current = Reflect.get(current, "cause");
   }
   return undefined;
+}
+
+/** Structured fields of a Postgres server ErrorResponse (pgconn's `PgError` subset). */
+interface LegacyPgServerError {
+  readonly severity: string;
+  readonly message: string;
+  readonly code: string;
+  readonly detail?: string;
+  readonly position?: number;
+}
+
+/**
+ * Extracts the server ErrorResponse from a driver error's `cause` chain. The
+ * `@effect/sql` `SqlError` wraps its reason on `cause`, and the reason wraps the
+ * node-postgres `DatabaseError` the same way; a `DatabaseError` is identified by
+ * its string `severity` plus a SQLSTATE-shaped `code` (never a node system error).
+ * `detail` and `position` mirror Go's `pgErr.Detail`/`pgErr.Position`
+ * (node-postgres carries `position` as a decimal string): `detail` only when
+ * non-empty, `position` only when > 0, matching Go's gates in `ExecBatch`
+ * (`pkg/migration/file.go:98-101` — `markError` no-ops on 0 anyway).
+ */
+function legacyExtractPgServerError(error: unknown): LegacyPgServerError | undefined {
+  let current: unknown = error;
+  for (let depth = 0; depth < 6 && typeof current === "object" && current !== null; depth++) {
+    const severity = Reflect.get(current, "severity");
+    const code = Reflect.get(current, "code");
+    if (typeof severity === "string" && typeof code === "string" && legacyIsSqlState(code)) {
+      const message = Reflect.get(current, "message");
+      const detail = Reflect.get(current, "detail");
+      const rawPosition = Reflect.get(current, "position");
+      const position = typeof rawPosition === "string" ? Number.parseInt(rawPosition, 10) : NaN;
+      return {
+        severity,
+        message: typeof message === "string" ? message : "",
+        code,
+        ...(typeof detail === "string" && detail.length > 0 ? { detail } : {}),
+        ...(Number.isInteger(position) && position > 0 ? { position } : {}),
+      };
+    }
+    current = Reflect.get(current, "cause");
+  }
+  return undefined;
+}
+
+/**
+ * Maps a failed statement to `LegacyDbExecError`. A server ErrorResponse renders
+ * pgconn's `PgError.Error()` byte-for-byte — `<Severity>: <Message> (SQLSTATE
+ * <Code>)` (pgconn `errors.go:51`) — which is the head line Go prints when a
+ * migration statement fails (`pkg/migration/file.go:112`, `%w`), and carries the
+ * structured `detail`/`position` fields the migration-apply error context renders
+ * (Go `file.go:96-110`). Non-server failures (socket drops, driver errors) keep
+ * the driver's own text.
+ */
+export function legacyToExecError(error: unknown): LegacyDbExecError {
+  const server = legacyExtractPgServerError(error);
+  if (server !== undefined) {
+    return new LegacyDbExecError({
+      message: `${server.severity}: ${server.message} (SQLSTATE ${server.code})`,
+      code: server.code,
+      detail: server.detail,
+      position: server.position,
+    });
+  }
+  return new LegacyDbExecError({ message: String(error), code: legacyExtractSqlState(error) });
 }
 
 /**
@@ -772,31 +840,15 @@ const connect = (
     });
 
     const session: LegacyDbSession = {
-      exec: (sql) =>
-        client.unsafe(sql).pipe(
-          Effect.asVoid,
-          Effect.mapError(
-            (error) =>
-              new LegacyDbExecError({ message: String(error), code: legacyExtractSqlState(error) }),
-          ),
-        ),
+      exec: (sql) => client.unsafe(sql).pipe(Effect.asVoid, Effect.mapError(legacyToExecError)),
       query: (sql, params) =>
-        client.unsafe<Record<string, unknown>>(sql, params).pipe(
-          Effect.mapError(
-            (error) =>
-              new LegacyDbExecError({
-                message: String(error),
-                code: legacyExtractSqlState(error),
-              }),
-          ),
-        ),
+        client
+          .unsafe<Record<string, unknown>>(sql, params)
+          .pipe(Effect.mapError(legacyToExecError)),
       extensionExists: (name) =>
         client`select 1 from pg_extension where extname = ${name}`.pipe(
           Effect.map((rows) => rows.length > 0),
-          Effect.mapError(
-            (error) =>
-              new LegacyDbExecError({ message: String(error), code: legacyExtractSqlState(error) }),
-          ),
+          Effect.mapError(legacyToExecError),
         ),
       queryRaw: (sql) =>
         Effect.gen(function* () {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { Effect, Exit } from "effect";
+import { SqlError, SqlSyntaxError, UnknownError } from "effect/unstable/sql/SqlError";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -14,6 +15,7 @@ import {
   legacyMergedConnectionOptions,
   legacySslConfigsFor,
   legacySslOptionFor,
+  legacyToExecError,
 } from "./legacy-db-connection.sql-pg.layer.ts";
 
 describe("legacyBuildConnectionUrl", () => {
@@ -491,5 +493,71 @@ describe("legacyIsTerminalConnectError (pgconn fallback termination)", () => {
     expect(legacyIsTerminalConnectError(new Error("connection refused"), true)).toBe(false);
     expect(legacyIsTerminalConnectError("boom", true)).toBe(false);
     expect(legacyIsTerminalConnectError(undefined, false)).toBe(false);
+  });
+});
+
+describe("legacyToExecError (pg server-error extraction)", () => {
+  /**
+   * The real failure chain for a statement error: `@effect/sql`'s `SqlError`
+   * exposes its reason as `cause`, and the reason exposes the node-postgres
+   * `DatabaseError` (an `Error` carrying `severity`/`code`/`detail`/`position`
+   * string fields) as `cause` again.
+   */
+  const sqlErrorChain = (
+    server: Partial<Record<"severity" | "code" | "detail" | "position", string>> & {
+      message: string;
+    },
+  ) =>
+    new SqlError({
+      reason: new SqlSyntaxError({
+        cause: Object.assign(new Error(server.message), server),
+        message: "Failed to execute statement",
+        operation: "execute",
+      }),
+    });
+
+  it("renders pgconn's PgError message and carries code, detail, and position", () => {
+    const error = legacyToExecError(
+      sqlErrorChain({
+        message: 'type "ltree" does not exist',
+        severity: "ERROR",
+        code: "42704",
+        detail: "Some detail line.",
+        position: "25",
+      }),
+    );
+    expect(error.message).toBe('ERROR: type "ltree" does not exist (SQLSTATE 42704)');
+    expect(error.code).toBe("42704");
+    expect(error.detail).toBe("Some detail line.");
+    expect(error.position).toBe(25);
+  });
+
+  it("omits detail and position when the server sent none (Go's non-empty gates)", () => {
+    const error = legacyToExecError(
+      sqlErrorChain({
+        message: 'syntax error at or near "BOOM"',
+        severity: "ERROR",
+        code: "42601",
+        detail: "",
+        position: "0",
+      }),
+    );
+    expect(error.message).toBe('ERROR: syntax error at or near "BOOM" (SQLSTATE 42601)');
+    expect(error.code).toBe("42601");
+    expect(error.detail).toBeUndefined();
+    expect(error.position).toBeUndefined();
+  });
+
+  it("keeps the driver text verbatim for non-server failures", () => {
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    const error = legacyToExecError(
+      new SqlError({
+        reason: new UnknownError({ cause, message: "Failed to execute statement" }),
+      }),
+    );
+    expect(error.message).toBe("effect/sql/SqlError: Failed to execute statement");
+    expect(error.code).toBe("ECONNRESET");
+    expect(error.detail).toBeUndefined();
+    expect(error.position).toBeUndefined();
   });
 });

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.ts
@@ -1,6 +1,7 @@
 import { Data, Effect, type FileSystem, type Path } from "effect";
 
 import { Output } from "../../shared/output/output.service.ts";
+import type { LegacyDbExecError } from "./legacy-db-connection.errors.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
   INSERT_MIGRATION_VERSION,
@@ -85,6 +86,41 @@ const errMessage = (e: unknown): string =>
     ? e.message
     : String(e);
 
+const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).length;
+
+/**
+ * Port of Go's `markError` (`pkg/migration/file.go:117-132`): renders a `^` caret
+ * line under the error position of the failing statement. `pos` is the server's
+ * 1-based error cursor (`pgErr.Position`); Go consumes it against **byte**
+ * lengths (`len(line)` on a Go string counts UTF-8 bytes) and pads the caret with
+ * `pos-1` space bytes, so multibyte statements shift the caret exactly as Go does
+ * (verified empirically against the Go implementation). The caret line REPLACES
+ * every line after the error line (Go's `append(lines[:j+1], caret)` truncates
+ * the tail). Position 0 (absent), a position past the end of the statement, or
+ * one landing exactly on a line break leave the statement untouched.
+ */
+export const legacyMarkError = (stat: string, pos: number): string => {
+  const lines = stat.split("\n");
+  for (const [j, line] of lines.entries()) {
+    const c = utf8ByteLength(line);
+    if (pos > c) {
+      pos -= c + 1;
+      continue;
+    }
+    // Show a caret below the error position
+    if (pos > 0) {
+      return [...lines.slice(0, j + 1), `${" ".repeat(pos - 1)}^`].join("\n");
+    }
+    break;
+  }
+  return stat;
+};
+
+// Go's `typeNamePattern` (`pkg/migration/file.go:31`): extracts the type name from
+// PostgreSQL error messages like `type "ltree" does not exist`. Unanchored, so it
+// matches identically inside the rendered `ERROR: … (SQLSTATE …)` head line.
+const TYPE_NAME_PATTERN = /type "([^"]+)" does not exist/;
+
 /**
  * Runs a single migration/seed file's statements (plus the optional history insert).
  * Mirrors Go's `(*MigrationFile).ExecBatch` (`pkg/migration/file.go`): statements run
@@ -117,10 +153,30 @@ const execMigrationBatch = <E>(
     const version = forceNoVersion ? "" : (matches?.[1] ?? "");
     const name = matches?.[2] ?? "";
 
-    // Mirror Go's `MigrationFile.ExecBatch` error context (`pkg/migration/file.go`):
-    // on a failed statement, append `At statement: <index>` and the statement text.
-    const atStatement = (e: unknown, index: number, stat: string) =>
-      new Error(`${errMessage(e)}\nAt statement: ${index}\n${stat}`);
+    // Mirror Go's `MigrationFile.ExecBatch` error context (`pkg/migration/file.go:88-113`):
+    // on a failed statement, render the `^` caret under the server-reported error
+    // position, the `Detail` line when present, the SQLSTATE-42704 extension hint,
+    // then `At statement: <index>` and the (caret-marked) statement text. The
+    // structured `detail`/`position` fields are only set by the driver for server
+    // ErrorResponses, mirroring Go's `errors.As(err, &pgErr)` gate.
+    const atStatement = (e: LegacyDbExecError, index: number, stat: string) => {
+      const marked = legacyMarkError(stat, e.position ?? 0);
+      const msg: Array<string> = [];
+      if (e.detail !== undefined && e.detail.length > 0) {
+        msg.push(e.detail);
+      }
+      // Provide helpful hint for extension type errors (SQLSTATE 42704: undefined_object)
+      const typeName = TYPE_NAME_PATTERN.exec(e.message)?.[1];
+      if (typeName !== undefined && e.code === "42704" && !typeName.includes(".")) {
+        msg.push("");
+        msg.push("Hint: This type may be defined in a schema that's not in your search_path.");
+        msg.push("      Use schema-qualified type references to avoid this error:");
+        msg.push(`        CREATE TABLE example (col extensions.${typeName});`);
+        msg.push("      Learn more: supabase migration new --help");
+      }
+      msg.push(`At statement: ${index}`, marked);
+      return new Error(`${errMessage(e)}\n${msg.join("\n")}`);
+    };
 
     // `executed` is the global statement index of the next statement to run, so the
     // error context stays accurate across flushed batches and standalone statements

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
@@ -10,20 +10,31 @@ import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
   legacyApplyMigrationFile,
   legacyIsPipelineIncompatible,
+  legacyMarkError,
   legacySeedGlobals,
 } from "./legacy-migration-apply.ts";
 
 class TestError extends Data.TaggedError("TestError")<{ readonly message: string }> {}
 
-class FakeExecError extends Data.TaggedError("LegacyDbExecError")<{ readonly message: string }> {}
+class FakeExecError extends Data.TaggedError("LegacyDbExecError")<{
+  readonly message: string;
+  readonly code?: string;
+  readonly detail?: string;
+  readonly position?: number;
+}> {}
 
-function fakeSession(opts: { failOn?: string } = {}) {
+function fakeSession(
+  opts: {
+    failOn?: string;
+    failWith?: { message: string; code?: string; detail?: string; position?: number };
+  } = {},
+) {
   const calls: Array<{ kind: "exec" | "query"; sql: string; params?: ReadonlyArray<unknown> }> = [];
   const session: LegacyDbSession = {
     exec: (sql) => {
       calls.push({ kind: "exec", sql });
       return opts.failOn !== undefined && sql.includes(opts.failOn)
-        ? Effect.fail(new FakeExecError({ message: "exec failed" }))
+        ? Effect.fail(new FakeExecError(opts.failWith ?? { message: "exec failed" }))
         : Effect.void;
     },
     query: (sql, params) => {
@@ -181,6 +192,163 @@ describe("legacyApplyMigrationFile", () => {
         }),
       ),
     );
+  });
+});
+
+describe("migration failure rendering (Go ExecBatch parity)", () => {
+  // Byte-exact ports of Go's `(*MigrationFile).ExecBatch` error layout
+  // (`pkg/migration/file.go:88-113`): `<pg error>\n[Detail]\n[42704 hint]\n`
+  // `At statement: <i>\n<caret-marked statement>`.
+  const failing = (
+    sql: string,
+    failWith: { message: string; code?: string; detail?: string; position?: number },
+  ) => {
+    const dir = mkdtempSync(join(tmpdir(), "legacy-apply-"));
+    const file = join(dir, "20240101120000_fail.sql");
+    writeFileSync(file, `${sql};`);
+    const { session } = fakeSession({ failOn: sql, failWith });
+    return run(session, file).pipe(
+      Effect.flip,
+      Effect.map((error) => error.message),
+      Effect.ensuring(Effect.sync(() => rmSync(dir, { recursive: true, force: true }))),
+    );
+  };
+
+  it.effect("marks the error position with a caret under the failing statement", () => {
+    const stat = "CREATE TABLE test (path ltree NOT NULL)";
+    return failing(stat, {
+      message: 'ERROR: type "ltree" does not exist (SQLSTATE 42704)',
+      code: "42704",
+      position: 25,
+    }).pipe(
+      Effect.tap((message) =>
+        Effect.sync(() => {
+          expect(message).toBe(
+            'ERROR: type "ltree" does not exist (SQLSTATE 42704)\n' +
+              "\n" +
+              "Hint: This type may be defined in a schema that's not in your search_path.\n" +
+              "      Use schema-qualified type references to avoid this error:\n" +
+              "        CREATE TABLE example (col extensions.ltree);\n" +
+              "      Learn more: supabase migration new --help\n" +
+              "At statement: 0\n" +
+              "CREATE TABLE test (path ltree NOT NULL)\n" +
+              "                        ^",
+          );
+        }),
+      ),
+    );
+  });
+
+  it.effect("renders the server Detail line before the statement context", () => {
+    const stat = "INSERT INTO child VALUES (1)";
+    return failing(stat, {
+      message:
+        'ERROR: insert or update on table "child" violates foreign key constraint "child_parent_id_fkey" (SQLSTATE 23503)',
+      code: "23503",
+      detail: 'Key (parent_id)=(1) is not present in table "parent".',
+    }).pipe(
+      Effect.tap((message) =>
+        Effect.sync(() => {
+          expect(message).toBe(
+            'ERROR: insert or update on table "child" violates foreign key constraint "child_parent_id_fkey" (SQLSTATE 23503)\n' +
+              'Key (parent_id)=(1) is not present in table "parent".\n' +
+              "At statement: 0\n" +
+              "INSERT INTO child VALUES (1)",
+          );
+        }),
+      ),
+    );
+  });
+
+  it.effect("skips the hint when the SQLSTATE is not 42704", () => {
+    // Go gates the hint on `pgErr.Code == "42704"` in addition to the message
+    // pattern — a matching message under a different code must stay hint-free.
+    const stat = "CREATE TABLE test (path ltree NOT NULL)";
+    return failing(stat, {
+      message: 'ERROR: type "ltree" does not exist (SQLSTATE 42P01)',
+      code: "42P01",
+    }).pipe(
+      Effect.tap((message) =>
+        Effect.sync(() => {
+          expect(message).toBe(
+            'ERROR: type "ltree" does not exist (SQLSTATE 42P01)\n' +
+              "At statement: 0\n" +
+              "CREATE TABLE test (path ltree NOT NULL)",
+          );
+        }),
+      ),
+    );
+  });
+
+  it.effect("skips the 42704 hint when the type is already schema-qualified", () => {
+    const stat = "CREATE TABLE test (path extensions.ltree NOT NULL)";
+    return failing(stat, {
+      message: 'ERROR: type "extensions.ltree" does not exist (SQLSTATE 42704)',
+      code: "42704",
+    }).pipe(
+      Effect.tap((message) =>
+        Effect.sync(() => {
+          expect(message).toBe(
+            'ERROR: type "extensions.ltree" does not exist (SQLSTATE 42704)\n' +
+              "At statement: 0\n" +
+              "CREATE TABLE test (path extensions.ltree NOT NULL)",
+          );
+        }),
+      ),
+    );
+  });
+
+  it.effect("keeps the plain layout for errors without position or detail", () => {
+    const stat = "ALTER TABLE a ADD COLUMN b int";
+    return failing(stat, { message: "exec failed" }).pipe(
+      Effect.tap((message) =>
+        Effect.sync(() => {
+          expect(message).toBe("exec failed\nAt statement: 0\nALTER TABLE a ADD COLUMN b int");
+        }),
+      ),
+    );
+  });
+});
+
+describe("legacyMarkError", () => {
+  // Every expectation below is pinned against Go's `markError` output
+  // (`pkg/migration/file.go:117-132`), captured by running the Go function
+  // directly on the same inputs.
+  it("places the caret under a mid-statement position", () => {
+    expect(legacyMarkError("create table t (col ltree)", 21)).toBe(
+      "create table t (col ltree)\n                    ^",
+    );
+  });
+
+  it("returns the statement unchanged for position 0 (absent)", () => {
+    expect(legacyMarkError("create table t (col ltree)", 0)).toBe("create table t (col ltree)");
+  });
+
+  it("returns the statement unchanged when the position is past the end", () => {
+    expect(legacyMarkError("abc", 99)).toBe("abc");
+  });
+
+  it("returns the statement unchanged when the position lands on a line break", () => {
+    expect(legacyMarkError("ab\ncd", 3)).toBe("ab\ncd");
+  });
+
+  it("marks a position on a later line and drops the lines after it", () => {
+    expect(legacyMarkError("create table t (\n  col ltree\n)", 20)).toBe(
+      "create table t (\n  col ltree\n  ^",
+    );
+    expect(legacyMarkError("l1\nl2\nl3\nl4", 4)).toBe("l1\nl2\n^");
+  });
+
+  it("places the caret under the last character when the position equals the line length", () => {
+    expect(legacyMarkError("abcde", 5)).toBe("abcde\n    ^");
+  });
+
+  it("consumes the position in UTF-8 bytes like Go, not characters", () => {
+    // "héllo" is 5 characters but 6 bytes; Go decrements the position by the
+    // BYTE length + 1 per line, so position 8 lands on column 1 of "world"
+    // (character counting would land on column 2). Verified against Go.
+    expect(legacyMarkError("héllo\nworld", 8)).toBe("héllo\nworld\n^");
+    expect(legacyMarkError("sélect 1", 3)).toBe("sélect 1\n  ^");
   });
 });
 


### PR DESCRIPTION
## What changed

A failed migration statement in `db push` / `db reset` (remote migrate) / `migration up|down` now renders the same failure text as the Go CLI's `(*MigrationFile).ExecBatch` (`apps/cli-go/pkg/migration/file.go:88-132`), byte-for-byte:

```
ERROR: type "ltree" does not exist (SQLSTATE 42704)

Hint: This type may be defined in a schema that's not in your search_path.
      Use schema-qualified type references to avoid this error:
        CREATE TABLE example (col extensions.ltree);
      Learn more: supabase migration new --help
At statement: 0
CREATE TABLE test (path ltree NOT NULL)
                        ^
```

Previously the TS apply path emitted only `<driver text>\nAt statement: <i>\n<stat>` — and with the real driver the head line was literally `effect/sql/SqlError: Failed to execute statement`. No caret, no `Detail`, no 42704 hint.

- **Driver boundary** (`legacy-db-connection.sql-pg.layer.ts`): a server ErrorResponse found on the `SqlError` cause chain is now rendered as pgconn's `PgError.Error()` — `<Severity>: <Message> (SQLSTATE <Code>)` (pgconn `errors.go:51`) — and `LegacyDbExecError` carries the structured `detail` / `position` fields (`detail` only when non-empty, `position` only when > 0, matching Go's gates). Non-server failures keep the driver text verbatim.
- **Apply mapper** (`legacy-migration-apply.ts`): `legacyMarkError` is a byte-faithful port of Go's `markError` — the server position is consumed against **UTF-8 byte** lengths (Go's `len(line)`), the caret line replaces every line after the error line (Go's `append(lines[:j+1], caret)` truncation), and position 0 / past-end / on-a-line-break leave the statement untouched. All semantics were pinned by running Go's `markError` directly on the same inputs. The `Detail` line and the SQLSTATE-42704 undefined-type hint block (gated on Go's `typeNamePattern` match + code `42704` + not schema-qualified) are reproduced with Go's exact ordering and indentation.
- `legacyIsSqlState` is hoisted out of `legacy-connect-errors.ts`'s private pattern so the connect-cause renderer and the exec-error mapper share the server-error discriminator.

## Behavior notes

- The pgconn-style head line applies to every session `exec`/`query` server error, not just migration apply — that is the correct owner (Go's session errors all bottom out in `PgError.Error()`). This incidentally improves the seed path too: `failed to send batch: ERROR: … (SQLSTATE …)` now matches Go's `SeedFile.ExecBatchWithCache` wrap more closely.
- Known, unchanged divergence (out of scope): non-server exec failures (socket drops mid-statement) keep the node driver's own text, which cannot byte-match Go's pgx wording.
- A new wire-level integration test drives the REAL driver stack (fake Postgres server → node-postgres `DatabaseError` → `@effect/sql-pg` `SqlError` chain → the new mapper) so a future `@effect/sql-pg`/`pg` bump that changes the error wrapping fails CI instead of silently regressing to the opaque head line.

Review pass (architect / engineer / security / DX): all approve. Deliberately left open: terminal-escape passthrough of server-controlled error text is intended Go parity (Go prints the same fields raw to stderr); a `describeLiveDataPlane` golden-path test against a real backend was deemed redundant with the new wire-level test.

Fixes CLI-1977
https://linear.app/supabase/issue/CLI-1977/migration-apply-errors-omit-gos-caret-detail-and-42704-extension-hint
