### PR TITLE
fix(cli): print Connecting line and relative paths in db pull output (CLI-1978)

### DIFF
--- a/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
@@ -323,9 +323,34 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
         yield* proxy.exec(rebuildDelegateArgs(flags), { env });
       });
 
+    // viper resolves `EXPERIMENTAL` from *either* the global `--experimental`
+    // pflag or `SUPABASE_EXPERIMENTAL` (`cmd/root.go:318-320,327,334`), so honor
+    // both forms; the legacy root only forwards `--experimental` to Go proxy
+    // argv, never into env. Resolved before connecting so the Connecting line
+    // below knows whether this run delegates to the Go child. Declarative mode
+    // never delegates (Go checks `usePgDelta` before `EXPERIMENTAL`,
+    // `pull.go:47-50`).
+    const delegatesExperimentalPull =
+      !useDeclarative &&
+      (experimental || legacyParseBoolEnv(toml.envLookup("SUPABASE_EXPERIMENTAL")));
+
     // Connectivity check (Go's `ConnectByConfig` at the top of `pull.Run`).
     yield* Effect.scoped(
       Effect.gen(function* () {
+        // Go's `ConnectByConfigStream` prints this to stderr before dialing
+        // (`internal/utils/connect.go:344-348`), local vs remote keyed off
+        // `utils.IsLocalDatabase` (mirrored by the resolver's `isLocal`). The
+        // delegated `--experimental` branch skips it: the Go child's own
+        // `ConnectByConfig` already prints the line, so the parent printing too
+        // would double it. (The parent still dials below — mirroring Go's early
+        // connectivity check — so a parent-side connect failure on the delegate
+        // path surfaces without the line; pre-existing delegate behavior.)
+        if (!delegatesExperimentalPull) {
+          yield* output.raw(
+            `Connecting to ${resolved.isLocal ? "local" : "remote"} database...\n`,
+            "stderr",
+          );
+        }
         const session = yield* connection.connect(resolved.conn, {
           isLocal: resolved.isLocal,
           dnsResolver,
@@ -373,8 +398,12 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
               Effect.mapError((cause) => new LegacyDbPullWriteError({ message: cause.message })),
             );
           }
+          // Go prints `utils.GetDeclarativeDir()` verbatim (`pull.go:119`): the
+          // config's declarative_schema_path or the relative `supabase/database`
+          // default — never the resolved absolute directory. The json payload
+          // below keeps the absolute path for machine consumers.
           yield* output.raw(
-            `Declarative schema written to ${legacyBold(declarativeDir)}\n`,
+            `Declarative schema written to ${legacyBold(declarativeDirRel)}\n`,
             "stderr",
           );
           if (output.format !== "text") {
@@ -397,12 +426,8 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
         // dumped statement with a PostgreSQL DDL AST parser (`multigres`, ~50 node
         // types) to route objects into structured files. No Postgres DDL parser
         // exists in TS yet, so porting it is tracked separately; until then the
-        // experimental path delegates the whole pull to Go. viper resolves
-        // `EXPERIMENTAL` from *either* the global `--experimental` pflag or
-        // `SUPABASE_EXPERIMENTAL` (`cmd/root.go:318-320,327,334`), so honor both
-        // forms here; the legacy root only forwards `--experimental` to Go proxy
-        // argv, never into env.
-        if (experimental || legacyParseBoolEnv(toml.envLookup("SUPABASE_EXPERIMENTAL"))) {
+        // experimental path delegates the whole pull to Go.
+        if (delegatesExperimentalPull) {
           // Go's structured-dump path returns before writing a migration or
           // touching schema_migrations (`pull.go:49-61`), so no history repair.
           yield* delegatePull(usePgDeltaDiff ? "pg-delta" : "migra", {
@@ -742,7 +767,14 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
         }
 
         for (const written of writtenMigrations) {
-          yield* output.raw(`Schema written to ${legacyBold(written.path)}\n`, "stderr");
+          // Go prints the workdir-relative path (`pull.go:76`): `GetMigrationPath`
+          // joins the relative `utils.MigrationsDir` and Go chdirs into the
+          // workdir. Display-only — `writtenMigrations` keeps absolute paths for
+          // file I/O and the json payload.
+          yield* output.raw(
+            `Schema written to ${legacyBold(path.relative(cliConfig.workdir, written.path))}\n`,
+            "stderr",
+          );
         }
 
         // Prompt to update the remote migration history table. Go calls

--- a/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
@@ -344,7 +344,11 @@ describe("legacy db pull", () => {
       expect(readFileSync(join(dir, written[0] ?? ""), "utf8")).toContain(
         "create table remote ();",
       );
-      expect(streamText(s.out, "stderr")).toContain("Schema written to");
+      // Go prints the workdir-relative path (`pull.go:76`), never the absolute one.
+      expect(streamText(s.out, "stderr")).toContain(
+        `Schema written to ${join("supabase", "migrations", written[0] ?? "")}\n`,
+      );
+      expect(streamText(s.out, "stderr")).not.toContain(tmp.current);
       expect(s.historyUpserts.length).toBe(1);
       expect(streamText(s.out, "stdout")).toContain("Finished supabase db pull.");
     }).pipe(Effect.provide(s.layer));
@@ -388,8 +392,13 @@ describe("legacy db pull", () => {
         expect(readFileSync(join(dir, written[2] ?? ""), "utf8")).toContain(
           "create index concurrently i on t (c);",
         );
-        // One "Schema written to" line and one history upsert per unit.
-        expect(streamText(s.out, "stderr").match(/Schema written to/gu)).toHaveLength(3);
+        // One "Schema written to" line per unit, each printing the workdir-relative
+        // path (Go's `pull.go:76`), and one history upsert per unit.
+        const err = streamText(s.out, "stderr");
+        expect(err.match(/Schema written to/gu)).toHaveLength(3);
+        for (const file of written) {
+          expect(err).toContain(`Schema written to ${join("supabase", "migrations", file)}\n`);
+        }
         expect(s.historyUpserts.length).toBe(3);
         // Go's UpdateMigrationTable prints all versions space-separated.
         expect(streamText(s.out, "stderr")).toContain(
@@ -488,7 +497,17 @@ describe("legacy db pull", () => {
     return Effect.gen(function* () {
       yield* legacyDbPull(flags());
       expect(s.provisionCalls[0]?.usePgDelta).toBe(false);
-      expect(streamText(s.out, "stderr")).toContain("Schema written to");
+      const err = streamText(s.out, "stderr");
+      // Go's `ConnectByConfig` prints the Connecting line to stderr before dialing
+      // (`internal/utils/connect.go:348`), ahead of any other pull output.
+      expect(err).toContain("Connecting to remote database...\n");
+      expect(err.indexOf("Connecting to remote database...")).toBeLessThan(
+        err.indexOf("Creating shadow database..."),
+      );
+      const dir = join(tmp.current, "supabase", "migrations");
+      const file = readdirSync(dir).find((f) => f.endsWith("_remote_schema.sql"));
+      expect(err).toContain(`Schema written to ${join("supabase", "migrations", file ?? "")}\n`);
+      expect(err).not.toContain(tmp.current);
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -496,8 +515,17 @@ describe("legacy db pull", () => {
     const s = setup(tmp.current, { edgeStdout: EXPORT_JSON });
     return Effect.gen(function* () {
       yield* legacyDbPull(flags({ declarative: Option.some(true) }));
-      expect(streamText(s.out, "stderr")).toContain("Preparing declarative schema export");
-      expect(streamText(s.out, "stderr")).toContain("Declarative schema written to");
+      const err = streamText(s.out, "stderr");
+      // Go's order: `ConnectByConfig` prints Connecting (`pull.go:40`), then
+      // `pullDeclarativePgDelta` prints Preparing (`pull.go:93`).
+      expect(err).toContain("Connecting to remote database...\n");
+      expect(err.indexOf("Connecting to remote database...")).toBeLessThan(
+        err.indexOf("Preparing declarative schema export"),
+      );
+      // Go prints `utils.GetDeclarativeDir()` — the relative default, not the
+      // resolved absolute directory (`pull.go:119`).
+      expect(err).toContain(`Declarative schema written to ${join("supabase", "database")}\n`);
+      expect(err).not.toContain(tmp.current);
       expect(
         existsSync(join(tmp.current, "supabase", "database", "schemas", "public", "t.sql")),
       ).toBe(true);
@@ -561,7 +589,9 @@ describe("legacy db pull", () => {
       return Effect.gen(function* () {
         yield* legacyDbPull(flags({ usePgDelta: Option.some(true) }));
         expect(streamText(s.out, "stderr")).toContain("Flag --use-pg-delta has been deprecated");
-        expect(streamText(s.out, "stderr")).toContain("Declarative schema written to");
+        expect(streamText(s.out, "stderr")).toContain(
+          `Declarative schema written to ${join("supabase", "database")}\n`,
+        );
       }).pipe(Effect.provide(s.layer));
     },
   );
@@ -658,11 +688,16 @@ describe("legacy db pull", () => {
         expect(content).toContain("create table dumped ();");
         expect(content).toContain("create table diffed ();");
         expect(content.indexOf("dumped")).toBeLessThan(content.indexOf("diffed"));
-        // stderr order: dump → shadow → diff → written.
+        // stderr order: connect → dump → shadow → diff → written. The Connecting
+        // line comes first (Go's `ConnectByConfig` at the top of `pull.Run`).
         const err = streamText(s.out, "stderr");
+        expect(err).toContain("Connecting to remote database...\n");
         expect(err).toContain("Dumping schema from remote database...");
         expect(err).toContain("Creating shadow database...");
-        expect(err).toContain("Schema written to");
+        expect(err).toContain(`Schema written to ${join("supabase", "migrations", file ?? "")}\n`);
+        expect(err.indexOf("Connecting to remote database")).toBeLessThan(
+          err.indexOf("Dumping schema"),
+        );
         expect(err.indexOf("Dumping schema")).toBeLessThan(err.indexOf("Creating shadow"));
         expect(s.historyUpserts.length).toBe(1);
       }).pipe(Effect.provide(s.layer));
@@ -715,7 +750,9 @@ describe("legacy db pull", () => {
       const file = readdirSync(dir).find((f) => f.endsWith("_remote_schema.sql"));
       expect(file).toBeDefined();
       expect(readFileSync(join(dir, file ?? ""), "utf8")).toContain("create table dumped ();");
-      expect(streamText(s.out, "stderr")).toContain("Schema written to");
+      expect(streamText(s.out, "stderr")).toContain(
+        `Schema written to ${join("supabase", "migrations", file ?? "")}\n`,
+      );
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -954,6 +991,9 @@ describe("legacy db pull", () => {
     return Effect.gen(function* () {
       yield* legacyDbPull(flags());
       expect(streamText(s.out, "stdout")).not.toContain("Finished supabase db pull.");
+      // Diagnostics still go to stderr in machine mode (Go writes the Connecting
+      // line to os.Stderr regardless of output format); stdout stays payload-only.
+      expect(streamText(s.out, "stderr")).toContain("Connecting to remote database...\n");
       const success = s.out.messages.find((m) => m.type === "success");
       expect(success?.data).toMatchObject({ declarative: false, remoteHistoryUpdated: true });
     }).pipe(Effect.provide(s.layer));
@@ -1115,6 +1155,9 @@ describe("legacy db pull", () => {
       }
       expect(s.proxyCalls).toHaveLength(1);
       expect(s.proxyCalls[0]?.env).toEqual({ SUPABASE_TELEMETRY_DISABLED: "1" });
+      // The Go child's own `ConnectByConfig` prints the Connecting line; the
+      // parent must not print it too (it would appear twice in the stream).
+      expect(streamText(s.out, "stderr")).not.toContain("Connecting to");
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -1175,6 +1218,9 @@ describe("legacy db pull", () => {
       yield* legacyDbPull(flags());
       expect(s.proxyCalls).toHaveLength(1);
       expect(s.proxyCalls[0]?.env).toEqual({ SUPABASE_TELEMETRY_DISABLED: "1" });
+      // The Go child's own `ConnectByConfig` prints the Connecting line; the
+      // parent must not print it too (it would appear twice in the stream).
+      expect(streamText(s.out, "stderr")).not.toContain("Connecting to");
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -1235,6 +1281,9 @@ describe("legacy db pull", () => {
     return Effect.gen(function* () {
       yield* legacyDbPull(flags({ local: Option.some(true) }));
       expect(s.provisionCalls[0]?.targetLocal).toBe(true);
+      // A local target prints the local wording (Go's `IsLocalDatabase` branch in
+      // `ConnectByConfigStream`, `internal/utils/connect.go:344-346`).
+      expect(streamText(s.out, "stderr")).toContain("Connecting to local database...\n");
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -1368,7 +1417,9 @@ describe("legacy db pull", () => {
       expect(streamText(s.out, "stderr")).toContain("does not support IPv6");
       expect(streamText(s.out, "stderr")).toContain("Retrying via the IPv4 connection pooler");
       expect(s.edgeRunCount).toBe(2);
-      expect(streamText(s.out, "stderr")).toContain("Schema written to");
+      expect(streamText(s.out, "stderr")).toMatch(
+        /Schema written to supabase[/\\]migrations[/\\]\d{14}_remote_schema\.sql\n/u,
+      );
     }).pipe(Effect.provide(s.layer));
   });
 
@@ -1384,7 +1435,9 @@ describe("legacy db pull", () => {
       yield* legacyDbPull(flags({ linked: Option.some(true), declarative: Option.some(true) }));
       expect(streamText(s.out, "stderr")).toContain("Retrying via the IPv4 connection pooler");
       expect(s.edgeRunCount).toBe(2);
-      expect(streamText(s.out, "stderr")).toContain("Declarative schema written to");
+      expect(streamText(s.out, "stderr")).toContain(
+        `Declarative schema written to ${join("supabase", "database")}\n`,
+      );
     }).pipe(Effect.provide(s.layer));
   });
 


### PR DESCRIPTION
## What changed

Two stdout/stderr parity divergences in the native `db pull` paths, both empirically confirmed against the Go binary:

1. **Missing `Connecting to remote/local database...` stderr line.** Go's `pull.Run` goes through `utils.ConnectByConfig`, which prints the line to stderr before dialing (`apps/cli-go/internal/utils/connect.go:344-348`), local vs remote keyed off `utils.IsLocalDatabase`. The TS handler called `connection.connect` directly and never printed it (`db push` and the other db/migration commands already print it manually — pull was the outlier). The line is now emitted right before dialing, same stream and ordering as Go. The delegated `--experimental` branch deliberately skips it: the Go child's own `ConnectByConfig` prints the line, so the parent printing too would double it. The delegate decision is hoisted into `delegatesExperimentalPull` and shared by both the Connecting-line guard and the delegate branch.

2. **`Schema written to` / `Declarative schema written to` printed absolute paths; Go prints workdir-relative ones.** Go chdirs into the workdir and joins relative constants (`pull.go:76` via `new.GetMigrationPath` → `supabase/migrations/<ts>_<name>.sql`; `pull.go:119` prints `utils.GetDeclarativeDir()` verbatim — the config's `declarative_schema_path` or the relative `supabase/database` default). The TS lines now render the workdir-relative path at the print sites only. `writtenMigrations` keeps absolute paths for file I/O, and the machine-output (`--output-format json`) fields `schemaWritten`/`schemaFiles` deliberately stay absolute — that machine contract is unchanged.

Tests: the weak `.toContain("Schema written to")` assertions are tightened to exact relative-path lines (with an absolute-workdir leak guard), plus new assertions for the Connecting line: remote and local wording, exact bytes and stderr ordering (before `Dumping schema…`/`Creating shadow…`/`Preparing declarative…`), presence in machine mode, and absence on both `--experimental` delegate forms (flag and `SUPABASE_EXPERIMENTAL` env). The tightened suite fails 10 tests against the unfixed handler.

## Review notes (deliberately out of scope, same bug class)

- `pull.debug.ts` / `legacy-debug-bundle.ts` print the pg-delta debug-bundle path absolute where Go prints the relative `supabase/.temp/pgdelta/debug/<id>` (`pgdelta_pull_debug.go:46-48`) — distinct lines from this issue's scope.
- `db schema declarative generate` (`generate.handler.ts:275`) prints the same `Declarative schema written to` sentence with an absolute path; Go prints the relative `GetDeclarativeDir()` there too (`declarative.go:156`).
- The delegated `--experimental` parent still dials before delegating (mirroring Go's early connectivity check); a parent-side connect failure on that path surfaces without a Connecting line. Pre-existing behavior, now documented in a comment.

Fixes CLI-1978

https://linear.app/supabase/issue/CLI-1978/db-pull-output-parity-missing-connecting-to-database-line-absolute