### PR TITLE
fix(cli): bump default pg-delta version to pick up PUBLIC-privilege revoke fix

### DIFF
--- a/apps/cli-go/pkg/config/pgdelta_version.go
+++ b/apps/cli-go/pkg/config/pgdelta_version.go
@@ -4,7 +4,7 @@ import "strings"
 
 // DefaultPgDeltaNpmVersion is the npm dist-tag/version used for @supabase/pg-delta
 // when supabase/.temp/pgdelta-version is absent or empty.
-const DefaultPgDeltaNpmVersion = "1.0.0-alpha.32"
+const DefaultPgDeltaNpmVersion = "1.0.0-alpha.33"
 
 const pgDeltaNpmVersionPlaceholder = "1.0.0-alpha.20"
 

--- a/apps/cli/src/legacy/commands/db/diff/diff.live.test.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.live.test.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+
+import { describeLive, runSupabaseLive } from "../../../../../tests/helpers/live.ts";
+
+const START_TIMEOUT_MS = 280_000;
+
+// CLI-1947 regression: pg-delta's `filterPublicBuiltInDefaults()` unconditionally
+// treated PUBLIC's implicit built-in privilege as a no-op on both sides of a diff,
+// so a declarative schema's `REVOKE ... FROM PUBLIC` on a function was silently
+// dropped from the generated migration — exit code 0, no error, just a missing
+// statement. Fixed upstream in @supabase/pg-delta@1.0.0-alpha.33
+// (supabase/pg-toolbelt#357). Verified directly against this repo's build: with
+// the pre-fix pin (1.0.0-alpha.32) the migration below contains only the CREATE
+// FUNCTION statement; the REVOKE is silently absent. `describeLive` is reused as
+// the "real local Docker stack is available" signal, same as stop/status — this
+// never calls the Management API. See AGENTS.md's "Live tests" section.
+describeLive("supabase db diff (live, pg-delta declarative privileges)", () => {
+  let projectDir: string | undefined;
+
+  afterEach(async () => {
+    if (projectDir === undefined) return;
+    // Best-effort cleanup even if an assertion above failed mid-lifecycle — a
+    // leaked local stack would otherwise pollute the CI runner for later jobs.
+    await runSupabaseLive(["stop", "--no-backup"], { cwd: projectDir }).catch(() => undefined);
+    await rm(projectDir, { recursive: true, force: true }).catch(() => undefined);
+    projectDir = undefined;
+  });
+
+  test(
+    "keeps REVOKE ... FROM PUBLIC on a function when diffing a declarative schema against local",
+    { timeout: START_TIMEOUT_MS },
+    async () => {
+      projectDir = await mkdtemp(path.join(tmpdir(), "sb-db-diff-live-"));
+
+      const init = await runSupabaseLive(["init"], { cwd: projectDir });
+      expect(init.exitCode, `stdout:\n${init.stdout}\nstderr:\n${init.stderr}`).toBe(0);
+
+      // `init`'s template already enables pg-delta by default (CLI-1877/#5511), but
+      // point `[db.migrations] schema_paths` at a declarative schema directory so
+      // `db diff --local` diffs against it instead of the (empty) local migration
+      // history. Go's `db.go:426` docs the exact syntax: paths relative to `supabase/`.
+      const configPath = path.join(projectDir, "supabase", "config.toml");
+      const config = readFileSync(configPath, "utf8");
+      expect(config).toContain("schema_paths = []");
+      writeFileSync(
+        configPath,
+        config.replace("schema_paths = []", 'schema_paths = ["./schemas/*.sql"]'),
+      );
+
+      // Minimal, deterministic repro: a fresh function's implicit PUBLIC EXECUTE
+      // grant, explicitly revoked. Verified empirically against this build: pre-fix
+      // (pg-delta 1.0.0-alpha.32) the generated migration contains only the CREATE
+      // FUNCTION statement; the REVOKE is silently dropped.
+      const schemasDir = path.join(projectDir, "supabase", "schemas");
+      mkdirSync(schemasDir, { recursive: true });
+      writeFileSync(
+        path.join(schemasDir, "01_probe_fn.sql"),
+        `create function public.probe_fn()
+returns void
+language sql
+as $$ select 1; $$;
+
+revoke execute on function public.probe_fn() from public;
+`,
+      );
+
+      // Exclude the heaviest, least relevant services — `db diff` only needs the
+      // local Postgres container reachable, same rationale as stop/status.
+      const start = await runSupabaseLive(
+        ["start", "--exclude", "studio", "--exclude", "analytics", "--exclude", "vector"],
+        { cwd: projectDir, exitTimeoutMs: START_TIMEOUT_MS },
+      );
+      expect(start.exitCode, `stdout:\n${start.stdout}\nstderr:\n${start.stderr}`).toBe(0);
+
+      const diff = await runSupabaseLive(
+        ["db", "diff", "--local", "--use-pg-delta", "-f", "revoke_public_execute"],
+        { cwd: projectDir, exitTimeoutMs: START_TIMEOUT_MS },
+      );
+      expect(diff.exitCode, `stdout:\n${diff.stdout}\nstderr:\n${diff.stderr}`).toBe(0);
+
+      const migrationsDir = path.join(projectDir, "supabase", "migrations");
+      const written =
+        existsSync(migrationsDir) &&
+        readdirSync(migrationsDir).find((f) => f.endsWith("_revoke_public_execute.sql"));
+      expect(written, `no migration written; stderr:\n${diff.stderr}`).toBeTruthy();
+      const sql = readFileSync(path.join(migrationsDir, written as string), "utf8");
+
+      // The negative-space regression: pre-fix, exit code 0 and this file would
+      // exist, but silently missing the REVOKE statement (only the CREATE FUNCTION
+      // survives). Anchor the match to the function's own REVOKE statement — up to
+      // its terminating `;` — so this cannot pass on an unrelated PUBLIC mention
+      // elsewhere in the file.
+      expect(sql).toContain("CREATE FUNCTION public.probe_fn()");
+      expect(sql).toMatch(
+        /REVOKE\s+(?:ALL|EXECUTE)\s+ON\s+FUNCTION\s+public\.probe_fn\(\)\s+FROM\s+[^;]*PUBLIC[^;]*;/i,
+      );
+    },
+  );
+});

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.deno-templates.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.deno-templates.ts
@@ -35,7 +35,7 @@ export const legacyPgDeltaDeclarativeApplyScript =
  * config field) is absent or empty. Mirrors Go's `DefaultPgDeltaNpmVersion`
  * (`apps/cli-go/pkg/config/pgdelta_version.go:7`).
  */
-export const LEGACY_DEFAULT_PG_DELTA_NPM_VERSION = "1.0.0-alpha.32";
+export const LEGACY_DEFAULT_PG_DELTA_NPM_VERSION = "1.0.0-alpha.33";
 
 /**
  * The literal version baked into the embedded templates above, replaced by


### PR DESCRIPTION
## What changed

`supabase db diff` (pg-delta engine) silently dropped `REVOKE ... FROM PUBLIC` privilege changes (default privileges and function EXECUTE) from generated migrations when diffing a declarative schema. Root cause was in the upstream `@supabase/pg-delta` library: `filterPublicBuiltInDefaults()` unconditionally stripped PUBLIC's implicit default privilege from both sides of a privilege diff, silently eating any `REVOKE ... FROM PUBLIC` the declarative schema asked for.

Fixed upstream in [supabase/pg-toolbelt#357](https://github.com/supabase/pg-toolbelt/pull/357) (merged), released as `@supabase/pg-delta@1.0.0-alpha.33`.

This PR:

- Bumps the two CLI-side "default pg-delta npm version" constants from `1.0.0-alpha.32` to `1.0.0-alpha.33` (`apps/cli-go/pkg/config/pgdelta_version.go`, `apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.deno-templates.ts`). These are the only version-pin sources of truth — the embedded Deno template scripts always use a fixed placeholder string that gets substituted at runtime, so they're unaffected.
- Adds `apps/cli/src/legacy/commands/db/diff/diff.live.test.ts`, a live regression test against a real local Docker stack: a declarative schema revoking a function's implicit PUBLIC `EXECUTE` grant, diffed with `db diff --local --use-pg-delta`, must produce a migration that actually contains the `REVOKE` statement. Verified empirically in both directions — passes with the `alpha.33` pin, and (temporarily reverting to `alpha.32`) reproduces the silent omission pre-fix.

Fixes #5930

## Related

Linear: CLI-1947