### PR TITLE
fix(cli): print declarative-schema-written line in sync bootstrap (CLI-1980)

### DIFF
--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/SIDE_EFFECTS.md
@@ -60,7 +60,10 @@ surfaces before an `--apply`/`--no-apply` conflict is ever checked.
 ## Output
 
 Text mode only. The generated SQL, the created-migration path, drop-statement
-warnings, and apply status are written to stderr.
+warnings, and apply status are written to stderr. The no-files bootstrap also
+prints `Declarative schema written to <dir>` (the relative declarative dir, Go's
+`GetDeclarativeDir()`) to stderr after generating, writing, and warming the
+catalog cache — on both the interactive-accept and `--yes` paths.
 `--no-apply` writes the migration only (never prompts/applies); `--apply` applies
 without prompting; both override the global `--yes`. `--no-apply` and `--apply`
 are mutually exclusive.

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -127,13 +127,15 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
         );
       }
 
+      // Go's `utils.GetDeclarativeDir()` — the config value verbatim (already
+      // `supabase/`-prefixed when relative) or the relative `supabase/database`
+      // default. Printed verbatim in the bootstrap's written-to line below, exactly
+      // as Go prints it (Go chdirs into the workdir, so its paths stay relative).
+      const declarativeDirRel = legacyResolveDeclarativeDir(path, toml.pgDelta);
       // `path.resolve` (not `path.join`) so an absolute `declarative_schema_path` is
       // used as-is, matching Go's `config.resolve` (which only prefixes the workdir onto
       // a relative path). `path.join(workdir, abs)` would mangle the absolute path.
-      const declarativeDir = path.resolve(
-        cliConfig.workdir,
-        legacyResolveDeclarativeDir(path, toml.pgDelta),
-      );
+      const declarativeDir = path.resolve(cliConfig.workdir, declarativeDirRel);
       const migrationsDir = path.join(cliConfig.workdir, "supabase", "migrations");
       const tempDir = legacyPgDeltaTempPath(path, cliConfig.workdir);
       const run: LegacyDeclarativeRunContext = {
@@ -249,6 +251,19 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
         if (!run.noCache) {
           yield* seam.exportCatalog({ mode: "declarative", noCache: run.noCache });
         }
+        // Go's delegated `declarative.Generate` prints the written-to line to stderr
+        // after the write and the catalog warm (`declarative.go:133→138-155→156`), on
+        // both the interactive-accept and --yes/SUPABASE_YES bootstrap paths, and
+        // regardless of --no-cache (the warm is skipped, the line is not). It prints
+        // `utils.GetDeclarativeDir()` — the relative dir above, never a resolved
+        // absolute path, because Go chdirs into the workdir (CLI-1980). NOTE: the
+        // generate and db pull ports of this same Go line still print the absolute
+        // dir today — pull's is moving to relative under CLI-1978; this rendering
+        // is the Go-faithful one.
+        yield* output.raw(
+          `Declarative schema written to ${legacyBold(declarativeDirRel)}\n`,
+          "stderr",
+        );
       }
 
       // Step 2: diff migrations state vs declarative; on error, save a debug bundle.

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -53,7 +53,10 @@ import {
   legacyGenerateDeclarativeOutput,
 } from "../declarative.orchestrate.ts";
 import { LegacyDeclarativeSeam } from "../../../shared/legacy-pgdelta.seam.service.ts";
-import { legacyWriteDeclarativeSchemas } from "../../../shared/legacy-pgdelta.write.ts";
+import {
+  legacyDeclarativeSchemaWrittenLine,
+  legacyWriteDeclarativeSchemas,
+} from "../../../shared/legacy-pgdelta.write.ts";
 import type { LegacyDbSchemaDeclarativeSyncFlags } from "./sync.command.ts";
 
 const DEFAULT_SYNC_NAME = "declarative_sync";
@@ -256,14 +259,10 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
         // both the interactive-accept and --yes/SUPABASE_YES bootstrap paths, and
         // regardless of --no-cache (the warm is skipped, the line is not). It prints
         // `utils.GetDeclarativeDir()` — the relative dir above, never a resolved
-        // absolute path, because Go chdirs into the workdir (CLI-1980). NOTE: the
-        // generate and db pull ports of this same Go line still print the absolute
-        // dir today — pull's is moving to relative under CLI-1978; this rendering
-        // is the Go-faithful one.
-        yield* output.raw(
-          `Declarative schema written to ${legacyBold(declarativeDirRel)}\n`,
-          "stderr",
-        );
+        // absolute path, because Go chdirs into the workdir (CLI-1980). NOTE:
+        // `generate`'s port of this same Go line still prints the absolute dir
+        // today — a follow-up candidate for the same relative-dir treatment.
+        yield* output.raw(legacyDeclarativeSchemaWrittenLine(declarativeDirRel), "stderr");
       }
 
       // Step 2: diff migrations state vs declarative; on error, save a debug bundle.

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
@@ -4,6 +4,7 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 
+import { stripAnsi } from "../../../../../../../tests/helpers/ansi.ts";
 import { mockOutput, mockStdin, mockTty } from "../../../../../../../tests/helpers/mocks.ts";
 import {
   mockLegacyCliConfig,
@@ -70,8 +71,16 @@ function setup(workdir: string, opts: SetupOpts = {}) {
   const cache = mockLegacyLinkedProjectCacheTracked();
   const execInheritCalls: ReadonlyArray<string>[] = [];
   const localPostgresImageChecks: Array<true> = [];
+  // Each catalog export records how many raw chunks had been emitted when it fired,
+  // so tests can assert output ordering relative to the exports (e.g. the bootstrap's
+  // written-to line lands after the declarative warm, before the diff's exports).
+  const exportCatalogCalls: Array<{ mode: string; rawChunksAt: number }> = [];
   const seam = Layer.succeed(LegacyDeclarativeSeam, {
-    exportCatalog: ({ mode }) => Effect.succeed(`supabase/.temp/pgdelta/${mode}.json`),
+    exportCatalog: ({ mode }) =>
+      Effect.sync(() => {
+        exportCatalogCalls.push({ mode, rawChunksAt: out.rawChunks.length });
+        return `supabase/.temp/pgdelta/${mode}.json`;
+      }),
     execInherit: (args) =>
       Effect.sync(() => {
         execInheritCalls.push(args);
@@ -186,7 +195,15 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     }),
     BunServices.layer,
   );
-  return { layer, out, execInheritCalls, dbExec, cache, localPostgresImageChecks };
+  return {
+    layer,
+    out,
+    execInheritCalls,
+    dbExec,
+    cache,
+    localPostgresImageChecks,
+    exportCatalogCalls,
+  };
 }
 
 const flags = (
@@ -445,6 +462,92 @@ describe("legacy db schema declarative sync integration", () => {
         legacyDbSchemaDeclarativeSync(flags({ noApply: Option.some(true) })),
       );
       expect(JSON.stringify(exit)).not.toContain("no declarative schema found");
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.effect("bootstrap prints the declarative-schema-written line after the catalog warm", () => {
+    // Go's bootstrap delegates to `declarative.Generate`, which prints
+    // `Declarative schema written to <dir>` to stderr AFTER WriteDeclarativeSchemas
+    // and the catalog warm (`declarative.go:133→138-155→156`), before sync's own
+    // diff (step 2). It prints `utils.GetDeclarativeDir()` — the relative
+    // `supabase/database` default — never the absolute resolved dir (CLI-1980).
+    const s = setup(tmp.current, {
+      experimental: true,
+      stdinIsTty: true,
+      diffSql: "",
+      exportJson: EXPORT_JSON,
+      promptConfirmResponses: [true], // generate a new one? yes (no migrations → no reset prompt)
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbSchemaDeclarativeSync(flags({ noApply: Option.some(true) }));
+      const line = `Declarative schema written to ${join("supabase", "database")}\n`;
+      const written = s.out.rawChunks
+        .map((c, index) => ({ text: stripAnsi(c.text), stream: c.stream, index }))
+        .filter((c) => c.text === line);
+      expect(written).toHaveLength(1);
+      expect(written[0]?.stream).toBe("stderr");
+      const lineAt = written[0]?.index ?? -1;
+      // The warm (first declarative-mode export) fires before the line is printed…
+      const warm = s.exportCatalogCalls.find((c) => c.mode === "declarative");
+      expect(warm?.rawChunksAt).toBeLessThanOrEqual(lineAt);
+      // …and the diff's first export (migrations catalog) fires after it, so the
+      // line sits at the end of the bootstrap, matching Go's ordering.
+      const diffStart = s.exportCatalogCalls.find((c) => c.mode === "migrations");
+      expect(diffStart?.rawChunksAt).toBeGreaterThan(lineAt);
+      // The generated files actually landed in the printed (resolved) dir.
+      expect(
+        existsSync(
+          join(tmp.current, "supabase", "database", "schemas", "public", "tables", "players.sql"),
+        ),
+      ).toBe(true);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.effect("--yes bootstrap prints the declarative-schema-written line too", () => {
+    // Go reaches the same delegated `declarative.Generate` print on the
+    // auto-confirmed (--yes / SUPABASE_YES) bootstrap as on the interactive accept.
+    const s = setup(tmp.current, {
+      experimental: true,
+      stdinIsTty: false,
+      yes: true,
+      diffSql: "",
+      exportJson: EXPORT_JSON,
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbSchemaDeclarativeSync(flags({ noApply: Option.some(true) }));
+      expect(
+        s.out.rawChunks.map((c) => ({ text: stripAnsi(c.text), stream: c.stream })),
+      ).toContainEqual({
+        text: `Declarative schema written to ${join("supabase", "database")}\n`,
+        stream: "stderr",
+      });
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.effect("--no-cache bootstrap still prints the declarative-schema-written line", () => {
+    // Go's print sits OUTSIDE the `if !noCache` warm gate (`declarative.go:138-156`):
+    // skipping the catalog warm must not skip the line.
+    const s = setup(tmp.current, {
+      experimental: true,
+      stdinIsTty: false,
+      yes: true,
+      diffSql: "",
+      exportJson: EXPORT_JSON,
+    });
+    return Effect.gen(function* () {
+      yield* legacyDbSchemaDeclarativeSync(flags({ noCache: true, noApply: Option.some(true) }));
+      const line = `Declarative schema written to ${join("supabase", "database")}\n`;
+      const written = s.out.rawChunks
+        .map((c, index) => ({ text: stripAnsi(c.text), stream: c.stream, index }))
+        .filter((c) => c.text === line);
+      expect(written).toHaveLength(1);
+      expect(written[0]?.stream).toBe("stderr");
+      // The warm really was skipped: the only declarative-mode export is the diff's,
+      // which fires after the line — yet the line still printed.
+      const lineAt = written[0]?.index ?? -1;
+      const declarativeExports = s.exportCatalogCalls.filter((c) => c.mode === "declarative");
+      expect(declarativeExports).toHaveLength(1);
+      expect(declarativeExports[0]?.rawChunksAt).toBeGreaterThan(lineAt);
     }).pipe(Effect.provide(s.layer));
   });
 

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.ts
@@ -1,7 +1,19 @@
 import { Effect, type FileSystem, type Path } from "effect";
 
+import { legacyBold } from "../../../shared/legacy-colors.ts";
 import { LegacyDeclarativeWriteError } from "./legacy-pgdelta.errors.ts";
 import type { LegacyDeclarativeOutput } from "./legacy-pgdelta.ts";
+
+/**
+ * Go's `declarative.Generate` / `pull.go`'s written-to line, printed by all three
+ * declarative write paths (`generate`, `pull --declarative`, `sync`'s bootstrap).
+ * Each caller passes its own dir rendering (`pull` and `sync` already print the
+ * relative `GetDeclarativeDir()` value; `generate` still prints the resolved
+ * absolute dir — a follow-up candidate for the same treatment) — this only pins
+ * the shared message text in one place.
+ */
+export const legacyDeclarativeSchemaWrittenLine = (dir: string): string =>
+  `Declarative schema written to ${legacyBold(dir)}\n`;
 
 /**
  * Materializes pg-delta declarative export output under the declarative dir.

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.unit.test.ts
@@ -6,9 +6,13 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, FileSystem, Path } from "effect";
 
+import { legacyBold } from "../../../shared/legacy-colors.ts";
 import { LegacyDeclarativeWriteError } from "./legacy-pgdelta.errors.ts";
 import type { LegacyDeclarativeOutput } from "./legacy-pgdelta.ts";
-import { legacyWriteDeclarativeSchemas } from "./legacy-pgdelta.write.ts";
+import {
+  legacyDeclarativeSchemaWrittenLine,
+  legacyWriteDeclarativeSchemas,
+} from "./legacy-pgdelta.write.ts";
 
 const write = (declarativeDir: string, output: LegacyDeclarativeOutput) =>
   Effect.gen(function* () {
@@ -82,6 +86,14 @@ describe("legacyWriteDeclarativeSchemas", () => {
           rmSync(dir, { recursive: true, force: true });
         }),
       ),
+    );
+  });
+});
+
+describe("legacyDeclarativeSchemaWrittenLine", () => {
+  it("formats the shared written-to line for the given dir", () => {
+    expect(legacyDeclarativeSchemaWrittenLine("supabase/database")).toBe(
+      `Declarative schema written to ${legacyBold("supabase/database")}\n`,
     );
   });
 });


### PR DESCRIPTION
## What changed

On the `db schema declarative sync` bootstrap path (no declarative files present → the CLI offers to generate them), the TS handler generated, wrote, and catalog-warmed the declarative schema but never told the user where the files were written. Go's bootstrap delegates to `declarative.Generate`, which prints `Declarative schema written to <dir>` to stderr after the write and the catalog warm (`apps/cli-go/internal/db/declarative/declarative.go:133→138-155→156`, reached via `cmd/db_schema_declarative.go:389→366`).

The sync bootstrap now emits that line:

- after `legacyWriteDeclarativeSchemas` and the catalog warm, matching Go's ordering;
- on both the interactive-accept and `--yes`/`SUPABASE_YES` paths (Go prints it in both);
- regardless of `--no-cache` (Go's print sits outside the `if !noCache` warm gate — the warm is skipped, the line is not);
- printing the **relative** dir, exactly what Go's `utils.GetDeclarativeDir()` returns (the `declarative_schema_path` config value — already `supabase/`-prefixed when relative — or the `supabase/database` default). Go chdirs into the workdir, so it never prints a resolved absolute path. This follows the convention being applied to `db pull`'s identical line in #5968 (CLI-1978).

Integration coverage: exact line text + stderr stream + single emission, ordering (after the declarative catalog warm, before the diff's exports) via export-call tracking in the existing seam mock, plus `--yes` and `--no-cache` scenarios. `SIDE_EFFECTS.md` documents the new stderr line.

## Review findings deliberately left open (out of scope for CLI-1980)

- **`generate` (and pre-#5968 `pull`) still print the absolute dir** for their ports of this same Go line (`generate/generate.handler.ts:275`, `pull/pull.handler.ts:377`). That is a separate pre-existing parity divergence: this PR's relative rendering is the Go-faithful one. `pull`'s is being fixed in #5968; `generate` needs the same one-line `declarativeDirRel` treatment as a follow-up. Once all three converge, the emission is a candidate for a hoisted shared helper per the repo's hoist-before-you-duplicate rule.
- **Zero-files-generated edge:** Go prints the written-to line before `runDeclarativeSync`'s "did generation produce files?" check, so a pathological zero-file generation still prints the line before erroring. The TS handler keeps its pre-existing files-check-before-warm ordering, so that failure path errors without the line. Left as-is to avoid reordering pre-existing bootstrap verification in this PR.

Fixes CLI-1980
https://linear.app/supabase/issue/CLI-1980/db-schema-declarative-sync-bootstrap-omits-the-declarative-schema
