### PR TITLE
fix(cli): honor --db-url sslmode

### DIFF
--- a/apps/cli-go/internal/debug/postgres.go
+++ b/apps/cli-go/internal/debug/postgres.go
@@ -34,6 +34,11 @@ func SetupPGX(config *pgx.ConnConfig) {
 	}
 	config.DialFunc = proxy.DialFunc
 	config.TLSConfig = nil
+	// pgconn reads Fallbacks independently of TLSConfig, so a restored sslmode=allow
+	// would still retry TLS through this plaintext proxy.
+	for _, fallback := range config.Fallbacks {
+		fallback.TLSConfig = nil
+	}
 }
 
 func (p *Proxy) DialFunc(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/apps/cli-go/internal/utils/connect.go
+++ b/apps/cli-go/internal/utils/connect.go
@@ -346,7 +346,7 @@ func ConnectByConfigStream(ctx context.Context, config pgconn.Config, w io.Write
 		return ConnectLocalPostgres(ctx, config, options...)
 	}
 	fmt.Fprintln(w, "Connecting to remote database...")
-	opts := append(options, func(cc *pgx.ConnConfig) {
+	opts := append(options, preserveTLSConfig(config), func(cc *pgx.ConnConfig) {
 		if DNSResolver.Value == DNS_OVER_HTTPS {
 			cc.LookupFunc = FallbackLookupIP
 		}
@@ -359,6 +359,33 @@ func ConnectByConfigStream(ctx context.Context, config pgconn.Config, w io.Write
 		}
 	})
 	return ConnectByUrl(ctx, ToPostgresURL(config), opts...)
+}
+
+// preserveTLSConfig replays the TLS state pgconn resolved from sslmode, which
+// ToPostgresURL cannot serialize (it lives in TLSConfig/Fallbacks, not
+// RuntimeParams) so the rebuilt URL re-resolves it from PGSSLMODE and libpq's
+// "prefer" default. Nil Fallbacks, which ParseConfig never produces, marks a
+// config assembled in code with no preference to replay.
+func preserveTLSConfig(config pgconn.Config) func(*pgx.ConnConfig) {
+	return func(cc *pgx.ConnConfig) {
+		if config.Fallbacks == nil {
+			return
+		}
+		cc.TLSConfig = config.TLSConfig
+		// Rebuild against the URL's endpoint: callers may override the port
+		// (GetPoolerConfig pins 5432), and extra HA hosts are dropped anyway.
+		cc.Fallbacks = nil
+		for _, fb := range config.Fallbacks {
+			if fb.Host != config.Host {
+				break
+			}
+			cc.Fallbacks = append(cc.Fallbacks, &pgconn.FallbackConfig{
+				Host:      cc.Host,
+				Port:      cc.Port,
+				TLSConfig: fb.TLSConfig,
+			})
+		}
+	}
 }
 
 func ConnectByConfig(ctx context.Context, config pgconn.Config, options ...func(*pgx.ConnConfig)) (*pgx.Conn, error) {

--- a/apps/cli-go/internal/utils/connect.go
+++ b/apps/cli-go/internal/utils/connect.go
@@ -346,7 +346,9 @@ func ConnectByConfigStream(ctx context.Context, config pgconn.Config, w io.Write
 		return ConnectLocalPostgres(ctx, config, options...)
 	}
 	fmt.Fprintln(w, "Connecting to remote database...")
-	opts := append(options, preserveTLSConfig(config), func(cc *pgx.ConnConfig) {
+	// Ahead of the caller's overrides so they still win, e.g. pgtest clearing TLS.
+	opts := append([]func(*pgx.ConnConfig){preserveTLSConfig(config)}, options...)
+	opts = append(opts, func(cc *pgx.ConnConfig) {
 		if DNSResolver.Value == DNS_OVER_HTTPS {
 			cc.LookupFunc = FallbackLookupIP
 		}

--- a/apps/cli-go/internal/utils/connect_test.go
+++ b/apps/cli-go/internal/utils/connect_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/h2non/gock"
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -410,4 +411,45 @@ func TestPostgresURLWithoutPassword(t *testing.T) {
 	// credential is never written to stdout by the db __shadow seam.
 	assert.Equal(t, `postgresql://postgres@[2406:da18:4fd:9b0d:80ec:9812:3e65:450b]:5432/?connect_timeout=10&options=test`, url)
 	assert.NotContains(t, url, "%21%40%23")
+}
+
+func TestPreserveTLSConfig(t *testing.T) {
+	const dsn = "postgresql://postgres:pw@example.com:5432/postgres"
+
+	t.Run("replays the sslmode resolved from the connection string", func(t *testing.T) {
+		for _, sslmode := range []string{"disable", "require", "verify-full"} {
+			parsed, err := pgconn.ParseConfig(dsn + "?sslmode=" + sslmode)
+			require.NoError(t, err)
+			rebuilt, err := pgx.ParseConfig(ToPostgresURL(*parsed))
+			require.NoError(t, err)
+			// Run test
+			preserveTLSConfig(*parsed)(rebuilt)
+			// Check TLS matches the DSN, not the re-parse default of "prefer"
+			assert.Equal(t, parsed.TLSConfig, rebuilt.TLSConfig, sslmode)
+		}
+	})
+
+	t.Run("mandates TLS even when PGSSLMODE would disable it", func(t *testing.T) {
+		t.Setenv("PGSSLMODE", "disable")
+		parsed, err := pgconn.ParseConfig(dsn + "?sslmode=require")
+		require.NoError(t, err)
+		require.NotNil(t, parsed.TLSConfig)
+		rebuilt, err := pgx.ParseConfig(ToPostgresURL(*parsed))
+		require.NoError(t, err)
+		require.Nil(t, rebuilt.TLSConfig)
+		// Run test
+		preserveTLSConfig(*parsed)(rebuilt)
+		// Check the env var no longer overrides the connection string
+		assert.NotNil(t, rebuilt.TLSConfig)
+	})
+
+	t.Run("leaves configs assembled in code untouched", func(t *testing.T) {
+		rebuilt, err := pgx.ParseConfig(ToPostgresURL(dbConfig))
+		require.NoError(t, err)
+		before := rebuilt.TLSConfig
+		// Run test
+		preserveTLSConfig(dbConfig)(rebuilt)
+		// Check libpq's default resolution is preserved
+		assert.Same(t, before, rebuilt.TLSConfig)
+	})
 }


### PR DESCRIPTION
## TL;DR

`sslmode` from `--db-url` never reached the connection `PGSSLMODE` and libpq's `prefer` default decided TLS instead....

## Problem

`pgconn.ParseConfig` folds `sslmode` into `TLSConfig`/`Fallbacks`, but `ToPostgresURL` serialises only `RuntimeParams`, so `ConnectByConfigStream`'s round-trip drops it.

| `--db-url` | before | after |
| --- | --- | --- |
| `?sslmode=require` + `PGSSLMODE=disable` | plaintext | TLS |
| `?sslmode=disable` | forced to TLS-only | plaintext |
| `?sslmode=verify-full` vs untrusted cert | accepted | rejected |

## Solution

Replay the TLS state pgconn already resolved instead of round-tripping it through a string. Code-assembled configs (local, linked, proxy) have a nil `Fallbacks` slice, which `ParseConfig` never produces, so they keep libpq's defaults.

TS already behaves this way; this brings the go-cli  to parity for the commands still routed thru it...

## Ref

- closes #5873 
-  #5872 builds on this
