### PR TITLE
chore: add oxc toolchain to root devDependencies for the VS Code extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
-  "typescript.experimental.useTsgo": true,
-  "oxc.useExecPath": true,
+  "typescript.experimental.useTsgo": true
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "@swc/core": "catalog:",
     "@typescript/native": "npm:typescript@^7.0.2",
     "nx": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
     "pkg-pr-new": "0.0.75",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "verdaccio": "^6.7.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,15 @@ importers:
       nx:
         specifier: 'catalog:'
         version: 23.1.0(@swc-node/register@1.12.1(@swc/core@1.15.46)(@swc/types@0.1.27)(@typescript/typescript6@6.0.2))(@swc/core@1.15.46)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.59.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.74.0(oxlint-tsgolint@0.25.0)
+      oxlint-tsgolint:
+        specifier: 'catalog:'
+        version: 0.25.0
       pkg-pr-new:
         specifier: 0.0.75
         version: 0.0.75


### PR DESCRIPTION
## Summary

oxlint and oxfmt were not working in VS Code. Two independent problems, both fixed here:

**1. Binary discovery.** The oxc extension (`oxc.oxc-vscode`) looks for the `oxlint`/`oxfmt` binaries in the **workspace-root** `node_modules` first, but this repo only installed them in per-workspace `node_modules` (e.g. `apps/cli`). The extension then fell back to a slow nested scan over every `package.json` (including the vendored `.repos/effect` tree). This adds `oxlint`, `oxfmt`, and `oxlint-tsgolint` (existing `catalog:` versions) to the root `devDependencies`, so the binaries land in root `node_modules/.bin` where the extension resolves them immediately.

**2. Server launch.** Removes `"oxc.useExecPath": true` from the committed `.vscode/settings.json`, because with pnpm this setting guarantees the language servers crash on startup:

- The extension's `node_modules` lookup finds `node_modules/.bin/oxlint` and classifies it as a native executable.
- Under pnpm, that file is not a binary — it's a generated **POSIX shell script** shim.
- `useExecPath: true` overrides the native classification and launches the found path as a **JavaScript module** under VS Code's Electron runtime (`ELECTRON_RUN_AS_NODE=1 <electron> <path> --lsp`).
- Node parsing a shell script as JS fails immediately: `SyntaxError: missing ) after argument list` on `basedir=$(dirname ...)`. Reproducible with `node node_modules/.bin/oxlint --lsp`.

With the setting removed (extension default), the shim is executed directly as a shell script, which execs the real binary via Node from `PATH` — verified the LSP server starts cleanly this way. The setting only works in setups where binary resolution falls through to `require.resolve` and finds the real JS entry point (e.g. npm installs); in any pnpm repo the `.bin` shim is always found first, so the crash was unconditional. (Arguably an upstream `oxc-vscode` bug — `useExecPath` should respect the native-loader classification.)

## Linked issue

Closes n/a — internal tooling fix by a Supabase maintainer.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(cli): …`).
- [ ] Tests added or updated for the change. (n/a — dependency/editor-config only)
- [x] `pnpm check:all` and `pnpm test` pass for the workspace(s) I touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)