### PR TITLE
test(cli-test-helpers): normalize D-Bus keyring noise in parity stderr

### DIFF
--- a/packages/cli-test-helpers/src/normalize.ts
+++ b/packages/cli-test-helpers/src/normalize.ts
@@ -132,6 +132,17 @@ export function normalize(output: string, options: NormalizeOptions = {}): strin
       //      strip it from both sides. (Same class of divergence that defers the
       //      login/logout parity tests in auth.e2e.test.ts.)
       .replace(/^Keyring is not supported on WSL\n?/gm, "")
+      //      Go wraps other Secret Service failures instead of mapping them to
+      //      the WSL message: when no D-Bus secrets daemon is running, keyring
+      //      ops fail with "The name org.freedesktop.secrets was not provided
+      //      by any .service files", printed inside store.go's "failed to
+      //      load/set/delete credentials: %w" wrappers (e.g. `projects delete`'s
+      //      best-effort credential cleanup, delete.go:46-48). Same
+      //      backend-availability noise, different wording — strip it too.
+      .replace(
+        /^[^\n]*The name org\.freedesktop\.secrets was not provided by any \.service files\n?/gm,
+        "",
+      )
       // 17c. Docker image-pull progress streamed to stderr. The Go CLI pre-pulls
       //      via the Docker API and renders progress with jsonmessage
       //      (`apps/cli-go/internal/utils/docker.go:206-214`), while the ts-legacy

--- a/packages/cli-test-helpers/src/normalize.unit.test.ts
+++ b/packages/cli-test-helpers/src/normalize.unit.test.ts
@@ -179,6 +179,17 @@ describe("normalize", () => {
     expect(normalize(table)).toBe(table.replace(/[ \t]+$/gm, ""));
   });
 
+  it("strips system-keyring availability noise in both Go wordings", () => {
+    const goStderr = [
+      "Do you want to delete project aaaaaaaaaaaaaaaaaaaa? This action is irreversible. [y/N] y",
+      "Keyring is not supported on WSL",
+      "failed to delete credentials: The name org.freedesktop.secrets was not provided by any .service files",
+    ].join("\n");
+    expect(normalize(goStderr)).toBe(
+      "Do you want to delete project aaaaaaaaaaaaaaaaaaaa? This action is irreversible. [y/N] y\n",
+    );
+  });
+
   it("can strip caller-provided patterns before shared normalization", () => {
     expect(
       normalize("status: transient\nversion: 2.0.0", { stripPatterns: [/^status: .+\n/gm] }),


### PR DESCRIPTION
The `projects delete --yes` parity e2e is failing on every develop-based PR (e.g. #5993 and unrelated branches). Go's best-effort keyring cleanup in `projects delete` (`delete.go:46`) prints its failure to stderr, and the parity normalizer only strips one of Go's two keyring-failure wordings: `Keyring is not supported on WSL` (emitted when the D-Bus client fails with `exec.ErrNotFound`). When the CI runner has a reachable D-Bus session bus but no secrets daemon, go-keyring instead fails with `The name org.freedesktop.secrets was not provided by any .service files`, wrapped as `failed to delete credentials: …` — which survives normalization and breaks the byte-for-byte stderr comparison. The TS port intentionally skips this no-op cleanup and relies on the harness treating Go's keyring-backend availability noise as environment detail.

The failure appeared without any repo change (same test passed and failed on the same rootfs image hours apart on 2026-07-29), pointing at runner-environment drift in D-Bus availability. This extends the existing normalization rule to strip the second wording, with a unit test covering both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)