### PR TITLE
feat(cli): central entitlement_required envelope handler

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -306,6 +306,48 @@ unchanged — see [Legacy Port Status and Go CLI Authority](#legacy-port-status-
 
 ---
 
+## Plan-gate envelope and the JSON error contract
+
+The management API marks entitlement denials with a structured envelope in the error body:
+`{ "message": "...", "error": { "code": "entitlement_required", "feature": "<key>", "upgrade_url": "<billing url>" } }`.
+
+Handling is CENTRAL — never add per-command wiring for envelope-carrying gates:
+
+- `mapLegacyHttpError` (`src/legacy/shared/legacy-http-errors.ts`) parses the envelope from the
+  raw response text (pre-truncation), attaches optional `entitlement` + `suggestion` +
+  `upgradeSuggested` fields to the tagged status error, and fires `cli_upgrade_suggested` exactly
+  once per denial (`trackUpgradeSuggested: false` opts out — vanity check-availability, Go
+  parity). `upgradeSuggested` feeds `statusCodeActionability` (see Error Classification): an
+  error class on a gated route declares the optional field and passes it through, and denials
+  classify as `plan_limit` with zero per-command wiring. For an envelope-less gate confirmed by
+  the fallback, callers pass the boolean per call: `mapper(cause, { upgradeSuggested })`.
+- The shared contract module is `src/shared/api/plan-gate.ts` (`PlanGateEntitlement`, parser,
+  `errorEntitlement` reader, hint prose). The next shell must reuse it and emit the identical
+  field shape.
+- Output: text mode prints the upgrade hint centrally in `textOutputLayer.fail` when the
+  normalized error carries `entitlement` (hint, then red message, then the --debug line);
+  json / stream-json carry the fields on the error object:
+  `{ "_tag": "Error", "error": { "code", "message", "suggestion", "entitlement": { "feature", "upgrade_url" } } }`.
+  `entitlement` presence is the machine-readable discriminator; consumers must treat it as an
+  optional enhancement (absent on envelope-less servers and older CLI versions).
+- `legacySuggestUpgrade` (`src/legacy/shared/legacy-upgrade-suggest.ts`) is only the
+  entitlements-lookup FALLBACK for envelope-less denials (v1 SSO, older servers). When the
+  response carries an envelope it returns the confirmed-gated boolean but performs no side
+  effects — hint, telemetry, and error fields are the central handler's. New commands must not
+  call it for envelope-emitting routes.
+- Known central-handler bypasses (all dormant while v1 SSO emits no envelope; fix when the routes
+  gain it): `sso add` POST and `sso update` PUT construct status errors without
+  `mapLegacyHttpError` (no attach), and `sso list`/`sso remove`/`sso show`/`sso update`'s GET
+  swap the mapped error for a bare replacement error on 404 (fields discarded — `NotFoundError`
+  variants; `list` uses `SamlDisabledError`). Route these through `mapLegacyHttpError` (or attach
+  via `src/shared/api/plan-gate.ts`) before enveloping SSO server-side.
+- Go divergence (deliberate, 2026-07-28): the Go binary kept per-site `SuggestUpgradeOnError`
+  wiring; the TS handler is central. Consistent with
+  [Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority), the 1:1
+  parity doctrine covers this subsystem's user-visible output only, not its internal structure.
+
+---
+
 ## Legacy Port: Go Parity Checklist
 
 When porting a Management-API-style command, verify each item before marking the command as `ported`:
@@ -346,12 +388,12 @@ The legacy shell sends the same PostHog events to the same product analytics pip
 - **Proxy handlers (`LegacyGoProxy.exec`) must NOT wrap with any instrumentation.** The Go subprocess fires its own telemetry; a TS wrapper would double-count `cli_command_executed`.
 - **When promoting a command from proxy to native, reproduce every `phtelemetry.*` call in the Go counterpart.** Grep `apps/cli-go/internal/<command>/` for `service.Capture`, `service.Alias`, `service.Identify`, `service.GroupIdentify`, and `TrackUpgradeSuggested` — note that most `internal/<command>/` packages were deleted in CLI-1970 once their commands went fully native, so this grep only finds something for the still-`wrapped` commands; check out commit `7b469f5b3` to grep an already-ported command's former Go source. The current Go custom events that legacy ports must reproduce when natively ported (already captured below, so this is only needed for a command not yet in this table):
 
-  | Command                                                                                                                                       | Event                   | Identity / groups                                                                                                                                                         | Go source                                                                                                                       |
-  | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-  | `login`                                                                                                                                       | `cli_login_completed`   | `analytics.alias(gotrueId, deviceId)` after token persists                                                                                                                | `internal/login/login.go:283-296` (deleted in CLI-1970; last present at commit 7b469f5b3)                                       |
-  | `link`                                                                                                                                        | `cli_project_linked`    | `analytics.groupIdentify("organization", slug, …)` + `analytics.groupIdentify("project", ref, …)` after link write                                                        | `internal/link/link.go:60` (deleted in CLI-1970; last present at commit 7b469f5b3)                                              |
-  | `start`                                                                                                                                       | `cli_stack_started`     | none — fired after stack health check passes                                                                                                                              | formerly `internal/start/start.go:1245` (deleted as unreachable in CLI-1966; last present at commit a253ccba2)                  |
-  | `sso/{list,create,update,remove}`, `branches/{create,update}`, `hostnames/{create,activate,get,reverify}`, `vanity_subdomains/{activate,get}` | `cli_upgrade_suggested` | none — payload is `{feature_key, org_slug}`, fired inside billing-gate error branch (`SuggestUpgradeOnError` is envelope-first; hostnames + vanity get are envelope-only) | call-sites under `internal/{sso,branches,hostnames,vanity_subdomains}/` (deleted in CLI-1970; last present at commit 7b469f5b3) |
+  | Command                                                                                                                                       | Event                   | Identity / groups                                                                                                                                                                                                                                                                                                                                                                                                                      | Go source                                                                                                                       |
+  | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+  | `login`                                                                                                                                       | `cli_login_completed`   | `analytics.alias(gotrueId, deviceId)` after token persists                                                                                                                                                                                                                                                                                                                                                                             | `internal/login/login.go:283-296` (deleted in CLI-1970; last present at commit 7b469f5b3)                                       |
+  | `link`                                                                                                                                        | `cli_project_linked`    | `analytics.groupIdentify("organization", slug, …)` + `analytics.groupIdentify("project", ref, …)` after link write                                                                                                                                                                                                                                                                                                                     | `internal/link/link.go:60` (deleted in CLI-1970; last present at commit 7b469f5b3)                                              |
+  | `start`                                                                                                                                       | `cli_stack_started`     | none — fired after stack health check passes                                                                                                                                                                                                                                                                                                                                                                                           | formerly `internal/start/start.go:1245` (deleted as unreachable in CLI-1966; last present at commit a253ccba2)                  |
+  | `sso/{list,create,update,remove}`, `branches/{create,update}`, `hostnames/{create,activate,get,reverify}`, `vanity_subdomains/{activate,get}` | `cli_upgrade_suggested` | none — payload is `{feature_key, org_slug}`. TS divergence (deliberate): envelope denials fire centrally at envelope parse in `mapLegacyHttpError` (feature from the envelope, org from `upgrade_url`; check-availability suppression = `trackUpgradeSuggested: false` on its mapper); the per-site `legacySuggestUpgrade` fallback fires only for envelope-less denials. Go stays per-site (`SuggestUpgradeOnError`, envelope-first). | call-sites under `internal/{sso,branches,hostnames,vanity_subdomains}/` (deleted in CLI-1970; last present at commit 7b469f5b3) |
 
   Reference pattern for login: `next/commands/login/login.handler.ts:38-62`.
 

--- a/apps/cli/src/legacy/cli/plan-gate-output.e2e.test.ts
+++ b/apps/cli/src/legacy/cli/plan-gate-output.e2e.test.ts
@@ -1,0 +1,110 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "vitest";
+import { runSupabase, stripAnsi } from "../../../tests/helpers/cli.ts";
+
+function parseJsonLines(output: string): Array<unknown> {
+  return stripAnsi(output)
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+function gatedEnvelope(feature: string) {
+  return {
+    message: "This feature requires a paid plan",
+    error: {
+      code: "entitlement_required",
+      feature,
+      upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+    },
+  };
+}
+
+async function withGatedApiStub<T>(
+  feature: string,
+  run: (env: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  const server = Bun.serve({
+    port: 0,
+    fetch: () => Response.json(gatedEnvelope(feature), { status: 403 }),
+  });
+  const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "supabase-e2e-profile-"));
+  const profilePath = path.join(profileDir, "profile.yaml");
+  await fs.writeFile(profilePath, `api_url: http://127.0.0.1:${server.port}\n`);
+
+  try {
+    return await run({
+      SUPABASE_PROFILE: profilePath,
+      SUPABASE_ACCESS_TOKEN: `sbp_${"a".repeat(40)}`,
+    });
+  } finally {
+    server.stop(true);
+    await fs.rm(profileDir, { recursive: true, force: true });
+  }
+}
+
+describe("legacy CLI plan-gate error output", () => {
+  test("carries entitlement on the JSON error for a gated denial", async () => {
+    await withGatedApiStub("physical_backups", async (env) => {
+      const result = await runSupabase(
+        ["backups", "list", "--project-ref", "abcdefghijklmnopqrst", "--output-format", "json"],
+        { entrypoint: "legacy", env },
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).not.toContain("Upgrade your plan:");
+      expect(parseJsonLines(result.stdout)).toEqual([
+        expect.objectContaining({
+          _tag: "Error",
+          error: expect.objectContaining({
+            entitlement: {
+              feature: "physical_backups",
+              upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+            },
+            suggestion: expect.stringContaining(
+              "https://supabase.com/dashboard/org/env-org/billing",
+            ),
+          }),
+        }),
+      ]);
+    });
+  });
+
+  test("prints the text-mode hint exactly once for a gated denial with no per-command wiring", async () => {
+    await withGatedApiStub("physical_backups", async (env) => {
+      const result = await runSupabase(
+        ["backups", "list", "--project-ref", "abcdefghijklmnopqrst"],
+        {
+          entrypoint: "legacy",
+          env,
+        },
+      );
+      expect(result.exitCode).not.toBe(0);
+      const stderr = stripAnsi(result.stderr);
+      expect(stderr.split("Upgrade your plan:").length - 1).toBe(1);
+      expect(stderr.indexOf("Upgrade your plan:")).toBeLessThan(
+        stderr.indexOf("unexpected list backup status 403"),
+      );
+      expect(stderr).toContain("Try rerunning the command with --debug");
+    });
+  });
+
+  test("prints the hint exactly once for a previously per-site-wired gated command", async () => {
+    await withGatedApiStub("custom_domain", async (env) => {
+      const result = await runSupabase(
+        ["domains", "get", "--project-ref", "abcdefghijklmnopqrst"],
+        {
+          entrypoint: "legacy",
+          env,
+        },
+      );
+      expect(result.exitCode).not.toBe(0);
+      const stderr = stripAnsi(result.stderr);
+      expect(stderr.split("Upgrade your plan:").length - 1).toBe(1);
+      expect(stderr).toContain("unexpected get hostname status 403");
+    });
+  });
+});

--- a/apps/cli/src/legacy/commands/backups/list/list.integration.test.ts
+++ b/apps/cli/src/legacy/commands/backups/list/list.integration.test.ts
@@ -6,8 +6,9 @@ import { type V1ListAllBackupsOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
-import { mockOutput } from "../../../../../tests/helpers/mocks.ts";
+import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import {
   LEGACY_VALID_REF,
   buildLegacyTestRuntime,
@@ -43,7 +44,7 @@ const LOGICAL_RESPONSE: typeof V1ListAllBackupsOutput.Type = {
 interface SetupOpts {
   format?: "text" | "json" | "stream-json";
   goOutput?: "env" | "pretty" | "json" | "toml" | "yaml";
-  response?: typeof V1ListAllBackupsOutput.Type;
+  response?: unknown;
   status?: number;
   network?: "fail";
   apiUrl?: string;
@@ -54,6 +55,7 @@ const tempRoot = useLegacyTempWorkdir("supabase-backups-list-int-");
 
 function setup(opts: SetupOpts = {}) {
   const out = mockOutput({ format: opts.format ?? "text" });
+  const analytics = mockAnalytics();
   const api = mockLegacyPlatformApi({
     response: { status: opts.status ?? 200, body: opts.response ?? PITR_RESPONSE },
     network: opts.network,
@@ -69,9 +71,10 @@ function setup(opts: SetupOpts = {}) {
     out,
     api,
     cliConfig,
+    analytics,
     goOutput: opts.goOutput === undefined ? Option.none() : Option.some(opts.goOutput),
   });
-  return { layer, out, api };
+  return { layer, out, api, analytics };
 }
 
 describe("legacy backups list integration", () => {
@@ -340,6 +343,40 @@ WalgEnabled = true
         expect(headers?.["user-agent"]).toBe("SupabaseCLI/1.42.0");
         expect(headers?.["x-supabase-command"]).toBeUndefined();
         expect(headers?.["x-supabase-command-run-id"]).toBeUndefined();
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.live(
+    "carries entitlement and fires central telemetry on a gated denial with zero wiring",
+    () => {
+      const { layer, out, analytics } = setup({
+        status: 403,
+        response: {
+          message: "Physical backups require the Pro plan",
+          error: {
+            code: "entitlement_required",
+            feature: "physical_backups",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        },
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyBackupsList({ projectRef: Option.some(LEGACY_VALID_REF) }),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
+          feature: "physical_backups",
+          upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+        });
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "physical_backups", org_slug: "env-org" },
+          },
+        ]);
       }).pipe(Effect.provide(layer));
     },
   );

--- a/apps/cli/src/legacy/commands/branches/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.handler.ts
@@ -117,21 +117,7 @@ export const legacyBranchesCreate = Effect.fn("legacy.branches.create")(function
         Effect.catch(
           legacyGateMapError(
             { projectRef: ref, featureKey: "branching_limit" },
-            (cause, upgradeSuggested) =>
-              Effect.gen(function* () {
-                const mapped = yield* Effect.flip(mapCreateErrorRaw(cause));
-                if (mapped._tag === "LegacyBranchesCreateUnexpectedStatusError") {
-                  return yield* Effect.fail(
-                    new LegacyBranchesCreateUnexpectedStatusError({
-                      status: mapped.status,
-                      body: mapped.body,
-                      message: mapped.message,
-                      upgradeSuggested,
-                    }),
-                  );
-                }
-                return yield* Effect.fail(mapped);
-              }),
+            (cause, upgradeSuggested) => mapCreateErrorRaw(cause, { upgradeSuggested }),
           ),
         ),
       );

--- a/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
@@ -1,6 +1,7 @@
 import type { V1CreateABranchOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { Command } from "effect/unstable/cli";
 
 import {
@@ -408,34 +409,41 @@ describe("legacy branches create integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("envelope on 402 suggests upgrade with no extra API calls", () => {
-    const { layer, out, analytics, api } = setup({
-      status: 402,
-      response: {
-        message: "Branching is supported only on the Pro plan or above",
-        error: {
-          code: "entitlement_required",
+  it.live(
+    "envelope on 402 carries entitlement and fires central telemetry with no extra API calls",
+    () => {
+      const { layer, out, analytics, api } = setup({
+        status: 402,
+        response: {
+          message: "Branching is supported only on the Pro plan or above",
+          error: {
+            code: "entitlement_required",
+            feature: "branching_limit",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        } as unknown as CreatedBranch,
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          legacyBranchesCreate({ ...baseFlags, name: Option.some("feat-x") }),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
           feature: "branching_limit",
           upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-        },
-      } as unknown as CreatedBranch,
-    });
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        legacyBranchesCreate({ ...baseFlags, name: Option.some("feat-x") }),
-      );
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(1);
-      expect(api.requests[0]?.url).toContain("/branches");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "branching_limit", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+        });
+        expect(api.requests).toHaveLength(1);
+        expect(api.requests[0]?.url).toContain("/branches");
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "branching_limit", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("does NOT fire upgrade suggested on 500 (Go skips 5xx)", () => {
     const { layer, analytics } = setup({ status: 500 });

--- a/apps/cli/src/legacy/commands/branches/update/update.handler.ts
+++ b/apps/cli/src/legacy/commands/branches/update/update.handler.ts
@@ -76,21 +76,7 @@ export const legacyBranchesUpdate = Effect.fn("legacy.branches.update")(function
         Effect.catch(
           legacyGateMapError(
             { projectRef: branchRef, featureKey: "branching_persistent" },
-            (cause, upgradeSuggested) =>
-              Effect.gen(function* () {
-                const mapped = yield* Effect.flip(mapUpdateError(cause));
-                if (mapped._tag === "LegacyBranchesUpdateUnexpectedStatusError") {
-                  return yield* Effect.fail(
-                    new LegacyBranchesUpdateUnexpectedStatusError({
-                      status: mapped.status,
-                      body: mapped.body,
-                      message: mapped.message,
-                      upgradeSuggested,
-                    }),
-                  );
-                }
-                return yield* Effect.fail(mapped);
-              }),
+            (cause, upgradeSuggested) => mapUpdateError(cause, { upgradeSuggested }),
           ),
         ),
       );

--- a/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
@@ -9,6 +9,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
 import {
+  mockAnalytics,
   mockOutput,
   mockProcessControl,
   mockRuntimeInfo,
@@ -494,6 +495,7 @@ function setup(
     out.layer,
     conn.layer,
     resolver.layer,
+    mockAnalytics().layer,
     mockLegacyCliConfig({ workdir }),
     BunServices.layer,
     child.layer,

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
@@ -27,6 +27,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../../../tests/helpers/legacy-mocks.ts";
+import { mockAnalytics } from "../../../../../../../tests/helpers/mocks.ts";
 import { CliArgs } from "../../../../../../shared/cli/cli-args.service.ts";
 import {
   LegacyDebugFlag,
@@ -182,6 +183,7 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     execCapture: () => Effect.succeed(""),
   });
   const layer = Layer.mergeAll(
+    mockAnalytics().layer,
     out.layer,
     telemetry.layer,
     cache.layer,

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.integration.test.ts
@@ -26,6 +26,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../../../tests/helpers/legacy-mocks.ts";
+import { mockAnalytics } from "../../../../../../../tests/helpers/mocks.ts";
 import { CliArgs } from "../../../../../../shared/cli/cli-args.service.ts";
 import {
   LegacyDebugFlag,
@@ -219,6 +220,7 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     resolvePoolerFallback: () => Effect.succeed(Option.none()),
   });
   const layer = Layer.mergeAll(
+    mockAnalytics().layer,
     out.layer,
     telemetry.layer,
     cache.layer,

--- a/apps/cli/src/legacy/commands/domains/activate/activate.handler.ts
+++ b/apps/cli/src/legacy/commands/domains/activate/activate.handler.ts
@@ -7,7 +7,6 @@ import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-proje
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { emitLegacyHostnameResult } from "../domains.emit.ts";
 import { mapLegacyDomainsHttpError } from "../domains.errors.ts";
-import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import type { LegacyDomainsActivateFlags } from "./activate.command.ts";
 
 const mapActivateError = mapLegacyDomainsHttpError("activate");
@@ -28,7 +27,7 @@ export const legacyDomainsActivate = Effect.fn("legacy.domains.activate")(functi
       output.format === "text" ? yield* output.task("Activating custom hostname...") : undefined;
     const response = yield* api.v1.activateCustomHostname({ ref }).pipe(
       Effect.tapError(() => activating?.fail() ?? Effect.void),
-      Effect.catch(legacyGateMapError({ projectRef: ref }, mapActivateError)),
+      Effect.catch(mapActivateError),
     );
     yield* activating?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/domains/activate/activate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/domains/activate/activate.integration.test.ts
@@ -2,6 +2,7 @@ import { type V1GetHostnameConfigOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import {
   buildLegacyTestRuntime,
@@ -68,33 +69,39 @@ function setup(opts: SetupOpts = {}) {
 const baseFlags = { projectRef: Option.none<string>(), includeRawOutput: false };
 
 describe("legacy domains activate integration", () => {
-  it.live("suggests upgrade from entitlement_required envelope on 400", () => {
-    const { layer, out, analytics, api } = setup({
-      status: 400,
-      response: {
-        message:
-          "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
-        error: {
-          code: "entitlement_required",
+  it.live(
+    "carries entitlement and fires central telemetry on an entitlement_required envelope",
+    () => {
+      const { layer, out, analytics, api } = setup({
+        status: 400,
+        response: {
+          message:
+            "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
+          error: {
+            code: "entitlement_required",
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        },
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(legacyDomainsActivate(baseFlags));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
           feature: "custom_domain",
           upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-        },
-      },
-    });
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(legacyDomainsActivate(baseFlags));
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(1);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "custom_domain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+        });
+        expect(api.requests).toHaveLength(1);
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "custom_domain", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("prints the completion status to stderr in text mode", () => {
     const { layer, out, api, telemetry, linkedProjectCache } = setup();

--- a/apps/cli/src/legacy/commands/domains/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/domains/create/create.handler.ts
@@ -10,7 +10,6 @@ import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.
 import { verifyLegacyCname } from "../domains.cname.ts";
 import { emitLegacyHostnameResult } from "../domains.emit.ts";
 import { mapLegacyDomainsHttpError } from "../domains.errors.ts";
-import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import type { LegacyDomainsCreateFlags } from "./create.command.ts";
 
 const mapCreateError = mapLegacyDomainsHttpError("create");
@@ -46,7 +45,7 @@ export const legacyDomainsCreate = Effect.fn("legacy.domains.create")(function* 
       .updateHostnameConfig({ ref, custom_hostname: flags.customHostname })
       .pipe(
         Effect.tapError(() => creating?.fail() ?? Effect.void),
-        Effect.catch(legacyGateMapError({ projectRef: ref }, mapCreateError)),
+        Effect.catch(mapCreateError),
       );
     yield* creating?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/domains/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/domains/create/create.integration.test.ts
@@ -2,6 +2,7 @@ import { type V1GetHostnameConfigOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import {
   LEGACY_VALID_REF,
@@ -117,34 +118,40 @@ describe("legacy domains create integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("suggests upgrade from entitlement_required envelope on 400", () => {
-    const { layer, out, analytics, api } = setup({
-      apiStatus: 400,
-      apiResponse: {
-        message:
-          "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
-        error: {
-          code: "entitlement_required",
+  it.live(
+    "carries entitlement and fires central telemetry on an entitlement_required envelope",
+    () => {
+      const { layer, out, analytics, api } = setup({
+        apiStatus: 400,
+        apiResponse: {
+          message:
+            "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
+          error: {
+            code: "entitlement_required",
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        },
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(legacyDomainsCreate(flags()));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
           feature: "custom_domain",
           upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-        },
-      },
-    });
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(legacyDomainsCreate(flags()));
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(2);
-      expect(postedToInitialize(api)).toBe(true);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "custom_domain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+        });
+        expect(api.requests).toHaveLength(2);
+        expect(postedToInitialize(api)).toBe(true);
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "custom_domain", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("plain 400 without envelope produces no upgrade hint", () => {
     const { layer, out, analytics, api } = setup({

--- a/apps/cli/src/legacy/commands/domains/domains.errors.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.errors.ts
@@ -34,12 +34,10 @@ export class LegacyDomainsUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
+  readonly upgradeSuggested?: boolean;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    // The gated create/get/activate/reverify wrappers currently do not retain
-    // the entitlement check's boolean on this shared error. Keep 404 on the
-    // conservative API-status policy until that typed signal is threaded.
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { upgradeSuggested: this.upgradeSuggested });
   }
 }
 

--- a/apps/cli/src/legacy/commands/domains/get/get.handler.ts
+++ b/apps/cli/src/legacy/commands/domains/get/get.handler.ts
@@ -7,7 +7,6 @@ import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-proje
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { emitLegacyHostnameResult } from "../domains.emit.ts";
 import { mapLegacyDomainsHttpError } from "../domains.errors.ts";
-import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import type { LegacyDomainsGetFlags } from "./get.command.ts";
 
 const mapGetError = mapLegacyDomainsHttpError("get");
@@ -32,7 +31,7 @@ export const legacyDomainsGet = Effect.fn("legacy.domains.get")(function* (
         : undefined;
     const response = yield* api.v1.getHostnameConfig({ ref }).pipe(
       Effect.tapError(() => fetching?.fail() ?? Effect.void),
-      Effect.catch(legacyGateMapError({ projectRef: ref }, mapGetError)),
+      Effect.catch(mapGetError),
     );
     yield* fetching?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/domains/get/get.integration.test.ts
+++ b/apps/cli/src/legacy/commands/domains/get/get.integration.test.ts
@@ -2,6 +2,7 @@ import { type V1GetHostnameConfigOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import {
   buildLegacyTestRuntime,
@@ -304,33 +305,39 @@ describe("legacy domains get integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("suggests upgrade from entitlement_required envelope on 400", () => {
-    const { layer, out, analytics, api } = setup({
-      status: 400,
-      response: {
-        message:
-          "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
-        error: {
-          code: "entitlement_required",
+  it.live(
+    "carries entitlement and fires central telemetry on an entitlement_required envelope",
+    () => {
+      const { layer, out, analytics, api } = setup({
+        status: 400,
+        response: {
+          message:
+            "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
+          error: {
+            code: "entitlement_required",
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        },
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(legacyDomainsGet(baseFlags));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
           feature: "custom_domain",
           upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-        },
-      },
-    });
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(legacyDomainsGet(baseFlags));
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(1);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "custom_domain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+        });
+        expect(api.requests).toHaveLength(1);
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "custom_domain", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("plain 404 without envelope produces no upgrade hint", () => {
     const { layer, out, analytics, api } = setup({

--- a/apps/cli/src/legacy/commands/domains/reverify/reverify.handler.ts
+++ b/apps/cli/src/legacy/commands/domains/reverify/reverify.handler.ts
@@ -7,7 +7,6 @@ import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-proje
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { emitLegacyHostnameResult } from "../domains.emit.ts";
 import { mapLegacyDomainsHttpError } from "../domains.errors.ts";
-import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import type { LegacyDomainsReverifyFlags } from "./reverify.command.ts";
 
 const mapReverifyError = mapLegacyDomainsHttpError("re-verify");
@@ -28,7 +27,7 @@ export const legacyDomainsReverify = Effect.fn("legacy.domains.reverify")(functi
       output.format === "text" ? yield* output.task("Re-verifying custom hostname...") : undefined;
     const response = yield* api.v1.verifyDnsConfig({ ref }).pipe(
       Effect.tapError(() => reverifying?.fail() ?? Effect.void),
-      Effect.catch(legacyGateMapError({ projectRef: ref }, mapReverifyError)),
+      Effect.catch(mapReverifyError),
     );
     yield* reverifying?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/domains/reverify/reverify.integration.test.ts
+++ b/apps/cli/src/legacy/commands/domains/reverify/reverify.integration.test.ts
@@ -2,6 +2,7 @@ import { type V1GetHostnameConfigOutput } from "@supabase/api/effect";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../../shared/api/plan-gate.ts";
 import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
 import {
   buildLegacyTestRuntime,
@@ -68,33 +69,39 @@ function setup(opts: SetupOpts = {}) {
 const baseFlags = { projectRef: Option.none<string>(), includeRawOutput: false };
 
 describe("legacy domains reverify integration", () => {
-  it.live("suggests upgrade from entitlement_required envelope on 400", () => {
-    const { layer, out, analytics, api } = setup({
-      status: 400,
-      response: {
-        message:
-          "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
-        error: {
-          code: "entitlement_required",
+  it.live(
+    "carries entitlement and fires central telemetry on an entitlement_required envelope",
+    () => {
+      const { layer, out, analytics, api } = setup({
+        status: 400,
+        response: {
+          message:
+            "Custom domains require the Custom Domain add-on, available on the Pro plan and above.",
+          error: {
+            code: "entitlement_required",
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        },
+      });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(legacyDomainsReverify(baseFlags));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
           feature: "custom_domain",
           upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-        },
-      },
-    });
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(legacyDomainsReverify(baseFlags));
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(1);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "custom_domain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+        });
+        expect(api.requests).toHaveLength(1);
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "custom_domain", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("prints the initializing status to stderr in text mode", () => {
     const { layer, out, api, telemetry, linkedProjectCache } = setup();

--- a/apps/cli/src/legacy/commands/seed/buckets/buckets.integration.test.ts
+++ b/apps/cli/src/legacy/commands/seed/buckets/buckets.integration.test.ts
@@ -8,7 +8,12 @@ import { Effect, Exit, Layer, Option } from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import type * as HttpClientError from "effect/unstable/http/HttpClientError";
 
-import { mockOutput, mockStdin, mockTty } from "../../../../../tests/helpers/mocks.ts";
+import {
+  mockAnalytics,
+  mockOutput,
+  mockStdin,
+  mockTty,
+} from "../../../../../tests/helpers/mocks.ts";
 import {
   LEGACY_VALID_REF,
   legacyJsonResponse,
@@ -187,6 +192,7 @@ function setupLegacySeedBuckets(
     out.layer,
     httpLayer,
     telemetry.layer,
+    mockAnalytics().layer,
     mockLegacyCliConfig({ workdir }),
     BunServices.layer,
     // Seed-bucket prompts model an interactive user answering via `confirm`.

--- a/apps/cli/src/legacy/commands/vanity-subdomains/check-availability/check-availability.handler.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/check-availability/check-availability.handler.ts
@@ -33,6 +33,7 @@ const mapCheckError = mapLegacyHttpError({
   statusError: LegacyVanitySubdomainsCheckUnexpectedStatusError,
   networkMessage: (cause) => `failed to check vanity subdomain: ${cause}`,
   statusMessage: (status, body) => `unexpected check vanity subdomain status ${status}: ${body}`,
+  trackUpgradeSuggested: false,
 });
 
 export const legacyVanitySubdomainsCheckAvailability = Effect.fn(
@@ -77,29 +78,18 @@ export const legacyVanitySubdomainsCheckAvailability = Effect.fn(
           Effect.tapError(() => checking?.fail() ?? Effect.void),
           Effect.catch((cause) =>
             Effect.gen(function* () {
-              // Flip the always-failing mapper into a success so we can inspect the
-              // tagged error before deciding whether to suggest an upgrade, then re-fail.
-              const mapped = yield* Effect.flip(mapCheckError(cause));
-              if (mapped._tag === "LegacyVanitySubdomainsCheckUnexpectedStatusError") {
-                // The check command calls SuggestUpgradeOnError without a following
-                // TrackUpgradeSuggested, so the analytics event is suppressed here too.
-                const upgradeSuggested = yield* legacySuggestUpgrade({
-                  projectRef: ref,
-                  featureKey: "vanity_subdomain",
-                  statusCode: mapped.status,
-                  response: legacyGateResponse(cause),
-                  trackAnalytics: false,
-                });
-                return yield* Effect.fail(
-                  new LegacyVanitySubdomainsCheckUnexpectedStatusError({
-                    status: mapped.status,
-                    body: mapped.body,
-                    message: mapped.message,
-                    upgradeSuggested,
-                  }),
-                );
-              }
-              return yield* Effect.fail(mapped);
+              // The check command calls SuggestUpgradeOnError without a following
+              // TrackUpgradeSuggested, so the analytics event is suppressed on
+              // both paths: `trackAnalytics` here, `trackUpgradeSuggested` on
+              // the mapper.
+              const upgradeSuggested = yield* legacySuggestUpgrade({
+                projectRef: ref,
+                featureKey: "vanity_subdomain",
+                statusCode: legacyGateResponse(cause)?.status ?? 0,
+                response: legacyGateResponse(cause),
+                trackAnalytics: false,
+              });
+              return yield* mapCheckError(cause, { upgradeSuggested });
             }),
           ),
         );

--- a/apps/cli/src/legacy/commands/vanity-subdomains/get/get.handler.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/get/get.handler.ts
@@ -15,7 +15,6 @@ import {
   legacyGoStruct,
 } from "../../../shared/legacy-go-struct-output.encoders.ts";
 import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
-import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import {
   LegacyVanitySubdomainsGetNetworkError,
   LegacyVanitySubdomainsGetUnexpectedStatusError,
@@ -53,7 +52,7 @@ export const legacyVanitySubdomainsGet = Effect.fn("legacy.vanity-subdomains.get
         output.format === "text" ? yield* output.task("Getting vanity subdomain...") : undefined;
       const response = yield* api.v1.getVanitySubdomainConfig({ ref }).pipe(
         Effect.tapError(() => fetching?.fail() ?? Effect.void),
-        Effect.catch(legacyGateMapError({ projectRef: ref }, mapGetError)),
+        Effect.catch(mapGetError),
       );
       yield* fetching?.clear() ?? Effect.void;
 

--- a/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.errors.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.errors.ts
@@ -45,11 +45,12 @@ export class LegacyVanitySubdomainsGetUnexpectedStatusError extends Data.TaggedE
   readonly status: number;
   readonly body: string;
   readonly message: string;
+  readonly upgradeSuggested?: boolean;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    // Unlike check/activate, this gated wrapper does not yet retain the typed
-    // entitlement result. Keep 404 conservative rather than masking a plan gate.
-    return statusCodeActionability(this.status);
+    // Unlike check/activate, non-gated 404s stay on the conservative
+    // API-status policy rather than reading as invalid input.
+    return statusCodeActionability(this.status, { upgradeSuggested: this.upgradeSuggested });
   }
 }
 

--- a/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.integration.test.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.integration.test.ts
@@ -6,6 +6,7 @@ import type {
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option } from "effect";
 
+import { errorEntitlement } from "../../../shared/api/plan-gate.ts";
 import { mockAnalytics, mockOutput } from "../../../../tests/helpers/mocks.ts";
 import {
   LEGACY_VALID_REF,
@@ -111,38 +112,44 @@ describe("legacy vanity-subdomains get", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("suggests upgrade from entitlement_required envelope on 400", () => {
-    const out = mockOutput({ format: "text" });
-    const analytics = mockAnalytics();
-    const api = mockLegacyPlatformApi({
-      response: {
-        status: 400,
-        body: {
-          message: "This feature requires the Pro, Team, or Enterprise organization plan.",
-          error: {
-            code: "entitlement_required",
-            feature: "vanity_subdomain",
-            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+  it.live(
+    "carries entitlement and fires central telemetry on an entitlement_required envelope",
+    () => {
+      const out = mockOutput({ format: "text" });
+      const analytics = mockAnalytics();
+      const api = mockLegacyPlatformApi({
+        response: {
+          status: 400,
+          body: {
+            message: "This feature requires the Pro, Team, or Enterprise organization plan.",
+            error: {
+              code: "entitlement_required",
+              feature: "vanity_subdomain",
+              upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+            },
           },
         },
-      },
-    });
-    const layer = runtimeWith({ out, api, analytics });
+      });
+      const layer = runtimeWith({ out, api, analytics });
 
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(legacyVanitySubdomainsGet({ projectRef: Option.none() }));
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(api.requests).toHaveLength(1);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "vanity_subdomain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+      return Effect.gen(function* () {
+        const exit = yield* Effect.exit(legacyVanitySubdomainsGet({ projectRef: Option.none() }));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(errorEntitlement(Option.getOrUndefined(Exit.findErrorOption(exit)))).toEqual({
+          feature: "vanity_subdomain",
+          upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+        });
+        expect(api.requests).toHaveLength(1);
+        expect(out.stderrText).not.toContain("Upgrade your plan:");
+        expect(analytics.captured).toEqual([
+          {
+            event: "cli_upgrade_suggested",
+            properties: { feature_key: "vanity_subdomain", org_slug: "env-org" },
+          },
+        ]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("plain 404 without envelope produces no upgrade hint", () => {
     const out = mockOutput({ format: "text" });

--- a/apps/cli/src/legacy/shared/legacy-db-config.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.layer.ts
@@ -135,7 +135,9 @@ const waitForTempRole = Effect.fnUntraced(function* (
 ) {
   const dbConn = yield* LegacyDbConnection;
   const debug = yield* LegacyDebugLogger;
-  const attempt = (n: number): Effect.Effect<void, LegacyDbConfigError, LegacyPlatformApiFactory> =>
+  const attempt = (
+    n: number,
+  ): Effect.Effect<void, LegacyDbConfigError, Analytics | LegacyPlatformApiFactory> =>
     // The temp-role probe always targets the remote Supavisor pooler, so it
     // connects with TLS (Go's pooler path goes through `ConnectByUrl`) and
     // honors `--dns-resolver` (`ConnectByConfigStream` installs the DoH
@@ -442,6 +444,7 @@ export const legacyDbConfigLayer = Layer.effect(
     // `BunServices.layer` is included as a concrete layer (not a captured-value
     // `Layer.succeed`) because it provides FileSystem/Path, which have no single
     // tag to snapshot and which `legacyManagementApiRuntimeLayer` does not expose.
+    const analytics = yield* Analytics;
     const ambientLayer = Layer.mergeAll(
       Layer.succeed(LegacyProfileFlag, yield* LegacyProfileFlag),
       Layer.succeed(LegacyWorkdirFlag, yield* LegacyWorkdirFlag),
@@ -452,7 +455,7 @@ export const legacyDbConfigLayer = Layer.effect(
       // built linked stack stays fully self-provided (`resolve`'s R stays `never`).
       Layer.succeed(LegacyDnsResolverFlag, yield* LegacyDnsResolverFlag),
       Layer.succeed(RuntimeInfo, yield* RuntimeInfo),
-      Layer.succeed(Analytics, yield* Analytics),
+      Layer.succeed(Analytics, analytics),
       Layer.succeed(TelemetryRuntime, yield* TelemetryRuntime),
       Layer.succeed(Tty, yield* Tty),
       Layer.succeed(Output, yield* Output),
@@ -598,6 +601,10 @@ export const legacyDbConfigLayer = Layer.effect(
                   Layer.provide(ambientLayer),
                 ),
                 localAmbientServices,
+                // The mappers' central envelope telemetry reads Analytics from the
+                // resolve effect itself, not the runtime layer; re-provide the
+                // snapshot so `resolve`'s R stays `never`.
+                Layer.succeed(Analytics, analytics),
               ),
             ),
           );
@@ -660,6 +667,7 @@ export const legacyDbConfigLayer = Layer.effect(
             Layer.mergeAll(
               legacyLinkedDbResolverRuntimeLayer(["db", "dump"]).pipe(Layer.provide(ambientLayer)),
               localAmbientServices,
+              Layer.succeed(Analytics, analytics),
             ),
           ),
         );

--- a/apps/cli/src/legacy/shared/legacy-http-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-http-errors.ts
@@ -3,6 +3,19 @@ import { Effect } from "effect";
 import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 
+import type { PlanGateEntitlement } from "../../shared/api/plan-gate.ts";
+import {
+  orgSlugFromUpgradeUrl,
+  parsePlanGateEnvelopeText,
+  planGateSuggestion,
+} from "../../shared/api/plan-gate.ts";
+import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import {
+  EventUpgradeSuggested,
+  PropFeatureKey,
+  PropOrgSlug,
+} from "../../shared/telemetry/event-catalog.ts";
+
 // HttpClientError reasons that indicate the server returned an actual response (vs a transport
 // failure). Anything in this set surfaces as an `UnexpectedStatusError`; everything else maps
 // to a `NetworkError`.
@@ -69,6 +82,9 @@ export type StatusErrorFactory<E> = new (args: {
   readonly status: number;
   readonly body: string;
   readonly message: string;
+  readonly entitlement?: PlanGateEntitlement;
+  readonly suggestion?: string;
+  readonly upgradeSuggested?: boolean;
 }) => E;
 
 /**
@@ -85,10 +101,22 @@ export function mapLegacyHttpError<N, S>(opts: {
   readonly statusError: StatusErrorFactory<S>;
   readonly networkMessage: (cause: string) => string;
   readonly statusMessage: (status: number, body: string) => string;
+  /**
+   * Set false where the Go twin fires no `TrackUpgradeSuggested` on an
+   * envelope denial (vanity check-availability), keeping telemetry 1:1.
+   */
+  readonly trackUpgradeSuggested?: boolean;
 }): (
   cause: SupabaseApiError,
-) => Effect.Effect<never, N | S | SupabaseApiInputError | HttpBody.HttpBodyError> {
-  return (cause) =>
+  extra?: {
+    /**
+     * Producer-confirmed plan-gate signal for envelope-less denials (the
+     * `legacySuggestUpgrade` fallback). Envelope denials set it centrally.
+     */
+    readonly upgradeSuggested?: boolean;
+  },
+) => Effect.Effect<never, N | S | SupabaseApiInputError | HttpBody.HttpBodyError, Analytics> {
+  return (cause, extra) =>
     Effect.gen(function* () {
       if (cause instanceof SupabaseApiInputError || cause instanceof HttpBody.HttpBodyError) {
         // These failures occur while the generated client validates or builds
@@ -102,12 +130,26 @@ export function mapLegacyHttpError<N, S>(opts: {
           const rawBody = yield* cause.response.text.pipe(
             Effect.orElseSucceed(() => cause.reason.description ?? ""),
           );
+          const entitlement = parsePlanGateEnvelopeText(rawBody);
+          if (entitlement !== undefined && opts.trackUpgradeSuggested !== false) {
+            const analytics = yield* Analytics;
+            yield* analytics.capture(EventUpgradeSuggested, {
+              [PropFeatureKey]: entitlement.feature,
+              [PropOrgSlug]: orgSlugFromUpgradeUrl(entitlement.upgrade_url),
+            });
+          }
           const body = sanitizeLegacyErrorBody(rawBody);
           return yield* Effect.fail(
             new opts.statusError({
               status,
               body,
               message: opts.statusMessage(status, body),
+              ...(entitlement !== undefined
+                ? { entitlement, suggestion: planGateSuggestion(entitlement.upgrade_url) }
+                : {}),
+              ...(entitlement !== undefined || extra?.upgradeSuggested === true
+                ? { upgradeSuggested: true }
+                : {}),
             }),
           );
         }

--- a/apps/cli/src/legacy/shared/legacy-http-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-http-errors.unit.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "@effect/vitest";
 import { SupabaseApiInputError } from "@supabase/api/effect";
-import { Data, Effect } from "effect";
+import { Data, Effect, Exit, Option } from "effect";
 import * as HttpBody from "effect/unstable/http/HttpBody";
-import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 
+import { mockAnalytics } from "../../../tests/helpers/mocks.ts";
+import {
+  legacyStatusCodeFailure,
+  legacyTransportFailure,
+} from "../../../tests/helpers/legacy-mocks.ts";
+import { errorEntitlement } from "../../shared/api/plan-gate.ts";
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
 import { mapLegacyHttpError } from "./legacy-http-errors.ts";
 
 class TestNetworkError extends Data.TaggedError("TestNetworkError")<{
@@ -24,6 +31,26 @@ const mapError = mapLegacyHttpError({
   statusMessage: (status, body) => `${status}: ${body}`,
 });
 
+const mapTestError = mapLegacyHttpError({
+  networkError: TestNetworkError,
+  statusError: TestStatusError,
+  networkMessage: (cause) => `network: ${cause}`,
+  statusMessage: (status, body) => `status ${status}: ${body}`,
+});
+
+const ENVELOPE_BODY = {
+  message: "gated",
+  error: {
+    code: "entitlement_required",
+    feature: "custom_domain",
+    upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+  },
+};
+
+function failedError(exit: Exit.Exit<never, unknown>): unknown {
+  return Option.getOrUndefined(Exit.findErrorOption(exit));
+}
+
 describe("mapLegacyHttpError", () => {
   it.effect("preserves generated API input errors", () =>
     Effect.gen(function* () {
@@ -38,7 +65,7 @@ describe("mapLegacyHttpError", () => {
         error_category: "impossible_state",
         error_fingerprint: "tag:SupabaseApiInputError:request_encoding",
       });
-    }),
+    }).pipe(Effect.provide(mockAnalytics().layer)),
   );
 
   it.effect("preserves request-body construction errors", () =>
@@ -56,6 +83,92 @@ describe("mapLegacyHttpError", () => {
         error_category: "impossible_state",
         error_fingerprint: "tag:HttpBodyError:request_encoding",
       });
-    }),
+    }).pipe(Effect.provide(mockAnalytics().layer)),
+  );
+
+  it.effect("attaches the parsed entitlement on an envelope body", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(mapTestError(legacyStatusCodeFailure(403, ENVELOPE_BODY)));
+      const error = failedError(exit);
+      expect(errorEntitlement(error)).toEqual({
+        feature: "custom_domain",
+        upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+      });
+      expect((error as TestStatusError).body).toContain("entitlement_required");
+    }).pipe(Effect.provide(mockAnalytics().layer)),
+  );
+
+  it.effect("fires cli_upgrade_suggested once per envelope denial", () => {
+    const analytics = mockAnalytics();
+    return Effect.gen(function* () {
+      yield* Effect.exit(mapTestError(legacyStatusCodeFailure(403, ENVELOPE_BODY)));
+      expect(analytics.captured).toEqual([
+        {
+          event: "cli_upgrade_suggested",
+          properties: { feature_key: "custom_domain", org_slug: "env-org" },
+        },
+      ]);
+    }).pipe(Effect.provide(analytics.layer));
+  });
+
+  it.effect("suppresses the event but keeps the fields with trackUpgradeSuggested=false", () => {
+    const analytics = mockAnalytics();
+    const mapUntracked = mapLegacyHttpError({
+      networkError: TestNetworkError,
+      statusError: TestStatusError,
+      networkMessage: (cause) => `network: ${cause}`,
+      statusMessage: (status, body) => `status ${status}: ${body}`,
+      trackUpgradeSuggested: false,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(mapUntracked(legacyStatusCodeFailure(403, ENVELOPE_BODY)));
+      expect(analytics.captured).toEqual([]);
+      expect(errorEntitlement(failedError(exit))).toEqual({
+        feature: "custom_domain",
+        upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+      });
+    }).pipe(Effect.provide(analytics.layer));
+  });
+
+  it.effect("fires no event without an envelope", () => {
+    const analytics = mockAnalytics();
+    return Effect.gen(function* () {
+      yield* Effect.exit(mapTestError(legacyStatusCodeFailure(403, { message: "denied" })));
+      expect(analytics.captured).toEqual([]);
+    }).pipe(Effect.provide(analytics.layer));
+  });
+
+  it.effect("parses the envelope from the raw body before truncation", () =>
+    Effect.gen(function* () {
+      const padded = { ...ENVELOPE_BODY, message: "x".repeat(1500) };
+      const exit = yield* Effect.exit(mapTestError(legacyStatusCodeFailure(403, padded)));
+      const error = failedError(exit);
+      expect(errorEntitlement(error)).toEqual({
+        feature: "custom_domain",
+        upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+      });
+      expect((error as TestStatusError).body.length).toBe(1024);
+    }).pipe(Effect.provide(mockAnalytics().layer)),
+  );
+
+  it.effect("attaches nothing on a plain 4xx body", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        mapTestError(legacyStatusCodeFailure(403, { message: "denied" })),
+      );
+      const error = failedError(exit);
+      expect(errorEntitlement(error)).toBeUndefined();
+      expect(Object.hasOwn(error as object, "entitlement")).toBe(false);
+    }).pipe(Effect.provide(mockAnalytics().layer)),
+  );
+
+  it.effect("maps transport failures to the network error unchanged", () =>
+    Effect.gen(function* () {
+      const request = HttpClientRequest.get("https://api.supabase.com/v1/projects/x");
+      const exit = yield* Effect.exit(mapTestError(legacyTransportFailure(request)));
+      const error = failedError(exit);
+      expect(error).toBeInstanceOf(TestNetworkError);
+      expect((error as TestNetworkError).message).toBe("network: ECONNREFUSED");
+    }).pipe(Effect.provide(mockAnalytics().layer)),
   );
 });

--- a/apps/cli/src/legacy/shared/legacy-upgrade-suggest.ts
+++ b/apps/cli/src/legacy/shared/legacy-upgrade-suggest.ts
@@ -9,6 +9,7 @@ import type * as HttpClientResponse from "effect/unstable/http/HttpClientRespons
 
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import { resolveLegacyAccessToken } from "./legacy-resolve-token.ts";
+import { parsePlanGateEnvelope, planGateSuggestion } from "../../shared/api/plan-gate.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import {
   EventUpgradeSuggested,
@@ -24,30 +25,6 @@ function readString(obj: unknown, key: string): string {
     return typeof value === "string" ? value : "";
   }
   return "";
-}
-
-interface LegacyPlanGateEnvelope {
-  readonly feature: string;
-  readonly upgradeUrl: string;
-}
-
-// Hand-validated: the packages/api codegen emits no non-2xx schemas.
-function parseLegacyPlanGateEnvelope(body: unknown): LegacyPlanGateEnvelope | undefined {
-  if (typeof body !== "object" || body === null) return undefined;
-  const error = (body as { readonly error?: unknown }).error;
-  if (typeof error !== "object" || error === null) return undefined;
-  const code = readString(error, "code");
-  const feature = readString(error, "feature");
-  const upgradeUrl = readString(error, "upgrade_url");
-  if (code !== "entitlement_required" || feature === "" || upgradeUrl === "") {
-    return undefined;
-  }
-  return { feature, upgradeUrl };
-}
-
-function legacyOrgSlugFromUpgradeUrl(upgradeUrl: string): string {
-  const match = /\/org\/([^/]+)/.exec(upgradeUrl);
-  return match?.[1] ?? "";
 }
 
 export function legacyGateResponse(
@@ -74,7 +51,12 @@ export const legacyGateMapError =
     });
 
 /**
- * Ports `plan_gate.go:SuggestUpgradeOnError`. Never fails the caller.
+ * Entitlements-lookup fallback for envelope-less plan-gate denials (older
+ * servers, ungated routes like v1 SSO). Envelope-carrying denials are handled
+ * centrally in `mapLegacyHttpError` (hint, telemetry, and error fields), so
+ * this stops after confirming the gate when the response body parses as an
+ * `entitlement_required` envelope. Ports Go's
+ * `plan_gate.go:SuggestUpgradeOnError`. Never fails the caller.
  *
  * The fallback bypasses the typed API client: its strict response schemas
  * reject the cli-e2e replay fixtures' placeholder refs (same workaround as
@@ -85,9 +67,8 @@ export const legacyGateMapError =
 export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
   readonly projectRef: string;
   /**
-   * Entitlements-fallback key. Omit for envelope-only sites: the domains
-   * add-on gate has no plan-level entitlement key, so the fallback would
-   * false-positive on unrelated 4xxs.
+   * Entitlements-fallback key. Without it the fallback no-ops: a lookup
+   * without a known key would false-positive on unrelated 4xxs.
    */
   readonly featureKey?: string;
   readonly statusCode: number;
@@ -114,7 +95,9 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
   readonly accessToken?: Option.Option<Redacted.Redacted<string>>;
   /**
    * Set false where the Go twin fires no `TrackUpgradeSuggested` (vanity
-   * check-availability), keeping telemetry 1:1.
+   * check-availability), keeping telemetry 1:1 on the fallback path. The
+   * central handler's equivalent switch is `trackUpgradeSuggested` on its
+   * `mapLegacyHttpError` options.
    */
   readonly trackAnalytics?: boolean;
 }) {
@@ -127,89 +110,76 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
   const cliConfig = yield* LegacyCliConfig;
   const httpClient = yield* HttpClient.HttpClient;
 
-  let gate:
-    | { readonly billingUrl: string; readonly feature: string; readonly orgSlug: string }
-    | undefined;
-
   if (opts.response !== undefined) {
     const body = yield* opts.response.json.pipe(Effect.option);
-    const envelope = Option.isSome(body) ? parseLegacyPlanGateEnvelope(body.value) : undefined;
+    const envelope = Option.isSome(body) ? parsePlanGateEnvelope(body.value) : undefined;
     if (envelope !== undefined) {
-      gate = {
-        billingUrl: envelope.upgradeUrl,
-        feature: envelope.feature,
-        orgSlug: legacyOrgSlugFromUpgradeUrl(envelope.upgradeUrl),
-      };
+      // Confirmed gated, but the central handler already attached the error
+      // fields, printed the hint, and fired the telemetry for this denial.
+      return true;
     }
   }
 
-  if (gate === undefined) {
-    if (opts.featureKey === undefined || opts.featureKey === "") {
-      return false;
-    }
-
-    const tokenOpt = opts.accessToken ?? (yield* resolveLegacyAccessToken);
-    const authHeader: (
-      req: HttpClientRequest.HttpClientRequest,
-    ) => HttpClientRequest.HttpClientRequest = Option.isSome(tokenOpt)
-      ? HttpClientRequest.bearerToken(tokenOpt.value)
-      : (req) => req;
-
-    const apiUrl = opts.apiUrl ?? cliConfig.apiUrl;
-    const projectReq = HttpClientRequest.get(`${apiUrl}/v1/projects/${opts.projectRef}`).pipe(
-      authHeader,
-      HttpClientRequest.setHeader("User-Agent", cliConfig.userAgent),
-    );
-    const projectResp = yield* httpClient.execute(projectReq).pipe(Effect.option);
-    if (projectResp._tag === "None" || projectResp.value.status !== 200) {
-      return false;
-    }
-    const projectBody = yield* projectResp.value.json.pipe(Effect.option);
-    if (projectBody._tag === "None") {
-      return false;
-    }
-    const orgSlug = readString(projectBody.value, "organization_slug");
-    if (orgSlug.length === 0) {
-      return false;
-    }
-
-    const entReq = HttpClientRequest.get(`${apiUrl}/v1/organizations/${orgSlug}/entitlements`).pipe(
-      authHeader,
-      HttpClientRequest.setHeader("User-Agent", cliConfig.userAgent),
-    );
-    const entResp = yield* httpClient.execute(entReq).pipe(Effect.option);
-    if (entResp._tag === "None" || entResp.value.status !== 200) {
-      return false;
-    }
-    const entBody = yield* entResp.value.json.pipe(Effect.option);
-    if (entBody._tag === "None") {
-      return false;
-    }
-    const entitlements = (entBody.value as { entitlements?: unknown }).entitlements;
-    if (!Array.isArray(entitlements)) {
-      return false;
-    }
-
-    const gated = entitlements.some((entry: unknown) => {
-      if (typeof entry !== "object" || entry === null) return false;
-      const feature = (entry as { feature?: unknown }).feature;
-      if (typeof feature !== "object" || feature === null) return false;
-      const key = (feature as { key?: unknown }).key;
-      const hasAccess = (entry as { hasAccess?: unknown }).hasAccess;
-      return key === opts.featureKey && hasAccess === false;
-    });
-    if (!gated) {
-      return false;
-    }
-
-    gate = {
-      billingUrl: legacyBillingUrl(cliConfig.profile, orgSlug),
-      feature: opts.featureKey,
-      orgSlug,
-    };
+  if (opts.featureKey === undefined || opts.featureKey === "") {
+    return false;
   }
 
-  const suggestion = `Your organization does not have access to this feature. Upgrade your plan: ${styleText("bold", gate.billingUrl)}`;
+  const tokenOpt = opts.accessToken ?? (yield* resolveLegacyAccessToken);
+  const authHeader: (
+    req: HttpClientRequest.HttpClientRequest,
+  ) => HttpClientRequest.HttpClientRequest = Option.isSome(tokenOpt)
+    ? HttpClientRequest.bearerToken(tokenOpt.value)
+    : (req) => req;
+
+  const apiUrl = opts.apiUrl ?? cliConfig.apiUrl;
+  const projectReq = HttpClientRequest.get(`${apiUrl}/v1/projects/${opts.projectRef}`).pipe(
+    authHeader,
+    HttpClientRequest.setHeader("User-Agent", cliConfig.userAgent),
+  );
+  const projectResp = yield* httpClient.execute(projectReq).pipe(Effect.option);
+  if (projectResp._tag === "None" || projectResp.value.status !== 200) {
+    return false;
+  }
+  const projectBody = yield* projectResp.value.json.pipe(Effect.option);
+  if (projectBody._tag === "None") {
+    return false;
+  }
+  const orgSlug = readString(projectBody.value, "organization_slug");
+  if (orgSlug.length === 0) {
+    return false;
+  }
+
+  const entReq = HttpClientRequest.get(`${apiUrl}/v1/organizations/${orgSlug}/entitlements`).pipe(
+    authHeader,
+    HttpClientRequest.setHeader("User-Agent", cliConfig.userAgent),
+  );
+  const entResp = yield* httpClient.execute(entReq).pipe(Effect.option);
+  if (entResp._tag === "None" || entResp.value.status !== 200) {
+    return false;
+  }
+  const entBody = yield* entResp.value.json.pipe(Effect.option);
+  if (entBody._tag === "None") {
+    return false;
+  }
+  const entitlements = (entBody.value as { entitlements?: unknown }).entitlements;
+  if (!Array.isArray(entitlements)) {
+    return false;
+  }
+
+  const gated = entitlements.some((entry: unknown) => {
+    if (typeof entry !== "object" || entry === null) return false;
+    const feature = (entry as { feature?: unknown }).feature;
+    if (typeof feature !== "object" || feature === null) return false;
+    const key = (feature as { key?: unknown }).key;
+    const hasAccess = (entry as { hasAccess?: unknown }).hasAccess;
+    return key === opts.featureKey && hasAccess === false;
+  });
+  if (!gated) {
+    return false;
+  }
+
+  const billingUrl = legacyBillingUrl(cliConfig.profile, orgSlug);
+  const suggestion = planGateSuggestion(styleText("bold", billingUrl));
 
   if (output.format === "text") {
     yield* output.raw(suggestion + "\n", "stderr");
@@ -217,8 +187,8 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
 
   if (opts.trackAnalytics !== false) {
     yield* analytics.capture(EventUpgradeSuggested, {
-      [PropFeatureKey]: gate.feature,
-      [PropOrgSlug]: gate.orgSlug,
+      [PropFeatureKey]: opts.featureKey,
+      [PropOrgSlug]: orgSlug,
     });
   }
 

--- a/apps/cli/src/legacy/shared/legacy-upgrade-suggest.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-upgrade-suggest.unit.test.ts
@@ -241,52 +241,23 @@ describe("legacySuggestUpgrade", () => {
     return legacyJsonResponse(request, status, body);
   }
 
-  it.live("envelope path suggests with zero API calls and envelope-derived telemetry", () => {
-    const { layer, out, analytics, api } = setup();
-    return Effect.gen(function* () {
-      yield* legacySuggestUpgrade({
-        projectRef: LEGACY_VALID_REF,
-        featureKey: "branching_limit",
-        statusCode: 402,
-        response: gateResponse(402, ENVELOPE_BODY),
-      });
-      expect(api.requests).toHaveLength(0);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(out.stderrText).toContain("/org/env-org/billing");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "branching_persistent", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("envelope path works without a featureKey (envelope-only sites)", () => {
-    const { layer, out, analytics, api } = setup();
-    return Effect.gen(function* () {
-      yield* legacySuggestUpgrade({
-        projectRef: LEGACY_VALID_REF,
-        statusCode: 400,
-        response: gateResponse(400, {
-          message: "add-on required",
-          error: {
-            code: "entitlement_required",
-            feature: "custom_domain",
-            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
-          },
-        }),
-      });
-      expect(api.requests).toHaveLength(0);
-      expect(out.stderrText).toContain("Upgrade your plan:");
-      expect(analytics.captured).toEqual([
-        {
-          event: "cli_upgrade_suggested",
-          properties: { feature_key: "custom_domain", org_slug: "env-org" },
-        },
-      ]);
-    }).pipe(Effect.provide(layer));
-  });
+  it.live(
+    "returns without hint, telemetry, or API calls when the response carries the envelope",
+    () => {
+      const { layer, out, analytics, api } = setup();
+      return Effect.gen(function* () {
+        yield* legacySuggestUpgrade({
+          projectRef: LEGACY_VALID_REF,
+          featureKey: "branching_limit",
+          statusCode: 402,
+          response: gateResponse(402, ENVELOPE_BODY),
+        });
+        expect(api.requests).toHaveLength(0);
+        expect(out.stderrText).toBe("");
+        expect(analytics.captured).toEqual([]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 
   it.live("a caller-provided reconciled token authenticates the fallback GETs", () => {
     // Go resolves credentials for the process-wide reconciled CurrentProfile —
@@ -376,33 +347,6 @@ describe("legacySuggestUpgrade", () => {
       });
       expect(api.requests).toHaveLength(2);
       expect(out.stderrText).toContain("/org/test-org/billing");
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("envelope path respects json output mode (no stderr, telemetry fires)", () => {
-    const { layer, out, analytics } = setup({ format: "json" });
-    return Effect.gen(function* () {
-      yield* legacySuggestUpgrade({
-        projectRef: LEGACY_VALID_REF,
-        statusCode: 402,
-        response: gateResponse(402, ENVELOPE_BODY),
-      });
-      expect(out.stderrText).toBe("");
-      expect(analytics.captured).toHaveLength(1);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("envelope path respects trackAnalytics=false", () => {
-    const { layer, out, analytics } = setup();
-    return Effect.gen(function* () {
-      yield* legacySuggestUpgrade({
-        projectRef: LEGACY_VALID_REF,
-        statusCode: 402,
-        response: gateResponse(402, ENVELOPE_BODY),
-        trackAnalytics: false,
-      });
-      expect(analytics.captured).toHaveLength(0);
-      expect(out.stderrText).toContain("Upgrade your plan:");
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/cli/src/shared/api/plan-gate.ts
+++ b/apps/cli/src/shared/api/plan-gate.ts
@@ -1,0 +1,66 @@
+export interface PlanGateEntitlement {
+  readonly feature: string;
+  readonly upgrade_url: string;
+}
+
+function readString(obj: unknown, key: string): string {
+  if (typeof obj === "object" && obj !== null && key in obj) {
+    const value = (obj as Record<string, unknown>)[key];
+    return typeof value === "string" ? value : "";
+  }
+  return "";
+}
+
+const MAX_FIELD_LEN = 2048;
+
+// Both fields print raw to the terminal and into machine-readable output, so a
+// value with control characters or absurd length is malformed: no envelope.
+function isCleanField(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_FIELD_LEN) return false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
+// Hand-validated: the packages/api codegen emits no non-2xx schemas.
+export function parsePlanGateEnvelope(body: unknown): PlanGateEntitlement | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const error = (body as { readonly error?: unknown }).error;
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = readString(error, "code");
+  const feature = readString(error, "feature");
+  const upgradeUrl = readString(error, "upgrade_url");
+  if (code !== "entitlement_required" || !isCleanField(feature) || !isCleanField(upgradeUrl)) {
+    return undefined;
+  }
+  return { feature, upgrade_url: upgradeUrl };
+}
+
+export function parsePlanGateEnvelopeText(raw: string): PlanGateEntitlement | undefined {
+  try {
+    return parsePlanGateEnvelope(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+export function planGateSuggestion(renderedUpgradeUrl: string): string {
+  return `Your organization does not have access to this feature. Upgrade your plan: ${renderedUpgradeUrl}`;
+}
+
+export function orgSlugFromUpgradeUrl(upgradeUrl: string): string {
+  const match = /\/org\/([^/?#]+)/.exec(upgradeUrl);
+  return match?.[1] ?? "";
+}
+
+export function errorEntitlement(error: unknown): PlanGateEntitlement | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const value = (error as { readonly entitlement?: unknown }).entitlement;
+  if (typeof value !== "object" || value === null) return undefined;
+  const feature = readString(value, "feature");
+  const upgradeUrl = readString(value, "upgrade_url");
+  if (!isCleanField(feature) || !isCleanField(upgradeUrl)) return undefined;
+  return { feature, upgrade_url: upgradeUrl };
+}

--- a/apps/cli/src/shared/api/plan-gate.unit.test.ts
+++ b/apps/cli/src/shared/api/plan-gate.unit.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  errorEntitlement,
+  orgSlugFromUpgradeUrl,
+  parsePlanGateEnvelope,
+  parsePlanGateEnvelopeText,
+  planGateSuggestion,
+} from "./plan-gate.ts";
+
+const ENVELOPE = {
+  message: "Custom domains require the Pro plan",
+  error: {
+    code: "entitlement_required",
+    feature: "custom_domain",
+    upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+  },
+};
+
+describe("parsePlanGateEnvelope", () => {
+  it("parses a full envelope into the wire shape", () => {
+    expect(parsePlanGateEnvelope(ENVELOPE)).toEqual({
+      feature: "custom_domain",
+      upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+    });
+  });
+
+  it("rejects a non-entitlement code", () => {
+    const body = { error: { ...ENVELOPE.error, code: "other" } };
+    expect(parsePlanGateEnvelope(body)).toBeUndefined();
+  });
+
+  it("rejects a missing feature", () => {
+    const body = { error: { code: "entitlement_required", upgrade_url: "https://x" } };
+    expect(parsePlanGateEnvelope(body)).toBeUndefined();
+  });
+
+  it("rejects a missing upgrade_url", () => {
+    const body = { error: { code: "entitlement_required", feature: "custom_domain" } };
+    expect(parsePlanGateEnvelope(body)).toBeUndefined();
+  });
+
+  it("rejects non-object bodies", () => {
+    expect(parsePlanGateEnvelope("nope")).toBeUndefined();
+    expect(parsePlanGateEnvelope(null)).toBeUndefined();
+    expect(parsePlanGateEnvelope([])).toBeUndefined();
+  });
+
+  it("rejects fields containing control characters", () => {
+    const ansi = {
+      error: { ...ENVELOPE.error, upgrade_url: "https://x/org/o/billing[2J[H" },
+    };
+    const newline = { error: { ...ENVELOPE.error, feature: "custom\ndomain" } };
+    expect(parsePlanGateEnvelope(ansi)).toBeUndefined();
+    expect(parsePlanGateEnvelope(newline)).toBeUndefined();
+  });
+
+  it("rejects oversized fields", () => {
+    const body = { error: { ...ENVELOPE.error, upgrade_url: `https://x/${"a".repeat(2048)}` } };
+    expect(parsePlanGateEnvelope(body)).toBeUndefined();
+  });
+});
+
+describe("parsePlanGateEnvelopeText", () => {
+  it("parses raw JSON text", () => {
+    expect(parsePlanGateEnvelopeText(JSON.stringify(ENVELOPE))).toEqual({
+      feature: "custom_domain",
+      upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+    });
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    expect(parsePlanGateEnvelopeText("{truncated")).toBeUndefined();
+    expect(parsePlanGateEnvelopeText("")).toBeUndefined();
+  });
+});
+
+describe("orgSlugFromUpgradeUrl", () => {
+  it("extracts the org slug", () => {
+    expect(orgSlugFromUpgradeUrl("https://supabase.com/dashboard/org/env-org/billing")).toBe(
+      "env-org",
+    );
+  });
+
+  it("returns empty string when no org segment exists", () => {
+    expect(orgSlugFromUpgradeUrl("https://supabase.com/dashboard/billing")).toBe("");
+  });
+
+  it("stops at query and fragment delimiters", () => {
+    expect(orgSlugFromUpgradeUrl("https://supabase.com/dashboard/org/env-org?tab=billing")).toBe(
+      "env-org",
+    );
+    expect(orgSlugFromUpgradeUrl("https://supabase.com/dashboard/org/env-org#billing")).toBe(
+      "env-org",
+    );
+  });
+});
+
+describe("errorEntitlement", () => {
+  it("reads a valid entitlement off an error-shaped object", () => {
+    const error = {
+      _tag: "SomeError",
+      entitlement: { feature: "custom_domain", upgrade_url: "https://x/org/o/billing" },
+    };
+    expect(errorEntitlement(error)).toEqual({
+      feature: "custom_domain",
+      upgrade_url: "https://x/org/o/billing",
+    });
+  });
+
+  it("rejects malformed entitlement values", () => {
+    expect(errorEntitlement({ entitlement: { feature: "x" } })).toBeUndefined();
+    expect(errorEntitlement({ entitlement: "custom_domain" })).toBeUndefined();
+    expect(errorEntitlement({})).toBeUndefined();
+    expect(errorEntitlement(undefined)).toBeUndefined();
+    expect(
+      errorEntitlement({
+        entitlement: { feature: "x", upgrade_url: "https://x/org/o[2J" },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("planGateSuggestion", () => {
+  it("wraps the rendered url in the fixed prose", () => {
+    expect(planGateSuggestion("URL")).toBe(
+      "Your organization does not have access to this feature. Upgrade your plan: URL",
+    );
+  });
+});

--- a/apps/cli/src/shared/output/normalize-error.ts
+++ b/apps/cli/src/shared/output/normalize-error.ts
@@ -1,5 +1,6 @@
 import { Cause, Option } from "effect";
 import { CliError } from "effect/unstable/cli";
+import { errorEntitlement, type PlanGateEntitlement } from "../api/plan-gate.ts";
 import { formatInvalidValueMessage } from "../cli/invalid-value-message.ts";
 import type { CliErrorSuggestionContext } from "../cli/subcommand-flag-suggestions.ts";
 import { formatCliErrorsForDisplay } from "../cli/subcommand-flag-suggestions.ts";
@@ -9,6 +10,7 @@ type NormalizedCliError = {
   readonly message: string;
   readonly detail?: string;
   readonly suggestion?: string;
+  readonly entitlement?: PlanGateEntitlement;
 };
 
 type ErrorRecord = Record<string, unknown>;
@@ -207,11 +209,13 @@ export function normalizeCliError(
     // `Fprintln(os.Stderr, CmdSuggestion)`). `readString` would trim exactly
     // that away.
     const suggestion = readRawString(error, "suggestion");
+    const entitlement = errorEntitlement(error);
     return {
       code,
       message,
       ...(detail && detail !== message ? { detail } : {}),
       ...(suggestion !== undefined && suggestion.length > 0 ? { suggestion } : {}),
+      ...(entitlement ? { entitlement } : {}),
     };
   }
 

--- a/apps/cli/src/shared/output/normalize-error.unit.test.ts
+++ b/apps/cli/src/shared/output/normalize-error.unit.test.ts
@@ -41,6 +41,30 @@ describe("normalizeCliError", () => {
     });
   });
 
+  test("passes entitlement and suggestion through the generic fallback", () => {
+    const error = {
+      _tag: "LegacyDomainsUnexpectedStatusError",
+      message: "unexpected get hostname status 400: {}",
+      suggestion:
+        "Your organization does not have access to this feature. Upgrade your plan: https://supabase.com/dashboard/org/env-org/billing",
+      entitlement: {
+        feature: "custom_domain",
+        upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+      },
+    };
+    expect(normalizeCliError(error)).toEqual({
+      code: "LegacyDomainsUnexpectedStatusError",
+      message: "unexpected get hostname status 400: {}",
+      suggestion: error.suggestion,
+      entitlement: error.entitlement,
+    });
+  });
+
+  test("drops malformed entitlement fields", () => {
+    const error = { _tag: "SomeError", message: "boom", entitlement: { feature: "x" } };
+    expect(normalizeCliError(error)).toEqual({ code: "SomeError", message: "boom" });
+  });
+
   test("MissingOption renders Go Cobra's `required flag(s) X not set` wording", () => {
     const error = { _tag: "MissingOption", option: "type" };
     expect(normalizeCliError(error)).toEqual({

--- a/apps/cli/src/shared/output/output.layer.ts
+++ b/apps/cli/src/shared/output/output.layer.ts
@@ -16,6 +16,7 @@ import {
 import { styleText } from "node:util";
 import { Effect, Layer, Option, Stdio, Stream } from "effect";
 
+import { type PlanGateEntitlement, planGateSuggestion } from "../api/plan-gate.ts";
 import { Tty } from "../runtime/tty.service.ts";
 import { CONTEXT_CANCELED_MESSAGE, NonInteractiveError } from "./errors.ts";
 import { MachineErrorContext } from "./machine-error-context.service.ts";
@@ -353,18 +354,33 @@ export const textOutputLayer = Layer.effect(
           };
         }),
       success: (message: string) => Effect.sync(() => log.success(message)),
-      fail: (err: { code: string; message: string; detail?: string; suggestion?: string }) =>
+      fail: (err: {
+        code: string;
+        message: string;
+        detail?: string;
+        suggestion?: string;
+        entitlement?: PlanGateEntitlement;
+      }) =>
         Effect.sync(() => {
           // Matches Go's `recoverAndExit` (apps/cli-go/cmd/root.go:300-303): a
-          // red-styled message on stderr, optionally followed by a suggestion.
+          // red-styled message on stderr, optionally followed by a suggestion;
+          // entitlement denials print Go's upgrade hint before the message.
           // Bypasses clack's `log.error` framing (`│` guide + `■` icon) so the
           // output byte-matches the Go CLI for parity tests.
+          if (err.entitlement !== undefined) {
+            process.stderr.write(
+              planGateSuggestion(styleText("bold", err.entitlement.upgrade_url)) + "\n",
+            );
+          }
           process.stderr.write(styleText("red", err.message) + "\n");
           if (err.detail !== undefined && err.detail !== err.message) {
             process.stderr.write(styleText("gray", err.detail) + "\n");
           }
-          if (err.suggestion !== undefined) {
-            process.stderr.write(err.suggestion + "\n");
+          // Entitlement errors' `suggestion` is the hint already rendered above;
+          // consume the slot so the --debug line keeps printing.
+          const suggestion = err.entitlement === undefined ? err.suggestion : undefined;
+          if (suggestion !== undefined) {
+            process.stderr.write(suggestion + "\n");
           } else if (
             err.message !== CONTEXT_CANCELED_MESSAGE &&
             !process.argv.includes("--debug")
@@ -460,7 +476,13 @@ export const jsonOutputLayer = Layer.effect(
         }),
       success: (message: string, data?: Record<string, unknown>) =>
         writeStdout(JSON.stringify({ ...data, message }) + "\n"),
-      fail: (err: { code: string; message: string; detail?: string; suggestion?: string }) =>
+      fail: (err: {
+        code: string;
+        message: string;
+        detail?: string;
+        suggestion?: string;
+        entitlement?: PlanGateEntitlement;
+      }) =>
         Effect.gen(function* () {
           const extra = yield* readMachineErrorContext();
           // `extra` spreads FIRST so the envelope's own `_tag`/`error` can
@@ -564,7 +586,13 @@ export const streamJsonOutputLayer = Layer.effect(
             timestamp: new Date().toISOString(),
           }) + "\n",
         ),
-      fail: (err: { code: string; message: string; detail?: string; suggestion?: string }) =>
+      fail: (err: {
+        code: string;
+        message: string;
+        detail?: string;
+        suggestion?: string;
+        entitlement?: PlanGateEntitlement;
+      }) =>
         Effect.gen(function* () {
           const extra = yield* readMachineErrorContext();
           const event: StreamEvent = {

--- a/apps/cli/src/shared/output/output.layer.unit.test.ts
+++ b/apps/cli/src/shared/output/output.layer.unit.test.ts
@@ -708,6 +708,38 @@ describe("Output", () => {
       }).pipe(Effect.provide(layer));
     });
 
+    it.effect("fail carries entitlement and suggestion on the JSON error object", () => {
+      const mock = mockStdio();
+      const layer = jsonOutputLayer.pipe(Layer.provide(mock.layer));
+      return Effect.gen(function* () {
+        const out = yield* Output;
+        yield* out.fail({
+          code: "LegacyDomainsUnexpectedStatusError",
+          message: "unexpected get hostname status 403: {}",
+          suggestion:
+            "Your organization does not have access to this feature. Upgrade your plan: https://supabase.com/dashboard/org/env-org/billing",
+          entitlement: {
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        });
+        expect(JSON.parse(mock.stdout[0]!)).toEqual({
+          _tag: "Error",
+          error: {
+            code: "LegacyDomainsUnexpectedStatusError",
+            message: "unexpected get hostname status 403: {}",
+            suggestion:
+              "Your organization does not have access to this feature. Upgrade your plan: https://supabase.com/dashboard/org/env-org/billing",
+            entitlement: {
+              feature: "custom_domain",
+              upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+            },
+          },
+        });
+        expect(mock.stderr).toEqual([]);
+      }).pipe(Effect.provide(layer));
+    });
+
     // CLI-2167 follow-up: `MachineErrorContext` is a command-scoped, opt-in
     // cell — merged ALONGSIDE the output layer (not nested inside its own
     // `Layer.provide`), matching how a real command runtime composes it, so
@@ -992,6 +1024,37 @@ describe("Output", () => {
           code: "E_FAIL",
           message: "boom",
           suggestion: "try again",
+        });
+        expect(parsed.timestamp).toBeDefined();
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("fail carries entitlement on the error event", () => {
+      const mock = mockStdio();
+      const layer = streamJsonOutputLayer.pipe(Layer.provide(mock.layer));
+      return Effect.gen(function* () {
+        const out = yield* Output;
+        yield* out.fail({
+          code: "LegacyDomainsUnexpectedStatusError",
+          message: "unexpected get hostname status 403: {}",
+          suggestion:
+            "Your organization does not have access to this feature. Upgrade your plan: https://supabase.com/dashboard/org/env-org/billing",
+          entitlement: {
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
+        });
+        const parsed = JSON.parse(mock.stdout[0]!);
+        expect(parsed.type).toBe("error");
+        expect(parsed.error).toEqual({
+          code: "LegacyDomainsUnexpectedStatusError",
+          message: "unexpected get hostname status 403: {}",
+          suggestion:
+            "Your organization does not have access to this feature. Upgrade your plan: https://supabase.com/dashboard/org/env-org/billing",
+          entitlement: {
+            feature: "custom_domain",
+            upgrade_url: "https://supabase.com/dashboard/org/env-org/billing",
+          },
         });
         expect(parsed.timestamp).toBeDefined();
       }).pipe(Effect.provide(layer));

--- a/apps/cli/src/shared/output/output.service.ts
+++ b/apps/cli/src/shared/output/output.service.ts
@@ -1,6 +1,7 @@
 import type { Effect } from "effect";
 import { Context } from "effect";
 
+import type { PlanGateEntitlement } from "../api/plan-gate.ts";
 import type { NonInteractiveError } from "./errors.ts";
 import type { OutputFormat, StreamEvent } from "./types.ts";
 
@@ -86,6 +87,7 @@ interface OutputShape {
     readonly message: string;
     readonly detail?: string;
     readonly suggestion?: string;
+    readonly entitlement?: PlanGateEntitlement;
   }) => Effect.Effect<void>;
   /**
    * Writes a raw chunk to stdout or stderr without framing.

--- a/apps/cli/src/shared/output/types.ts
+++ b/apps/cli/src/shared/output/types.ts
@@ -1,3 +1,5 @@
+import type { PlanGateEntitlement } from "../api/plan-gate.ts";
+
 export type OutputFormat = "text" | "json" | "stream-json";
 
 export type StreamEvent =
@@ -27,6 +29,7 @@ export type StreamEvent =
         readonly message: string;
         readonly detail?: string;
         readonly suggestion?: string;
+        readonly entitlement?: PlanGateEntitlement;
       };
       readonly timestamp: string;
     }

--- a/apps/cli/tests/helpers/legacy-mocks.ts
+++ b/apps/cli/tests/helpers/legacy-mocks.ts
@@ -446,12 +446,18 @@ export function legacyTransportFailure(
  * given status code. Useful for the direct-service mock when the handler under
  * test branches on `HttpClientError.isHttpClientError(cause)` + `cause.response.status`.
  */
-export function legacyStatusCodeFailure(status: number): HttpClientError.HttpClientError {
+export function legacyStatusCodeFailure(
+  status: number,
+  body?: unknown,
+): HttpClientError.HttpClientError {
   const request = HttpClientRequestModule.get("https://api.supabase.com/mock");
-  const response = HttpClientResponse.fromWeb(
-    request,
-    new Response("", { status, headers: { "content-type": "application/json" } }),
-  );
+  const response =
+    body === undefined
+      ? HttpClientResponse.fromWeb(
+          request,
+          new Response("", { status, headers: { "content-type": "application/json" } }),
+        )
+      : legacyJsonResponse(request, status, body);
   return new HttpClientError.HttpClientError({
     reason: new HttpClientError.StatusCodeError({ request, response }),
   });

--- a/apps/cli/tests/helpers/legacy-storage.ts
+++ b/apps/cli/tests/helpers/legacy-storage.ts
@@ -13,7 +13,7 @@ import { LegacyProjectNotLinkedError } from "../../src/legacy/config/legacy-proj
 import { LegacyProjectRefResolver } from "../../src/legacy/config/legacy-project-ref.service.ts";
 import { LegacyYesFlag } from "../../src/shared/legacy/global-flags.ts";
 import type { OutputFormat } from "../../src/shared/output/types.ts";
-import { mockOutput, mockRuntimeInfo, mockStdin, mockTty } from "./mocks.ts";
+import { mockAnalytics, mockOutput, mockRuntimeInfo, mockStdin, mockTty } from "./mocks.ts";
 import {
   LEGACY_VALID_REF,
   legacyJsonResponse,
@@ -207,6 +207,7 @@ export function setupLegacyStorage(workdir: string, opts: SetupLegacyStorageOpti
     httpLayer,
     telemetry.layer,
     linkedCache.layer,
+    mockAnalytics().layer,
     mockLegacyCliConfig({ workdir }),
     BunServices.layer,
     projectRefLayer,


### PR DESCRIPTION
The management API marks plan-gated denials with a structured `entitlement_required` envelope (shipped in GROWTH-957), but the CLI consumed it per call site: ~14 commands wired their own hint emission, unwired commands (like `backups list`) showed nothing, and agents in JSON mode had to regex prose to discover an upgrade was needed. I moved the envelope handling into one central path so any plan-gated denial, on any command, surfaces which feature is gated and where to upgrade, for both humans and agents, with zero extra round trips and zero per-command wiring.

Re-landed on post-CLI-1970 develop: with the Go-to-TS port complete, every Management API command now flows through the TS shell's error mapper, so the central handler covers the full command surface.

fixes GROWTH-1050

**Changed:**

- `mapLegacyHttpError` now parses the envelope once from the raw response text (before the 1024-char body truncation) and attaches optional `entitlement: { feature, upgrade_url }`, `suggestion`, and `upgradeSuggested` fields to the tagged status error. Effect's `Data.TaggedError` copies extra constructor args onto the instance, so the output fields needed no per-family error-class edits, only the factory type widens.
- The parser, hint prose, and `errorEntitlement` reader now live in `src/shared/api/plan-gate.ts` (management-API contract, reusable by the next shell), hoisted out of `legacy-upgrade-suggest.ts`.
- JSON and stream-json error output carry the fields verbatim: `{ "_tag": "Error", "error": { code, message, suggestion, entitlement } }`. `entitlement` presence is the machine-readable discriminator; the field is an optional enhancement, absent on envelope-less servers.
- Text mode renders the upgrade hint centrally in `textOutputLayer.fail` (hint, then red message, then the `--debug` line), byte-identical to the previous per-site output. Entitlement errors treat the `suggestion` slot as consumed so the `--debug` line keeps printing.
- `cli_upgrade_suggested` fires at envelope-parse time inside `mapLegacyHttpError`, exactly once per denial in every output mode, with the same `{feature_key, org_slug}` payload. The vanity `check-availability` Go-parity suppression became a `trackUpgradeSuggested: false` mapper flag.
- `legacySuggestUpgrade` is now fallback-only (entitlements round-trip for envelope-less denials: v1 SSO, older servers). On envelope-carrying denials it returns the confirmed-gated boolean for error classification but performs no side effects. The five envelope-only `legacyGateMapError` wrappers (domains x4, vanity get) were dead under that guard and are deleted.
- Error-taxonomy integration (new since the original branch; #6132 landed in between): the centrally attached `upgradeSuggested` feeds `statusCodeActionability`, so every envelope-carrying gate now classifies as `plan_limit` in the `cli_command_executed` failure taxonomy with zero per-command wiring. The domains and vanity-get error classes pick up the typed signal their "until that typed signal is threaded" comments were waiting for. For envelope-less gates the mapper accepts the fallback boolean per call, `mapper(cause, { upgradeSuggested })`, which replaced the flip-and-reconstruct threading in `branches create/update` that would otherwise have dropped the centrally attached fields.
- Contract pins: a `backups list` integration test proves a never-wired command gets fields + telemetry; e2e tests pin the JSON error shape and text-mode exactly-once for both the never-wired and previously-wired buckets (the double-print regression guard); AGENTS.md documents the central-handler doctrine, the dormant v1 SSO bypasses, and scopes the deliberate Go divergence under ADR-0016's authority rules.

Not in scope: `shared/functions/download.ts` and `deploy.ts` map transport errors locally (`shared/` cannot import `legacy/`), so they would swallow an envelope if a functions route ever gained a gate. No functions route is entitlement-gated today; flagging for whenever one is.
