### PR TITLE
fix(cli): start secrets selinux

### DIFF
--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -93,8 +93,8 @@ vi.mock("../../../../shared/functions/deploy.ts", async () => {
         )[0];
         const multilineEnvDir = args
           .flatMap((value, index) => (args[index - 1] === "-v" ? [value] : []))
-          .find((value) => value.endsWith(":/root/.supabase/multiline-env:ro"))
-          ?.slice(0, -":/root/.supabase/multiline-env:ro".length);
+          .find((value) => value.endsWith(":/root/.supabase/multiline-env:ro,Z"))
+          ?.slice(0, -":/root/.supabase/multiline-env:ro,Z".length);
         const enrichedOptions =
           envFile === undefined && multilineEnvDir === undefined
             ? options
@@ -482,7 +482,7 @@ describe("legacy functions serve integration", () => {
         expect(dockerRun.args).toContain("public.ecr.aws/supabase/edge-runtime:v1.73.13");
         expect(
           extractFlagValues(dockerRun.args, "-v").some((value) =>
-            value.endsWith(":/root/index.ts:ro"),
+            value.endsWith(":/root/index.ts:ro,Z"),
           ),
         ).toBe(true);
         expect(dockerRun.args[dockerRun.args.length - 1]).toBe(
@@ -568,8 +568,8 @@ describe("legacy functions serve integration", () => {
             throw new Error("expected docker run call before docker logs spawn");
           }
           multilineEnvDirWhenLogsStarted = extractFlagValues(dockerRun.args, "-v")
-            .find((value) => value.endsWith(":/root/.supabase/multiline-env:ro"))
-            ?.slice(0, -":/root/.supabase/multiline-env:ro".length);
+            .find((value) => value.endsWith(":/root/.supabase/multiline-env:ro,Z"))
+            ?.slice(0, -":/root/.supabase/multiline-env:ro,Z".length);
           multilineEnvDirExistedWhenLogsStarted =
             multilineEnvDirWhenLogsStarted !== undefined &&
             existsSync(multilineEnvDirWhenLogsStarted);
@@ -615,7 +615,7 @@ describe("legacy functions serve integration", () => {
       expect(dockerRun.args.join(" ")).not.toContain("EOF_ENV_0");
 
       const multilineBind = extractFlagValues(dockerRun.args, "-v").find((value) =>
-        value.endsWith(":/root/.supabase/multiline-env:ro"),
+        value.endsWith(":/root/.supabase/multiline-env:ro,Z"),
       );
       expect(multilineBind).toBeDefined();
       if (multilineBind === undefined) {
@@ -727,7 +727,7 @@ describe("legacy functions serve integration", () => {
         }
         expect(
           extractFlagValues(dockerRun.args, "-v").some((value) =>
-            value.endsWith(":/root/.supabase/multiline-env:ro"),
+            value.endsWith(":/root/.supabase/multiline-env:ro,Z"),
           ),
         ).toBe(false);
       });
@@ -1445,7 +1445,7 @@ describe("legacy functions serve integration", () => {
       );
       expect(
         extractFlagValues(dockerRun.args, "-v").some((value) =>
-          value.endsWith(":/root/index.ts:ro"),
+          value.endsWith(":/root/index.ts:ro,Z"),
         ),
       ).toBe(true);
       expect(commandScript).not.toContain("@ts-nocheck");

--- a/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/start/SIDE_EFFECTS.md
@@ -113,8 +113,10 @@ written to `<workdir>/supabase/.temp/start-secrets/<containerName>/` (directory 
 `0700`, files mode `0644` — world-readable, since Kong (uid 100) and Postgres's
 post-privilege-drop `postgres` user read these bind-mounted files as non-root, and a
 Linux/Podman bind mount preserves the host file's mode verbatim) and
-bind-mounted `:ro` into the container at the exact path each container's
-entrypoint/`Cmd` expects — see `container-lifecycle.ts`'s `legacyStageStartSecretFiles`
+bind-mounted `:ro,Z` into the container at the exact path each container's
+entrypoint/`Cmd` expects (`Z` — private SELinux relabel of these CLI-generated files so
+the confined container can read them on SELinux-enforcing hosts; no-op elsewhere) —
+see `container-lifecycle.ts`'s `legacyStageStartSecretFiles`
 doc comment for the full rationale (CWE-214/522: keeping secret content out of the
 `docker create` argv the host can see via `ps`/`/proc/<pid>/cmdline`) and for why this
 directory is a DETERMINISTIC, PERSISTENT path under the project's own workdir rather
@@ -132,7 +134,7 @@ script + value files, and bootstrap `index.ts` template (`shared/functions/serve
 `writeDockerEnvFile`/`writeDockerMultilineEnvScript`/`writeServeMainTemplateFile`) are
 staged the same way, under `<workdir>/supabase/.temp/start-secrets/<edgeRuntime
 containerName>/{env,multiline-env,main}/` (directory mode `0700`, files mode `0600`),
-bind-mounted `:ro` into the container — a deterministic, persistent path rather than
+bind-mounted `:ro,Z` into the container — a deterministic, persistent path rather than
 `os.tmpdir()` (which is frequently tmpfs and gets wiped on reboot) so
 `legacyCleanupStartSecrets` (see the Exit Codes/rollback section below) can reclaim
 them on `stop` or a failed-start rollback, exactly like the Kong/Postgres/Supavisor

--- a/apps/cli/src/legacy/commands/start/lib/container-lifecycle.ts
+++ b/apps/cli/src/legacy/commands/start/lib/container-lifecycle.ts
@@ -546,8 +546,9 @@ function legacyDockerStartContainer(
  * an arbitrary host-invoking uid at `0600` would get `EACCES` there — Go's
  * own equivalent (heredoc'd directly into the container by a root-authored
  * entrypoint script) already lands at world-readable `0644`, matching this
- * exactly — then returns the `<hostPath>:<containerPath>:ro`
- * bind for each. Mirrors this same session's `-e KEY`-only env fix
+ * exactly — then returns the `<hostPath>:<containerPath>:ro,Z` bind for each
+ * (`Z`: private SELinux relabel — see the inline comment at the bind).
+ * Mirrors this same session's `-e KEY`-only env fix
  * (`legacyDockerCreateContainer`'s doc comment) for entrypoint/`Cmd`-bound
  * secret content instead of env values: the file's HOST path is the only
  * thing that ever reaches `docker create`'s argv, never the secret `content`
@@ -603,7 +604,12 @@ function legacyStageStartSecretFiles(
             // `077`/`027`) can't silently narrow this to `0600` and break the non-root
             // in-container reader (see this function's doc comment).
             await chmod(hostPath, 0o644);
-            return `${hostPath}:${secretFile.containerPath}:ro`;
+            // `Z`: SELinux-enforcing hosts (e.g. Fedora + rootless Podman) relabel this
+            // CLI-generated file so the confined container can read it (supabase/cli#5989).
+            // Private label, not shared `z` — each staged dir is 1:1 with one container,
+            // and no sibling container has any business reading these secrets. No-op
+            // elsewhere; Docker/Podman ignore ENOTSUP from non-labelable filesystems.
+            return `${hostPath}:${secretFile.containerPath}:ro,Z`;
           }),
         );
         return { binds, cleanup: () => rm(dir, { recursive: true, force: true }) };

--- a/apps/cli/src/legacy/commands/start/lib/container-lifecycle.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/container-lifecycle.unit.test.ts
@@ -376,9 +376,9 @@ describe("legacyStartContainer secretFiles", () => {
       let dirModeAtCreateTime: number | undefined;
       const mock = mockSpawner((args) => {
         if (args[0] === "create") {
-          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro"));
+          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro,Z"));
           if (bind !== undefined) {
-            hostPath = bind.slice(0, bind.length - ":/etc/kong/kong.yml:ro".length);
+            hostPath = bind.slice(0, bind.length - ":/etc/kong/kong.yml:ro,Z".length);
             modeAtCreateTime = statSync(hostPath).mode & 0o777;
             dirModeAtCreateTime = statSync(dirname(hostPath)).mode & 0o777;
           }
@@ -407,7 +407,7 @@ describe("legacyStartContainer secretFiles", () => {
           expect(hostPath).toBeDefined();
           expect(modeAtCreateTime).toBe(0o644);
           expect(dirModeAtCreateTime).toBe(0o700);
-          expect(create).toContain(`${hostPath}:/etc/kong/kong.yml:ro`);
+          expect(create).toContain(`${hostPath}:/etc/kong/kong.yml:ro,Z`);
 
           // Deterministic — rooted in the project's own workdir, not an OS temp dir, and
           // scoped by container name so sibling services never collide.
@@ -432,9 +432,9 @@ describe("legacyStartContainer secretFiles", () => {
       let modeAtCreateTime: number | undefined;
       const mock = mockSpawner((args) => {
         if (args[0] === "create") {
-          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro"));
+          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro,Z"));
           if (bind !== undefined) {
-            hostPath = bind.slice(0, bind.length - ":/etc/kong/kong.yml:ro".length);
+            hostPath = bind.slice(0, bind.length - ":/etc/kong/kong.yml:ro,Z".length);
             modeAtCreateTime = statSync(hostPath).mode & 0o777;
           }
           return { exitCode: 0, stdout: "container-id-umask\n" };
@@ -502,8 +502,8 @@ describe("legacyStartContainer secretFiles", () => {
     let hostPath: string | undefined;
     const mock = mockSpawner((args) => {
       if (args[0] === "create") {
-        const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro"));
-        hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro".length);
+        const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro,Z"));
+        hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro,Z".length);
         return { exitCode: 1, stderr: "no such image\n" };
       }
       return { exitCode: 0 };
@@ -536,8 +536,8 @@ describe("legacyStartContainer secretFiles", () => {
       let hostPath: string | undefined;
       const mock = mockSpawner((args) => {
         if (args[0] === "create") {
-          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro"));
-          hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro".length);
+          const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro,Z"));
+          hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro,Z".length);
           return { exitCode: 0, stdout: "container-id-abc\n" };
         }
         if (args[0] === "start") {
@@ -587,8 +587,8 @@ describe("legacyStartContainer secretFiles", () => {
         Effect.gen(function* () {
           const args = command._tag === "StandardCommand" ? command.args : [];
           if (args[0] === "create") {
-            const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro"));
-            hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro".length);
+            const bind = args.find((a) => a.endsWith(":/etc/kong/kong.yml:ro,Z"));
+            hostPath = bind?.slice(0, bind.length - ":/etc/kong/kong.yml:ro,Z".length);
             yield* Deferred.succeed(createStarted, undefined);
             // Never resolves on its own — only interruption ends this "process".
             return ChildProcessSpawner.makeHandle({

--- a/apps/cli/src/legacy/commands/start/lib/docker-create-args.ts
+++ b/apps/cli/src/legacy/commands/start/lib/docker-create-args.ts
@@ -159,7 +159,7 @@ export interface LegacyStartContainerSpec {
    * non-root in-container user reading it (e.g. Kong, Postgres) doesn't hit
    * `EACCES` once the bind mount preserves this host mode verbatim; see
    * `legacyStageStartSecretFiles`'s doc comment — in a fresh temp
-   * directory) and appends a `<tempHostPath>:<containerPath>:ro` bind (the
+   * directory) and appends a `<tempHostPath>:<containerPath>:ro,Z` bind (the
    * bind's SOURCE is a generated temp-file path, never the secret itself —
    * safe in argv) to {@link binds} BEFORE this builder ever sees the spec,
    * then removes the temp file/directory once the container is created and

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -855,7 +855,9 @@ export ${name}="\${${name}%x}"`;
   await writeFile(path, script, { mode: 0o600 });
 
   return {
-    bind: `${dir}:${containerDir}:ro`,
+    // `Z`: private SELinux relabel of this CLI-staged dir (supabase/cli#5989);
+    // single-consumer bind, no-op without SELinux.
+    bind: `${dir}:${containerDir}:ro,Z`,
     scriptPath: join(containerDir, scriptName).replaceAll("\\", "/"),
   };
 }
@@ -1238,7 +1240,8 @@ async function writeServeMainTemplateFile(template: string, dir: string) {
   await mkdir(dir, { recursive: true, mode: 0o700 });
   const pathname = join(dir, "index.ts");
   await writeFile(pathname, template);
-  return { bind: `${pathname}:${serveMainContainerPath}:ro` } as const;
+  // `Z` — same SELinux relabel rationale as `writeDockerMultilineEnvScript`'s bind.
+  return { bind: `${pathname}:${serveMainContainerPath}:ro,Z` } as const;
 }
 
 function edgeRuntimeImageTag(version: string) {


### PR DESCRIPTION
## TL;DR

fixes `supabase start` failing with `EACCES on SELinux-enforcing hosts` (Fedora + rootless Podman) 
 containers couldn't read the CLI-staged files under `supabase/.temp/start-secrets/`
 (Postgres's `pgsodium_root.key` first, then Kong/Supavisor secrets and edge-runtime artifacts)

It was happening because of the missing SELinux relabel on those bind mounts,
the files keep the workspace label, which a confined container can't read despite the file mode.

So I've introduced a `Z` mount option for the three bind sites, which fixes it up: 
each file gets a private per-container label, sibling containers still can't read them, and user project sources are never touched. 
No-op without SELinux, and Docker/Podman both ignore ENOTSUP from non-labelable filesystems, so nothing currently working changes...

## refs

- closes #5989
Follow-up to #5990
