### PR TITLE
test(cli): parity keyring noise

### DIFF
--- a/packages/cli-test-helpers/src/normalize.ts
+++ b/packages/cli-test-helpers/src/normalize.ts
@@ -143,6 +143,16 @@ export function normalize(output: string, options: NormalizeOptions = {}): strin
         /^[^\n]*The name org\.freedesktop\.secrets was not provided by any \.service files\n?/gm,
         "",
       )
+      //      Third shape of the same class: a session bus that is present but
+      //      unreachable surfaces godbus errors ("dbus: couldn't determine
+      //      address of session bus") inside the same store.go wrappers,
+      //      including DeleteAll's "failed to delete all credentials in
+      //      Supabase CLI: %w" (logout). Anchored on the credentials wrappers
+      //      so genuine command errors are never stripped.
+      .replace(
+        /^failed to (?:load|set|delete(?: all)?) credentials(?: in [^:\n]+)?: dbus:[^\n]*\n?/gm,
+        "",
+      )
       // 17c. Docker image-pull progress streamed to stderr. The Go CLI pre-pulls
       //      via the Docker API and renders progress with jsonmessage
       //      (`apps/cli-go/internal/utils/docker.go:206-214`), while the ts-legacy

--- a/packages/cli-test-helpers/src/normalize.unit.test.ts
+++ b/packages/cli-test-helpers/src/normalize.unit.test.ts
@@ -190,6 +190,23 @@ describe("normalize", () => {
     );
   });
 
+  it("strips dbus session-bus keyring noise under every credentials wrapper", () => {
+    expect(
+      normalize("failed to load credentials: dbus: couldn't determine address of session bus\n"),
+    ).toBe("");
+    expect(
+      normalize(
+        "failed to delete all credentials in Supabase CLI: dbus: couldn't determine address of session bus\n",
+      ),
+    ).toBe("");
+  });
+
+  it("keeps genuine credentials failures intact", () => {
+    expect(normalize("failed to delete credentials: permission denied\n")).toBe(
+      "failed to delete credentials: permission denied\n",
+    );
+  });
+
   it("can strip caller-provided patterns before shared normalization", () => {
     expect(
       normalize("status: transient\nversion: 2.0.0", { stripPatterns: [/^status: .+\n/gm] }),


### PR DESCRIPTION
fixes:
<details>
<summary>ss</summary>

<img width="1266" height="909" alt="image" src="https://github.com/user-attachments/assets/082dcec5-3634-4408-83ac-f9b42a7d3da7" />

</details>