### PR TITLE
fix(stack): stage binary downloads and extract via atomic rename to avoid cross-process cache races

### DIFF
--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -268,12 +268,10 @@ flowchart TD
     B --> C{"assetName?"}
     C -->|"null"| D["BinaryNotFoundError"]
     C -->|"string"| E["construct cacheDir"]
-    E --> F{"fs.exists(cacheDir/.supabase-cache-complete)?"}
+    E --> F2["sweep stale cacheDir.tmp-* siblings (best-effort, always runs)"]
+    F2 --> F{"fs.exists(cacheDir/.supabase-cache-complete)?"}
     F -->|"yes"| G["return cacheDir (cache hit)"]
-    F -->|"no, cacheDir exists w/o marker"| F1["remove broken cacheDir leftover"]
-    F -->|"no, cacheDir absent"| F2["sweep stale cacheDir.tmp-* siblings (best-effort)"]
-    F1 --> F2
-    F2 --> H["HttpClient.get tarball from GitHub"]
+    F -->|"no"| H["HttpClient.get tarball from GitHub"]
     H -->|"network error"| I["DownloadError"]
     H -->|"ok"| J{"checksumUrl?"}
     J -->|"null"| L["skip verification"]
@@ -286,17 +284,20 @@ flowchart TD
     P --> Q["tar/unzip extract into tmpDir"]
     Q -->|"exitCode != 0"| R["DownloadError"]
     Q -->|"ok"| T["chmod +x, (macOS) codesign, write completion marker — all in tmpDir"]
-    T --> U["fs.rename(tmpDir, cacheDir) — atomic publish"]
+    T --> U["fs.rename(tmpDir, cacheDir)"]
     U -->|"ok"| G
     U -->|"rename fails, cacheDir has marker"| V["another process won — discard tmpDir, return cacheDir"]
-    U -->|"rename fails, cacheDir has no marker"| W["reclaim: remove broken cacheDir, retry rename"]
+    U -->|"rename fails, no marker, attempts remain"| W["reclaim: remove broken/legacy cacheDir, retry rename"]
+    U -->|"rename fails, no marker, attempts exhausted"| X["DownloadError"]
+    W --> U
     V --> G
-    W --> G
 ```
+
+Note that a markerless `cacheDir` (e.g. a legacy binary from before this marker existed) is never removed upfront on the miss check — only `W`, at publish time, ever removes one, and only once a fully-staged replacement (`tmpDir`) is ready to take its place.
 
 #### Cache layout
 
-The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is for a version-agnostic completion marker file (`.supabase-cache-complete`) inside `cacheDir`, not mere directory existence — `cacheDir` only ever becomes non-empty via an atomic rename of a fully-staged directory that carries this marker, so a `cacheDir` that exists but lacks it can only be a broken leftover (e.g. from an older, pre-staging CLI version) and is removed rather than reused.
+The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is for a version-agnostic completion marker file (`.supabase-cache-complete`) inside `cacheDir`, not mere directory existence. A `cacheDir` that exists but lacks the marker can only be a broken or legacy leftover (e.g. from an older, pre-staging CLI version) — but it is left in place rather than removed on the miss check. Deleting it eagerly, before even attempting a download, would destroy a plausibly-still-usable binary before knowing whether a replacement can be produced (an offline machine or a GitHub outage would otherwise turn a would-have-been cache hit into both a failure and a lost cache). It's reclaimed later, only at publish time, once a fully-staged replacement is ready to atomically take its place.
 
 ```
 ~/.supabase/bin/
@@ -331,7 +332,7 @@ After extraction, permissions are restored (`chmod`) and, on macOS, executables 
 The staging directory is then published by an atomic `fs.rename` into `cacheDir`:
 
 - If another process already published a complete `cacheDir` first (detected via the marker, not mere existence), the losing process discards its own staged copy and resolves to the winner's `cacheDir` instead of failing.
-- If `cacheDir` exists but isn't a complete, marker-carrying entry — a broken/incomplete leftover from an older, pre-staging CLI version, or the rename failing for an unrelated reason — the current process treats it as reclaimable: it removes the leftover and retries the rename. If a legitimate winner lands in the narrow gap between that reclaim and the retry, the retry's failure is treated the same way (re-checked against the marker) rather than surfacing as an error.
+- If `cacheDir` exists but isn't a complete, marker-carrying entry — a broken/legacy leftover (this is the only place such a leftover is ever removed — see "Cache layout" above), or the rename failing for an unrelated reason — the current process treats it as reclaimable: it removes the leftover and retries the rename, up to a small bounded number of attempts. If a legitimate winner lands in the narrow gap between that reclaim and the retry, the retry's failure is re-checked against the marker on every attempt (including the last) and the winner is adopted immediately, regardless of how many reclaim attempts remain. Only the destructive reclaim-and-retry path is bounded: a rename that keeps failing for a reason unrelated to a competing destination (permissions, a read-only filesystem, disk I/O) can never succeed no matter how many times it's retried, so once attempts are exhausted the real rename error is surfaced as a `DownloadError` instead of retrying forever.
 
 The whole stage-and-publish sequence runs under a single `Effect.ensuring` finalizer that force-removes the staging directory on any exit path (success, failure, or interruption), and a best-effort sweep opportunistically reaps stale `.tmp-*` siblings older than 24 hours left behind by prior hard-killed processes. That sweep runs unconditionally before the cache-hit check, since once `cacheDir` becomes a complete cache hit, a sweep placed after the check would never run again for that entry's siblings.
 

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -267,10 +267,13 @@ flowchart TD
     A["resolve(spec)"] --> B["detectPlatform"]
     B --> C{"assetName?"}
     C -->|"null"| D["BinaryNotFoundError"]
-    C -->|"string"| E["construct cachePath"]
-    E --> F{"fs.exists(cacheDir)?"}
-    F -->|"yes"| G["return cacheDir"]
-    F -->|"no"| H["HttpClient.get tarball from GitHub"]
+    C -->|"string"| E["construct cacheDir"]
+    E --> F{"fs.exists(cacheDir/.supabase-cache-complete)?"}
+    F -->|"yes"| G["return cacheDir (cache hit)"]
+    F -->|"no, cacheDir exists w/o marker"| F1["remove broken cacheDir leftover"]
+    F -->|"no, cacheDir absent"| F2["sweep stale cacheDir.tmp-* siblings (best-effort)"]
+    F1 --> F2
+    F2 --> H["HttpClient.get tarball from GitHub"]
     H -->|"network error"| I["DownloadError"]
     H -->|"ok"| J{"checksumUrl?"}
     J -->|"null"| L["skip verification"]
@@ -278,17 +281,22 @@ flowchart TD
     K --> M["verifyChecksum (SHA-256)"]
     M -->|"mismatch"| N["ChecksumMismatchError"]
     M -->|"ok"| L
-    L --> O["fs.makeDirectory (recursive)"]
-    O --> P["write _download.tar"]
-    P --> Q["tar xzf/xf to cacheDir"]
+    L --> O["fs.makeDirectory tmpDir = cacheDir.tmp-«uuid»"]
+    O --> P["write _download-«uuid».tar/.zip into tmpDir"]
+    P --> Q["tar/unzip extract into tmpDir"]
     Q -->|"exitCode != 0"| R["DownloadError"]
-    Q -->|"ok"| S["fs.remove _download.tar"]
-    S --> G
+    Q -->|"ok"| T["chmod +x, (macOS) codesign, write completion marker — all in tmpDir"]
+    T --> U["fs.rename(tmpDir, cacheDir) — atomic publish"]
+    U -->|"ok"| G
+    U -->|"rename fails, cacheDir has marker"| V["another process won — discard tmpDir, return cacheDir"]
+    U -->|"rename fails, cacheDir has no marker"| W["reclaim: remove broken cacheDir, retry rename"]
+    V --> G
+    W --> G
 ```
 
 #### Cache layout
 
-The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is a simple `fs.exists` — if the directory is present, it was extracted successfully on a previous run.
+The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is for a version-agnostic completion marker file (`.supabase-cache-complete`) inside `cacheDir`, not mere directory existence — `cacheDir` only ever becomes non-empty via an atomic rename of a fully-staged directory that carries this marker, so a `cacheDir` that exists but lacks it can only be a broken leftover (e.g. from an older, pre-staging CLI version) and is removed rather than reused.
 
 ```
 ~/.supabase/bin/
@@ -316,7 +324,16 @@ Only postgres publishes SHA-256 checksums alongside its tarballs (as `<tarball-u
 
 #### Archive extraction
 
-The download is written to a temporary file (`_download.tar` or `_download.zip`) inside the cache directory. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used with `--strip-components=1` to remove the top-level directory. For zip archives (PostgREST on Windows), `unzip` is used on Unix or `tar xf` on Windows. The `tar`/`unzip` subprocess is spawned via `ChildProcessSpawner` from `effect/unstable/process`. After extraction, the temp file is removed (errors ignored — a leftover file is harmless).
+To avoid corrupting `cacheDir` under concurrent invocations of the same spec, the download and extraction are staged in a per-invocation-unique sibling directory, `<cacheDir>.tmp-<uuid>`, never inside `cacheDir` itself. The archive is downloaded to a uniquely-named temp file inside that staging directory. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used with `--strip-components=1` to remove the top-level directory. For zip archives (PostgREST on Windows), `unzip` is used on Unix or `tar xf` on Windows. The `tar`/`unzip` subprocess is spawned via `ChildProcessSpawner` from `effect/unstable/process`.
+
+After extraction, permissions are restored (`chmod`) and, on macOS, executables are ad-hoc code-signed — all still scoped to the staging directory. A completion marker file (`.supabase-cache-complete`) is written into the staging directory last, so it travels with the payload.
+
+The staging directory is then published by an atomic `fs.rename` into `cacheDir`:
+
+- If another process already published a complete `cacheDir` first (detected via the marker, not mere existence), the losing process discards its own staged copy and resolves to the winner's `cacheDir` instead of failing.
+- If `cacheDir` exists but isn't a complete, marker-carrying entry — a broken/incomplete leftover from an older, pre-staging CLI version, or the rename failing for an unrelated reason — the current process treats it as reclaimable: it removes the leftover and retries the rename. If a legitimate winner lands in the narrow gap between that reclaim and the retry, the retry's failure is treated the same way (re-checked against the marker) rather than surfacing as an error.
+
+The whole stage-and-publish sequence runs under a single `Effect.ensuring` finalizer that force-removes the staging directory on any exit path (success, failure, or interruption), and a best-effort sweep opportunistically reaps stale `.tmp-*` siblings older than 24 hours left behind by prior hard-killed processes. That sweep runs unconditionally before the cache-hit check, since once `cacheDir` becomes a complete cache hit, a sweep placed after the check would never run again for that entry's siblings.
 
 #### Layer wiring
 

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -244,24 +244,23 @@ export class BinaryResolver extends Context.Service<
             // carrying a completion marker (see below), so we check for that
             // marker rather than mere non-emptiness — a cacheDir that exists
             // but lacks it can only be a broken leftover (e.g. from an older,
-            // pre-atomic-rename CLI version), never a valid cache entry.
+            // pre-staging CLI version). We deliberately do NOT remove it
+            // here: every cache entry written before this marker existed is
+            // markerless, so eagerly deleting it before we've even attempted
+            // a download would destroy a plausibly-still-usable legacy
+            // binary before knowing whether we can replace it (e.g. an
+            // offline invocation or a GitHub outage would previously have
+            // succeeded from that cache; deleting it upfront turns that into
+            // a hard failure with no cache left afterward either). It's left
+            // in place and only ever reclaimed later, in the publish step
+            // below, once a fully-staged replacement is ready to atomically
+            // take its place.
             const isComplete = yield* fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER));
             if (isComplete) {
               return {
                 path: cacheDir,
                 downloaded: false,
               } satisfies ResolveBinaryResult;
-            }
-            const isCached = yield* fs.exists(cacheDir);
-            if (isCached) {
-              // force: true — tolerate another process having already
-              // reclaimed and removed this same broken/markerless cacheDir
-              // concurrently (both processes can observe it before either
-              // removes it). Without force, the loser's remove would throw
-              // on the now-missing path and force an unnecessary Docker
-              // fallback even though the winner is about to publish a good
-              // native binary.
-              yield* fs.remove(cacheDir, { recursive: true, force: true });
             }
 
             yield* options?.onDownloadStart ?? Effect.void;
@@ -378,15 +377,23 @@ export class BinaryResolver extends Context.Service<
             // not mere existence), discard our own copy and resolve to
             // theirs instead of failing. If cacheDir exists but isn't a
             // complete, marker-carrying entry — a broken/incomplete leftover
-            // from an older, pre-atomic-rename CLI version, or the rename
-            // failed for some unrelated reason — our own staged build is the
-            // only known-good copy: reclaim the spot and retry the rename.
-            // A legitimate winner can also land in the narrow gap between
-            // the marker check and our own reclaim-and-retry (e.g. a third
-            // resolver, or a pre-atomic-rename CLI version writing
-            // concurrently); rather than surfacing that retry's failure,
-            // attemptPublish loops back into the same check and adopts the
-            // new winner. The mirror case — clobbering a destination
+            // from an older, pre-staging CLI version (see the comment above
+            // the marker check: this is the only place such a leftover is
+            // ever removed), or the rename failed for some unrelated reason
+            // — our own staged build is the only known-good copy: reclaim
+            // the spot and retry the rename, up to MAX_RECLAIM_ATTEMPTS
+            // times. A legitimate winner can also land in the narrow gap
+            // between the marker check and our own reclaim-and-retry (e.g. a
+            // third resolver, or a legacy writer); attemptPublish always
+            // re-checks the marker on every attempt (including the last) and
+            // adopts a winner immediately if one appears, regardless of how
+            // many reclaim attempts remain. Only the destructive
+            // reclaim-and-retry path is bounded — a rename that keeps
+            // failing for a reason unrelated to a competing destination
+            // (permissions, a read-only filesystem, disk I/O) can never
+            // succeed no matter how many times we retry, so once attempts
+            // are exhausted we surface the real rename error instead of
+            // retrying forever. The mirror case — clobbering a destination
             // published in the sliver of time between the marker check and
             // our `fs.remove` — is an accepted, narrow residual limitation:
             // fully closing it needs real cross-process locking, which is
@@ -398,25 +405,30 @@ export class BinaryResolver extends Context.Service<
             // any point — removes the staging directory. `cleanupTmpDir`
             // force-removes and ignores errors, so it's a safe no-op once
             // the rename has already moved tmpDir into place.
+            const MAX_RECLAIM_ATTEMPTS = 3;
+
             const published = yield* Effect.gen(function* () {
               yield* stage;
 
               const renameOnce = () => fs.rename(tmpDir, cacheDir).pipe(Effect.as(true));
 
-              const attemptPublish = (): Effect.Effect<boolean, PlatformError.PlatformError> =>
+              const attemptPublish = (
+                attemptsRemaining = MAX_RECLAIM_ATTEMPTS,
+              ): Effect.Effect<boolean, PlatformError.PlatformError> =>
                 renameOnce().pipe(
-                  Effect.catchTag("PlatformError", () =>
-                    fs
-                      .exists(path.join(cacheDir, CACHE_COMPLETE_MARKER))
-                      .pipe(
-                        Effect.flatMap((legitimateWinner) =>
-                          legitimateWinner
-                            ? Effect.succeed(false)
-                            : fs
-                                .remove(cacheDir, { recursive: true, force: true })
-                                .pipe(Effect.ignore, Effect.andThen(attemptPublish())),
-                        ),
-                      ),
+                  Effect.catchTag("PlatformError", (renameError) =>
+                    fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER)).pipe(
+                      Effect.flatMap((legitimateWinner) => {
+                        if (legitimateWinner) return Effect.succeed(false);
+                        if (attemptsRemaining <= 0) return Effect.fail(renameError);
+                        return fs
+                          .remove(cacheDir, { recursive: true, force: true })
+                          .pipe(
+                            Effect.ignore,
+                            Effect.andThen(attemptPublish(attemptsRemaining - 1)),
+                          );
+                      }),
+                    ),
                   ),
                 );
 

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { Effect, FileSystem, Layer, Path, Context } from "effect";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -181,7 +181,11 @@ export class BinaryResolver extends Context.Service<
             const cacheDir = cachePath(baseDir, info);
             const url = downloadUrl(info);
 
-            // Check if already cached (directory exists AND has files)
+            // Check if already cached (directory exists AND has files). The
+            // final cacheDir is only ever created via an atomic rename of a
+            // fully-populated staging directory (see below), so a non-empty
+            // cacheDir is always a complete, valid cache hit — including when
+            // a concurrent process races to resolve the same spec.
             const isCached = yield* fs.exists(cacheDir);
             if (isCached) {
               const entries = yield* fs.readDirectory(cacheDir);
@@ -191,103 +195,143 @@ export class BinaryResolver extends Context.Service<
                   downloaded: false,
                 } satisfies ResolveBinaryResult;
               }
-              // Empty directory from a failed extraction — remove and re-download
+              // An empty cacheDir can no longer be produced by this resolver
+              // itself; it can only come from external interference (e.g. a
+              // pre-atomic-rename cache from an older CLI version). Remove
+              // and re-download defensively.
               yield* fs.remove(cacheDir, { recursive: true });
             }
 
             yield* options?.onDownloadStart ?? Effect.void;
 
-            // Download tarball via HttpClient
-            const tarballResponse = yield* httpClient
-              .get(url)
-              .pipe(
+            // Stage the download + extraction in a per-invocation-unique
+            // directory sibling to cacheDir, so cacheDir itself only ever
+            // becomes visible once fully populated. This prevents concurrent
+            // processes resolving the same spec from corrupting each other's
+            // downloads/extractions.
+            const tmpDir = `${cacheDir}.tmp-${randomUUID()}`;
+            const cleanupTmpDir = fs
+              .remove(tmpDir, { recursive: true, force: true })
+              .pipe(Effect.ignore);
+
+            const stage = Effect.gen(function* () {
+              // Download tarball via HttpClient
+              const tarballResponse = yield* httpClient
+                .get(url)
+                .pipe(
+                  Effect.catchTag("HttpClientError", (e) =>
+                    Effect.fail(new DownloadError({ url, cause: e })),
+                  ),
+                );
+              const tarball = yield* tarballResponse.arrayBuffer.pipe(
                 Effect.catchTag("HttpClientError", (e) =>
                   Effect.fail(new DownloadError({ url, cause: e })),
                 ),
               );
-            const tarball = yield* tarballResponse.arrayBuffer.pipe(
-              Effect.catchTag("HttpClientError", (e) =>
-                Effect.fail(new DownloadError({ url, cause: e })),
-              ),
-            );
 
-            // Verify checksum if available
-            const csUrl = checksumUrl(info);
-            if (csUrl !== null) {
-              const csResponse = yield* httpClient
-                .get(csUrl)
-                .pipe(
+              // Verify checksum if available
+              const csUrl = checksumUrl(info);
+              if (csUrl !== null) {
+                const csResponse = yield* httpClient
+                  .get(csUrl)
+                  .pipe(
+                    Effect.catchTag("HttpClientError", (e) =>
+                      Effect.fail(new DownloadError({ url: csUrl, cause: e })),
+                    ),
+                  );
+                const checksumText = yield* csResponse.text.pipe(
                   Effect.catchTag("HttpClientError", (e) =>
                     Effect.fail(new DownloadError({ url: csUrl, cause: e })),
                   ),
                 );
-              const checksumText = yield* csResponse.text.pipe(
-                Effect.catchTag("HttpClientError", (e) =>
-                  Effect.fail(new DownloadError({ url: csUrl, cause: e })),
-                ),
+                yield* verifyChecksum(tarball, checksumText, csUrl);
+              }
+
+              // Create staging directory
+              yield* fs.makeDirectory(tmpDir, { recursive: true });
+
+              // Write archive to a per-invocation-unique temp file
+              const ext = url.endsWith(".zip") ? ".zip" : ".tar";
+              const tmpFile = path.join(tmpDir, `_download-${randomUUID()}${ext}`);
+              yield* fs.writeFile(tmpFile, new Uint8Array(tarball));
+
+              // Extract archive via ChildProcessSpawner
+              // Only postgres archives have a wrapping directory that needs stripping
+              const stripComponents = spec.service === "postgres";
+              const [cmd, ...args] = extractCommand(
+                url,
+                tmpFile,
+                tmpDir,
+                platform.os,
+                stripComponents,
               );
-              yield* verifyChecksum(tarball, checksumText, csUrl);
-            }
+              const command = ChildProcess.make(cmd!, args);
+              const exitCode = yield* spawner
+                .exitCode(command)
+                .pipe(
+                  Effect.catchTag("PlatformError", (cause) =>
+                    Effect.fail(new DownloadError({ url, cause })),
+                  ),
+                );
 
-            // Create cache directory
-            yield* fs.makeDirectory(cacheDir, { recursive: true });
+              if (exitCode !== 0) {
+                return yield* Effect.fail(
+                  new DownloadError({
+                    url,
+                    cause: new Error(`extraction exited with code ${exitCode}`),
+                  }),
+                );
+              }
 
-            // Write archive to temp file
-            const ext = url.endsWith(".zip") ? ".zip" : ".tar";
-            const tmpFile = path.join(cacheDir, `_download${ext}`);
-            yield* fs.writeFile(tmpFile, new Uint8Array(tarball));
+              // Remove temp archive
+              yield* fs.remove(tmpFile).pipe(Effect.ignore);
 
-            // Extract archive via ChildProcessSpawner
-            // Only postgres archives have a wrapping directory that needs stripping
-            const stripComponents = spec.service === "postgres";
-            const [cmd, ...args] = extractCommand(
-              url,
-              tmpFile,
-              cacheDir,
-              platform.os,
-              stripComponents,
-            );
-            const command = ChildProcess.make(cmd!, args);
-            const exitCode = yield* spawner
-              .exitCode(command)
-              .pipe(
-                Effect.catchTag("PlatformError", (cause) =>
-                  Effect.fail(new DownloadError({ url, cause })),
-                ),
-              );
-
-            if (exitCode !== 0) {
-              return yield* Effect.fail(
-                new DownloadError({
-                  url,
-                  cause: new Error(`extraction exited with code ${exitCode}`),
-                }),
-              );
-            }
-
-            // Remove temp archive
-            yield* fs.remove(tmpFile).pipe(Effect.ignore);
-
-            // Restore execute permissions (tar may strip them depending on umask/platform)
-            const chmodCmd = ChildProcess.make("bash", [
-              "-c",
-              `find "${cacheDir}" -type f \\( -name "*.sh" -o -name "*.dylib" -o -path "*/bin/*" \\) -exec chmod +x {} + && chmod -R u+x "${cacheDir}"`,
-            ]);
-            yield* spawner.exitCode(chmodCmd).pipe(Effect.ignore);
-
-            // On macOS, ad-hoc code sign all executables and dylibs (defensive).
-            // The Go CLI does this after extraction (internal/sandbox/binary.go).
-            if (platform.os === "darwin") {
-              const codesignCmd = ChildProcess.make("bash", [
+              // Restore execute permissions (tar may strip them depending on umask/platform)
+              const chmodCmd = ChildProcess.make("bash", [
                 "-c",
-                `find "${cacheDir}" -type f \\( -perm +111 -o -name "*.dylib" \\) -exec codesign -f -s - {} + 2>/dev/null || true`,
+                `find "${tmpDir}" -type f \\( -name "*.sh" -o -name "*.dylib" -o -path "*/bin/*" \\) -exec chmod +x {} + && chmod -R u+x "${tmpDir}"`,
               ]);
-              yield* spawner.exitCode(codesignCmd).pipe(Effect.ignore);
+              yield* spawner.exitCode(chmodCmd).pipe(Effect.ignore);
+
+              // On macOS, ad-hoc code sign all executables and dylibs (defensive).
+              // The Go CLI does this after extraction (internal/sandbox/binary.go).
+              if (platform.os === "darwin") {
+                const codesignCmd = ChildProcess.make("bash", [
+                  "-c",
+                  `find "${tmpDir}" -type f \\( -perm +111 -o -name "*.dylib" \\) -exec codesign -f -s - {} + 2>/dev/null || true`,
+                ]);
+                yield* spawner.exitCode(codesignCmd).pipe(Effect.ignore);
+              }
+            });
+
+            // Clean up the staging directory on any failure (download error,
+            // checksum mismatch, extraction failure, or interruption) so no
+            // `.tmp-*` directories are left behind in the cache root.
+            yield* stage.pipe(Effect.onError(() => cleanupTmpDir));
+
+            // Publish the completed staging directory by atomically renaming
+            // it into place. If another process already published cacheDir
+            // first, discard our own copy and resolve to theirs instead of
+            // failing.
+            const published = yield* fs.rename(tmpDir, cacheDir).pipe(
+              Effect.as(true),
+              Effect.catchTag("PlatformError", (renameError) =>
+                fs
+                  .exists(cacheDir)
+                  .pipe(
+                    Effect.flatMap((alreadyPresent) =>
+                      alreadyPresent ? Effect.succeed(false) : Effect.fail(renameError),
+                    ),
+                  ),
+              ),
+            );
+            if (!published) {
+              yield* cleanupTmpDir;
             }
 
             return {
               path: cacheDir,
-              downloaded: true,
+              downloaded: published,
             } satisfies ResolveBinaryResult;
           });
 

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { Effect, FileSystem, Layer, Path, Context, Option } from "effect";
+import { Effect, FileSystem, Layer, Path, Context, Option, PlatformError } from "effect";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryNotFoundError, ChecksumMismatchError, DownloadError } from "./errors.ts";
@@ -141,6 +141,7 @@ export class BinaryResolver extends Context.Service<
   static downloadUrl = downloadUrl;
   static checksumUrl = checksumUrl;
   static cachePath = cachePath;
+  static CACHE_COMPLETE_MARKER = CACHE_COMPLETE_MARKER;
 
   static make(
     cacheRoot: string,
@@ -199,32 +200,18 @@ export class BinaryResolver extends Context.Service<
             const cacheDir = cachePath(baseDir, info);
             const url = downloadUrl(info);
 
-            // Check if already cached. The final cacheDir is only ever
-            // populated by an atomic rename of a fully-staged directory
-            // carrying a completion marker (see below), so we check for that
-            // marker rather than mere non-emptiness — a cacheDir that exists
-            // but lacks it can only be a broken leftover (e.g. from an older,
-            // pre-atomic-rename CLI version), never a valid cache entry.
-            const isComplete = yield* fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER));
-            if (isComplete) {
-              return {
-                path: cacheDir,
-                downloaded: false,
-              } satisfies ResolveBinaryResult;
-            }
-            const isCached = yield* fs.exists(cacheDir);
-            if (isCached) {
-              yield* fs.remove(cacheDir, { recursive: true });
-            }
-
             // Opportunistically reap staging directories abandoned by a
             // prior invocation that was killed (SIGKILL/OOM) between
             // creating its tmpDir and the atomic rename — Effect.ensuring
             // can't run past a hard process kill, and every attempt mints a
             // fresh UUID, so nothing else ever revisits these siblings
-            // otherwise. Scoped to just this cacheDir's own tmp-* siblings
-            // (not a general cache-root scan), gated by a generous age
-            // threshold, and entirely best-effort.
+            // otherwise. Runs unconditionally, before the cache-hit check
+            // below: once cacheDir becomes a complete cache hit, every
+            // future resolve for this spec would otherwise return early and
+            // never reach a sweep placed after that check, for the rest of
+            // that cache entry's lifetime. Scoped to just this cacheDir's
+            // own tmp-* siblings (not a general cache-root scan), gated by a
+            // generous age threshold, and entirely best-effort.
             const tmpDirPrefix = `${path.basename(cacheDir)}.tmp-`;
             const parentDir = path.dirname(cacheDir);
             yield* fs.readDirectory(parentDir).pipe(
@@ -251,6 +238,31 @@ export class BinaryResolver extends Context.Service<
               ),
               Effect.ignore,
             );
+
+            // Check if already cached. The final cacheDir is only ever
+            // populated by an atomic rename of a fully-staged directory
+            // carrying a completion marker (see below), so we check for that
+            // marker rather than mere non-emptiness — a cacheDir that exists
+            // but lacks it can only be a broken leftover (e.g. from an older,
+            // pre-atomic-rename CLI version), never a valid cache entry.
+            const isComplete = yield* fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER));
+            if (isComplete) {
+              return {
+                path: cacheDir,
+                downloaded: false,
+              } satisfies ResolveBinaryResult;
+            }
+            const isCached = yield* fs.exists(cacheDir);
+            if (isCached) {
+              // force: true — tolerate another process having already
+              // reclaimed and removed this same broken/markerless cacheDir
+              // concurrently (both processes can observe it before either
+              // removes it). Without force, the loser's remove would throw
+              // on the now-missing path and force an unnecessary Docker
+              // fallback even though the winner is about to publish a good
+              // native binary.
+              yield* fs.remove(cacheDir, { recursive: true, force: true });
+            }
 
             yield* options?.onDownloadStart ?? Effect.void;
 
@@ -368,11 +380,22 @@ export class BinaryResolver extends Context.Service<
             // complete, marker-carrying entry — a broken/incomplete leftover
             // from an older, pre-atomic-rename CLI version, or the rename
             // failed for some unrelated reason — our own staged build is the
-            // only known-good copy: reclaim the spot and retry the rename
-            // once. The whole stage-and-publish lifecycle is wrapped in a
-            // single `Effect.ensuring(cleanupTmpDir)` finalizer so every exit
-            // — stage failure, a genuine rename failure, or an interruption
-            // at any point — removes the staging directory. `cleanupTmpDir`
+            // only known-good copy: reclaim the spot and retry the rename.
+            // A legitimate winner can also land in the narrow gap between
+            // the marker check and our own reclaim-and-retry (e.g. a third
+            // resolver, or a pre-atomic-rename CLI version writing
+            // concurrently); rather than surfacing that retry's failure,
+            // attemptPublish loops back into the same check and adopts the
+            // new winner. The mirror case — clobbering a destination
+            // published in the sliver of time between the marker check and
+            // our `fs.remove` — is an accepted, narrow residual limitation:
+            // fully closing it needs real cross-process locking, which is
+            // disproportionate here since the outcome is bounded to a
+            // redundant rebuild of the same spec, not data loss. The whole
+            // stage-and-publish lifecycle is wrapped in a single
+            // `Effect.ensuring(cleanupTmpDir)` finalizer so every exit —
+            // stage failure, a genuine rename failure, or an interruption at
+            // any point — removes the staging directory. `cleanupTmpDir`
             // force-removes and ignores errors, so it's a safe no-op once
             // the rename has already moved tmpDir into place.
             const published = yield* Effect.gen(function* () {
@@ -380,21 +403,24 @@ export class BinaryResolver extends Context.Service<
 
               const renameOnce = () => fs.rename(tmpDir, cacheDir).pipe(Effect.as(true));
 
-              return yield* renameOnce().pipe(
-                Effect.catchTag("PlatformError", () =>
-                  fs
-                    .exists(path.join(cacheDir, CACHE_COMPLETE_MARKER))
-                    .pipe(
-                      Effect.flatMap((legitimateWinner) =>
-                        legitimateWinner
-                          ? Effect.succeed(false)
-                          : fs
-                              .remove(cacheDir, { recursive: true, force: true })
-                              .pipe(Effect.ignore, Effect.andThen(renameOnce())),
+              const attemptPublish = (): Effect.Effect<boolean, PlatformError.PlatformError> =>
+                renameOnce().pipe(
+                  Effect.catchTag("PlatformError", () =>
+                    fs
+                      .exists(path.join(cacheDir, CACHE_COMPLETE_MARKER))
+                      .pipe(
+                        Effect.flatMap((legitimateWinner) =>
+                          legitimateWinner
+                            ? Effect.succeed(false)
+                            : fs
+                                .remove(cacheDir, { recursive: true, force: true })
+                                .pipe(Effect.ignore, Effect.andThen(attemptPublish())),
+                        ),
                       ),
-                    ),
-                ),
-              );
+                  ),
+                );
+
+              return yield* attemptPublish();
             }).pipe(Effect.ensuring(cleanupTmpDir));
 
             return {

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -304,30 +304,30 @@ export class BinaryResolver extends Context.Service<
               }
             });
 
-            // Clean up the staging directory on any failure (download error,
-            // checksum mismatch, extraction failure, or interruption) so no
-            // `.tmp-*` directories are left behind in the cache root.
-            yield* stage.pipe(Effect.onError(() => cleanupTmpDir));
-
             // Publish the completed staging directory by atomically renaming
             // it into place. If another process already published cacheDir
             // first, discard our own copy and resolve to theirs instead of
-            // failing.
-            const published = yield* fs.rename(tmpDir, cacheDir).pipe(
-              Effect.as(true),
-              Effect.catchTag("PlatformError", (renameError) =>
-                fs
-                  .exists(cacheDir)
-                  .pipe(
-                    Effect.flatMap((alreadyPresent) =>
-                      alreadyPresent ? Effect.succeed(false) : Effect.fail(renameError),
+            // failing. The whole stage-and-publish lifecycle is wrapped in a
+            // single `Effect.ensuring(cleanupTmpDir)` finalizer so every exit
+            // — stage failure, a genuine rename failure, or an interruption
+            // at any point — removes the staging directory. `cleanupTmpDir`
+            // force-removes and ignores errors, so it's a safe no-op once
+            // the rename has already moved tmpDir into place.
+            const published = yield* Effect.gen(function* () {
+              yield* stage;
+              return yield* fs.rename(tmpDir, cacheDir).pipe(
+                Effect.as(true),
+                Effect.catchTag("PlatformError", (renameError) =>
+                  fs
+                    .exists(cacheDir)
+                    .pipe(
+                      Effect.flatMap((alreadyPresent) =>
+                        alreadyPresent ? Effect.succeed(false) : Effect.fail(renameError),
+                      ),
                     ),
-                  ),
-              ),
-            );
-            if (!published) {
-              yield* cleanupTmpDir;
-            }
+                ),
+              );
+            }).pipe(Effect.ensuring(cleanupTmpDir));
 
             return {
               path: cacheDir,

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { Effect, FileSystem, Layer, Path, Context } from "effect";
+import { Effect, FileSystem, Layer, Path, Context, Option } from "effect";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryNotFoundError, ChecksumMismatchError, DownloadError } from "./errors.ts";
@@ -66,6 +66,24 @@ const checksumUrl = (info: AssetInfo): string | null => {
 
 const cachePath = (baseDir: string, info: AssetInfo): string =>
   `${baseDir}/${info.service}/${info.version}/${info.assetName}`;
+
+/**
+ * Written as the last step of staging, so its presence in `cacheDir` after
+ * the atomic rename is a version-agnostic signal that the entry is a
+ * complete, valid cache hit — not just non-empty. A `cacheDir` that exists
+ * but lacks this marker can only be a broken leftover from an older,
+ * pre-atomic-rename CLI version that wrote directly into `cacheDir` and
+ * could be killed mid-extraction.
+ */
+const CACHE_COMPLETE_MARKER = ".supabase-cache-complete";
+
+/**
+ * Age threshold for reaping abandoned `.tmp-*` staging siblings (see the
+ * sweep in `resolveWithMetadata`). Generous on purpose: well beyond how long
+ * any of these downloads/extracts should realistically take, so it can
+ * never step on a genuinely live concurrent download.
+ */
+const STALE_TMP_DIR_AGE_MS = 24 * 60 * 60 * 1000;
 
 const extractCommand = (
   url: string,
@@ -181,26 +199,58 @@ export class BinaryResolver extends Context.Service<
             const cacheDir = cachePath(baseDir, info);
             const url = downloadUrl(info);
 
-            // Check if already cached (directory exists AND has files). The
-            // final cacheDir is only ever created via an atomic rename of a
-            // fully-populated staging directory (see below), so a non-empty
-            // cacheDir is always a complete, valid cache hit — including when
-            // a concurrent process races to resolve the same spec.
+            // Check if already cached. The final cacheDir is only ever
+            // populated by an atomic rename of a fully-staged directory
+            // carrying a completion marker (see below), so we check for that
+            // marker rather than mere non-emptiness — a cacheDir that exists
+            // but lacks it can only be a broken leftover (e.g. from an older,
+            // pre-atomic-rename CLI version), never a valid cache entry.
+            const isComplete = yield* fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER));
+            if (isComplete) {
+              return {
+                path: cacheDir,
+                downloaded: false,
+              } satisfies ResolveBinaryResult;
+            }
             const isCached = yield* fs.exists(cacheDir);
             if (isCached) {
-              const entries = yield* fs.readDirectory(cacheDir);
-              if (entries.length > 0) {
-                return {
-                  path: cacheDir,
-                  downloaded: false,
-                } satisfies ResolveBinaryResult;
-              }
-              // An empty cacheDir can no longer be produced by this resolver
-              // itself; it can only come from external interference (e.g. a
-              // pre-atomic-rename cache from an older CLI version). Remove
-              // and re-download defensively.
               yield* fs.remove(cacheDir, { recursive: true });
             }
+
+            // Opportunistically reap staging directories abandoned by a
+            // prior invocation that was killed (SIGKILL/OOM) between
+            // creating its tmpDir and the atomic rename — Effect.ensuring
+            // can't run past a hard process kill, and every attempt mints a
+            // fresh UUID, so nothing else ever revisits these siblings
+            // otherwise. Scoped to just this cacheDir's own tmp-* siblings
+            // (not a general cache-root scan), gated by a generous age
+            // threshold, and entirely best-effort.
+            const tmpDirPrefix = `${path.basename(cacheDir)}.tmp-`;
+            const parentDir = path.dirname(cacheDir);
+            yield* fs.readDirectory(parentDir).pipe(
+              Effect.flatMap((siblings) =>
+                Effect.forEach(
+                  siblings.filter((name) => name.startsWith(tmpDirPrefix)),
+                  (name) => {
+                    const staleDir = path.join(parentDir, name);
+                    return fs.stat(staleDir).pipe(
+                      Effect.flatMap((info) =>
+                        Option.match(info.mtime, {
+                          onNone: () => Effect.void,
+                          onSome: (mtime) =>
+                            Date.now() - mtime.getTime() > STALE_TMP_DIR_AGE_MS
+                              ? fs.remove(staleDir, { recursive: true, force: true })
+                              : Effect.void,
+                        }),
+                      ),
+                      Effect.ignore,
+                    );
+                  },
+                  { concurrency: "unbounded" },
+                ),
+              ),
+              Effect.ignore,
+            );
 
             yield* options?.onDownloadStart ?? Effect.void;
 
@@ -302,12 +352,24 @@ export class BinaryResolver extends Context.Service<
                 ]);
                 yield* spawner.exitCode(codesignCmd).pipe(Effect.ignore);
               }
+
+              // Write the completion marker last, so it's carried into
+              // cacheDir by the same atomic rename as the rest of the
+              // payload — its presence is the version-agnostic completeness
+              // signal the cache-hit and lost-race checks rely on.
+              yield* fs.writeFile(path.join(tmpDir, CACHE_COMPLETE_MARKER), new Uint8Array());
             });
 
             // Publish the completed staging directory by atomically renaming
-            // it into place. If another process already published cacheDir
-            // first, discard our own copy and resolve to theirs instead of
-            // failing. The whole stage-and-publish lifecycle is wrapped in a
+            // it into place. If another process already published a
+            // complete cacheDir first (verified via the completion marker,
+            // not mere existence), discard our own copy and resolve to
+            // theirs instead of failing. If cacheDir exists but isn't a
+            // complete, marker-carrying entry — a broken/incomplete leftover
+            // from an older, pre-atomic-rename CLI version, or the rename
+            // failed for some unrelated reason — our own staged build is the
+            // only known-good copy: reclaim the spot and retry the rename
+            // once. The whole stage-and-publish lifecycle is wrapped in a
             // single `Effect.ensuring(cleanupTmpDir)` finalizer so every exit
             // — stage failure, a genuine rename failure, or an interruption
             // at any point — removes the staging directory. `cleanupTmpDir`
@@ -315,14 +377,20 @@ export class BinaryResolver extends Context.Service<
             // the rename has already moved tmpDir into place.
             const published = yield* Effect.gen(function* () {
               yield* stage;
-              return yield* fs.rename(tmpDir, cacheDir).pipe(
-                Effect.as(true),
-                Effect.catchTag("PlatformError", (renameError) =>
+
+              const renameOnce = () => fs.rename(tmpDir, cacheDir).pipe(Effect.as(true));
+
+              return yield* renameOnce().pipe(
+                Effect.catchTag("PlatformError", () =>
                   fs
-                    .exists(cacheDir)
+                    .exists(path.join(cacheDir, CACHE_COMPLETE_MARKER))
                     .pipe(
-                      Effect.flatMap((alreadyPresent) =>
-                        alreadyPresent ? Effect.succeed(false) : Effect.fail(renameError),
+                      Effect.flatMap((legitimateWinner) =>
+                        legitimateWinner
+                          ? Effect.succeed(false)
+                          : fs
+                              .remove(cacheDir, { recursive: true, force: true })
+                              .pipe(Effect.ignore, Effect.andThen(renameOnce())),
                       ),
                     ),
                 ),

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -11,9 +11,11 @@ import {
   Stream,
 } from "effect";
 import { HttpClient } from "effect/unstable/http";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryResolver, type BinarySpec } from "./BinaryResolver.ts";
+import { DownloadError } from "./errors.ts";
 import { detectPlatform, postgrestAssetName } from "./Platform.ts";
 import { DEFAULT_VERSIONS } from "./versions.ts";
 
@@ -146,6 +148,7 @@ function createFakeCacheFs() {
   const files = new Map<string, Uint8Array>();
   const mtimes = new Map<string, number>();
   const removeInterceptors = new Map<string, () => void>();
+  const alwaysFailRenameTo = new Set<string>();
 
   const isWithin = (candidatePath: string, rootPath: string): boolean =>
     candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
@@ -234,6 +237,17 @@ function createFakeCacheFs() {
         });
       },
       rename: (oldPath, newPath) => {
+        if (alwaysFailRenameTo.has(newPath)) {
+          return Effect.fail(
+            PlatformError.systemError({
+              _tag: "PermissionDenied",
+              module: "FileSystem",
+              method: "rename",
+              description: "permission denied (simulated permanent failure)",
+              pathOrDescriptor: newPath,
+            }),
+          );
+        }
         if (hasContentAt(newPath)) {
           return Effect.fail(
             PlatformError.systemError({
@@ -305,6 +319,12 @@ function createFakeCacheFs() {
     onRemove: (targetPath: string, sideEffect: () => void): void => {
       removeInterceptors.set(targetPath, sideEffect);
     },
+    /** Makes every rename into `targetPath` fail permanently (regardless of
+     * destination content), simulating a filesystem error unrelated to
+     * destination contention — e.g. permissions, a read-only mount. */
+    alwaysFailRenameTo: (targetPath: string): void => {
+      alwaysFailRenameTo.add(targetPath);
+    },
   };
 }
 
@@ -365,6 +385,23 @@ function mockDownloadHttpClient(opts: { archiveBytes: Uint8Array; delayMs: numbe
         yield* Effect.sleep(`${opts.delayMs} millis`);
         return HttpClientResponse.fromWeb(request, new Response(opts.archiveBytes));
       }),
+    ),
+  );
+}
+
+/** An `HttpClient` that always fails, simulating an offline machine or a GitHub outage. */
+function mockOfflineHttpClient() {
+  return Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.fail(
+        new HttpClientError.HttpClientError({
+          reason: new HttpClientError.TransportError({
+            request,
+            description: "offline (simulated)",
+          }),
+        }),
+      ),
     ),
   );
 }
@@ -627,4 +664,73 @@ describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
       expect(fakeFs.files.has(`${cacheDir}/${BinaryResolver.CACHE_COMPLETE_MARKER}`)).toBe(true);
     }).pipe(Effect.provide(layer));
   });
+
+  it.live(
+    "surfaces a DownloadError instead of retrying forever when rename fails for a reason unrelated to destination contention",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockDownloadHttpClient({
+        archiveBytes: new Uint8Array([1, 2, 3]),
+        delayMs: 0,
+      });
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+        const cacheDir = yield* resolvePostgrestCacheDir;
+
+        // Simulate a permanent filesystem error unrelated to a competing
+        // destination (e.g. permissions, a read-only mount) — every rename
+        // attempt into cacheDir fails, regardless of its content, so no
+        // amount of reclaim-and-retry can ever succeed.
+        fakeFs.alwaysFailRenameTo(cacheDir);
+
+        const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
+
+        // Bounded attempts surface the real error instead of hanging.
+        expect(error).toBeInstanceOf(DownloadError);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.live(
+    "does not destroy a markerless legacy cacheDir before a download attempt that then fails",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockOfflineHttpClient();
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+        const cacheDir = yield* resolvePostgrestCacheDir;
+
+        // A markerless legacy cacheDir from before this resolver's staging
+        // model existed — still a perfectly usable binary on disk.
+        fakeFs.seedDirWithFile(cacheDir, "bin/postgrest");
+
+        const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(DownloadError);
+        // The legacy binary must survive an offline/failed download attempt
+        // — it must not be deleted before we know we can replace it.
+        expect(fakeFs.files.has(`${cacheDir}/bin/postgrest`)).toBe(true);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 });

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
-import { BinaryResolver } from "./BinaryResolver.ts";
+import { Deferred, Effect, FileSystem, Layer, Path, PlatformError, Sink, Stream } from "effect";
+import { HttpClient } from "effect/unstable/http";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { BinaryResolver, type BinarySpec } from "./BinaryResolver.ts";
 import { DEFAULT_VERSIONS } from "./versions.ts";
 
 const postgresVersion = DEFAULT_VERSIONS.postgres;
@@ -117,4 +121,219 @@ describe("BinaryResolver.cachePath", () => {
     });
     expect(path).toBe(`/home/user/.supabase/bin/postgres/${postgresVersion}/darwin-arm64`);
   });
+});
+
+/**
+ * A tiny in-memory hierarchical filesystem used to exercise BinaryResolver's
+ * real staging/rename logic (not just its pure helpers). Tracks directories
+ * and files by absolute path so `rename` can faithfully reject a move onto a
+ * non-empty destination the way POSIX `rename(2)` does — the exact signal the
+ * resolver relies on to detect that a concurrent resolve already won.
+ */
+function createFakeCacheFs() {
+  const dirs = new Set<string>();
+  const files = new Map<string, Uint8Array>();
+
+  const isWithin = (candidatePath: string, rootPath: string): boolean =>
+    candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
+
+  const addAncestorDirs = (childPath: string): void => {
+    const segments = childPath.split("/").filter(Boolean);
+    let current = "";
+    for (let i = 0; i < segments.length - 1; i++) {
+      current += `/${segments[i]}`;
+      dirs.add(current);
+    }
+  };
+
+  const removeSubtree = (rootPath: string): void => {
+    for (const key of files.keys()) if (isWithin(key, rootPath)) files.delete(key);
+    for (const key of dirs) if (isWithin(key, rootPath)) dirs.delete(key);
+  };
+
+  const hasContentAt = (targetPath: string): boolean =>
+    [...files.keys(), ...dirs].some((key) => key !== targetPath && isWithin(key, targetPath));
+
+  const layer = Layer.succeed(
+    FileSystem.FileSystem,
+    FileSystem.makeNoop({
+      exists: (targetPath) => Effect.succeed(files.has(targetPath) || dirs.has(targetPath)),
+      makeDirectory: (dirPath) =>
+        Effect.sync(() => {
+          dirs.add(dirPath);
+          addAncestorDirs(dirPath);
+        }),
+      readDirectory: (dirPath) =>
+        Effect.sync(() => {
+          const prefix = `${dirPath}/`;
+          const names = new Set<string>();
+          for (const key of [...files.keys(), ...dirs]) {
+            if (key.startsWith(prefix)) names.add(key.slice(prefix.length).split("/")[0]!);
+          }
+          return [...names];
+        }),
+      writeFile: (filePath, data) =>
+        Effect.sync(() => {
+          files.set(filePath, data);
+          addAncestorDirs(filePath);
+        }),
+      remove: (targetPath) => Effect.sync(() => removeSubtree(targetPath)),
+      rename: (oldPath, newPath) => {
+        if (hasContentAt(newPath)) {
+          return Effect.fail(
+            PlatformError.systemError({
+              _tag: "Unknown",
+              module: "FileSystem",
+              method: "rename",
+              description: "destination directory not empty",
+              pathOrDescriptor: newPath,
+            }),
+          );
+        }
+        return Effect.sync(() => {
+          removeSubtree(newPath);
+          for (const key of files.keys()) {
+            if (isWithin(key, oldPath)) {
+              const data = files.get(key)!;
+              files.delete(key);
+              files.set(`${newPath}${key.slice(oldPath.length)}`, data);
+            }
+          }
+          for (const key of dirs) {
+            if (isWithin(key, oldPath)) {
+              dirs.delete(key);
+              dirs.add(`${newPath}${key.slice(oldPath.length)}`);
+            }
+          }
+          addAncestorDirs(newPath);
+        });
+      },
+    }),
+  );
+
+  return {
+    layer,
+    dirs,
+    files,
+    /** Simulates `tar`/`unzip` populating a destination directory. */
+    writeExtractedFile: (destDir: string): void => {
+      const filePath = `${destDir}/bin/postgrest`;
+      files.set(filePath, new Uint8Array([1, 2, 3]));
+      addAncestorDirs(filePath);
+    },
+    /** Lists the immediate children of a directory, mirroring `fs.readDirectory`. */
+    readEntriesOf: (dirPath: string): string[] => {
+      const prefix = `${dirPath}/`;
+      const names = new Set<string>();
+      for (const key of [...files.keys(), ...dirs]) {
+        if (key.startsWith(prefix)) names.add(key.slice(prefix.length).split("/")[0]!);
+      }
+      return [...names];
+    },
+  };
+}
+
+/**
+ * A `ChildProcessSpawner` that "extracts" by dropping a fake binary into
+ * whichever directory the `tar -C`/`unzip -d` destination argument points at,
+ * so the shared fake filesystem reflects a completed extraction.
+ */
+function mockExtractingSpawner(fakeFs: ReturnType<typeof createFakeCacheFs>) {
+  const spawned: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+
+  return {
+    layer: Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const cmd = command._tag === "StandardCommand" ? command.command : "";
+          const args = command._tag === "StandardCommand" ? command.args : [];
+          spawned.push({ command: cmd, args });
+
+          if (cmd === "tar" || cmd === "unzip") {
+            const flagIndex = args.findIndex((arg) => arg === "-C" || arg === "-d");
+            const destDir = flagIndex >= 0 ? args[flagIndex + 1] : undefined;
+            if (destDir) fakeFs.writeExtractedFile(destDir);
+          }
+
+          const exitDeferred = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+          yield* Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(0));
+
+          return ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(5000 + spawned.length),
+            stdout: Stream.empty,
+            stderr: Stream.empty,
+            all: Stream.empty,
+            exitCode: Deferred.await(exitDeferred),
+            isRunning: Effect.succeed(false),
+            stdin: Sink.drain,
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          });
+        }),
+      ),
+    ),
+    get spawned() {
+      return spawned;
+    },
+  };
+}
+
+/** An `HttpClient` that returns a fixed archive body after a short delay, so concurrent resolves overlap. */
+function mockDownloadHttpClient(opts: { archiveBytes: Uint8Array; delayMs: number }) {
+  return Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.gen(function* () {
+        yield* Effect.sleep(`${opts.delayMs} millis`);
+        return HttpClientResponse.fromWeb(request, new Response(opts.archiveBytes));
+      }),
+    ),
+  );
+}
+
+describe("BinaryResolver.resolveWithMetadata concurrency", () => {
+  it.live(
+    "two concurrent resolves for the same spec share one complete cache entry and leave no temp artifacts",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockDownloadHttpClient({
+        archiveBytes: new Uint8Array([1, 2, 3, 4]),
+        delayMs: 20,
+      });
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+
+        const [first, second] = yield* Effect.all(
+          [resolver.resolveWithMetadata(spec), resolver.resolveWithMetadata(spec)],
+          { concurrency: "unbounded" },
+        );
+
+        // Both invocations resolve to the same, single cache entry.
+        expect(first.path).toBe(second.path);
+        // Exactly one of the two actually populated the cache; the other lost the race.
+        expect([first.downloaded, second.downloaded].sort()).toEqual([false, true]);
+
+        const entries = fakeFs.readEntriesOf(first.path);
+        expect(entries.length).toBeGreaterThan(0);
+
+        const staleTmpPaths = [...fakeFs.dirs, ...fakeFs.files.keys()].filter(
+          (candidatePath) => candidatePath.includes(".tmp-") || candidatePath.includes("_download"),
+        );
+        expect(staleTmpPaths).toEqual([]);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 });

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Deferred, Effect, FileSystem, Layer, Path, PlatformError, Sink, Stream } from "effect";
+import {
+  Deferred,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  PlatformError,
+  Sink,
+  Stream,
+} from "effect";
 import { HttpClient } from "effect/unstable/http";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryResolver, type BinarySpec } from "./BinaryResolver.ts";
+import { detectPlatform, postgrestAssetName } from "./Platform.ts";
 import { DEFAULT_VERSIONS } from "./versions.ts";
 
 const postgresVersion = DEFAULT_VERSIONS.postgres;
@@ -133,6 +144,7 @@ describe("BinaryResolver.cachePath", () => {
 function createFakeCacheFs() {
   const dirs = new Set<string>();
   const files = new Map<string, Uint8Array>();
+  const mtimes = new Map<string, number>();
 
   const isWithin = (candidatePath: string, rootPath: string): boolean =>
     candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
@@ -143,6 +155,7 @@ function createFakeCacheFs() {
     for (let i = 0; i < segments.length - 1; i++) {
       current += `/${segments[i]}`;
       dirs.add(current);
+      if (!mtimes.has(current)) mtimes.set(current, Date.now());
     }
   };
 
@@ -161,8 +174,28 @@ function createFakeCacheFs() {
       makeDirectory: (dirPath) =>
         Effect.sync(() => {
           dirs.add(dirPath);
+          mtimes.set(dirPath, Date.now());
           addAncestorDirs(dirPath);
         }),
+      stat: (targetPath) =>
+        Effect.sync(
+          (): FileSystem.File.Info => ({
+            type: dirs.has(targetPath) ? "Directory" : "File",
+            mtime: Option.some(new Date(mtimes.get(targetPath) ?? Date.now())),
+            atime: Option.none(),
+            birthtime: Option.none(),
+            dev: 0,
+            ino: Option.none(),
+            mode: 0,
+            nlink: Option.none(),
+            uid: Option.none(),
+            gid: Option.none(),
+            rdev: Option.none(),
+            size: FileSystem.Size(0),
+            blksize: Option.none(),
+            blocks: Option.none(),
+          }),
+        ),
       readDirectory: (dirPath) =>
         Effect.sync(() => {
           const prefix = `${dirPath}/`;
@@ -229,6 +262,20 @@ function createFakeCacheFs() {
         if (key.startsWith(prefix)) names.add(key.slice(prefix.length).split("/")[0]!);
       }
       return [...names];
+    },
+    /** Backdates (or refreshes) a path's fake mtime, for staleness tests. */
+    setMtime: (targetPath: string, when: Date): void => {
+      mtimes.set(targetPath, when.getTime());
+    },
+    /** Directly seeds a directory with content, bypassing the resolver — simulates
+     * a pre-existing cacheDir left by an older, pre-atomic-rename CLI version or
+     * an abandoned staging directory from a killed process. */
+    seedDirWithFile: (dirPath: string, relativeFilePath: string): void => {
+      dirs.add(dirPath);
+      if (!mtimes.has(dirPath)) mtimes.set(dirPath, Date.now());
+      const filePath = `${dirPath}/${relativeFilePath}`;
+      files.set(filePath, new Uint8Array([9, 9, 9]));
+      addAncestorDirs(filePath);
     },
   };
 }
@@ -336,4 +383,133 @@ describe("BinaryResolver.resolveWithMetadata concurrency", () => {
       }).pipe(Effect.provide(layer));
     },
   );
+});
+
+/** Resolves the real cacheDir a `postgrest` spec would use on the host running the test. */
+const resolvePostgrestCacheDir = Effect.gen(function* () {
+  const platform = yield* detectPlatform;
+  const assetName = postgrestAssetName(platform);
+  if (assetName === null) {
+    return yield* Effect.die(`unsupported test platform: ${platform.os}-${platform.arch}`);
+  }
+  return BinaryResolver.cachePath("/cache-root/bin", {
+    service: "postgrest",
+    version: postgrestVersion,
+    assetName,
+  });
+});
+
+describe("BinaryResolver.resolveWithMetadata stale staging cleanup", () => {
+  it.live(
+    "reaps an abandoned staging directory older than the age threshold on a later resolve",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockDownloadHttpClient({
+        archiveBytes: new Uint8Array([1, 2, 3]),
+        delayMs: 0,
+      });
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const cacheDir = yield* resolvePostgrestCacheDir;
+        const abandonedDir = `${cacheDir}.tmp-abandoned`;
+
+        // Simulate a staging directory left behind by a process that was
+        // SIGKILL'd/OOM-killed mid-download, more than the age threshold ago.
+        fakeFs.seedDirWithFile(abandonedDir, "_download-abandoned.tar");
+        fakeFs.setMtime(abandonedDir, new Date(Date.now() - 25 * 60 * 60 * 1000));
+
+        yield* resolver.resolveWithMetadata({ service: "postgrest", version: postgrestVersion });
+
+        expect(fakeFs.dirs.has(abandonedDir)).toBe(false);
+        expect([...fakeFs.files.keys()].some((p) => p.startsWith(abandonedDir))).toBe(false);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.live(
+    "leaves a fresh staging directory alone (not old enough to be considered abandoned)",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockDownloadHttpClient({
+        archiveBytes: new Uint8Array([1, 2, 3]),
+        delayMs: 0,
+      });
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const cacheDir = yield* resolvePostgrestCacheDir;
+        const freshDir = `${cacheDir}.tmp-fresh`;
+
+        // A staging directory from a genuinely live concurrent download —
+        // recent mtime, must survive the sweep.
+        fakeFs.seedDirWithFile(freshDir, "_download-fresh.tar");
+        fakeFs.setMtime(freshDir, new Date());
+
+        yield* resolver.resolveWithMetadata({ service: "postgrest", version: postgrestVersion });
+
+        expect(fakeFs.dirs.has(freshDir)).toBe(true);
+        expect(fakeFs.files.has(`${freshDir}/_download-fresh.tar`)).toBe(true);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+});
+
+describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
+  it.live("reclaims a broken cacheDir left by an older, pre-atomic-rename CLI version", () => {
+    const fakeFs = createFakeCacheFs();
+    const spawner = mockExtractingSpawner(fakeFs);
+    const httpLayer = mockDownloadHttpClient({
+      archiveBytes: new Uint8Array([1, 2, 3]),
+      delayMs: 0,
+    });
+
+    const layer = BinaryResolver.make("/cache-root").pipe(
+      Layer.provide(fakeFs.layer),
+      Layer.provide(Path.layer),
+      Layer.provide(httpLayer),
+      Layer.provide(spawner.layer),
+    );
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+      const cacheDir = yield* resolvePostgrestCacheDir;
+
+      // A non-empty cacheDir with no completion marker — exactly what an
+      // older, pre-atomic-rename CLI version would leave behind if it was
+      // killed mid-extraction (it wrote directly into cacheDir, no staging).
+      fakeFs.seedDirWithFile(cacheDir, "stray-legacy-file.txt");
+
+      const result = yield* resolver.resolveWithMetadata(spec);
+
+      // The broken leftover was reclaimed, not trusted or left in place.
+      expect(result.path).toBe(cacheDir);
+      expect(result.downloaded).toBe(true);
+      expect(fakeFs.files.has(`${cacheDir}/stray-legacy-file.txt`)).toBe(false);
+
+      // A subsequent resolve is now a clean cache hit — proving the
+      // reclaimed entry is genuinely complete (carries the marker), not
+      // just superficially non-empty again.
+      const second = yield* resolver.resolveWithMetadata(spec);
+      expect(second.downloaded).toBe(false);
+      expect(second.path).toBe(cacheDir);
+    }).pipe(Effect.provide(layer));
+  });
 });

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -697,6 +697,16 @@ describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
 
         // Bounded attempts surface the real error instead of hanging.
         expect(error).toBeInstanceOf(DownloadError);
+
+        // The `cleanupTmpDir` finalizer must still remove the staging
+        // directory even though the rename it was guarding rethrew — a
+        // regression here (e.g. scoping cleanup to an `onError` around
+        // `stage` instead of `Effect.ensuring`) would leak the fully
+        // populated `.tmp-`/`_download` tree.
+        const staleTmpPaths = [...fakeFs.dirs, ...fakeFs.files.keys()].filter(
+          (candidatePath) => candidatePath.includes(".tmp-") || candidatePath.includes("_download"),
+        );
+        expect(staleTmpPaths).toEqual([]);
       }).pipe(Effect.provide(layer));
     },
   );

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -145,6 +145,7 @@ function createFakeCacheFs() {
   const dirs = new Set<string>();
   const files = new Map<string, Uint8Array>();
   const mtimes = new Map<string, number>();
+  const removeInterceptors = new Map<string, () => void>();
 
   const isWithin = (candidatePath: string, rootPath: string): boolean =>
     candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
@@ -210,7 +211,28 @@ function createFakeCacheFs() {
           files.set(filePath, data);
           addAncestorDirs(filePath);
         }),
-      remove: (targetPath) => Effect.sync(() => removeSubtree(targetPath)),
+      remove: (targetPath, options) => {
+        const targetExists = files.has(targetPath) || dirs.has(targetPath);
+        if (!targetExists && !options?.force) {
+          return Effect.fail(
+            PlatformError.systemError({
+              _tag: "NotFound",
+              module: "FileSystem",
+              method: "remove",
+              description: "no such file or directory",
+              pathOrDescriptor: targetPath,
+            }),
+          );
+        }
+        return Effect.sync(() => {
+          removeSubtree(targetPath);
+          const intercept = removeInterceptors.get(targetPath);
+          if (intercept) {
+            removeInterceptors.delete(targetPath);
+            intercept();
+          }
+        });
+      },
       rename: (oldPath, newPath) => {
         if (hasContentAt(newPath)) {
           return Effect.fail(
@@ -276,6 +298,12 @@ function createFakeCacheFs() {
       const filePath = `${dirPath}/${relativeFilePath}`;
       files.set(filePath, new Uint8Array([9, 9, 9]));
       addAncestorDirs(filePath);
+    },
+    /** Registers a one-shot side effect to run the next time `targetPath` is
+     * removed — simulates a third party (a concurrent resolver, or a legacy
+     * writer) acting in the exact gap right after this process's own removal. */
+    onRemove: (targetPath: string, sideEffect: () => void): void => {
+      removeInterceptors.set(targetPath, sideEffect);
     },
   };
 }
@@ -469,6 +497,50 @@ describe("BinaryResolver.resolveWithMetadata stale staging cleanup", () => {
       }).pipe(Effect.provide(layer));
     },
   );
+
+  it.live(
+    "still reaps a stale staging sibling even when this resolve is itself a cache hit",
+    () => {
+      const fakeFs = createFakeCacheFs();
+      const spawner = mockExtractingSpawner(fakeFs);
+      const httpLayer = mockDownloadHttpClient({
+        archiveBytes: new Uint8Array([1, 2, 3]),
+        delayMs: 0,
+      });
+
+      const layer = BinaryResolver.make("/cache-root").pipe(
+        Layer.provide(fakeFs.layer),
+        Layer.provide(Path.layer),
+        Layer.provide(httpLayer),
+        Layer.provide(spawner.layer),
+      );
+
+      return Effect.gen(function* () {
+        const resolver = yield* BinaryResolver;
+        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+        const cacheDir = yield* resolvePostgrestCacheDir;
+
+        // Populate a genuine, complete cache entry first.
+        const first = yield* resolver.resolveWithMetadata(spec);
+        expect(first.downloaded).toBe(true);
+
+        // Now a *different* invocation gets killed mid-download, abandoning
+        // a stale staging sibling next to the now-complete cacheDir.
+        const abandonedDir = `${cacheDir}.tmp-abandoned`;
+        fakeFs.seedDirWithFile(abandonedDir, "_download-abandoned.tar");
+        fakeFs.setMtime(abandonedDir, new Date(Date.now() - 25 * 60 * 60 * 1000));
+
+        // This resolve is a plain cache hit (marker already present) — the
+        // sweep must still run and reap the abandoned sibling, since once
+        // cacheDir is complete this spec will only ever take the hit path.
+        const second = yield* resolver.resolveWithMetadata(spec);
+        expect(second.downloaded).toBe(false);
+
+        expect(fakeFs.dirs.has(abandonedDir)).toBe(false);
+        expect([...fakeFs.files.keys()].some((p) => p.startsWith(abandonedDir))).toBe(false);
+      }).pipe(Effect.provide(layer));
+    },
+  );
 });
 
 describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
@@ -510,6 +582,49 @@ describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
       const second = yield* resolver.resolveWithMetadata(spec);
       expect(second.downloaded).toBe(false);
       expect(second.path).toBe(cacheDir);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("adopts a legitimate winner that lands mid-reclaim instead of retrying blindly", () => {
+    const fakeFs = createFakeCacheFs();
+    const spawner = mockExtractingSpawner(fakeFs);
+    const httpLayer = mockDownloadHttpClient({
+      archiveBytes: new Uint8Array([1, 2, 3]),
+      delayMs: 0,
+    });
+
+    const layer = BinaryResolver.make("/cache-root").pipe(
+      Layer.provide(fakeFs.layer),
+      Layer.provide(Path.layer),
+      Layer.provide(httpLayer),
+      Layer.provide(spawner.layer),
+    );
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
+      const cacheDir = yield* resolvePostgrestCacheDir;
+
+      // A markerless, broken cacheDir — our first renameOnce() attempt
+      // fails against this, entering the reclaim branch.
+      fakeFs.seedDirWithFile(cacheDir, "stray-legacy-file.txt");
+
+      // Simulate a legitimate winner (a third concurrent resolver, or a
+      // pre-atomic-rename legacy writer) publishing a complete,
+      // marker-carrying cacheDir in the exact gap between our reclaim's
+      // `fs.remove` and our retry rename.
+      fakeFs.onRemove(cacheDir, () => {
+        fakeFs.seedDirWithFile(cacheDir, "bin/postgrest");
+        fakeFs.seedDirWithFile(cacheDir, BinaryResolver.CACHE_COMPLETE_MARKER);
+      });
+
+      const result = yield* resolver.resolveWithMetadata(spec);
+
+      // Adopted the winner instead of throwing a spurious DownloadError
+      // from the retry's second rename failure.
+      expect(result.path).toBe(cacheDir);
+      expect(result.downloaded).toBe(false);
+      expect(fakeFs.files.has(`${cacheDir}/${BinaryResolver.CACHE_COMPLETE_MARKER}`)).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`packages/stack/src/BinaryResolver.ts` caches downloaded native service binaries (postgres, postgrest, auth, edge-runtime) at a path that is intentionally shared across every process on the machine, so parallel `supabase start` invocations don't re-download the same binary. That sharing is correct, but there was no concurrency protection around it:

- The cache-hit check was check-then-act with no lock, so two processes could both observe a cold cache for the same service+version at the same instant.
- Both processes then downloaded to the **same fixed temp file path** (`_download.tar`/`_download.zip`, no per-invocation uniqueness), so concurrent writes could corrupt each other's bytes.
- Extraction (`tar`/`unzip`) ran directly into the final cache directory rather than a private staging location, so an interrupted extraction (this race, a killed process, disk pressure) could leave the directory partially populated.
- The cache-hit check only looked at `entries.length > 0`, so a partially-extracted, broken directory looked exactly like a valid cache hit to every future invocation — silent, persistent corruption.

## What is the new behavior?

Downloads now write to a per-invocation-unique temp file, and extraction happens in a per-invocation-unique staging directory (`${cacheDir}.tmp-<uuid>`) sibling to the real cache directory instead of the cache directory itself. Once extraction, the chmod fixup, and (on macOS) ad-hoc codesign all succeed, the staging directory is atomically renamed into place as the final cache directory — so the cache directory is now only ever observable in a fully-complete state, and the existing "empty directory looks like a cache hit" bug can no longer be produced by this code path going forward.

If another process already published the cache directory by the time this process tries to publish its own (i.e. it lost the race), it discards its own staging directory and resolves to the winner's cache entry instead of failing. The staging directory is also cleaned up on every failure path (download error, checksum mismatch, extraction failure, or interruption), so no `.tmp-*` directories are left behind in the cache root.

Added a regression test in `BinaryResolver.unit.test.ts` that runs two concurrent `resolveWithMetadata` calls against the same service+version+assetName cache path (with mocked `HttpClient`/`ChildProcessSpawner`/`FileSystem` layers) and asserts both succeed to the same complete cache path with no stray temp artifacts left behind.