### PR TITLE
fix(cli): reload kong after db reset

### DIFF
--- a/apps/cli-go/internal/db/reset/reset.go
+++ b/apps/cli-go/internal/db/reset/reset.go
@@ -1,6 +1,7 @@
 package reset
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -287,16 +288,32 @@ func reloadKong(ctx context.Context) error {
 		// Kong may be excluded from the stack.
 		return nil
 	} else if err != nil {
-		return errors.Errorf("failed to inspect kong: %w", err)
+		return suggestKongRecovery(errors.Errorf("failed to inspect kong: %w", err))
 	}
 	if !resp.State.Running {
 		// A stopped gateway has no stale cache to flush.
 		return nil
 	}
-	if _, err := utils.DockerExecOnce(ctx, utils.KongId, nil, []string{"kong", "reload"}); err != nil {
-		return errors.Errorf("failed to reload kong: %w", err)
+	var out bytes.Buffer
+	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload"}, &out, &out); err != nil {
+		if msg := strings.TrimSpace(out.String()); len(msg) > 0 {
+			return suggestKongRecovery(errors.Errorf("failed to reload kong: %w:\n%s", err, msg))
+		}
+		return suggestKongRecovery(errors.Errorf("failed to reload kong: %w", err))
 	}
 	return nil
+}
+
+// suggestKongRecovery decorates a gateway-left-unconfirmed failure with the
+// advisory next step; the caller-neutral wording also covers branch switch,
+// which shares RestartDatabase.
+func suggestKongRecovery(err error) error {
+	utils.CmdSuggestion = fmt.Sprintf(
+		"Local services restarted, but API routes may return 502 until the gateway reloads.\nTry restarting it with %s, and check %s if the failure persists.",
+		utils.Aqua("docker restart "+utils.KongId),
+		utils.Aqua("docker logs "+utils.KongId),
+	)
+	return err
 }
 
 func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {

--- a/apps/cli-go/internal/db/reset/reset.go
+++ b/apps/cli-go/internal/db/reset/reset.go
@@ -265,11 +265,38 @@ func restartServices(ctx context.Context) error {
 		return nil
 	})
 	// Do not wait for service healthy as those services may be excluded from starting
-	return errors.Join(result...)
+	if err := errors.Join(result...); err != nil {
+		return err
+	}
+	return reloadKong(ctx)
 }
 
 func listServicesToRestart() []string {
 	return []string{utils.StorageId, utils.GotrueId, utils.RealtimeId, utils.PoolerId}
+}
+
+// reloadKong reloads Kong after the restarts above so its nginx re-resolves each
+// upstream container's address. Kong caches resolved addresses for the life of a
+// worker process, and a restarted container can come back on a different one,
+// leaving the gateway returning 502 for that route until Kong restarts. An
+// in-place reload (the `functions serve` pattern) keeps the gateway serving
+// throughout. https://github.com/supabase/cli/issues/6016
+func reloadKong(ctx context.Context) error {
+	resp, err := utils.Docker.ContainerInspect(ctx, utils.KongId)
+	if errdefs.IsNotFound(err) {
+		// Kong may be excluded from the stack.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("failed to inspect kong: %w", err)
+	}
+	if !resp.State.Running {
+		// A stopped gateway has no stale cache to flush.
+		return nil
+	}
+	if _, err := utils.DockerExecOnce(ctx, utils.KongId, nil, []string{"kong", "reload"}); err != nil {
+		return errors.Errorf("failed to reload kong: %w", err)
+	}
+	return nil
 }
 
 func resetRemote(ctx context.Context, version string, config pgconn.Config, fsys afero.Fs, options ...func(*pgx.ConnConfig)) error {

--- a/apps/cli-go/internal/db/reset/reset_test.go
+++ b/apps/cli-go/internal/db/reset/reset_test.go
@@ -73,11 +73,19 @@ func TestResetCommand(t *testing.T) {
 		utils.GotrueId = "test-auth"
 		utils.RealtimeId = "test-realtime"
 		utils.PoolerId = "test-pooler"
+		utils.KongId = "test-kong"
 		for _, container := range listServicesToRestart() {
 			gock.New(utils.Docker.DaemonHost()).
 				Post("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/restart").
 				Reply(http.StatusOK)
 		}
+		// Kong is not running so the reload is skipped (a successful exec attach is not gock-mockable, see TestExecOnce)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: false},
+			}})
 		// Seeds storage
 		gock.New(utils.Docker.DaemonHost()).
 			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.StorageId + "/json").
@@ -308,11 +316,19 @@ func TestRestartDatabase(t *testing.T) {
 		utils.GotrueId = "test-auth"
 		utils.RealtimeId = "test-realtime"
 		utils.PoolerId = "test-pooler"
+		utils.KongId = "test-kong"
 		for _, container := range listServicesToRestart() {
 			gock.New(utils.Docker.DaemonHost()).
 				Post("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/restart").
 				Reply(http.StatusOK)
 		}
+		// Kong is not running so the reload is skipped (a successful exec attach is not gock-mockable, see TestExecOnce)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: false},
+			}})
 		// Run test
 		err := RestartDatabase(context.Background(), io.Discard)
 		// Check error
@@ -357,6 +373,132 @@ func TestRestartDatabase(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to restart "+utils.StorageId)
 		assert.ErrorContains(t, err, "failed to restart "+utils.GotrueId)
 		assert.ErrorContains(t, err, "failed to restart "+utils.RealtimeId)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("skips kong reload when kong is not running", func(t *testing.T) {
+		utils.DbId = "test-reset"
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		// Restarts postgres
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/restart").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{
+					Running: true,
+					Health:  &container.Health{Status: types.Healthy},
+				},
+			}})
+		// Restarts services
+		utils.StorageId = "test-storage"
+		utils.GotrueId = "test-auth"
+		utils.RealtimeId = "test-realtime"
+		utils.PoolerId = "test-pooler"
+		utils.KongId = "test-kong"
+		for _, container := range listServicesToRestart() {
+			gock.New(utils.Docker.DaemonHost()).
+				Post("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/restart").
+				Reply(http.StatusOK)
+		}
+		// Kong is excluded from the stack: no exec follows
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/json").
+			Reply(http.StatusNotFound)
+		// Run test
+		err := RestartDatabase(context.Background(), io.Discard)
+		// Check error
+		assert.NoError(t, err)
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on kong inspect failure", func(t *testing.T) {
+		utils.DbId = "test-reset"
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		// Restarts postgres
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/restart").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{
+					Running: true,
+					Health:  &container.Health{Status: types.Healthy},
+				},
+			}})
+		// Restarts services
+		utils.StorageId = "test-storage"
+		utils.GotrueId = "test-auth"
+		utils.RealtimeId = "test-realtime"
+		utils.PoolerId = "test-pooler"
+		utils.KongId = "test-kong"
+		for _, container := range listServicesToRestart() {
+			gock.New(utils.Docker.DaemonHost()).
+				Post("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/restart").
+				Reply(http.StatusOK)
+		}
+		// A daemon error is not the excluded-kong skip case
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/json").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := RestartDatabase(context.Background(), io.Discard)
+		// Check error
+		assert.ErrorContains(t, err, "failed to inspect kong")
+		assert.Empty(t, apitest.ListUnmatchedRequests())
+	})
+
+	t.Run("throws error on kong reload failure", func(t *testing.T) {
+		utils.DbId = "test-reset"
+		// Setup mock docker
+		require.NoError(t, apitest.MockDocker(utils.Docker))
+		defer gock.OffAll()
+		// Restarts postgres
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/restart").
+			Reply(http.StatusOK)
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.DbId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{
+					Running: true,
+					Health:  &container.Health{Status: types.Healthy},
+				},
+			}})
+		// Restarts services
+		utils.StorageId = "test-storage"
+		utils.GotrueId = "test-auth"
+		utils.RealtimeId = "test-realtime"
+		utils.PoolerId = "test-pooler"
+		utils.KongId = "test-kong"
+		for _, container := range listServicesToRestart() {
+			gock.New(utils.Docker.DaemonHost()).
+				Post("/v" + utils.Docker.ClientVersion() + "/containers/" + container + "/restart").
+				Reply(http.StatusOK)
+		}
+		// Kong is up but the reload exec fails
+		gock.New(utils.Docker.DaemonHost()).
+			Get("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/json").
+			Reply(http.StatusOK).
+			JSON(container.InspectResponse{ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			}})
+		gock.New(utils.Docker.DaemonHost()).
+			Post("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/exec").
+			Reply(http.StatusServiceUnavailable)
+		// Run test
+		err := RestartDatabase(context.Background(), io.Discard)
+		// Check error
+		assert.ErrorContains(t, err, "failed to reload kong")
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 

--- a/apps/cli-go/internal/db/reset/reset_test.go
+++ b/apps/cli-go/internal/db/reset/reset_test.go
@@ -453,6 +453,9 @@ func TestRestartDatabase(t *testing.T) {
 		err := RestartDatabase(context.Background(), io.Discard)
 		// Check error
 		assert.ErrorContains(t, err, "failed to inspect kong")
+		assert.Contains(t, utils.CmdSuggestion, "API routes may return 502")
+		assert.Contains(t, utils.CmdSuggestion, "docker restart test-kong")
+		t.Cleanup(func() { utils.CmdSuggestion = "" })
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 
@@ -499,6 +502,9 @@ func TestRestartDatabase(t *testing.T) {
 		err := RestartDatabase(context.Background(), io.Discard)
 		// Check error
 		assert.ErrorContains(t, err, "failed to reload kong")
+		assert.Contains(t, utils.CmdSuggestion, "API routes may return 502")
+		assert.Contains(t, utils.CmdSuggestion, "docker restart test-kong")
+		t.Cleanup(func() { utils.CmdSuggestion = "" })
 		assert.Empty(t, apitest.ListUnmatchedRequests())
 	})
 

--- a/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
@@ -60,8 +60,13 @@ The seam subprocesses run with `SUPABASE_TELEMETRY_DISABLED=1`, stderr inherited
 The recreate seam drops & recreates the `postgres`/`_supabase` databases (PG≤14) or
 removes & recreates the db container/volume (PG15), applies the initial schema +
 roles, then runs `MigrateAndSeed` (migrations `≤ --version`, seed unless `--no-seed`)
-and restarts the storage/auth/realtime/pooler containers. Bucket objects are then
-seeded over the Storage gateway (reusing the `seed buckets` local path).
+and restarts the storage/auth/realtime/pooler containers, then reloads Kong
+(`kong reload`, skipped when the gateway is absent or stopped) so its nginx
+re-resolves the restarted containers' addresses — otherwise routes to a moved
+container keep returning 502 after the reset succeeds (issue #6016). Bucket
+objects are then seeded over the Storage gateway (reusing the `seed buckets`
+local path); the in-place reload keeps Kong serving throughout, so this never
+races a restarting gateway.
 
 ## API Routes
 

--- a/apps/cli/src/legacy/commands/db/shared/legacy-db-bootstrap.seam.service.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-db-bootstrap.seam.service.ts
@@ -40,7 +40,10 @@ interface LegacyDbBootstrapSeamShape {
   /**
    * The PG14/PG15 container-recreate half of local `db reset`
    * (`reset.RecreateLocalDatabase`): recreate the db container/volume, init schema,
-   * migrate + seed up to `version`, and restart the satellite containers. The
+   * migrate + seed up to `version`, restart the satellite containers
+   * (storage/auth/realtime/pooler), and reload Kong so its nginx re-resolves
+   * the restarted containers' addresses — otherwise routes to a container that
+   * moved keep returning 502 after the reset succeeds (issue #6016). The
    * caller has already printed `Resetting local database…`; the seam tees the
    * remaining progress (`Recreating database...`, `Restarting containers...`) to
    * stderr. `version` is the resolved migration version ("" for all migrations);


### PR DESCRIPTION
## **TL;DR** 
 fixes `/auth/v1/*` (and any gateway route) returning 502 forever after `supabase db reset`, which was happening because the reset restarts auth/storage/
`realtime/pooler` but Kong's nginx keeps dialling their old cached container IPs for the life of its process. Now sorted by running an in-place `kong reload` after the satellite restarts (the same pattern `functions serve` uses), so the gateway re-resolves the moved containers while staying up the whole time 

skipped cleanly, when Kong is absent/stopped, loud failure instead of a silent broken gateway
otherwise. 

## ref: 
- closes https://github.com/supabase/cli/issues/6016
