### PR TITLE
fix(cli): keep bulk function deploys going and always sync metadata (INC-699)

### DIFF
--- a/apps/cli-go/pkg/function/deploy.go
+++ b/apps/cli-go/pkg/function/deploy.go
@@ -109,7 +109,12 @@ func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []FunctionDepl
 	// exists nowhere but this client until the final bulk update request persists it. Bailing
 	// out on the first upload error strands that metadata and makes every subsequent deploy
 	// fail with a version conflict, so we keep going and report the errors at the end.
-	var bundleErrs []error
+	//
+	// Upload errors are recorded per function index rather than surfaced through the job
+	// queue's error channel, so they are reported in input order regardless of completion
+	// order under concurrent --jobs, matching the TS port.
+	uploadErrs := make([]error, len(toDeploy))
+	var queueErrs []error
 	for i, meta := range toDeploy {
 		param := api.V1DeployAFunctionParams{
 			Slug:       meta.Name,
@@ -119,7 +124,8 @@ func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []FunctionDepl
 			fmt.Fprintln(os.Stderr, "Deploying Function:", *meta.Name)
 			resp, err := s.upload(ctx, param, meta, fsys)
 			if err != nil {
-				return err
+				uploadErrs[i] = err
+				return nil
 			}
 			toUpdate[i].Id = resp.Id
 			toUpdate[i].Name = resp.Name
@@ -133,10 +139,10 @@ func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []FunctionDepl
 			toUpdate[i].CreatedAt = resp.CreatedAt
 			return nil
 		}
-		bundleErrs = append(bundleErrs, jq.Put(bundle))
+		queueErrs = append(queueErrs, jq.Put(bundle))
 	}
-	bundleErrs = append(bundleErrs, jq.Collect())
-	bundleErr := errors.Join(bundleErrs...)
+	queueErrs = append(queueErrs, jq.Collect())
+	bundleErr := errors.Join(append(uploadErrs, queueErrs...)...)
 	// Failed uploads leave their slot zero valued, ie. without a function id.
 	uploaded := make(api.BulkUpdateFunctionBody, 0, len(toUpdate))
 	for _, f := range toUpdate {

--- a/apps/cli-go/pkg/function/deploy.go
+++ b/apps/cli-go/pkg/function/deploy.go
@@ -105,6 +105,11 @@ func toRelPath(fp string) string {
 func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []FunctionDeployMetadata, fsys fs.FS) error {
 	jq := queue.NewJobQueue(s.maxJobs)
 	toUpdate := make(api.BulkUpdateFunctionBody, len(toDeploy))
+	// Bulk uploads only write the bundle and bump the version remotely, so the new metadata
+	// exists nowhere but this client until the final bulk update request persists it. Bailing
+	// out on the first upload error strands that metadata and makes every subsequent deploy
+	// fail with a version conflict, so we keep going and report the errors at the end.
+	var bundleErrs []error
 	for i, meta := range toDeploy {
 		param := api.V1DeployAFunctionParams{
 			Slug:       meta.Name,
@@ -128,23 +133,30 @@ func (s *EdgeRuntimeAPI) bulkUpload(ctx context.Context, toDeploy []FunctionDepl
 			toUpdate[i].CreatedAt = resp.CreatedAt
 			return nil
 		}
-		if err := jq.Put(bundle); err != nil {
-			return err
+		bundleErrs = append(bundleErrs, jq.Put(bundle))
+	}
+	bundleErrs = append(bundleErrs, jq.Collect())
+	bundleErr := errors.Join(bundleErrs...)
+	// Failed uploads leave their slot zero valued, ie. without a function id.
+	uploaded := make(api.BulkUpdateFunctionBody, 0, len(toUpdate))
+	for _, f := range toUpdate {
+		if len(f.Id) > 0 {
+			uploaded = append(uploaded, f)
 		}
 	}
-	if err := jq.Collect(); err != nil {
-		return err
+	if len(uploaded) == 0 {
+		return bundleErr
 	}
 	for attempt := 0; ; attempt++ {
-		resp, err := s.client.V1BulkUpdateFunctionsWithResponse(ctx, s.project, toUpdate)
+		resp, err := s.client.V1BulkUpdateFunctionsWithResponse(ctx, s.project, uploaded)
 		if err != nil {
-			return errors.Errorf("failed to bulk update: %w", err)
+			return errors.Join(bundleErr, errors.Errorf("failed to bulk update: %w", err))
 		} else if resp.JSON200 != nil {
-			return nil
+			return bundleErr
 		} else if resp.StatusCode() != http.StatusTooManyRequests || attempt >= deployRateLimitMaxRetries {
-			return errors.Errorf("unexpected bulk update status %d: %s", resp.StatusCode(), string(resp.Body))
+			return errors.Join(bundleErr, errors.Errorf("unexpected bulk update status %d: %s", resp.StatusCode(), string(resp.Body)))
 		} else if err := waitForRateLimit(ctx, responseHeaders(resp.HTTPResponse), attempt, "bulk updating functions"); err != nil {
-			return err
+			return errors.Join(bundleErr, err)
 		}
 	}
 }

--- a/apps/cli-go/pkg/function/deploy_test.go
+++ b/apps/cli-go/pkg/function/deploy_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	fs "testing/fstest"
+	"time"
 
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
@@ -346,6 +348,51 @@ func TestDeployAll(t *testing.T) {
 		// Check error
 		assert.ErrorContains(t, err, "unexpected deploy status 409")
 		assert.ErrorContains(t, err, "unexpected bulk update status 400")
+		assert.Empty(t, gock.Pending())
+		assert.Empty(t, gock.GetUnmatchedRequests())
+	})
+
+	t.Run("reports concurrent upload failures in input order", func(t *testing.T) {
+		client2 := NewEdgeRuntimeAPI(mockProject, *apiClient, WithMaxJobs(2))
+		toDeploy := []FunctionDeployMetadata{
+			{
+				Name:           cast.Ptr("first-fn"),
+				EntrypointPath: "testdata/shared/whatever.ts",
+			},
+			{
+				Name:           cast.Ptr("second-fn"),
+				EntrypointPath: "testdata/geometries/Geometries.js",
+			},
+		}
+		fsys := testImports
+		// Setup mock api
+		defer gock.OffAll()
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "first-fn").
+			Reply(http.StatusConflict).
+			Delay(500 * time.Millisecond).
+			JSON(map[string]string{"message": "first failed"})
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "second-fn").
+			Reply(http.StatusConflict).
+			JSON(map[string]string{"message": "second failed"})
+		// Run test
+		err := client2.bulkUpload(context.Background(), toDeploy, fsys)
+		// Check error
+		require.Error(t, err)
+		// JSON replies are newline-terminated by json.Encoder, so filter out the
+		// resulting blank lines between joined errors before counting entries.
+		var lines []string
+		for _, line := range strings.Split(err.Error(), "\n") {
+			if len(line) > 0 {
+				lines = append(lines, line)
+			}
+		}
+		require.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "first failed")
+		assert.Contains(t, lines[1], "second failed")
 		assert.Empty(t, gock.Pending())
 		assert.Empty(t, gock.GetUnmatchedRequests())
 	})

--- a/apps/cli-go/pkg/function/deploy_test.go
+++ b/apps/cli-go/pkg/function/deploy_test.go
@@ -311,6 +311,45 @@ func TestDeployAll(t *testing.T) {
 		assert.Empty(t, gock.GetUnmatchedRequests())
 	})
 
+	t.Run("reports upload and bulk update failures together", func(t *testing.T) {
+		c := config.FunctionConfig{
+			"test-ts": {
+				Enabled:    true,
+				Entrypoint: "testdata/shared/whatever.ts",
+			},
+			"test-js": {
+				Enabled:    true,
+				Entrypoint: "testdata/geometries/Geometries.js",
+			},
+		}
+		// Setup in-memory fs
+		fsys := testImports
+		// Setup mock api
+		defer gock.OffAll()
+		mockFunctionList()
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "test-ts").
+			Reply(http.StatusCreated).
+			JSON(api.DeployFunctionResponse{Id: "test-ts", Name: "test-ts", Slug: "test-ts"})
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "test-js").
+			Reply(http.StatusConflict).
+			JSON(map[string]string{"message": "deployment already exists"})
+		gock.New(mockApiHost).
+			Put("/v1/projects/"+mockProject+"/functions").
+			Reply(http.StatusBadRequest).
+			JSON(map[string]string{"message": "bulk update rejected"})
+		// Run test
+		err := client.Deploy(context.Background(), c, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "unexpected deploy status 409")
+		assert.ErrorContains(t, err, "unexpected bulk update status 400")
+		assert.Empty(t, gock.Pending())
+		assert.Empty(t, gock.GetUnmatchedRequests())
+	})
+
 	t.Run("preserves remote verify_jwt when not configured", func(t *testing.T) {
 		c := config.FunctionConfig{"demo": {
 			Enabled:    true,

--- a/apps/cli-go/pkg/function/deploy_test.go
+++ b/apps/cli-go/pkg/function/deploy_test.go
@@ -3,7 +3,9 @@ package function
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -26,6 +28,23 @@ func assertFormEqual(t *testing.T, actual []byte) {
 		assert.NoError(t, os.WriteFile(snapshot, actual, 0600))
 	}
 	assert.Equal(t, string(expected), string(actual))
+}
+
+// captureBody records the request body without consuming it, so tests can assert
+// on the exact payload sent to a mocked endpoint.
+func captureBody(out *[]byte) gock.MatchFunc {
+	return func(req *http.Request, _ *gock.Request) (bool, error) {
+		if req.Body == nil {
+			return true, nil
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return false, err
+		}
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		*out = body
+		return true, nil
+	}
 }
 
 func mockFunctionList(functions ...api.FunctionResponse) {
@@ -212,6 +231,82 @@ func TestDeployAll(t *testing.T) {
 		err := client.Deploy(context.Background(), c, fsys)
 		// Check error
 		assert.NoError(t, err)
+		assert.Empty(t, gock.Pending())
+		assert.Empty(t, gock.GetUnmatchedRequests())
+	})
+
+	t.Run("bulk updates successful uploads when one fails", func(t *testing.T) {
+		c := config.FunctionConfig{
+			"test-ts": {
+				Enabled:    true,
+				Entrypoint: "testdata/shared/whatever.ts",
+			},
+			"test-js": {
+				Enabled:    true,
+				Entrypoint: "testdata/geometries/Geometries.js",
+			},
+		}
+		// Setup in-memory fs
+		fsys := testImports
+		// Setup mock api
+		defer gock.OffAll()
+		mockFunctionList()
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "test-ts").
+			Reply(http.StatusCreated).
+			JSON(api.DeployFunctionResponse{Id: "test-ts", Name: "test-ts", Slug: "test-ts"})
+		gock.New(mockApiHost).
+			Post("/v1/projects/"+mockProject+"/functions/deploy").
+			MatchParam("slug", "test-js").
+			Reply(http.StatusConflict).
+			JSON(map[string]string{"message": "deployment already exists"})
+		var bulkBody []byte
+		gock.New(mockApiHost).
+			Put("/v1/projects/"+mockProject+"/functions").
+			AddMatcher(captureBody(&bulkBody)).
+			Reply(http.StatusOK).
+			JSON(api.BulkUpdateFunctionResponse{})
+		// Run test
+		err := client.Deploy(context.Background(), c, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "unexpected deploy status 409")
+		assert.Empty(t, gock.Pending())
+		assert.Empty(t, gock.GetUnmatchedRequests())
+		var toUpdate api.BulkUpdateFunctionBody
+		require.NoError(t, json.Unmarshal(bulkBody, &toUpdate))
+		require.Len(t, toUpdate, 1)
+		assert.Equal(t, "test-ts", toUpdate[0].Slug)
+	})
+
+	t.Run("skips bulk update when all uploads fail", func(t *testing.T) {
+		c := config.FunctionConfig{
+			"test-ts": {
+				Enabled:    true,
+				Entrypoint: "testdata/shared/whatever.ts",
+			},
+			"test-js": {
+				Enabled:    true,
+				Entrypoint: "testdata/geometries/Geometries.js",
+			},
+		}
+		// Setup in-memory fs
+		fsys := testImports
+		// Setup mock api
+		defer gock.OffAll()
+		mockFunctionList()
+		for slug := range c {
+			gock.New(mockApiHost).
+				Post("/v1/projects/"+mockProject+"/functions/deploy").
+				MatchParam("slug", slug).
+				Reply(http.StatusConflict).
+				JSON(map[string]string{"message": "deployment already exists"})
+		}
+		// Run test
+		err := client.Deploy(context.Background(), c, fsys)
+		// Check error
+		assert.ErrorContains(t, err, "unexpected deploy status 409")
+		// No bulk update is mocked, so any PUT would show up as unmatched
 		assert.Empty(t, gock.Pending())
 		assert.Empty(t, gock.GetUnmatchedRequests())
 	})

--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
@@ -496,6 +496,130 @@ describe("legacy functions deploy", () => {
     );
   });
 
+  // INC-699: a `bundleOnly` upload bumps the remote version without persisting
+  // metadata, so a partially failed bulk deploy must still send the final PUT for
+  // whatever uploaded — otherwise the remote metadata is stranded and every later
+  // deploy conflicts.
+  describe("partial bulk upload failures (INC-699)", () => {
+    function setupBulkDeploy(deployStatuses: ReadonlyArray<number>) {
+      const out = mockOutput({ format: "text" });
+      let deployCalls = 0;
+      const api = mockLegacyPlatformApi({
+        handler: (request, recorded) => {
+          if (request.method === "GET") {
+            return Effect.succeed(legacyJsonResponse(request, 200, []));
+          }
+          if (request.method === "POST") {
+            const status = deployStatuses[deployCalls] ?? 201;
+            deployCalls += 1;
+            const slug = recorded.urlParams.includes("slug=bye-world")
+              ? "bye-world"
+              : "hello-world";
+            if (status !== 201) {
+              return Effect.succeed(
+                legacyJsonResponse(request, status, { message: `rejected ${slug}` }),
+              );
+            }
+            return Effect.succeed(
+              legacyJsonResponse(request, 201, {
+                id: `${slug}-id`,
+                slug,
+                name: slug,
+                status: "ACTIVE",
+                version: 2,
+                created_at: 1_687_423_025_152,
+                updated_at: 1_687_423_025_152,
+                verify_jwt: true,
+                import_map: true,
+                entrypoint_path: `functions/${slug}/index.ts`,
+                import_map_path: `functions/${slug}/deno.json`,
+              }),
+            );
+          }
+          return Effect.succeed(legacyJsonResponse(request, 200, {}));
+        },
+      });
+      const layer = Layer.mergeAll(
+        buildLegacyTestRuntime({
+          out,
+          api,
+          cliConfig: mockLegacyCliConfig({ workdir: tempRoot.current }),
+          runtimeInfo: mockRuntimeInfo({ cwd: tempRoot.current }),
+        }),
+        Layer.succeed(LegacyYesFlag, false),
+        Stdio.layerTest({
+          args: Effect.succeed(["functions", "deploy", "hello-world", "bye-world", "--use-api"]),
+        }),
+      );
+      return { out, api, layer };
+    }
+
+    it.live("still persists the functions that uploaded when one upload fails", () => {
+      const { out, api, layer } = setupBulkDeploy([201, 409]);
+
+      return Effect.gen(function* () {
+        yield* Effect.tryPromise(() => writeProjectConfig(tempRoot.current));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "hello-world"));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "bye-world"));
+
+        const error = yield* legacyFunctionsDeploy({
+          ...baseFlags,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe(
+          'unexpected deploy status 409: {"message":"rejected bye-world"}',
+        );
+
+        // Both uploads ran — the 201 was not interrupted by the sibling 409.
+        expect(
+          api.requests.filter(
+            (request) => request.method === "POST" && request.url.endsWith("/functions/deploy"),
+          ),
+        ).toHaveLength(2);
+        const bulkUpdate = api.requests.find((request) => request.method === "PUT");
+        expect(bulkUpdate?.body).toMatchObject([{ slug: "hello-world" }]);
+        expect(out.stdoutText).not.toContain("Deployed Functions on project");
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.tryPromise(() => rm(tempRoot.current, { recursive: true, force: true })),
+        ),
+      );
+    });
+
+    it.live("skips the bulk update entirely when every upload fails", () => {
+      const { out, api, layer } = setupBulkDeploy([409, 400]);
+
+      return Effect.gen(function* () {
+        yield* Effect.tryPromise(() => writeProjectConfig(tempRoot.current));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "hello-world"));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "bye-world"));
+
+        const error = yield* legacyFunctionsDeploy({
+          ...baseFlags,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.flip);
+
+        // Go's `errors.Join`: one message per failed upload, in input order.
+        expect((error as Error).message).toBe(
+          [
+            'unexpected deploy status 409: {"message":"rejected hello-world"}',
+            'unexpected deploy status 400: {"message":"rejected bye-world"}',
+          ].join("\n"),
+        );
+        expect(api.requests.some((request) => request.method === "PUT")).toBe(false);
+        expect(out.stdoutText).not.toContain("Deployed Functions on project");
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.tryPromise(() => rm(tempRoot.current, { recursive: true, force: true })),
+        ),
+      );
+    });
+  });
+
   it.live("rejects the bundler mutex with cobra's exact error text", () => {
     const out = mockOutput({ format: "text" });
     const api = mockLegacyPlatformApi();

--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
@@ -501,16 +501,20 @@ describe("legacy functions deploy", () => {
   // whatever uploaded — otherwise the remote metadata is stranded and every later
   // deploy conflicts.
   describe("partial bulk upload failures (INC-699)", () => {
-    function setupBulkDeploy(deployStatuses: ReadonlyArray<number>) {
+    function setupBulkDeploy(opts: {
+      readonly deployStatuses: ReadonlyArray<number>;
+      readonly bulkStatuses?: ReadonlyArray<number>;
+    }) {
       const out = mockOutput({ format: "text" });
       let deployCalls = 0;
+      let bulkCalls = 0;
       const api = mockLegacyPlatformApi({
         handler: (request, recorded) => {
           if (request.method === "GET") {
             return Effect.succeed(legacyJsonResponse(request, 200, []));
           }
           if (request.method === "POST") {
-            const status = deployStatuses[deployCalls] ?? 201;
+            const status = opts.deployStatuses[deployCalls] ?? 201;
             deployCalls += 1;
             const slug = recorded.urlParams.includes("slug=bye-world")
               ? "bye-world"
@@ -536,6 +540,15 @@ describe("legacy functions deploy", () => {
               }),
             );
           }
+          if (request.method === "PUT") {
+            const status = opts.bulkStatuses?.[bulkCalls] ?? 200;
+            bulkCalls += 1;
+            if (status !== 200) {
+              return Effect.succeed(
+                legacyJsonResponse(request, status, { message: "bulk update rejected" }),
+              );
+            }
+          }
           return Effect.succeed(legacyJsonResponse(request, 200, {}));
         },
       });
@@ -555,7 +568,7 @@ describe("legacy functions deploy", () => {
     }
 
     it.live("still persists the functions that uploaded when one upload fails", () => {
-      const { out, api, layer } = setupBulkDeploy([201, 409]);
+      const { out, api, layer } = setupBulkDeploy({ deployStatuses: [201, 409] });
 
       return Effect.gen(function* () {
         yield* Effect.tryPromise(() => writeProjectConfig(tempRoot.current));
@@ -590,7 +603,7 @@ describe("legacy functions deploy", () => {
     });
 
     it.live("skips the bulk update entirely when every upload fails", () => {
-      const { out, api, layer } = setupBulkDeploy([409, 400]);
+      const { out, api, layer } = setupBulkDeploy({ deployStatuses: [409, 400] });
 
       return Effect.gen(function* () {
         yield* Effect.tryPromise(() => writeProjectConfig(tempRoot.current));
@@ -611,6 +624,38 @@ describe("legacy functions deploy", () => {
         );
         expect(api.requests.some((request) => request.method === "PUT")).toBe(false);
         expect(out.stdoutText).not.toContain("Deployed Functions on project");
+      }).pipe(
+        Effect.provide(layer),
+        Effect.ensuring(
+          Effect.tryPromise(() => rm(tempRoot.current, { recursive: true, force: true })),
+        ),
+      );
+    });
+
+    it.live("reports the upload failure and the bulk update failure together", () => {
+      const { api, layer } = setupBulkDeploy({
+        deployStatuses: [201, 409],
+        bulkStatuses: [400],
+      });
+
+      return Effect.gen(function* () {
+        yield* Effect.tryPromise(() => writeProjectConfig(tempRoot.current));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "hello-world"));
+        yield* Effect.tryPromise(() => writeLocalFunction(tempRoot.current, "bye-world"));
+
+        const error = yield* legacyFunctionsDeploy({
+          ...baseFlags,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe(
+          [
+            'unexpected deploy status 409: {"message":"rejected bye-world"}',
+            'unexpected bulk update status 400: {"message":"bulk update rejected"}',
+          ].join("\n"),
+        );
+        expect(api.requests.filter((request) => request.method === "PUT")).toHaveLength(1);
       }).pipe(
         Effect.provide(layer),
         Effect.ensuring(

--- a/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
@@ -68,6 +68,16 @@ interface RecordedRequest {
   readonly path: string;
   readonly urlParams: string;
   readonly headers: Readonly<Record<string, string | undefined>>;
+  /** Parsed JSON body, for the non-multipart requests (e.g. the bulk update PUT). */
+  readonly body?: unknown;
+}
+
+function readJsonBody(request: HttpClientRequest.HttpClientRequest): unknown {
+  // Docker bundle uploads are raw `EZBR`-prefixed Uint8Array bodies, not JSON.
+  if (request.body._tag !== "Uint8Array" || !request.body.contentType.includes("json")) {
+    return undefined;
+  }
+  return JSON.parse(new TextDecoder().decode(request.body.body));
 }
 
 interface RecordedMultipart {
@@ -235,6 +245,7 @@ function mockDeployApi(
               path,
               urlParams,
               headers: request.headers,
+              body: readJsonBody(request),
             });
             const multipart = readMultipart(request);
             if (multipart !== undefined) {
@@ -263,6 +274,11 @@ function mockDeployApi(
                 UrlParams.getFirst(request.urlParams, "slug"),
                 () => "hello-world",
               );
+              if (status !== 201) {
+                return jsonResponse(request, status, {
+                  message: `deployment already exists for ${slug}`,
+                });
+              }
               return jsonResponse(request, 201, {
                 ...makeFunction({
                   slug,
@@ -283,6 +299,9 @@ function mockDeployApi(
                   { message: "Too Many Requests" },
                   { "Retry-After": "0" },
                 );
+              }
+              if (status !== 200) {
+                return jsonResponse(request, status, { message: "bulk update rejected" });
               }
               return jsonResponse(request, 200, {
                 functions: [],
@@ -697,6 +716,109 @@ describe("functions deploy", () => {
         `Deployed Functions on project ${PROJECT_REF}: hello-world, bye-world\n`,
       );
     }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
+  });
+
+  // INC-699: a `bundleOnly` upload bumps the remote version without persisting
+  // metadata, so a partially failed bulk deploy must still send the final PUT for
+  // whatever uploaded — otherwise the remote metadata is stranded and every later
+  // deploy conflicts.
+  describe("partial bulk upload failures (INC-699)", () => {
+    it.live("still persists the functions that uploaded when one upload fails", () => {
+      const tempDir = makeTempDir();
+
+      return Effect.gen(function* () {
+        yield* Effect.promise(() => writeProjectConfig(tempDir));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "bye-world"));
+
+        const { out, api, layer } = setup(tempDir, {
+          api: { deployStatuses: [201, 409] },
+        });
+
+        const error = yield* functionsDeploy({
+          ...BASE_FLAGS,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.provide(layer), Effect.flip);
+
+        expect(error).toBeInstanceOf(Error);
+        if (error instanceof Error) {
+          expect(error.message).toBe(
+            'unexpected deploy status 409: {"message":"deployment already exists for bye-world"}',
+          );
+        }
+
+        // Both uploads ran — the 201 was not interrupted by the sibling 409.
+        expect(
+          api.requests.filter((request) => request.path.endsWith("/functions/deploy")),
+        ).toHaveLength(2);
+        const bulkUpdate = api.requests.find((request) => request.method === "PUT");
+        expect(bulkUpdate).toBeDefined();
+        expect(bulkUpdate?.body).toMatchObject([{ slug: "hello-world" }]);
+        expect(out.stdoutText).not.toContain("Deployed Functions on project");
+      }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
+    });
+
+    it.live("skips the bulk update entirely when every upload fails", () => {
+      const tempDir = makeTempDir();
+
+      return Effect.gen(function* () {
+        yield* Effect.promise(() => writeProjectConfig(tempDir));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "bye-world"));
+
+        const { out, api, layer } = setup(tempDir, {
+          api: { deployStatuses: [409, 400] },
+        });
+
+        const error = yield* functionsDeploy({
+          ...BASE_FLAGS,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.provide(layer), Effect.flip);
+
+        // Go's `errors.Join`: one message per failed upload, in input order.
+        expect(error).toBeInstanceOf(Error);
+        if (error instanceof Error) {
+          expect(error.message).toBe(
+            [
+              'unexpected deploy status 409: {"message":"deployment already exists for hello-world"}',
+              'unexpected deploy status 400: {"message":"deployment already exists for bye-world"}',
+            ].join("\n"),
+          );
+        }
+        expect(api.requests.some((request) => request.method === "PUT")).toBe(false);
+        expect(out.stdoutText).not.toContain("Deployed Functions on project");
+      }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
+    });
+
+    it.live("reports the upload failure and the bulk update failure together", () => {
+      const tempDir = makeTempDir();
+
+      return Effect.gen(function* () {
+        yield* Effect.promise(() => writeProjectConfig(tempDir));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "hello-world"));
+        yield* Effect.promise(() => writeLocalFunction(tempDir, "bye-world"));
+
+        const { api, layer } = setup(tempDir, {
+          api: { deployStatuses: [201, 409], bulkStatuses: [400] },
+        });
+
+        const error = yield* functionsDeploy({
+          ...BASE_FLAGS,
+          functionNames: ["hello-world", "bye-world"],
+        }).pipe(Effect.provide(layer), Effect.flip);
+
+        expect(error).toBeInstanceOf(Error);
+        if (error instanceof Error) {
+          expect(error.message).toBe(
+            [
+              'unexpected deploy status 409: {"message":"deployment already exists for bye-world"}',
+              'unexpected bulk update status 400: {"message":"bulk update rejected"}',
+            ].join("\n"),
+          );
+        }
+        expect(api.requests.filter((request) => request.method === "PUT")).toHaveLength(1);
+      }).pipe(Effect.ensuring(cleanupTempDir(tempDir)));
+    });
   });
 
   it.live("uploads import maps using the same relative path as metadata", () => {

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -1972,7 +1972,11 @@ const deployViaApi = Effect.fnUntraced(function* (
     return;
   }
 
-  const deployed = yield* Effect.forEach(
+  // INC-699: each bundleOnly upload writes the bundle and bumps the remote version without
+  // persisting metadata, which only the final bulk update does. Failing fast on the first
+  // upload error strands that metadata remotely and makes every later deploy conflict, so
+  // run every upload to completion, always persist what succeeded, then report the errors.
+  const results = yield* Effect.forEach(
     enabled,
     (config) =>
       Effect.gen(function* () {
@@ -1987,10 +1991,37 @@ const deployViaApi = Effect.fnUntraced(function* (
             true,
           ),
         );
-      }),
+      }).pipe(
+        Effect.map((value) => ({ success: true as const, value })),
+        Effect.catch((error) => Effect.succeed({ success: false as const, error })),
+      ),
     { concurrency: jobs },
   );
-  yield* bulkUpdateRemoteFunctions(api, projectRef, deployed);
+
+  const deployed: BulkUpdateFunction[] = [];
+  const messages: string[] = [];
+  for (const result of results) {
+    if (result.success) {
+      deployed.push(result.value);
+    } else {
+      messages.push(result.error.message);
+    }
+  }
+
+  if (deployed.length === 0) {
+    return yield* Effect.fail(new Error(messages.join("\n")));
+  }
+
+  const updated = yield* bulkUpdateRemoteFunctions(api, projectRef, deployed).pipe(
+    Effect.map(() => ({ success: true as const })),
+    Effect.catch((error) => Effect.succeed({ success: false as const, error })),
+  );
+  if (!updated.success) {
+    messages.push(updated.error.message);
+  }
+  if (messages.length > 0) {
+    return yield* Effect.fail(new Error(messages.join("\n")));
+  }
 });
 
 const deployViaDocker = Effect.fnUntraced(function* (

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -2000,16 +2000,18 @@ const deployViaApi = Effect.fnUntraced(function* (
 
   const deployed: BulkUpdateFunction[] = [];
   const messages: string[] = [];
+  const causes: Array<Extract<(typeof results)[number], { readonly success: false }>["error"]> = [];
   for (const result of results) {
     if (result.success) {
       deployed.push(result.value);
     } else {
       messages.push(result.error.message);
+      causes.push(result.error);
     }
   }
 
   if (deployed.length === 0) {
-    return yield* Effect.fail(new Error(messages.join("\n")));
+    return yield* Effect.fail(new AggregateError(causes, messages.join("\n")));
   }
 
   const updated = yield* bulkUpdateRemoteFunctions(api, projectRef, deployed).pipe(
@@ -2018,9 +2020,10 @@ const deployViaApi = Effect.fnUntraced(function* (
   );
   if (!updated.success) {
     messages.push(updated.error.message);
+    causes.push(updated.error);
   }
   if (messages.length > 0) {
-    return yield* Effect.fail(new Error(messages.join("\n")));
+    return yield* Effect.fail(new AggregateError(causes, messages.join("\n")));
   }
 });
 


### PR DESCRIPTION
## Summary

Bulk `functions deploy` uploads each function with `bundleOnly=true`, which writes the bundle and bumps the remote version **without persisting metadata** — only the final `PUT /v1/projects/{ref}/functions` does. The flow failed fast: any single upload error (409 `deployment already exists`, 400 `Bundle generation timed out`, …) aborted the deploy before that PUT, stranding the new version metadata client-side. The backend was left with stale versions, so every subsequent deploy computed a conflicting version and failed with 409 — the poisoned-project loop driving [INDATA-999](https://linear.app/supabase/issue/INDATA-999/investigate-missing-ipv6-address-for-2-projects).

This change makes the bulk path continue through per-function failures, in both the Go CLI and the TS port (identical semantics, since legacy TS is a 1:1 Go port):

* Run every upload to completion instead of aborting on the first error; failed functions are skipped and their errors collected.
* Always send the final bulk update PUT assembled from the functions that uploaded successfully, so remote metadata stays consistent. The PUT is only skipped when every upload failed (nothing new to sync, nothing stranded).
* Still exit non-zero on partial failure, reporting each failed function's error (messages joined with newlines, `errors.Join` semantics on the Go side). If the PUT itself fails, its error is appended after the upload errors.

A failed bulk deploy no longer poisons the project: re-running the deploy just works.

### Before — fail-fast strands the metadata

```mermaid
flowchart TD
    A["POST fn-a ?bundleOnly=true → 201<br/><i>bundle stored, version bumped</i>"]
    B["POST fn-b ?bundleOnly=true → 201<br/><i>bundle stored, version bumped</i>"]
    C["POST fn-c ?bundleOnly=true → 409<br/><i>CLI aborts the whole deploy</i>"]
    D["PUT /functions metadata sync<br/><i>never sent — new versions lost</i>"]
    E["Backend metadata now stale<br/><i>every re-deploy hits 409</i>"]
    A --> B --> C
    C -.-x D -.-> E
    classDef ok fill:#e1f5ee,stroke:#0f6e56,color:#04342c
    classDef bad fill:#fcebeb,stroke:#a32d2d,color:#501313
    classDef skipped fill:#f1efe8,stroke:#5f5e5a,color:#2c2c2a,stroke-dasharray:6 4
    class A,B ok
    class C,E bad
    class D skipped
```

### After — failures are skipped, successes always synced

```mermaid
flowchart TD
    A["POST fn-a ?bundleOnly=true → 201<br/><i>bundle stored, version bumped</i>"]
    B["POST fn-b ?bundleOnly=true → 201<br/><i>bundle stored, version bumped</i>"]
    C["POST fn-c ?bundleOnly=true → 409<br/><i>error collected, flow continues</i>"]
    D["PUT /functions with fn-a, fn-b<br/><i>metadata synced for successes</i>"]
    E["Exit 1, report fn-c failure<br/><i>state consistent — retry works</i>"]
    A --> B --> C --> D --> E
    classDef ok fill:#e1f5ee,stroke:#0f6e56,color:#04342c
    classDef tolerated fill:#faeeda,stroke:#854f0b,color:#412402
    classDef outcome fill:#f1efe8,stroke:#5f5e5a,color:#2c2c2a
    class A,B,D ok
    class C tolerated
    class E outcome
```

## Reviewer notes

* The final PUT already only ever carried the functions being deployed (never the full remote set), so sending the successful subset is upsert-safe.
* The single-function path (no `bundleOnly`) and the Docker bundler path (per-function upserts persist metadata server-side) are unaffected and untouched.
* Error ordering: both implementations report upload errors in input order regardless of `--jobs` concurrency — Go records failures per function index instead of reading the job queue's completion-order error channel, matching TS.
* On failure, the TS error is an `AggregateError` carrying the original error objects; its `message` stays byte-identical to Go's `errors.Join` output.

## Linked issue

Incident: [INDATA-999](https://linear.app/supabase/issue/INDATA-999/investigate-missing-ipv6-address-for-2-projects) (bulk edge function deployments failing / 409 deployment already exists). Internal incident, no `open-for-contribution` issue — Supabase maintainer.

## Checklist

- [X] The PR title follows [Conventional Commits](<https://www.conventionalcommits.org/>) (e.g. `fix(cli): …`).
- [X] Tests added or updated for the change.
- [X] `pnpm check:all` and `pnpm test` pass for the workspace(s) I touched (`apps/cli` integration suites; `go build`/`go vet`/`go test ./pkg/function/...` incl. `-race` for `apps/cli-go`).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)