### PR TITLE
test(cli): deflake e2e image pulls

### DIFF
--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -337,7 +337,9 @@ describe("legacy gen types e2e", () => {
     "generates all supported languages from a tokenless local stack",
     {
       timeout:
-        LOCAL_IMAGE_BUDGET_MS + LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length,
+        LOCAL_IMAGE_BUDGET_MS +
+        LOCAL_POSTGRES_TIMEOUT_MS +
+        TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length,
     },
     async () => {
       const home = makeTempHome();
@@ -386,7 +388,7 @@ describe("legacy gen types e2e", () => {
 
   remoteTest(
     "generates all supported languages from a remote project",
-    { timeout: TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length },
+    { timeout: RESOLVE_BUDGET_MS + TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length },
     async () => {
       const home = makeTempHome();
       const project = await makeTempStackProject("supabase-typegen-remote-e2e-");

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -223,10 +223,11 @@ async function ensurePgmetaImage(deadline?: number) {
 async function startLocalPostgres(input: { readonly projectId: string; readonly dbPort: number }) {
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
-  // Sized so a slow-but-healthy Postgres pull cannot starve pg-meta's
-  // resolution; the local test's own timeout includes this allowance.
+  // One shared window (already counted in the local test's timeout), with
+  // pg-meta's slice reserved up front: Postgres may spend the window only up
+  // to the point that still leaves pg-meta the default budget.
   const imageDeadline = resolveDeadline(LOCAL_IMAGE_BUDGET_MS);
-  const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE, imageDeadline);
+  const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE, imageDeadline - RESOLVE_BUDGET_MS);
   await ensurePgmetaImage(imageDeadline);
 
   await expectDockerSucceeded(["network", "create", networkName], 30_000);

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -10,7 +10,11 @@ import {
 import { dockerfileServiceImage } from "../../../../shared/services/dockerfile-images.ts";
 import { localDbContainerId, localNetworkId } from "../../../shared/legacy-docker-ids.ts";
 import { legacyGetRegistryImageUrl } from "../../../shared/legacy-docker-registry.ts";
-import { ensureImage, resolveDeadline } from "../../../../../tests/helpers/docker-image.ts";
+import {
+  RESOLVE_BUDGET_MS,
+  ensureImage,
+  resolveDeadline,
+} from "../../../../../tests/helpers/docker-image.ts";
 import { resolvePgmetaImage } from "./types.shared.ts";
 
 const TYPEGEN_LANGS = ["typescript", "go", "swift", "python"] as const;
@@ -19,6 +23,10 @@ type TypegenLang = (typeof TYPEGEN_LANGS)[number];
 const LOCAL_POSTGRES_IMAGE = legacyGetRegistryImageUrl(dockerfileServiceImage("pg"));
 const LOCAL_POSTGRES_TIMEOUT_MS = 120_000;
 const TYPEGEN_TIMEOUT_MS = 90_000;
+// Image resolution happens inside the test bodies, ahead of the startup and
+// per-language windows the test timeouts already budget — so each timeout has
+// to include its own image setup allowance on top.
+const LOCAL_IMAGE_BUDGET_MS = LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS;
 const REMOTE_E2E_FLAG = "SUPABASE_TYPEGEN_E2E_REMOTE";
 const REMOTE_PROJECT_REF_ENV = "SUPABASE_TEST_PROJECT_REF";
 const OUTPUT_TAIL_LENGTH = 4_000;
@@ -215,10 +223,9 @@ async function ensurePgmetaImage(deadline?: number) {
 async function startLocalPostgres(input: { readonly projectId: string; readonly dbPort: number }) {
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
-  // The outer test budget is LOCAL_POSTGRES_TIMEOUT_MS + a typegen window per
-  // language, so image setup can afford a roomier budget than the default —
-  // a slow-but-healthy Postgres pull must not starve pg-meta's resolution.
-  const imageDeadline = resolveDeadline(LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS);
+  // Sized so a slow-but-healthy Postgres pull cannot starve pg-meta's
+  // resolution; the local test's own timeout includes this allowance.
+  const imageDeadline = resolveDeadline(LOCAL_IMAGE_BUDGET_MS);
   const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE, imageDeadline);
   await ensurePgmetaImage(imageDeadline);
 
@@ -328,7 +335,10 @@ function expectLocalSmokeTable(lang: TypegenLang, stdout: string) {
 describe("legacy gen types e2e", () => {
   test(
     "generates all supported languages from a tokenless local stack",
-    { timeout: LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length },
+    {
+      timeout:
+        LOCAL_IMAGE_BUDGET_MS + LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS * TYPEGEN_LANGS.length,
+    },
     async () => {
       const home = makeTempHome();
       const project = await makeTempStackProject("supabase-typegen-local-e2e-");

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -10,7 +10,7 @@ import {
 import { dockerfileServiceImage } from "../../../../shared/services/dockerfile-images.ts";
 import { localDbContainerId, localNetworkId } from "../../../shared/legacy-docker-ids.ts";
 import { legacyGetRegistryImageUrl } from "../../../shared/legacy-docker-registry.ts";
-import { ensureImage } from "../../../../../tests/helpers/docker-image.ts";
+import { ensureImage, resolveDeadline } from "../../../../../tests/helpers/docker-image.ts";
 import { resolvePgmetaImage } from "./types.shared.ts";
 
 const TYPEGEN_LANGS = ["typescript", "go", "swift", "python"] as const;
@@ -201,18 +201,23 @@ async function waitForLocalPostgres(containerName: string) {
   );
 }
 
+// `gen types` starts pg-meta itself (local AND remote non-ts languages) via a
+// single-registry rewrite with no fallback (`resolvePgmetaImage`), so pre-resolve
+// it and retag the winning candidate onto the exact reference the CLI will run.
+async function ensurePgmetaImage(deadline?: number) {
+  const expected = resolvePgmetaImage();
+  const resolved = await ensureImage(dockerfileServiceImage("pgmeta"), deadline);
+  if (resolved !== expected) {
+    await expectDockerSucceeded(["tag", resolved, expected], 30_000);
+  }
+}
+
 async function startLocalPostgres(input: { readonly projectId: string; readonly dbPort: number }) {
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
-  const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE);
-  // `gen types --local` starts pg-meta itself via a single-registry rewrite
-  // with no fallback (`resolvePgmetaImage`), so pre-resolve it here and retag
-  // the winning candidate onto the exact reference the CLI will `docker run`.
-  const pgmetaExpected = resolvePgmetaImage();
-  const pgmetaResolved = await ensureImage(dockerfileServiceImage("pgmeta"));
-  if (pgmetaResolved !== pgmetaExpected) {
-    await expectDockerSucceeded(["tag", pgmetaResolved, pgmetaExpected], 30_000);
-  }
+  const imageDeadline = resolveDeadline();
+  const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE, imageDeadline);
+  await ensurePgmetaImage(imageDeadline);
 
   await expectDockerSucceeded(["network", "create", networkName], 30_000);
   await expectDockerSucceeded(
@@ -382,6 +387,8 @@ describe("legacy gen types e2e", () => {
           `Set ${REMOTE_E2E_FLAG}=1, ${REMOTE_PROJECT_REF_ENV}, and SUPABASE_ACCESS_TOKEN to run remote typegen e2e.`,
         );
       }
+
+      await ensurePgmetaImage();
 
       for (const lang of TYPEGEN_LANGS) {
         const result = await runSupabase(

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -215,7 +215,10 @@ async function ensurePgmetaImage(deadline?: number) {
 async function startLocalPostgres(input: { readonly projectId: string; readonly dbPort: number }) {
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
-  const imageDeadline = resolveDeadline();
+  // The outer test budget is LOCAL_POSTGRES_TIMEOUT_MS + a typegen window per
+  // language, so image setup can afford a roomier budget than the default —
+  // a slow-but-healthy Postgres pull must not starve pg-meta's resolution.
+  const imageDeadline = resolveDeadline(LOCAL_POSTGRES_TIMEOUT_MS + TYPEGEN_TIMEOUT_MS);
   const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE, imageDeadline);
   await ensurePgmetaImage(imageDeadline);
 

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -10,6 +10,7 @@ import {
 import { dockerfileServiceImage } from "../../../../shared/services/dockerfile-images.ts";
 import { localDbContainerId, localNetworkId } from "../../../shared/legacy-docker-ids.ts";
 import { legacyGetRegistryImageUrl } from "../../../shared/legacy-docker-registry.ts";
+import { ensureImage } from "../../../../../tests/helpers/docker-image.ts";
 
 const TYPEGEN_LANGS = ["typescript", "go", "swift", "python"] as const;
 type TypegenLang = (typeof TYPEGEN_LANGS)[number];
@@ -202,6 +203,7 @@ async function waitForLocalPostgres(containerName: string) {
 async function startLocalPostgres(input: { readonly projectId: string; readonly dbPort: number }) {
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
+  const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE);
 
   await expectDockerSucceeded(["network", "create", networkName], 30_000);
   await expectDockerSucceeded(
@@ -219,7 +221,7 @@ async function startLocalPostgres(input: { readonly projectId: string; readonly 
       `${input.dbPort}:5432`,
       "-e",
       "POSTGRES_PASSWORD=postgres",
-      LOCAL_POSTGRES_IMAGE,
+      postgresImage,
       "postgres",
       "-D",
       "/etc/postgresql",

--- a/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.e2e.test.ts
@@ -11,6 +11,7 @@ import { dockerfileServiceImage } from "../../../../shared/services/dockerfile-i
 import { localDbContainerId, localNetworkId } from "../../../shared/legacy-docker-ids.ts";
 import { legacyGetRegistryImageUrl } from "../../../shared/legacy-docker-registry.ts";
 import { ensureImage } from "../../../../../tests/helpers/docker-image.ts";
+import { resolvePgmetaImage } from "./types.shared.ts";
 
 const TYPEGEN_LANGS = ["typescript", "go", "swift", "python"] as const;
 type TypegenLang = (typeof TYPEGEN_LANGS)[number];
@@ -204,6 +205,14 @@ async function startLocalPostgres(input: { readonly projectId: string; readonly 
   const containerName = localDbContainerId(input.projectId);
   const networkName = localNetworkId(input.projectId);
   const postgresImage = await ensureImage(LOCAL_POSTGRES_IMAGE);
+  // `gen types --local` starts pg-meta itself via a single-registry rewrite
+  // with no fallback (`resolvePgmetaImage`), so pre-resolve it here and retag
+  // the winning candidate onto the exact reference the CLI will `docker run`.
+  const pgmetaExpected = resolvePgmetaImage();
+  const pgmetaResolved = await ensureImage(dockerfileServiceImage("pgmeta"));
+  if (pgmetaResolved !== pgmetaExpected) {
+    await expectDockerSucceeded(["tag", pgmetaResolved, pgmetaExpected], 30_000);
+  }
 
   await expectDockerSucceeded(["network", "create", networkName], 30_000);
   await expectDockerSucceeded(

--- a/apps/cli/src/legacy/commands/start/lib/image-prepull.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/image-prepull.unit.test.ts
@@ -125,7 +125,7 @@ describe("legacyEnsureImagesCached", () => {
     }),
   );
 
-  // Every pull attempt fails, so this drives the real DOCKER_PULL_RETRY_DELAYS_MS
+  // Every pull attempt fails, so this drives the real LEGACY_DOCKER_PULL_RETRY_DELAYS_MS
   // backoff (4s + 8s) to exhaustion across all 3 registry candidates (~36s) —
   // needs more than Vitest's 5s default.
   it.live(

--- a/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
@@ -10,7 +10,7 @@ import { legacyGetRegistryImageUrlCandidates } from "./legacy-docker-registry.ts
 
 type Spawner = ChildProcessSpawner["Service"];
 
-const DOCKER_PULL_RETRY_DELAYS_MS = [4_000, 8_000] as const;
+export const LEGACY_DOCKER_PULL_RETRY_DELAYS_MS = [4_000, 8_000] as const;
 
 const spawnError = () =>
   // Never embed the spawn error verbatim: it can leak the full argv and
@@ -45,7 +45,7 @@ const concat = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
  * unconditionally — Go retries on any non-nil error as long as the context
  * wasn't canceled, with no message-pattern gating — up to 2 times per
  * candidate (3 total attempts) with an escalating 4s/8s backoff
- * (`DOCKER_PULL_RETRY_DELAYS_MS`), matching Go's `2<<(i+1)` seconds for `i` in
+ * (`LEGACY_DOCKER_PULL_RETRY_DELAYS_MS`), matching Go's `2<<(i+1)` seconds for `i` in
  * `0,1`. A spawn failure (the Docker/Podman binary itself couldn't be run) is
  * a different, non-retryable case — see `spawnError` below. Used by both the
  * foreground `db dump`-style run-to-completion containers
@@ -158,7 +158,7 @@ export function legacyMakeDockerImageResolver(
       for (const candidate of candidates) {
         for (
           let attemptIndex = 0;
-          attemptIndex <= DOCKER_PULL_RETRY_DELAYS_MS.length;
+          attemptIndex <= LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length;
           attemptIndex += 1
         ) {
           const attempt = attemptIndex + 1;
@@ -172,7 +172,7 @@ export function legacyMakeDockerImageResolver(
                 ? result.value.stderr
                 : `docker pull exited with code ${result.value.exitCode}`;
             failures.push(`${candidate} attempt ${attempt}: ${message}`);
-            if (attemptIndex === DOCKER_PULL_RETRY_DELAYS_MS.length) {
+            if (attemptIndex === LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length) {
               break;
             }
           } else {
@@ -186,7 +186,7 @@ export function legacyMakeDockerImageResolver(
             return yield* Effect.fail(spawnError());
           }
 
-          const delay = DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
+          const delay = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
           if (delay === undefined) {
             break;
           }

--- a/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
+++ b/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { LEGACY_EDGE_RUNTIME_IMAGE } from "../../legacy/shared/legacy-edge-runtime-image.ts";
+import { ensureImage } from "../../../tests/helpers/docker-image.ts";
 import { dockerfileServiceImage } from "../services/dockerfile-images.ts";
 import { bundleServeMainTemplate } from "./serve-main-bundler.ts";
 
@@ -131,6 +132,7 @@ describe("functions serve runtime template (offline)", () => {
     "boots under edge-runtime with networking disabled and fetches nothing remote",
     { timeout: SERVE_OFFLINE_TEST_TIMEOUT_MS },
     async () => {
+      const runtimeImage = await ensureImage(LEGACY_EDGE_RUNTIME_IMAGE);
       const dir = await mkdtemp(join(tmpdir(), "supabase-serve-offline-e2e-"));
       const container = `supabase-serve-offline-e2e-${process.pid.toString()}`;
       try {
@@ -159,7 +161,7 @@ describe("functions serve runtime template (offline)", () => {
             `${dir}:/app:ro`,
             "--entrypoint",
             "edge-runtime",
-            LEGACY_EDGE_RUNTIME_IMAGE,
+            runtimeImage,
             "start",
             "--main-service=/app",
             "--port=8081",
@@ -194,6 +196,7 @@ describe("functions serve runtime template (offline)", () => {
     "returns canonical JWT auth failures",
     { timeout: SERVE_OFFLINE_TEST_TIMEOUT_MS },
     async () => {
+      const runtimeImage = await ensureImage(LEGACY_EDGE_RUNTIME_IMAGE);
       const dir = await mkdtemp(join(tmpdir(), "supabase-serve-auth-e2e-"));
       const container = `supabase-serve-auth-e2e-${process.pid.toString()}`;
       try {
@@ -224,7 +227,7 @@ describe("functions serve runtime template (offline)", () => {
             `${dir}:/app:ro`,
             "--entrypoint",
             "edge-runtime",
-            LEGACY_EDGE_RUNTIME_IMAGE,
+            runtimeImage,
             "start",
             "--main-service=/app",
             "--port=8081",
@@ -275,6 +278,10 @@ describe("functions serve runtime template (offline)", () => {
     "preserves function CORS headers and exposes JWT errors through Kong",
     { timeout: SERVE_OFFLINE_TEST_TIMEOUT_MS },
     async () => {
+      const [runtimeImage, kongImage] = await Promise.all([
+        ensureImage(LEGACY_EDGE_RUNTIME_IMAGE),
+        ensureImage(LEGACY_KONG_IMAGE),
+      ]);
       const dir = await mkdtemp(join(tmpdir(), "supabase-serve-kong-e2e-"));
       const network = `supabase-serve-kong-e2e-${process.pid.toString()}`;
       const runtimeContainer = `${network}-runtime`;
@@ -315,7 +322,7 @@ describe("functions serve runtime template (offline)", () => {
             `${dir}:/app:ro`,
             "--entrypoint",
             "edge-runtime",
-            LEGACY_EDGE_RUNTIME_IMAGE,
+            runtimeImage,
             "start",
             "--main-service=/app",
             "--port=8081",
@@ -345,7 +352,7 @@ describe("functions serve runtime template (offline)", () => {
             "KONG_NGINX_WORKER_PROCESSES=1",
             "-v",
             `${join(dir, "kong.yml")}:/home/kong/kong.yml:ro`,
-            LEGACY_KONG_IMAGE,
+            kongImage,
             "kong",
             "docker-start",
           ],

--- a/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
+++ b/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
@@ -34,7 +34,10 @@ function hasDocker(): boolean {
 
 const dockerAvailable = hasDocker();
 const SERVE_OFFLINE_STARTUP_TIMEOUT_MS = 60_000;
-const SERVE_OFFLINE_TEST_TIMEOUT_MS = 120_000;
+// Cold-cache image resolution (up to one shared 90s resolveDeadline budget)
+// runs inside the test body, ahead of the 60s startup wait — the test budget
+// must cover both stacked, or a healthy near-cap pull trips vitest first.
+const SERVE_OFFLINE_TEST_TIMEOUT_MS = 180_000;
 const AUTH_FUNCTIONS_CONFIG = JSON.stringify({
   test: {
     entrypointPath: "/tmp/test/index.ts",

--- a/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
+++ b/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
@@ -35,7 +35,6 @@ function hasDocker(): boolean {
 const dockerAvailable = hasDocker();
 const SERVE_OFFLINE_STARTUP_TIMEOUT_MS = 60_000;
 const SERVE_OFFLINE_TEST_TIMEOUT_MS = 120_000;
-const LEGACY_KONG_IMAGE = `public.ecr.aws/supabase/${dockerfileServiceImage("kong").replace(/^.*\//, "")}`;
 const AUTH_FUNCTIONS_CONFIG = JSON.stringify({
   test: {
     entrypointPath: "/tmp/test/index.ts",
@@ -280,7 +279,7 @@ describe("functions serve runtime template (offline)", () => {
     async () => {
       const [runtimeImage, kongImage] = await Promise.all([
         ensureImage(LEGACY_EDGE_RUNTIME_IMAGE),
-        ensureImage(LEGACY_KONG_IMAGE),
+        ensureImage(dockerfileServiceImage("kong")),
       ]);
       const dir = await mkdtemp(join(tmpdir(), "supabase-serve-kong-e2e-"));
       const network = `supabase-serve-kong-e2e-${process.pid.toString()}`;

--- a/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
+++ b/apps/cli/src/shared/functions/serve-main-offline.e2e.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { LEGACY_EDGE_RUNTIME_IMAGE } from "../../legacy/shared/legacy-edge-runtime-image.ts";
-import { ensureImage } from "../../../tests/helpers/docker-image.ts";
+import { ensureImage, resolveDeadline } from "../../../tests/helpers/docker-image.ts";
 import { dockerfileServiceImage } from "../services/dockerfile-images.ts";
 import { bundleServeMainTemplate } from "./serve-main-bundler.ts";
 
@@ -277,9 +277,10 @@ describe("functions serve runtime template (offline)", () => {
     "preserves function CORS headers and exposes JWT errors through Kong",
     { timeout: SERVE_OFFLINE_TEST_TIMEOUT_MS },
     async () => {
+      const imageDeadline = resolveDeadline();
       const [runtimeImage, kongImage] = await Promise.all([
-        ensureImage(LEGACY_EDGE_RUNTIME_IMAGE),
-        ensureImage(dockerfileServiceImage("kong")),
+        ensureImage(LEGACY_EDGE_RUNTIME_IMAGE, imageDeadline),
+        ensureImage(dockerfileServiceImage("kong"), imageDeadline),
       ]);
       const dir = await mkdtemp(join(tmpdir(), "supabase-serve-kong-e2e-"));
       const network = `supabase-serve-kong-e2e-${process.pid.toString()}`;

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -10,7 +10,7 @@ const PULL_ATTEMPT_TIMEOUT_MS = 120_000;
 // Overall per-image ceiling. Deliberately BELOW the tightest e2e test budget
 // (120s): a stalled registry must leave the caller room to run its test body,
 // and vitest cannot preempt a blocked synchronous spawn to enforce that itself.
-const RESOLVE_DEADLINE_MS = 90_000;
+export const RESOLVE_BUDGET_MS = 90_000;
 const PULL_MAX_BUFFER = 16 * 1024 * 1024;
 const PULL_ATTEMPTS = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length + 1;
 
@@ -43,7 +43,7 @@ export function ensureImage(image: string, deadline = resolveDeadline()): Promis
  * deadlines would otherwise stack beyond the test budget. Callers with roomier
  * test timeouts can size the budget to their own setup window.
  */
-export function resolveDeadline(budgetMs = RESOLVE_DEADLINE_MS): number {
+export function resolveDeadline(budgetMs = RESOLVE_BUDGET_MS): number {
   return Date.now() + budgetMs;
 }
 
@@ -54,10 +54,13 @@ function spawnFailed(result: { error?: Error; signal: NodeJS.Signals | null }): 
 async function resolveImage(image: string, deadline: number): Promise<string> {
   const candidates = legacyGetRegistryImageUrlCandidates(image);
   for (const candidate of candidates) {
+    // Bounded by the shared deadline too: a cached hit still answers in
+    // milliseconds, but a stalled daemon can no longer stack 15s inspects
+    // past a budget an earlier image already consumed.
     const inspect = spawnSync("docker", ["image", "inspect", candidate], {
       encoding: "utf8",
       stdio: ["ignore", "ignore", "pipe"],
-      timeout: INSPECT_TIMEOUT_MS,
+      timeout: Math.min(INSPECT_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
       killSignal: "SIGKILL",
     });
     if (spawnFailed(inspect)) {

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -38,12 +38,13 @@ export function ensureImage(image: string, deadline = resolveDeadline()): Promis
 
 /**
  * One deadline for a whole test's image setup: pass the same value to every
- * `ensureImage` call so multi-image tests pay at most one RESOLVE_DEADLINE_MS
- * total — the synchronous spawns serialize regardless of Promise.all, so
- * per-image deadlines would otherwise stack beyond the test budget.
+ * `ensureImage` call so multi-image tests pay at most one budget in total —
+ * the synchronous spawns serialize regardless of Promise.all, so per-image
+ * deadlines would otherwise stack beyond the test budget. Callers with roomier
+ * test timeouts can size the budget to their own setup window.
  */
-export function resolveDeadline(): number {
-  return Date.now() + RESOLVE_DEADLINE_MS;
+export function resolveDeadline(budgetMs = RESOLVE_DEADLINE_MS): number {
+  return Date.now() + budgetMs;
 }
 
 function spawnFailed(result: { error?: Error; signal: NodeJS.Signals | null }): boolean {

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -7,6 +7,9 @@ import { legacyIsDockerDaemonUnreachable } from "../../src/legacy/shared/legacy-
 
 const INSPECT_TIMEOUT_MS = 15_000;
 const PULL_ATTEMPT_TIMEOUT_MS = 120_000;
+// Overall per-image ceiling, matched to the tightest e2e test budget: a stalled
+// registry eats at most one test's worth of wall clock, never attempts × 120s.
+const RESOLVE_DEADLINE_MS = 120_000;
 const PULL_MAX_BUFFER = 16 * 1024 * 1024;
 const PULL_ATTEMPTS = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length + 1;
 
@@ -55,15 +58,21 @@ async function resolveImage(image: string): Promise<string> {
     }
   }
 
+  const deadline = Date.now() + RESOLVE_DEADLINE_MS;
   const failures: Array<string> = [];
   for (const candidate of candidates) {
     for (let attemptIndex = 0; attemptIndex < PULL_ATTEMPTS; attemptIndex += 1) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        failures.push(`resolution deadline exceeded (${RESOLVE_DEADLINE_MS}ms budget)`);
+        return allRegistriesFailed(image, failures);
+      }
       console.error(
         `[ensureImage] pulling ${candidate} (attempt ${attemptIndex + 1}/${PULL_ATTEMPTS})`,
       );
       const pull = spawnSync("docker", ["pull", candidate], {
         encoding: "utf8",
-        timeout: PULL_ATTEMPT_TIMEOUT_MS,
+        timeout: Math.min(PULL_ATTEMPT_TIMEOUT_MS, remainingMs),
         killSignal: "SIGKILL",
         maxBuffer: PULL_MAX_BUFFER,
       });
@@ -83,6 +92,10 @@ async function resolveImage(image: string): Promise<string> {
       if (delay !== undefined) await sleep(delay);
     }
   }
+  return allRegistriesFailed(image, failures);
+}
+
+function allRegistriesFailed(image: string, failures: ReadonlyArray<string>): never {
   throw new Error(
     `failed to pull ${image} from all registries (set SUPABASE_INTERNAL_IMAGE_REGISTRY to pin one):\n${failures.join("\n")}`,
   );

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -7,9 +7,10 @@ import { legacyIsDockerDaemonUnreachable } from "../../src/legacy/shared/legacy-
 
 const INSPECT_TIMEOUT_MS = 15_000;
 const PULL_ATTEMPT_TIMEOUT_MS = 120_000;
-// Overall per-image ceiling, matched to the tightest e2e test budget: a stalled
-// registry eats at most one test's worth of wall clock, never attempts × 120s.
-const RESOLVE_DEADLINE_MS = 120_000;
+// Overall per-image ceiling. Deliberately BELOW the tightest e2e test budget
+// (120s): a stalled registry must leave the caller room to run its test body,
+// and vitest cannot preempt a blocked synchronous spawn to enforce that itself.
+const RESOLVE_DEADLINE_MS = 90_000;
 const PULL_MAX_BUFFER = 16 * 1024 * 1024;
 const PULL_ATTEMPTS = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length + 1;
 

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -71,8 +71,12 @@ async function resolveImage(image: string): Promise<string> {
       console.error(
         `[ensureImage] pulling ${candidate} (attempt ${attemptIndex + 1}/${PULL_ATTEMPTS})`,
       );
+      // stdout carries the (unbounded) layer-progress stream — ignore it so a
+      // large healthy pull can never die on ENOBUFS; docker writes errors to
+      // stderr, which stays small and is all the failure text needs.
       const pull = spawnSync("docker", ["pull", candidate], {
         encoding: "utf8",
+        stdio: ["ignore", "ignore", "pipe"],
         timeout: Math.min(PULL_ATTEMPT_TIMEOUT_MS, remainingMs),
         killSignal: "SIGKILL",
         maxBuffer: PULL_MAX_BUFFER,
@@ -81,7 +85,7 @@ async function resolveImage(image: string): Promise<string> {
         throw new Error(`failed to run docker: ${pull.error?.message ?? "unknown spawn error"}`);
       }
       if (pull.status === 0) return candidate;
-      const output = `${pull.stdout ?? ""}${pull.stderr ?? ""}`.trim();
+      const output = (pull.stderr ?? "").trim();
       const reason =
         pull.signal !== null && pull.signal !== undefined
           ? `killed by ${pull.signal} after ${PULL_ATTEMPT_TIMEOUT_MS}ms`

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -60,13 +60,18 @@ async function resolveImage(image: string): Promise<string> {
   }
 
   const deadline = Date.now() + RESOLVE_DEADLINE_MS;
+  // Equal split so a candidate that stalls (accepts the connection but never
+  // completes) can never starve the fallbacks that come after it — every
+  // registry is guaranteed its share of the overall deadline.
+  const perCandidateBudgetMs = Math.floor(RESOLVE_DEADLINE_MS / candidates.length);
   const failures: Array<string> = [];
   for (const candidate of candidates) {
+    const candidateDeadline = Math.min(Date.now() + perCandidateBudgetMs, deadline);
     for (let attemptIndex = 0; attemptIndex < PULL_ATTEMPTS; attemptIndex += 1) {
-      const remainingMs = deadline - Date.now();
+      const remainingMs = candidateDeadline - Date.now();
       if (remainingMs <= 0) {
-        failures.push(`resolution deadline exceeded (${RESOLVE_DEADLINE_MS}ms budget)`);
-        return allRegistriesFailed(image, failures);
+        failures.push(`${candidate}: candidate budget exhausted (${perCandidateBudgetMs}ms)`);
+        break;
       }
       console.error(
         `[ensureImage] pulling ${candidate} (attempt ${attemptIndex + 1}/${PULL_ATTEMPTS})`,
@@ -94,7 +99,9 @@ async function resolveImage(image: string): Promise<string> {
             : `exit ${pull.status ?? "unknown"}`;
       failures.push(`${candidate} attempt ${attemptIndex + 1}: ${reason}`);
       const delay = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
-      if (delay !== undefined) await sleep(delay);
+      if (delay === undefined) continue;
+      if (Date.now() + delay >= candidateDeadline) break;
+      await sleep(delay);
     }
   }
   return allRegistriesFailed(image, failures);

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -69,17 +69,21 @@ async function resolveImage(image: string, deadline: number): Promise<string> {
     }
   }
 
-  // Equal split so a candidate that stalls (accepts the connection but never
-  // completes) can never starve the fallbacks that come after it — every
-  // registry is guaranteed its share of the remaining deadline.
-  const perCandidateBudgetMs = Math.max(1, Math.floor((deadline - Date.now()) / candidates.length));
   const failures: Array<string> = [];
-  for (const candidate of candidates) {
-    const candidateDeadline = Math.min(Date.now() + perCandidateBudgetMs, deadline);
+  for (const [candidateIndex, candidate] of candidates.entries()) {
+    // Recomputed per candidate: remaining time split across the candidates
+    // still to run. A stalled candidate can never starve the fallbacks after
+    // it, and a fast-failing one carries its unused budget forward — the last
+    // candidate gets all remaining time.
+    const candidateBudgetMs = Math.max(
+      1,
+      Math.floor((deadline - Date.now()) / (candidates.length - candidateIndex)),
+    );
+    const candidateDeadline = Math.min(Date.now() + candidateBudgetMs, deadline);
     for (let attemptIndex = 0; attemptIndex < PULL_ATTEMPTS; attemptIndex += 1) {
       const remainingMs = candidateDeadline - Date.now();
       if (remainingMs <= 0) {
-        failures.push(`${candidate}: candidate budget exhausted (${perCandidateBudgetMs}ms)`);
+        failures.push(`${candidate}: candidate budget exhausted (${candidateBudgetMs}ms)`);
         break;
       }
       console.error(

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { LEGACY_DOCKER_PULL_RETRY_DELAYS_MS } from "../../src/legacy/shared/legacy-docker-image-resolve.ts";
+import { legacyGetRegistryImageUrlCandidates } from "../../src/legacy/shared/legacy-docker-registry.ts";
+import { legacyIsDockerDaemonUnreachable } from "../../src/legacy/shared/legacy-docker-suggest.ts";
+
+const INSPECT_TIMEOUT_MS = 15_000;
+const PULL_ATTEMPT_TIMEOUT_MS = 120_000;
+const PULL_MAX_BUFFER = 16 * 1024 * 1024;
+const PULL_ATTEMPTS = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length + 1;
+
+const resolvedImages = new Map<string, Promise<string>>();
+
+/**
+ * Resolves an image for a raw e2e `docker run`/`docker pull` the same way the
+ * production resolver does (`legacy-docker-image-resolve.ts`): any candidate
+ * already in the local cache wins, otherwise each registry fallback
+ * (ECR → GHCR → Docker Hub) is pulled explicitly with 4s/8s retries. A raw
+ * `docker run` of an uncached image implicit-pulls from a single registry,
+ * where CI regularly fails with `toomanyrequests: Rate exceeded`. Returns the
+ * resolved reference the caller must use in its own docker argv. Results
+ * (including failures) are memoized per process so parallel/subsequent tests
+ * never re-pay the retry ladder. Every subprocess call is timeout-bounded —
+ * vitest's own testTimeout cannot preempt a hung synchronous spawn.
+ */
+export function ensureImage(image: string): Promise<string> {
+  const memo = resolvedImages.get(image);
+  if (memo !== undefined) return memo;
+  const resolving = resolveImage(image);
+  resolvedImages.set(image, resolving);
+  return resolving;
+}
+
+function spawnFailed(result: { error?: Error; signal: NodeJS.Signals | null }): boolean {
+  return result.error !== undefined && (result.signal === null || result.signal === undefined);
+}
+
+async function resolveImage(image: string): Promise<string> {
+  const candidates = legacyGetRegistryImageUrlCandidates(image);
+  for (const candidate of candidates) {
+    const inspect = spawnSync("docker", ["image", "inspect", candidate], {
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: INSPECT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+    if (spawnFailed(inspect)) {
+      throw new Error(`failed to run docker: ${inspect.error?.message ?? "unknown spawn error"}`);
+    }
+    if (inspect.status === 0) return candidate;
+    const stderr = (inspect.stderr ?? "").trim();
+    if (legacyIsDockerDaemonUnreachable(stderr)) {
+      throw new Error(`docker daemon unreachable: ${stderr}`);
+    }
+  }
+
+  const failures: Array<string> = [];
+  for (const candidate of candidates) {
+    for (let attemptIndex = 0; attemptIndex < PULL_ATTEMPTS; attemptIndex += 1) {
+      console.error(
+        `[ensureImage] pulling ${candidate} (attempt ${attemptIndex + 1}/${PULL_ATTEMPTS})`,
+      );
+      const pull = spawnSync("docker", ["pull", candidate], {
+        encoding: "utf8",
+        timeout: PULL_ATTEMPT_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+        maxBuffer: PULL_MAX_BUFFER,
+      });
+      if (spawnFailed(pull)) {
+        throw new Error(`failed to run docker: ${pull.error?.message ?? "unknown spawn error"}`);
+      }
+      if (pull.status === 0) return candidate;
+      const output = `${pull.stdout ?? ""}${pull.stderr ?? ""}`.trim();
+      const reason =
+        pull.signal !== null && pull.signal !== undefined
+          ? `killed by ${pull.signal} after ${PULL_ATTEMPT_TIMEOUT_MS}ms`
+          : output.length > 0
+            ? output
+            : `exit ${pull.status ?? "unknown"}`;
+      failures.push(`${candidate} attempt ${attemptIndex + 1}: ${reason}`);
+      const delay = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
+      if (delay !== undefined) await sleep(delay);
+    }
+  }
+  throw new Error(
+    `failed to pull ${image} from all registries (set SUPABASE_INTERNAL_IMAGE_REGISTRY to pin one):\n${failures.join("\n")}`,
+  );
+}

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -28,19 +28,29 @@ const resolvedImages = new Map<string, Promise<string>>();
  * never re-pay the retry ladder. Every subprocess call is timeout-bounded —
  * vitest's own testTimeout cannot preempt a hung synchronous spawn.
  */
-export function ensureImage(image: string): Promise<string> {
+export function ensureImage(image: string, deadline = resolveDeadline()): Promise<string> {
   const memo = resolvedImages.get(image);
   if (memo !== undefined) return memo;
-  const resolving = resolveImage(image);
+  const resolving = resolveImage(image, deadline);
   resolvedImages.set(image, resolving);
   return resolving;
+}
+
+/**
+ * One deadline for a whole test's image setup: pass the same value to every
+ * `ensureImage` call so multi-image tests pay at most one RESOLVE_DEADLINE_MS
+ * total — the synchronous spawns serialize regardless of Promise.all, so
+ * per-image deadlines would otherwise stack beyond the test budget.
+ */
+export function resolveDeadline(): number {
+  return Date.now() + RESOLVE_DEADLINE_MS;
 }
 
 function spawnFailed(result: { error?: Error; signal: NodeJS.Signals | null }): boolean {
   return result.error !== undefined && (result.signal === null || result.signal === undefined);
 }
 
-async function resolveImage(image: string): Promise<string> {
+async function resolveImage(image: string, deadline: number): Promise<string> {
   const candidates = legacyGetRegistryImageUrlCandidates(image);
   for (const candidate of candidates) {
     const inspect = spawnSync("docker", ["image", "inspect", candidate], {
@@ -59,11 +69,10 @@ async function resolveImage(image: string): Promise<string> {
     }
   }
 
-  const deadline = Date.now() + RESOLVE_DEADLINE_MS;
   // Equal split so a candidate that stalls (accepts the connection but never
   // completes) can never starve the fallbacks that come after it — every
-  // registry is guaranteed its share of the overall deadline.
-  const perCandidateBudgetMs = Math.floor(RESOLVE_DEADLINE_MS / candidates.length);
+  // registry is guaranteed its share of the remaining deadline.
+  const perCandidateBudgetMs = Math.max(1, Math.floor((deadline - Date.now()) / candidates.length));
   const failures: Array<string> = [];
   for (const candidate of candidates) {
     const candidateDeadline = Math.min(Date.now() + perCandidateBudgetMs, deadline);


### PR DESCRIPTION
## **TL;DR**

fixes the recurring red e2e shards (`docker: toomanyrequests: Rate exceeded`): 
raw `docker run`s implicit-pulled uncached images from a single registry, 
so one rate-limit killed the shard.

 Now `ensureImage()` (tests/helpers) resolves images like prod's resolver cached first, 
then 4s/8s-retried pulls across ECR → GHCR → Docker Hub ->  at every raw-run site, timeout-bounded, daemon-aware, memoized. 
Verified both ways: rate-limited registries reproduce the CI failure verbatim unfixed, pass via the Hub fallback fixed....
## ref:
<details>
<summary>fixes: (ss)</summary>

<img width="1736" height="1296" alt="image" src="https://github.com/user-attachments/assets/6361bebf-b1b1-4e2d-b976-af9204fff080" />

</details>
