### PR TITLE
fix(cli): reuse existing volumes

### DIFF
--- a/apps/cli/src/legacy/commands/start/lib/container-lifecycle.ts
+++ b/apps/cli/src/legacy/commands/start/lib/container-lifecycle.ts
@@ -284,10 +284,25 @@ export function legacyEnsureStartNetwork(
 }
 
 /**
+ * Whether `volume create`'s stderr reports the volume already existing —
+ * podman's "volume with name <name> already exists: volume already exists",
+ * either half. A "...but was not created for the current specification"
+ * conflict deliberately does not match, so a real spec conflict still fails.
+ */
+function legacyIsVolumeAlreadyExistsError(stderr: string): boolean {
+  return /volume (?:with name \S+ )?already exists/iu.test(stderr);
+}
+
+/**
  * Go's per-source-name `Docker.VolumeCreate` call (`docker.go:407-415`) via
- * `docker volume create --label ...`. Unlike network creation, Go applies no
- * "already exists" tolerance here — `VolumeCreate` is already idempotent for a
- * repeated name with matching options, so any non-zero exit is a real failure.
+ * `docker volume create --label ...`, treating "already exists" as success the
+ * same way {@link legacyEnsureStartNetwork} does; any other non-zero exit is a
+ * real failure.
+ *
+ * Go's Engine API is idempotent for a repeated name, including against Podman's
+ * Docker-compat endpoint; `podman volume create` goes through libpod instead
+ * and rejects it, so every `stop`/`start` cycle aborted the bring-up on the
+ * volumes `stop` preserves (supabase/cli#6020).
  */
 export function legacyEnsureStartVolume(
   spawner: Spawner,
@@ -322,7 +337,7 @@ export function legacyEnsureStartVolume(
           () => new LegacyStartVolumeCreateError({ message: "failed to create volume" }),
         ),
       );
-      if (exitCode !== 0) {
+      if (exitCode !== 0 && !legacyIsVolumeAlreadyExistsError(stderr)) {
         const message = stderr.trim();
         return yield* Effect.fail(
           new LegacyStartVolumeCreateError({

--- a/apps/cli/src/legacy/commands/start/lib/container-lifecycle.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/container-lifecycle.unit.test.ts
@@ -763,7 +763,42 @@ describe("legacyEnsureStartVolume", () => {
     );
   });
 
-  it.live("fails on any non-zero exit, with no already-exists tolerance", () => {
+  it.live("treats podman's already-exists rejection as success", () => {
+    const mock = mockSpawner(() => ({
+      exitCode: 125,
+      stderr: "Error: volume with name supabase_db_proj already exists: volume already exists\n",
+    }));
+    return legacyEnsureStartVolume(mock.spawner, "supabase_db_proj", {}).pipe(
+      Effect.map(() => {
+        // Just needs to not fail — no return value to assert on.
+      }),
+    );
+  });
+
+  it.live("treats an already-exists rejection without the trailing sentinel as success", () => {
+    const mock = mockSpawner(() => ({
+      exitCode: 125,
+      stderr: "volume with name supabase_db_proj already exists\n",
+    }));
+    return legacyEnsureStartVolume(mock.spawner, "supabase_db_proj", {}).pipe(
+      Effect.map(() => {
+        // Just needs to not fail — no return value to assert on.
+      }),
+    );
+  });
+
+  it.live("fails with LegacyStartVolumeCreateError on any other failure", () => {
+    const mock = mockSpawner(() => ({ exitCode: 1, stderr: "permission denied\n" }));
+    return legacyEnsureStartVolume(mock.spawner, "supabase_db_proj", {}).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error).toBeInstanceOf(LegacyStartVolumeCreateError);
+        expect(error.message).toBe("failed to create volume: permission denied");
+      }),
+    );
+  });
+
+  it.live("still fails when the volume exists under a different specification", () => {
     const mock = mockSpawner(() => ({
       exitCode: 1,
       stderr:

--- a/apps/cli/src/legacy/commands/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.integration.test.ts
@@ -1344,6 +1344,26 @@ describe("legacy start integration", () => {
       }).pipe(Effect.provide(layer));
     });
 
+    it.live("brings the stack up when podman rejects re-creating preserved volumes (#6020)", () => {
+      const route = defaultRoute();
+      const { layer, analytics } = setup({
+        route: (args) => {
+          if (args[0] === "volume" && args[1] === "create") {
+            const name = args[args.length - 1] ?? "";
+            return {
+              exitCode: 125,
+              stderr: [`Error: volume with name ${name} already exists: volume already exists`],
+            };
+          }
+          return route(args);
+        },
+      });
+      return Effect.gen(function* () {
+        yield* legacyStart(flags());
+        expect(analytics.captured.some((c) => c.event === "cli_stack_started")).toBe(true);
+      }).pipe(Effect.provide(layer));
+    });
+
     it.live(
       "reuses the bring-up-resolved local config values for the final status print instead of re-deriving them",
       () => {


### PR DESCRIPTION
## TL;DR

`supabase start` dying on Podman with `failed to create volume: ... already exists`.  <br>It never happened in Go because Go called the Docker **Engine API**,  <br>which is idempotent for a repeated volume name (and stays idempotent against Podman, whose Docker-compat endpoint just hands back the existing volume). After the port we shell out to the **container CLI** instead, and `podman volume create` goes through libpod rather than that compat endpoint, which rejects a repeated name outright.  <br>Fixed by treating an already exists rejection as success in `legacyEnsureStartVolume`, the same way `legacyEnsureStartNetwork` right above it already does, plus unit + integration tests.

## Why it kept biting

Named volumes survive `stop` unless `--no-backup`, so every `stop`/`start` cycle re-creates volumes that were kept on purpose:

```
failed to create volume: Error: volume with name supabase_db_xxx already exists: volume already exists
```

`docker volume create` is unconditionally idempotent, so only Podman hosts ever reached this branch.

## refs:

* closes supabase/cli#6020