### PR TITLE
fix(cli): order migrations by version

### DIFF
--- a/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
@@ -261,6 +261,20 @@ describe("legacy db push", () => {
     });
   });
 
+  it.live("reports up to date when an 8-digit and 14-digit version share a prefix (#6036)", () => {
+    const { layer, out, conn } = setup(tmp.current, {
+      toml: 'project_id = "test"\n',
+      files: { ...migrationFile("20260420"), ...migrationFile("20260420010000") },
+      remoteMigrations: ["20260420", "20260420010000"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(out.stdoutText).toBe("Local database is up to date.\n");
+      expect(conn.execs).not.toContain("BEGIN");
+    });
+  });
+
   it.live("emits a json result for an up-to-date run", () => {
     const { layer, out } = setup(tmp.current, { toml: 'project_id = "test"\n', format: "json" });
     return Effect.gen(function* () {

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.ts
@@ -1,4 +1,5 @@
 import { legacyBold } from "../../../shared/legacy-colors.ts";
+import { legacySortMigrationPathsByVersion } from "../../../shared/legacy-migration-history.ts";
 
 /**
  * `pkg/migration/file.go` — local migration filenames are `<digits>_<name>.sql`.
@@ -43,22 +44,22 @@ export type LegacyPendingMigrations =
 
 /**
  * Two-pointer reconciliation of local migration paths vs remote applied versions.
- * Mirrors Go's `FindPendingMigrations` exactly, including its **string**
- * comparison of versions (`remote == local` / `remote < local`) — version
- * prefixes are fixed-width timestamps, so lexical order equals chronological
- * order, matching Go.
+ * Mirrors Go's `FindPendingMigrations`, including its **string** comparison of
+ * versions (`remote == local` / `remote < local`).
+ * Both sides must agree on ordering, so `localMigrations` is re-sorted by version.
  */
 export function legacyFindPendingMigrations(
   localMigrations: ReadonlyArray<string>,
   remoteMigrations: ReadonlyArray<string>,
 ): LegacyPendingMigrations {
+  const sortedLocal = legacySortMigrationPathsByVersion(localMigrations);
   const unapplied: Array<string> = [];
   const missing: Array<string> = [];
   let i = 0;
   let j = 0;
-  while (i < remoteMigrations.length && j < localMigrations.length) {
+  while (i < remoteMigrations.length && j < sortedLocal.length) {
     const remote = remoteMigrations[i]!;
-    const filename = baseName(localMigrations[j]!);
+    const filename = baseName(sortedLocal[j]!);
     // ListLocalMigrations guarantees a match, so the capture group is present.
     const local = MIGRATE_FILE_PATTERN.exec(filename)![1]!;
     if (remote === local) {
@@ -69,12 +70,12 @@ export function legacyFindPendingMigrations(
       i++;
     } else {
       // Include out-of-order local migrations.
-      unapplied.push(localMigrations[j]!);
+      unapplied.push(sortedLocal[j]!);
       j++;
     }
   }
   // Ensure all remote versions exist on local.
-  if (j === localMigrations.length) {
+  if (j === sortedLocal.length) {
     missing.push(...remoteMigrations.slice(i));
   }
   if (missing.length > 0) {
@@ -84,7 +85,7 @@ export function legacyFindPendingMigrations(
   if (unapplied.length > 0) {
     return { kind: "missing-remote", paths: unapplied };
   }
-  return { kind: "ok", pending: localMigrations.slice(remoteMigrations.length) };
+  return { kind: "ok", pending: sortedLocal.slice(remoteMigrations.length) };
 }
 
 /**
@@ -98,7 +99,11 @@ export function legacyIncludeAllPending(
   remoteCount: number,
   diff: ReadonlyArray<string>,
 ): ReadonlyArray<string> {
-  return [...diff, ...localMigrations.slice(remoteCount + diff.length)];
+  // Slices the same version-ordered list `diff` was taken from — indexing a
+  // name-ordered list with a version-ordered offset would skip a pending
+  // migration and re-apply an already-applied one.
+  const sortedLocal = legacySortMigrationPathsByVersion(localMigrations);
+  return [...diff, ...sortedLocal.slice(remoteCount + diff.length)];
 }
 
 /** Go's `suggestIgnoreFlag` (`internal/migration/up/up.go:63-67`). */

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migration-pending.unit.test.ts
@@ -23,6 +23,36 @@ describe("legacyFindPendingMigrations", () => {
     expect(result).toEqual({ kind: "ok", pending: [] });
   });
 
+  it("is up to date when one version is a string prefix of another (#6036)", () => {
+    // Not limited to long timestamps: any prefix pair inverts, because
+    // `10_name.sql` sorts before `1_name.sql` by name ('0' < '_') while remote
+    // reads back "1" before "10".
+    const result = legacyFindPendingMigrations(local("10", "1"), ["1", "10"]);
+    expect(result).toEqual({ kind: "ok", pending: [] });
+  });
+
+  it("is up to date when an 8-digit and a 14-digit version share a prefix (#6036)", () => {
+    // Local files arrive in name order, where `20260420010000_name.sql` precedes
+    // `20260420_name.sql` ('0' < '_') — the reverse of the version order
+    // `schema_migrations` is read back in.
+    const result = legacyFindPendingMigrations(local("20260420010000", "20260420"), [
+      "20260420",
+      "20260420010000",
+    ]);
+    expect(result).toEqual({ kind: "ok", pending: [] });
+  });
+
+  it("returns mixed-width pending migrations in version order", () => {
+    const result = legacyFindPendingMigrations(local("20260420010000", "20260420"), []);
+    expect(result).toEqual({
+      kind: "ok",
+      pending: [
+        "supabase/migrations/20260420_name.sql",
+        "supabase/migrations/20260420010000_name.sql",
+      ],
+    });
+  });
+
   it("reports missing-local when remote has a version with no local file", () => {
     const result = legacyFindPendingMigrations(local("0001", "0003"), ["0001", "0002", "0003"]);
     expect(result).toEqual({ kind: "missing-local", versions: ["0002"] });
@@ -51,6 +81,19 @@ describe("legacyFindPendingMigrations", () => {
 });
 
 describe("legacyIncludeAllPending", () => {
+  it("slices the version-ordered list, not the name-ordered one (#6036)", () => {
+    // Local files arrive name-ordered as [20, 1, 2]; version order is [1, 2, 20].
+    // With "2" applied, the diff is [1] and the slice must resume at "20".
+    // Indexing the name-ordered list instead would return "2" — already applied —
+    // and silently drop "20".
+    const locals = local("20", "1", "2");
+    const diff = ["supabase/migrations/1_name.sql"];
+    expect(legacyIncludeAllPending(locals, 1, diff)).toEqual([
+      "supabase/migrations/1_name.sql",
+      "supabase/migrations/20_name.sql",
+    ]);
+  });
+
   it("prepends the out-of-order diff then the migrations beyond remote+diff", () => {
     const locals = local("0001", "0002", "0003");
     const diff = ["supabase/migrations/0001_name.sql"];

--- a/apps/cli/src/legacy/commands/migration/up/up.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.handler.ts
@@ -18,6 +18,7 @@ import {
   legacyFindPendingMigrations,
   legacyListLocalMigrationPaths,
   legacyListRemoteMigrations,
+  legacySortMigrationPathsByVersion,
   legacySuggestRevertHistory,
 } from "../../../shared/legacy-migration-history.ts";
 import { legacyUpsertVaultSecrets } from "../../../shared/legacy-vault.ts";
@@ -106,8 +107,14 @@ const runUp = Effect.fnUntraced(function* (
             );
           }
           // Go's `--include-all`: the out-of-order set + everything after the
-          // applied prefix (`up.go:47`).
-          pending = [...result.paths, ...local.slice(remote.length + result.paths.length)];
+          // applied prefix (`up.go:47`). Slices the same version-ordered list
+          // `result.paths` was taken from — indexing a name-ordered list with a
+          // version-ordered offset would skip a pending migration and re-apply
+          // an already-applied one.
+          pending = [
+            ...result.paths,
+            ...legacySortMigrationPathsByVersion(local).slice(remote.length + result.paths.length),
+          ];
         } else {
           pending = result.paths;
         }

--- a/apps/cli/src/legacy/shared/legacy-migration-history.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.ts
@@ -295,6 +295,25 @@ export const legacyLoadLocalVersions = (
 /** Basename of a path, handling both `/` and `\` separators (keeps the helper pure). */
 const baseName = (filePath: string): string => filePath.split(/[\\/]/u).pop() ?? filePath;
 
+/**
+ * Orders local migration paths by version so they line up with
+ * `schema_migrations` (`ORDER BY version`) before a two-pointer walk compares
+ * the two lists. Go sorts these by file name and compares by version, which
+ * only agrees while versions are the same width: `20260420010000_b.sql` sorts
+ * before `20260420_a.sql` by name (`'0'` < `'_'`) but after it by version,
+ * desynchronising the walk (supabase/cli#6036). Stable and keyed on the version
+ * alone, so same-width sets keep the exact name order Go produced.
+ */
+export function legacySortMigrationPathsByVersion(
+  localPaths: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  return [...localPaths].sort((a, b) => {
+    const versionA = MIGRATE_FILE_PATTERN.exec(baseName(a))?.[1] ?? "";
+    const versionB = MIGRATE_FILE_PATTERN.exec(baseName(b))?.[1] ?? "";
+    return versionA < versionB ? -1 : versionA > versionB ? 1 : 0;
+  });
+}
+
 /** Outcome of `legacyFindPendingMigrations` — Go's `(slice, error)` as a tagged union. */
 export type LegacyPendingMigrations =
   | { readonly kind: "pending"; readonly paths: ReadonlyArray<string> }
@@ -309,19 +328,21 @@ export type LegacyPendingMigrations =
  * paths, or flags a remote version missing from local (`missing-local`) or an
  * out-of-order local migration (`missing-remote`). `localPaths` are full paths
  * whose basenames match `<version>_<name>.sql`; `remoteVersions` are sorted.
+ * Both sides must agree on ordering, so `localPaths` is re-sorted by version.
  */
 export function legacyFindPendingMigrations(
   localPaths: ReadonlyArray<string>,
   remoteVersions: ReadonlyArray<string>,
 ): LegacyPendingMigrations {
+  const sortedLocal = legacySortMigrationPathsByVersion(localPaths);
   const unapplied: Array<string> = [];
   const missing: Array<string> = [];
   let i = 0;
   let j = 0;
-  while (i < remoteVersions.length && j < localPaths.length) {
+  while (i < remoteVersions.length && j < sortedLocal.length) {
     const remote = remoteVersions[i]!;
     // `legacyListLocalMigrations` guarantees the basename matches the pattern.
-    const local = MIGRATE_FILE_PATTERN.exec(baseName(localPaths[j]!))?.[1] ?? "";
+    const local = MIGRATE_FILE_PATTERN.exec(baseName(sortedLocal[j]!))?.[1] ?? "";
     if (remote === local) {
       i++;
       j++;
@@ -330,17 +351,17 @@ export function legacyFindPendingMigrations(
       i++;
     } else {
       // Out-of-order local migration (older than an applied remote one).
-      unapplied.push(localPaths[j]!);
+      unapplied.push(sortedLocal[j]!);
       j++;
     }
   }
   // Any remote versions past the end of local are also missing.
-  if (j === localPaths.length) {
+  if (j === sortedLocal.length) {
     for (let k = i; k < remoteVersions.length; k++) missing.push(remoteVersions[k]!);
   }
   if (missing.length > 0) return { kind: "missing-local", versions: missing };
   if (unapplied.length > 0) return { kind: "missing-remote", paths: unapplied };
-  return { kind: "pending", paths: localPaths.slice(remoteVersions.length) };
+  return { kind: "pending", paths: sortedLocal.slice(remoteVersions.length) };
 }
 
 /**

--- a/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-history.unit.test.ts
@@ -130,6 +130,15 @@ describe("legacyFindPendingMigrations (Go TestPendingMigrations / TestIgnoreVers
     expect(result).toEqual({ kind: "pending", paths: [mig("1"), mig("2")] });
   });
 
+  it("is up to date when an 8-digit and a 14-digit version share a prefix (#6036)", () => {
+    // Local files arrive in name order, where `20260420010000_…` precedes
+    // `20260420_…` ('0' < '_') — the reverse of the version order
+    // `schema_migrations` is read back in.
+    const local = ["20260420010000", "20260420"].map(mig);
+    const result = legacyFindPendingMigrations(local, ["20260420", "20260420010000"]);
+    expect(result).toEqual({ kind: "pending", paths: [] });
+  });
+
   it("flags out-of-order local migrations as missing-remote", () => {
     // local [0,1,2,3], remote [0,2] → unapplied [1] (1 sits before applied 2).
     const local = ["20221201000000", "20221201000001", "20221201000002", "20221201000003"].map(mig);


### PR DESCRIPTION
## TL;DR

Fixing `db push` failing with  `Remote migration versions not found in local migrations directory`
 for a version that's sitting right there on disk, which happened because local files arrive in **name** order while `schema_migrations` comes back in **version** order, and 
those two disagree whenever one version is a string prefix of another (`1` vs `10`, or `20260420` vs `20260420010000`): `10_b.sql` sorts before `1_a.sql` (`'0'` < `'_'`), 
so the two-pointer merge desynchronises and reports an already-applied version as missing. `migration up` walks the same merge, and `migration repair --status reverted` is no way out, the versions just come back as `ErrMissingRemote`...

 sorted now by ordering local paths by version before the walk: 
a new `legacySortMigrationPathsByVersion` called from both `legacyFindPendingMigrations` implementations,
 rather than from `legacyListLocalMigrations` where the name ordering originates that list also feeds the `pgdelta` cache hash, so reordering it there would drift the cache key. TS shell only, since that's the user-facing path today via legacy....

`--include-all` needed the same treatment: 
it slices the local list at `remoteCount + diff.length`, so with `diff` now version-ordered it has to index the version-ordered list too. Left name-ordered it would re-apply an already-applied migration and silently skip a pending one (`1,2,20` with `2` applied → `[1, 2]` instead of `[1, 20]`).

## Refs

- Closes supabase/cli#6036