### PR TITLE
fix(stack): harden service artifact resolution

### DIFF
--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -6,7 +6,7 @@ FROM axllent/mailpit:v1.30.2 AS mailpit
 FROM postgrest/postgrest:v14.15 AS postgrest
 FROM supabase/postgres-meta:v0.96.6 AS pgmeta
 FROM supabase/studio:2026.07.27-sha-cbb076d AS studio
-FROM darthsim/imgproxy:v3.8.0 AS imgproxy
+FROM darthsim/imgproxy:v3.27.2 AS imgproxy
 FROM supabase/edge-runtime:v1.74.2 AS edgeruntime
 FROM timberio/vector:0.53.0-alpine AS vector
 FROM supabase/supavisor:2.9.7 AS supavisor

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -239,12 +239,12 @@ flowchart LR
 
 **File:** `src/BinaryResolver.ts`
 
-`BinaryResolver` is the most complex piece of the package. Given a service name and version, it locates or downloads the correct binary for the current platform, verifies its integrity, and returns a path to the extracted directory.
+Given a service name and version, `BinaryResolver` asks the artifact catalog for a supported native release, reuses or downloads the corresponding binary for the current platform, verifies its integrity, and returns a path to the extracted directory.
 
 #### Service interface
 
 ```ts
-class BinaryResolver extends ServiceMap.Service<
+class BinaryResolver extends Context.Service<
   BinaryResolver,
   {
     readonly resolve: (
@@ -254,7 +254,7 @@ class BinaryResolver extends ServiceMap.Service<
 >()("local/BinaryResolver") {}
 
 interface BinarySpec {
-  readonly service: ServiceName; // "postgres" | "postgrest" | "auth"
+  readonly service: ServiceName;
   readonly version: string;
   readonly cacheDir?: string; // defaults to ~/.supabase/bin
 }
@@ -265,59 +265,63 @@ interface BinarySpec {
 ```mermaid
 flowchart TD
     A["resolve(spec)"] --> B["detectPlatform"]
-    B --> C{"assetName?"}
-    C -->|"null"| D["BinaryNotFoundError"]
-    C -->|"string"| E["construct cacheDir"]
-    E --> F2["sweep stale cacheDir.tmp-* siblings (best-effort, always runs)"]
-    F2 --> F{"fs.exists(cacheDir/.supabase-cache-complete)?"}
-    F -->|"yes"| G["return cacheDir (cache hit)"]
-    F -->|"no"| H["HttpClient.get tarball from GitHub"]
-    H -->|"network error"| I["DownloadError"]
-    H -->|"ok"| J{"checksumUrl?"}
-    J -->|"null"| L["skip verification"]
-    J -->|"string"| K["HttpClient.get .sha256 file"]
-    K --> M["verifyChecksum (SHA-256)"]
-    M -->|"mismatch"| N["ChecksumMismatchError"]
-    M -->|"ok"| L
-    L --> O["fs.makeDirectory tmpDir = cacheDir.tmp-«uuid»"]
-    O --> P["write _download-«uuid».tar/.zip into tmpDir"]
-    P --> Q["tar/unzip extract into tmpDir"]
-    Q -->|"exitCode != 0"| R["DownloadError"]
-    Q -->|"ok"| T["chmod +x, (macOS) codesign, write completion marker — all in tmpDir"]
-    T --> U["fs.rename(tmpDir, cacheDir)"]
-    U -->|"ok"| G
-    U -->|"rename fails, cacheDir has marker"| V["another process won — discard tmpDir, return cacheDir"]
-    U -->|"rename fails, no marker, attempts remain"| W["reclaim: remove broken/legacy cacheDir, retry rename"]
-    U -->|"rename fails, no marker, attempts exhausted"| X["DownloadError"]
-    W --> U
-    V --> G
+    B --> C{"native release in artifact catalog?"}
+    C -->|"no"| D["BinaryNotFoundError"]
+    C -->|"yes"| E["construct provider-scoped cacheDir"]
+    E --> F["sweep stale .partial-* siblings (best-effort)"]
+    F --> G{"cacheDir has .complete marker and payload?"}
+    G -->|"yes"| H["return cacheDir"]
+    G -->|"no"| I{"compatible legacy cache has expected executable?"}
+    I -->|"yes"| J["return legacy cacheDir"]
+    I -->|"no"| K["acquire owner-aware cache lock"]
+    K --> L{"cacheDir complete after lock?"}
+    L -->|"yes"| H
+    L -->|"no"| M["HttpClient.get release archive"]
+    M -->|"network error"| N["DownloadError"]
+    M -->|"ok"| O{"checksum URL?"}
+    O -->|"no"| Q["skip verification"]
+    O -->|"yes"| P["download and verify SHA-256"]
+    P -->|"mismatch"| R["ChecksumMismatchError"]
+    P -->|"ok"| Q
+    Q --> S["extract into unique .partial-* staging directory"]
+    S -->|"exitCode != 0"| T["DownloadError"]
+    S -->|"ok"| U["chmod, macOS codesign, write .complete marker"]
+    U --> V["replace markerless cacheDir and atomically rename staging directory"]
+    V --> H
 ```
 
-Note that a markerless `cacheDir` (e.g. a legacy binary from before this marker existed) is never removed upfront on the miss check — only `W`, at publish time, ever removes one, and only once a fully-staged replacement (`tmpDir`) is ready to take its place.
+A markerless provider-scoped `cacheDir` is not removed on the initial miss. It is replaced only after a complete artifact has been staged, so a failed download does not destroy the previous files.
 
 #### Cache layout
 
-The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is for a version-agnostic completion marker file (`.supabase-cache-complete`) inside `cacheDir`, not mere directory existence. A `cacheDir` that exists but lacks the marker can only be a broken or legacy leftover (e.g. from an older, pre-staging CLI version) — but it is left in place rather than removed on the miss check. Deleting it eagerly, before even attempting a download, would destroy a plausibly-still-usable binary before knowing whether a replacement can be produced (an offline machine or a GitHub outage would otherwise turn a would-have-been cache hit into both a failure and a lost cache). It's reclaimed later, only at publish time, once a fully-staged replacement is ready to atomically take its place.
+The cache identity is `<cacheDir>/<service>/<provider>/<version>/<assetName>/`. Including the provider prevents artifacts from different release sources from colliding when the catalog changes. A current cache entry is reusable only when it contains both the version-agnostic `.complete` marker and a payload file.
+
+The resolver also recognizes the previous `<cacheDir>/<service>/<version>/<assetName>/` layout for the four release providers supported by the old resolver. It reuses such an entry only when the service's expected executable exists. This keeps upgrades working offline without allowing a future provider change to inherit an artifact from an unrelated source.
 
 ```
 ~/.supabase/bin/
   postgres/
-    17.6.1.081-cli/
-      darwin-arm64/       <- extracted binary tree
-        start.sh
-        bin/
-          postgres
+    github.com_supabase_postgres/
+      17.6.1.081/
+        darwin-arm64/       <- extracted binary tree
+          .complete
+          bin/
+            postgres
   postgrest/
-    14.5/
-      macos-aarch64/
-        postgrest
+    github.com_PostgREST_postgrest/
+      14.5/
+        macos-aarch64/
+          .complete
+          postgrest
   auth/
-    2.187.0/
-      arm64/
-        auth
+    github.com_supabase_auth/
+      2.187.0/
+        arm64/
+          .complete
+          auth
 ```
 
-The cache path components — `<service>/<version>/<assetName>` — are exposed as static methods (`BinaryResolver.downloadUrl`, `BinaryResolver.checksumUrl`, `BinaryResolver.cachePath`) so they can be tested without constructing the full Effect service. These static helpers are the pure core; the Effect service wraps them with the actual I/O.
+`BinaryResolver.cachePath` exposes this path calculation for focused unit tests. Release URLs, archive formats, checksums, and provider identities come from `ServiceArtifacts` rather than resolver-specific static helpers.
 
 #### Checksum verification
 
@@ -325,22 +329,17 @@ Only postgres publishes SHA-256 checksums alongside its tarballs (as `<tarball-u
 
 #### Archive extraction
 
-To avoid corrupting `cacheDir` under concurrent invocations of the same spec, the download and extraction are staged in a per-invocation-unique sibling directory, `<cacheDir>.tmp-<uuid>`, never inside `cacheDir` itself. The archive is downloaded to a uniquely-named temp file inside that staging directory. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used with `--strip-components=1` to remove the top-level directory. For zip archives (PostgREST on Windows), `unzip` is used on Unix or `tar xf` on Windows. The `tar`/`unzip` subprocess is spawned via `ChildProcessSpawner` from `effect/unstable/process`.
+To avoid corrupting `cacheDir` under concurrent invocations of the same spec, one resolver holds `<cacheDir>.lock` while downloading and publishing. The lock records its owner PID. Waiters retain locks owned by live processes, immediately reclaim locks whose owner is no longer running, and reclaim ownerless locks after a short grace period that fits within the retry budget. Lock release runs as an `Effect.acquireUseRelease` finalizer.
 
-After extraction, permissions are restored (`chmod`) and, on macOS, executables are ad-hoc code-signed — all still scoped to the staging directory. A completion marker file (`.supabase-cache-complete`) is written into the staging directory last, so it travels with the payload.
+The lock holder extracts into a per-invocation-unique sibling directory named `.<assetName>.partial-*`, never inside `cacheDir` itself. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used and catalog metadata decides whether to strip the top-level directory. For zip archives, `unzip` is used on Unix or `tar xf` on Windows. The subprocess is spawned through `ChildProcessSpawner`.
 
-The staging directory is then published by an atomic `fs.rename` into `cacheDir`:
+After extraction, permissions are restored (`chmod`) and, on macOS, executables are ad-hoc code-signed. The `.complete` marker is written last and records the provider, service, version, asset, and source URL. The resolver then removes any markerless provider-scoped destination and atomically renames the complete staging directory into `cacheDir`.
 
-- If another process already published a complete `cacheDir` first (detected via the marker, not mere existence), the losing process discards its own staged copy and resolves to the winner's `cacheDir` instead of failing.
-- If `cacheDir` exists but isn't a complete, marker-carrying entry — a broken/legacy leftover (this is the only place such a leftover is ever removed — see "Cache layout" above), or the rename failing for an unrelated reason — the current process treats it as reclaimable: it removes the leftover and retries the rename, up to a small bounded number of attempts. If a legitimate winner lands in the narrow gap between that reclaim and the retry, the retry's failure is re-checked against the marker on every attempt (including the last) and the winner is adopted immediately, regardless of how many reclaim attempts remain. Only the destructive reclaim-and-retry path is bounded: a rename that keeps failing for a reason unrelated to a competing destination (permissions, a read-only filesystem, disk I/O) can never succeed no matter how many times it's retried, so once attempts are exhausted the real rename error is surfaced as a `DownloadError` instead of retrying forever.
-
-The whole stage-and-publish sequence runs under a single `Effect.ensuring` finalizer that force-removes the staging directory on any exit path (success, failure, or interruption), and a best-effort sweep opportunistically reaps stale `.tmp-*` siblings older than 24 hours left behind by prior hard-killed processes. That sweep runs unconditionally before the cache-hit check, since once `cacheDir` becomes a complete cache hit, a sweep placed after the check would never run again for that entry's siblings.
+An `Effect.ensuring` finalizer force-removes the staging directory on success, failure, or interruption. A best-effort sweep also reaps `.partial-*` siblings older than 24 hours. The sweep runs before the cache-hit check so abandoned staging directories are eventually removed even when the final cache is already complete.
 
 #### Layer wiring
 
-`BinaryResolver` requires `FileSystem | Path | HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner` from the environment. The HOME directory is read via `Config.string("HOME")` rather than `process.env["HOME"]` directly.
-
-`BinaryResolver.layer` requires all four platform services from the environment. There is no `defaultLayer` — platform layers are provided at the entry point level (`bun.ts` / `node.ts`), not baked into `BinaryResolver`.
+`BinaryResolver.make(cacheRoot)` requires `FileSystem | Path | HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner` from the environment. Entry-point layers provide those platform services and use `defaultCacheRoot()` when the caller does not configure a cache root.
 
 ---
 
@@ -1097,18 +1096,19 @@ graph TB
 
 ### Test file table
 
-| File                                 | Type        | What it tests                                                                                                                |
-| ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `src/Platform.unit.test.ts`          | Unit        | `detectPlatform`, all three asset-name mapping functions                                                                     |
-| `src/BinaryResolver.unit.test.ts`    | Unit        | Static helpers: `downloadUrl`, `checksumUrl`, `cachePath`                                                                    |
-| `src/services/services.unit.test.ts` | Unit        | `makePostgresService`, `makePostgresServiceDocker`, `makePostgrestService`, `makeAuthServiceNative`, `makeAuthServiceDocker` |
-| `src/ApiProxy.unit.test.ts`          | Unit        | `transformAuthorization` key translation logic, CORS headers, route routing                                                  |
-| `src/StackBuilder.unit.test.ts`      | Unit        | `StackBuilder.build()` with prepared artifacts and mocked platform services                                                  |
-| `src/prefetch.unit.test.ts`          | Unit        | `StackPreparation` / `prefetch` cache hits, Docker fallback order, and pull behavior                                         |
-| `src/Stack.unit.test.ts`             | Integration | Public `Stack` facade over `StackLifecycleCoordinator`, including pre-start `Downloading` state publication                  |
-| `src/createStack.unit.test.ts`       | Unit        | Type shape assertions + missing `stackConfig` error                                                                          |
-| `tests/createStack.e2e.test.ts`      | E2e         | Full stack lifecycle: health checks, auth sign up/in/out, PostgREST CRUD                                                     |
-| `tests/parallelStacks.e2e.test.ts`   | E2e         | Concurrent stacks: port uniqueness, health check validation                                                                  |
+| File                                     | Type        | What it tests                                                                                                                |
+| ---------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `src/Platform.unit.test.ts`              | Unit        | `detectPlatform`, all three asset-name mapping functions                                                                     |
+| `src/BinaryResolver.unit.test.ts`        | Unit        | Native release descriptors and provider-scoped `cachePath`                                                                   |
+| `src/BinaryResolver.integration.test.ts` | Integration | Concurrent cache publication, legacy-cache reuse, abandoned-lock recovery, and stale staging cleanup                         |
+| `src/services/services.unit.test.ts`     | Unit        | `makePostgresService`, `makePostgresServiceDocker`, `makePostgrestService`, `makeAuthServiceNative`, `makeAuthServiceDocker` |
+| `src/ApiProxy.unit.test.ts`              | Unit        | `transformAuthorization` key translation logic, CORS headers, route routing                                                  |
+| `src/StackBuilder.unit.test.ts`          | Unit        | `StackBuilder.build()` with prepared artifacts and mocked platform services                                                  |
+| `src/prefetch.unit.test.ts`              | Unit        | `StackPreparation` / `prefetch` cache hits, Docker fallback order, and pull behavior                                         |
+| `src/Stack.unit.test.ts`                 | Integration | Public `Stack` facade over `StackLifecycleCoordinator`, including pre-start `Downloading` state publication                  |
+| `src/createStack.unit.test.ts`           | Unit        | Type shape assertions + missing `stackConfig` error                                                                          |
+| `tests/createStack.e2e.test.ts`          | E2e         | Full stack lifecycle: health checks, auth sign up/in/out, PostgREST CRUD                                                     |
+| `tests/parallelStacks.e2e.test.ts`       | E2e         | Concurrent stacks: port uniqueness, health check validation                                                                  |
 
 ### Mock patterns
 

--- a/packages/stack/docs/service-versioning.md
+++ b/packages/stack/docs/service-versioning.md
@@ -36,6 +36,27 @@ The important separation is:
 - `stack.json` pins what a named local stack should use by default
 - `local-versions.json` and `--service-version` override the pinned baseline at runtime
 
+## Artifact Providers and Runtime Support
+
+Every service in the Stack has one artifact definition, regardless of who maintains it. The
+definition records its Docker image provider, tag convention, and whether a supported native
+release is available. Runtime code consumes the resulting service resolution and does not need to
+know which registry or release repository supplied it.
+
+Supabase-managed images currently retain their ECR, Docker Hub, and GHCR candidates. External
+services such as imgproxy, Mailpit, and Vector retain their upstream Docker images and are marked
+Docker-only. Other services remain Docker-only until a supported native release is explicitly added
+to the catalog.
+
+Native artifacts are cached by service, provider, version, platform, and architecture. Downloads
+are extracted into a staging directory under a cross-process lock and published with an atomic
+rename. A cache entry is reusable only after its completion marker has been written, so interrupted
+downloads and extractions cannot be mistaken for valid installations.
+
+This provider boundary is where the future `supabase/slim-services` GHCR images and native release
+artifacts will be connected. That source change should not require changes to Stack lifecycle or
+service definitions.
+
 ## 1. Source of Truth for CLI Defaults
 
 The old Go CLI used `pkg/config/templates/Dockerfile` as a version manifest so Dependabot could

--- a/packages/stack/src/BinaryResolver.integration.test.ts
+++ b/packages/stack/src/BinaryResolver.integration.test.ts
@@ -1,0 +1,303 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir, uptime } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Fiber, Layer } from "effect";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { afterEach } from "vitest";
+import { BinaryResolver } from "./BinaryResolver.ts";
+import { DownloadError } from "./errors.ts";
+import { detectPlatform } from "./Platform.ts";
+import { nativeReleaseForService } from "./ServiceArtifacts.ts";
+import { DEFAULT_VERSIONS } from "./versions.ts";
+
+const tempRoots: string[] = [];
+
+const makeTempRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), "stack-binary-resolver-"));
+  tempRoots.push(root);
+  return root;
+};
+
+const makeArchive = (root: string): Uint8Array => {
+  const source = join(root, "source");
+  const archive = join(root, "auth.tar.gz");
+  execFileSync("mkdir", ["-p", source]);
+  writeFileSync(join(source, "auth"), "#!/bin/sh\necho auth\n");
+  execFileSync("tar", ["czf", archive, "-C", source, "."]);
+  return readFileSync(archive);
+};
+
+const makeResolverLayer = (cacheRoot: string, archive: Uint8Array, onRequest: () => void) => {
+  const client = HttpClient.make((request) =>
+    Effect.sync(() => {
+      onRequest();
+      return HttpClientResponse.fromWeb(request, new Response(archive, { status: 200 }));
+    }),
+  );
+  return BinaryResolver.make(cacheRoot).pipe(
+    Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+    Layer.provide(NodeServices.layer),
+  );
+};
+
+const makeUnavailableResolverLayer = (cacheRoot: string) => {
+  const client = HttpClient.make((request) =>
+    Effect.succeed(
+      HttpClientResponse.fromWeb(request, new Response("unavailable", { status: 503 })),
+    ),
+  );
+  return BinaryResolver.make(cacheRoot).pipe(
+    Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+    Layer.provide(NodeServices.layer),
+  );
+};
+
+const authCachePath = (cacheRoot: string) =>
+  Effect.gen(function* () {
+    const platform = yield* detectPlatform;
+    const release = nativeReleaseForService("auth", DEFAULT_VERSIONS.auth, platform);
+    if (release === undefined) {
+      return yield* Effect.die(`unsupported test platform: ${platform.os}-${platform.arch}`);
+    }
+    return BinaryResolver.cachePath(join(cacheRoot, "bin"), {
+      service: "auth",
+      provider: release.provider,
+      version: DEFAULT_VERSIONS.auth,
+      assetName: release.assetName,
+    });
+  });
+
+const legacyAuthCachePath = (cacheRoot: string) =>
+  Effect.gen(function* () {
+    const platform = yield* detectPlatform;
+    const release = nativeReleaseForService("auth", DEFAULT_VERSIONS.auth, platform);
+    if (release === undefined) {
+      return yield* Effect.die(`unsupported test platform: ${platform.os}-${platform.arch}`);
+    }
+    return join(cacheRoot, "bin", "auth", DEFAULT_VERSIONS.auth, release.assetName);
+  });
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("BinaryResolver cache publication", () => {
+  it.live("publishes one complete cache entry for concurrent resolvers", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    let requestCount = 0;
+    const layer = makeResolverLayer(root, archive, () => {
+      requestCount += 1;
+    });
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const results = yield* Effect.all(
+        [
+          resolver.resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth }),
+          resolver.resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(requestCount).toBe(1);
+      expect(results.filter((result) => result.downloaded)).toHaveLength(1);
+      expect(results[0]?.path).toBe(results[1]?.path);
+      expect(readFileSync(join(results[0]!.path, "auth"), "utf8")).toContain("echo auth");
+      expect(readFileSync(join(results[0]!.path, ".complete"), "utf8")).toContain(
+        "github.com/supabase/auth",
+      );
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("reuses a complete cache from the legacy layout without downloading", () => {
+    const root = makeTempRoot();
+    const layer = makeUnavailableResolverLayer(root);
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const legacyCacheDir = yield* legacyAuthCachePath(root);
+      mkdirSync(legacyCacheDir, { recursive: true });
+      writeFileSync(join(legacyCacheDir, "auth"), "legacy auth binary");
+
+      const result = yield* resolver.resolveWithMetadata({
+        service: "auth",
+        version: DEFAULT_VERSIONS.auth,
+      });
+
+      expect(result).toEqual({ path: legacyCacheDir, downloaded: false });
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("preserves a markerless provider cache when replacement download fails", () => {
+    const root = makeTempRoot();
+    const layer = makeUnavailableResolverLayer(root);
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const cacheDir = yield* authCachePath(root);
+      const legacyBinary = join(cacheDir, "auth");
+      mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(legacyBinary, "legacy auth binary");
+
+      const error = yield* resolver
+        .resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(DownloadError);
+      expect(readFileSync(legacyBinary, "utf8")).toBe("legacy auth binary");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("recovers an abandoned lock before the retry budget is exhausted", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    let requestCount = 0;
+    const layer = makeResolverLayer(root, archive, () => {
+      requestCount += 1;
+    });
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const cacheDir = yield* authCachePath(root);
+      const abandonedLock = `${cacheDir}.lock`;
+      mkdirSync(abandonedLock, { recursive: true });
+      writeFileSync(join(abandonedLock, "owner.pid"), "2147483647");
+      const abandonedAt = new Date(Date.now() - 6_000);
+      utimesSync(abandonedLock, abandonedAt, abandonedAt);
+
+      const results = yield* Effect.all(
+        [
+          resolver.resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth }),
+          resolver.resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(results.filter((result) => result.downloaded)).toHaveLength(1);
+      expect(results.every((result) => result.path === cacheDir)).toBe(true);
+      expect(requestCount).toBe(1);
+      expect(existsSync(abandonedLock)).toBe(false);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("preserves a live legacy numeric lock owner", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    let requestCount = 0;
+    const layer = makeResolverLayer(root, archive, () => {
+      requestCount += 1;
+    });
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const cacheDir = yield* authCachePath(root);
+      const lockPath = `${cacheDir}.lock`;
+      mkdirSync(lockPath, { recursive: true });
+      writeFileSync(join(lockPath, "owner.pid"), String(process.pid));
+      const staleTime = new Date(Date.now() - 6_000);
+      utimesSync(lockPath, staleTime, staleTime);
+
+      const resolution = yield* resolver
+        .resolveWithMetadata({ service: "auth", version: DEFAULT_VERSIONS.auth })
+        .pipe(Effect.forkChild);
+      yield* Effect.sleep("150 millis");
+
+      expect(requestCount).toBe(0);
+      expect(existsSync(lockPath)).toBe(true);
+      writeFileSync(join(lockPath, "owner.pid"), "2147483647");
+      yield* Fiber.join(resolution);
+      expect(requestCount).toBe(1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("reclaims a lock whose PID belongs to a different process generation", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    let requestCount = 0;
+    const layer = makeResolverLayer(root, archive, () => {
+      requestCount += 1;
+    });
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const cacheDir = yield* authCachePath(root);
+      const lockPath = `${cacheDir}.lock`;
+      mkdirSync(lockPath, { recursive: true });
+      writeFileSync(
+        join(lockPath, "owner.reused"),
+        JSON.stringify({
+          pid: process.pid,
+          bootMinute: Math.round((Date.now() - uptime() * 1_000) / 60_000),
+          startIdentity: "another-process-generation",
+        }),
+      );
+
+      const result = yield* resolver.resolveWithMetadata({
+        service: "auth",
+        version: DEFAULT_VERSIONS.auth,
+      });
+
+      expect(result.downloaded).toBe(true);
+      expect(requestCount).toBe(1);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("quarantines and reclaims an abandoned ownerless lock", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    const layer = makeResolverLayer(root, archive, () => {});
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const cacheDir = yield* authCachePath(root);
+      const lockPath = `${cacheDir}.lock`;
+      mkdirSync(lockPath, { recursive: true });
+      const abandonedAt = new Date(Date.now() - 6_000);
+      utimesSync(lockPath, abandonedAt, abandonedAt);
+
+      const result = yield* resolver.resolveWithMetadata({
+        service: "auth",
+        version: DEFAULT_VERSIONS.auth,
+      });
+
+      expect(result.downloaded).toBe(true);
+      expect(existsSync(lockPath)).toBe(false);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("reaps stale staging directories even when the artifact is cached", () => {
+    const root = makeTempRoot();
+    const archive = makeArchive(root);
+    const layer = makeResolverLayer(root, archive, () => {});
+
+    return Effect.gen(function* () {
+      const resolver = yield* BinaryResolver;
+      const spec = { service: "auth", version: DEFAULT_VERSIONS.auth } as const;
+      const first = yield* resolver.resolveWithMetadata(spec);
+      const staleStaging = join(dirname(first.path), `.${basename(first.path)}.partial-abandoned`);
+      mkdirSync(staleStaging);
+      writeFileSync(join(staleStaging, "partial"), "partial artifact");
+      const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1_000);
+      utimesSync(staleStaging, staleTime, staleTime);
+
+      const second = yield* resolver.resolveWithMetadata(spec);
+
+      expect(second.downloaded).toBe(false);
+      expect(existsSync(staleStaging)).toBe(false);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -1,15 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
-import { Effect, FileSystem, Layer, Path, Context, Option, PlatformError } from "effect";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { rmdir } from "node:fs/promises";
+import { uptime } from "node:os";
+import { Context, Data, Effect, FileSystem, Layer, Option, Path, Result, Schedule } from "effect";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryNotFoundError, ChecksumMismatchError, DownloadError } from "./errors.ts";
+import { detectPlatform } from "./Platform.ts";
 import {
-  authAssetName,
-  detectPlatform,
-  edgeRuntimeAssetName,
-  postgresAssetName,
-  postgrestAssetName,
-} from "./Platform.ts";
+  nativeReleaseForService,
+  type ArchiveFormat,
+  type NativeReleaseArtifact,
+} from "./ServiceArtifacts.ts";
 import type { ServiceName } from "./versions.ts";
 
 export interface BinarySpec {
@@ -29,104 +32,173 @@ export interface ResolveBinaryOptions {
 
 interface AssetInfo {
   readonly service: ServiceName;
+  readonly provider: string;
   readonly version: string;
   readonly assetName: string;
 }
 
-const authReleaseTag = (version: string): string =>
-  version.includes("-rc.") ? `rc${version}` : `v${version}`;
-
-const downloadUrl = (info: AssetInfo): string => {
-  const { service, version, assetName } = info;
-  switch (service) {
-    case "postgres": {
-      // Native binary releases use the "-cli" suffix (e.g. "17.6.1.081-cli")
-      const cliVersion = `${version}-cli`;
-      return `https://github.com/supabase/postgres/releases/download/v${cliVersion}/supabase-postgres-v${cliVersion}-${assetName}.tar.gz`;
-    }
-    case "postgrest": {
-      const ext = assetName.startsWith("windows") ? "zip" : "tar.xz";
-      return `https://github.com/PostgREST/postgrest/releases/download/v${version}/postgrest-v${version}-${assetName}.${ext}`;
-    }
-    case "auth":
-      return `https://github.com/supabase/auth/releases/download/${authReleaseTag(version)}/auth-v${version}-${assetName}.tar.gz`;
-    case "edge-runtime":
-      return `https://github.com/supabase/edge-runtime/releases/download/v${version}/edge-runtime-v${version}-${assetName}.tar.gz`;
-    default:
-      throw new Error(`No native binary download available for service: ${service}`);
-  }
-};
-
-const checksumUrl = (info: AssetInfo): string | null => {
-  if (info.service === "postgres") {
-    return `${downloadUrl(info)}.sha256`;
-  }
-  return null;
-};
-
 const cachePath = (baseDir: string, info: AssetInfo): string =>
-  `${baseDir}/${info.service}/${info.version}/${info.assetName}`;
+  `${baseDir}/${info.service}/${info.provider.replaceAll("/", "_")}/${info.version}/${info.assetName}`;
 
-/**
- * Written as the last step of staging, so its presence in `cacheDir` after
- * the atomic rename is a version-agnostic signal that the entry is a
- * complete, valid cache hit — not just non-empty. A `cacheDir` that exists
- * but lacks this marker can only be a broken leftover from an older,
- * pre-atomic-rename CLI version that wrote directly into `cacheDir` and
- * could be killed mid-extraction.
- */
-const CACHE_COMPLETE_MARKER = ".supabase-cache-complete";
-
-/**
- * The paths each service's runner actually executes from a resolved directory
- * (see `services/*.ts`), checked as an AND-of-ORs: every inner group must have
- * at least one member present (alternates cover e.g. postgrest's Windows .zip
- * carrying the .exe suffix). A markerless legacy cache entry is only trusted
- * as a download-failure fallback when the full layout is present — mere
- * non-emptiness would also accept a partial leftover from a killed
- * pre-staging writer, and "resolving" one of those masks the DownloadError
- * that lets the stack fall back to a Docker image instead of exec-ing a
- * missing binary.
- */
-const SERVICE_ENTRYPOINTS: Partial<
-  Record<BinarySpec["service"], ReadonlyArray<ReadonlyArray<string>>>
-> = {
-  postgres: [
-    ["share/supabase-cli/bin/supabase-postgres-init.sh"],
-    ["bin/pg_isready"],
-    ["bin/postgres", "bin/postgres.exe"],
-    // The init service drives all provisioning through psql, and the server
-    // loads its shared libraries from lib/ (LD_/DYLD_LIBRARY_PATH in
-    // services/postgres.ts) — a cache missing either can't boot.
-    ["bin/psql", "bin/psql.exe"],
-    ["lib"],
-  ],
-  postgrest: [["postgrest", "postgrest.exe"]],
-  auth: [["auth"]],
-  "edge-runtime": [["bin/edge-runtime"]],
+const LEGACY_NATIVE_PROVIDERS: Partial<Record<ServiceName, string>> = {
+  postgres: "github.com/supabase/postgres",
+  postgrest: "github.com/PostgREST/postgrest",
+  auth: "github.com/supabase/auth",
+  "edge-runtime": "github.com/supabase/edge-runtime",
 };
 
-/**
- * Age threshold for reaping abandoned `.tmp-*` staging siblings (see the
- * sweep in `resolveWithMetadata`). Generous on purpose: well beyond how long
- * any of these downloads/extracts should realistically take, so it can
- * never step on a genuinely live concurrent download.
- */
-const STALE_TMP_DIR_AGE_MS = 24 * 60 * 60 * 1000;
+const legacyCachePath = (baseDir: string, info: AssetInfo): string | undefined =>
+  LEGACY_NATIVE_PROVIDERS[info.service] === info.provider
+    ? `${baseDir}/${info.service}/${info.version}/${info.assetName}`
+    : undefined;
+
+const legacyExecutablePath = (
+  directory: string,
+  service: ServiceName,
+  platformOs: string,
+): string | undefined => {
+  const executableSuffix = platformOs === "win32" ? ".exe" : "";
+  switch (service) {
+    case "postgres":
+      return `${directory}/bin/postgres${executableSuffix}`;
+    case "postgrest":
+      return `${directory}/postgrest${executableSuffix}`;
+    case "auth":
+      return `${directory}/auth${executableSuffix}`;
+    case "edge-runtime":
+      return `${directory}/bin/edge-runtime${executableSuffix}`;
+    default:
+      return undefined;
+  }
+};
+
+const legacyCacheRequiredPaths = (
+  directory: string,
+  service: ServiceName,
+  platformOs: string,
+): ReadonlyArray<string> => {
+  const executable = legacyExecutablePath(directory, service, platformOs);
+  if (executable === undefined) return [];
+  return service === "postgres"
+    ? [executable, `${directory}/share/supabase-cli/bin/supabase-postgres-init.sh`]
+    : [executable];
+};
+
+const CACHE_COMPLETE_MARKER = ".complete";
+const LEGACY_CACHE_LOCK_OWNER_FILE = "owner.pid";
+const CACHE_LOCK_OWNER_PREFIX = "owner.";
+const CACHE_LOCK_OWNER_GRACE_MS = 5_000;
+const STALE_STAGING_AGE_MS = 24 * 60 * 60 * 1_000;
+const CACHE_LOCK_RETRY_SCHEDULE = Schedule.max([
+  Schedule.spaced("100 millis"),
+  Schedule.recurs(600),
+]);
+
+interface CacheLockOwner {
+  readonly pid: number;
+  readonly bootMinute: number;
+  readonly startIdentity?: string;
+}
+
+const currentBootMinute = (): number => Math.round((Date.now() - uptime() * 1_000) / 60_000);
+
+const processStartIdentity = (pid: number): string | undefined => {
+  try {
+    if (process.platform === "linux") {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fieldsAfterCommand = stat
+        .slice(stat.lastIndexOf(")") + 2)
+        .trim()
+        .split(/\s+/);
+      const startTicks = fieldsAfterCommand[19];
+      return startTicks === undefined ? undefined : `linux:${startTicks}`;
+    }
+    if (process.platform === "win32") {
+      const ticks = execFileSync(
+        "powershell.exe",
+        ["-NoProfile", "-Command", `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 2_000 },
+      ).trim();
+      return ticks.length === 0 ? undefined : `win32:${ticks}`;
+    }
+    const started = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+    return started.length === 0 ? undefined : `${process.platform}:${started}`;
+  } catch {
+    return undefined;
+  }
+};
+
+const cacheLockOwnerContent = (): string => {
+  const startIdentity = processStartIdentity(process.pid);
+  const owner: CacheLockOwner = {
+    pid: process.pid,
+    bootMinute: currentBootMinute(),
+    ...(startIdentity === undefined ? {} : { startIdentity }),
+  };
+  return JSON.stringify(owner);
+};
+
+const parseCacheLockOwner = (content: string): CacheLockOwner | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "pid" in parsed &&
+      typeof parsed.pid === "number" &&
+      Number.isSafeInteger(parsed.pid) &&
+      parsed.pid > 0 &&
+      "bootMinute" in parsed &&
+      typeof parsed.bootMinute === "number" &&
+      Number.isSafeInteger(parsed.bootMinute) &&
+      (!("startIdentity" in parsed) || typeof parsed.startIdentity === "string")
+    ) {
+      const startIdentity =
+        "startIdentity" in parsed && typeof parsed.startIdentity === "string"
+          ? parsed.startIdentity
+          : undefined;
+      return {
+        pid: parsed.pid,
+        bootMinute: parsed.bootMinute,
+        ...(startIdentity === undefined ? {} : { startIdentity }),
+      };
+    }
+    if (typeof parsed === "number" && Number.isSafeInteger(parsed) && parsed > 0) {
+      return { pid: parsed, bootMinute: currentBootMinute() };
+    }
+  } catch {}
+  return undefined;
+};
+
+const cacheLockOwnerFile = (): string => `${CACHE_LOCK_OWNER_PREFIX}${process.pid}.${randomUUID()}`;
+
+const isCacheLockOwnerFile = (entry: string): boolean =>
+  entry === LEGACY_CACHE_LOCK_OWNER_FILE || entry.startsWith(CACHE_LOCK_OWNER_PREFIX);
+
+const removeEmptyDirectory = (directory: string): Effect.Effect<void> =>
+  Effect.promise(() => rmdir(directory).catch(() => undefined));
+
+class CacheLockBusy extends Data.TaggedError("CacheLockBusy")<{
+  readonly path: string;
+}> {}
 
 const extractCommand = (
-  url: string,
+  archive: ArchiveFormat,
   archivePath: string,
   destDir: string,
   os: string,
   stripComponents: boolean,
 ): string[] => {
-  if (url.endsWith(".zip")) {
+  if (archive === "zip") {
     return os === "win32"
       ? ["tar", "xf", archivePath, "-C", destDir]
       : ["unzip", "-o", archivePath, "-d", destDir];
   }
-  const flag = url.endsWith(".tar.gz") ? "xzf" : "xf";
+  const flag = archive === "tar.gz" ? "xzf" : "xf";
   const args = ["tar", flag, archivePath, "-C", destDir];
   if (stripComponents) args.push("--strip-components=1");
   return args;
@@ -167,10 +239,9 @@ export class BinaryResolver extends Context.Service<
   }
 >()("local/BinaryResolver") {
   // Static pure functions — tested in unit tests
-  static downloadUrl = downloadUrl;
-  static checksumUrl = checksumUrl;
   static cachePath = cachePath;
-  static CACHE_COMPLETE_MARKER = CACHE_COMPLETE_MARKER;
+  static legacyExecutablePath = legacyExecutablePath;
+  static legacyCacheRequiredPaths = legacyCacheRequiredPaths;
 
   static make(
     cacheRoot: string,
@@ -191,31 +262,309 @@ export class BinaryResolver extends Context.Service<
         const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
         const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
 
+        const isCompleteCache = (directory: string) =>
+          Effect.gen(function* () {
+            if (!(yield* fs.exists(path.join(directory, CACHE_COMPLETE_MARKER)))) {
+              return false;
+            }
+            const entries = yield* fs.readDirectory(directory);
+            return entries.some((entry) => entry !== CACHE_COMPLETE_MARKER);
+          });
+
+        const isReusableLegacyCache = (
+          directory: string,
+          service: ServiceName,
+          platformOs: string,
+        ) => {
+          const requiredPaths = legacyCacheRequiredPaths(directory, service, platformOs);
+          return requiredPaths.length === 0
+            ? Effect.succeed(false)
+            : Effect.forEach(requiredPaths, fs.exists).pipe(
+                Effect.map((results) => results.every(Boolean)),
+              );
+        };
+
+        const cleanupStaleStaging = (directory: string, prefix: string) =>
+          fs.readDirectory(directory).pipe(
+            Effect.flatMap((entries) =>
+              Effect.forEach(
+                entries.filter((entry) => entry.startsWith(prefix)),
+                (entry) => {
+                  const stagingPath = path.join(directory, entry);
+                  return fs.stat(stagingPath).pipe(
+                    Effect.flatMap((info) =>
+                      Option.match(info.mtime, {
+                        onNone: () => Effect.void,
+                        onSome: (modifiedAt) =>
+                          Date.now() - modifiedAt.getTime() >= STALE_STAGING_AGE_MS
+                            ? fs.remove(stagingPath, { recursive: true, force: true })
+                            : Effect.void,
+                      }),
+                    ),
+                    Effect.ignore,
+                  );
+                },
+                { concurrency: "unbounded" },
+              ),
+            ),
+            Effect.ignore,
+          );
+
+        const acquireCacheLock = (
+          lockPath: string,
+          url: string,
+        ): Effect.Effect<
+          { readonly lockPath: string; readonly ownerPath: string },
+          DownloadError
+        > => {
+          const isProcessAlive = (owner: CacheLockOwner) =>
+            Effect.sync(() => {
+              if (Math.abs(owner.bootMinute - currentBootMinute()) > 2) {
+                return false;
+              }
+              try {
+                process.kill(owner.pid, 0);
+                return (
+                  owner.startIdentity === undefined ||
+                  processStartIdentity(owner.pid) === owner.startIdentity
+                );
+              } catch (error) {
+                return !(
+                  typeof error === "object" &&
+                  error !== null &&
+                  "code" in error &&
+                  error.code === "ESRCH"
+                );
+              }
+            });
+
+          const reclaimStaleLock = Effect.gen(function* () {
+            const info = yield* fs.stat(lockPath).pipe(Effect.option);
+            if (Option.isNone(info)) {
+              return;
+            }
+            const modifiedAt = Option.getOrUndefined(info.value.mtime);
+            const isPastOwnerGrace =
+              modifiedAt !== undefined &&
+              Date.now() - modifiedAt.getTime() >= CACHE_LOCK_OWNER_GRACE_MS;
+            const entries = yield* fs.readDirectory(lockPath).pipe(Effect.option);
+            if (Option.isNone(entries)) {
+              return;
+            }
+            const ownerFiles = entries.value.filter(isCacheLockOwnerFile);
+            if (ownerFiles.length === 0) {
+              if (!isPastOwnerGrace) return;
+            }
+
+            const observedOwners = new Map<string, string>();
+            for (const ownerFile of ownerFiles) {
+              const ownerPath = path.join(lockPath, ownerFile);
+              const owner = yield* fs.readFileString(ownerPath).pipe(Effect.option);
+              if (Option.isSome(owner)) {
+                const parsedOwner = parseCacheLockOwner(owner.value);
+                if (parsedOwner !== undefined) {
+                  if (yield* isProcessAlive(parsedOwner)) {
+                    return;
+                  }
+                  observedOwners.set(ownerFile, owner.value);
+                  continue;
+                }
+              }
+              if (!isPastOwnerGrace) {
+                return;
+              }
+              observedOwners.set(
+                ownerFile,
+                Option.getOrElse(owner, () => ""),
+              );
+            }
+
+            const quarantinePath = `${lockPath}.stale-${randomUUID()}`;
+            const moved = yield* fs.rename(lockPath, quarantinePath).pipe(Effect.result);
+            if (Result.isFailure(moved)) {
+              return;
+            }
+
+            const quarantineEntries = yield* fs.readDirectory(quarantinePath).pipe(Effect.option);
+            if (Option.isNone(quarantineEntries)) {
+              return;
+            }
+            const quarantinedOwnerFiles = quarantineEntries.value.filter(isCacheLockOwnerFile);
+            let observedStillMatches = quarantinedOwnerFiles.length === observedOwners.size;
+            for (const ownerFile of quarantinedOwnerFiles) {
+              const content = yield* fs
+                .readFileString(path.join(quarantinePath, ownerFile))
+                .pipe(Effect.option);
+              if (Option.isNone(content) || observedOwners.get(ownerFile) !== content.value) {
+                observedStillMatches = false;
+              }
+            }
+            if (!observedStillMatches) {
+              yield* fs.rename(quarantinePath, lockPath).pipe(Effect.ignore);
+              return;
+            }
+            yield* fs.remove(quarantinePath, { recursive: true, force: true }).pipe(Effect.ignore);
+          });
+
+          const acquire: Effect.Effect<
+            { readonly lockPath: string; readonly ownerPath: string },
+            CacheLockBusy | DownloadError
+          > = Effect.gen(function* () {
+            const result = yield* fs.makeDirectory(lockPath).pipe(Effect.result);
+            if (Result.isSuccess(result)) {
+              const ownerPath = path.join(lockPath, cacheLockOwnerFile());
+              const ownerResult = yield* fs
+                .writeFileString(ownerPath, cacheLockOwnerContent())
+                .pipe(Effect.result);
+              if (Result.isFailure(ownerResult)) {
+                yield* fs.remove(ownerPath, { force: true }).pipe(Effect.ignore);
+                yield* removeEmptyDirectory(lockPath);
+                return yield* Effect.fail(new DownloadError({ url, cause: ownerResult.failure }));
+              }
+              const ownerInstalled = yield* fs
+                .exists(ownerPath)
+                .pipe(Effect.mapError((cause) => new DownloadError({ url, cause })));
+              if (!ownerInstalled) {
+                return yield* Effect.fail(new CacheLockBusy({ path: lockPath }));
+              }
+              return { lockPath, ownerPath };
+            }
+
+            const error = result.failure;
+            if (error.reason._tag !== "AlreadyExists") {
+              return yield* Effect.fail(new DownloadError({ url, cause: error }));
+            }
+
+            yield* reclaimStaleLock;
+            return yield* Effect.fail(new CacheLockBusy({ path: lockPath }));
+          });
+
+          return acquire.pipe(
+            Effect.retry({
+              while: (error) => error._tag === "CacheLockBusy",
+              schedule: CACHE_LOCK_RETRY_SCHEDULE,
+            }),
+            Effect.catchTag("CacheLockBusy", (error) =>
+              Effect.fail(
+                new DownloadError({
+                  url,
+                  cause: new Error(`Timed out waiting for artifact cache lock: ${error.path}`),
+                }),
+              ),
+            ),
+          );
+        };
+
+        const extractRelease = (
+          release: NativeReleaseArtifact,
+          destination: string,
+          platformOs: string,
+        ) =>
+          Effect.gen(function* () {
+            const tarballResponse = yield* httpClient
+              .get(release.downloadUrl)
+              .pipe(
+                Effect.catchTag("HttpClientError", (cause) =>
+                  Effect.fail(new DownloadError({ url: release.downloadUrl, cause })),
+                ),
+              );
+            const tarball = yield* tarballResponse.arrayBuffer.pipe(
+              Effect.catchTag("HttpClientError", (cause) =>
+                Effect.fail(new DownloadError({ url: release.downloadUrl, cause })),
+              ),
+            );
+
+            const checksumUrl = release.checksumUrl;
+            if (checksumUrl !== null) {
+              const checksumResponse = yield* httpClient
+                .get(checksumUrl)
+                .pipe(
+                  Effect.catchTag("HttpClientError", (cause) =>
+                    Effect.fail(new DownloadError({ url: checksumUrl, cause })),
+                  ),
+                );
+              const checksumText = yield* checksumResponse.text.pipe(
+                Effect.catchTag("HttpClientError", (cause) =>
+                  Effect.fail(new DownloadError({ url: checksumUrl, cause })),
+                ),
+              );
+              yield* verifyChecksum(tarball, checksumText, checksumUrl);
+            }
+
+            const archivePath = path.join(destination, `_download.${release.archive}`);
+            yield* fs.writeFile(archivePath, new Uint8Array(tarball));
+
+            const [command, ...args] = extractCommand(
+              release.archive,
+              archivePath,
+              destination,
+              platformOs,
+              release.stripComponents,
+            );
+            if (command === undefined) {
+              return yield* Effect.fail(
+                new DownloadError({
+                  url: release.downloadUrl,
+                  cause: new Error("No extraction command was configured"),
+                }),
+              );
+            }
+            const exitCode = yield* spawner
+              .exitCode(ChildProcess.make(command, args))
+              .pipe(
+                Effect.catchTag("PlatformError", (cause) =>
+                  Effect.fail(new DownloadError({ url: release.downloadUrl, cause })),
+                ),
+              );
+            if (exitCode !== 0) {
+              return yield* Effect.fail(
+                new DownloadError({
+                  url: release.downloadUrl,
+                  cause: new Error(`extraction exited with code ${exitCode}`),
+                }),
+              );
+            }
+
+            yield* fs.remove(archivePath).pipe(Effect.ignore);
+
+            if (platformOs !== "win32") {
+              yield* spawner
+                .exitCode(ChildProcess.make("chmod", ["-R", "u+x", destination]))
+                .pipe(Effect.ignore);
+            }
+
+            if (platformOs === "darwin") {
+              yield* spawner
+                .exitCode(
+                  ChildProcess.make("find", [
+                    destination,
+                    "-type",
+                    "f",
+                    "(",
+                    "-perm",
+                    "+111",
+                    "-o",
+                    "-name",
+                    "*.dylib",
+                    ")",
+                    "-exec",
+                    "codesign",
+                    "-f",
+                    "-s",
+                    "-",
+                    "{}",
+                    "+",
+                  ]),
+                )
+                .pipe(Effect.ignore);
+            }
+          });
+
         const resolveWithMetadata = (spec: BinarySpec, options?: ResolveBinaryOptions) => {
           const core = Effect.gen(function* () {
             const platform = yield* detectPlatform;
-
-            // Map service + platform → asset name
-            let assetName: string | null;
-            switch (spec.service) {
-              case "postgres":
-                assetName = postgresAssetName(platform);
-                break;
-              case "postgrest":
-                assetName = postgrestAssetName(platform);
-                break;
-              case "auth":
-                assetName = authAssetName(platform);
-                break;
-              case "edge-runtime":
-                assetName = edgeRuntimeAssetName(platform);
-                break;
-              default:
-                assetName = null;
-                break;
-            }
-
-            if (assetName === null) {
+            const release = nativeReleaseForService(spec.service, spec.version, platform);
+            if (release === undefined) {
               return yield* Effect.fail(
                 new BinaryNotFoundError({
                   service: spec.service,
@@ -224,271 +573,86 @@ export class BinaryResolver extends Context.Service<
               );
             }
 
-            const info: AssetInfo = { service: spec.service, version: spec.version, assetName };
+            const info: AssetInfo = {
+              service: spec.service,
+              provider: release.provider,
+              version: spec.version,
+              assetName: release.assetName,
+            };
             const baseDir = spec.cacheDir ?? binDir;
             const cacheDir = cachePath(baseDir, info);
-            const url = downloadUrl(info);
-
-            // Opportunistically reap staging directories abandoned by a
-            // prior invocation that was killed (SIGKILL/OOM) between
-            // creating its tmpDir and the atomic rename — Effect.ensuring
-            // can't run past a hard process kill, and every attempt mints a
-            // fresh UUID, so nothing else ever revisits these siblings
-            // otherwise. Runs unconditionally, before the cache-hit check
-            // below: once cacheDir becomes a complete cache hit, every
-            // future resolve for this spec would otherwise return early and
-            // never reach a sweep placed after that check, for the rest of
-            // that cache entry's lifetime. Scoped to just this cacheDir's
-            // own tmp-* siblings (not a general cache-root scan), gated by a
-            // generous age threshold, and entirely best-effort.
-            const tmpDirPrefix = `${path.basename(cacheDir)}.tmp-`;
+            const legacyDir = legacyCachePath(baseDir, info);
             const parentDir = path.dirname(cacheDir);
-            yield* fs.readDirectory(parentDir).pipe(
-              Effect.flatMap((siblings) =>
-                Effect.forEach(
-                  siblings.filter((name) => name.startsWith(tmpDirPrefix)),
-                  (name) => {
-                    const staleDir = path.join(parentDir, name);
-                    return fs.stat(staleDir).pipe(
-                      Effect.flatMap((info) =>
-                        Option.match(info.mtime, {
-                          onNone: () => Effect.void,
-                          onSome: (mtime) =>
-                            Date.now() - mtime.getTime() > STALE_TMP_DIR_AGE_MS
-                              ? fs.remove(staleDir, { recursive: true, force: true })
-                              : Effect.void,
-                        }),
-                      ),
-                      Effect.ignore,
-                    );
-                  },
-                  { concurrency: "unbounded" },
-                ),
-              ),
-              Effect.ignore,
-            );
-
-            // Check if already cached. The final cacheDir is only ever
-            // populated by an atomic rename of a fully-staged directory
-            // carrying a completion marker (see below), so we check for that
-            // marker rather than mere non-emptiness — a cacheDir that exists
-            // but lacks it can only be a broken leftover (e.g. from an older,
-            // pre-staging CLI version). We deliberately do NOT remove it
-            // here: every cache entry written before this marker existed is
-            // markerless, so eagerly deleting it before we've even attempted
-            // a download would destroy a plausibly-still-usable legacy
-            // binary before knowing whether we can replace it (e.g. an
-            // offline invocation or a GitHub outage would previously have
-            // succeeded from that cache; deleting it upfront turns that into
-            // a hard failure with no cache left afterward either). It's left
-            // in place and only ever reclaimed later, in the publish step
-            // below, once a fully-staged replacement is ready to atomically
-            // take its place.
-            const isComplete = yield* fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER));
-            if (isComplete) {
+            const stagingPrefix = `.${release.assetName}.partial-`;
+            yield* cleanupStaleStaging(parentDir, stagingPrefix);
+            if (yield* isCompleteCache(cacheDir)) {
               return {
                 path: cacheDir,
                 downloaded: false,
               } satisfies ResolveBinaryResult;
             }
+            if (
+              legacyDir !== undefined &&
+              (yield* isReusableLegacyCache(legacyDir, spec.service, platform.os))
+            ) {
+              return {
+                path: legacyDir,
+                downloaded: false,
+              } satisfies ResolveBinaryResult;
+            }
 
-            yield* options?.onDownloadStart ?? Effect.void;
+            yield* fs.makeDirectory(parentDir, { recursive: true });
+            const lockPath = `${cacheDir}.lock`;
 
-            // Stage the download + extraction in a per-invocation-unique
-            // directory sibling to cacheDir, so cacheDir itself only ever
-            // becomes visible once fully populated. This prevents concurrent
-            // processes resolving the same spec from corrupting each other's
-            // downloads/extractions.
-            const tmpDir = `${cacheDir}.tmp-${randomUUID()}`;
-            const cleanupTmpDir = fs
-              .remove(tmpDir, { recursive: true, force: true })
-              .pipe(Effect.ignore);
+            return yield* Effect.acquireUseRelease(
+              acquireCacheLock(lockPath, release.downloadUrl),
+              () =>
+                Effect.gen(function* () {
+                  if (yield* isCompleteCache(cacheDir)) {
+                    return {
+                      path: cacheDir,
+                      downloaded: false,
+                    } satisfies ResolveBinaryResult;
+                  }
 
-            const stage = Effect.gen(function* () {
-              // Download tarball via HttpClient
-              const tarballResponse = yield* httpClient
-                .get(url)
-                .pipe(
-                  Effect.catchTag("HttpClientError", (e) =>
-                    Effect.fail(new DownloadError({ url, cause: e })),
-                  ),
-                );
-              const tarball = yield* tarballResponse.arrayBuffer.pipe(
-                Effect.catchTag("HttpClientError", (e) =>
-                  Effect.fail(new DownloadError({ url, cause: e })),
-                ),
-              );
+                  yield* options?.onDownloadStart ?? Effect.void;
 
-              // Verify checksum if available
-              const csUrl = checksumUrl(info);
-              if (csUrl !== null) {
-                const csResponse = yield* httpClient
-                  .get(csUrl)
-                  .pipe(
-                    Effect.catchTag("HttpClientError", (e) =>
-                      Effect.fail(new DownloadError({ url: csUrl, cause: e })),
+                  const stagingDir = yield* fs.makeTempDirectory({
+                    directory: parentDir,
+                    prefix: stagingPrefix,
+                  });
+                  return yield* Effect.gen(function* () {
+                    yield* extractRelease(release, stagingDir, platform.os);
+                    yield* fs.writeFile(
+                      path.join(stagingDir, CACHE_COMPLETE_MARKER),
+                      new TextEncoder().encode(
+                        JSON.stringify({
+                          provider: release.provider,
+                          service: spec.service,
+                          version: spec.version,
+                          asset: release.assetName,
+                          url: release.downloadUrl,
+                        }),
+                      ),
+                    );
+                    yield* fs.remove(cacheDir, { recursive: true, force: true });
+                    yield* fs.rename(stagingDir, cacheDir);
+                    return {
+                      path: cacheDir,
+                      downloaded: true,
+                    } satisfies ResolveBinaryResult;
+                  }).pipe(
+                    Effect.ensuring(
+                      fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore),
                     ),
                   );
-                const checksumText = yield* csResponse.text.pipe(
-                  Effect.catchTag("HttpClientError", (e) =>
-                    Effect.fail(new DownloadError({ url: csUrl, cause: e })),
-                  ),
-                );
-                yield* verifyChecksum(tarball, checksumText, csUrl);
-              }
-
-              // Create staging directory
-              yield* fs.makeDirectory(tmpDir, { recursive: true });
-
-              // Write archive to a per-invocation-unique temp file
-              const ext = url.endsWith(".zip") ? ".zip" : ".tar";
-              const tmpFile = path.join(tmpDir, `_download-${randomUUID()}${ext}`);
-              yield* fs.writeFile(tmpFile, new Uint8Array(tarball));
-
-              // Extract archive via ChildProcessSpawner
-              // Only postgres archives have a wrapping directory that needs stripping
-              const stripComponents = spec.service === "postgres";
-              const [cmd, ...args] = extractCommand(
-                url,
-                tmpFile,
-                tmpDir,
-                platform.os,
-                stripComponents,
-              );
-              const command = ChildProcess.make(cmd!, args);
-              const exitCode = yield* spawner
-                .exitCode(command)
-                .pipe(
-                  Effect.catchTag("PlatformError", (cause) =>
-                    Effect.fail(new DownloadError({ url, cause })),
-                  ),
-                );
-
-              if (exitCode !== 0) {
-                return yield* Effect.fail(
-                  new DownloadError({
-                    url,
-                    cause: new Error(`extraction exited with code ${exitCode}`),
-                  }),
-                );
-              }
-
-              // Remove temp archive
-              yield* fs.remove(tmpFile).pipe(Effect.ignore);
-
-              // Restore execute permissions (tar may strip them depending on umask/platform)
-              const chmodCmd = ChildProcess.make("bash", [
-                "-c",
-                `find "${tmpDir}" -type f \\( -name "*.sh" -o -name "*.dylib" -o -path "*/bin/*" \\) -exec chmod +x {} + && chmod -R u+x "${tmpDir}"`,
-              ]);
-              yield* spawner.exitCode(chmodCmd).pipe(Effect.ignore);
-
-              // On macOS, ad-hoc code sign all executables and dylibs (defensive).
-              // The Go CLI does this after extraction (internal/sandbox/binary.go).
-              if (platform.os === "darwin") {
-                const codesignCmd = ChildProcess.make("bash", [
-                  "-c",
-                  `find "${tmpDir}" -type f \\( -perm +111 -o -name "*.dylib" \\) -exec codesign -f -s - {} + 2>/dev/null || true`,
-                ]);
-                yield* spawner.exitCode(codesignCmd).pipe(Effect.ignore);
-              }
-
-              // Write the completion marker last, so it's carried into
-              // cacheDir by the same atomic rename as the rest of the
-              // payload — its presence is the version-agnostic completeness
-              // signal the cache-hit and lost-race checks rely on.
-              yield* fs.writeFile(path.join(tmpDir, CACHE_COMPLETE_MARKER), new Uint8Array());
-            });
-
-            // Publish the completed staging directory by atomically renaming
-            // it into place. If another process already published a
-            // complete cacheDir first (verified via the completion marker,
-            // not mere existence), discard our own copy and resolve to
-            // theirs instead of failing. If cacheDir exists but isn't a
-            // complete, marker-carrying entry — a broken/incomplete leftover
-            // from an older, pre-staging CLI version (see the comment above
-            // the marker check: this is the only place such a leftover is
-            // ever removed), or the rename failed for some unrelated reason
-            // — our own staged build is the only known-good copy: reclaim
-            // the spot and retry the rename, up to MAX_RECLAIM_ATTEMPTS
-            // times. A legitimate winner can also land in the narrow gap
-            // between the marker check and our own reclaim-and-retry (e.g. a
-            // third resolver, or a legacy writer); attemptPublish always
-            // re-checks the marker on every attempt (including the last) and
-            // adopts a winner immediately if one appears, regardless of how
-            // many reclaim attempts remain. Only the destructive
-            // reclaim-and-retry path is bounded — a rename that keeps
-            // failing for a reason unrelated to a competing destination
-            // (permissions, a read-only filesystem, disk I/O) can never
-            // succeed no matter how many times we retry, so once attempts
-            // are exhausted we surface the real rename error instead of
-            // retrying forever. The mirror case — clobbering a destination
-            // published in the sliver of time between the marker check and
-            // our `fs.remove` — is an accepted, narrow residual limitation:
-            // fully closing it needs real cross-process locking, which is
-            // disproportionate here since the outcome is bounded to a
-            // redundant rebuild of the same spec, not data loss. The whole
-            // stage-and-publish lifecycle is wrapped in a single
-            // `Effect.ensuring(cleanupTmpDir)` finalizer so every exit —
-            // stage failure, a genuine rename failure, or an interruption at
-            // any point — removes the staging directory. `cleanupTmpDir`
-            // force-removes and ignores errors, so it's a safe no-op once
-            // the rename has already moved tmpDir into place.
-            const MAX_RECLAIM_ATTEMPTS = 3;
-
-            const published = yield* Effect.gen(function* () {
-              yield* stage;
-
-              const renameOnce = () => fs.rename(tmpDir, cacheDir).pipe(Effect.as(true));
-
-              const attemptPublish = (
-                attemptsRemaining = MAX_RECLAIM_ATTEMPTS,
-              ): Effect.Effect<boolean, PlatformError.PlatformError> =>
-                renameOnce().pipe(
-                  Effect.catchTag("PlatformError", (renameError) =>
-                    fs.exists(path.join(cacheDir, CACHE_COMPLETE_MARKER)).pipe(
-                      Effect.flatMap((legitimateWinner) => {
-                        if (legitimateWinner) return Effect.succeed(false);
-                        if (attemptsRemaining <= 0) return Effect.fail(renameError);
-                        return fs
-                          .remove(cacheDir, { recursive: true, force: true })
-                          .pipe(
-                            Effect.ignore,
-                            Effect.andThen(attemptPublish(attemptsRemaining - 1)),
-                          );
-                      }),
-                    ),
-                  ),
-                );
-
-              return yield* attemptPublish();
-            }).pipe(
-              Effect.ensuring(cleanupTmpDir),
-              // A cache entry written by a pre-marker CLI release is non-empty
-              // but markerless, so it fails the completeness check above and
-              // lands here to be replaced. When the replacement cannot be
-              // fetched (offline, GitHub outage), that previously-working
-              // binary is strictly better than a hard failure — the same
-              // trade every pre-marker release already made on every resolve.
-              Effect.catchTag("DownloadError", (error) => {
-                const requirements = SERVICE_ENTRYPOINTS[spec.service];
-                if (requirements === undefined) return Effect.fail(error);
-                return Effect.forEach(requirements, (alternatives) =>
-                  Effect.forEach(alternatives, (entry) =>
-                    fs.exists(path.join(cacheDir, entry)).pipe(Effect.mapError(() => error)),
-                  ).pipe(Effect.map((found) => found.some(Boolean))),
-                ).pipe(
-                  Effect.flatMap((groups) =>
-                    groups.every(Boolean) ? Effect.succeed(false) : Effect.fail(error),
-                  ),
-                );
-              }),
+                }),
+              ({ lockPath: acquiredLockPath, ownerPath }) =>
+                Effect.gen(function* () {
+                  yield* fs.remove(ownerPath, { force: true }).pipe(Effect.ignore);
+                  yield* removeEmptyDirectory(acquiredLockPath);
+                }),
             );
-
-            return {
-              path: cacheDir,
-              downloaded: published,
-            } satisfies ResolveBinaryResult;
           });
 
           // Absorb PlatformError (from FileSystem ops) into DownloadError

--- a/packages/stack/src/BinaryResolver.ts
+++ b/packages/stack/src/BinaryResolver.ts
@@ -89,10 +89,7 @@ const LEGACY_CACHE_LOCK_OWNER_FILE = "owner.pid";
 const CACHE_LOCK_OWNER_PREFIX = "owner.";
 const CACHE_LOCK_OWNER_GRACE_MS = 5_000;
 const STALE_STAGING_AGE_MS = 24 * 60 * 60 * 1_000;
-const CACHE_LOCK_RETRY_SCHEDULE = Schedule.max([
-  Schedule.spaced("100 millis"),
-  Schedule.recurs(600),
-]);
+const CACHE_LOCK_RETRY_SCHEDULE = Schedule.spaced("100 millis");
 
 interface CacheLockOwner {
   readonly pid: number;

--- a/packages/stack/src/BinaryResolver.unit.test.ts
+++ b/packages/stack/src/BinaryResolver.unit.test.ts
@@ -1,22 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
-import {
-  Deferred,
-  Effect,
-  FileSystem,
-  Layer,
-  Option,
-  Path,
-  PlatformError,
-  Sink,
-  Stream,
-} from "effect";
-import { HttpClient } from "effect/unstable/http";
-import * as HttpClientError from "effect/unstable/http/HttpClientError";
-import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
-import { ChildProcessSpawner } from "effect/unstable/process";
-import { BinaryResolver, type BinarySpec } from "./BinaryResolver.ts";
-import { DownloadError } from "./errors.ts";
-import { detectPlatform, postgresAssetName, postgrestAssetName } from "./Platform.ts";
+import { BinaryResolver } from "./BinaryResolver.ts";
+import { nativeReleaseForService } from "./ServiceArtifacts.ts";
 import { DEFAULT_VERSIONS } from "./versions.ts";
 
 const postgresVersion = DEFAULT_VERSIONS.postgres;
@@ -25,103 +9,64 @@ const authVersion = DEFAULT_VERSIONS.auth;
 const authRcVersion = "2.188.0-rc.15";
 const edgeRuntimeVersion = DEFAULT_VERSIONS["edge-runtime"];
 
-describe("BinaryResolver.downloadUrl", () => {
+describe("nativeReleaseForService", () => {
   it("constructs postgres URL (appends -cli suffix for native binaries)", () => {
-    const url = BinaryResolver.downloadUrl({
-      service: "postgres",
-      version: postgresVersion,
-      assetName: "darwin-arm64",
+    const release = nativeReleaseForService("postgres", postgresVersion, {
+      os: "darwin",
+      arch: "arm64",
     });
-    expect(url).toBe(
+    expect(release?.downloadUrl).toBe(
       `https://github.com/supabase/postgres/releases/download/v${postgresVersion}-cli/supabase-postgres-v${postgresVersion}-cli-darwin-arm64.tar.gz`,
     );
+    expect(release?.checksumUrl).toBe(`${release?.downloadUrl}.sha256`);
+    expect(release?.stripComponents).toBe(true);
   });
 
   it("constructs postgrest URL", () => {
-    const url = BinaryResolver.downloadUrl({
-      service: "postgrest",
-      version: postgrestVersion,
-      assetName: "macos-aarch64",
+    const release = nativeReleaseForService("postgrest", postgrestVersion, {
+      os: "darwin",
+      arch: "arm64",
     });
-    expect(url).toBe(
+    expect(release?.downloadUrl).toBe(
       `https://github.com/PostgREST/postgrest/releases/download/v${postgrestVersion}/postgrest-v${postgrestVersion}-macos-aarch64.tar.xz`,
     );
   });
 
   it("constructs postgrest Windows URL with .zip extension", () => {
-    const url = BinaryResolver.downloadUrl({
-      service: "postgrest",
-      version: postgrestVersion,
-      assetName: "windows-x86-64",
+    const release = nativeReleaseForService("postgrest", postgrestVersion, {
+      os: "win32",
+      arch: "x64",
     });
-    expect(url).toBe(
+    expect(release?.downloadUrl).toBe(
       `https://github.com/PostgREST/postgrest/releases/download/v${postgrestVersion}/postgrest-v${postgrestVersion}-windows-x86-64.zip`,
     );
+    expect(release?.archive).toBe("zip");
   });
 
   it("constructs auth URL for rc releases", () => {
-    const url = BinaryResolver.downloadUrl({
-      service: "auth",
-      version: authRcVersion,
-      assetName: "arm64",
+    const release = nativeReleaseForService("auth", authRcVersion, {
+      os: "linux",
+      arch: "arm64",
     });
-    expect(url).toBe(
+    expect(release?.downloadUrl).toBe(
       `https://github.com/supabase/auth/releases/download/rc${authRcVersion}/auth-v${authRcVersion}-arm64.tar.gz`,
     );
   });
 
   it("constructs edge-runtime URL", () => {
-    const url = BinaryResolver.downloadUrl({
-      service: "edge-runtime",
-      version: edgeRuntimeVersion,
-      assetName: "aarch64-darwin",
+    const release = nativeReleaseForService("edge-runtime", edgeRuntimeVersion, {
+      os: "darwin",
+      arch: "arm64",
     });
-    expect(url).toBe(
+    expect(release?.downloadUrl).toBe(
       `https://github.com/supabase/edge-runtime/releases/download/v${edgeRuntimeVersion}/edge-runtime-v${edgeRuntimeVersion}-aarch64-darwin.tar.gz`,
     );
   });
-});
 
-describe("BinaryResolver.checksumUrl", () => {
-  it("appends .sha256 for postgres", () => {
-    const url = BinaryResolver.checksumUrl({
-      service: "postgres",
-      version: postgresVersion,
-      assetName: "darwin-arm64",
-    });
-    expect(url).toBe(
-      `https://github.com/supabase/postgres/releases/download/v${postgresVersion}-cli/supabase-postgres-v${postgresVersion}-cli-darwin-arm64.tar.gz.sha256`,
-    );
-  });
-
-  it("returns null for postgrest (no checksum published)", () => {
+  it("returns no native release for unsupported platforms", () => {
     expect(
-      BinaryResolver.checksumUrl({
-        service: "postgrest",
-        version: postgrestVersion,
-        assetName: "macos-aarch64",
-      }),
-    ).toBeNull();
-  });
-
-  it("returns null for auth (no checksum published)", () => {
-    expect(
-      BinaryResolver.checksumUrl({
-        service: "auth",
-        version: authVersion,
-        assetName: "arm64",
-      }),
-    ).toBeNull();
-  });
-
-  it("returns null for edge-runtime (no checksum published)", () => {
-    expect(
-      BinaryResolver.checksumUrl({
-        service: "edge-runtime",
-        version: edgeRuntimeVersion,
-        assetName: "aarch64-darwin",
-      }),
-    ).toBeNull();
+      nativeReleaseForService("auth", authVersion, { os: "win32", arch: "arm64" }),
+    ).toBeUndefined();
   });
 });
 
@@ -129,761 +74,37 @@ describe("BinaryResolver.cachePath", () => {
   it("constructs cache path", () => {
     const path = BinaryResolver.cachePath("/home/user/.supabase/bin", {
       service: "postgres",
+      provider: "github.com/supabase/postgres",
       version: postgresVersion,
       assetName: "darwin-arm64",
     });
-    expect(path).toBe(`/home/user/.supabase/bin/postgres/${postgresVersion}/darwin-arm64`);
+    expect(path).toBe(
+      `/home/user/.supabase/bin/postgres/github.com_supabase_postgres/${postgresVersion}/darwin-arm64`,
+    );
   });
 });
 
-/**
- * A tiny in-memory hierarchical filesystem used to exercise BinaryResolver's
- * real staging/rename logic (not just its pure helpers). Tracks directories
- * and files by absolute path so `rename` can faithfully reject a move onto a
- * non-empty destination the way POSIX `rename(2)` does — the exact signal the
- * resolver relies on to detect that a concurrent resolve already won.
- */
-function createFakeCacheFs() {
-  const dirs = new Set<string>();
-  const files = new Map<string, Uint8Array>();
-  const mtimes = new Map<string, number>();
-  const removeInterceptors = new Map<string, () => void>();
-  const alwaysFailRenameTo = new Set<string>();
+describe("BinaryResolver.legacyExecutablePath", () => {
+  it("recognizes the executable suffix used by Windows archives", () => {
+    expect(BinaryResolver.legacyExecutablePath("C:/cache/postgrest", "postgrest", "win32")).toBe(
+      "C:/cache/postgrest/postgrest.exe",
+    );
+  });
 
-  const isWithin = (candidatePath: string, rootPath: string): boolean =>
-    candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
-
-  const addAncestorDirs = (childPath: string): void => {
-    const segments = childPath.split("/").filter(Boolean);
-    let current = "";
-    for (let i = 0; i < segments.length - 1; i++) {
-      current += `/${segments[i]}`;
-      dirs.add(current);
-      if (!mtimes.has(current)) mtimes.set(current, Date.now());
-    }
-  };
-
-  const removeSubtree = (rootPath: string): void => {
-    for (const key of files.keys()) if (isWithin(key, rootPath)) files.delete(key);
-    for (const key of dirs) if (isWithin(key, rootPath)) dirs.delete(key);
-  };
-
-  const hasContentAt = (targetPath: string): boolean =>
-    [...files.keys(), ...dirs].some((key) => key !== targetPath && isWithin(key, targetPath));
-
-  const layer = Layer.succeed(
-    FileSystem.FileSystem,
-    FileSystem.makeNoop({
-      exists: (targetPath) => Effect.succeed(files.has(targetPath) || dirs.has(targetPath)),
-      makeDirectory: (dirPath) =>
-        Effect.sync(() => {
-          dirs.add(dirPath);
-          mtimes.set(dirPath, Date.now());
-          addAncestorDirs(dirPath);
-        }),
-      stat: (targetPath) =>
-        Effect.sync(
-          (): FileSystem.File.Info => ({
-            type: dirs.has(targetPath) ? "Directory" : "File",
-            mtime: Option.some(new Date(mtimes.get(targetPath) ?? Date.now())),
-            atime: Option.none(),
-            birthtime: Option.none(),
-            dev: 0,
-            ino: Option.none(),
-            mode: 0,
-            nlink: Option.none(),
-            uid: Option.none(),
-            gid: Option.none(),
-            rdev: Option.none(),
-            size: FileSystem.Size(0),
-            blksize: Option.none(),
-            blocks: Option.none(),
-          }),
-        ),
-      readDirectory: (dirPath) =>
-        Effect.sync(() => {
-          const prefix = `${dirPath}/`;
-          const names = new Set<string>();
-          for (const key of [...files.keys(), ...dirs]) {
-            if (key.startsWith(prefix)) names.add(key.slice(prefix.length).split("/")[0]!);
-          }
-          return [...names];
-        }),
-      writeFile: (filePath, data) =>
-        Effect.sync(() => {
-          files.set(filePath, data);
-          addAncestorDirs(filePath);
-        }),
-      remove: (targetPath, options) => {
-        const targetExists = files.has(targetPath) || dirs.has(targetPath);
-        if (!targetExists && !options?.force) {
-          return Effect.fail(
-            PlatformError.systemError({
-              _tag: "NotFound",
-              module: "FileSystem",
-              method: "remove",
-              description: "no such file or directory",
-              pathOrDescriptor: targetPath,
-            }),
-          );
-        }
-        return Effect.sync(() => {
-          removeSubtree(targetPath);
-          const intercept = removeInterceptors.get(targetPath);
-          if (intercept) {
-            removeInterceptors.delete(targetPath);
-            intercept();
-          }
-        });
-      },
-      rename: (oldPath, newPath) => {
-        if (alwaysFailRenameTo.has(newPath)) {
-          return Effect.fail(
-            PlatformError.systemError({
-              _tag: "PermissionDenied",
-              module: "FileSystem",
-              method: "rename",
-              description: "permission denied (simulated permanent failure)",
-              pathOrDescriptor: newPath,
-            }),
-          );
-        }
-        if (hasContentAt(newPath)) {
-          return Effect.fail(
-            PlatformError.systemError({
-              _tag: "Unknown",
-              module: "FileSystem",
-              method: "rename",
-              description: "destination directory not empty",
-              pathOrDescriptor: newPath,
-            }),
-          );
-        }
-        return Effect.sync(() => {
-          removeSubtree(newPath);
-          for (const key of files.keys()) {
-            if (isWithin(key, oldPath)) {
-              const data = files.get(key)!;
-              files.delete(key);
-              files.set(`${newPath}${key.slice(oldPath.length)}`, data);
-            }
-          }
-          for (const key of dirs) {
-            if (isWithin(key, oldPath)) {
-              dirs.delete(key);
-              dirs.add(`${newPath}${key.slice(oldPath.length)}`);
-            }
-          }
-          addAncestorDirs(newPath);
-        });
-      },
-    }),
-  );
-
-  return {
-    layer,
-    dirs,
-    files,
-    /** Simulates `tar`/`unzip` populating a destination directory. */
-    writeExtractedFile: (destDir: string): void => {
-      const filePath = `${destDir}/bin/postgrest`;
-      files.set(filePath, new Uint8Array([1, 2, 3]));
-      addAncestorDirs(filePath);
-    },
-    /** Lists the immediate children of a directory, mirroring `fs.readDirectory`. */
-    readEntriesOf: (dirPath: string): string[] => {
-      const prefix = `${dirPath}/`;
-      const names = new Set<string>();
-      for (const key of [...files.keys(), ...dirs]) {
-        if (key.startsWith(prefix)) names.add(key.slice(prefix.length).split("/")[0]!);
-      }
-      return [...names];
-    },
-    /** Backdates (or refreshes) a path's fake mtime, for staleness tests. */
-    setMtime: (targetPath: string, when: Date): void => {
-      mtimes.set(targetPath, when.getTime());
-    },
-    /** Directly seeds a directory with content, bypassing the resolver — simulates
-     * a pre-existing cacheDir left by an older, pre-atomic-rename CLI version or
-     * an abandoned staging directory from a killed process. */
-    seedDirWithFile: (dirPath: string, relativeFilePath: string): void => {
-      dirs.add(dirPath);
-      if (!mtimes.has(dirPath)) mtimes.set(dirPath, Date.now());
-      const filePath = `${dirPath}/${relativeFilePath}`;
-      files.set(filePath, new Uint8Array([9, 9, 9]));
-      addAncestorDirs(filePath);
-    },
-    /** Registers a one-shot side effect to run the next time `targetPath` is
-     * removed — simulates a third party (a concurrent resolver, or a legacy
-     * writer) acting in the exact gap right after this process's own removal. */
-    onRemove: (targetPath: string, sideEffect: () => void): void => {
-      removeInterceptors.set(targetPath, sideEffect);
-    },
-    /** Makes every rename into `targetPath` fail permanently (regardless of
-     * destination content), simulating a filesystem error unrelated to
-     * destination contention — e.g. permissions, a read-only mount. */
-    alwaysFailRenameTo: (targetPath: string): void => {
-      alwaysFailRenameTo.add(targetPath);
-    },
-  };
-}
-
-/**
- * A `ChildProcessSpawner` that "extracts" by dropping a fake binary into
- * whichever directory the `tar -C`/`unzip -d` destination argument points at,
- * so the shared fake filesystem reflects a completed extraction.
- */
-function mockExtractingSpawner(fakeFs: ReturnType<typeof createFakeCacheFs>) {
-  const spawned: Array<{ command: string; args: ReadonlyArray<string> }> = [];
-
-  return {
-    layer: Layer.succeed(
-      ChildProcessSpawner.ChildProcessSpawner,
-      ChildProcessSpawner.make((command) =>
-        Effect.gen(function* () {
-          const cmd = command._tag === "StandardCommand" ? command.command : "";
-          const args = command._tag === "StandardCommand" ? command.args : [];
-          spawned.push({ command: cmd, args });
-
-          if (cmd === "tar" || cmd === "unzip") {
-            const flagIndex = args.findIndex((arg) => arg === "-C" || arg === "-d");
-            const destDir = flagIndex >= 0 ? args[flagIndex + 1] : undefined;
-            if (destDir) fakeFs.writeExtractedFile(destDir);
-          }
-
-          const exitDeferred = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
-          yield* Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(0));
-
-          return ChildProcessSpawner.makeHandle({
-            pid: ChildProcessSpawner.ProcessId(5000 + spawned.length),
-            stdout: Stream.empty,
-            stderr: Stream.empty,
-            all: Stream.empty,
-            exitCode: Deferred.await(exitDeferred),
-            isRunning: Effect.succeed(false),
-            stdin: Sink.drain,
-            kill: () => Effect.void,
-            unref: Effect.succeed(Effect.void),
-            getInputFd: () => Sink.drain,
-            getOutputFd: () => Stream.empty,
-          });
-        }),
-      ),
-    ),
-    get spawned() {
-      return spawned;
-    },
-  };
-}
-
-/** An `HttpClient` that returns a fixed archive body after a short delay, so concurrent resolves overlap. */
-function mockDownloadHttpClient(opts: { archiveBytes: Uint8Array; delayMs: number }) {
-  return Layer.succeed(
-    HttpClient.HttpClient,
-    HttpClient.make((request) =>
-      Effect.gen(function* () {
-        yield* Effect.sleep(`${opts.delayMs} millis`);
-        return HttpClientResponse.fromWeb(request, new Response(opts.archiveBytes));
-      }),
-    ),
-  );
-}
-
-/** An `HttpClient` that always fails, simulating an offline machine or a GitHub outage. */
-function mockOfflineHttpClient() {
-  return Layer.succeed(
-    HttpClient.HttpClient,
-    HttpClient.make((request) =>
-      Effect.fail(
-        new HttpClientError.HttpClientError({
-          reason: new HttpClientError.TransportError({
-            request,
-            description: "offline (simulated)",
-          }),
-        }),
-      ),
-    ),
-  );
-}
-
-describe("BinaryResolver.resolveWithMetadata concurrency", () => {
-  it.live(
-    "two concurrent resolves for the same spec share one complete cache entry and leave no temp artifacts",
-    () => {
-      const fakeFs = createFakeCacheFs();
-      const spawner = mockExtractingSpawner(fakeFs);
-      const httpLayer = mockDownloadHttpClient({
-        archiveBytes: new Uint8Array([1, 2, 3, 4]),
-        delayMs: 20,
-      });
-
-      const layer = BinaryResolver.make("/cache-root").pipe(
-        Layer.provide(fakeFs.layer),
-        Layer.provide(Path.layer),
-        Layer.provide(httpLayer),
-        Layer.provide(spawner.layer),
-      );
-
-      return Effect.gen(function* () {
-        const resolver = yield* BinaryResolver;
-        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-
-        const [first, second] = yield* Effect.all(
-          [resolver.resolveWithMetadata(spec), resolver.resolveWithMetadata(spec)],
-          { concurrency: "unbounded" },
-        );
-
-        // Both invocations resolve to the same, single cache entry.
-        expect(first.path).toBe(second.path);
-        // Exactly one of the two actually populated the cache; the other lost the race.
-        expect([first.downloaded, second.downloaded].sort()).toEqual([false, true]);
-
-        const entries = fakeFs.readEntriesOf(first.path);
-        expect(entries.length).toBeGreaterThan(0);
-
-        const staleTmpPaths = [...fakeFs.dirs, ...fakeFs.files.keys()].filter(
-          (candidatePath) => candidatePath.includes(".tmp-") || candidatePath.includes("_download"),
-        );
-        expect(staleTmpPaths).toEqual([]);
-      }).pipe(Effect.provide(layer));
-    },
-  );
-});
-
-/** Resolves the real cacheDir a `postgres` spec would use on the host running the test. */
-const resolvePostgresCacheDir = Effect.gen(function* () {
-  const platform = yield* detectPlatform;
-  const assetName = postgresAssetName(platform);
-  if (assetName === null) {
-    return yield* Effect.die(`unsupported test platform: ${platform.os}-${platform.arch}`);
-  }
-  return BinaryResolver.cachePath("/cache-root/bin", {
-    service: "postgres",
-    version: postgresVersion,
-    assetName,
+  it("keeps Unix executable names unchanged", () => {
+    expect(BinaryResolver.legacyExecutablePath("/cache/postgrest", "postgrest", "linux")).toBe(
+      "/cache/postgrest/postgrest",
+    );
   });
 });
 
-/** Resolves the real cacheDir a `postgrest` spec would use on the host running the test. */
-const resolvePostgrestCacheDir = Effect.gen(function* () {
-  const platform = yield* detectPlatform;
-  const assetName = postgrestAssetName(platform);
-  if (assetName === null) {
-    return yield* Effect.die(`unsupported test platform: ${platform.os}-${platform.arch}`);
-  }
-  return BinaryResolver.cachePath("/cache-root/bin", {
-    service: "postgrest",
-    version: postgrestVersion,
-    assetName,
-  });
-});
-
-describe("BinaryResolver.resolveWithMetadata stale staging cleanup", () => {
-  it.live(
-    "reaps an abandoned staging directory older than the age threshold on a later resolve",
-    () => {
-      const fakeFs = createFakeCacheFs();
-      const spawner = mockExtractingSpawner(fakeFs);
-      const httpLayer = mockDownloadHttpClient({
-        archiveBytes: new Uint8Array([1, 2, 3]),
-        delayMs: 0,
-      });
-
-      const layer = BinaryResolver.make("/cache-root").pipe(
-        Layer.provide(fakeFs.layer),
-        Layer.provide(Path.layer),
-        Layer.provide(httpLayer),
-        Layer.provide(spawner.layer),
-      );
-
-      return Effect.gen(function* () {
-        const resolver = yield* BinaryResolver;
-        const cacheDir = yield* resolvePostgrestCacheDir;
-        const abandonedDir = `${cacheDir}.tmp-abandoned`;
-
-        // Simulate a staging directory left behind by a process that was
-        // SIGKILL'd/OOM-killed mid-download, more than the age threshold ago.
-        fakeFs.seedDirWithFile(abandonedDir, "_download-abandoned.tar");
-        fakeFs.setMtime(abandonedDir, new Date(Date.now() - 25 * 60 * 60 * 1000));
-
-        yield* resolver.resolveWithMetadata({ service: "postgrest", version: postgrestVersion });
-
-        expect(fakeFs.dirs.has(abandonedDir)).toBe(false);
-        expect([...fakeFs.files.keys()].some((p) => p.startsWith(abandonedDir))).toBe(false);
-      }).pipe(Effect.provide(layer));
-    },
-  );
-
-  it.live(
-    "leaves a fresh staging directory alone (not old enough to be considered abandoned)",
-    () => {
-      const fakeFs = createFakeCacheFs();
-      const spawner = mockExtractingSpawner(fakeFs);
-      const httpLayer = mockDownloadHttpClient({
-        archiveBytes: new Uint8Array([1, 2, 3]),
-        delayMs: 0,
-      });
-
-      const layer = BinaryResolver.make("/cache-root").pipe(
-        Layer.provide(fakeFs.layer),
-        Layer.provide(Path.layer),
-        Layer.provide(httpLayer),
-        Layer.provide(spawner.layer),
-      );
-
-      return Effect.gen(function* () {
-        const resolver = yield* BinaryResolver;
-        const cacheDir = yield* resolvePostgrestCacheDir;
-        const freshDir = `${cacheDir}.tmp-fresh`;
-
-        // A staging directory from a genuinely live concurrent download —
-        // recent mtime, must survive the sweep.
-        fakeFs.seedDirWithFile(freshDir, "_download-fresh.tar");
-        fakeFs.setMtime(freshDir, new Date());
-
-        yield* resolver.resolveWithMetadata({ service: "postgrest", version: postgrestVersion });
-
-        expect(fakeFs.dirs.has(freshDir)).toBe(true);
-        expect(fakeFs.files.has(`${freshDir}/_download-fresh.tar`)).toBe(true);
-      }).pipe(Effect.provide(layer));
-    },
-  );
-
-  it.live(
-    "still reaps a stale staging sibling even when this resolve is itself a cache hit",
-    () => {
-      const fakeFs = createFakeCacheFs();
-      const spawner = mockExtractingSpawner(fakeFs);
-      const httpLayer = mockDownloadHttpClient({
-        archiveBytes: new Uint8Array([1, 2, 3]),
-        delayMs: 0,
-      });
-
-      const layer = BinaryResolver.make("/cache-root").pipe(
-        Layer.provide(fakeFs.layer),
-        Layer.provide(Path.layer),
-        Layer.provide(httpLayer),
-        Layer.provide(spawner.layer),
-      );
-
-      return Effect.gen(function* () {
-        const resolver = yield* BinaryResolver;
-        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-        const cacheDir = yield* resolvePostgrestCacheDir;
-
-        // Populate a genuine, complete cache entry first.
-        const first = yield* resolver.resolveWithMetadata(spec);
-        expect(first.downloaded).toBe(true);
-
-        // Now a *different* invocation gets killed mid-download, abandoning
-        // a stale staging sibling next to the now-complete cacheDir.
-        const abandonedDir = `${cacheDir}.tmp-abandoned`;
-        fakeFs.seedDirWithFile(abandonedDir, "_download-abandoned.tar");
-        fakeFs.setMtime(abandonedDir, new Date(Date.now() - 25 * 60 * 60 * 1000));
-
-        // This resolve is a plain cache hit (marker already present) — the
-        // sweep must still run and reap the abandoned sibling, since once
-        // cacheDir is complete this spec will only ever take the hit path.
-        const second = yield* resolver.resolveWithMetadata(spec);
-        expect(second.downloaded).toBe(false);
-
-        expect(fakeFs.dirs.has(abandonedDir)).toBe(false);
-        expect([...fakeFs.files.keys()].some((p) => p.startsWith(abandonedDir))).toBe(false);
-      }).pipe(Effect.provide(layer));
-    },
-  );
-});
-
-describe("BinaryResolver.resolveWithMetadata cache completeness", () => {
-  it.live("reclaims a broken cacheDir left by an older, pre-atomic-rename CLI version", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockDownloadHttpClient({
-      archiveBytes: new Uint8Array([1, 2, 3]),
-      delayMs: 0,
-    });
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
+describe("BinaryResolver.legacyCacheRequiredPaths", () => {
+  it("requires the Postgres initialization payload as well as the executable", () => {
+    expect(BinaryResolver.legacyCacheRequiredPaths("/cache/postgres", "postgres", "linux")).toEqual(
+      [
+        "/cache/postgres/bin/postgres",
+        "/cache/postgres/share/supabase-cli/bin/supabase-postgres-init.sh",
+      ],
     );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-      const cacheDir = yield* resolvePostgrestCacheDir;
-
-      // A non-empty cacheDir with no completion marker — exactly what an
-      // older, pre-atomic-rename CLI version would leave behind if it was
-      // killed mid-extraction (it wrote directly into cacheDir, no staging).
-      fakeFs.seedDirWithFile(cacheDir, "stray-legacy-file.txt");
-
-      const result = yield* resolver.resolveWithMetadata(spec);
-
-      // The broken leftover was reclaimed, not trusted or left in place.
-      expect(result.path).toBe(cacheDir);
-      expect(result.downloaded).toBe(true);
-      expect(fakeFs.files.has(`${cacheDir}/stray-legacy-file.txt`)).toBe(false);
-
-      // A subsequent resolve is now a clean cache hit — proving the
-      // reclaimed entry is genuinely complete (carries the marker), not
-      // just superficially non-empty again.
-      const second = yield* resolver.resolveWithMetadata(spec);
-      expect(second.downloaded).toBe(false);
-      expect(second.path).toBe(cacheDir);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("adopts a legitimate winner that lands mid-reclaim instead of retrying blindly", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockDownloadHttpClient({
-      archiveBytes: new Uint8Array([1, 2, 3]),
-      delayMs: 0,
-    });
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-      const cacheDir = yield* resolvePostgrestCacheDir;
-
-      // A markerless, broken cacheDir — our first renameOnce() attempt
-      // fails against this, entering the reclaim branch.
-      fakeFs.seedDirWithFile(cacheDir, "stray-legacy-file.txt");
-
-      // Simulate a legitimate winner (a third concurrent resolver, or a
-      // pre-atomic-rename legacy writer) publishing a complete,
-      // marker-carrying cacheDir in the exact gap between our reclaim's
-      // `fs.remove` and our retry rename.
-      fakeFs.onRemove(cacheDir, () => {
-        fakeFs.seedDirWithFile(cacheDir, "bin/postgrest");
-        fakeFs.seedDirWithFile(cacheDir, BinaryResolver.CACHE_COMPLETE_MARKER);
-      });
-
-      const result = yield* resolver.resolveWithMetadata(spec);
-
-      // Adopted the winner instead of throwing a spurious DownloadError
-      // from the retry's second rename failure.
-      expect(result.path).toBe(cacheDir);
-      expect(result.downloaded).toBe(false);
-      expect(fakeFs.files.has(`${cacheDir}/${BinaryResolver.CACHE_COMPLETE_MARKER}`)).toBe(true);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live(
-    "surfaces a DownloadError instead of retrying forever when rename fails for a reason unrelated to destination contention",
-    () => {
-      const fakeFs = createFakeCacheFs();
-      const spawner = mockExtractingSpawner(fakeFs);
-      const httpLayer = mockDownloadHttpClient({
-        archiveBytes: new Uint8Array([1, 2, 3]),
-        delayMs: 0,
-      });
-
-      const layer = BinaryResolver.make("/cache-root").pipe(
-        Layer.provide(fakeFs.layer),
-        Layer.provide(Path.layer),
-        Layer.provide(httpLayer),
-        Layer.provide(spawner.layer),
-      );
-
-      return Effect.gen(function* () {
-        const resolver = yield* BinaryResolver;
-        const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-        const cacheDir = yield* resolvePostgrestCacheDir;
-
-        // Simulate a permanent filesystem error unrelated to a competing
-        // destination (e.g. permissions, a read-only mount) — every rename
-        // attempt into cacheDir fails, regardless of its content, so no
-        // amount of reclaim-and-retry can ever succeed.
-        fakeFs.alwaysFailRenameTo(cacheDir);
-
-        const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
-
-        // Bounded attempts surface the real error instead of hanging.
-        expect(error).toBeInstanceOf(DownloadError);
-
-        // The `cleanupTmpDir` finalizer must still remove the staging
-        // directory even though the rename it was guarding rethrew — a
-        // regression here (e.g. scoping cleanup to an `onError` around
-        // `stage` instead of `Effect.ensuring`) would leak the fully
-        // populated `.tmp-`/`_download` tree.
-        const staleTmpPaths = [...fakeFs.dirs, ...fakeFs.files.keys()].filter(
-          (candidatePath) => candidatePath.includes(".tmp-") || candidatePath.includes("_download"),
-        );
-        expect(staleTmpPaths).toEqual([]);
-      }).pipe(Effect.provide(layer));
-    },
-  );
-
-  it.live("falls back to a markerless legacy cacheDir when the replacement download fails", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-      const cacheDir = yield* resolvePostgrestCacheDir;
-
-      // A markerless legacy cacheDir from before this resolver's staging
-      // model existed — a binary that served every earlier release. When
-      // the replacement cannot be fetched, resolving to it beats failing.
-      fakeFs.seedDirWithFile(cacheDir, "postgrest");
-
-      const result = yield* resolver.resolveWithMetadata(spec);
-
-      expect(result.path).toBe(cacheDir);
-      expect(result.downloaded).toBe(false);
-      expect(fakeFs.files.has(`${cacheDir}/postgrest`)).toBe(true);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("accepts a Windows legacy cache whose executable carries the .exe suffix", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-      const cacheDir = yield* resolvePostgrestCacheDir;
-
-      fakeFs.seedDirWithFile(cacheDir, "postgrest.exe");
-
-      const result = yield* resolver.resolveWithMetadata(spec);
-
-      expect(result.path).toBe(cacheDir);
-      expect(result.downloaded).toBe(false);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("rejects a postgres legacy cache with the init script but no bin payload", () => {
-    // The init script alone cannot run postgres — the health check invokes
-    // bin/pg_isready and the script needs the server binaries. A partial
-    // extraction stopping after share/ must not suppress the Docker fallback.
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgres", version: postgresVersion };
-      const cacheDir = yield* resolvePostgresCacheDir;
-
-      fakeFs.seedDirWithFile(cacheDir, "share/supabase-cli/bin/supabase-postgres-init.sh");
-
-      const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
-      expect(error).toBeInstanceOf(DownloadError);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("accepts a postgres legacy cache carrying the full expected layout", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgres", version: postgresVersion };
-      const cacheDir = yield* resolvePostgresCacheDir;
-
-      fakeFs.seedDirWithFile(cacheDir, "share/supabase-cli/bin/supabase-postgres-init.sh");
-      fakeFs.seedDirWithFile(cacheDir, "bin/pg_isready");
-      fakeFs.seedDirWithFile(cacheDir, "bin/postgres");
-      fakeFs.seedDirWithFile(cacheDir, "bin/psql");
-      fakeFs.seedDirWithFile(cacheDir, "lib/libpq.dylib");
-
-      const result = yield* resolver.resolveWithMetadata(spec);
-      expect(result.path).toBe(cacheDir);
-      expect(result.downloaded).toBe(false);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("rejects a partial markerless leftover that lacks the service entrypoint", () => {
-    // A pre-staging writer killed mid-extraction leaves a non-empty dir with
-    // no executable. Resolving it would mask the DownloadError that lets the
-    // stack fall back to a Docker image — so non-emptiness is not enough.
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-      const cacheDir = yield* resolvePostgrestCacheDir;
-
-      fakeFs.seedDirWithFile(cacheDir, "_download-interrupted.tar");
-
-      const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
-
-      expect(error).toBeInstanceOf(DownloadError);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.live("still fails offline when no legacy cache entry exists to fall back to", () => {
-    const fakeFs = createFakeCacheFs();
-    const spawner = mockExtractingSpawner(fakeFs);
-    const httpLayer = mockOfflineHttpClient();
-
-    const layer = BinaryResolver.make("/cache-root").pipe(
-      Layer.provide(fakeFs.layer),
-      Layer.provide(Path.layer),
-      Layer.provide(httpLayer),
-      Layer.provide(spawner.layer),
-    );
-
-    return Effect.gen(function* () {
-      const resolver = yield* BinaryResolver;
-      const spec: BinarySpec = { service: "postgrest", version: postgrestVersion };
-
-      const error = yield* resolver.resolveWithMetadata(spec).pipe(Effect.flip);
-
-      expect(error).toBeInstanceOf(DownloadError);
-    }).pipe(Effect.provide(layer));
   });
 });

--- a/packages/stack/src/ServiceArtifacts.ts
+++ b/packages/stack/src/ServiceArtifacts.ts
@@ -1,0 +1,213 @@
+import {
+  authAssetName,
+  edgeRuntimeAssetName,
+  postgresAssetName,
+  postgrestAssetName,
+  type PlatformInfo,
+} from "./Platform.ts";
+import type { ServiceName } from "./versions.ts";
+
+type ArtifactOwnership = "supabase" | "upstream";
+type ServiceRuntimeSupport = "native-preferred" | "docker-only";
+export type ArchiveFormat = "tar.gz" | "tar.xz" | "zip";
+
+export interface NativeReleaseArtifact {
+  readonly provider: string;
+  readonly assetName: string;
+  readonly archive: ArchiveFormat;
+  readonly downloadUrl: string;
+  readonly checksumUrl: string | null;
+  readonly stripComponents: boolean;
+}
+
+interface NativeReleaseSource {
+  readonly provider: string;
+  readonly resolve: (version: string, platform: PlatformInfo) => NativeReleaseArtifact | undefined;
+}
+
+interface DockerImageSource {
+  readonly ownership: ArtifactOwnership;
+  readonly repository: string;
+  readonly tagPrefix?: string;
+}
+
+export interface ServiceArtifactDefinition {
+  readonly runtimeSupport: ServiceRuntimeSupport;
+  readonly docker: DockerImageSource;
+  readonly native?: NativeReleaseSource;
+}
+
+const SUPABASE_ECR_REGISTRY = "public.ecr.aws/supabase";
+const SUPABASE_DOCKER_HUB_REGISTRY = "supabase";
+const SUPABASE_GHCR_REGISTRY = "ghcr.io/supabase";
+
+const nativeRelease = (
+  provider: string,
+  assetName: string | null,
+  archive: ArchiveFormat,
+  downloadUrl: string,
+  options?: {
+    readonly checksumUrl?: string;
+    readonly stripComponents?: boolean;
+  },
+): NativeReleaseArtifact | undefined =>
+  assetName === null
+    ? undefined
+    : {
+        provider,
+        assetName,
+        archive,
+        downloadUrl,
+        checksumUrl: options?.checksumUrl ?? null,
+        stripComponents: options?.stripComponents ?? false,
+      };
+
+const authReleaseTag = (version: string): string =>
+  version.includes("-rc.") ? `rc${version}` : `v${version}`;
+
+export const SERVICE_ARTIFACTS: Record<ServiceName, ServiceArtifactDefinition> = {
+  postgres: {
+    runtimeSupport: "native-preferred",
+    docker: { ownership: "supabase", repository: "postgres" },
+    native: {
+      provider: "github.com/supabase/postgres",
+      resolve: (version, platform) => {
+        const assetName = postgresAssetName(platform);
+        const cliVersion = `${version}-cli`;
+        const url = `https://github.com/supabase/postgres/releases/download/v${cliVersion}/supabase-postgres-v${cliVersion}-${assetName}.tar.gz`;
+        return nativeRelease("github.com/supabase/postgres", assetName, "tar.gz", url, {
+          checksumUrl: `${url}.sha256`,
+          stripComponents: true,
+        });
+      },
+    },
+  },
+  postgrest: {
+    runtimeSupport: "native-preferred",
+    docker: { ownership: "supabase", repository: "postgrest", tagPrefix: "v" },
+    native: {
+      provider: "github.com/PostgREST/postgrest",
+      resolve: (version, platform) => {
+        const assetName = postgrestAssetName(platform);
+        const archive = assetName?.startsWith("windows") === true ? "zip" : "tar.xz";
+        return nativeRelease(
+          "github.com/PostgREST/postgrest",
+          assetName,
+          archive,
+          `https://github.com/PostgREST/postgrest/releases/download/v${version}/postgrest-v${version}-${assetName}.${archive}`,
+        );
+      },
+    },
+  },
+  auth: {
+    runtimeSupport: "native-preferred",
+    docker: { ownership: "supabase", repository: "gotrue", tagPrefix: "v" },
+    native: {
+      provider: "github.com/supabase/auth",
+      resolve: (version, platform) => {
+        const assetName = authAssetName(platform);
+        return nativeRelease(
+          "github.com/supabase/auth",
+          assetName,
+          "tar.gz",
+          `https://github.com/supabase/auth/releases/download/${authReleaseTag(version)}/auth-v${version}-${assetName}.tar.gz`,
+        );
+      },
+    },
+  },
+  "edge-runtime": {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "edge-runtime", tagPrefix: "v" },
+    native: {
+      provider: "github.com/supabase/edge-runtime",
+      resolve: (version, platform) => {
+        const assetName = edgeRuntimeAssetName(platform);
+        return nativeRelease(
+          "github.com/supabase/edge-runtime",
+          assetName,
+          "tar.gz",
+          `https://github.com/supabase/edge-runtime/releases/download/v${version}/edge-runtime-v${version}-${assetName}.tar.gz`,
+        );
+      },
+    },
+  },
+  realtime: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "realtime", tagPrefix: "v" },
+  },
+  storage: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "storage-api", tagPrefix: "v" },
+  },
+  imgproxy: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "upstream", repository: "darthsim/imgproxy" },
+  },
+  mailpit: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "upstream", repository: "axllent/mailpit" },
+  },
+  pgmeta: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "postgres-meta", tagPrefix: "v" },
+  },
+  studio: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "studio" },
+  },
+  analytics: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "logflare" },
+  },
+  vector: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "upstream", repository: "timberio/vector" },
+  },
+  pooler: {
+    runtimeSupport: "docker-only",
+    docker: { ownership: "supabase", repository: "supavisor" },
+  },
+};
+
+export const nativeReleaseForService = (
+  service: ServiceName,
+  version: string,
+  platform: PlatformInfo,
+): NativeReleaseArtifact | undefined =>
+  SERVICE_ARTIFACTS[service].native?.resolve(version, platform);
+
+export const isDockerOnlyService = (service: ServiceName): boolean =>
+  SERVICE_ARTIFACTS[service].runtimeSupport === "docker-only";
+
+const dockerTag = (service: ServiceName, version: string): string => {
+  const source = SERVICE_ARTIFACTS[service].docker;
+  return `${source.tagPrefix ?? ""}${version}`;
+};
+
+export const dockerImageForArtifact = (service: ServiceName, version: string): string => {
+  const source = SERVICE_ARTIFACTS[service].docker;
+  const repository =
+    source.ownership === "supabase"
+      ? `${SUPABASE_ECR_REGISTRY}/${source.repository}`
+      : source.repository;
+  return `${repository}:${dockerTag(service, version)}`;
+};
+
+export const dockerImageCandidatesForArtifact = (
+  service: ServiceName,
+  version: string,
+): ReadonlyArray<string> => {
+  const source = SERVICE_ARTIFACTS[service].docker;
+  const tag = dockerTag(service, version);
+  if (source.ownership === "upstream") {
+    return [`${source.repository}:${tag}`];
+  }
+  return [
+    `${SUPABASE_ECR_REGISTRY}/${source.repository}:${tag}`,
+    `${SUPABASE_DOCKER_HUB_REGISTRY}/${source.repository}:${tag}`,
+    `${SUPABASE_GHCR_REGISTRY}/${source.repository}:${tag}`,
+  ];
+};
+
+export const imageTagPrefixForService = (service: ServiceName): string | undefined =>
+  SERVICE_ARTIFACTS[service].docker.tagPrefix;

--- a/packages/stack/src/StackPreparation.ts
+++ b/packages/stack/src/StackPreparation.ts
@@ -4,6 +4,7 @@ import { BinaryResolver } from "./BinaryResolver.ts";
 import type { ChecksumMismatchError } from "./errors.ts";
 import { DockerPullError } from "./errors.ts";
 import type { ServiceResolution } from "./resolve.ts";
+import { isDockerOnlyService } from "./ServiceArtifacts.ts";
 import {
   DEFAULT_VERSIONS,
   SERVICE_NAMES,
@@ -38,19 +39,6 @@ type StackPreparationEvent =
   | ServiceDownloadStarted
   | ServiceDownloadFinished
   | PreparationCompleted;
-
-const dockerOnlyServices = new Set<ServiceName>([
-  "edge-runtime",
-  "realtime",
-  "storage",
-  "imgproxy",
-  "mailpit",
-  "pgmeta",
-  "studio",
-  "analytics",
-  "vector",
-  "pooler",
-]);
 
 const DOCKER_PULL_RETRY_DELAYS_MS = [500] as const;
 const RETRYABLE_PULL_PATTERNS = [
@@ -120,7 +108,7 @@ export const prepareAssetsWithDependencies = (
         );
       }
 
-      if (dockerOnlyServices.has(service)) {
+      if (isDockerOnlyService(service)) {
         return resolveDockerImageForService(spawner, service, versions[service], {
           onDownloadStart: markDownloadStart(),
         }).pipe(

--- a/packages/stack/src/versions.ts
+++ b/packages/stack/src/versions.ts
@@ -1,3 +1,9 @@
+import {
+  dockerImageCandidatesForArtifact,
+  dockerImageForArtifact,
+  imageTagPrefixForService,
+} from "./ServiceArtifacts.ts";
+
 export type ServiceName =
   | "postgres"
   | "postgrest"
@@ -52,7 +58,7 @@ export const DEFAULT_VERSIONS: VersionManifest = {
   "edge-runtime": "1.74.2",
   realtime: "2.120.3",
   storage: "1.67.20",
-  imgproxy: "v3.8.0",
+  imgproxy: "v3.27.2",
   mailpit: "v1.30.2",
   pgmeta: "0.96.6",
   studio: "2026.07.27-sha-cbb076d",
@@ -61,48 +67,12 @@ export const DEFAULT_VERSIONS: VersionManifest = {
   pooler: "2.9.7",
 } as const;
 
-/** Default registry. Matches the Go CLI default (`public.ecr.aws`). */
-const DEFAULT_REGISTRY = "public.ecr.aws/supabase";
-const DOCKER_HUB_SUPABASE_REGISTRY = "supabase";
-const GHCR_SUPABASE_REGISTRY = "ghcr.io/supabase";
-
-const IMAGE_REPOSITORIES: Record<ServiceName, string> = {
-  postgres: "postgres",
-  postgrest: "postgrest",
-  auth: "gotrue",
-  "edge-runtime": "edge-runtime",
-  realtime: "realtime",
-  storage: "storage-api",
-  imgproxy: "darthsim/imgproxy",
-  mailpit: "axllent/mailpit",
-  pgmeta: "postgres-meta",
-  studio: "studio",
-  analytics: "logflare",
-  vector: "timberio/vector",
-  pooler: "supavisor",
-};
-
-const SUPABASE_REGISTRY_SERVICES = new Set<ServiceName>([
-  "postgres",
-  "postgrest",
-  "auth",
-  "edge-runtime",
-  "realtime",
-  "storage",
-  "pgmeta",
-  "studio",
-  "analytics",
-  "pooler",
-]);
-
-export const IMAGE_TAG_PREFIX: Partial<Record<ServiceName, string>> = {
-  postgrest: "v",
-  auth: "v",
-  "edge-runtime": "v",
-  realtime: "v",
-  storage: "v",
-  pgmeta: "v",
-};
+export const IMAGE_TAG_PREFIX: Partial<Record<ServiceName, string>> = Object.fromEntries(
+  SERVICE_NAMES.flatMap((service) => {
+    const prefix = imageTagPrefixForService(service);
+    return prefix === undefined ? [] : [[service, prefix]];
+  }),
+);
 
 /**
  * Returns the full Docker image URL for a service.
@@ -111,27 +81,14 @@ export const IMAGE_TAG_PREFIX: Partial<Record<ServiceName, string>> = {
  * `public.ecr.aws/supabase/` by default (faster than Docker Hub).
  */
 export function dockerImageForService(service: ServiceName, version: string): string {
-  const repository = IMAGE_REPOSITORIES[service];
-  if (SUPABASE_REGISTRY_SERVICES.has(service)) {
-    return `${DEFAULT_REGISTRY}/${repository}:${IMAGE_TAG_PREFIX[service] ?? ""}${version}`;
-  }
-  return `${repository}:${IMAGE_TAG_PREFIX[service] ?? ""}${version}`;
+  return dockerImageForArtifact(service, version);
 }
 
 export function dockerImageCandidatesForService(
   service: ServiceName,
   version: string,
 ): ReadonlyArray<string> {
-  const repository = IMAGE_REPOSITORIES[service];
-  const tag = `${IMAGE_TAG_PREFIX[service] ?? ""}${version}`;
-  if (!SUPABASE_REGISTRY_SERVICES.has(service)) {
-    return [`${repository}:${tag}`];
-  }
-  return [
-    `${DEFAULT_REGISTRY}/${repository}:${tag}`,
-    `${DOCKER_HUB_SUPABASE_REGISTRY}/${repository}:${tag}`,
-    `${GHCR_SUPABASE_REGISTRY}/${repository}:${tag}`,
-  ];
+  return dockerImageCandidatesForArtifact(service, version);
 }
 
 function assertFullVersions(

--- a/packages/stack/src/versions.unit.test.ts
+++ b/packages/stack/src/versions.unit.test.ts
@@ -12,6 +12,8 @@ import {
   normalizeServiceVersion,
   type VersionManifest,
 } from "./versions.ts";
+import { SERVICE_ARTIFACTS } from "./ServiceArtifacts.ts";
+import { SERVICE_NAMES } from "./versions.ts";
 
 const sampleDockerfile = `
 FROM supabase/postgres:17.0.0.1 AS pg
@@ -89,6 +91,10 @@ after`;
 });
 
 describe("dockerImageForService", () => {
+  it("defines artifact capabilities for every stack service", () => {
+    expect(Object.keys(SERVICE_ARTIFACTS).sort()).toEqual([...SERVICE_NAMES].sort());
+  });
+
   it("returns correct image for postgres", () => {
     expect(dockerImageForService("postgres", DEFAULT_VERSIONS.postgres)).toBe(
       `public.ecr.aws/supabase/postgres:${DEFAULT_VERSIONS.postgres}`,
@@ -125,6 +131,21 @@ describe("dockerImageForService", () => {
     expect(dockerImageCandidatesForService("imgproxy", DEFAULT_VERSIONS.imgproxy)).toEqual([
       `darthsim/imgproxy:${DEFAULT_VERSIONS.imgproxy}`,
     ]);
+  });
+
+  it("keeps non-managed services Docker-only", () => {
+    expect(SERVICE_ARTIFACTS.imgproxy).toMatchObject({
+      runtimeSupport: "docker-only",
+      docker: { ownership: "upstream", repository: "darthsim/imgproxy" },
+    });
+    expect(SERVICE_ARTIFACTS.mailpit).toMatchObject({
+      runtimeSupport: "docker-only",
+      docker: { ownership: "upstream", repository: "axllent/mailpit" },
+    });
+    expect(SERVICE_ARTIFACTS.vector).toMatchObject({
+      runtimeSupport: "docker-only",
+      docker: { ownership: "upstream", repository: "timberio/vector" },
+    });
   });
 });
 


### PR DESCRIPTION
Stack layer 1 of 7.

Rebuilds the non-Fleet artifact foundation from #5819 as a focused change:

- centralizes the complete managed and upstream service catalog
- keeps imgproxy, Mailpit, and Vector Docker-only
- adds Supabase registry candidates and native release descriptors as the seam for slim-services
- makes native artifact caching safe under concurrent preparation

Fleet remains out of scope for this stack.

Stack: #6041 → #6042 → #6043 → #6044 → #6045 → #6046 → #6047

Supersedes #5819