### PR TITLE
refactor(stack): centralize service activation policy

### DIFF
--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -101,6 +101,7 @@ export class Orchestrator extends Context.Service<
           healthy: Deferred.Deferred<void>;
           completed: Deferred.Deferred<number>;
           stopped: Deferred.Deferred<void>;
+          readonly readinessWaiters: Set<Deferred.Deferred<void>>;
           stoppedByUser: boolean;
           requested: boolean;
         }
@@ -115,6 +116,7 @@ export class Orchestrator extends Context.Service<
             healthy: Deferred.makeUnsafe<void>(),
             completed: Deferred.makeUnsafe<number>(),
             stopped: Deferred.makeUnsafe<void>(),
+            readinessWaiters: new Set(),
             stoppedByUser: false,
             requested: false,
           });
@@ -133,6 +135,13 @@ export class Orchestrator extends Context.Service<
           if (svc === undefined) return Effect.succeed(null);
           return transition(svc.state, event);
         };
+
+        const signalHealthy = (svc: ServiceSignals): Effect.Effect<void> =>
+          Effect.forEach(
+            [svc.healthy, ...svc.readinessWaiters],
+            (waiter) => Deferred.succeed(waiter, void 0),
+            { discard: true },
+          );
 
         // Helper: run all hooks for a given trigger in sequence
         const runHooks = (def: ServiceDef, trigger: HookTrigger): Effect.Effect<void> =>
@@ -353,7 +362,7 @@ export class Orchestrator extends Context.Service<
                               yield* runHooks(def, "healthy");
                               const current = SubscriptionRef.getUnsafe(svcSig.state);
                               if (current.status !== "Failed") {
-                                yield* Deferred.succeed(svcSig.healthy, void 0);
+                                yield* signalHealthy(svcSig);
                               }
                             }
                           }
@@ -386,7 +395,7 @@ export class Orchestrator extends Context.Service<
                     if (svcSig) {
                       const current = SubscriptionRef.getUnsafe(svcSig.state);
                       if (current.status !== "Failed") {
-                        yield* Deferred.succeed(svcSig.healthy, void 0);
+                        yield* signalHealthy(svcSig);
                       }
                     }
                   }
@@ -595,28 +604,45 @@ export class Orchestrator extends Context.Service<
               );
             }
 
-            // Long-running: race healthy vs a terminal state
-            return Effect.race(
-              Deferred.await(svc.healthy),
-              SubscriptionRef.changes(svc.state).pipe(
-                Stream.filter((s) => s.status === "Failed" || s.status === "Stopped"),
-                Stream.take(1),
-                Stream.runDrain,
-                Effect.andThen(
-                  Effect.gen(function* () {
-                    const current = SubscriptionRef.getUnsafe(svc.state);
-                    return yield* Effect.fail(
-                      new ServiceReadyError({
-                        name: def.name,
-                        reason:
-                          current.status === "Stopped"
-                            ? "Service stopped before becoming ready"
-                            : (current.error ?? "Service entered Failed state"),
-                      }),
-                    );
-                  }),
+            // A waiter belongs to the readiness request, not to one service signal
+            // generation. Dependency retries may replace svc.healthy while this
+            // request is pending, so signal the stable waiter from any generation.
+            const readiness = Deferred.makeUnsafe<void>();
+            svc.readinessWaiters.add(readiness);
+            return Deferred.isDone(svc.healthy).pipe(
+              Effect.flatMap((alreadyHealthy) =>
+                alreadyHealthy ? Deferred.succeed(readiness, void 0) : Effect.void,
+              ),
+              Effect.andThen(
+                Effect.race(
+                  Deferred.await(readiness),
+                  SubscriptionRef.changes(svc.state).pipe(
+                    Stream.filter(
+                      (state) => state.status === "Failed" || state.status === "Stopped",
+                    ),
+                    Stream.take(1),
+                    Stream.runDrain,
+                    Effect.andThen(
+                      Deferred.isDone(readiness).pipe(
+                        Effect.flatMap((ready) => {
+                          if (ready) return Effect.void;
+                          const terminal = SubscriptionRef.getUnsafe(svc.state);
+                          return Effect.fail(
+                            new ServiceReadyError({
+                              name: def.name,
+                              reason:
+                                terminal.status === "Stopped"
+                                  ? "Service stopped before becoming ready"
+                                  : (terminal.error ?? "Service entered Failed state"),
+                            }),
+                          );
+                        }),
+                      ),
+                    ),
+                  ),
                 ),
               ),
+              Effect.ensuring(Effect.sync(() => svc.readinessWaiters.delete(readiness))),
             );
           });
 

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -102,6 +102,7 @@ export class Orchestrator extends Context.Service<
           completed: Deferred.Deferred<number>;
           stopped: Deferred.Deferred<void>;
           readonly readinessWaiters: Set<Deferred.Deferred<void>>;
+          readonly completionWaiters: Set<Deferred.Deferred<number>>;
           stoppedByUser: boolean;
           requested: boolean;
         }
@@ -117,6 +118,7 @@ export class Orchestrator extends Context.Service<
             completed: Deferred.makeUnsafe<number>(),
             stopped: Deferred.makeUnsafe<void>(),
             readinessWaiters: new Set(),
+            completionWaiters: new Set(),
             stoppedByUser: false,
             requested: false,
           });
@@ -454,8 +456,14 @@ export class Orchestrator extends Context.Service<
             const handleResult = (r: SpawnResult) =>
               Effect.gen(function* () {
                 if (r._tag === "Exited") {
-                  const completeSig = services.get(def.name)?.completed;
-                  if (completeSig) yield* Deferred.succeed(completeSig, r.exitCode);
+                  const service = services.get(def.name);
+                  if (service !== undefined) {
+                    yield* Effect.forEach(
+                      [service.completed, ...service.completionWaiters],
+                      (waiter) => Deferred.succeed(waiter, r.exitCode),
+                      { discard: true },
+                    );
+                  }
                   if (r.exitCode !== 0 && r.exitCode !== 143) {
                     yield* appendRecentServiceLogs(
                       def.name,
@@ -579,8 +587,17 @@ export class Orchestrator extends Context.Service<
             }
 
             if (restartPolicy === "no") {
-              // One-shot: wait for completed, check exit code
-              return Deferred.await(svc.completed).pipe(
+              const completion = Deferred.makeUnsafe<number>();
+              svc.completionWaiters.add(completion);
+              return Deferred.isDone(svc.completed).pipe(
+                Effect.flatMap((alreadyCompleted) =>
+                  alreadyCompleted
+                    ? Deferred.await(svc.completed).pipe(
+                        Effect.flatMap((exitCode) => Deferred.succeed(completion, exitCode)),
+                      )
+                    : Effect.void,
+                ),
+                Effect.andThen(Deferred.await(completion)),
                 Effect.flatMap((exitCode) =>
                   exitCode === 0
                     ? Effect.void
@@ -592,6 +609,7 @@ export class Orchestrator extends Context.Service<
                         }),
                       ),
                 ),
+                Effect.ensuring(Effect.sync(() => svc.completionWaiters.delete(completion))),
               );
             }
 

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -7,6 +7,7 @@ import {
   FiberMap,
   Layer,
   Context,
+  Semaphore,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -119,6 +120,7 @@ export class Orchestrator extends Context.Service<
 
         // FiberMap to track running service fibers — auto-interrupted on scope close
         const fibers = yield* FiberMap.make<string>();
+        const startServiceLock = Semaphore.makeUnsafe(1);
 
         // Helper: send a validated FSM event — only does the state transition
         const sendEvent = (
@@ -538,7 +540,10 @@ export class Orchestrator extends Context.Service<
             }
           };
           collectDependents(name);
-          return graph.startOrder.filter((def) => names.has(def.name));
+          return graph.startOrder.filter(
+            (def) =>
+              names.has(def.name) && (def.name === name || FiberMap.hasUnsafe(fibers, def.name)),
+          );
         };
 
         const waitReadySingle = (def: ServiceDef): Effect.Effect<void, ServiceReadyError> =>
@@ -547,7 +552,6 @@ export class Orchestrator extends Context.Service<
             if (!svc) return Effect.void;
             const restartPolicy = def.restart ?? defaults.restart;
 
-            // Check if already failed
             const current = SubscriptionRef.getUnsafe(svc.state);
             if (current.status === "Failed") {
               return Effect.fail(
@@ -575,11 +579,20 @@ export class Orchestrator extends Context.Service<
               );
             }
 
-            // Long-running: race healthy vs failure
+            if (current.status === "Stopped") {
+              return Effect.fail(
+                new ServiceReadyError({
+                  name: def.name,
+                  reason: "Service stopped before becoming ready",
+                }),
+              );
+            }
+
+            // Long-running: race healthy vs a terminal state
             return Effect.race(
               Deferred.await(svc.healthy),
               SubscriptionRef.changes(svc.state).pipe(
-                Stream.filter((s) => s.status === "Failed"),
+                Stream.filter((s) => s.status === "Failed" || s.status === "Stopped"),
                 Stream.take(1),
                 Stream.runDrain,
                 Effect.andThen(
@@ -588,7 +601,10 @@ export class Orchestrator extends Context.Service<
                     return yield* Effect.fail(
                       new ServiceReadyError({
                         name: def.name,
-                        reason: current.error ?? "Service entered Failed state",
+                        reason:
+                          current.status === "Stopped"
+                            ? "Service stopped before becoming ready"
+                            : (current.error ?? "Service entered Failed state"),
                       }),
                     );
                   }),
@@ -612,10 +628,72 @@ export class Orchestrator extends Context.Service<
                 return yield* Effect.fail(new ServiceNotFoundError({ name }));
               }
               const order = graph.startOrderFor(name);
+              const orderNames = new Set(order.map((service) => service.name));
+              const resetNames = new Set<string>();
+              let dependencySignalsReset = false;
               for (const d of order) {
+                const service = services.get(d.name);
+                const state = service?.state;
+                const status =
+                  state === undefined ? undefined : SubscriptionRef.getUnsafe(state).status;
+                const restartPolicy = d.restart ?? defaults.restart;
+
+                // A successful one-shot remains a satisfied dependency after its
+                // process exits. Naturally stopped long-running services can be
+                // started again even when their restart policy did not relaunch them.
+                if (
+                  status === "Stopped" &&
+                  d.name !== name &&
+                  service?.stoppedByUser !== true &&
+                  restartPolicy === "no"
+                ) {
+                  continue;
+                }
+
+                if (status === "Failed") {
+                  // The failed fiber may still be unwinding its process scope.
+                  // Remove it before replacing the signals used by the retry.
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                  dependencySignalsReset = true;
+                } else if (status === "Stopped") {
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                  dependencySignalsReset = true;
+                } else if (dependencySignalsReset && status === "Pending") {
+                  // This fiber may be waiting on Deferreds replaced by a retried dependency.
+                  // Relaunch it so it observes the dependency's new signal generation.
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                }
                 yield* FiberMap.run(fibers, d.name, runServiceSafe(d), { onlyIfMissing: true });
               }
-            }),
+
+              // A caller may retry a dependency directly while dependents started by an
+              // earlier request are still waiting on its old Deferred generation.
+              for (const d of graph.startOrder) {
+                if (orderNames.has(d.name)) continue;
+                const dependsOnResetService = graph
+                  .startOrderFor(d.name)
+                  .some((dependency) => resetNames.has(dependency.name));
+                const service = services.get(d.name);
+                if (
+                  dependsOnResetService &&
+                  service !== undefined &&
+                  FiberMap.hasUnsafe(fibers, d.name) &&
+                  SubscriptionRef.getUnsafe(service.state).status === "Pending"
+                ) {
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  yield* FiberMap.run(fibers, d.name, runServiceSafe(d), {
+                    onlyIfMissing: true,
+                  });
+                }
+              }
+            }).pipe(startServiceLock.withPermit),
 
           stop: () =>
             Effect.gen(function* () {

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -102,6 +102,7 @@ export class Orchestrator extends Context.Service<
           completed: Deferred.Deferred<number>;
           stopped: Deferred.Deferred<void>;
           stoppedByUser: boolean;
+          requested: boolean;
         }
         const services = new Map<string, ServiceSignals>();
 
@@ -115,6 +116,7 @@ export class Orchestrator extends Context.Service<
             completed: Deferred.makeUnsafe<number>(),
             stopped: Deferred.makeUnsafe<void>(),
             stoppedByUser: false,
+            requested: false,
           });
         }
 
@@ -540,10 +542,15 @@ export class Orchestrator extends Context.Service<
             }
           };
           collectDependents(name);
-          return graph.startOrder.filter(
-            (def) =>
-              names.has(def.name) && (def.name === name || FiberMap.hasUnsafe(fibers, def.name)),
-          );
+          return graph.startOrder.filter((def) => {
+            const service = services.get(def.name);
+            return (
+              names.has(def.name) &&
+              (def.name === name ||
+                FiberMap.hasUnsafe(fibers, def.name) ||
+                (service?.requested === true && service.stoppedByUser !== true))
+            );
+          });
         };
 
         const waitReadySingle = (def: ServiceDef): Effect.Effect<void, ServiceReadyError> =>
@@ -617,6 +624,8 @@ export class Orchestrator extends Context.Service<
           start: () =>
             Effect.gen(function* () {
               for (const def of graph.startOrder) {
+                const service = services.get(def.name);
+                if (service !== undefined) service.requested = true;
                 yield* FiberMap.run(fibers, def.name, runServiceSafe(def));
               }
             }),
@@ -669,6 +678,7 @@ export class Orchestrator extends Context.Service<
                   yield* resetService(d.name);
                   resetNames.add(d.name);
                 }
+                if (service !== undefined) service.requested = true;
                 yield* FiberMap.run(fibers, d.name, runServiceSafe(d), { onlyIfMissing: true });
               }
 
@@ -688,6 +698,7 @@ export class Orchestrator extends Context.Service<
                 ) {
                   yield* FiberMap.remove(fibers, d.name);
                   yield* resetService(d.name);
+                  service.requested = true;
                   yield* FiberMap.run(fibers, d.name, runServiceSafe(d), {
                     onlyIfMissing: true,
                   });
@@ -776,6 +787,8 @@ export class Orchestrator extends Context.Service<
                 yield* resetService(affectedDef.name);
               }
               for (const affectedDef of affected) {
+                const service = services.get(affectedDef.name);
+                if (service !== undefined) service.requested = true;
                 yield* FiberMap.run(fibers, affectedDef.name, runServiceSafe(affectedDef));
               }
             }),

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -703,6 +703,46 @@ describe("Orchestrator", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.live("preserves one-shot readiness waiters when a dependency retry relaunches them", () => {
+    let attempts = 0;
+    const { layer } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("setup", {
+          restart: "no",
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "20 millis" },
+    );
+
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("setup");
+      yield* waitForFailed(orc, "db");
+      const ready = yield* orc.waitReady("setup").pipe(Effect.forkScoped);
+
+      yield* orc.startService("db");
+      yield* Fiber.join(ready);
+
+      expect(attempts).toBe(2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.live("startService leaves never-requested dependents pending when retrying a service", () => {
     let attempts = 0;
     const { layer, proc } = setupOrchestrator(

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -511,6 +511,235 @@ describe("Orchestrator", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.live("startService restarts stopped transitive dependencies", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("web", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "500 millis" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("web");
+      yield* proc.waitForSpawnCount(2);
+      yield* orc.stopService("db");
+      yield* waitForStopped(orc, "db");
+
+      yield* orc.startService("web");
+      yield* proc.waitForSpawnCount(3);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "web", "db"]);
+      expect((yield* orc.getState("db")).status).not.toBe("Stopped");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService preserves successful one-shot dependencies", () => {
+    const { layer, proc } = setupOrchestrator([
+      svc("setup", { restart: "no" }),
+      svc("api", {
+        dependencies: [{ service: "setup", condition: "completed" }],
+      }),
+      svc("worker", {
+        dependencies: [{ service: "setup", condition: "completed" }],
+      }),
+    ]);
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawnCount(2);
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.startService("worker");
+      yield* proc.waitForSpawnCount(3);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["setup", "api", "worker"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService reruns a directly requested successful one-shot", () => {
+    const { layer, proc } = setupOrchestrator([svc("setup", { restart: "no" })]);
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("setup");
+      yield* proc.waitForSpawn("setup");
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.startService("setup");
+      yield* proc.waitForSpawn("setup", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["setup", "setup"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService restarts a naturally stopped long-running service", () => {
+    const { layer, proc } = setupOrchestrator([svc("api", { restart: "on-failure" })], {
+      exitCode: 0,
+      exitDelay: "25 millis",
+    });
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api");
+      yield* waitForStopped(orc, "api");
+
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["api", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService replaces a failed fiber before retrying", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("api", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* waitForFailed(orc, "api");
+
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api", 2);
+      yield* Effect.sleep(Duration.millis(25));
+
+      expect(attempts).toBe(2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService serializes concurrent retries of the same failed service", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("api", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+      ],
+      { exitDelay: "50 millis" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* waitForFailed(orc, "api");
+
+      yield* Effect.all([orc.startService("api"), orc.startService("api")], {
+        concurrency: "unbounded",
+      });
+      yield* orc.waitReady("api");
+
+      expect(attempts).toBe(2);
+      expect(proc.spawned.map((record) => record.command)).toEqual(["api", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService relaunches dependents waiting on a retried service", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* waitForFailed(orc, "db");
+
+      yield* orc.startService("db");
+      yield* proc.waitForSpawn("api");
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService leaves never-requested dependents pending when retrying a service", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("db");
+      yield* waitForFailed(orc, "db");
+
+      yield* orc.startService("db");
+      yield* proc.waitForSpawn("db", 2);
+      yield* Effect.sleep(Duration.millis(25));
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db"]);
+      expect((yield* orc.getState("api")).status).toBe("Pending");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.live("restartService stops and restarts a service", () => {
     const { layer, proc } = setupOrchestrator([svc("a")], {
       exitDelay: "5 seconds",
@@ -560,6 +789,29 @@ describe("Orchestrator", () => {
         unrelated: 1,
         web: 2,
       });
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("restartService leaves never-started dependents pending", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("db");
+      yield* proc.waitForSpawn("db");
+
+      yield* orc.restartService("db");
+      yield* proc.waitForSpawn("db", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db"]);
+      expect((yield* orc.getState("api")).status).toBe("Pending");
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
@@ -1365,6 +1617,19 @@ describe("Orchestrator", () => {
       }).pipe(Effect.provide(layer), Effect.scoped);
     });
 
+    it.live("waitReady resolves after a one-shot service has already completed", () => {
+      const { layer } = setupOrchestrator([svc("a", { restart: "no" })], {
+        exitCode: 0,
+        exitDelay: "10 millis",
+      });
+      return Effect.gen(function* () {
+        const orc = yield* Orchestrator;
+        yield* orc.start();
+        yield* waitForStopped(orc, "a");
+        yield* orc.waitReady("a");
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    });
+
     it.live("waitReady fails when one-shot exits with non-zero code", () => {
       const { layer } = setupOrchestrator([svc("a", { restart: "no" })], {
         exitCode: 1,
@@ -1397,6 +1662,31 @@ describe("Orchestrator", () => {
         const orc = yield* Orchestrator;
         yield* orc.start();
         const exit = yield* orc.waitReady("a").pipe(Effect.exit);
+        expect(Exit.isFailure(exit)).toBe(true);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    });
+
+    it.live("waitReady fails when a starting service is stopped", () => {
+      const { layer, proc } = setupOrchestrator(
+        [
+          svc("a", {
+            healthCheck: {
+              probe: { _tag: "Exec", command: "true", args: [] },
+              initialDelaySeconds: 999,
+            },
+          }),
+        ],
+        { exitDelay: "5 seconds" },
+      );
+      return Effect.gen(function* () {
+        const orc = yield* Orchestrator;
+        yield* orc.start();
+        yield* proc.waitForSpawn("a");
+        const ready = yield* orc.waitReady("a").pipe(Effect.forkScoped);
+
+        yield* orc.stopService("a");
+
+        const exit = yield* Fiber.await(ready);
         expect(Exit.isFailure(exit)).toBe(true);
       }).pipe(Effect.provide(layer), Effect.scoped);
     });

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -693,9 +693,11 @@ describe("Orchestrator", () => {
       const orc = yield* Orchestrator;
       yield* orc.startService("api");
       yield* waitForFailed(orc, "db");
+      const ready = yield* orc.waitReady("api").pipe(Effect.forkScoped);
 
       yield* orc.startService("db");
       yield* proc.waitForSpawn("api");
+      yield* Fiber.join(ready);
 
       expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db", "api"]);
     }).pipe(Effect.provide(layer), Effect.scoped);

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -181,6 +181,10 @@ await stack.startService("auth"); // Restart it (blocks until ready)
 await stack.restartService("auth"); // Stop + start in one call
 ```
 
+Service activation is dependency-aware. Starting Storage also starts imgproxy when enabled, and
+starting Analytics also starts Vector when enabled, so a public service never comes up without the
+companion it calls or feeds.
+
 Common service names include `"postgres"`, `"postgrest"`, `"auth"`, `"realtime"`, `"storage"`,
 `"imgproxy"`, `"mailpit"`, `"pgmeta"`, `"studio"`, `"analytics"`, `"vector"`, and `"pooler"`.
 

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -799,6 +799,12 @@ Before the orchestrator exists, it publishes synthetic service states derived fr
 why `getAllStates()` and `allStateChanges()` can surface `Downloading` during cold-cache startup
 even though no process has been spawned yet.
 
+`ServiceActivation.ts` is the central policy for service reachability. It distinguishes services
+reached through the HTTP or WebSocket proxy from direct listeners and internal companions. The
+coordinator also expands public activation into required companion targets: Storage activates
+imgproxy, and Analytics activates Vector, when those services are enabled. Process dependencies
+remain the responsibility of the process graph.
+
 #### StackInfo
 
 ```ts

--- a/packages/stack/src/ServiceActivation.ts
+++ b/packages/stack/src/ServiceActivation.ts
@@ -1,0 +1,43 @@
+import type { ServiceName } from "./versions.ts";
+
+type ServiceAccess = "proxy-http" | "proxy-websocket" | "direct" | "companion";
+
+export interface ServiceActivationPolicy {
+  /** How a caller reaches the service while the stack is running lazily. */
+  readonly access: ServiceAccess;
+}
+
+/**
+ * Central ownership map for lazy startup. Services with a direct TCP or HTTP
+ * endpoint must be running before that endpoint is published. Companion
+ * services are activated with the public service that consumes them.
+ */
+export const SERVICE_ACTIVATION_POLICY: Readonly<Record<ServiceName, ServiceActivationPolicy>> = {
+  postgres: { access: "direct" },
+  postgrest: { access: "proxy-http" },
+  auth: { access: "proxy-http" },
+  "edge-runtime": { access: "proxy-http" },
+  realtime: { access: "direct" },
+  storage: { access: "proxy-http" },
+  imgproxy: { access: "companion" },
+  mailpit: { access: "direct" },
+  pgmeta: { access: "proxy-http" },
+  studio: { access: "direct" },
+  analytics: { access: "proxy-http" },
+  vector: { access: "companion" },
+  pooler: { access: "direct" },
+};
+
+export const eagerServices = (enabled: ReadonlyArray<ServiceName>): ReadonlyArray<ServiceName> =>
+  enabled.filter((service) => SERVICE_ACTIVATION_POLICY[service].access === "direct");
+
+export const activationTargetsForService = (
+  enabledServices: ReadonlyArray<ServiceName>,
+  service: ServiceName,
+): ReadonlyArray<ServiceName> => {
+  const enabled = new Set(enabledServices);
+  const companions: ReadonlyArray<ServiceName> =
+    service === "storage" ? ["imgproxy"] : service === "analytics" ? ["vector"] : [];
+
+  return [service, ...companions].filter((target) => enabled.has(target));
+};

--- a/packages/stack/src/ServiceActivation.unit.test.ts
+++ b/packages/stack/src/ServiceActivation.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  activationTargetsForService,
+  eagerServices,
+  SERVICE_ACTIVATION_POLICY,
+} from "./ServiceActivation.ts";
+import { SERVICE_NAMES } from "./versions.ts";
+
+describe("service activation", () => {
+  it("defines an access policy for every stack service", () => {
+    expect(Object.keys(SERVICE_ACTIVATION_POLICY).sort()).toEqual([...SERVICE_NAMES].sort());
+  });
+
+  it("starts direct endpoints eagerly", () => {
+    expect(eagerServices(SERVICE_NAMES)).toEqual([
+      "postgres",
+      "realtime",
+      "mailpit",
+      "studio",
+      "pooler",
+    ]);
+  });
+
+  it("activates storage and analytics companions together", () => {
+    expect(activationTargetsForService(SERVICE_NAMES, "storage")).toEqual(["storage", "imgproxy"]);
+    expect(activationTargetsForService(SERVICE_NAMES, "analytics")).toEqual([
+      "analytics",
+      "vector",
+    ]);
+  });
+
+  it("omits disabled companions", () => {
+    const enabled = SERVICE_NAMES.filter(
+      (service) => service !== "imgproxy" && service !== "vector",
+    );
+    expect(activationTargetsForService(enabled, "storage")).toEqual(["storage"]);
+    expect(activationTargetsForService(enabled, "analytics")).toEqual(["analytics"]);
+  });
+});

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -18,6 +18,7 @@ import { cleanupLocalStackResources } from "./cleanup.ts";
 import { StackBuildError } from "./errors.ts";
 import { configureFunctionsRuntime, type FunctionsConfig } from "./functions.ts";
 import { detectPlatform, dockerHostAddress } from "./Platform.ts";
+import { activationTargetsForService } from "./ServiceActivation.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
 import { StackPreparation } from "./StackPreparation.ts";
 import type { PreparedStackArtifacts } from "./StackPreparation.ts";
@@ -31,6 +32,7 @@ import {
 import { changedProjectedStates, projectStackStates } from "./StackStateProjection.ts";
 import { StackServiceState } from "./StackServiceState.ts";
 import type { EdgeRuntimeReloadConfig, StackInfo } from "./Stack.ts";
+import { SERVICE_NAMES, type ServiceName } from "./versions.ts";
 
 type LifecyclePhase =
   | "idle"
@@ -194,6 +196,7 @@ export class StackLifecycleCoordinator extends Context.Service<
         const scope = yield* Effect.scope;
 
         const info = stackInfoFor(config);
+        const enabledServices = enabledServicesForConfig(config);
         const stateRef = yield* SubscriptionRef.make(initialPublicStates(config));
         const phaseRef = yield* Ref.make<LifecyclePhase>("idle");
 
@@ -219,6 +222,17 @@ export class StackLifecycleCoordinator extends Context.Service<
               return yield* Effect.fail(new ServiceNotFoundError({ name }));
             }
             return match;
+          });
+        const requireKnownServiceName = (
+          name: string,
+        ): Effect.Effect<ServiceName, ServiceNotFoundError> =>
+          Effect.gen(function* () {
+            yield* requireKnownService(name);
+            const service = SERVICE_NAMES.find((candidate) => candidate === name);
+            if (service === undefined) {
+              return yield* Effect.fail(new ServiceNotFoundError({ name }));
+            }
+            return service;
           });
 
         let preparedArtifacts: PreparedStackArtifacts | undefined;
@@ -495,6 +509,19 @@ export class StackLifecycleCoordinator extends Context.Service<
               (previous, current) => [current, changedStatesBetween(previous, current)],
             ),
           );
+        const startServices = (services: ReadonlyArray<ServiceName>) =>
+          Effect.gen(function* () {
+            const runtime = yield* ensureRuntime;
+            yield* Effect.forEach(
+              services,
+              (service) => runtime.orchestrator.startService(service),
+              { discard: true },
+            );
+            yield* Effect.forEach(services, (service) => runtime.orchestrator.waitReady(service), {
+              concurrency: "unbounded",
+              discard: true,
+            });
+          });
         const disposeOnce = () =>
           Effect.gen(function* () {
             if (disposed) {
@@ -537,16 +564,18 @@ export class StackLifecycleCoordinator extends Context.Service<
           dispose: disposeOnce,
           startService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
-              const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.startService(name);
-              yield* runtime.orchestrator.waitReady(name);
+              const service = yield* requireKnownServiceName(name);
+              yield* startServices(activationTargetsForService(enabledServices, service));
             }),
           stopService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
+              const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.stopService(name);
+              yield* Effect.forEach(
+                activationTargetsForService(enabledServices, service).toReversed(),
+                (target) => runtime.orchestrator.stopService(target),
+                { discard: true },
+              );
             }),
           restartService: (name) =>
             Effect.gen(function* () {


### PR DESCRIPTION
Stack layer 2 of 7, based on #6041.

Defines one activation policy for every stack service and moves companion ownership into the stack lifecycle:

- distinguishes direct, HTTP-proxied, WebSocket-proxied, and companion services
- starts imgproxy with Storage and Vector with Analytics
- keeps service activation dependency-aware for explicit lifecycle calls
- covers the full service matrix without introducing Fleet behavior