### PR TITLE
feat(stack): start HTTP services through lazy proxy

### DIFF
--- a/packages/process-compose/tests/helpers/mocks.ts
+++ b/packages/process-compose/tests/helpers/mocks.ts
@@ -13,6 +13,7 @@ export function mockChildProcessSpawner(
     exitCode?: number;
     stdout?: string[];
     stderr?: string[];
+    beforeSpawn?: (record: SpawnRecord) => Effect.Effect<void>;
     onSpawn?: (record: SpawnRecord) => void;
   } = {},
 ) {
@@ -27,6 +28,7 @@ export function mockChildProcessSpawner(
           const cmd = command._tag === "StandardCommand" ? command.command : "";
           const args = command._tag === "StandardCommand" ? command.args : [];
           const record: SpawnRecord = { command: cmd, args };
+          yield* opts.beforeSpawn?.(record) ?? Effect.void;
           spawned.push(record);
           opts.onSpawn?.(record);
 

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -9,6 +9,7 @@ Programmatic local Supabase stack for TypeScript. Create a local Supabase runtim
 - **Native binaries with Docker fallback** -- uses native services when available and falls back to Docker images automatically
 - **Automatic port allocation** -- all ports are optional and auto-assigned to avoid conflicts
 - **API proxy with opaque keys** -- SDKs use `publishableKey`/`secretKey` (like production), translated to JWTs internally
+- **Lazy HTTP services** -- opt into `startupMode: "lazy"` to start proxied services on their first request while keeping direct listeners reachable
 - **`AsyncDisposable` support** -- use `await using` for automatic cleanup
 - **Streaming logs and status** -- real-time `AsyncIterable` streams for service state changes and log output
 - **Per-service lifecycle control** -- start, stop, and restart individual services independently
@@ -75,13 +76,14 @@ await stack.dispose();
 
 ### Top-level settings
 
-| Field            | Type                             | Required | Default  | Description                                                                                                                                                     |
-| ---------------- | -------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`           | `"native" \| "auto" \| "docker"` | No       | `"auto"` | Resolution mode. `"native"` requires native binaries, `"auto"` tries native first and falls back to Docker, and `"docker"` uses Docker images for all services. |
-| `jwtSecret`      | `string`                         | No       |          | Secret for JWT signing (min 32 characters). Defaults to a well-known dev secret                                                                                 |
-| `port`           | `number`                         | No       |          | API proxy port (auto-allocated if omitted)                                                                                                                      |
-| `publishableKey` | `string`                         | No       |          | Custom opaque publishable key                                                                                                                                   |
-| `secretKey`      | `string`                         | No       |          | Custom opaque secret key                                                                                                                                        |
+| Field            | Type                             | Required | Default   | Description                                                                                                                                                     |
+| ---------------- | -------------------------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`           | `"native" \| "auto" \| "docker"` | No       | `"auto"`  | Resolution mode. `"native"` requires native binaries, `"auto"` tries native first and falls back to Docker, and `"docker"` uses Docker images for all services. |
+| `startupMode`    | `"eager" \| "lazy"`              | No       | `"eager"` | In lazy mode, HTTP services start on their first proxied request. Direct TCP/HTTP listeners still start with the stack.                                         |
+| `jwtSecret`      | `string`                         | No       |           | Secret for JWT signing (min 32 characters). Defaults to a well-known dev secret                                                                                 |
+| `port`           | `number`                         | No       |           | API proxy port (auto-allocated if omitted)                                                                                                                      |
+| `publishableKey` | `string`                         | No       |           | Custom opaque publishable key                                                                                                                                   |
+| `secretKey`      | `string`                         | No       |           | Custom opaque secret key                                                                                                                                        |
 
 ### `postgres`
 

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -707,6 +707,7 @@ public service projection metadata, and exact cleanup targets.
 
 ```ts
 interface ResolvedStackConfig {
+  readonly startupMode: "eager" | "lazy";
   readonly jwtSecret: string;
   readonly apiPort: number;
   readonly dbPort: number;
@@ -804,6 +805,12 @@ reached through the HTTP or WebSocket proxy from direct listeners and internal c
 coordinator also expands public activation into required companion targets: Storage activates
 imgproxy, and Analytics activates Vector, when those services are enabled. Process dependencies
 remain the responsibility of the process graph.
+
+The package defaults to `startupMode: "eager"`. In `"lazy"` mode, `start()` starts and waits only
+for services with direct endpoints. Each HTTP proxy route activates its target service before it
+forwards the request, and concurrent activation remains single-flight in the orchestrator. Proxy
+requests made before startup or after shutdown receive `503 Service Unavailable`. `waitAllReady()`
+waits for the set of services activated so far instead of blocking on intentionally dormant ones.
 
 #### StackInfo
 

--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -9,6 +9,8 @@ import {
   HttpServerRequest,
   HttpServerResponse,
 } from "effect/unstable/http";
+import { StackServiceActivator } from "./ServiceActivation.ts";
+import type { ServiceName } from "./versions.ts";
 
 export interface ProxyConfig {
   readonly listenPort: number;
@@ -113,6 +115,7 @@ function addCorsHeaders(
 const COLD_START_RETRY_SCHEDULE = Schedule.spaced("250 millis").pipe(Schedule.upTo({ times: 8 }));
 
 interface ProxyHandlerOptions {
+  readonly service: ServiceName;
   readonly backendPort: number;
   readonly stripPrefix?: string;
   readonly backendPath?: string;
@@ -128,10 +131,19 @@ interface ProxyHandlerOptions {
 function makeProxyHandler(
   client: HttpClient.HttpClient,
   config: ProxyConfig,
+  activator: StackServiceActivator["Service"],
   opts: ProxyHandlerOptions,
 ) {
   return (req: HttpServerRequest.HttpServerRequest) =>
     Effect.gen(function* () {
+      const activation = yield* Effect.result(activator.activate(opts.service));
+      if (Result.isFailure(activation)) {
+        return HttpServerResponse.text("Service unavailable", {
+          status: 503,
+          headers: { "retry-after": "1" },
+        });
+      }
+
       let backendPath = opts.backendPath;
 
       if (backendPath === undefined) {
@@ -209,18 +221,24 @@ export class ApiProxy extends Context.Service<
 >()("local/ApiProxy") {
   static layer = (
     config: ProxyConfig,
-  ): Layer.Layer<ApiProxy, never, HttpServer.HttpServer | HttpClient.HttpClient> =>
+  ): Layer.Layer<
+    ApiProxy,
+    never,
+    HttpServer.HttpServer | HttpClient.HttpClient | StackServiceActivator
+  > =>
     Layer.effect(ApiProxy)(
       Effect.gen(function* () {
         const server = yield* HttpServer.HttpServer;
         const client = yield* HttpClient.HttpClient;
+        const activator = yield* StackServiceActivator;
 
         const routes = [
           HttpRouter.route("*", "/health", HttpServerResponse.text("OK", { status: 200 })),
           HttpRouter.route(
             "*",
             "/.well-known/oauth-authorization-server",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               backendPath: "/.well-known/oauth-authorization-server",
             }),
@@ -228,7 +246,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/verify",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -236,7 +255,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/callback",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -244,7 +264,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/authorize",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -252,7 +273,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
               transformAuth: true,
@@ -261,7 +283,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/rest/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestPort,
               stripPrefix: "/rest/v1",
               transformAuth: true,
@@ -270,7 +293,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/rest-admin/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestAdminPort,
               stripPrefix: "/rest-admin/v1",
             }),
@@ -278,7 +302,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/graphql/v1",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestPort,
               backendPath: "/rpc/graphql",
               transformAuth: true,
@@ -288,7 +313,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/functions/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "edge-runtime",
               backendPort: config.edgeRuntimePort,
               stripPrefix: "/functions/v1",
               transformAuth: true,
@@ -299,7 +325,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/realtime/v1/api/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "realtime",
               backendPort: config.realtimePort,
               stripPrefix: "/realtime/v1",
               transformAuth: true,
@@ -308,7 +335,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/realtime/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "realtime",
               backendPort: config.realtimePort,
               stripPrefix: "/realtime/v1",
             }),
@@ -316,7 +344,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/storage/v1/s3/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "storage",
               backendPort: config.storagePort,
               stripPrefix: "/storage/v1",
             }),
@@ -324,7 +353,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/storage/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "storage",
               backendPort: config.storagePort,
               stripPrefix: "/storage/v1",
               transformAuth: true,
@@ -333,7 +363,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/pg/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "pgmeta",
               backendPort: config.pgmetaPort,
               stripPrefix: "/pg",
             }),
@@ -341,7 +372,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/analytics/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "analytics",
               backendPort: config.analyticsPort,
               stripPrefix: "/analytics/v1",
             }),
@@ -349,7 +381,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/pooler/v2/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "pooler",
               backendPort: config.poolerPort,
               stripPrefix: "/pooler",
             }),
@@ -357,7 +390,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/mcp",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "studio",
               backendPort: config.studioPort,
               backendPath: "/api/mcp",
             }),

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -1,10 +1,13 @@
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as http from "node:http";
 import { gzipSync } from "node:zlib";
-import { Layer, ManagedRuntime } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { ApiProxy, type ProxyConfig } from "./ApiProxy.ts";
+import { StackNotRunningError } from "./errors.ts";
+import { StackServiceActivator } from "./ServiceActivation.ts";
+import type { ServiceName } from "./versions.ts";
 
 interface EchoServer {
   readonly port: number;
@@ -102,18 +105,23 @@ function startFlakyBackend(opts: { failFirst: number; body: string }): Promise<F
 }
 
 // Builds the full proxy layer backed by a Node HTTP server.
-function buildProxyLayer(config: ProxyConfig): Layer.Layer<ApiProxy, never, never> {
+function buildProxyLayer(
+  config: ProxyConfig,
+  activatorLayer: Layer.Layer<StackServiceActivator> = StackServiceActivator.noop,
+): Layer.Layer<ApiProxy, never, never> {
   return ApiProxy.layer(config).pipe(
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
     Layer.provide(FetchHttpClient.layer),
+    Layer.provide(activatorLayer),
   ) as Layer.Layer<ApiProxy, never, never>;
 }
 
 // Spins up a proxy for an ad-hoc config and returns its URL plus a disposer.
 async function startProxy(
   config: ProxyConfig,
+  activatorLayer?: Layer.Layer<StackServiceActivator>,
 ): Promise<{ url: string; dispose: () => Promise<void> }> {
-  const proxyRuntime = ManagedRuntime.make(buildProxyLayer(config));
+  const proxyRuntime = ManagedRuntime.make(buildProxyLayer(config, activatorLayer));
   const proxy = await proxyRuntime.runPromise(ApiProxy);
   const addr = proxy.address;
   let url = "";
@@ -204,6 +212,38 @@ describe("ApiProxy", () => {
   test("non-OPTIONS responses include CORS headers", async () => {
     const res = await fetch(`${proxyUrl}/health`);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("activates the routed service before forwarding", async () => {
+    const activated: ServiceName[] = [];
+    const activatorLayer = Layer.succeed(StackServiceActivator, {
+      activate: (service) =>
+        Effect.sync(() => {
+          activated.push(service);
+        }),
+    });
+    const proxy = await startProxy(configForPort(echoServer.port), activatorLayer);
+    try {
+      const res = await fetch(`${proxy.url}/rest/v1/users`);
+      expect(res.status).toBe(200);
+      expect(activated).toEqual(["postgrest"]);
+    } finally {
+      await proxy.dispose();
+    }
+  });
+
+  test("returns 503 when the stack cannot activate a service", async () => {
+    const activatorLayer = Layer.succeed(StackServiceActivator, {
+      activate: () => Effect.fail(new StackNotRunningError({ phase: "idle" })),
+    });
+    const proxy = await startProxy(configForPort(echoServer.port), activatorLayer);
+    try {
+      const res = await fetch(`${proxy.url}/rest/v1/users`);
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+    } finally {
+      await proxy.dispose();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/stack/src/ServiceActivation.ts
+++ b/packages/stack/src/ServiceActivation.ts
@@ -1,3 +1,7 @@
+import { ServiceNotFoundError } from "@supabase/process-compose";
+import type { ServiceReadyError } from "@supabase/process-compose";
+import { Context, Effect, Layer } from "effect";
+import { StackBuildError, StackNotRunningError } from "./errors.ts";
 import type { ServiceName } from "./versions.ts";
 
 type ServiceAccess = "proxy-http" | "proxy-websocket" | "direct" | "companion";
@@ -36,8 +40,48 @@ export const activationTargetsForService = (
   service: ServiceName,
 ): ReadonlyArray<ServiceName> => {
   const enabled = new Set(enabledServices);
-  const companions: ReadonlyArray<ServiceName> =
-    service === "storage" ? ["imgproxy"] : service === "analytics" ? ["vector"] : [];
+  const targets = new Set<ServiceName>();
+  const addWithCompanions = (target: ServiceName): void => {
+    if (!enabled.has(target) || targets.has(target)) return;
+    targets.add(target);
+    if (target === "storage") addWithCompanions("imgproxy");
+    if (target === "analytics") addWithCompanions("vector");
+    if (target === "studio") addWithCompanions("analytics");
+  };
+  addWithCompanions(service);
 
-  return [service, ...companions].filter((target) => enabled.has(target));
+  return [...targets];
 };
+
+/** Services exclusively owned by a public service for stop/restart operations. */
+export const lifecycleTargetsForService = (
+  enabledServices: ReadonlyArray<ServiceName>,
+  service: ServiceName,
+): ReadonlyArray<ServiceName> => {
+  const enabled = new Set(enabledServices);
+  const targets: ServiceName[] = [];
+  const add = (target: ServiceName): void => {
+    if (enabled.has(target)) targets.push(target);
+  };
+
+  add(service);
+  if (service === "storage") add("imgproxy");
+  if (service === "analytics") add("vector");
+  return targets;
+};
+
+export class StackServiceActivator extends Context.Service<
+  StackServiceActivator,
+  {
+    readonly activate: (
+      service: ServiceName,
+    ) => Effect.Effect<
+      void,
+      ServiceNotFoundError | ServiceReadyError | StackBuildError | StackNotRunningError
+    >;
+  }
+>()("stack/StackServiceActivator") {
+  static noop = Layer.succeed(this, {
+    activate: () => Effect.void,
+  });
+}

--- a/packages/stack/src/ServiceActivation.unit.test.ts
+++ b/packages/stack/src/ServiceActivation.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   activationTargetsForService,
   eagerServices,
+  lifecycleTargetsForService,
   SERVICE_ACTIVATION_POLICY,
 } from "./ServiceActivation.ts";
 import { SERVICE_NAMES } from "./versions.ts";
@@ -21,9 +22,14 @@ describe("service activation", () => {
     ]);
   });
 
-  it("activates storage and analytics companions together", () => {
+  it("activates service companions transitively", () => {
     expect(activationTargetsForService(SERVICE_NAMES, "storage")).toEqual(["storage", "imgproxy"]);
     expect(activationTargetsForService(SERVICE_NAMES, "analytics")).toEqual([
+      "analytics",
+      "vector",
+    ]);
+    expect(activationTargetsForService(SERVICE_NAMES, "studio")).toEqual([
+      "studio",
       "analytics",
       "vector",
     ]);
@@ -35,5 +41,12 @@ describe("service activation", () => {
     );
     expect(activationTargetsForService(enabled, "storage")).toEqual(["storage"]);
     expect(activationTargetsForService(enabled, "analytics")).toEqual(["analytics"]);
+    expect(activationTargetsForService(enabled, "studio")).toEqual(["studio", "analytics"]);
+  });
+
+  it("does not assign shared public dependencies to their consumers", () => {
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "storage")).toEqual(["storage", "imgproxy"]);
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "analytics")).toEqual(["analytics", "vector"]);
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "studio")).toEqual(["studio"]);
   });
 });

--- a/packages/stack/src/Stack.ts
+++ b/packages/stack/src/Stack.ts
@@ -66,7 +66,7 @@ export class Stack extends Context.Service<
     ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
     readonly restartService: (
       name: string,
-    ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
+    ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
     readonly reloadFunctions: (
       opts?: FunctionsConfig,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -497,10 +497,9 @@ describe("Stack", () => {
     return Effect.gen(function* () {
       const coordinator = yield* StackLifecycleCoordinator;
       yield* coordinator.start();
-      yield* coordinator.activateService("auth");
       yield* coordinator.stop();
 
-      const error = yield* coordinator.activateService("auth").pipe(Effect.flip);
+      const error = yield* coordinator.activateService("postgres").pipe(Effect.flip);
       expect(error._tag).toBe("StackNotRunningError");
     }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
   });

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -589,4 +589,23 @@ describe("Stack", () => {
       expect(error._tag).toBe("StackNotRunningError");
     }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
   });
+
+  it.live("resets inactive service state when a lazy stack starts again", () => {
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.stopService("auth");
+      yield* Effect.sleep("20 millis");
+      expect((yield* coordinator.getState("auth")).status).toBe("Stopped");
+
+      yield* coordinator.stop();
+      yield* coordinator.start();
+
+      expect((yield* coordinator.getState("auth")).status).toBe("Pending");
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
 });

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -491,6 +491,92 @@ describe("Stack", () => {
     }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
   );
 
+  it.live("dispose waits for an in-flight lazy activation", () =>
+    Effect.gen(function* () {
+      const spawnStarted = yield* Deferred.make<void>();
+      const allowSpawn = yield* Deferred.make<void>();
+      const spawner = mockChildProcessSpawner({
+        beforeSpawn: (record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          )
+            ? Deferred.succeed(spawnStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(allowSpawn)),
+              )
+            : Effect.void,
+      });
+      const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, spawner);
+
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        yield* coordinator.start();
+        const activationFiber = yield* coordinator
+          .activateService("auth")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(spawnStarted);
+
+        const disposeFiber = yield* coordinator
+          .dispose()
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Fiber.join(disposeFiber);
+        yield* Deferred.succeed(allowSpawn, undefined);
+        yield* Effect.sleep("20 millis");
+        yield* Fiber.interrupt(activationFiber);
+
+        expect(spawner.spawned.some((record) => record.command.endsWith("/auth"))).toBe(false);
+
+        const error = yield* coordinator.activateService("auth").pipe(Effect.flip);
+        expect(error._tag).toBe("StackNotRunningError");
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
+  );
+
+  it.live("restarts lazy dependents after their stopped dependency", () => {
+    return Effect.gen(function* () {
+      const authHealthServer = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: () => new Response("ok"),
+          }),
+        ),
+        (server) => Effect.sync(() => server.stop(true)),
+      );
+      const authPort = authHealthServer.port;
+      if (authPort === undefined) {
+        throw new Error("Expected the auth health test server to bind a TCP port");
+      }
+      const authConfig = defaultConfig.auth;
+      if (authConfig === false) {
+        throw new Error("Expected auth to be enabled in the default test config");
+      }
+      const { coordinatorLayer, spawner } = setupLayer({
+        ...defaultConfig,
+        startupMode: "lazy",
+        ports: { ...defaultPorts, authPort },
+        auth: { ...authConfig, port: authPort },
+      });
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        const isAuthStart = (record: { readonly args: ReadonlyArray<string> }) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          );
+        yield* coordinator.start();
+        yield* coordinator.activateService("auth");
+        const initialAuthStarts = spawner.spawned.filter(isAuthStart).length;
+        expect(initialAuthStarts).toBeGreaterThan(0);
+
+        yield* coordinator.stopService("postgres");
+        yield* coordinator.restartService("postgres");
+        yield* coordinator.waitAllReady();
+
+        expect(spawner.spawned.filter(isAuthStart).length).toBeGreaterThan(initialAuthStarts);
+        yield* coordinator.stop();
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds"));
+  });
+
   it.live("rejects a cached activation after the stack has stopped", () => {
     const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
 

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -490,4 +490,18 @@ describe("Stack", () => {
       }).pipe(Effect.provide(coordinatorLayer));
     }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
   );
+
+  it.live("rejects a cached activation after the stack has stopped", () => {
+    const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.activateService("auth");
+      yield* coordinator.stop();
+
+      const error = yield* coordinator.activateService("auth").pipe(Effect.flip);
+      expect(error._tag).toBe("StackNotRunningError");
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
 });

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { createHmac } from "node:crypto";
-import { Effect, Exit, Fiber, Layer, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Stream } from "effect";
 import { mockChildProcessSpawner } from "../../process-compose/tests/helpers/mocks.ts";
 import { mockBinaryResolver } from "../tests/helpers/mocks.ts";
 import { defaultPublishableKey, defaultSecretKey, generateJwt } from "./JwtGenerator.ts";
@@ -43,6 +43,7 @@ const defaultConfig: ResolvedStackConfig = {
   runtimeRoot: "/tmp/supabase-runtime",
   projectDir: "/tmp/supabase-project",
   mode: "native",
+  startupMode: "eager",
   jwtSecret: testJwtSecret,
   ports: defaultPorts,
   apiPort: 54321,
@@ -99,23 +100,23 @@ const edgeRuntimeConfig: ResolvedStackConfig = {
   },
 };
 
-function setupLayer(config: ResolvedStackConfig = defaultConfig) {
+function setupLayer(
+  config: ResolvedStackConfig = defaultConfig,
+  spawner = mockChildProcessSpawner(),
+) {
   const resolver = mockBinaryResolver();
-  const spawner = mockChildProcessSpawner();
   const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
   const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
-  );
-
-  const layer = Stack.layer(config).pipe(
-    Layer.provide(coordinatorLayer),
     Layer.provide(spawner.layer),
     Layer.provide(BunServices.layer),
   );
 
-  return { layer, resolver, spawner };
+  const layer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+
+  return { coordinatorLayer, layer, resolver, spawner };
 }
 
 describe("Stack", () => {
@@ -128,6 +129,8 @@ describe("Stack", () => {
 
       expect(info.url).toBe("http://127.0.0.1:54321");
       expect(info.dbUrl).toBe("postgresql://postgres:postgres@127.0.0.1:54322/postgres");
+      expect(info.serviceEndpoints.auth).toBe("http://127.0.0.1:54321/auth/v1");
+      expect(info.serviceEndpoints.postgrest).toBe("http://127.0.0.1:54321/rest/v1");
     }).pipe(Effect.provide(layer));
   });
 
@@ -139,7 +142,7 @@ describe("Stack", () => {
       const info = yield* stack.getInfo();
 
       expect(info.serviceEndpoints.functions).toBe("http://127.0.0.1:54321/functions/v1");
-      expect(info.serviceEndpoints.edge_runtime).toBe("http://127.0.0.1:54325");
+      expect(info.serviceEndpoints.edge_runtime).toBe("http://127.0.0.1:54321/functions/v1");
     }).pipe(Effect.provide(layer));
   });
 
@@ -397,4 +400,94 @@ describe("Stack", () => {
       expect(startedContainers).toEqual([]);
     }).pipe(Effect.provide(layer));
   });
+
+  it.live("lazy startup starts direct services without starting HTTP backends", () => {
+    const { layer, spawner } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.start();
+      yield* stack.waitAllReady();
+
+      expect(
+        spawner.spawned.some((record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"bash"'),
+          ),
+        ),
+      ).toBe(true);
+      expect(spawner.spawned.some((record) => record.command.endsWith("/auth"))).toBe(false);
+      expect(spawner.spawned.some((record) => record.command.endsWith("/postgrest"))).toBe(false);
+
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy activation honors explicitly stopped transitive dependencies", () => {
+    const config: ResolvedStackConfig = {
+      ...defaultConfig,
+      mode: "auto",
+      startupMode: "lazy",
+      storage: {
+        port: defaultPorts.storagePort,
+        dataDir: "/tmp/supabase/storage",
+        fileSizeLimit: "50MiB",
+        s3ProtocolEnabled: true,
+        version: DEFAULT_VERSIONS.storage,
+      },
+      imgproxy: {
+        port: defaultPorts.imgproxyPort,
+        version: DEFAULT_VERSIONS.imgproxy,
+      },
+    };
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.stopService("imgproxy");
+
+      const error = yield* coordinator.activateService("storage").pipe(Effect.flip);
+
+      expect(error._tag).toBe("StackBuildError");
+      if (error._tag === "StackBuildError") {
+        expect(error.detail).toContain("imgproxy was explicitly stopped");
+      }
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy readiness includes an activation that is still starting", () =>
+    Effect.gen(function* () {
+      const spawnStarted = yield* Deferred.make<void>();
+      const spawner = mockChildProcessSpawner({
+        beforeSpawn: (record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          )
+            ? Deferred.succeed(spawnStarted, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.void,
+      });
+      const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, spawner);
+
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        yield* coordinator.start();
+        const activationFiber = yield* coordinator
+          .activateService("auth")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(spawnStarted);
+
+        const readyFiber = yield* coordinator
+          .waitAllReady()
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        expect(readyFiber.pollUnsafe()).toBeUndefined();
+
+        yield* coordinator.stop().pipe(Effect.timeout("1 second"));
+        yield* Fiber.interrupt(readyFiber);
+        yield* Fiber.interrupt(activationFiber);
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
+  );
 });

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -148,6 +148,8 @@ export interface StackConfig {
   readonly runtimeRoot?: string;
   readonly projectDir?: string;
   readonly mode?: "native" | "auto" | "docker";
+  /** Start all services immediately, or defer proxied services until first use. */
+  readonly startupMode?: "eager" | "lazy";
   readonly jwtSecret?: string;
   readonly port?: number;
   readonly publishableKey?: string;
@@ -272,6 +274,7 @@ export interface ResolvedStackConfig {
   readonly runtimeRoot: string;
   readonly projectDir: string;
   readonly mode: "native" | "auto" | "docker";
+  readonly startupMode: "eager" | "lazy";
   readonly jwtSecret: string;
   readonly ports: AllocatedPorts;
   readonly apiPort: number;

--- a/packages/stack/src/StackBuilder.unit.test.ts
+++ b/packages/stack/src/StackBuilder.unit.test.ts
@@ -42,6 +42,7 @@ const baseConfig: ResolvedStackConfig = {
   runtimeRoot: "/tmp/supabase-runtime",
   projectDir: "/tmp/supabase-project",
   mode: "auto",
+  startupMode: "eager",
   jwtSecret: testJwtSecret,
   ports: basePorts,
   apiPort: 3000,

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -659,12 +659,13 @@ export class StackLifecycleCoordinator extends Context.Service<
               return;
             }
             disposed = true;
+            yield* Ref.set(phaseRef, "stopping");
             yield* cleanupLocalStackResources({
               stop: () =>
                 runtimeState === undefined ? Effect.void : runtimeState.orchestrator.stop(),
               cleanupTargets: runtimeState?.cleanupTargets ?? { dockerContainerNames: [] },
               config,
-            });
+            }).pipe(Effect.ensuring(Ref.set(phaseRef, "stopped")));
           });
 
         yield* Effect.addFinalizer(disposeOnce);
@@ -694,15 +695,18 @@ export class StackLifecycleCoordinator extends Context.Service<
                 if (
                   runtime.graph.startOrder.some((definition) => definition.name === "postgres-init")
                 ) {
-                  yield* runtime.orchestrator.startService("postgres-init").pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new StackBuildError({
-                          detail: "Prepared graph does not contain postgres-init",
-                          cause,
-                        }),
-                    ),
-                  );
+                  const postgresInit = yield* runtime.orchestrator.getState("postgres-init");
+                  if (postgresInit.status === "Pending") {
+                    yield* runtime.orchestrator.startService("postgres-init").pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new StackBuildError({
+                            detail: "Prepared graph does not contain postgres-init",
+                            cause,
+                          }),
+                      ),
+                    );
+                  }
                   yield* runtime.orchestrator.waitReady("postgres-init").pipe(
                     Effect.catchTag("ServiceNotFoundError", (cause) =>
                       Effect.fail(

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -853,8 +853,16 @@ export class StackLifecycleCoordinator extends Context.Service<
           reloadFunctions: (opts) =>
             Effect.gen(function* () {
               yield* requireKnownService("edge-runtime");
-              const runtime = yield* ensureRuntime;
               yield* configureFunctions(configWithFunctionOptions(opts));
+              if (config.startupMode === "lazy" && !activatedServices.has("edge-runtime")) {
+                manuallyStoppedServices.delete("edge-runtime");
+                yield* startServices(
+                  activationTargetsForService(enabledServices, "edge-runtime"),
+                  Effect.void,
+                );
+                return;
+              }
+              const runtime = yield* ensureRuntime;
               yield* withActivationLocks(
                 ["edge-runtime"],
                 runtime.orchestrator
@@ -878,9 +886,9 @@ export class StackLifecycleCoordinator extends Context.Service<
               }
 
               yield* configureFunctions(nextConfig);
-              yield* withActivationLocks(
-                ["edge-runtime"],
-                runtime.orchestrator.updateServiceDefinition("edge-runtime", edgeRuntimeDef).pipe(
+              const updateDefinition = runtime.orchestrator
+                .updateServiceDefinition("edge-runtime", edgeRuntimeDef)
+                .pipe(
                   Effect.mapError(
                     (cause) =>
                       new StackBuildError({
@@ -888,6 +896,19 @@ export class StackLifecycleCoordinator extends Context.Service<
                         cause,
                       }),
                   ),
+                );
+              if (config.startupMode === "lazy" && !activatedServices.has("edge-runtime")) {
+                yield* updateDefinition;
+                manuallyStoppedServices.delete("edge-runtime");
+                yield* startServices(
+                  activationTargetsForService(enabledServices, "edge-runtime"),
+                  Effect.void,
+                );
+                return;
+              }
+              yield* withActivationLocks(
+                ["edge-runtime"],
+                updateDefinition.pipe(
                   Effect.andThen(runtime.orchestrator.restartService("edge-runtime")),
                   Effect.andThen(runtime.orchestrator.waitReady("edge-runtime")),
                 ),

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -216,6 +216,7 @@ export class StackLifecycleCoordinator extends Context.Service<
         const phaseRef = yield* Ref.make<LifecyclePhase>("idle");
         const activatedServices = new Set<ServiceName>();
         const manuallyStoppedServices = new Set<ServiceName>();
+        const restartIntents = new Set<ServiceName>();
         const lifecycleLock = Semaphore.makeUnsafe(1);
         const activationLocks = new Map(
           SERVICE_NAMES.map((service) => [service, Semaphore.makeUnsafe(1)] as const),
@@ -666,7 +667,7 @@ export class StackLifecycleCoordinator extends Context.Service<
               cleanupTargets: runtimeState?.cleanupTargets ?? { dockerContainerNames: [] },
               config,
             }).pipe(Effect.ensuring(Ref.set(phaseRef, "stopped")));
-          });
+          }).pipe(withLifecycleLock);
 
         yield* Effect.addFinalizer(disposeOnce);
 
@@ -679,6 +680,7 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* Ref.set(phaseRef, "starting");
               activatedServices.clear();
               manuallyStoppedServices.clear();
+              restartIntents.clear();
               const runtime = yield* ensureRuntime;
               yield* configureFunctions(config);
               if (config.startupMode === "lazy") {
@@ -788,6 +790,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                           .startOrderFor(activated)
                           .some((definition) => definition.name === target)
                       ) {
+                        restartIntents.add(activated);
                         activatedServices.delete(activated);
                       }
                     }
@@ -800,6 +803,15 @@ export class StackLifecycleCoordinator extends Context.Service<
               const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
               const companionTargets = lifecycleTargetsForService(enabledServices, service);
+              const interruptedTargets = SERVICE_NAMES.filter(
+                (candidate) =>
+                  restartIntents.has(candidate) &&
+                  companionTargets.some((target) =>
+                    runtime.graph
+                      .startOrderFor(candidate)
+                      .some((definition) => definition.name === target),
+                  ),
+              );
               const restartRoots = companionTargets.filter(
                 (candidate) =>
                   !companionTargets.some(
@@ -810,7 +822,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                         .some((definition) => definition.name === other),
                   ),
               );
-              const affected = new Set<ServiceName>(companionTargets);
+              const affected = new Set<ServiceName>([...companionTargets, ...interruptedTargets]);
               for (const activated of activatedServices) {
                 if (
                   companionTargets.some((target) =>
@@ -825,7 +837,9 @@ export class StackLifecycleCoordinator extends Context.Service<
               const lockTargets = SERVICE_NAMES.filter((candidate) => affected.has(candidate));
               const restoreTargets = lockTargets.filter(
                 (candidate) =>
-                  companionTargets.includes(candidate) || activatedServices.has(candidate),
+                  companionTargets.includes(candidate) ||
+                  activatedServices.has(candidate) ||
+                  restartIntents.has(candidate),
               );
               yield* withActivationLocks(
                 lockTargets,
@@ -835,6 +849,9 @@ export class StackLifecycleCoordinator extends Context.Service<
                   }
                   for (const target of companionTargets) {
                     manuallyStoppedServices.delete(target);
+                  }
+                  for (const target of restoreTargets) {
+                    restartIntents.delete(target);
                   }
                   for (const root of restartRoots) {
                     yield* runtime.orchestrator.restartService(root);

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -1,6 +1,6 @@
 import { LogBuffer, Orchestrator } from "@supabase/process-compose";
 import { ServiceNotFoundError } from "@supabase/process-compose";
-import type { LogEntry, ServiceReadyError } from "@supabase/process-compose";
+import type { LogEntry, ResolvedGraph, ServiceReadyError } from "@supabase/process-compose";
 import {
   Deferred,
   Effect,
@@ -8,6 +8,7 @@ import {
   Layer,
   Path,
   Ref,
+  Semaphore,
   Context,
   Stream,
   SubscriptionRef,
@@ -15,10 +16,14 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type { CleanupTargets } from "./CleanupTargets.ts";
 import { cleanupLocalStackResources } from "./cleanup.ts";
-import { StackBuildError } from "./errors.ts";
+import { StackBuildError, StackNotRunningError } from "./errors.ts";
 import { configureFunctionsRuntime, type FunctionsConfig } from "./functions.ts";
 import { detectPlatform, dockerHostAddress } from "./Platform.ts";
-import { activationTargetsForService } from "./ServiceActivation.ts";
+import {
+  activationTargetsForService,
+  eagerServices,
+  lifecycleTargetsForService,
+} from "./ServiceActivation.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
 import { StackPreparation } from "./StackPreparation.ts";
 import type { PreparedStackArtifacts } from "./StackPreparation.ts";
@@ -45,6 +50,7 @@ type LifecyclePhase =
 
 interface RuntimeState {
   readonly orchestrator: Orchestrator["Service"];
+  readonly graph: ResolvedGraph;
   readonly cleanupTargets: CleanupTargets;
 }
 
@@ -71,52 +77,55 @@ const initialPublicStates = (config: ResolvedStackConfig): ReadonlyArray<StackSe
       }),
   );
 
-const stackInfoFor = (config: ResolvedStackConfig): StackInfo => ({
-  url: `http://127.0.0.1:${config.apiPort}`,
-  dbUrl: `postgresql://postgres:postgres@127.0.0.1:${config.dbPort}/postgres`,
-  publishableKey: config.publishableKey,
-  secretKey: config.secretKey,
-  anonJwt: config.anonJwt,
-  serviceRoleJwt: config.serviceRoleJwt,
-  serviceEndpoints: {
-    ...(config.auth === false ? {} : { auth: `http://127.0.0.1:${config.auth.port}` }),
-    ...(config.postgrest === false
-      ? {}
-      : { postgrest: `http://127.0.0.1:${config.postgrest.port}` }),
-    ...(config.edgeRuntime === false
-      ? {}
-      : {
-          functions: `http://127.0.0.1:${config.apiPort}/functions/v1`,
-          edge_runtime: `http://127.0.0.1:${config.edgeRuntime.port}`,
-        }),
-    ...(config.realtime === false ? {} : { realtime: `http://127.0.0.1:${config.realtime.port}` }),
-    ...(config.storage === false
-      ? {}
-      : {
-          storage: `http://127.0.0.1:${config.storage.port}`,
-          storage_s3: `http://127.0.0.1:${config.apiPort}/storage/v1/s3`,
-        }),
-    ...(config.imgproxy === false ? {} : { imgproxy: `http://127.0.0.1:${config.imgproxy.port}` }),
-    ...(config.mailpit === false
-      ? {}
-      : {
-          mailpit: `http://127.0.0.1:${config.mailpit.port}`,
-          mailpit_smtp: `smtp://127.0.0.1:${config.mailpit.smtpPort}`,
-          mailpit_pop3: `pop3://127.0.0.1:${config.mailpit.pop3Port}`,
-        }),
-    ...(config.pgmeta === false ? {} : { pgmeta: `http://127.0.0.1:${config.pgmeta.port}` }),
-    ...(config.studio === false ? {} : { studio: `http://127.0.0.1:${config.studio.port}` }),
-    ...(config.analytics === false
-      ? {}
-      : { analytics: `http://127.0.0.1:${config.analytics.port}` }),
-    ...(config.pooler === false
-      ? {}
-      : {
-          pooler: `postgresql://postgres:postgres@127.0.0.1:${config.pooler.port}/postgres`,
-          pooler_admin: `http://127.0.0.1:${config.pooler.apiPort}`,
-        }),
-  },
-});
+const stackInfoFor = (config: ResolvedStackConfig): StackInfo => {
+  const apiUrl = `http://127.0.0.1:${config.apiPort}`;
+  return {
+    url: apiUrl,
+    dbUrl: `postgresql://postgres:postgres@127.0.0.1:${config.dbPort}/postgres`,
+    publishableKey: config.publishableKey,
+    secretKey: config.secretKey,
+    anonJwt: config.anonJwt,
+    serviceRoleJwt: config.serviceRoleJwt,
+    serviceEndpoints: {
+      ...(config.auth === false ? {} : { auth: `${apiUrl}/auth/v1` }),
+      ...(config.postgrest === false ? {} : { postgrest: `${apiUrl}/rest/v1` }),
+      ...(config.edgeRuntime === false
+        ? {}
+        : {
+            functions: `${apiUrl}/functions/v1`,
+            edge_runtime: `${apiUrl}/functions/v1`,
+          }),
+      ...(config.realtime === false
+        ? {}
+        : { realtime: `http://127.0.0.1:${config.realtime.port}` }),
+      ...(config.storage === false
+        ? {}
+        : {
+            storage: `${apiUrl}/storage/v1`,
+            storage_s3: `${apiUrl}/storage/v1/s3`,
+          }),
+      ...(config.imgproxy === false || config.startupMode === "lazy"
+        ? {}
+        : { imgproxy: `http://127.0.0.1:${config.imgproxy.port}` }),
+      ...(config.mailpit === false
+        ? {}
+        : {
+            mailpit: `http://127.0.0.1:${config.mailpit.port}`,
+            mailpit_smtp: `smtp://127.0.0.1:${config.mailpit.smtpPort}`,
+            mailpit_pop3: `pop3://127.0.0.1:${config.mailpit.pop3Port}`,
+          }),
+      ...(config.pgmeta === false ? {} : { pgmeta: `${apiUrl}/pg` }),
+      ...(config.studio === false ? {} : { studio: `http://127.0.0.1:${config.studio.port}` }),
+      ...(config.analytics === false ? {} : { analytics: `${apiUrl}/analytics/v1` }),
+      ...(config.pooler === false
+        ? {}
+        : {
+            pooler: `postgresql://postgres:postgres@127.0.0.1:${config.pooler.port}/postgres`,
+            pooler_admin: `http://127.0.0.1:${config.pooler.apiPort}`,
+          }),
+    },
+  };
+};
 
 const changedStatesBetween = (
   previous: ReadonlyArray<StackServiceState> | undefined,
@@ -141,12 +150,18 @@ export class StackLifecycleCoordinator extends Context.Service<
     readonly startService: (
       name: string,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
+    readonly activateService: (
+      name: ServiceName,
+    ) => Effect.Effect<
+      void,
+      ServiceNotFoundError | ServiceReadyError | StackBuildError | StackNotRunningError
+    >;
     readonly stopService: (
       name: string,
     ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
     readonly restartService: (
       name: string,
-    ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
+    ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
     readonly reloadFunctions: (
       opts?: FunctionsConfig,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
@@ -199,6 +214,12 @@ export class StackLifecycleCoordinator extends Context.Service<
         const enabledServices = enabledServicesForConfig(config);
         const stateRef = yield* SubscriptionRef.make(initialPublicStates(config));
         const phaseRef = yield* Ref.make<LifecyclePhase>("idle");
+        const activatedServices = new Set<ServiceName>();
+        const manuallyStoppedServices = new Set<ServiceName>();
+        const lifecycleLock = Semaphore.makeUnsafe(1);
+        const activationLocks = new Map(
+          SERVICE_NAMES.map((service) => [service, Semaphore.makeUnsafe(1)] as const),
+        );
 
         const logBufferServices = yield* Layer.buildWithScope(LogBuffer.layer, scope);
         const logBuffer = Context.get(logBufferServices, LogBuffer);
@@ -411,6 +432,7 @@ export class StackLifecycleCoordinator extends Context.Service<
 
             return {
               orchestrator,
+              graph,
               cleanupTargets,
             } satisfies RuntimeState;
           }).pipe(
@@ -509,19 +531,125 @@ export class StackLifecycleCoordinator extends Context.Service<
               (previous, current) => [current, changedStatesBetween(previous, current)],
             ),
           );
-        const startServices = (services: ReadonlyArray<ServiceName>) =>
+        const publicServiceClosure = (
+          runtime: RuntimeState,
+          services: ReadonlyArray<ServiceName>,
+        ): ReadonlyArray<ServiceName> => {
+          const closure = new Set<ServiceName>();
+          for (const service of services) {
+            for (const definition of runtime.graph.startOrderFor(service)) {
+              const publicName = SERVICE_NAMES.find((candidate) => candidate === definition.name);
+              if (publicName !== undefined) closure.add(publicName);
+            }
+          }
+          return SERVICE_NAMES.filter((service) => closure.has(service));
+        };
+        const withActivationLocks = <A, E, R>(
+          services: ReadonlyArray<ServiceName>,
+          effect: Effect.Effect<A, E, R>,
+        ): Effect.Effect<A, E, R> =>
+          SERVICE_NAMES.filter((service) => services.includes(service)).reduceRight(
+            (current, service) => {
+              const lock = activationLocks.get(service);
+              return lock === undefined ? current : lock.withPermit(current);
+            },
+            effect,
+          );
+        const withLifecycleLock = lifecycleLock.withPermit;
+        const startServices = <E, R>(
+          services: ReadonlyArray<ServiceName>,
+          beforeStart: Effect.Effect<void, E, R>,
+          serializeActivation = false,
+        ) =>
           Effect.gen(function* () {
             const runtime = yield* ensureRuntime;
-            yield* Effect.forEach(
-              services,
-              (service) => runtime.orchestrator.startService(service),
-              { discard: true },
+            const closure = publicServiceClosure(runtime, services);
+            const inactiveClosure = closure.filter((service) => !activatedServices.has(service));
+            const beginActivation = withActivationLocks(
+              inactiveClosure,
+              Effect.gen(function* () {
+                const inactiveServices = services.filter(
+                  (service) => !activatedServices.has(service),
+                );
+                if (inactiveServices.length === 0) {
+                  return [];
+                }
+                yield* beforeStart;
+                const inactiveServiceClosure = publicServiceClosure(runtime, inactiveServices);
+                const explicitlyStoppedDependency = inactiveServiceClosure.find((service) =>
+                  manuallyStoppedServices.has(service),
+                );
+                if (explicitlyStoppedDependency !== undefined) {
+                  return yield* Effect.fail(
+                    new StackBuildError({
+                      detail: `Cannot activate a service whose dependency ${explicitlyStoppedDependency} was explicitly stopped`,
+                    }),
+                  );
+                }
+                for (const service of inactiveServiceClosure) {
+                  activatedServices.add(service);
+                }
+                yield* Effect.forEach(
+                  inactiveServices,
+                  (service) =>
+                    runtime.orchestrator.startService(service).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new StackBuildError({
+                            detail: `Prepared graph does not contain enabled service ${service}`,
+                            cause,
+                          }),
+                      ),
+                    ),
+                  { discard: true },
+                ).pipe(
+                  Effect.onError(() =>
+                    Effect.sync(() => {
+                      for (const service of inactiveServiceClosure) {
+                        activatedServices.delete(service);
+                      }
+                    }),
+                  ),
+                );
+                return inactiveServiceClosure;
+              }),
             );
-            yield* Effect.forEach(services, (service) => runtime.orchestrator.waitReady(service), {
+            const newlyActivated = yield* serializeActivation
+              ? beginActivation.pipe(withLifecycleLock)
+              : beginActivation;
+            const waitKnownReady = (service: ServiceName) =>
+              runtime.orchestrator.waitReady(service).pipe(
+                Effect.catchTag("ServiceNotFoundError", (cause) =>
+                  Effect.fail(
+                    new StackBuildError({
+                      detail: `Prepared graph does not contain enabled service ${service}`,
+                      cause,
+                    }),
+                  ),
+                ),
+              );
+            yield* Effect.forEach(services, waitKnownReady, {
               concurrency: "unbounded",
               discard: true,
-            });
+            }).pipe(
+              Effect.onError(() =>
+                withActivationLocks(
+                  newlyActivated,
+                  Effect.sync(() => {
+                    for (const service of newlyActivated) {
+                      activatedServices.delete(service);
+                    }
+                  }),
+                ),
+              ),
+            );
           });
+        const requireRunningPhase = Effect.gen(function* () {
+          const phase = yield* Ref.get(phaseRef);
+          if (phase !== "running") {
+            return yield* Effect.fail(new StackNotRunningError({ phase }));
+          }
+        });
         const disposeOnce = () =>
           Effect.gen(function* () {
             if (disposed) {
@@ -545,12 +673,56 @@ export class StackLifecycleCoordinator extends Context.Service<
           start: () =>
             Effect.gen(function* () {
               yield* Ref.set(phaseRef, "starting");
+              activatedServices.clear();
+              manuallyStoppedServices.clear();
               const runtime = yield* ensureRuntime;
               yield* configureFunctions(config);
-              yield* runtime.orchestrator.start();
-              yield* runtime.orchestrator.waitAllReady();
+              if (config.startupMode === "lazy") {
+                const eagerTargets = new Set<ServiceName>();
+                for (const service of eagerServices(enabledServices)) {
+                  for (const target of activationTargetsForService(enabledServices, service)) {
+                    eagerTargets.add(target);
+                  }
+                }
+                yield* startServices(
+                  SERVICE_NAMES.filter((service) => eagerTargets.has(service)),
+                  Effect.void,
+                );
+                if (
+                  runtime.graph.startOrder.some((definition) => definition.name === "postgres-init")
+                ) {
+                  yield* runtime.orchestrator.startService("postgres-init").pipe(
+                    Effect.mapError(
+                      (cause) =>
+                        new StackBuildError({
+                          detail: "Prepared graph does not contain postgres-init",
+                          cause,
+                        }),
+                    ),
+                  );
+                  yield* runtime.orchestrator.waitReady("postgres-init").pipe(
+                    Effect.catchTag("ServiceNotFoundError", (cause) =>
+                      Effect.fail(
+                        new StackBuildError({
+                          detail: "Prepared graph does not contain postgres-init",
+                          cause,
+                        }),
+                      ),
+                    ),
+                  );
+                }
+              } else {
+                for (const service of enabledServices) {
+                  activatedServices.add(service);
+                }
+                yield* runtime.orchestrator.start();
+                yield* runtime.orchestrator.waitAllReady();
+              }
               yield* Ref.set(phaseRef, "running");
-            }),
+            }).pipe(
+              Effect.onError(() => Ref.set(phaseRef, "stopped")),
+              withLifecycleLock,
+            ),
           stop: () =>
             Effect.gen(function* () {
               if (runtimeState === undefined) {
@@ -558,39 +730,127 @@ export class StackLifecycleCoordinator extends Context.Service<
                 return;
               }
               yield* Ref.set(phaseRef, "stopping");
-              yield* runtimeState.orchestrator.stop();
+              yield* withActivationLocks(SERVICE_NAMES, runtimeState.orchestrator.stop());
               yield* Ref.set(phaseRef, "stopped");
-            }),
+            }).pipe(withLifecycleLock),
           dispose: disposeOnce,
           startService: (name) =>
             Effect.gen(function* () {
               const service = yield* requireKnownServiceName(name);
-              yield* startServices(activationTargetsForService(enabledServices, service));
+              const targets = activationTargetsForService(enabledServices, service);
+              for (const target of targets) {
+                manuallyStoppedServices.delete(target);
+                activatedServices.delete(target);
+              }
+              yield* startServices(targets, Effect.void);
+            }).pipe(withLifecycleLock),
+          activateService: (name) =>
+            Effect.gen(function* () {
+              // Reject requests immediately while start/stop owns the lifecycle
+              // lock, then check again after acquiring it to close the race.
+              yield* requireRunningPhase;
+              const service = yield* requireKnownServiceName(name);
+              yield* startServices(
+                activationTargetsForService(enabledServices, service),
+                requireRunningPhase,
+                true,
+              );
             }),
           stopService: (name) =>
             Effect.gen(function* () {
               const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
-              yield* Effect.forEach(
-                activationTargetsForService(enabledServices, service).toReversed(),
-                (target) => runtime.orchestrator.stopService(target),
-                { discard: true },
+              const targets = lifecycleTargetsForService(enabledServices, service);
+              yield* withActivationLocks(
+                targets,
+                Effect.gen(function* () {
+                  yield* Effect.forEach(
+                    targets.toReversed(),
+                    (target) => runtime.orchestrator.stopService(target),
+                    { discard: true },
+                  );
+                  for (const target of targets) {
+                    manuallyStoppedServices.add(target);
+                    for (const activated of activatedServices) {
+                      if (
+                        runtime.graph
+                          .startOrderFor(activated)
+                          .some((definition) => definition.name === target)
+                      ) {
+                        activatedServices.delete(activated);
+                      }
+                    }
+                  }
+                }),
               );
-            }),
+            }).pipe(withLifecycleLock),
           restartService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
+              const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.restartService(name);
-            }),
+              const companionTargets = lifecycleTargetsForService(enabledServices, service);
+              const restartRoots = companionTargets.filter(
+                (candidate) =>
+                  !companionTargets.some(
+                    (other) =>
+                      other !== candidate &&
+                      runtime.graph
+                        .startOrderFor(candidate)
+                        .some((definition) => definition.name === other),
+                  ),
+              );
+              const affected = new Set<ServiceName>(companionTargets);
+              for (const activated of activatedServices) {
+                if (
+                  companionTargets.some((target) =>
+                    runtime.graph
+                      .startOrderFor(activated)
+                      .some((definition) => definition.name === target),
+                  )
+                ) {
+                  affected.add(activated);
+                }
+              }
+              const lockTargets = SERVICE_NAMES.filter((candidate) => affected.has(candidate));
+              const restoreTargets = lockTargets.filter(
+                (candidate) =>
+                  companionTargets.includes(candidate) || activatedServices.has(candidate),
+              );
+              yield* withActivationLocks(
+                lockTargets,
+                Effect.gen(function* () {
+                  for (const target of lockTargets) {
+                    activatedServices.delete(target);
+                  }
+                  for (const target of companionTargets) {
+                    manuallyStoppedServices.delete(target);
+                  }
+                  for (const root of restartRoots) {
+                    yield* runtime.orchestrator.restartService(root);
+                  }
+                  yield* Effect.forEach(
+                    restoreTargets,
+                    (target) => runtime.orchestrator.waitReady(target),
+                    { concurrency: "unbounded", discard: true },
+                  );
+                  for (const target of restoreTargets) {
+                    activatedServices.add(target);
+                  }
+                }),
+              );
+            }).pipe(withLifecycleLock),
           reloadFunctions: (opts) =>
             Effect.gen(function* () {
               yield* requireKnownService("edge-runtime");
               const runtime = yield* ensureRuntime;
               yield* configureFunctions(configWithFunctionOptions(opts));
-              yield* runtime.orchestrator.restartService("edge-runtime");
-              yield* runtime.orchestrator.waitReady("edge-runtime");
-            }),
+              yield* withActivationLocks(
+                ["edge-runtime"],
+                runtime.orchestrator
+                  .restartService("edge-runtime")
+                  .pipe(Effect.andThen(runtime.orchestrator.waitReady("edge-runtime"))),
+              );
+            }).pipe(withLifecycleLock),
           reloadEdgeRuntime: (opts) =>
             Effect.gen(function* () {
               yield* requireKnownService("edge-runtime");
@@ -607,9 +867,9 @@ export class StackLifecycleCoordinator extends Context.Service<
               }
 
               yield* configureFunctions(nextConfig);
-              yield* runtime.orchestrator
-                .updateServiceDefinition("edge-runtime", edgeRuntimeDef)
-                .pipe(
+              yield* withActivationLocks(
+                ["edge-runtime"],
+                runtime.orchestrator.updateServiceDefinition("edge-runtime", edgeRuntimeDef).pipe(
                   Effect.mapError(
                     (cause) =>
                       new StackBuildError({
@@ -617,10 +877,11 @@ export class StackLifecycleCoordinator extends Context.Service<
                         cause,
                       }),
                   ),
-                );
-              yield* runtime.orchestrator.restartService("edge-runtime");
-              yield* runtime.orchestrator.waitReady("edge-runtime");
-            }),
+                  Effect.andThen(runtime.orchestrator.restartService("edge-runtime")),
+                  Effect.andThen(runtime.orchestrator.waitReady("edge-runtime")),
+                ),
+              );
+            }).pipe(withLifecycleLock),
           getState: (name) =>
             Effect.gen(function* () {
               const currentStates = SubscriptionRef.getUnsafe(stateRef);
@@ -646,7 +907,25 @@ export class StackLifecycleCoordinator extends Context.Service<
           waitAllReady: () =>
             Effect.gen(function* () {
               const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.waitAllReady();
+              if (config.startupMode === "eager") {
+                yield* runtime.orchestrator.waitAllReady();
+                return;
+              }
+              yield* Effect.forEach(
+                [...activatedServices],
+                (service) =>
+                  runtime.orchestrator.waitReady(service).pipe(
+                    Effect.catchTag("ServiceNotFoundError", (cause) =>
+                      Effect.fail(
+                        new StackBuildError({
+                          detail: `Prepared graph does not contain enabled service ${service}`,
+                          cause,
+                        }),
+                      ),
+                    ),
+                  ),
+                { concurrency: "unbounded", discard: true },
+              );
             }),
           subscribeLogs: (name) => logBuffer.subscribe(name),
           subscribeAllLogs: (services) =>

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -568,14 +568,17 @@ export class StackLifecycleCoordinator extends Context.Service<
             const beginActivation = withActivationLocks(
               inactiveClosure,
               Effect.gen(function* () {
+                yield* beforeStart;
                 const inactiveServices = services.filter(
                   (service) => !activatedServices.has(service),
                 );
                 if (inactiveServices.length === 0) {
                   return [];
                 }
-                yield* beforeStart;
-                const inactiveServiceClosure = publicServiceClosure(runtime, inactiveServices);
+                const inactiveServiceClosure = publicServiceClosure(
+                  runtime,
+                  inactiveServices,
+                ).filter((service) => !activatedServices.has(service));
                 const explicitlyStoppedDependency = inactiveServiceClosure.find((service) =>
                   manuallyStoppedServices.has(service),
                 );

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -692,11 +692,15 @@ export class StackLifecycleCoordinator extends Context.Service<
                   SERVICE_NAMES.filter((service) => eagerTargets.has(service)),
                   Effect.void,
                 );
+                const postgresInitStartedByEagerService = [...eagerTargets].some((service) =>
+                  runtime.graph
+                    .startOrderFor(service)
+                    .some((definition) => definition.name === "postgres-init"),
+                );
                 if (
                   runtime.graph.startOrder.some((definition) => definition.name === "postgres-init")
                 ) {
-                  const postgresInit = yield* runtime.orchestrator.getState("postgres-init");
-                  if (postgresInit.status === "Pending") {
+                  if (!postgresInitStartedByEagerService) {
                     yield* runtime.orchestrator.startService("postgres-init").pipe(
                       Effect.mapError(
                         (cause) =>

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -684,6 +684,20 @@ export class StackLifecycleCoordinator extends Context.Service<
               const runtime = yield* ensureRuntime;
               yield* configureFunctions(config);
               if (config.startupMode === "lazy") {
+                yield* SubscriptionRef.update(stateRef, (states) =>
+                  states.map(
+                    (state) =>
+                      new StackServiceState({
+                        name: state.name,
+                        status: "Pending",
+                        pid: null,
+                        exitCode: null,
+                        restartCount: 0,
+                        startedAt: null,
+                        error: null,
+                      }),
+                  ),
+                );
                 const eagerTargets = new Set<ServiceName>();
                 for (const service of eagerServices(enabledServices)) {
                   for (const target of activationTargetsForService(enabledServices, service)) {

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -545,6 +545,7 @@ export async function resolveConfig(
     runtimeRoot: roots.runtimeRoot,
     projectDir,
     mode: resolvedMode,
+    startupMode: config.startupMode ?? "eager",
     jwtSecret,
     ports,
     apiPort: ports.apiPort,

--- a/packages/stack/src/createStack.unit.test.ts
+++ b/packages/stack/src/createStack.unit.test.ts
@@ -83,6 +83,7 @@ describe("createStack types", () => {
   it("StackConfig interface has expected shape", () => {
     const check = (_config: StackConfig) => {
       const _jwtSecret: string | undefined = _config.jwtSecret;
+      const _startupMode: "eager" | "lazy" | undefined = _config.startupMode;
       const _projectDir: string | undefined = _config.projectDir;
       const _functions = _config.functions;
       const _postgres: PostgresConfig | undefined = _config.postgres;
@@ -92,6 +93,7 @@ describe("createStack types", () => {
       const _publishableKey: string | undefined = _config.publishableKey;
       const _secretKey: string | undefined = _config.secretKey;
       void _jwtSecret;
+      void _startupMode;
       void _projectDir;
       void _functions;
       void _postgres;
@@ -235,5 +237,17 @@ describe("resolveConfig edge runtime defaults", () => {
         version: DEFAULT_VERSIONS["edge-runtime"],
       }),
     );
+  });
+});
+
+describe("resolveConfig startup mode", () => {
+  it("keeps eager startup as the package default", async () => {
+    const config = await resolveConfig();
+    expect(config.startupMode).toBe("eager");
+  });
+
+  it("preserves an explicit lazy startup mode", async () => {
+    const config = await resolveConfig({ startupMode: "lazy" });
+    expect(config.startupMode).toBe("lazy");
   });
 });

--- a/packages/stack/src/errors.ts
+++ b/packages/stack/src/errors.ts
@@ -27,6 +27,10 @@ export class StackBuildError extends Data.TaggedError("StackBuildError")<{
   readonly cause?: unknown;
 }> {}
 
+export class StackNotRunningError extends Data.TaggedError("StackNotRunningError")<{
+  readonly phase: string;
+}> {}
+
 export class PortConflictError extends Data.TaggedError("PortConflictError")<{
   readonly port: number;
   readonly service: string;
@@ -58,6 +62,12 @@ export function toStackError(err: unknown): StackError {
       case "StackBuildError":
         return new StackError({
           code: "BUILD_ERROR",
+          message: taggedMessage,
+          cause: err,
+        });
+      case "StackNotRunningError":
+        return new StackError({
+          code: "STACK_NOT_RUNNING",
           message: taggedMessage,
           cause: err,
         });

--- a/packages/stack/src/layers.ts
+++ b/packages/stack/src/layers.ts
@@ -7,6 +7,7 @@ import { BinaryResolver } from "./BinaryResolver.ts";
 import type { PlatformFactory } from "./createStack.ts";
 import type { DaemonMessage, DaemonStartMessage } from "./daemon.ts";
 import { RemoteStack } from "./RemoteStack.ts";
+import { StackServiceActivator } from "./ServiceActivation.ts";
 import { Stack } from "./Stack.ts";
 import { StackLifecycleCoordinator } from "./StackLifecycleCoordinator.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
@@ -45,7 +46,13 @@ export const foregroundLayer = (
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
   );
-  const stackLayer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+  const stackLayer = Stack.layer(config);
+  const serviceActivatorLayer = Layer.effect(
+    StackServiceActivator,
+    Effect.map(StackLifecycleCoordinator, (coordinator) => ({
+      activate: coordinator.activateService,
+    })),
+  );
 
   const proxyConfig: ProxyConfig = {
     listenPort: config.apiPort,
@@ -64,9 +71,16 @@ export const foregroundLayer = (
     anonJwt: config.anonJwt,
     serviceRoleJwt: config.serviceRoleJwt,
   };
-  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(Layer.provide(FetchHttpClient.layer));
+  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(serviceActivatorLayer),
+  );
 
-  return Layer.mergeAll(stackLayer, apiProxyLayer).pipe(Layer.provide(platform), Layer.orDie);
+  return Layer.mergeAll(stackLayer, apiProxyLayer).pipe(
+    Layer.provide(coordinatorLayer),
+    Layer.provide(platform),
+    Layer.orDie,
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -112,7 +126,16 @@ export const foregroundDaemonLayer = (
     anonJwt: config.anonJwt,
     serviceRoleJwt: config.serviceRoleJwt,
   };
-  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(Layer.provide(FetchHttpClient.layer));
+  const serviceActivatorLayer = Layer.effect(
+    StackServiceActivator,
+    Effect.map(StackLifecycleCoordinator, (coordinator) => ({
+      activate: coordinator.activateService,
+    })),
+  );
+  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(serviceActivatorLayer),
+  );
   const stateManagerLayer = StateManager.make(
     singleStackStateManagerPaths(config.stackRoot, config.runtimeRoot, config.name),
   );
@@ -125,9 +148,10 @@ export const foregroundDaemonLayer = (
     Layer.provide(stackPreparationLayer),
     Layer.provide(metadataPersistenceLayer),
   );
-  const stackLayer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+  const stackLayer = Stack.layer(config);
 
   return Layer.mergeAll(stackLayer, apiProxyLayer, stateManagerLayer).pipe(
+    Layer.provide(coordinatorLayer),
     Layer.provide(platform),
     Layer.orDie,
   );


### PR DESCRIPTION
Stack layer 3 of 7, based on #6042.

Adds lazy startup as an optional stack-package lifecycle mode:

- activates HTTP services at the central proxy boundary before forwarding
- gates activation on the running lifecycle phase and returns 503 outside it
- keeps eager startup as the package default
- exposes only central proxy URLs to callers
- resets lifecycle state correctly when startup fails