### PR TITLE
fix(stack): reserve ports through service startup

### DIFF
--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -584,7 +584,7 @@ export class Orchestrator extends Context.Service<
           runService(def, options).pipe(
             Effect.catch((error) =>
               sendEvent(def.name, {
-                _tag: "DependencyFailed",
+                _tag: "SpawnFailed",
                 error: `Spawn failed: ${error.service} - ${String(error.cause)}`,
               }).pipe(Effect.asVoid),
             ),

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -1,3 +1,6 @@
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   Cause,
   Deferred,
@@ -6,6 +9,7 @@ import {
   Exit,
   FiberMap,
   Layer,
+  Schedule,
   Context,
   Semaphore,
   Stream,
@@ -15,7 +19,13 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { buildGraph, type ResolvedGraph } from "./DependencyGraph.ts";
 import { type HealthProbeCallbacks, runHealthProbe } from "./HealthProbe.ts";
 import { LogBuffer } from "./LogBuffer.ts";
-import type { HookTrigger, OrchestratorConfig, RestartPolicy, ServiceDef } from "./ServiceDef.ts";
+import type {
+  HookTrigger,
+  OrchestratorConfig,
+  RestartPolicy,
+  ServiceDef,
+  ServiceStartOptions,
+} from "./ServiceDef.ts";
 import { defaults } from "./ServiceDef.ts";
 import { initial } from "./ServiceState.ts";
 import { makeSupervisedCommand, usesSupervisor } from "./Supervisor.ts";
@@ -43,11 +53,17 @@ const waitForProcessToStop = (handle: {
 export class Orchestrator extends Context.Service<
   Orchestrator,
   {
-    readonly start: () => Effect.Effect<void>;
-    readonly startService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
+    readonly start: (options?: ServiceStartOptions) => Effect.Effect<void>;
+    readonly startService: (
+      name: string,
+      options?: ServiceStartOptions,
+    ) => Effect.Effect<void, ServiceNotFoundError>;
     readonly stop: () => Effect.Effect<void>;
     readonly stopService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
-    readonly restartService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
+    readonly restartService: (
+      name: string,
+      options?: ServiceStartOptions,
+    ) => Effect.Effect<void, ServiceNotFoundError>;
     readonly updateServiceDefinition: (
       name: string,
       def: ServiceDef,
@@ -180,7 +196,10 @@ export class Orchestrator extends Context.Service<
         const shouldRestartOnUnhealthy = (policy: RestartPolicy): boolean => policy !== "no";
 
         // The full lifecycle loop for a single service
-        const runService = (def: ServiceDef): Effect.Effect<void, SpawnError> =>
+        const runService = (
+          def: ServiceDef,
+          options?: ServiceStartOptions,
+        ): Effect.Effect<void, SpawnError> =>
           Effect.gen(function* () {
             let restartCount = 0;
             const maxRestarts = def.maxRestarts ?? defaults.maxRestarts;
@@ -241,16 +260,45 @@ export class Orchestrator extends Context.Service<
                 Effect.gen(function* () {
                   const unhealthyRestart = Deferred.makeUnsafe<void>();
                   const supervised = usesSupervisor(def);
+                  const spawnGate =
+                    supervised && options?.beforeSpawn !== undefined
+                      ? yield* Effect.tryPromise({
+                          try: async () => {
+                            const directory = await mkdtemp(
+                              join(tmpdir(), "process-compose-spawn-gate-"),
+                            );
+                            return {
+                              directory,
+                              requestPath: join(directory, "request"),
+                              releasePath: join(directory, "release"),
+                            };
+                          },
+                          catch: (cause) => new SpawnError({ service: def.command, cause }),
+                        })
+                      : undefined;
+                  if (spawnGate !== undefined) {
+                    yield* Effect.addFinalizer(() =>
+                      Effect.promise(() =>
+                        rm(spawnGate.directory, { recursive: true, force: true }),
+                      ),
+                    );
+                  }
 
                   // Build command
                   const cmd = supervised
-                    ? makeSupervisedCommand(def)
+                    ? makeSupervisedCommand(def, spawnGate)
                     : ChildProcess.make(def.command, def.args ?? [], {
                         cwd: def.cwd,
                         env: def.env,
                         extendEnv: true,
                         stdin: "ignore",
                       });
+
+                  // Release external resources such as port reservations only
+                  // once dependencies are satisfied and spawning is imminent.
+                  if (!supervised) {
+                    yield* options?.beforeSpawn?.(def.name) ?? Effect.void;
+                  }
 
                   // Spawn the process
                   const handle = yield* spawner
@@ -306,6 +354,22 @@ export class Orchestrator extends Context.Service<
                       Effect.andThen(runCleanup()),
                     ),
                   );
+
+                  if (spawnGate !== undefined) {
+                    yield* Effect.tryPromise({
+                      try: () => access(spawnGate.requestPath),
+                      catch: (cause) => cause,
+                    }).pipe(
+                      Effect.retry(Schedule.spaced("10 millis")),
+                      Effect.timeout("10 seconds"),
+                      Effect.mapError((cause) => new SpawnError({ service: def.command, cause })),
+                    );
+                    yield* options?.beforeSpawn?.(def.name) ?? Effect.void;
+                    yield* Effect.tryPromise({
+                      try: () => writeFile(spawnGate.releasePath, "release", { flag: "wx" }),
+                      catch: (cause) => new SpawnError({ service: def.command, cause }),
+                    });
+                  }
 
                   // Transition to Running
                   yield* sendEvent(def.name, {
@@ -516,8 +580,8 @@ export class Orchestrator extends Context.Service<
             }
           });
 
-        const runServiceSafe = (def: ServiceDef) =>
-          runService(def).pipe(
+        const runServiceSafe = (def: ServiceDef, options?: ServiceStartOptions) =>
+          runService(def, options).pipe(
             Effect.catch((error) =>
               sendEvent(def.name, {
                 _tag: "DependencyFailed",
@@ -551,23 +615,26 @@ export class Orchestrator extends Context.Service<
 
         const restartClosureFor = (name: string): ReadonlyArray<ServiceDef> => {
           const names = new Set<string>([name]);
-          const collectDependents = (current: string): void => {
+          const visited = new Set<string>();
+          const collectDependents = (current: string): boolean => {
+            if (visited.has(current)) return names.has(current);
+            visited.add(current);
+            let hasActiveDependent = false;
             for (const dependent of graph.dependentsOf(current)) {
-              if (names.has(dependent.name)) continue;
-              names.add(dependent.name);
-              collectDependents(dependent.name);
+              const dependentService = services.get(dependent.name);
+              const dependentIsActive =
+                FiberMap.hasUnsafe(fibers, dependent.name) ||
+                (dependentService?.requested === true && dependentService.stoppedByUser !== true);
+              const descendantIsActive = collectDependents(dependent.name);
+              if (dependentIsActive || descendantIsActive) {
+                names.add(dependent.name);
+                hasActiveDependent = true;
+              }
             }
+            return hasActiveDependent;
           };
           collectDependents(name);
-          return graph.startOrder.filter((def) => {
-            const service = services.get(def.name);
-            return (
-              names.has(def.name) &&
-              (def.name === name ||
-                FiberMap.hasUnsafe(fibers, def.name) ||
-                (service?.requested === true && service.stoppedByUser !== true))
-            );
-          });
+          return graph.startOrder.filter((def) => names.has(def.name));
         };
 
         const waitReadySingle = (def: ServiceDef): Effect.Effect<void, ServiceReadyError> =>
@@ -665,16 +732,16 @@ export class Orchestrator extends Context.Service<
           });
 
         return {
-          start: () =>
+          start: (options) =>
             Effect.gen(function* () {
               for (const def of graph.startOrder) {
                 const service = services.get(def.name);
                 if (service !== undefined) service.requested = true;
-                yield* FiberMap.run(fibers, def.name, runServiceSafe(def));
+                yield* FiberMap.run(fibers, def.name, runServiceSafe(def, options));
               }
             }),
 
-          startService: (name: string) =>
+          startService: (name: string, options) =>
             Effect.gen(function* () {
               const def = lookupDef(name);
               if (def === undefined) {
@@ -723,7 +790,9 @@ export class Orchestrator extends Context.Service<
                   resetNames.add(d.name);
                 }
                 if (service !== undefined) service.requested = true;
-                yield* FiberMap.run(fibers, d.name, runServiceSafe(d), { onlyIfMissing: true });
+                yield* FiberMap.run(fibers, d.name, runServiceSafe(d, options), {
+                  onlyIfMissing: true,
+                });
               }
 
               // A caller may retry a dependency directly while dependents started by an
@@ -743,7 +812,7 @@ export class Orchestrator extends Context.Service<
                   yield* FiberMap.remove(fibers, d.name);
                   yield* resetService(d.name);
                   service.requested = true;
-                  yield* FiberMap.run(fibers, d.name, runServiceSafe(d), {
+                  yield* FiberMap.run(fibers, d.name, runServiceSafe(d, options), {
                     onlyIfMissing: true,
                   });
                 }
@@ -816,7 +885,7 @@ export class Orchestrator extends Context.Service<
               yield* sendEvent(name, { _tag: "ProcessExited", exitCode: 143 });
             }),
 
-          restartService: (name: string) =>
+          restartService: (name: string, options) =>
             Effect.gen(function* () {
               const def = lookupDef(name);
               if (def === undefined) {
@@ -833,7 +902,7 @@ export class Orchestrator extends Context.Service<
               for (const affectedDef of affected) {
                 const service = services.get(affectedDef.name);
                 if (service !== undefined) service.requested = true;
-                yield* FiberMap.run(fibers, affectedDef.name, runServiceSafe(affectedDef));
+                yield* FiberMap.run(fibers, affectedDef.name, runServiceSafe(affectedDef, options));
               }
             }),
 

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -204,6 +204,14 @@ export class Orchestrator extends Context.Service<
             let restartCount = 0;
             const maxRestarts = def.maxRestarts ?? defaults.maxRestarts;
             const restartPolicy = def.restart ?? defaults.restart;
+            const prepareStart = () =>
+              options
+                ?.beforeStart?.(def.name)
+                .pipe(
+                  Effect.mapError((cause) => new SpawnError({ service: def.command, cause })),
+                ) ?? Effect.void;
+
+            yield* prepareStart();
 
             // Re-create signals on each run (needed for restarts)
             const resetSignals = Effect.sync(() => {
@@ -556,6 +564,10 @@ export class Orchestrator extends Context.Service<
 
             while (shouldRestart(result) && (maxRestarts === 0 || restartCount < maxRestarts)) {
               restartCount++;
+
+              // The previous process scope has closed, so external resources can
+              // be reserved safely for the duration of this restart's backoff.
+              yield* prepareStart();
 
               if (result._tag === "UnhealthyRestart") {
                 yield* appendRecentServiceLogs(

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -446,6 +446,31 @@ describe("Orchestrator", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.live("stopping a supervisor during its spawn handshake cleans it up", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("postgres", {
+          command: "docker",
+          args: ["run", "--rm", "postgres"],
+          supervision: {
+            orphanCleanup: [{ _tag: "DockerRemove", containerName: "supabase-postgres-test" }],
+          },
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("postgres", { beforeSpawn: () => Effect.void });
+      yield* proc.waitForSpawnCount(1);
+
+      yield* orc.stopService("postgres");
+      yield* proc.waitForKillCount(1);
+
+      expect(proc.killed[0]?.command).toBe(process.execPath);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.live("ServiceDef shutdown does not expose killMode", () => {
     const service: ServiceDef = {
       name: "a",
@@ -508,6 +533,31 @@ describe("Orchestrator", () => {
       const names = proc.spawned.map((s) => s.command).sort();
       // Should start db, api, web — but NOT unrelated
       expect(names).toEqual(["api", "db", "web"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("runs beforeSpawn for each service at its spawn boundary", () => {
+    const events: string[] = [];
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      {
+        exitDelay: "500 millis",
+        onSpawn: ({ command }) => events.push(`spawn:${command}`),
+      },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api", {
+        beforeSpawn: (name) => Effect.sync(() => events.push(`release:${name}`)),
+      });
+      yield* proc.waitForSpawnCount(2);
+
+      expect(events).toEqual(["release:db", "spawn:db", "release:api", "spawn:api"]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
@@ -666,6 +716,7 @@ describe("Orchestrator", () => {
 
   it.live("startService relaunches dependents waiting on a retried service", () => {
     let attempts = 0;
+    const beforeSpawn: string[] = [];
     const { layer, proc } = setupOrchestrator(
       [
         svc("db", {
@@ -691,15 +742,20 @@ describe("Orchestrator", () => {
     );
     return Effect.gen(function* () {
       const orc = yield* Orchestrator;
-      yield* orc.startService("api");
+      yield* orc.startService("api", {
+        beforeSpawn: (name) => Effect.sync(() => beforeSpawn.push(name)),
+      });
       yield* waitForFailed(orc, "db");
       const ready = yield* orc.waitReady("api").pipe(Effect.forkScoped);
 
-      yield* orc.startService("db");
+      yield* orc.startService("db", {
+        beforeSpawn: (name) => Effect.sync(() => beforeSpawn.push(name)),
+      });
       yield* proc.waitForSpawn("api");
       yield* Fiber.join(ready);
 
       expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db", "api"]);
+      expect(beforeSpawn).toEqual(["db", "db", "api"]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
@@ -854,6 +910,46 @@ describe("Orchestrator", () => {
 
       expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db"]);
       expect((yield* orc.getState("api")).status).toBe("Pending");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("restartService replays completed dependencies of active dependents", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("setup", {
+          restart: "no",
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+        svc("api", {
+          dependencies: [{ service: "setup", condition: "completed" }],
+        }),
+      ],
+      {
+        perService: {
+          db: { exitDelay: "5 seconds" },
+          setup: { exitDelay: "10 millis" },
+          api: { exitDelay: "5 seconds" },
+        },
+      },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawnCount(3);
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.restartService("db");
+      yield* proc.waitForSpawnCount(6);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual([
+        "db",
+        "setup",
+        "api",
+        "db",
+        "setup",
+        "api",
+      ]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -1616,6 +1616,7 @@ describe("Orchestrator", () => {
   describe("unhealthy restart", () => {
     it.live("restarts service when it becomes unhealthy and restart policy allows", () => {
       let checkCalls = 0;
+      const prepared: string[] = [];
       const { layer, proc } = setupOrchestrator(
         [
           svc("a", {
@@ -1645,11 +1646,14 @@ describe("Orchestrator", () => {
       );
       return Effect.gen(function* () {
         const orc = yield* Orchestrator;
-        yield* orc.start();
+        yield* orc.start({
+          beforeStart: (name) => Effect.sync(() => prepared.push(name)),
+        });
         yield* proc.waitForSpawn("a", 2);
         // Should have spawned the main service twice (original + 1 restart)
         const mainSpawns = proc.spawned.filter((s) => s.command === "a");
         expect(mainSpawns.length).toBe(2);
+        expect(prepared).toEqual(["a", "a"]);
       }).pipe(Effect.provide(layer), Effect.scoped);
     });
 

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -1613,6 +1613,24 @@ describe("Orchestrator", () => {
     });
   });
 
+  it.live("fails readiness when a pre-start hook fails", () => {
+    const { layer } = setupOrchestrator([svc("api")], { exitDelay: "5 seconds" });
+
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api", {
+        beforeStart: () => Effect.fail(new Error("port reservation failed")),
+      });
+
+      const error = yield* orc.waitReady("api").pipe(Effect.flip);
+      expect(error._tag).toBe("ServiceReadyError");
+      if (error._tag === "ServiceReadyError") {
+        expect(error.reason).toContain("port reservation failed");
+      }
+      expect((yield* orc.getState("api")).status).toBe("Failed");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   describe("unhealthy restart", () => {
     it.live("restarts service when it becomes unhealthy and restart policy allows", () => {
       let checkCalls = 0;

--- a/packages/process-compose/src/ServiceDef.ts
+++ b/packages/process-compose/src/ServiceDef.ts
@@ -89,6 +89,11 @@ export interface OrchestratorConfig {
   readonly shutdownTimeoutSeconds?: number;
 }
 
+export interface ServiceStartOptions {
+  /** Runs after dependencies are satisfied and immediately before each spawn. */
+  readonly beforeSpawn?: (name: string) => Effect.Effect<void>;
+}
+
 export const defaults = {
   healthCheck: {
     initialDelaySeconds: 0,

--- a/packages/process-compose/src/ServiceDef.ts
+++ b/packages/process-compose/src/ServiceDef.ts
@@ -90,6 +90,8 @@ export interface OrchestratorConfig {
 }
 
 export interface ServiceStartOptions {
+  /** Runs when a service lifecycle starts and again after each process exit before backoff. */
+  readonly beforeStart?: (name: string) => Effect.Effect<void, unknown>;
   /** Runs after dependencies are satisfied and immediately before each spawn. */
   readonly beforeSpawn?: (name: string) => Effect.Effect<void>;
 }

--- a/packages/process-compose/src/ServiceTransition.ts
+++ b/packages/process-compose/src/ServiceTransition.ts
@@ -32,6 +32,7 @@ export type ServiceEvent =
 const allowed = new Set<`${ServiceStatus}:${ServiceEvent["_tag"]}`>([
   "Pending:DependenciesSatisfied",
   "Pending:DependencyFailed",
+  "Pending:SpawnFailed",
   "Pending:StopRequested",
   "Starting:ProcessSpawned",
   "Starting:SpawnFailed",

--- a/packages/process-compose/src/ServiceTransition.ts
+++ b/packages/process-compose/src/ServiceTransition.ts
@@ -8,6 +8,7 @@ import { ServiceState, type ServiceStatus } from "./ServiceState.ts";
 export type ServiceEvent =
   | { readonly _tag: "DependenciesSatisfied" }
   | { readonly _tag: "DependencyFailed"; readonly error: string }
+  | { readonly _tag: "SpawnFailed"; readonly error: string }
   | {
       readonly _tag: "ProcessSpawned";
       readonly pid: number;
@@ -33,6 +34,7 @@ const allowed = new Set<`${ServiceStatus}:${ServiceEvent["_tag"]}`>([
   "Pending:DependencyFailed",
   "Pending:StopRequested",
   "Starting:ProcessSpawned",
+  "Starting:SpawnFailed",
   "Starting:StopRequested",
   "Running:HealthCheckPassed",
   "Running:ProcessExited",
@@ -67,6 +69,7 @@ export const applyEvent = (state: ServiceState, event: ServiceEvent): ServiceSta
       return new ServiceState({ ...state, status: "Starting" });
 
     case "DependencyFailed":
+    case "SpawnFailed":
       return new ServiceState({
         ...state,
         status: "Failed",

--- a/packages/process-compose/src/ServiceTransition.unit.test.ts
+++ b/packages/process-compose/src/ServiceTransition.unit.test.ts
@@ -60,6 +60,15 @@ describe("ServiceTransition", () => {
       expect(result?.error).toBe("spawn gate failed");
     });
 
+    it("Pending + SpawnFailed → Failed with error", () => {
+      const result = applyEvent(make("db"), {
+        _tag: "SpawnFailed",
+        error: "pre-start failed",
+      });
+      expect(result?.status).toBe("Failed");
+      expect(result?.error).toBe("pre-start failed");
+    });
+
     it("Running + HealthCheckPassed → Healthy", () => {
       const state = make("db", { status: "Running", pid: 1234 });
       const next = applyEvent(state, { _tag: "HealthCheckPassed" });

--- a/packages/process-compose/src/ServiceTransition.unit.test.ts
+++ b/packages/process-compose/src/ServiceTransition.unit.test.ts
@@ -52,7 +52,7 @@ describe("ServiceTransition", () => {
     });
 
     it("Starting + SpawnFailed → Failed with error", () => {
-      const result = applyEvent(state("Starting"), {
+      const result = applyEvent(make("db", { status: "Starting" }), {
         _tag: "SpawnFailed",
         error: "spawn gate failed",
       });

--- a/packages/process-compose/src/ServiceTransition.unit.test.ts
+++ b/packages/process-compose/src/ServiceTransition.unit.test.ts
@@ -51,6 +51,15 @@ describe("ServiceTransition", () => {
       expect(next!.startedAt).toBe(1000);
     });
 
+    it("Starting + SpawnFailed → Failed with error", () => {
+      const result = applyEvent(state("Starting"), {
+        _tag: "SpawnFailed",
+        error: "spawn gate failed",
+      });
+      expect(result?.status).toBe("Failed");
+      expect(result?.error).toBe("spawn gate failed");
+    });
+
     it("Running + HealthCheckPassed → Healthy", () => {
       const state = make("db", { status: "Running", pid: 1234 });
       const next = applyEvent(state, { _tag: "HealthCheckPassed" });

--- a/packages/process-compose/src/Supervisor.ts
+++ b/packages/process-compose/src/Supervisor.ts
@@ -14,6 +14,12 @@ interface SupervisorRuntimeConfig {
   readonly shutdownSignal: ChildProcess.Signal;
   readonly shutdownTimeoutMs: number;
   readonly cleanup: ReadonlyArray<ExternalCleanupAction>;
+  readonly spawnGate?: SupervisorSpawnGate;
+}
+
+export interface SupervisorSpawnGate {
+  readonly requestPath: string;
+  readonly releasePath: string;
 }
 
 export const supervisorRuntimePath = fileURLToPath(
@@ -22,7 +28,7 @@ export const supervisorRuntimePath = fileURLToPath(
 
 export const usesSupervisor = (def: ServiceDef): boolean => def.supervision != null;
 
-export const makeSupervisedCommand = (def: ServiceDef) => {
+export const makeSupervisedCommand = (def: ServiceDef, spawnGate?: SupervisorSpawnGate) => {
   const runtimeConfig: SupervisorRuntimeConfig = {
     command: def.command,
     args: def.args ?? [],
@@ -30,6 +36,7 @@ export const makeSupervisedCommand = (def: ServiceDef) => {
     shutdownSignal: def.shutdown?.signal ?? defaults.shutdown.signal,
     shutdownTimeoutMs: (def.shutdown?.timeoutSeconds ?? defaults.shutdown.timeoutSeconds) * 1000,
     cleanup: def.supervision?.orphanCleanup ?? [],
+    spawnGate,
   };
   const encoded = Buffer.from(JSON.stringify(runtimeConfig)).toString("base64url");
   const selfDispatch = isSupervisorSelfDispatchEnabled(import.meta.url);

--- a/packages/process-compose/src/SupervisorRuntime.unit.test.ts
+++ b/packages/process-compose/src/SupervisorRuntime.unit.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 const supervisorRuntimePath = fileURLToPath(new URL("./supervisor-runtime.ts", import.meta.url));
 
@@ -39,6 +39,35 @@ const isPidAlive = (pid: number): boolean => {
 };
 
 describe("supervisor-runtime", () => {
+  test("waits for the spawn gate before starting the supervised child", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "process-compose-supervisor-gate-"));
+    const requestPath = path.join(tempDir, "request");
+    const releasePath = path.join(tempDir, "release");
+    const readyFile = path.join(tempDir, "ready");
+    const encodedConfig = Buffer.from(
+      JSON.stringify({
+        command: process.execPath,
+        args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(readyFile)}, "ready")`],
+        spawnGate: { requestPath, releasePath },
+      }),
+    ).toString("base64url");
+    const supervisor = spawn(process.execPath, [supervisorRuntimePath, encodedConfig], {
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    try {
+      await waitFor(() => existsSync(requestPath));
+      expect(existsSync(readyFile)).toBe(false);
+      writeFileSync(releasePath, "release", { flag: "wx" });
+      await waitFor(() => existsSync(readyFile));
+      supervisor.stdin.end();
+      await waitFor(() => supervisor.exitCode != null);
+    } finally {
+      supervisor.kill("SIGKILL");
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test(
     "kills the child tree and runs orphan cleanup when parent stdin closes",
     { timeout: 15_000 },

--- a/packages/process-compose/src/index.ts
+++ b/packages/process-compose/src/index.ts
@@ -11,6 +11,7 @@ export type {
   HookLog,
   LifecycleHook,
   OrchestratorConfig,
+  ServiceStartOptions,
   ServiceDef,
 } from "./ServiceDef.ts";
 export { defaults } from "./ServiceDef.ts";

--- a/packages/process-compose/src/supervisor-runtime.ts
+++ b/packages/process-compose/src/supervisor-runtime.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from "node:child_process";
-import { realpathSync, rmSync } from "node:fs";
+import { existsSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { ChildProcess } from "effect/unstable/process";
 import type { ExternalCleanupAction } from "./ServiceDef.ts";
@@ -17,6 +17,10 @@ interface SupervisorRuntimeConfig {
   readonly shutdownSignal?: ChildProcess.Signal;
   readonly shutdownTimeoutMs?: number;
   readonly cleanup?: ReadonlyArray<ExternalCleanupAction>;
+  readonly spawnGate?: {
+    readonly requestPath: string;
+    readonly releasePath: string;
+  };
 }
 
 interface ChildExit {
@@ -135,6 +139,15 @@ const cleanupActionsFrom = (value: unknown): ReadonlyArray<ExternalCleanupAction
   return actions.every((action) => action != null) ? actions : undefined;
 };
 
+const spawnGateFrom = (value: unknown): SupervisorRuntimeConfig["spawnGate"] => {
+  if (!isObject(value)) return undefined;
+  const requestPath = getField(value, "requestPath");
+  const releasePath = getField(value, "releasePath");
+  return typeof requestPath === "string" && typeof releasePath === "string"
+    ? { requestPath, releasePath }
+    : undefined;
+};
+
 const parseSupervisorRuntimeConfig = (encodedConfig: string): SupervisorRuntimeConfig => {
   const value: unknown = JSON.parse(Buffer.from(encodedConfig, "base64url").toString("utf8"));
   if (!isObject(value)) {
@@ -156,6 +169,7 @@ const parseSupervisorRuntimeConfig = (encodedConfig: string): SupervisorRuntimeC
     shutdownSignal: signalFrom(getField(value, "shutdownSignal")),
     shutdownTimeoutMs: typeof shutdownTimeoutMs === "number" ? shutdownTimeoutMs : undefined,
     cleanup: cleanupActionsFrom(getField(value, "cleanup")),
+    spawnGate: spawnGateFrom(getField(value, "spawnGate")),
   };
 };
 
@@ -166,6 +180,18 @@ export function runSupervisorRuntime(encodedConfig = process.argv[2]): void {
 
   const config = parseSupervisorRuntimeConfig(encodedConfig);
   const childEnv = withoutSupervisorRuntimeEnv();
+
+  if (config.spawnGate !== undefined) {
+    writeFileSync(config.spawnGate.requestPath, "ready", { flag: "wx" });
+    const deadline = Date.now() + 60_000;
+    const waitArray = new Int32Array(new SharedArrayBuffer(4));
+    while (!existsSync(config.spawnGate.releasePath)) {
+      if (Date.now() >= deadline) throw new Error("Timed out waiting for supervised spawn release");
+      Atomics.wait(waitArray, 0, 0, 25);
+    }
+    unlinkSync(config.spawnGate.requestPath);
+    unlinkSync(config.spawnGate.releasePath);
+  }
 
   const isWindows = process.platform === "win32";
   const child = spawn(config.command, config.args ?? [], {

--- a/packages/process-compose/tests/helpers/mocks.ts
+++ b/packages/process-compose/tests/helpers/mocks.ts
@@ -1,4 +1,5 @@
 import { Deferred, Effect, Layer, Sink, Stream } from "effect";
+import { writeFileSync } from "node:fs";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 interface SpawnRecord {
@@ -7,6 +8,24 @@ interface SpawnRecord {
 }
 
 const encoder = new TextEncoder();
+
+const signalSupervisorSpawnGate = (args: ReadonlyArray<string>): void => {
+  const encoded = args.at(-1);
+  if (encoded === undefined) return;
+  try {
+    const config: unknown = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+    if (typeof config !== "object" || config === null || !("spawnGate" in config)) return;
+    const gate = config.spawnGate;
+    if (
+      typeof gate === "object" &&
+      gate !== null &&
+      "requestPath" in gate &&
+      typeof gate.requestPath === "string"
+    ) {
+      writeFileSync(gate.requestPath, "ready", { flag: "wx" });
+    }
+  } catch {}
+};
 
 export function mockChildProcessSpawner(
   opts: {
@@ -28,6 +47,7 @@ export function mockChildProcessSpawner(
           const cmd = command._tag === "StandardCommand" ? command.command : "";
           const args = command._tag === "StandardCommand" ? command.args : [];
           const record: SpawnRecord = { command: cmd, args };
+          signalSupervisorSpawnGate(args);
           yield* opts.beforeSpawn?.(record) ?? Effect.void;
           spawned.push(record);
           opts.onSpawn?.(record);

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -7,7 +7,7 @@ Programmatic local Supabase stack for TypeScript. Create a local Supabase runtim
 - **Single entry point** -- `createStack()` resolves config and returns a handle; `start()` prepares assets, starts services, and waits for readiness
 - **Preparation-aware startup** -- cold-cache startup can surface `Downloading` before normal runtime states like `Starting`, `Initializing`, and `Healthy`
 - **Native binaries with Docker fallback** -- uses native services when available and falls back to Docker images automatically
-- **Automatic port allocation** -- all ports are optional and auto-assigned to avoid conflicts
+- **Leased port allocation** -- optional ports are auto-assigned and held until their service starts
 - **API proxy with opaque keys** -- SDKs use `publishableKey`/`secretKey` (like production), translated to JWTs internally
 - **Lazy proxied services** -- opt into `startupMode: "lazy"` to start HTTP and Realtime WebSocket services on first use while keeping direct listeners reachable
 - **`AsyncDisposable` support** -- use `await using` for automatic cleanup

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -1210,6 +1210,7 @@ function setupLayer(config: ResolvedStackConfig = defaultConfig) {
   const spawner = mockChildProcessSpawner(); // from @supabase/process-compose mocks
   const portLease: PortLease = {
     ports: config.ports,
+    reserve: () => Effect.void,
     release: () => Effect.void,
     releaseAll: Effect.void,
   };

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -433,7 +433,7 @@ class JwtGenerator extends ServiceMap.Service<
 
 **File:** `src/PortAllocator.ts`
 
-`PortAllocator` resolves all port numbers before the stack starts. It supports two strategies: an explicit port requested by the caller, or a randomly assigned port from the OS.
+`PortAllocator` resolves all port numbers before the stack starts. It supports explicit caller ports and random OS-assigned ports. `createStack()` uses leased allocation: each selected port remains bound until the API proxy or corresponding service dependency closure is ready to bind it.
 
 #### Interface
 
@@ -460,16 +460,20 @@ export interface AllocatedPorts {
 export const allocatePorts = (
   input: PortInput,
 ): Effect.Effect<AllocatedPorts, PortAllocationError>;
+
+export const reservePorts = (
+  input: PortInput,
+): Effect.Effect<PortLease, PortAllocationError>;
 ```
 
 #### Two strategies
 
-- **Explicit port** (`input.apiPort !== undefined`) → `probeExactPort(port)`: binds the specific port on `127.0.0.1` to confirm it is available. Fails with `PortAllocationError` if the port is already in use.
-- **Omitted** → `probeRandomPort(exclude)`: binds port `0` on `127.0.0.1` so the OS assigns a free port, then closes the server immediately and returns the assigned port number.
+- **Explicit port** (`input.apiPort !== undefined`) binds the specific port on `127.0.0.1` and fails with `PortAllocationError` if it is already in use.
+- **Omitted** binds port `0` on `127.0.0.1`, allowing the OS to assign a free port.
 
 #### Collision avoidance
 
-Allocated ports are tracked in a `Set<number>`. When `probeRandomPort` returns a port already in the set (rare but possible under concurrent allocation), it retries automatically. This prevents two services from racing to the same port.
+Allocated ports are tracked in a `Set<number>` and OS listeners prevent concurrent stacks from receiving the same assignment. The API lease is released immediately before the central proxy binds. Backend leases remain active in lazy mode and are released only for the graph dependency closure being started. Any remaining listeners are closed during stack disposal. `allocatePorts()` remains available as a probe-only low-level API; stack construction uses `reservePorts()`.
 
 ---
 
@@ -885,7 +889,7 @@ metadata persisted separately for crash recovery.
 
 **File:** `src/createStack.ts`
 
-`createStack` is the platform-agnostic core. It wires all layers, delegates to a `ManagedRuntime`, and returns a rich `Stack` interface. It takes a `PlatformFactory` parameter — a function `(apiPort: number) => PlatformLayer` — so the platform-specific HTTP server (Bun or Node.js) can be bound to the already-resolved port. The platform layer also supplies the proxy's `ProxyWebSocketConnector`; custom factories can import that service contract from `@supabase/stack/effect`. Platform-specific layers (`BunHttpServer`, `NodeHttpServer`, and their WebSocket connectors) are provided by the entry points (`bun.ts`, `node.ts`), not baked in.
+`createStack` is the platform-agnostic core. It wires all layers, delegates to a `ManagedRuntime`, and returns a rich `Stack` interface. It takes a `PlatformFactory` parameter — a function receiving `{ apiPort, releaseApiPort }` — so the platform-specific HTTP server (Bun or Node.js) can release the reserved API port immediately before binding it. The platform layer also supplies the proxy's `ProxyWebSocketConnector`; custom factories can import that service contract from `@supabase/stack/effect`. Platform-specific layers (`BunHttpServer`, `NodeHttpServer`, and their WebSocket connectors) are provided by the entry points (`bun.ts`, `node.ts`), not baked in.
 
 `createStack` also owns `resolveConfig()`, the internal async function that turns a raw
 `StackConfig` into a `ResolvedStackConfig`: it allocates ports via `PortAllocator`, generates JWTs
@@ -1204,12 +1208,17 @@ spawner; the key idea is that tests compose `Stack.layer(config)` on top of a re
 function setupLayer(config: ResolvedStackConfig = defaultConfig) {
   const resolver = mockBinaryResolver();
   const spawner = mockChildProcessSpawner(); // from @supabase/process-compose mocks
+  const portLease: PortLease = {
+    ports: config.ports,
+    release: () => Effect.void,
+    releaseAll: Effect.void,
+  };
 
   const preparationLayer = StackPreparation.layer.pipe(
     Layer.provide(resolver.layer),
     Layer.provide(spawner.layer),
   );
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(preparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
@@ -1219,6 +1228,9 @@ function setupLayer(config: ResolvedStackConfig = defaultConfig) {
   return { layer, resolver, spawner };
 }
 ```
+
+Production setup passes the real reserved `PortLease`; tests use the no-op lease above because
+their mocked processes do not bind the configured ports.
 
 The `mockChildProcessSpawner` is reused from `@supabase/process-compose`'s test helpers — it
 stubs process spawning without forking real OS processes, making `Stack` / coordinator tests fast

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -139,11 +139,14 @@ const readOwnerContents = async (lockPath: string): Promise<string | undefined> 
 
 const ownerIsActive = (contents: string): boolean => {
   const owner = parseOwner(contents);
+  const observedStartIdentity = owner === undefined ? undefined : processStartIdentity(owner.pid);
   return (
     owner !== undefined &&
     Math.abs(owner.bootMinute - currentBootMinute()) <= 2 &&
     processIsAlive(owner.pid) &&
-    (owner.startIdentity === undefined || processStartIdentity(owner.pid) === owner.startIdentity)
+    (owner.startIdentity === undefined ||
+      observedStartIdentity === undefined ||
+      observedStartIdentity === owner.startIdentity)
   );
 };
 

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir, uptime } from "node:os";
+import { join } from "node:path";
+
+const LOCK_STALE_AFTER_MS = 5_000;
+const LOCK_RETRY_AFTER_MS = 25;
+const SHARED_LOCK_ROOT = join(
+  process.platform === "win32" ? tmpdir() : "/tmp",
+  "supabase-stack-managed-port-locks",
+);
+const DEFAULT_LOCK_PATH = join(SHARED_LOCK_ROOT, "allocation.lock");
+
+interface LockOwner {
+  readonly pid: number;
+  readonly bootMinute: number;
+  readonly token: string;
+  readonly startIdentity?: string;
+}
+
+const errorCode = (error: unknown): string | undefined =>
+  typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+
+const processIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+};
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const currentBootMinute = (): number => Math.round((Date.now() - uptime() * 1_000) / 60_000);
+
+const processStartIdentity = (pid: number): string | undefined => {
+  try {
+    if (process.platform === "linux") {
+      const processStat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fieldsAfterCommand = processStat
+        .slice(processStat.lastIndexOf(")") + 2)
+        .trim()
+        .split(/\s+/);
+      const startTicks = fieldsAfterCommand[19];
+      return startTicks === undefined ? undefined : `linux:${startTicks}`;
+    }
+    if (process.platform === "win32") {
+      const ticks = execFileSync(
+        "powershell.exe",
+        ["-NoProfile", "-Command", `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 2_000 },
+      ).trim();
+      return ticks.length === 0 ? undefined : `win32:${ticks}`;
+    }
+    const started = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+    return started.length === 0 ? undefined : `${process.platform}:${started}`;
+  } catch {
+    return undefined;
+  }
+};
+
+const parseOwner = (contents: string): LockOwner | undefined => {
+  try {
+    const value: unknown = JSON.parse(contents);
+    if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+      return { pid: value, bootMinute: currentBootMinute(), token: "legacy" };
+    }
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "pid" in value &&
+      typeof value.pid === "number" &&
+      Number.isSafeInteger(value.pid) &&
+      value.pid > 0 &&
+      "bootMinute" in value &&
+      typeof value.bootMinute === "number" &&
+      Number.isSafeInteger(value.bootMinute) &&
+      "token" in value &&
+      typeof value.token === "string" &&
+      value.token.length > 0 &&
+      (!("startIdentity" in value) || typeof value.startIdentity === "string")
+    ) {
+      const startIdentity =
+        "startIdentity" in value && typeof value.startIdentity === "string"
+          ? value.startIdentity
+          : undefined;
+      return {
+        pid: value.pid,
+        bootMinute: value.bootMinute,
+        token: value.token,
+        ...(startIdentity === undefined ? {} : { startIdentity }),
+      };
+    }
+  } catch {
+    // Older lock owners wrote only their PID. They remain readable during upgrades.
+    const pid = Number(contents.trim());
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      return { pid, bootMinute: currentBootMinute(), token: "legacy" };
+    }
+  }
+  return undefined;
+};
+
+const readOwnerContents = async (lockPath: string): Promise<string | undefined> => {
+  try {
+    return await readFile(join(lockPath, "owner"), "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return undefined;
+    throw error;
+  }
+};
+
+const ownerIsActive = (contents: string): boolean => {
+  const owner = parseOwner(contents);
+  return (
+    owner !== undefined &&
+    Math.abs(owner.bootMinute - currentBootMinute()) <= 2 &&
+    processIsAlive(owner.pid) &&
+    (owner.startIdentity === undefined || processStartIdentity(owner.pid) === owner.startIdentity)
+  );
+};
+
+const shouldReclaimLock = async (
+  lockPath: string,
+): Promise<{ readonly ownerContents: string | undefined; readonly stale: boolean }> => {
+  const ownerContents = await readOwnerContents(lockPath);
+  if (ownerContents !== undefined) {
+    return { ownerContents, stale: !ownerIsActive(ownerContents) };
+  }
+
+  try {
+    const info = await stat(lockPath);
+    return {
+      ownerContents,
+      stale: Date.now() - info.mtime.getTime() >= LOCK_STALE_AFTER_MS,
+    };
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { ownerContents, stale: false };
+    throw error;
+  }
+};
+
+const moveLockGeneration = async (
+  lockPath: string,
+  expectedOwner: string | undefined,
+): Promise<string | undefined> => {
+  const quarantinePath = `${lockPath}.${randomUUID()}.stale`;
+  try {
+    await rename(lockPath, quarantinePath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return undefined;
+    throw error;
+  }
+
+  const movedOwner = await readOwnerContents(quarantinePath);
+  if (movedOwner === expectedOwner) return quarantinePath;
+
+  try {
+    await rename(quarantinePath, lockPath);
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY") throw error;
+  }
+  return undefined;
+};
+
+const reclaimLock = async (lockPath: string, expectedOwner: string | undefined): Promise<void> => {
+  const quarantinePath = await moveLockGeneration(lockPath, expectedOwner);
+  if (quarantinePath !== undefined) {
+    await rm(quarantinePath, { recursive: true, force: true });
+  }
+};
+
+const prepareSharedLockRoot = async (): Promise<void> => {
+  if (process.platform === "win32") {
+    await mkdir(SHARED_LOCK_ROOT, { recursive: true });
+    return;
+  }
+
+  for (let attempt = 0; attempt < 200; attempt++) {
+    await mkdir(SHARED_LOCK_ROOT, { recursive: true, mode: 0o777 });
+    try {
+      await chmod(SHARED_LOCK_ROOT, 0o777);
+    } catch (error) {
+      if (errorCode(error) !== "EPERM" && errorCode(error) !== "EACCES") throw error;
+    }
+    const info = await stat(SHARED_LOCK_ROOT);
+    if ((info.mode & 0o007) === 0o007) return;
+    await delay(LOCK_RETRY_AFTER_MS);
+  }
+  throw new Error(`Shared managed-port lock directory is not writable: ${SHARED_LOCK_ROOT}`);
+};
+
+export type ReleaseManagedPortLock = () => Promise<void>;
+
+/** Serialize port selection and lease handoff across foreground and detached stacks. */
+export async function acquireManagedPortLock(
+  lockPath = DEFAULT_LOCK_PATH,
+): Promise<ReleaseManagedPortLock> {
+  if (lockPath === DEFAULT_LOCK_PATH) {
+    await prepareSharedLockRoot();
+  }
+  for (;;) {
+    const startIdentity = processStartIdentity(process.pid);
+    const ownerContents = JSON.stringify({
+      pid: process.pid,
+      bootMinute: currentBootMinute(),
+      token: randomUUID(),
+      ...(startIdentity === undefined ? {} : { startIdentity }),
+    } satisfies LockOwner);
+
+    try {
+      await mkdir(lockPath, { mode: 0o777 });
+      try {
+        if (process.platform !== "win32") {
+          // The shared generation must remain removable by a different user.
+          // mkdir applies the process umask, so make the effective mode explicit.
+          await chmod(lockPath, 0o777);
+        }
+        await writeFile(join(lockPath, "owner"), ownerContents, "utf8");
+        if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
+      } catch (error) {
+        const quarantinePath = await moveLockGeneration(lockPath, ownerContents);
+        if (quarantinePath !== undefined) {
+          await rm(quarantinePath, { recursive: true, force: true });
+        }
+        throw error;
+      }
+
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        const quarantinePath = await moveLockGeneration(lockPath, ownerContents);
+        if (quarantinePath !== undefined) {
+          await rm(quarantinePath, { recursive: true, force: true });
+        }
+      };
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+    }
+
+    const observed = await shouldReclaimLock(lockPath);
+    if (observed.stale) {
+      await reclaimLock(lockPath, observed.ownerContents);
+      continue;
+    }
+    await delay(LOCK_RETRY_AFTER_MS);
+  }
+}

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { constants, readFileSync } from "node:fs";
-import { chmod, mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { tmpdir, uptime } from "node:os";
 import { join } from "node:path";
 
@@ -189,6 +189,25 @@ const moveLockGeneration = async (
     await rename(quarantinePath, lockPath);
   } catch (error) {
     if (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY") throw error;
+
+    // Another contender filled the pathname while we verified the moved
+    // generation. Put the earlier, live generation back and quarantine the
+    // contender. New owners validate again after a stabilization interval, so
+    // the displaced contender cannot report successful acquisition.
+    const displacedPath = `${lockPath}.${randomUUID()}.superseded`;
+    try {
+      await rename(lockPath, displacedPath);
+      await rename(quarantinePath, lockPath);
+    } catch (restoreError) {
+      try {
+        await rename(displacedPath, lockPath);
+      } catch {
+        // Preserve the original failure, which explains why ownership could
+        // not be restored. A later acquisition can reclaim either generation.
+      }
+      throw restoreError;
+    }
+    await rm(displacedPath, { recursive: true, force: true });
   }
   return undefined;
 };
@@ -260,7 +279,21 @@ export async function acquireManagedPortLock(
           // mkdir applies the process umask, so make the effective mode explicit.
           await chmod(lockPath, 0o777);
         }
-        await writeFile(join(lockPath, "owner"), ownerContents, "utf8");
+        const ownerHandle = await open(
+          join(lockPath, "owner"),
+          constants.O_WRONLY |
+            constants.O_CREAT |
+            constants.O_EXCL |
+            (process.platform === "win32" ? 0 : constants.O_NOFOLLOW),
+          0o644,
+        );
+        try {
+          await ownerHandle.writeFile(ownerContents, "utf8");
+        } finally {
+          await ownerHandle.close();
+        }
+        if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
+        await delay(LOCK_RETRY_AFTER_MS, signal);
         if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
       } catch (error) {
         const quarantinePath = await moveLockGeneration(lockPath, ownerContents);

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { constants, readFileSync } from "node:fs";
+import { chmod, mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir, uptime } from "node:os";
 import { join } from "node:path";
 
@@ -34,8 +34,25 @@ const processIsAlive = (pid: number): boolean => {
   }
 };
 
-const delay = (milliseconds: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, milliseconds));
+const abortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? new Error("Managed-port lock acquisition was aborted");
+
+const delay = (milliseconds: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(abortReason(signal));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, milliseconds);
+    const onAbort = () => {
+      clearTimeout(timer);
+      if (signal !== undefined) reject(abortReason(signal));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 
 const currentBootMinute = (): number => Math.round((Date.now() - uptime() * 1_000) / 60_000);
 
@@ -180,22 +197,34 @@ const reclaimLock = async (lockPath: string, expectedOwner: string | undefined):
   }
 };
 
-const prepareSharedLockRoot = async (): Promise<void> => {
+const prepareSharedLockRoot = async (signal?: AbortSignal): Promise<void> => {
   if (process.platform === "win32") {
     await mkdir(SHARED_LOCK_ROOT, { recursive: true });
     return;
   }
 
   for (let attempt = 0; attempt < 200; attempt++) {
+    signal?.throwIfAborted();
     await mkdir(SHARED_LOCK_ROOT, { recursive: true, mode: 0o777 });
+    const handle = await open(
+      SHARED_LOCK_ROOT,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
     try {
-      await chmod(SHARED_LOCK_ROOT, 0o777);
-    } catch (error) {
-      if (errorCode(error) !== "EPERM" && errorCode(error) !== "EACCES") throw error;
+      const info = await handle.stat();
+      if (!info.isDirectory()) {
+        throw new Error(`Shared managed-port lock root is not a directory: ${SHARED_LOCK_ROOT}`);
+      }
+      try {
+        await handle.chmod(0o777);
+      } catch (error) {
+        if (errorCode(error) !== "EPERM" && errorCode(error) !== "EACCES") throw error;
+      }
+      if (((await handle.stat()).mode & 0o007) === 0o007) return;
+    } finally {
+      await handle.close();
     }
-    const info = await stat(SHARED_LOCK_ROOT);
-    if ((info.mode & 0o007) === 0o007) return;
-    await delay(LOCK_RETRY_AFTER_MS);
+    await delay(LOCK_RETRY_AFTER_MS, signal);
   }
   throw new Error(`Shared managed-port lock directory is not writable: ${SHARED_LOCK_ROOT}`);
 };
@@ -205,11 +234,13 @@ export type ReleaseManagedPortLock = () => Promise<void>;
 /** Serialize port selection and lease handoff across foreground and detached stacks. */
 export async function acquireManagedPortLock(
   lockPath = DEFAULT_LOCK_PATH,
+  signal?: AbortSignal,
 ): Promise<ReleaseManagedPortLock> {
   if (lockPath === DEFAULT_LOCK_PATH) {
-    await prepareSharedLockRoot();
+    await prepareSharedLockRoot(signal);
   }
   for (;;) {
+    signal?.throwIfAborted();
     const startIdentity = processStartIdentity(process.pid);
     const ownerContents = JSON.stringify({
       pid: process.pid,
@@ -254,6 +285,6 @@ export async function acquireManagedPortLock(
       await reclaimLock(lockPath, observed.ownerContents);
       continue;
     }
-    await delay(LOCK_RETRY_AFTER_MS);
+    await delay(LOCK_RETRY_AFTER_MS, signal);
   }
 }

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -270,17 +270,19 @@ export async function acquireManagedPortLock(
       token: randomUUID(),
       ...(startIdentity === undefined ? {} : { startIdentity }),
     } satisfies LockOwner);
+    const candidatePath = `${lockPath}.${randomUUID()}.candidate`;
+    let installed = false;
 
     try {
-      await mkdir(lockPath, { mode: 0o777 });
+      await mkdir(candidatePath, { mode: 0o777 });
       try {
         if (process.platform !== "win32") {
           // The shared generation must remain removable by a different user.
           // mkdir applies the process umask, so make the effective mode explicit.
-          await chmod(lockPath, 0o777);
+          await chmod(candidatePath, 0o777);
         }
         const ownerHandle = await open(
-          join(lockPath, "owner"),
+          join(candidatePath, "owner"),
           constants.O_WRONLY |
             constants.O_CREAT |
             constants.O_EXCL |
@@ -292,14 +294,13 @@ export async function acquireManagedPortLock(
         } finally {
           await ownerHandle.close();
         }
+        await rename(candidatePath, lockPath);
+        installed = true;
         if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
         await delay(LOCK_RETRY_AFTER_MS, signal);
         if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
       } catch (error) {
-        const quarantinePath = await moveLockGeneration(lockPath, ownerContents);
-        if (quarantinePath !== undefined) {
-          await rm(quarantinePath, { recursive: true, force: true });
-        }
+        await rm(candidatePath, { recursive: true, force: true });
         throw error;
       }
 
@@ -313,7 +314,12 @@ export async function acquireManagedPortLock(
         }
       };
     } catch (error) {
-      if (errorCode(error) !== "EEXIST") throw error;
+      if (
+        installed ||
+        (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY")
+      ) {
+        throw error;
+      }
     }
 
     const observed = await shouldReclaimLock(lockPath);

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -301,6 +301,12 @@ export async function acquireManagedPortLock(
         if ((await readOwnerContents(lockPath)) !== ownerContents) continue;
       } catch (error) {
         await rm(candidatePath, { recursive: true, force: true });
+        if (installed) {
+          const quarantinePath = await moveLockGeneration(lockPath, ownerContents);
+          if (quarantinePath !== undefined) {
+            await rm(quarantinePath, { recursive: true, force: true });
+          }
+        }
         throw error;
       }
 
@@ -314,10 +320,7 @@ export async function acquireManagedPortLock(
         }
       };
     } catch (error) {
-      if (
-        installed ||
-        (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY")
-      ) {
+      if (installed || (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY")) {
         throw error;
       }
     }

--- a/packages/stack/src/ManagedPortLock.unit.test.ts
+++ b/packages/stack/src/ManagedPortLock.unit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "@effect/vitest";
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir, uptime } from "node:os";
+import { join } from "node:path";
+import { acquireManagedPortLock } from "./ManagedPortLock.ts";
+
+describe("ManagedPortLock", () => {
+  it("serializes independent port allocators", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      const releaseFirst = await acquireManagedPortLock(lockPath);
+      let secondAcquired = false;
+      const second = acquireManagedPortLock(lockPath).then((release) => {
+        secondAcquired = true;
+        return release;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(secondAcquired).toBe(false);
+
+      await releaseFirst();
+      const releaseSecond = await second;
+      expect(secondAcquired).toBe(true);
+      await releaseSecond();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("creates lock generations that other users can remove", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-mode-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      const release = await acquireManagedPortLock(lockPath);
+      if (process.platform !== "win32") {
+        expect((await stat(lockPath)).mode & 0o777).toBe(0o777);
+      }
+      await release();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a legacy numeric owner held while its process is alive", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-legacy-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      await mkdir(lockPath);
+      await writeFile(join(lockPath, "owner"), String(process.pid), "utf8");
+      const staleTime = new Date(Date.now() - 10_000);
+      await utimes(lockPath, staleTime, staleTime);
+
+      let acquired = false;
+      const pending = acquireManagedPortLock(lockPath).then((release) => {
+        acquired = true;
+        return release;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(acquired).toBe(false);
+
+      await rm(lockPath, { recursive: true, force: true });
+      const release = await pending;
+      await release();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reclaims a reused PID from a different process generation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-generation-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      await mkdir(lockPath, { mode: 0o777 });
+      await writeFile(
+        join(lockPath, "owner"),
+        JSON.stringify({
+          pid: process.pid,
+          bootMinute: Math.round((Date.now() - uptime() * 1_000) / 60_000),
+          token: "abandoned",
+          startIdentity: "different-process-generation",
+        }),
+        "utf8",
+      );
+
+      const release = await acquireManagedPortLock(lockPath);
+      await release();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets only one allocator replace an abandoned lock generation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-stale-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      await mkdir(lockPath);
+      await writeFile(join(lockPath, "owner"), "invalid owner", "utf8");
+      const staleTime = new Date(Date.now() - 10_000);
+      await utimes(lockPath, staleTime, staleTime);
+
+      let active = 0;
+      let maxActive = 0;
+      const first = acquireManagedPortLock(lockPath).then(async (release) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 75));
+        active -= 1;
+        await release();
+      });
+      const second = acquireManagedPortLock(lockPath).then(async (release) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        active -= 1;
+        await release();
+      });
+
+      await Promise.all([first, second]);
+      expect(maxActive).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/stack/src/ManagedPortLock.unit.test.ts
+++ b/packages/stack/src/ManagedPortLock.unit.test.ts
@@ -29,6 +29,27 @@ describe("ManagedPortLock", () => {
     }
   });
 
+  it("cancels a waiter without acquiring the lock later", async () => {
+    const root = await mkdtemp(join(tmpdir(), "managed-port-lock-abort-"));
+    const lockPath = join(root, "allocation.lock");
+
+    try {
+      const releaseFirst = await acquireManagedPortLock(lockPath);
+      const controller = new AbortController();
+      const pending = acquireManagedPortLock(lockPath, controller.signal);
+      const interrupted = expect(pending).rejects.toBeDefined();
+
+      controller.abort();
+      await interrupted;
+      await releaseFirst();
+
+      const releaseNext = await acquireManagedPortLock(lockPath);
+      await releaseNext();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("creates lock generations that other users can remove", async () => {
     const root = await mkdtemp(join(tmpdir(), "managed-port-lock-mode-"));
     const lockPath = join(root, "allocation.lock");

--- a/packages/stack/src/PortAllocator.ts
+++ b/packages/stack/src/PortAllocator.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server } from "node:net";
-import { Data, Effect, Schema } from "effect";
+import { Data, Effect, Schema, Semaphore } from "effect";
 
 export const DEFAULT_API_PORT = 54321;
 export const DEFAULT_DB_PORT = 54322;
@@ -233,6 +233,7 @@ const bindPort = (port: number): Effect.Effect<BoundPort, PortAllocationError> =
 
 export interface PortLease {
   readonly ports: AllocatedPorts;
+  readonly reserve: (fields: ReadonlyArray<PortField>) => Effect.Effect<void, PortAllocationError>;
   readonly release: (fields: ReadonlyArray<PortField>) => Effect.Effect<void>;
   readonly releaseAll: Effect.Effect<void>;
 }
@@ -254,11 +255,39 @@ const releaseReservations = (
     { discard: true },
   );
 
-const makePortLease = (ports: AllocatedPorts, reservations: Map<PortField, Server>): PortLease => ({
-  ports,
-  release: (fields) => releaseReservations(reservations, fields),
-  releaseAll: Effect.suspend(() => releaseReservations(reservations, [...reservations.keys()])),
-});
+const reserveReservations = (
+  ports: AllocatedPorts,
+  reservations: Map<PortField, Server>,
+  fields: ReadonlyArray<PortField>,
+): Effect.Effect<void, PortAllocationError> =>
+  Effect.suspend(() => {
+    const acquired: Array<PortField> = [];
+    return Effect.forEach(
+      fields,
+      (field) => {
+        if (reservations.has(field)) return Effect.void;
+        return Effect.tap(bindPort(ports[field]), ({ server }) =>
+          Effect.sync(() => {
+            reservations.set(field, server);
+            acquired.push(field);
+          }),
+        );
+      },
+      { discard: true },
+    ).pipe(Effect.onError(() => releaseReservations(reservations, acquired)));
+  });
+
+const makePortLease = (ports: AllocatedPorts, reservations: Map<PortField, Server>): PortLease => {
+  const lock = Semaphore.makeUnsafe(1);
+  return {
+    ports,
+    reserve: (fields) => lock.withPermit(reserveReservations(ports, reservations, fields)),
+    release: (fields) => lock.withPermit(releaseReservations(reservations, fields)),
+    releaseAll: lock.withPermit(
+      Effect.suspend(() => releaseReservations(reservations, [...reservations.keys()])),
+    ),
+  };
+};
 
 const reserveRandomPort = (
   exclude: ReadonlySet<number>,

--- a/packages/stack/src/PortAllocator.ts
+++ b/packages/stack/src/PortAllocator.ts
@@ -1,4 +1,4 @@
-import { createServer } from "node:net";
+import { createServer, type Server } from "node:net";
 import { Data, Effect, Schema } from "effect";
 
 export const DEFAULT_API_PORT = 54321;
@@ -101,7 +101,7 @@ export const PORT_FIELDS = [
   "poolerApiPort",
 ] as const satisfies ReadonlyArray<keyof AllocatedPorts>;
 
-type PortField = (typeof PORT_FIELDS)[number];
+export type PortField = (typeof PORT_FIELDS)[number];
 
 export const DEFAULT_PORTS: Partial<AllocatedPorts> = {
   apiPort: DEFAULT_API_PORT,
@@ -116,9 +116,12 @@ export const DEFAULT_PORTS: Partial<AllocatedPorts> = {
   edgeRuntimeInspectorPort: DEFAULT_EDGE_RUNTIME_INSPECTOR_PORT,
 };
 
-interface PortAllocationOptions {
+export interface PortSelectionOptions {
   readonly reserved?: ReadonlySet<number>;
   readonly preferred?: Partial<AllocatedPorts>;
+}
+
+interface PortAllocationOptions extends PortSelectionOptions {
   readonly probe?: PortProbe;
 }
 
@@ -184,6 +187,158 @@ const defaultPortProbe: PortProbe = {
   exact: probeExactPort,
   random: probeRandomPort,
 };
+
+const closeServer = (server: Server): Effect.Effect<void> =>
+  Effect.callback<void>((resume) => {
+    server.close(() => resume(Effect.void));
+    return Effect.void;
+  });
+
+interface BoundPort {
+  readonly port: number;
+  readonly server: Server;
+}
+
+const bindPort = (port: number): Effect.Effect<BoundPort, PortAllocationError> =>
+  Effect.callback<BoundPort, PortAllocationError>((resume) => {
+    const server = createServer((socket) => socket.destroy());
+    const onError = (cause: unknown) => {
+      resume(
+        Effect.fail(
+          new PortAllocationError({
+            detail:
+              port === 0 ? "Failed to reserve a random port" : `Port ${port} is not available`,
+            cause,
+          }),
+        ),
+      );
+    };
+    server.once("error", onError);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        void Effect.runPromise(closeServer(server));
+        resume(
+          Effect.fail(
+            new PortAllocationError({ detail: "Reserved TCP port has no numeric address" }),
+          ),
+        );
+        return;
+      }
+      resume(Effect.succeed({ port: address.port, server }));
+    });
+    return closeServer(server);
+  });
+
+export interface PortLease {
+  readonly ports: AllocatedPorts;
+  readonly release: (fields: ReadonlyArray<PortField>) => Effect.Effect<void>;
+  readonly releaseAll: Effect.Effect<void>;
+}
+
+const releaseReservations = (
+  reservations: Map<PortField, Server>,
+  fields: ReadonlyArray<PortField>,
+) =>
+  Effect.forEach(
+    fields,
+    (field) => {
+      const server = reservations.get(field);
+      if (server === undefined) {
+        return Effect.void;
+      }
+      reservations.delete(field);
+      return closeServer(server);
+    },
+    { discard: true },
+  );
+
+const makePortLease = (ports: AllocatedPorts, reservations: Map<PortField, Server>): PortLease => ({
+  ports,
+  release: (fields) => releaseReservations(reservations, fields),
+  releaseAll: Effect.suspend(() => releaseReservations(reservations, [...reservations.keys()])),
+});
+
+const reserveRandomPort = (
+  exclude: ReadonlySet<number>,
+): Effect.Effect<BoundPort, PortAllocationError> =>
+  Effect.flatMap(bindPort(0), (bound) =>
+    exclude.has(bound.port)
+      ? closeServer(bound.server).pipe(Effect.andThen(reserveRandomPort(exclude)))
+      : Effect.succeed(bound),
+  );
+
+/**
+ * Allocate and keep every selected TCP port bound until its lease is released.
+ * This closes the probe-then-bind race for lazily started services.
+ */
+export const reservePorts = (
+  input: PortInput,
+  options: PortSelectionOptions = {},
+): Effect.Effect<PortLease, PortAllocationError> =>
+  Effect.suspend(() => {
+    const reservations = new Map<PortField, Server>();
+    const reserve = Effect.gen(function* () {
+      const reserved = options.reserved ?? new Set<number>();
+      const preferred = options.preferred ?? {};
+      const allocated = new Set<number>();
+      const partial: Partial<Record<PortField, number>> = {};
+
+      for (const field of PORT_FIELDS) {
+        const exclude = new Set([...reserved, ...allocated]);
+        const explicit = input[field];
+        const preferredPort = preferred[field];
+        let bound: BoundPort;
+
+        if (explicit !== undefined) {
+          if (exclude.has(explicit)) {
+            return yield* new PortAllocationError({ detail: `Port ${explicit} is not available` });
+          }
+          bound = yield* bindPort(explicit);
+        } else if (preferredPort !== undefined && !exclude.has(preferredPort)) {
+          bound = yield* bindPort(preferredPort).pipe(
+            Effect.catchTag("PortAllocationError", () => reserveRandomPort(exclude)),
+          );
+        } else {
+          bound = yield* reserveRandomPort(exclude);
+        }
+
+        allocated.add(bound.port);
+        reservations.set(field, bound.server);
+        partial[field] = bound.port;
+      }
+
+      return makePortLease(Schema.decodeUnknownSync(AllocatedPortsSchema)(partial), reservations);
+    });
+
+    return reserve.pipe(
+      Effect.onError(() => releaseReservations(reservations, [...reservations.keys()])),
+    );
+  });
+
+/** Reserve an already-resolved subset of ports, typically in a daemon process. */
+export const reserveAllocatedPorts = (
+  ports: AllocatedPorts,
+  fields: ReadonlyArray<PortField>,
+): Effect.Effect<PortLease, PortAllocationError> =>
+  Effect.suspend(() => {
+    const reservations = new Map<PortField, Server>();
+    const reserve = Effect.forEach(
+      fields,
+      (field) =>
+        Effect.tap(bindPort(ports[field]), ({ server }) =>
+          Effect.sync(() => {
+            reservations.set(field, server);
+          }),
+        ),
+      { discard: true },
+    ).pipe(Effect.as(makePortLease(ports, reservations)));
+
+    return reserve.pipe(
+      Effect.onError(() => releaseReservations(reservations, [...reservations.keys()])),
+    );
+  });
 
 export const allocatePorts = (
   input: PortInput,

--- a/packages/stack/src/PortAllocator.unit.test.ts
+++ b/packages/stack/src/PortAllocator.unit.test.ts
@@ -142,6 +142,12 @@ describe("allocatePorts", () => {
       await Effect.runPromise(lease.release(["apiPort"]));
       const available = await Effect.runPromise(allocatePorts({ apiPort: lease.ports.apiPort }));
       expect(available.apiPort).toBe(lease.ports.apiPort);
+
+      await Effect.runPromise(lease.reserve(["apiPort"]));
+      const reservedAgain = await Effect.runPromise(
+        allocatePorts({ apiPort: lease.ports.apiPort }).pipe(Effect.exit),
+      );
+      expect(reservedAgain._tag).toBe("Failure");
     } finally {
       await Effect.runPromise(lease.releaseAll);
     }

--- a/packages/stack/src/PortAllocator.unit.test.ts
+++ b/packages/stack/src/PortAllocator.unit.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import { createServer } from "node:net";
 import type { Server } from "node:net";
 import { Effect } from "effect";
-import { allocatePorts, DEFAULT_PORTS, PortAllocationError } from "./PortAllocator.ts";
+import {
+  allocatePorts,
+  DEFAULT_PORTS,
+  PortAllocationError,
+  reservePorts,
+} from "./PortAllocator.ts";
 
 const listen = (port: number) =>
   Effect.callback<Server, Error>((resume) => {
@@ -123,6 +128,53 @@ describe("allocatePorts", () => {
     if (exit._tag === "Failure") {
       expect(JSON.stringify(exit.cause)).toContain("is not available");
     }
+  });
+
+  it("keeps allocated ports unavailable until their lease is released", async () => {
+    const lease = await Effect.runPromise(reservePorts({}));
+
+    try {
+      const occupied = await Effect.runPromise(
+        allocatePorts({ apiPort: lease.ports.apiPort }).pipe(Effect.exit),
+      );
+      expect(occupied._tag).toBe("Failure");
+
+      await Effect.runPromise(lease.release(["apiPort"]));
+      const available = await Effect.runPromise(allocatePorts({ apiPort: lease.ports.apiPort }));
+      expect(available.apiPort).toBe(lease.ports.apiPort);
+    } finally {
+      await Effect.runPromise(lease.releaseAll);
+    }
+  });
+
+  it("keeps concurrent port leases disjoint", async () => {
+    const [first, second] = await Promise.all([
+      Effect.runPromise(reservePorts({})),
+      Effect.runPromise(reservePorts({})),
+    ]);
+
+    try {
+      const firstPorts = new Set(Object.values(first.ports));
+      expect(Object.values(second.ports).every((port) => !firstPorts.has(port))).toBe(true);
+    } finally {
+      await Promise.all([
+        Effect.runPromise(first.releaseAll),
+        Effect.runPromise(second.releaseAll),
+      ]);
+    }
+  });
+
+  it("releases partial reservations when lease allocation fails", async () => {
+    const port = await Effect.runPromise(
+      Effect.scoped(Effect.map(occupyFreePort(), (occupied) => occupied.port)),
+    );
+    const failed = await Effect.runPromise(
+      reservePorts({ apiPort: port, dbPort: port }).pipe(Effect.exit),
+    );
+    expect(failed._tag).toBe("Failure");
+
+    const available = await Effect.runPromise(allocatePorts({ apiPort: port }));
+    expect(available.apiPort).toBe(port);
   });
 
   it("preferred ports are reused when available", async () => {

--- a/packages/stack/src/ServicePorts.ts
+++ b/packages/stack/src/ServicePorts.ts
@@ -1,0 +1,51 @@
+import type { PortField } from "./PortAllocator.ts";
+import type { ResolvedStackConfig } from "./StackBuilder.ts";
+
+export const allocatedPortFieldsForConfig = (
+  config: ResolvedStackConfig,
+): ReadonlyArray<PortField> => {
+  const fields: Array<PortField> = ["apiPort", "dbPort"];
+  if (config.postgrest !== false) fields.push("postgrestPort", "postgrestAdminPort");
+  if (config.auth !== false) fields.push("authPort");
+  if (config.edgeRuntime !== false) fields.push("edgeRuntimePort", "edgeRuntimeInspectorPort");
+  if (config.realtime !== false) fields.push("realtimePort");
+  if (config.storage !== false) fields.push("storagePort");
+  if (config.imgproxy !== false) fields.push("imgproxyPort");
+  if (config.mailpit !== false) fields.push("mailpitPort", "mailpitSmtpPort", "mailpitPop3Port");
+  if (config.pgmeta !== false) fields.push("pgmetaPort");
+  if (config.studio !== false) fields.push("studioPort");
+  if (config.analytics !== false) fields.push("analyticsPort");
+  if (config.pooler !== false) fields.push("poolerPort", "poolerApiPort");
+  return fields;
+};
+
+export const portFieldsForService = (name: string): ReadonlyArray<PortField> => {
+  switch (name) {
+    case "postgres":
+      return ["dbPort"];
+    case "postgrest":
+      return ["postgrestPort", "postgrestAdminPort"];
+    case "auth":
+      return ["authPort"];
+    case "edge-runtime":
+      return ["edgeRuntimePort", "edgeRuntimeInspectorPort"];
+    case "realtime":
+      return ["realtimePort"];
+    case "storage":
+      return ["storagePort"];
+    case "imgproxy":
+      return ["imgproxyPort"];
+    case "mailpit":
+      return ["mailpitPort", "mailpitSmtpPort", "mailpitPop3Port"];
+    case "pgmeta":
+      return ["pgmetaPort"];
+    case "studio":
+      return ["studioPort"];
+    case "analytics":
+      return ["analyticsPort"];
+    case "pooler":
+      return ["poolerPort", "poolerApiPort"];
+    default:
+      return [];
+  }
+};

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -102,6 +102,7 @@ const edgeRuntimeConfig: ResolvedStackConfig = {
 
 const noopPortLease = (ports: AllocatedPorts): PortLease => ({
   ports,
+  reserve: () => Effect.void,
   release: () => Effect.void,
   releaseAll: Effect.void,
 });
@@ -628,6 +629,7 @@ describe("Stack", () => {
     const released = new Set<PortField>();
     const lease: PortLease = {
       ports: defaultPorts,
+      reserve: () => Effect.void,
       release: (fields) =>
         Effect.sync(() => {
           for (const field of fields) released.add(field);

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -520,7 +520,8 @@ describe("Stack", () => {
               )
             : Effect.void,
       });
-      const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, spawner);
+      const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+      const { coordinatorLayer } = setupLayer(config, noopPortLease(config.ports), spawner);
 
       yield* Effect.gen(function* () {
         const coordinator = yield* StackLifecycleCoordinator;

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -5,7 +5,7 @@ import { Deferred, Effect, Exit, Fiber, Layer, Stream } from "effect";
 import { mockChildProcessSpawner } from "../../process-compose/tests/helpers/mocks.ts";
 import { mockBinaryResolver } from "../tests/helpers/mocks.ts";
 import { defaultPublishableKey, defaultSecretKey, generateJwt } from "./JwtGenerator.ts";
-import type { AllocatedPorts } from "./PortAllocator.ts";
+import type { AllocatedPorts, PortField, PortLease } from "./PortAllocator.ts";
 import { Stack } from "./Stack.ts";
 import { StackLifecycleCoordinator } from "./StackLifecycleCoordinator.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
@@ -100,13 +100,20 @@ const edgeRuntimeConfig: ResolvedStackConfig = {
   },
 };
 
+const noopPortLease = (ports: AllocatedPorts): PortLease => ({
+  ports,
+  release: () => Effect.void,
+  releaseAll: Effect.void,
+});
+
 function setupLayer(
   config: ResolvedStackConfig = defaultConfig,
+  portLease: PortLease = noopPortLease(config.ports),
   spawner = mockChildProcessSpawner(),
 ) {
   const resolver = mockBinaryResolver();
   const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
@@ -297,7 +304,10 @@ describe("Stack", () => {
     });
     const spawner = mockChildProcessSpawner();
     const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-    const coordinatorLayer = StackLifecycleCoordinator.layer(defaultConfig).pipe(
+    const coordinatorLayer = StackLifecycleCoordinator.layer(
+      defaultConfig,
+      noopPortLease(defaultConfig.ports),
+    ).pipe(
       Layer.provide(StackBuilder.layer),
       Layer.provide(stackPreparationLayer),
       Layer.provide(StackMetadataPersistence.noop),
@@ -379,7 +389,10 @@ describe("Stack", () => {
     const resolver = mockBinaryResolver({ failServices: ["postgres", "postgrest", "auth"] });
     const spawner = mockChildProcessSpawner({ exitCode: 1 });
     const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-    const coordinatorLayer = StackLifecycleCoordinator.layer(defaultConfig).pipe(
+    const coordinatorLayer = StackLifecycleCoordinator.layer(
+      defaultConfig,
+      noopPortLease(defaultConfig.ports),
+    ).pipe(
       Layer.provide(StackBuilder.layer),
       Layer.provide(stackPreparationLayer),
       Layer.provide(StackMetadataPersistence.noop),
@@ -468,7 +481,8 @@ describe("Stack", () => {
             ? Deferred.succeed(spawnStarted, undefined).pipe(Effect.andThen(Effect.never))
             : Effect.void,
       });
-      const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, spawner);
+      const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+      const { coordinatorLayer } = setupLayer(config, noopPortLease(config.ports), spawner);
 
       yield* Effect.gen(function* () {
         const coordinator = yield* StackLifecycleCoordinator;
@@ -578,7 +592,8 @@ describe("Stack", () => {
   });
 
   it.live("rejects a cached activation after the stack has stopped", () => {
-    const { coordinatorLayer } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
 
     return Effect.gen(function* () {
       const coordinator = yield* StackLifecycleCoordinator;
@@ -607,5 +622,37 @@ describe("Stack", () => {
       expect((yield* coordinator.getState("auth")).status).toBe("Pending");
       yield* coordinator.stop();
     }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("releases only the ports in a lazy service dependency closure", () => {
+    const released = new Set<PortField>();
+    const lease: PortLease = {
+      ports: defaultPorts,
+      release: (fields) =>
+        Effect.sync(() => {
+          for (const field of fields) released.add(field);
+        }),
+      releaseAll: Effect.void,
+    };
+    const { layer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, lease);
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.start();
+
+      expect(released.has("dbPort")).toBe(true);
+      expect(released.has("authPort")).toBe(false);
+      expect(released.has("postgrestPort")).toBe(false);
+
+      const startFiber = yield* stack
+        .startService("auth")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Effect.sleep("50 millis");
+      expect(released.has("authPort")).toBe(true);
+      expect(released.has("postgrestPort")).toBe(false);
+
+      yield* Fiber.interrupt(startFiber);
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
   });
 });

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -895,7 +895,13 @@ export class StackBuilder extends Context.Service<
                 config.analytics !== false ? `http://${serviceHost}:${config.analytics.port}` : "",
               analyticsApiKey: config.analytics !== false ? config.analytics.apiKey : "api-key",
               networkArgs: dockerNetworkArgs(platform.os, [config.studio.port]),
-              dependencies: [{ service: "pgmeta", condition: "healthy" }],
+              dependencies:
+                config.analytics === false
+                  ? [{ service: "pgmeta", condition: "healthy" }]
+                  : [
+                      { service: "pgmeta", condition: "healthy" },
+                      { service: "analytics", condition: "healthy" },
+                    ],
             }),
             enabled: true,
           });

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -19,11 +19,13 @@ import { cleanupLocalStackResources } from "./cleanup.ts";
 import { StackBuildError, StackNotRunningError } from "./errors.ts";
 import { configureFunctionsRuntime, type FunctionsConfig } from "./functions.ts";
 import { detectPlatform, dockerHostAddress } from "./Platform.ts";
+import type { PortLease } from "./PortAllocator.ts";
 import {
   activationTargetsForService,
   eagerServices,
   lifecycleTargetsForService,
 } from "./ServiceActivation.ts";
+import { portFieldsForService } from "./ServicePorts.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
 import { StackPreparation } from "./StackPreparation.ts";
 import type { PreparedStackArtifacts } from "./StackPreparation.ts";
@@ -187,6 +189,7 @@ export class StackLifecycleCoordinator extends Context.Service<
 >()("stack/StackLifecycleCoordinator") {
   static layer = (
     config: ResolvedStackConfig,
+    portLease: PortLease,
   ): Layer.Layer<
     StackLifecycleCoordinator,
     StackBuildError,
@@ -555,6 +558,9 @@ export class StackLifecycleCoordinator extends Context.Service<
             effect,
           );
         const withLifecycleLock = lifecycleLock.withPermit;
+        const serviceStartOptions = {
+          beforeSpawn: (name: string) => portLease.release(portFieldsForService(name)),
+        };
         const startServices = <E, R>(
           services: ReadonlyArray<ServiceName>,
           beforeStart: Effect.Effect<void, E, R>,
@@ -594,7 +600,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                 yield* Effect.forEach(
                   inactiveServices,
                   (service) =>
-                    runtime.orchestrator.startService(service).pipe(
+                    runtime.orchestrator.startService(service, serviceStartOptions).pipe(
                       Effect.mapError(
                         (cause) =>
                           new StackBuildError({
@@ -664,7 +670,10 @@ export class StackLifecycleCoordinator extends Context.Service<
                 runtimeState === undefined ? Effect.void : runtimeState.orchestrator.stop(),
               cleanupTargets: runtimeState?.cleanupTargets ?? { dockerContainerNames: [] },
               config,
-            }).pipe(Effect.ensuring(Ref.set(phaseRef, "stopped")));
+            }).pipe(
+              Effect.ensuring(portLease.releaseAll),
+              Effect.ensuring(Ref.set(phaseRef, "stopped")),
+            );
           }).pipe(withLifecycleLock);
 
         yield* Effect.addFinalizer(disposeOnce);
@@ -715,15 +724,17 @@ export class StackLifecycleCoordinator extends Context.Service<
                   runtime.graph.startOrder.some((definition) => definition.name === "postgres-init")
                 ) {
                   if (!postgresInitStartedByEagerService) {
-                    yield* runtime.orchestrator.startService("postgres-init").pipe(
-                      Effect.mapError(
-                        (cause) =>
-                          new StackBuildError({
-                            detail: "Prepared graph does not contain postgres-init",
-                            cause,
-                          }),
-                      ),
-                    );
+                    yield* runtime.orchestrator
+                      .startService("postgres-init", serviceStartOptions)
+                      .pipe(
+                        Effect.mapError(
+                          (cause) =>
+                            new StackBuildError({
+                              detail: "Prepared graph does not contain postgres-init",
+                              cause,
+                            }),
+                        ),
+                      );
                   }
                   yield* runtime.orchestrator.waitReady("postgres-init").pipe(
                     Effect.catchTag("ServiceNotFoundError", (cause) =>
@@ -740,7 +751,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                 for (const service of enabledServices) {
                   activatedServices.add(service);
                 }
-                yield* runtime.orchestrator.start();
+                yield* runtime.orchestrator.start(serviceStartOptions);
                 yield* runtime.orchestrator.waitAllReady();
               }
               yield* Ref.set(phaseRef, "running");
@@ -866,7 +877,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                     restartIntents.delete(target);
                   }
                   for (const root of restartRoots) {
-                    yield* runtime.orchestrator.restartService(root);
+                    yield* runtime.orchestrator.restartService(root, serviceStartOptions);
                   }
                   yield* Effect.forEach(
                     restoreTargets,
@@ -895,7 +906,7 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* withActivationLocks(
                 ["edge-runtime"],
                 runtime.orchestrator
-                  .restartService("edge-runtime")
+                  .restartService("edge-runtime", serviceStartOptions)
                   .pipe(Effect.andThen(runtime.orchestrator.waitReady("edge-runtime"))),
               );
             }).pipe(withLifecycleLock),
@@ -938,7 +949,9 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* withActivationLocks(
                 ["edge-runtime"],
                 updateDefinition.pipe(
-                  Effect.andThen(runtime.orchestrator.restartService("edge-runtime")),
+                  Effect.andThen(
+                    runtime.orchestrator.restartService("edge-runtime", serviceStartOptions),
+                  ),
                   Effect.andThen(runtime.orchestrator.waitReady("edge-runtime")),
                 ),
               );

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -559,6 +559,7 @@ export class StackLifecycleCoordinator extends Context.Service<
           );
         const withLifecycleLock = lifecycleLock.withPermit;
         const serviceStartOptions = {
+          beforeStart: (name: string) => portLease.reserve(portFieldsForService(name)),
           beforeSpawn: (name: string) => portLease.release(portFieldsForService(name)),
         };
         const startServices = <E, R>(

--- a/packages/stack/src/bun.ts
+++ b/packages/stack/src/bun.ts
@@ -43,10 +43,10 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
 // ---------------------------------------------------------------------------
 
 /** Bun platform factory for use with foregroundLayer / daemonLayer. */
-export const platformFactory: PlatformFactory = (apiPort) =>
+export const platformFactory: PlatformFactory = ({ apiPort, releaseApiPort }) =>
   Layer.mergeAll(
     BunServices.layer,
-    BunHttpServer.layer({ port: apiPort }),
+    Layer.unwrap(releaseApiPort.pipe(Effect.as(BunHttpServer.layer({ port: apiPort })))),
     proxyWebSocketConnectorLayer,
   );
 

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -689,7 +689,7 @@ export const projectDaemonLayer = (opts: {
   FileSystem.FileSystem | Path.Path | UnixHttpClient
 > =>
   Effect.acquireUseRelease(
-    Effect.promise(() => acquireManagedPortLock()),
+    Effect.promise((signal) => acquireManagedPortLock(undefined, signal)),
     () =>
       Effect.gen(function* () {
         const config = yield* Effect.promise(() =>

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -733,24 +733,26 @@ export async function createStack(
   let resolved: ResolvedStackConfig;
   const releasePortLock = await acquireManagedPortLock();
   try {
-    resolved = await resolveConfig(config, {
-      portAllocator: (input, options) =>
-        reservePorts(input, options).pipe(
-          Effect.tap((lease) =>
-            Effect.sync(() => {
-              portLease = lease;
-            }),
+    try {
+      resolved = await resolveConfig(config, {
+        portAllocator: (input, options) =>
+          reservePorts(input, options).pipe(
+            Effect.tap((lease) =>
+              Effect.sync(() => {
+                portLease = lease;
+              }),
+            ),
+            Effect.map((lease) => lease.ports),
           ),
-          Effect.map((lease) => lease.ports),
-        ),
-    });
+      });
+    } finally {
+      await releasePortLock();
+    }
   } catch (error: unknown) {
     if (portLease !== undefined) {
       await Effect.runPromise(portLease.releaseAll);
     }
     throw error;
-  } finally {
-    await releasePortLock();
   }
 
   if (portLease === undefined) {

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -16,6 +16,7 @@ import {
   defaultSecretKey,
   generateJwt,
 } from "./JwtGenerator.ts";
+import { acquireManagedPortLock } from "./ManagedPortLock.ts";
 import {
   daemonLayer,
   foregroundLayer,
@@ -30,7 +31,18 @@ import {
   defaultManagedStackRoot,
   shortTempPrefixRoot,
 } from "./paths.ts";
-import { allocatePorts, DEFAULT_PORTS, PORT_FIELDS, type AllocatedPorts } from "./PortAllocator.ts";
+import {
+  allocatePorts,
+  DEFAULT_PORTS,
+  PORT_FIELDS,
+  reservePorts,
+  type AllocatedPorts,
+  type PortInput,
+  type PortAllocationError,
+  type PortLease,
+  type PortSelectionOptions,
+} from "./PortAllocator.ts";
+import { allocatedPortFieldsForConfig } from "./ServicePorts.ts";
 import { StackMetadataSchema } from "./StackMetadata.ts";
 import { InvalidStackStateError, StackAlreadyRunningError } from "./StateManager.ts";
 import { Stack } from "./Stack.ts";
@@ -84,7 +96,12 @@ export type PlatformLayer = Layer.Layer<PlatformServices>;
  * Custom factories can implement the connector via the exported
  * `ProxyWebSocketConnector` service from `@supabase/stack/effect`.
  */
-export type PlatformFactory = (apiPort: number) => PlatformLayer;
+export interface PlatformFactoryOptions {
+  readonly apiPort: number;
+  readonly releaseApiPort: Effect.Effect<void>;
+}
+
+export type PlatformFactory = (options: PlatformFactoryOptions) => PlatformLayer;
 
 export interface ReadyOptions {
   readonly timeout?: number;
@@ -122,6 +139,10 @@ interface ResolveConfigOptions {
   readonly runtimeRoot?: string;
   readonly preferredPorts?: Partial<AllocatedPorts>;
   readonly reservedPorts?: ReadonlySet<number>;
+  readonly portAllocator?: (
+    input: PortInput,
+    options: PortSelectionOptions,
+  ) => Effect.Effect<AllocatedPorts, PortAllocationError>;
 }
 
 interface ResolvedRoots {
@@ -512,7 +533,7 @@ export async function resolveConfig(
   const postgresDataDir = resolveDataDir(postgresInput.dataDir, roots.stackRoot, "postgres");
 
   const ports = await Effect.runPromise(
-    allocatePorts(
+    (opts.portAllocator ?? allocatePorts)(
       {
         apiPort: config.port,
         dbPort: postgresInput.port,
@@ -667,19 +688,24 @@ export const projectDaemonLayer = (opts: {
   DaemonStartError | InvalidStackStateError | StackAlreadyRunningError,
   FileSystem.FileSystem | Path.Path | UnixHttpClient
 > =>
-  Effect.gen(function* () {
-    const config = yield* Effect.promise(() =>
-      resolveDaemonConfig({
-        cacheRoot: opts.cacheRoot,
-        cwd: opts.cwd,
-        projectDir: opts.projectDir,
-        projectStateRoot: opts.projectStateRoot,
-        name: opts.name,
-        ...opts.stackConfig,
+  Effect.acquireUseRelease(
+    Effect.promise(() => acquireManagedPortLock()),
+    () =>
+      Effect.gen(function* () {
+        const config = yield* Effect.promise(() =>
+          resolveDaemonConfig({
+            cacheRoot: opts.cacheRoot,
+            cwd: opts.cwd,
+            projectDir: opts.projectDir,
+            projectStateRoot: opts.projectStateRoot,
+            name: opts.name,
+            ...opts.stackConfig,
+          }),
+        );
+        return yield* daemonLayer(config, opts.daemonEntryPoint);
       }),
-    );
-    return yield* daemonLayer(config, opts.daemonEntryPoint);
-  });
+    (release) => Effect.promise(release),
+  );
 
 function possibleCleanupTargetsForConfig(config: ResolvedStackConfig): CleanupTargets {
   const dockerContainerNames = [`supabase-postgres-${config.apiPort}`];
@@ -703,67 +729,103 @@ export async function createStack(
   config: StackConfig | undefined,
   platformFactory: PlatformFactory,
 ): Promise<StackHandle> {
-  const resolved = await resolveConfig(config);
-  const fullLayer = foregroundLayer(resolved, platformFactory);
-  const runtime = ManagedRuntime.make(fullLayer);
+  let portLease: PortLease | undefined;
+  let resolved: ResolvedStackConfig;
+  const releasePortLock = await acquireManagedPortLock();
+  try {
+    resolved = await resolveConfig(config, {
+      portAllocator: (input, options) =>
+        reservePorts(input, options).pipe(
+          Effect.tap((lease) =>
+            Effect.sync(() => {
+              portLease = lease;
+            }),
+          ),
+          Effect.map((lease) => lease.ports),
+        ),
+    });
+  } catch (error: unknown) {
+    if (portLease !== undefined) {
+      await Effect.runPromise(portLease.releaseAll);
+    }
+    throw error;
+  } finally {
+    await releasePortLock();
+  }
+
+  if (portLease === undefined) {
+    throw new Error("Stack port allocation completed without a port lease");
+  }
+
+  const activeFields = new Set(allocatedPortFieldsForConfig(resolved));
+  const unusedFields = PORT_FIELDS.filter((field) => !activeFields.has(field));
+  await Effect.runPromise(portLease.release(unusedFields));
 
   try {
-    const services = await runtime.context();
-    const localStack = await runtime.runPromise(
-      Effect.gen(function* () {
-        return yield* Stack;
-      }),
-    );
-    const info = await runtime.runPromise(localStack.getInfo());
+    const fullLayer = foregroundLayer(resolved, platformFactory, portLease);
+    const runtime = ManagedRuntime.make(fullLayer);
 
-    const run = <A>(effect: Effect.Effect<A, unknown>) =>
-      runtime.runPromise(effect).catch((error: unknown) => {
-        throw toStackError(error);
-      });
+    try {
+      const services = await runtime.context();
+      const localStack = await runtime.runPromise(
+        Effect.gen(function* () {
+          return yield* Stack;
+        }),
+      );
+      const info = await runtime.runPromise(localStack.getInfo());
 
-    const gracefulDispose = async () => {
+      const run = <A>(effect: Effect.Effect<A, unknown>) =>
+        runtime.runPromise(effect).catch((error: unknown) => {
+          throw toStackError(error);
+        });
+
+      const gracefulDispose = async () => {
+        await runtime.dispose().catch(() => {});
+      };
+
+      const stack: StackHandle = {
+        url: info.url,
+        dbUrl: info.dbUrl,
+        publishableKey: info.publishableKey,
+        secretKey: info.secretKey,
+        start: () => run(localStack.start()),
+        stop: () => run(localStack.stop()),
+        dispose: gracefulDispose,
+        startService: (name) => run(localStack.startService(name)),
+        stopService: (name) => run(localStack.stopService(name)),
+        restartService: (name) => run(localStack.restartService(name)),
+        reloadFunctions: (opts) => run(localStack.reloadFunctions(opts)),
+        reloadEdgeRuntime: (opts) => run(localStack.reloadEdgeRuntime(opts)),
+        ready: (opts) => {
+          const effect =
+            opts?.timeout != null
+              ? localStack.waitAllReady().pipe(Effect.timeout(Duration.millis(opts.timeout)))
+              : localStack.waitAllReady();
+          return run(effect);
+        },
+        serviceReady: (name, opts) => {
+          const effect =
+            opts?.timeout != null
+              ? localStack.waitReady(name).pipe(Effect.timeout(Duration.millis(opts.timeout)))
+              : localStack.waitReady(name);
+          return run(effect);
+        },
+        getStatus: () => run(localStack.getAllStates()),
+        getServiceStatus: (name) => run(localStack.getState(name)),
+        statusChanges: () => Stream.toAsyncIterableWith(localStack.allStateChanges(), services),
+        logs: () => Stream.toAsyncIterableWith(localStack.subscribeAllLogs(), services),
+        serviceLogs: (name) => Stream.toAsyncIterableWith(localStack.subscribeLogs(name), services),
+        logHistory: (name, limit) => run(localStack.logHistory(name, limit)),
+        [Symbol.asyncDispose]: gracefulDispose,
+      };
+
+      return stack;
+    } catch (error: unknown) {
       await runtime.dispose().catch(() => {});
-    };
-
-    const stack: StackHandle = {
-      url: info.url,
-      dbUrl: info.dbUrl,
-      publishableKey: info.publishableKey,
-      secretKey: info.secretKey,
-      start: () => run(localStack.start()),
-      stop: () => run(localStack.stop()),
-      dispose: gracefulDispose,
-      startService: (name) => run(localStack.startService(name)),
-      stopService: (name) => run(localStack.stopService(name)),
-      restartService: (name) => run(localStack.restartService(name)),
-      reloadFunctions: (opts) => run(localStack.reloadFunctions(opts)),
-      reloadEdgeRuntime: (opts) => run(localStack.reloadEdgeRuntime(opts)),
-      ready: (opts) => {
-        const effect =
-          opts?.timeout != null
-            ? localStack.waitAllReady().pipe(Effect.timeout(Duration.millis(opts.timeout)))
-            : localStack.waitAllReady();
-        return run(effect);
-      },
-      serviceReady: (name, opts) => {
-        const effect =
-          opts?.timeout != null
-            ? localStack.waitReady(name).pipe(Effect.timeout(Duration.millis(opts.timeout)))
-            : localStack.waitReady(name);
-        return run(effect);
-      },
-      getStatus: () => run(localStack.getAllStates()),
-      getServiceStatus: (name) => run(localStack.getState(name)),
-      statusChanges: () => Stream.toAsyncIterableWith(localStack.allStateChanges(), services),
-      logs: () => Stream.toAsyncIterableWith(localStack.subscribeAllLogs(), services),
-      serviceLogs: (name) => Stream.toAsyncIterableWith(localStack.subscribeLogs(name), services),
-      logHistory: (name, limit) => run(localStack.logHistory(name, limit)),
-      [Symbol.asyncDispose]: gracefulDispose,
-    };
-
-    return stack;
+      throw error;
+    }
   } catch (error: unknown) {
-    await runtime.dispose().catch(() => {});
+    await Effect.runPromise(portLease.releaseAll);
     dockerForceRemove(possibleCleanupTargetsForConfig(resolved).dockerContainerNames);
     cleanupAutoManagedPaths(resolved);
     throw toStackError(error);

--- a/packages/stack/src/daemon-bun.ts
+++ b/packages/stack/src/daemon-bun.ts
@@ -1,15 +1,15 @@
 import { BunServices } from "@effect/platform-bun";
 import * as BunHttpServer from "@effect/platform-bun/BunHttpServer";
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import { runDaemon } from "./daemon.ts";
 import { proxyWebSocketConnectorLayer } from "./ProxyWebSocket.bun.ts";
 
 export function runBunDaemon(): void {
   runDaemon(
-    (apiPort) =>
+    ({ apiPort, releaseApiPort }) =>
       Layer.mergeAll(
         BunServices.layer,
-        BunHttpServer.layer({ port: apiPort }),
+        Layer.unwrap(releaseApiPort.pipe(Effect.as(BunHttpServer.layer({ port: apiPort })))),
         proxyWebSocketConnectorLayer,
       ),
     (socketPath) => BunHttpServer.layer({ idleTimeout: 0, unix: socketPath }),

--- a/packages/stack/src/daemon-node.ts
+++ b/packages/stack/src/daemon-node.ts
@@ -1,15 +1,21 @@
 import { NodeServices } from "@effect/platform-node";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { createServer } from "node:http";
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import { runDaemon } from "./daemon.ts";
 import { proxyWebSocketConnectorLayer } from "./ProxyWebSocket.node.ts";
 
 runDaemon(
-  (apiPort) =>
+  ({ apiPort, releaseApiPort }) =>
     Layer.mergeAll(
       NodeServices.layer,
-      NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+      Layer.unwrap(
+        releaseApiPort.pipe(
+          Effect.as(
+            NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+          ),
+        ),
+      ),
       proxyWebSocketConnectorLayer,
     ),
   (socketPath) =>

--- a/packages/stack/src/daemon.ts
+++ b/packages/stack/src/daemon.ts
@@ -2,6 +2,8 @@ import { Effect, Layer, ManagedRuntime } from "effect";
 import { HttpServer } from "effect/unstable/http";
 import type { PlatformFactory } from "./createStack.ts";
 import { DaemonServer } from "./DaemonServer.ts";
+import { reserveAllocatedPorts, type PortLease } from "./PortAllocator.ts";
+import { allocatedPortFieldsForConfig } from "./ServicePorts.ts";
 import { runningServiceVersionsForConfig } from "./StackMetadata.ts";
 import { foregroundDaemonLayer } from "./layers.ts";
 import { Stack } from "./Stack.ts";
@@ -50,10 +52,19 @@ export async function runDaemon(
   let daemonRuntime: ManagedRuntime.ManagedRuntime<DaemonServer, never> | undefined;
   let stateManager: StateManagerService | undefined;
   let daemonState: StackState | undefined;
+  let portLease: PortLease | undefined;
 
   try {
+    portLease = await Effect.runPromise(
+      reserveAllocatedPorts(config.ports, allocatedPortFieldsForConfig(config)),
+    );
+
     // Build the app layer (Stack + ApiProxy)
-    const appLayer = foregroundDaemonLayer({ ...config, name, projectDir }, platformFactory);
+    const appLayer = foregroundDaemonLayer(
+      { ...config, name, projectDir },
+      platformFactory,
+      portLease,
+    );
 
     appRuntime = ManagedRuntime.make(appLayer);
 
@@ -109,6 +120,9 @@ export async function runDaemon(
     };
     process.send?.(errorMsg);
     await shutdownDaemon({ appRuntime, daemonRuntime, stateManager, daemonState });
+    if (portLease !== undefined) {
+      await Effect.runPromise(portLease.releaseAll);
+    }
     process.exit(1);
   }
 }

--- a/packages/stack/src/effect.ts
+++ b/packages/stack/src/effect.ts
@@ -41,12 +41,20 @@ export {
   JwtGenerator,
 } from "./JwtGenerator.ts";
 
-export type { AllocatedPorts, PortInput } from "./PortAllocator.ts";
+export type {
+  AllocatedPorts,
+  PortField,
+  PortInput,
+  PortLease,
+  PortSelectionOptions,
+} from "./PortAllocator.ts";
 export {
   allocatePorts,
   DEFAULT_API_PORT,
   DEFAULT_DB_PORT,
   PortAllocationError,
+  reserveAllocatedPorts,
+  reservePorts,
 } from "./PortAllocator.ts";
 
 export type { ProxyConfig } from "./ApiProxy.ts";
@@ -156,6 +164,7 @@ export { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
 
 export type {
   PlatformFactory,
+  PlatformFactoryOptions,
   PlatformLayer,
   PlatformServices,
   ReadyOptions,

--- a/packages/stack/src/layers.ts
+++ b/packages/stack/src/layers.ts
@@ -6,6 +6,7 @@ import { ApiProxy, type ProxyConfig } from "./ApiProxy.ts";
 import { BinaryResolver } from "./BinaryResolver.ts";
 import type { PlatformFactory } from "./createStack.ts";
 import type { DaemonMessage, DaemonStartMessage } from "./daemon.ts";
+import type { PortLease } from "./PortAllocator.ts";
 import { RemoteStack } from "./RemoteStack.ts";
 import { StackServiceActivator } from "./ServiceActivation.ts";
 import { Stack } from "./Stack.ts";
@@ -34,14 +35,18 @@ import { terminateChildProcess } from "./terminateChild.ts";
 export const foregroundLayer = (
   config: ResolvedStackConfig,
   platformFactory: PlatformFactory,
+  portLease: PortLease,
 ): Layer.Layer<Stack> => {
-  const platform = platformFactory(config.apiPort);
+  const platform = platformFactory({
+    apiPort: config.apiPort,
+    releaseApiPort: portLease.release(["apiPort"]),
+  });
 
   const binaryResolverLayer = BinaryResolver.make(config.cacheRoot).pipe(
     Layer.provide(FetchHttpClient.layer),
   );
   const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(binaryResolverLayer));
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
@@ -104,8 +109,12 @@ export interface DaemonConfig extends ResolvedStackConfig {
 export const foregroundDaemonLayer = (
   config: DaemonConfig,
   platformFactory: PlatformFactory,
+  portLease: PortLease,
 ): Layer.Layer<Stack | StateManager> => {
-  const platform = platformFactory(config.apiPort);
+  const platform = platformFactory({
+    apiPort: config.apiPort,
+    releaseApiPort: portLease.release(["apiPort"]),
+  });
 
   const binaryResolverLayer = BinaryResolver.make(config.cacheRoot).pipe(
     Layer.provide(FetchHttpClient.layer),
@@ -145,7 +154,7 @@ export const foregroundDaemonLayer = (
   const metadataPersistenceLayer = StackMetadataPersistence.fromStateManager(config.name).pipe(
     Layer.provide(stateManagerLayer),
   );
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(metadataPersistenceLayer),

--- a/packages/stack/src/node.ts
+++ b/packages/stack/src/node.ts
@@ -119,10 +119,14 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
 // ---------------------------------------------------------------------------
 
 /** Node platform factory for use with foregroundLayer / daemonLayer. */
-export const platformFactory: PlatformFactory = (apiPort) =>
+export const platformFactory: PlatformFactory = ({ apiPort, releaseApiPort }) =>
   Layer.mergeAll(
     NodeServices.layer,
-    NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+    Layer.unwrap(
+      releaseApiPort.pipe(
+        Effect.as(NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie)),
+      ),
+    ),
     proxyWebSocketConnectorLayer,
   );
 


### PR DESCRIPTION
Stack layer 5 of 7, based on #6044.

Closes the lazy-start port race by replacing probe-only allocation with real OS leases:

- holds selected ports until the owning proxy or service is ready to bind
- releases only the process-graph dependency closure being started
- reserves daemon-selected ports with the same lifecycle
- cleans up partial allocations and all remaining listeners on disposal
- covers concurrent stack allocation and lease retention