### PR TITLE
fix(stack): preserve lazy lifecycle in detached mode

### DIFF
--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -203,7 +203,10 @@ await stack.serviceReady("postgres"); // Wait for one service
 await stack.serviceReady("auth", { timeout: 10_000 });
 ```
 
-Note: `start()` already blocks until all services are ready. Use `ready()` and `serviceReady()` after manually starting individual services.
+In eager mode, `start()` blocks until every enabled service is ready. In lazy mode it waits only
+for direct listeners and services activated so far. Calling `serviceReady()` for a dormant lazy
+service fails immediately; activate it through the proxy or call `startService()` first. Foreground
+and detached stacks use the same readiness rules.
 
 ### Status
 

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -815,6 +815,15 @@ for services with direct endpoints. Each HTTP proxy route activates its target s
 forwards the request, and concurrent activation remains single-flight in the orchestrator. Proxy
 requests made before startup or after shutdown receive `503 Service Unavailable`. `waitAllReady()`
 waits for the set of services activated so far instead of blocking on intentionally dormant ones.
+Activation records the process graph's actual dependency closure, so readiness includes implicitly
+started public dependencies as well as the requested service. Readiness is only valid while the
+stack is running, and waiting for an unactivated lazy service fails immediately with a typed build
+error. Activation state is cleared across stop/start cycles.
+
+Detached mode preserves these semantics instead of reconstructing readiness from status snapshots.
+The daemon exposes `/ready` and `/services/:name/ready`, both of which delegate to the lifecycle
+coordinator. Typed error discriminants preserve service-not-found, service-readiness, and stack-build
+failures across the HTTP boundary.
 
 Realtime WebSocket upgrades use the same activation boundary. The proxy rewrites the public
 `/realtime/v1/websocket` path to Realtime's `/socket/websocket` endpoint, translates opaque API

--- a/packages/stack/docs/detach-mode.md
+++ b/packages/stack/docs/detach-mode.md
@@ -201,8 +201,8 @@ wait healthy`, so detached mode exposes the same pre-runtime status behavior as 
 | `getState(name)`           | `GET /status` → `Effect` (filter by name)                      |
 | `allStateChanges()`        | `GET /status/stream` (SSE → `Stream`, including `Downloading`) |
 | `stateChanges(name)`       | `GET /status/stream` (SSE → `Stream`, filter by name)          |
-| `waitReady(name)`          | `GET /status/stream` (SSE → `Stream`, take until ready)        |
-| `waitAllReady()`           | `GET /status/stream` (SSE → `Stream`, take until all ready)    |
+| `waitReady(name)`          | `GET /services/:name/ready` → `Effect`                         |
+| `waitAllReady()`           | `GET /ready` → `Effect`                                        |
 | `subscribeAllLogs()`       | `GET /logs` (SSE → `Stream`)                                   |
 | `subscribeLogs(name)`      | `GET /logs/:name` (SSE → `Stream`)                             |
 | `logHistory(name, limit?)` | `GET /logs/:name/history?limit=N` → `Effect`                   |
@@ -250,8 +250,9 @@ runtime-dispatch rationale.
 
 Parent and child send JSON messages via `process.send()` / `process.on("message")`.
 
-This channel is only used for the initial startup handshake — once the daemon confirms
-it's ready (or reports an error), the CLI disconnects the channel. All subsequent
+This channel is only used for the initial startup handshake. The parent validates the response and
+applies a bounded startup timeout. Once the daemon confirms it's ready (or reports an error), the
+CLI disconnects the channel. All subsequent
 communication (stop, status, logs) happens over the Unix socket HTTP API instead.
 
 ```
@@ -285,12 +286,18 @@ and the CLI displays the error and exits with a non-zero code.
 | Endpoint                 | Method | Description                                                                         |
 | ------------------------ | ------ | ----------------------------------------------------------------------------------- |
 | `/health`                | GET    | Liveness check (200 OK)                                                             |
+| `/ready`                 | GET    | Wait for all activated services using foreground lifecycle semantics                |
 | `/status`                | GET    | All service states + connection info (JSON)                                         |
 | `/status/stream`         | GET    | SSE stream of all service state changes, including `Downloading` during preparation |
 | `/stop`                  | POST   | Graceful shutdown → dispose + exit                                                  |
+| `/services/:name/ready`  | GET    | Wait for one activated service                                                      |
 | `/logs`                  | GET    | SSE stream of all logs                                                              |
 | `/logs/:service`         | GET    | SSE stream for one service                                                          |
 | `/logs/:service/history` | GET    | Recent log entries for one service (JSON, `?limit=N`)                               |
+
+Management errors include a stable discriminator. `RemoteStack` maps service-not-found,
+service-readiness, and stack-build responses back to the same typed failures exposed by a
+foreground stack.
 
 ### `supabase` — New/modified commands
 

--- a/packages/stack/src/DaemonProtocol.ts
+++ b/packages/stack/src/DaemonProtocol.ts
@@ -1,0 +1,22 @@
+import { Schema } from "effect";
+import { StackStateSchema } from "./StateManager.ts";
+
+const DaemonErrorCodeSchema = Schema.Literals([
+  "SERVICE_NOT_FOUND",
+  "SERVICE_NOT_READY",
+  "STACK_BUILD_ERROR",
+]);
+
+export const DaemonErrorResponseSchema = Schema.Struct({
+  code: DaemonErrorCodeSchema,
+  error: Schema.String,
+  service: Schema.optionalKey(Schema.String),
+  exitCode: Schema.optionalKey(Schema.Number),
+});
+
+export type DaemonErrorResponse = typeof DaemonErrorResponseSchema.Type;
+
+export const DaemonMessageSchema = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("started"), state: StackStateSchema }),
+  Schema.Struct({ type: Schema.Literal("error"), message: Schema.String }),
+]);

--- a/packages/stack/src/DaemonServer.integration.test.ts
+++ b/packages/stack/src/DaemonServer.integration.test.ts
@@ -396,4 +396,19 @@ describe("DaemonServer", () => {
       await freshRuntime.dispose();
     }
   });
+
+  test("POST /stop resolves awaitShutdown when cleanup defects", async () => {
+    const freshRuntime = ManagedRuntime.make(
+      buildDaemonLayer(mockStack(), Effect.die("state cleanup failed")),
+    );
+    try {
+      const daemon = await freshRuntime.runPromise(DaemonServer);
+      const shutdownPromise = freshRuntime.runPromise(daemon.awaitShutdown);
+
+      await fetch(`${getUrl(daemon.address)}/stop`, { method: "POST" });
+      await shutdownPromise;
+    } finally {
+      await freshRuntime.dispose();
+    }
+  });
 });

--- a/packages/stack/src/DaemonServer.integration.test.ts
+++ b/packages/stack/src/DaemonServer.integration.test.ts
@@ -131,8 +131,9 @@ function mockStack() {
 
 function buildDaemonLayer(
   mock: ReturnType<typeof mockStack>,
+  beforeShutdown: Effect.Effect<void> = Effect.void,
 ): Layer.Layer<DaemonServer, never, never> {
-  return DaemonServer.layer.pipe(
+  return DaemonServer.layerWithShutdown(beforeShutdown).pipe(
     Layer.provide(mock.layer),
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
   ) as Layer.Layer<DaemonServer, never, never>;
@@ -351,6 +352,28 @@ describe("DaemonServer", () => {
     const body = (await res.json()) as { ok: boolean };
     expect(body.ok).toBe(true);
     expect(mock.stopped).toBe(true);
+  });
+
+  test("POST /stop unregisters the daemon before responding", async () => {
+    const freshMock = mockStack();
+    let registered = true;
+    const freshRuntime = ManagedRuntime.make(
+      buildDaemonLayer(
+        freshMock,
+        Effect.sync(() => {
+          registered = false;
+        }),
+      ),
+    );
+    try {
+      const daemon = await freshRuntime.runPromise(DaemonServer);
+      const res = await fetch(`${getUrl(daemon.address)}/stop`, { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(registered).toBe(false);
+    } finally {
+      await freshRuntime.dispose();
+    }
   });
 
   test("POST /stop resolves awaitShutdown", async () => {

--- a/packages/stack/src/DaemonServer.ts
+++ b/packages/stack/src/DaemonServer.ts
@@ -7,6 +7,7 @@ import {
   HttpServerResponse,
 } from "effect/unstable/http";
 import * as Sse from "effect/unstable/encoding/Sse";
+import type { DaemonErrorResponse } from "./DaemonProtocol.ts";
 import { EdgeRuntimeReloadConfigSchema, Stack } from "./Stack.ts";
 
 // ---------------------------------------------------------------------------
@@ -20,253 +21,313 @@ export class DaemonServer extends Context.Service<
     readonly awaitShutdown: Effect.Effect<void>;
   }
 >()("stack/DaemonServer") {
-  static layer: Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> = Layer.effect(
-    this,
-    Effect.gen(function* () {
-      const stack = yield* Stack;
-      const server = yield* HttpServer.HttpServer;
-      const shutdownDeferred = yield* Deferred.make<void>();
-      const textEncoder = new TextEncoder();
+  static layerWithShutdown = (
+    beforeShutdown: Effect.Effect<void> = Effect.void,
+  ): Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> =>
+    Layer.effect(
+      this,
+      Effect.gen(function* () {
+        const stack = yield* Stack;
+        const server = yield* HttpServer.HttpServer;
+        const shutdownDeferred = yield* Deferred.make<void>();
+        const textEncoder = new TextEncoder();
+        const errorResponse = (body: DaemonErrorResponse, status: 404 | 500) =>
+          HttpServerResponse.jsonUnsafe(body, { status });
+        const notFoundResponse = (name: string) =>
+          errorResponse(
+            { code: "SERVICE_NOT_FOUND", error: `Service not found: ${name}`, service: name },
+            404,
+          );
+        const notReadyResponse = (name: string, reason: string, exitCode?: number) =>
+          errorResponse(
+            {
+              code: "SERVICE_NOT_READY",
+              error: reason,
+              service: name,
+              ...(exitCode === undefined ? {} : { exitCode }),
+            },
+            500,
+          );
+        const buildErrorResponse = (detail: string) =>
+          errorResponse({ code: "STACK_BUILD_ERROR", error: detail }, 500);
 
-      // Helper: wrap an Effect Stream as a text/event-stream response
-      const sseResponse = <A>(
-        stream: Stream.Stream<A>,
-        event: string,
-        toData: (a: A) => string,
-      ): HttpServerResponse.HttpServerResponse =>
-        HttpServerResponse.stream(
-          stream.pipe(
-            Stream.map((a) =>
-              textEncoder.encode(
-                Sse.encoder.write({ _tag: "Event", event, id: undefined, data: toData(a) }),
+        // Helper: wrap an Effect Stream as a text/event-stream response
+        const sseResponse = <A>(
+          stream: Stream.Stream<A>,
+          event: string,
+          toData: (a: A) => string,
+        ): HttpServerResponse.HttpServerResponse =>
+          HttpServerResponse.stream(
+            stream.pipe(
+              Stream.map((a) =>
+                textEncoder.encode(
+                  Sse.encoder.write({ _tag: "Event", event, id: undefined, data: toData(a) }),
+                ),
               ),
             ),
-          ),
-          {
-            status: 200,
-            contentType: "text/event-stream",
-            headers: Headers.fromInput({
-              "cache-control": "no-cache",
-              connection: "keep-alive",
+            {
+              status: 200,
+              contentType: "text/event-stream",
+              headers: Headers.fromInput({
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+              }),
+            },
+          );
+
+        const routes = [
+          // Health check
+          HttpRouter.route("GET", "/health", HttpServerResponse.text("OK", { status: 200 })),
+
+          // Status: connection info + all service states
+          HttpRouter.route(
+            "GET",
+            "/status",
+            Effect.gen(function* () {
+              const info = yield* stack.getInfo();
+              const services = yield* stack.getAllStates();
+              return HttpServerResponse.jsonUnsafe({ info, services });
             }),
-          },
-        );
-
-      const routes = [
-        // Health check
-        HttpRouter.route("GET", "/health", HttpServerResponse.text("OK", { status: 200 })),
-
-        // Status: connection info + all service states
-        HttpRouter.route(
-          "GET",
-          "/status",
-          Effect.gen(function* () {
-            const info = yield* stack.getInfo();
-            const services = yield* stack.getAllStates();
-            return HttpServerResponse.jsonUnsafe({ info, services });
-          }),
-        ),
-
-        // Status stream: SSE of service state changes
-        HttpRouter.route(
-          "GET",
-          "/status/stream",
-          Effect.sync(() =>
-            sseResponse(stack.allStateChanges(), "state", (s) => JSON.stringify(s)),
           ),
-        ),
 
-        // Start: begin service startup
-        HttpRouter.route(
-          "POST",
-          "/start",
-          Effect.gen(function* () {
-            yield* stack.start();
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }),
-        ),
+          // Status stream: SSE of service state changes
+          HttpRouter.route(
+            "GET",
+            "/status/stream",
+            Effect.sync(() =>
+              sseResponse(stack.allStateChanges(), "state", (s) => JSON.stringify(s)),
+            ),
+          ),
 
-        // Stop: graceful shutdown
-        HttpRouter.route(
-          "POST",
-          "/stop",
-          Effect.gen(function* () {
-            yield* stack.stop();
-            yield* Deferred.succeed(shutdownDeferred, void 0);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }),
-        ),
-
-        // Logs: SSE of all logs
-        HttpRouter.route(
-          "GET",
-          "/logs",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const services = parseServices(searchParams.service);
-            return sseResponse(stack.subscribeAllLogs(services), "log", (e) => JSON.stringify(e));
-          }),
-        ),
-
-        // Merged log history across all services
-        HttpRouter.route(
-          "GET",
-          "/logs/history",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const limit = parseLimit(searchParams.limit);
-            const services = parseServices(searchParams.service);
-            const entries = yield* stack.logHistoryAll(limit, services);
-            return HttpServerResponse.jsonUnsafe(entries);
-          }),
-        ),
-
-        // Log history for a service (registered before /logs/:service to avoid shadowing)
-        HttpRouter.route(
-          "GET",
-          "/logs/:service/history",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const service = parseSingleParam(routeParams.service)!;
-            const limit = parseLimit(searchParams.limit);
-            const entries = yield* stack.logHistory(service, limit);
-            return HttpServerResponse.jsonUnsafe(entries);
-          }),
-        ),
-
-        // Logs for a specific service: SSE
-        HttpRouter.route(
-          "GET",
-          "/logs/:service",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            const service = parseSingleParam(routeParams.service)!;
-            return sseResponse(stack.subscribeLogs(service), "log", (e) => JSON.stringify(e));
-          }),
-        ),
-
-        // Per-service control
-        HttpRouter.route(
-          "POST",
-          "/services/:name/start",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.startService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          // Start: begin service startup
+          HttpRouter.route(
+            "POST",
+            "/start",
+            Effect.gen(function* () {
+              yield* stack.start();
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
-            ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
-          ),
-        ),
-
-        HttpRouter.route(
-          "POST",
-          "/services/:name/stop",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.stopService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/services/:name/restart",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.restartService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          HttpRouter.route(
+            "GET",
+            "/ready",
+            stack.waitAllReady().pipe(
+              Effect.as(HttpServerResponse.jsonUnsafe({ ok: true })),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/functions/reload",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            yield* stack.reloadFunctions({
-              envFile: parseSingleParam(searchParams.envFile),
-              noVerifyJwt: parseBoolean(searchParams.noVerifyJwt),
-            });
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          // Stop: graceful shutdown
+          HttpRouter.route(
+            "POST",
+            "/stop",
+            Effect.gen(function* () {
+              yield* stack.stop();
+              yield* beforeShutdown;
+              yield* Deferred.succeed(shutdownDeferred, void 0).pipe(
+                Effect.delay("25 millis"),
+                Effect.forkDetach,
+              );
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }),
+          ),
+
+          // Logs: SSE of all logs
+          HttpRouter.route(
+            "GET",
+            "/logs",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const services = parseServices(searchParams.service);
+              return sseResponse(stack.subscribeAllLogs(services), "log", (e) => JSON.stringify(e));
+            }),
+          ),
+
+          // Merged log history across all services
+          HttpRouter.route(
+            "GET",
+            "/logs/history",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const limit = parseLimit(searchParams.limit);
+              const services = parseServices(searchParams.service);
+              const entries = yield* stack.logHistoryAll(limit, services);
+              return HttpServerResponse.jsonUnsafe(entries);
+            }),
+          ),
+
+          // Log history for a service (registered before /logs/:service to avoid shadowing)
+          HttpRouter.route(
+            "GET",
+            "/logs/:service/history",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const service = parseSingleParam(routeParams.service)!;
+              const limit = parseLimit(searchParams.limit);
+              const entries = yield* stack.logHistory(service, limit);
+              return HttpServerResponse.jsonUnsafe(entries);
+            }),
+          ),
+
+          // Logs for a specific service: SSE
+          HttpRouter.route(
+            "GET",
+            "/logs/:service",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              const service = parseSingleParam(routeParams.service)!;
+              return sseResponse(stack.subscribeLogs(service), "log", (e) => JSON.stringify(e));
+            }),
+          ),
+
+          // Per-service control
+          HttpRouter.route(
+            "POST",
+            "/services/:name/start",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.startService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/edge-runtime/reload",
-          Effect.gen(function* () {
-            const body = yield* HttpServerRequest.schemaBodyJson(EdgeRuntimeReloadConfigSchema);
-            yield* stack.reloadEdgeRuntime(body);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          HttpRouter.route(
+            "GET",
+            "/services/:name/ready",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.waitReady(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
-            Effect.catchTag("StackBuildError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.message }, { status: 500 })),
+          ),
+
+          HttpRouter.route(
+            "POST",
+            "/services/:name/stop",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.stopService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
             ),
           ),
-        ),
-      ];
 
-      const httpEffect = yield* HttpRouter.toHttpEffect(HttpRouter.addAll(routes));
-      yield* Effect.forkScoped(server.serve(httpEffect));
+          HttpRouter.route(
+            "POST",
+            "/services/:name/restart",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.restartService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
 
-      return {
-        address: server.address,
-        awaitShutdown: Deferred.await(shutdownDeferred),
-      };
-    }),
-  );
+          HttpRouter.route(
+            "POST",
+            "/functions/reload",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              yield* stack.reloadFunctions({
+                envFile: parseSingleParam(searchParams.envFile),
+                noVerifyJwt: parseBoolean(searchParams.noVerifyJwt),
+              });
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
+
+          HttpRouter.route(
+            "POST",
+            "/edge-runtime/reload",
+            Effect.gen(function* () {
+              const body = yield* HttpServerRequest.schemaBodyJson(EdgeRuntimeReloadConfigSchema);
+              yield* stack.reloadEdgeRuntime(body);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
+        ];
+
+        const httpEffect = yield* HttpRouter.toHttpEffect(HttpRouter.addAll(routes));
+        yield* Effect.forkScoped(server.serve(httpEffect));
+
+        return {
+          address: server.address,
+          awaitShutdown: Deferred.await(shutdownDeferred),
+        };
+      }),
+    );
+
+  static layer: Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> =
+    this.layerWithShutdown();
 }
 
 function parseLimit(value: string | ReadonlyArray<string> | undefined): number | undefined {

--- a/packages/stack/src/DaemonServer.ts
+++ b/packages/stack/src/DaemonServer.ts
@@ -136,10 +136,13 @@ export class DaemonServer extends Context.Service<
             "/stop",
             Effect.gen(function* () {
               yield* stack.stop();
-              yield* beforeShutdown;
-              yield* Deferred.succeed(shutdownDeferred, void 0).pipe(
-                Effect.delay("25 millis"),
-                Effect.forkDetach,
+              yield* beforeShutdown.pipe(
+                Effect.ensuring(
+                  Deferred.succeed(shutdownDeferred, void 0).pipe(
+                    Effect.delay("25 millis"),
+                    Effect.forkDetach,
+                  ),
+                ),
               );
               return HttpServerResponse.jsonUnsafe({ ok: true });
             }),

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -2,25 +2,19 @@ import { createHash, randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { constants, readFileSync } from "node:fs";
 import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
-import { tmpdir, uptime } from "node:os";
+import { homedir, tmpdir, uptime } from "node:os";
 import { dirname, join } from "node:path";
 
 const LOCK_STALE_AFTER_MS = 5_000;
 const LOCK_RETRY_AFTER_MS = 25;
-const CURRENT_UID = process.getuid?.();
 const SHARED_LOCK_ROOT = join(
   process.platform === "win32" ? tmpdir() : "/tmp",
   "supabase-stack-managed-port-locks",
 );
-const PRIVATE_LOCK_ROOT = join(
-  tmpdir(),
-  process.platform === "win32"
-    ? "supabase-stack-state-locks"
-    : `supabase-stack-state-locks-${CURRENT_UID ?? "user"}`,
-);
+const PRIVATE_LOCK_ROOT = join(homedir(), ".supabase", "stack-state-locks");
 const DEFAULT_LOCK_PATH = join(SHARED_LOCK_ROOT, "allocation.lock");
 
-/** Build a stable per-user lock path without exposing caller-controlled path segments. */
+/** Build a stable lock path below an already user-owned state root. */
 export const privateManagedLockPath = (scope: string): string =>
   join(PRIVATE_LOCK_ROOT, `${createHash("sha256").update(scope).digest("hex")}.lock`);
 
@@ -264,23 +258,7 @@ const prepareSharedLockRoot = async (signal?: AbortSignal): Promise<void> => {
 
 const preparePrivateLockRoot = async (): Promise<void> => {
   await mkdir(PRIVATE_LOCK_ROOT, { recursive: true, mode: 0o700 });
-  if (process.platform === "win32") return;
-
-  const handle = await open(
-    PRIVATE_LOCK_ROOT,
-    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
-  );
-  try {
-    const info = await handle.stat();
-    if (!info.isDirectory() || CURRENT_UID === undefined || info.uid !== CURRENT_UID) {
-      throw new Error(
-        `Private stack lock root is not owned by the current user: ${PRIVATE_LOCK_ROOT}`,
-      );
-    }
-    await handle.chmod(0o700);
-  } finally {
-    await handle.close();
-  }
+  if (process.platform !== "win32") await chmod(PRIVATE_LOCK_ROOT, 0o700);
 };
 
 export type ReleaseManagedPortLock = () => Promise<void>;

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { constants, readFileSync } from "node:fs";
 import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { tmpdir, uptime } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 const LOCK_STALE_AFTER_MS = 5_000;
 const LOCK_RETRY_AFTER_MS = 25;
@@ -12,6 +12,10 @@ const SHARED_LOCK_ROOT = join(
   "supabase-stack-managed-port-locks",
 );
 const DEFAULT_LOCK_PATH = join(SHARED_LOCK_ROOT, "allocation.lock");
+
+/** Build a stable, host-wide lock path without exposing caller-controlled path segments. */
+export const managedLockPath = (scope: string): string =>
+  join(SHARED_LOCK_ROOT, `${createHash("sha256").update(scope).digest("hex")}.lock`);
 
 interface LockOwner {
   readonly pid: number;
@@ -258,7 +262,7 @@ export async function acquireManagedPortLock(
   lockPath = DEFAULT_LOCK_PATH,
   signal?: AbortSignal,
 ): Promise<ReleaseManagedPortLock> {
-  if (lockPath === DEFAULT_LOCK_PATH) {
+  if (dirname(lockPath) === SHARED_LOCK_ROOT) {
     await prepareSharedLockRoot(signal);
   }
   for (;;) {

--- a/packages/stack/src/ManagedPortLock.ts
+++ b/packages/stack/src/ManagedPortLock.ts
@@ -7,15 +7,22 @@ import { dirname, join } from "node:path";
 
 const LOCK_STALE_AFTER_MS = 5_000;
 const LOCK_RETRY_AFTER_MS = 25;
+const CURRENT_UID = process.getuid?.();
 const SHARED_LOCK_ROOT = join(
   process.platform === "win32" ? tmpdir() : "/tmp",
   "supabase-stack-managed-port-locks",
 );
+const PRIVATE_LOCK_ROOT = join(
+  tmpdir(),
+  process.platform === "win32"
+    ? "supabase-stack-state-locks"
+    : `supabase-stack-state-locks-${CURRENT_UID ?? "user"}`,
+);
 const DEFAULT_LOCK_PATH = join(SHARED_LOCK_ROOT, "allocation.lock");
 
-/** Build a stable, host-wide lock path without exposing caller-controlled path segments. */
-export const managedLockPath = (scope: string): string =>
-  join(SHARED_LOCK_ROOT, `${createHash("sha256").update(scope).digest("hex")}.lock`);
+/** Build a stable per-user lock path without exposing caller-controlled path segments. */
+export const privateManagedLockPath = (scope: string): string =>
+  join(PRIVATE_LOCK_ROOT, `${createHash("sha256").update(scope).digest("hex")}.lock`);
 
 interface LockOwner {
   readonly pid: number;
@@ -255,6 +262,27 @@ const prepareSharedLockRoot = async (signal?: AbortSignal): Promise<void> => {
   throw new Error(`Shared managed-port lock directory is not writable: ${SHARED_LOCK_ROOT}`);
 };
 
+const preparePrivateLockRoot = async (): Promise<void> => {
+  await mkdir(PRIVATE_LOCK_ROOT, { recursive: true, mode: 0o700 });
+  if (process.platform === "win32") return;
+
+  const handle = await open(
+    PRIVATE_LOCK_ROOT,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const info = await handle.stat();
+    if (!info.isDirectory() || CURRENT_UID === undefined || info.uid !== CURRENT_UID) {
+      throw new Error(
+        `Private stack lock root is not owned by the current user: ${PRIVATE_LOCK_ROOT}`,
+      );
+    }
+    await handle.chmod(0o700);
+  } finally {
+    await handle.close();
+  }
+};
+
 export type ReleaseManagedPortLock = () => Promise<void>;
 
 /** Serialize port selection and lease handoff across foreground and detached stacks. */
@@ -262,8 +290,13 @@ export async function acquireManagedPortLock(
   lockPath = DEFAULT_LOCK_PATH,
   signal?: AbortSignal,
 ): Promise<ReleaseManagedPortLock> {
-  if (dirname(lockPath) === SHARED_LOCK_ROOT) {
+  const lockRoot = dirname(lockPath);
+  const isSharedLock = lockRoot === SHARED_LOCK_ROOT;
+  const isPrivateLock = lockRoot === PRIVATE_LOCK_ROOT;
+  if (isSharedLock) {
     await prepareSharedLockRoot(signal);
+  } else if (isPrivateLock) {
+    await preparePrivateLockRoot();
   }
   for (;;) {
     signal?.throwIfAborted();
@@ -278,12 +311,13 @@ export async function acquireManagedPortLock(
     let installed = false;
 
     try {
-      await mkdir(candidatePath, { mode: 0o777 });
+      await mkdir(candidatePath, { mode: isPrivateLock ? 0o700 : 0o777 });
       try {
         if (process.platform !== "win32") {
-          // The shared generation must remain removable by a different user.
+          // Shared generations must remain removable by a different user, while
+          // state generations are private to the user who owns their state files.
           // mkdir applies the process umask, so make the effective mode explicit.
-          await chmod(candidatePath, 0o777);
+          await chmod(candidatePath, isPrivateLock ? 0o700 : 0o777);
         }
         const ownerHandle = await open(
           join(candidatePath, "owner"),

--- a/packages/stack/src/ManagedPortLock.unit.test.ts
+++ b/packages/stack/src/ManagedPortLock.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
 import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir, uptime } from "node:os";
-import { join } from "node:path";
-import { acquireManagedPortLock } from "./ManagedPortLock.ts";
+import { dirname, join } from "node:path";
+import { acquireManagedPortLock, privateManagedLockPath } from "./ManagedPortLock.ts";
 
 describe("ManagedPortLock", () => {
   it("serializes independent port allocators", async () => {
@@ -62,6 +62,19 @@ describe("ManagedPortLock", () => {
       await release();
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps state lock generations private to the current user", async () => {
+    const lockPath = privateManagedLockPath(`test:${process.pid}:${Date.now()}`);
+    const release = await acquireManagedPortLock(lockPath);
+    try {
+      if (process.platform !== "win32") {
+        expect((await stat(dirname(lockPath))).mode & 0o777).toBe(0o700);
+        expect((await stat(lockPath)).mode & 0o777).toBe(0o700);
+      }
+    } finally {
+      await release();
     }
   });
 

--- a/packages/stack/src/RemoteStack.integration.test.ts
+++ b/packages/stack/src/RemoteStack.integration.test.ts
@@ -1,11 +1,14 @@
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { ServiceNotFoundError, type LogEntry } from "@supabase/process-compose";
-import { Effect, Layer, ManagedRuntime, Stream } from "effect";
+import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabase/process-compose";
+import { Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect";
 import * as http from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { DaemonServer } from "./DaemonServer.ts";
+import { StackBuildError } from "./errors.ts";
+import { RemoteStack } from "./RemoteStack.ts";
 import { Stack, type StackInfo } from "./Stack.ts";
 import { StackServiceState } from "./StackServiceState.ts";
+import { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -53,7 +56,14 @@ const MOCK_LOGS: ReadonlyArray<LogEntry> = [
 // Mock Stack (server-side, backing the DaemonServer)
 // ---------------------------------------------------------------------------
 
-function mockStack() {
+function mockStack(
+  options: {
+    readonly startServiceBuildError?: string;
+    readonly startServiceReadyError?: string;
+    readonly waitReadyBuildError?: string;
+    readonly restartServiceReadyError?: string;
+  } = {},
+) {
   let stopped = false;
   const serviceCalls: string[] = [];
 
@@ -71,9 +81,18 @@ function mockStack() {
     startService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
-        : Effect.sync(() => {
-            serviceCalls.push(`start:${name}`);
-          }),
+        : options.startServiceBuildError !== undefined
+          ? Effect.fail(new StackBuildError({ detail: options.startServiceBuildError }))
+          : options.startServiceReadyError !== undefined
+            ? Effect.fail(
+                new ServiceReadyError({
+                  name,
+                  reason: options.startServiceReadyError,
+                }),
+              )
+            : Effect.sync(() => {
+                serviceCalls.push(`start:${name}`);
+              }),
     stopService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
@@ -83,9 +102,16 @@ function mockStack() {
     restartService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
-        : Effect.sync(() => {
-            serviceCalls.push(`restart:${name}`);
-          }),
+        : options.restartServiceReadyError !== undefined
+          ? Effect.fail(
+              new ServiceReadyError({
+                name,
+                reason: options.restartServiceReadyError,
+              }),
+            )
+          : Effect.sync(() => {
+              serviceCalls.push(`restart:${name}`);
+            }),
     reloadFunctions: () =>
       Effect.sync(() => {
         serviceCalls.push("reload-functions");
@@ -108,9 +134,18 @@ function mockStack() {
     allStateChanges: () => Stream.fromIterable(MOCK_STATES),
     waitReady: (name: string) => {
       const match = MOCK_STATES.find((s) => s.name === name);
-      return match ? Effect.void : Effect.fail(new ServiceNotFoundError({ name }));
+      if (match === undefined) return Effect.fail(new ServiceNotFoundError({ name }));
+      if (options.waitReadyBuildError !== undefined) {
+        return Effect.fail(new StackBuildError({ detail: options.waitReadyBuildError }));
+      }
+      return Effect.sync(() => {
+        serviceCalls.push(`ready:${name}`);
+      });
     },
-    waitAllReady: () => Effect.void,
+    waitAllReady: () =>
+      Effect.sync(() => {
+        serviceCalls.push("ready:all");
+      }),
     subscribeLogs: (name: string) =>
       Stream.fromIterable(MOCK_LOGS.filter((l) => l.service === name)),
     subscribeAllLogs: (services?: ReadonlyArray<string>) =>
@@ -149,7 +184,18 @@ function buildServerLayer(
   return DaemonServer.layer.pipe(
     Layer.provide(mock.layer),
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
-  ) as Layer.Layer<DaemonServer, never, never>;
+  );
+}
+
+function buildClientLayer(url: string): Layer.Layer<Stack, never, never> {
+  const clientLayer = Layer.succeed(UnixHttpClient, {
+    request: (socketPath, path, init) =>
+      Effect.tryPromise({
+        try: () => fetch(`${url}${path}`, init),
+        catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+      }),
+  });
+  return RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer));
 }
 
 // ---------------------------------------------------------------------------
@@ -166,123 +212,11 @@ describe("RemoteStack integration", () => {
     serverRuntime = ManagedRuntime.make(buildServerLayer(mock));
     const daemon = await serverRuntime.runPromise(DaemonServer);
 
-    // Build RemoteStack layer targeting the server's TCP address.
-    // RemoteStack uses Bun's `fetch({ unix })` but we test with TCP here
-    // since the HTTP behavior is identical.
     const addr = daemon.address;
     if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
     const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
-
-    // For TCP testing, we override the fetch helper by using a custom layer
-    // that patches the socket path to a TCP URL. Since RemoteStack uses
-    // `fetch("http://localhost/...", { unix })`, we can't directly test TCP.
-    //
-    // Instead, we'll test the RemoteStack methods via raw fetch to the TCP
-    // server, validating the HTTP contract that RemoteStack relies on.
-    // The DaemonServer integration tests already cover the HTTP endpoints.
-    //
-    // For a true end-to-end test, we'd need a Unix socket server.
-    // Here we verify the RemoteStack layer constructor + method wiring.
-
-    // Use the RemoteStack layer with a Unix socket path.
-    // Since we can't use Unix socket with the TCP test server,
-    // we test the layer construction only.
     const url = `http://${host}:${addr.port}`;
-
-    // Create a RemoteStack-like client that uses TCP instead of Unix socket
-    clientRuntime = ManagedRuntime.make(
-      Layer.succeed(Stack, {
-        getInfo: () =>
-          Effect.promise(async () => {
-            const res = await fetch(`${url}/status`);
-            const body = (await res.json()) as { info: StackInfo };
-            return body.info;
-          }),
-        start: () => Effect.void,
-        stop: () =>
-          Effect.promise(async () => {
-            await fetch(`${url}/stop`, { method: "POST" });
-          }),
-        dispose: () =>
-          Effect.promise(async () => {
-            await fetch(`${url}/stop`, { method: "POST" });
-          }),
-        startService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/start`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        stopService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/stop`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        restartService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/restart`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        reloadFunctions: () =>
-          Effect.gen(function* () {
-            yield* Effect.promise(() => fetch(`${url}/functions/reload`, { method: "POST" }));
-          }),
-        reloadEdgeRuntime: () =>
-          Effect.gen(function* () {
-            yield* Effect.promise(() =>
-              fetch(`${url}/edge-runtime/reload`, {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({ edgeRuntime: {} }),
-              }),
-            );
-          }),
-        getState: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() => fetch(`${url}/status`));
-            const body = (yield* Effect.promise(() => res.json())) as {
-              services: Array<StackServiceState>;
-            };
-            const s = body.services.find((s) => s.name === name);
-            if (!s) return yield* new ServiceNotFoundError({ name });
-            return new StackServiceState(s);
-          }),
-        getAllStates: () =>
-          Effect.promise(async () => {
-            const res = await fetch(`${url}/status`);
-            const body = (await res.json()) as { services: Array<StackServiceState> };
-            return body.services.map((s) => new StackServiceState(s));
-          }),
-        stateChanges: () => Effect.succeed(Stream.empty),
-        allStateChanges: () => Stream.empty,
-        waitReady: () => Effect.void,
-        waitAllReady: () => Effect.void,
-        subscribeLogs: () => Stream.empty,
-        subscribeAllLogs: () => Stream.empty,
-        logHistory: (name: string, limit?: number) =>
-          Effect.promise(async () => {
-            const query = limit !== undefined ? `?limit=${limit}` : "";
-            const res = await fetch(`${url}/logs/${name}/history${query}`);
-            return (await res.json()) as ReadonlyArray<LogEntry>;
-          }),
-        logHistoryAll: (limit?: number, services?: ReadonlyArray<string>) =>
-          Effect.promise(async () => {
-            const searchParams = new URLSearchParams();
-            if (limit !== undefined) searchParams.set("limit", String(limit));
-            for (const service of services ?? []) {
-              searchParams.append("service", service);
-            }
-            const query = searchParams.toString();
-            const res = await fetch(`${url}/logs/history${query.length > 0 ? `?${query}` : ""}`);
-            return (await res.json()) as ReadonlyArray<LogEntry>;
-          }),
-      }),
-    );
+    clientRuntime = ManagedRuntime.make(buildClientLayer(url));
   });
 
   afterAll(async () => {
@@ -331,6 +265,115 @@ describe("RemoteStack integration", () => {
       Effect.flatMap(Stack, (stack) => stack.startService("unknown")),
     );
     expect(exit._tag).toBe("Failure");
+  });
+
+  test("waitReady delegates to the daemon coordinator", async () => {
+    await clientRuntime.runPromise(Effect.flatMap(Stack, (stack) => stack.waitReady("auth")));
+    expect(mock.serviceCalls).toContain("ready:auth");
+  });
+
+  test("waitAllReady delegates to the daemon coordinator", async () => {
+    await clientRuntime.runPromise(Effect.flatMap(Stack, (stack) => stack.waitAllReady()));
+    expect(mock.serviceCalls).toContain("ready:all");
+  });
+
+  test("interrupting waitReady aborts the daemon request", async () => {
+    let notifyRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      notifyRequestStarted = resolve;
+    });
+    let aborted = false;
+    const clientLayer = Layer.succeed(UnixHttpClient, {
+      request: (socketPath, path, init) =>
+        Effect.tryPromise({
+          try: () =>
+            new Promise<Response>((_resolve, reject) => {
+              notifyRequestStarted?.();
+              init?.signal?.addEventListener(
+                "abort",
+                () => {
+                  aborted = true;
+                  reject(new DOMException("Aborted", "AbortError"));
+                },
+                { once: true },
+              );
+            }),
+          catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+        }),
+    });
+    const runtime = ManagedRuntime.make(
+      RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer)),
+    );
+    try {
+      const fiber = runtime.runFork(Effect.flatMap(Stack, (stack) => stack.waitReady("auth")));
+      await requestStarted;
+      await runtime.runPromise(Fiber.interrupt(fiber));
+      expect(aborted).toBe(true);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  test("preserves StackBuildError across remote service operations", async () => {
+    const failingMock = mockStack({
+      restartServiceReadyError: "restart failed readiness",
+      startServiceBuildError: "stack is stopped",
+      waitReadyBuildError: "service has not been activated",
+    });
+    const failingServer = ManagedRuntime.make(buildServerLayer(failingMock));
+    let failingClient: ManagedRuntime.ManagedRuntime<Stack, never> | undefined;
+    try {
+      const daemon = await failingServer.runPromise(DaemonServer);
+      const addr = daemon.address;
+      if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
+      const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
+      failingClient = ManagedRuntime.make(buildClientLayer(`http://${host}:${addr.port}`));
+
+      const startError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.startService("auth")).pipe(Effect.flip),
+      );
+      expect(startError._tag).toBe("StackBuildError");
+
+      const readyError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.waitReady("auth")).pipe(Effect.flip),
+      );
+      expect(readyError._tag).toBe("StackBuildError");
+
+      const restartError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.restartService("auth")).pipe(Effect.flip),
+      );
+      expect(restartError._tag).toBe("ServiceReadyError");
+      if (restartError._tag === "ServiceReadyError") {
+        expect(restartError.reason).toBe("restart failed readiness");
+      }
+    } finally {
+      await failingClient?.dispose();
+      await failingServer.dispose();
+    }
+  });
+
+  test("preserves ServiceReadyError from remote startService", async () => {
+    const failingMock = mockStack({ startServiceReadyError: "start failed readiness" });
+    const failingServer = ManagedRuntime.make(buildServerLayer(failingMock));
+    let failingClient: ManagedRuntime.ManagedRuntime<Stack, never> | undefined;
+    try {
+      const daemon = await failingServer.runPromise(DaemonServer);
+      const addr = daemon.address;
+      if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
+      const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
+      failingClient = ManagedRuntime.make(buildClientLayer(`http://${host}:${addr.port}`));
+
+      const error = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.startService("auth")).pipe(Effect.flip),
+      );
+      expect(error._tag).toBe("ServiceReadyError");
+      if (error._tag === "ServiceReadyError") {
+        expect(error.reason).toBe("start failed readiness");
+      }
+    } finally {
+      await failingClient?.dispose();
+      await failingServer.dispose();
+    }
   });
 
   test("stopService records the call", async () => {

--- a/packages/stack/src/RemoteStack.integration.test.ts
+++ b/packages/stack/src/RemoteStack.integration.test.ts
@@ -272,6 +272,14 @@ describe("RemoteStack integration", () => {
     expect(mock.serviceCalls).toContain("ready:auth");
   });
 
+  test("waitReady rejects dot path segments locally", async () => {
+    const error = await clientRuntime.runPromise(
+      Effect.flatMap(Stack, (stack) => stack.waitReady("..")).pipe(Effect.flip),
+    );
+    expect(error._tag).toBe("ServiceNotFoundError");
+    expect(mock.serviceCalls).not.toContain("ready:all");
+  });
+
   test("waitAllReady delegates to the daemon coordinator", async () => {
     await clientRuntime.runPromise(Effect.flatMap(Stack, (stack) => stack.waitAllReady()));
     expect(mock.serviceCalls).toContain("ready:all");

--- a/packages/stack/src/RemoteStack.ts
+++ b/packages/stack/src/RemoteStack.ts
@@ -7,6 +7,7 @@ import { StackBuildError } from "./errors.ts";
 import { Stack, StackInfoSchema } from "./Stack.ts";
 import { StackServiceState, StackServiceStatusSchema } from "./StackServiceState.ts";
 import { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
+import { SERVICE_NAMES } from "./versions.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,6 +48,13 @@ const decodeLogEntryEvent = Schema.decodeUnknownSync(LogEntryEventSchema);
 function requestHeaders(init?: RequestInit) {
   return Object.fromEntries(new Headers(init?.headers).entries());
 }
+
+const publicServicePath = (name: string): Effect.Effect<string, ServiceNotFoundError> => {
+  const service = SERVICE_NAMES.find((candidate) => candidate === name);
+  return service === undefined
+    ? Effect.fail(new ServiceNotFoundError({ name }))
+    : Effect.succeed(encodeURIComponent(service));
+};
 
 function makeRequest(path: string, init?: RequestInit) {
   const url = `http://localhost${path}`;
@@ -278,13 +286,10 @@ export const RemoteStack = {
           startService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(
-                  socketPath,
-                  `/services/${encodeURIComponent(name)}/start`,
-                  {
-                    method: "POST",
-                  },
-                );
+                const servicePath = yield* publicServicePath(name);
+                const response = yield* unixResponse(socketPath, `/services/${servicePath}/start`, {
+                  method: "POST",
+                });
                 yield* expectDaemonOk(response, name);
               }),
             ),
@@ -292,13 +297,10 @@ export const RemoteStack = {
           stopService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(
-                  socketPath,
-                  `/services/${encodeURIComponent(name)}/stop`,
-                  {
-                    method: "POST",
-                  },
-                );
+                const servicePath = yield* publicServicePath(name);
+                const response = yield* unixResponse(socketPath, `/services/${servicePath}/stop`, {
+                  method: "POST",
+                });
                 yield* expectDaemonOk(response, name).pipe(
                   Effect.catchTag("ServiceReadyError", (error) => Effect.die(error)),
                 );
@@ -308,9 +310,10 @@ export const RemoteStack = {
           restartService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
+                const servicePath = yield* publicServicePath(name);
                 const response = yield* unixResponse(
                   socketPath,
-                  `/services/${encodeURIComponent(name)}/restart`,
+                  `/services/${servicePath}/restart`,
                   {
                     method: "POST",
                   },
@@ -395,9 +398,10 @@ export const RemoteStack = {
             withUnixHttpClient(
               withAbortSignal((signal) =>
                 Effect.gen(function* () {
+                  const servicePath = yield* publicServicePath(name);
                   const response = yield* unixResponse(
                     socketPath,
-                    `/services/${encodeURIComponent(name)}/ready`,
+                    `/services/${servicePath}/ready`,
                     { signal },
                   );
                   yield* expectDaemonOk(response, name);

--- a/packages/stack/src/RemoteStack.ts
+++ b/packages/stack/src/RemoteStack.ts
@@ -2,6 +2,8 @@ import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabas
 import { Effect, Layer, Schema, Stream } from "effect";
 import * as Sse from "effect/unstable/encoding/Sse";
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { DaemonErrorResponseSchema } from "./DaemonProtocol.ts";
+import { StackBuildError } from "./errors.ts";
 import { Stack, StackInfoSchema } from "./Stack.ts";
 import { StackServiceState, StackServiceStatusSchema } from "./StackServiceState.ts";
 import { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
@@ -25,15 +27,12 @@ const StatusServiceSchema = Schema.Struct({
   restartCount: Schema.Number,
   startedAt: Schema.NullOr(Schema.Number),
   error: Schema.NullOr(Schema.String),
+  dormant: Schema.optionalKey(Schema.Boolean),
 });
 
 const StatusResponseSchema = Schema.Struct({
   info: StackInfoSchema,
   services: Schema.Array(StatusServiceSchema),
-});
-
-const ServiceErrorResponseSchema = Schema.Struct({
-  error: Schema.String,
 });
 
 const StatusServiceEventSchema = Schema.fromJsonString(StatusServiceSchema);
@@ -85,6 +84,46 @@ function unixResponse(socketPath: string, path: string, init?: RequestInit) {
     HttpClientResponse.fromWeb(request, response),
   );
 }
+
+function withAbortSignal<A, E, R>(
+  effect: (signal: AbortSignal) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => new AbortController()),
+    (controller) => effect(controller.signal),
+    (controller) => Effect.sync(() => controller.abort()),
+  );
+}
+
+const failDaemonResponse = (
+  response: HttpClientResponse.HttpClientResponse,
+  fallbackName: string,
+): Effect.Effect<never, ServiceNotFoundError | ServiceReadyError | StackBuildError> =>
+  Effect.gen(function* () {
+    const body = yield* HttpClientResponse.schemaBodyJson(DaemonErrorResponseSchema)(response).pipe(
+      Effect.orDie,
+    );
+    switch (body.code) {
+      case "SERVICE_NOT_FOUND":
+        return yield* new ServiceNotFoundError({ name: body.service ?? fallbackName });
+      case "SERVICE_NOT_READY":
+        return yield* new ServiceReadyError({
+          name: body.service ?? fallbackName,
+          reason: body.error,
+          ...(body.exitCode === undefined ? {} : { exitCode: body.exitCode }),
+        });
+      case "STACK_BUILD_ERROR":
+        return yield* new StackBuildError({ detail: body.error });
+    }
+  });
+
+const expectDaemonOk = (
+  response: HttpClientResponse.HttpClientResponse,
+  fallbackName: string,
+): Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError> =>
+  response.status >= 200 && response.status < 300
+    ? Effect.void
+    : failDaemonResponse(response, fallbackName);
 
 /** Fetch JSON from the daemon, dying on HTTP errors. */
 function fetchStatus(socketPath: string, path: string, method = "GET") {
@@ -171,6 +210,7 @@ function toServiceState(
     restartCount: raw.restartCount,
     startedAt: raw.startedAt,
     error: raw.error,
+    ...(raw.dormant === undefined ? {} : { dormant: raw.dormant }),
   });
 }
 
@@ -213,7 +253,9 @@ export const RemoteStack = {
             withUnixHttpClient(
               Effect.gen(function* () {
                 const response = yield* unixResponse(socketPath, "/start", { method: "POST" });
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "stack").pipe(
+                  Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
+                );
               }),
             ),
 
@@ -236,45 +278,44 @@ export const RemoteStack = {
           startService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/start`, {
-                  method: "POST",
-                });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({ name, reason: body.error });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const response = yield* unixResponse(
+                  socketPath,
+                  `/services/${encodeURIComponent(name)}/start`,
+                  {
+                    method: "POST",
+                  },
+                );
+                yield* expectDaemonOk(response, name);
               }),
             ),
 
           stopService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/stop`, {
-                  method: "POST",
-                });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const response = yield* unixResponse(
+                  socketPath,
+                  `/services/${encodeURIComponent(name)}/stop`,
+                  {
+                    method: "POST",
+                  },
+                );
+                yield* expectDaemonOk(response, name).pipe(
+                  Effect.catchTag("ServiceReadyError", (error) => Effect.die(error)),
+                );
               }),
             ),
 
           restartService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/restart`, {
-                  method: "POST",
-                });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const response = yield* unixResponse(
+                  socketPath,
+                  `/services/${encodeURIComponent(name)}/restart`,
+                  {
+                    method: "POST",
+                  },
+                );
+                yield* expectDaemonOk(response, name);
               }),
             ),
 
@@ -290,19 +331,7 @@ export const RemoteStack = {
                   })}`,
                   { method: "POST" },
                 );
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name: "edge-runtime" });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({
-                    name: "edge-runtime",
-                    reason: body.error,
-                  });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "edge-runtime");
               }),
             ),
 
@@ -314,19 +343,7 @@ export const RemoteStack = {
                   headers: { "content-type": "application/json" },
                   body: JSON.stringify(opts),
                 });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name: "edge-runtime" });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({
-                    name: "edge-runtime",
-                    reason: body.error,
-                  });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "edge-runtime");
               }),
             ),
 
@@ -376,67 +393,35 @@ export const RemoteStack = {
 
           waitReady: (name: string) =>
             withUnixHttpClient(
-              Effect.gen(function* () {
-                // Check current state first
-                const { services } = yield* fetchStatus(socketPath, "/status");
-                const match = services.find((s) => s.name === name);
-                if (!match) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                if (match.status === "Healthy" || match.status === "Running") return;
-
-                // Wait for state change via SSE
-                yield* withUnixHttpClient(
-                  sseStream(socketPath, "/status/stream", (data) => {
-                    const raw = decodeStatusServiceEvent(data);
-                    return toServiceState(raw);
-                  }).pipe(
-                    Stream.filter((s) => s.name === name),
-                    Stream.takeUntil((s) => s.status === "Healthy" || s.status === "Running"),
-                    Stream.runDrain,
-                  ),
-                );
-              }),
+              withAbortSignal((signal) =>
+                Effect.gen(function* () {
+                  const response = yield* unixResponse(
+                    socketPath,
+                    `/services/${encodeURIComponent(name)}/ready`,
+                    { signal },
+                  );
+                  yield* expectDaemonOk(response, name);
+                }),
+              ),
             ),
 
           waitAllReady: () =>
             withUnixHttpClient(
-              Effect.gen(function* () {
-                // Check current state first
-                const { services } = yield* fetchStatus(socketPath, "/status");
-                const allReady = services.every(
-                  (s) => s.status === "Healthy" || s.status === "Running",
-                );
-                if (allReady) return;
-
-                // Track service readiness via SSE
-                const readySet = new Set(
-                  services
-                    .filter((s) => s.status === "Healthy" || s.status === "Running")
-                    .map((s) => s.name),
-                );
-                const totalCount = services.length;
-
-                yield* withUnixHttpClient(
-                  sseStream(socketPath, "/status/stream", (data) => {
-                    const raw = decodeStatusServiceEvent(data);
-                    return toServiceState(raw);
-                  }).pipe(
-                    Stream.takeUntil((s) => {
-                      if (s.status === "Healthy" || s.status === "Running") {
-                        readySet.add(s.name);
-                      }
-                      return readySet.size >= totalCount;
-                    }),
-                    Stream.runDrain,
-                  ),
-                );
-              }),
+              withAbortSignal((signal) =>
+                Effect.gen(function* () {
+                  const response = yield* unixResponse(socketPath, "/ready", { signal });
+                  yield* expectDaemonOk(response, "stack").pipe(
+                    Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
+                  );
+                }),
+              ),
             ),
 
           subscribeLogs: (name: string) =>
             withUnixHttpClientStream(
-              sseStream<LogEntry>(socketPath, `/logs/${name}`, (data) => decodeLogEntryEvent(data)),
+              sseStream<LogEntry>(socketPath, `/logs/${encodeURIComponent(name)}`, (data) =>
+                decodeLogEntryEvent(data),
+              ),
             ),
 
           subscribeAllLogs: (services) => {
@@ -448,7 +433,9 @@ export const RemoteStack = {
 
           logHistory: (name: string, limit?: number) => {
             const query = limit !== undefined ? `?limit=${limit}` : "";
-            return withUnixHttpClient(fetchLogEntries(socketPath, `/logs/${name}/history${query}`));
+            return withUnixHttpClient(
+              fetchLogEntries(socketPath, `/logs/${encodeURIComponent(name)}/history${query}`),
+            );
           },
 
           logHistoryAll: (limit?: number, services?: ReadonlyArray<string>) => {

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -489,10 +489,16 @@ describe("Stack", () => {
         const coordinator = yield* StackLifecycleCoordinator;
         yield* coordinator.start();
         expect((yield* coordinator.getState("auth")).dormant).toBe(true);
+        const activeStateFiber = yield* coordinator.allStateChanges().pipe(
+          Stream.filter((state) => state.name === "auth" && state.dormant !== true),
+          Stream.runHead,
+          Effect.forkChild({ startImmediately: true }),
+        );
         const activationFiber = yield* coordinator
           .activateService("auth")
           .pipe(Effect.forkChild({ startImmediately: true }));
         yield* Deferred.await(spawnStarted);
+        expect((yield* Fiber.join(activeStateFiber))._tag).toBe("Some");
         expect((yield* coordinator.getState("auth")).dormant).toBeUndefined();
 
         const readyFiber = yield* coordinator

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -488,10 +488,12 @@ describe("Stack", () => {
       yield* Effect.gen(function* () {
         const coordinator = yield* StackLifecycleCoordinator;
         yield* coordinator.start();
+        expect((yield* coordinator.getState("auth")).dormant).toBe(true);
         const activationFiber = yield* coordinator
           .activateService("auth")
           .pipe(Effect.forkChild({ startImmediately: true }));
         yield* Deferred.await(spawnStarted);
+        expect((yield* coordinator.getState("auth")).dormant).toBeUndefined();
 
         const readyFiber = yield* coordinator
           .waitAllReady()
@@ -591,6 +593,39 @@ describe("Stack", () => {
         yield* coordinator.stop();
       }).pipe(Effect.provide(coordinatorLayer));
     }).pipe(Effect.scoped, Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy readiness fails fast before a service is activated", () => {
+    const { layer } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const beforeStart = yield* stack.waitAllReady().pipe(Effect.flip);
+      expect(beforeStart._tag).toBe("StackBuildError");
+
+      yield* stack.start();
+      const authNotActivated = yield* stack.waitReady("auth").pipe(Effect.flip);
+      expect(authNotActivated._tag).toBe("StackBuildError");
+
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("keeps unactivated services dormant after a stop and start cycle", () => {
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      expect((yield* coordinator.getState("auth")).dormant).toBe(true);
+
+      yield* coordinator.stop();
+      yield* coordinator.start();
+
+      expect((yield* coordinator.getState("auth")).dormant).toBe(true);
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
   });
 
   it.live("rejects a cached activation after the stack has stopped", () => {

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -533,6 +533,18 @@ export class StackLifecycleCoordinator extends Context.Service<
               (previous, current) => [current, changedStatesBetween(previous, current)],
             ),
           );
+        const annotateDormancy = (state: StackServiceState): StackServiceState => {
+          const service = SERVICE_NAMES.find((candidate) => candidate === state.name);
+          const dormant =
+            config.startupMode === "lazy" &&
+            Ref.getUnsafe(phaseRef) === "running" &&
+            (state.status === "Pending" || state.status === "Stopped") &&
+            service !== undefined &&
+            !activatedServices.has(service) &&
+            !manuallyStoppedServices.has(service);
+          return dormant ? new StackServiceState({ ...state, dormant: true }) : state;
+        };
+        const publicAllStateChanges = () => allStateChanges().pipe(Stream.map(annotateDormancy));
         const publicServiceClosure = (
           runtime: RuntimeState,
           services: ReadonlyArray<ServiceName>,
@@ -964,23 +976,52 @@ export class StackLifecycleCoordinator extends Context.Service<
               if (match === undefined) {
                 return yield* Effect.fail(new ServiceNotFoundError({ name }));
               }
-              return match;
+              return annotateDormancy(match);
             }),
-          getAllStates: () => Effect.sync(() => SubscriptionRef.getUnsafe(stateRef)),
+          getAllStates: () =>
+            Effect.sync(() => SubscriptionRef.getUnsafe(stateRef).map(annotateDormancy)),
           stateChanges: (name) =>
             Effect.gen(function* () {
               yield* requireKnownService(name);
-              return Stream.filter(allStateChanges(), (state) => state.name === name);
+              return Stream.filter(publicAllStateChanges(), (state) => state.name === name);
             }),
-          allStateChanges,
+          allStateChanges: publicAllStateChanges,
           waitReady: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
-              const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.waitReady(name);
+              const service = yield* requireKnownServiceName(name);
+              yield* withActivationLocks(
+                [service],
+                Effect.gen(function* () {
+                  const phase = yield* Ref.get(phaseRef);
+                  if (phase !== "running") {
+                    return yield* Effect.fail(
+                      new StackBuildError({
+                        detail: `Cannot wait for service ${name} while the stack is ${phase}`,
+                      }),
+                    );
+                  }
+                  if (config.startupMode === "lazy" && !activatedServices.has(service)) {
+                    return yield* Effect.fail(
+                      new StackBuildError({
+                        detail: `Service ${name} has not been activated in lazy startup mode`,
+                      }),
+                    );
+                  }
+                  const runtime = yield* ensureRuntime;
+                  yield* runtime.orchestrator.waitReady(name);
+                }),
+              );
             }),
           waitAllReady: () =>
             Effect.gen(function* () {
+              const phase = yield* Ref.get(phaseRef);
+              if (phase !== "running") {
+                return yield* Effect.fail(
+                  new StackBuildError({
+                    detail: `Cannot wait for stack readiness while the stack is ${phase}`,
+                  }),
+                );
+              }
               const runtime = yield* ensureRuntime;
               if (config.startupMode === "eager") {
                 yield* runtime.orchestrator.waitAllReady();

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -63,7 +63,8 @@ const sameState = (a: StackServiceState | undefined, b: StackServiceState): bool
   a.exitCode === b.exitCode &&
   a.restartCount === b.restartCount &&
   a.startedAt === b.startedAt &&
-  a.error === b.error;
+  a.error === b.error &&
+  a.dormant === b.dormant;
 
 const initialPublicStates = (config: ResolvedStackConfig): ReadonlyArray<StackServiceState> =>
   enabledServicesForConfig(config).map(
@@ -214,6 +215,7 @@ export class StackLifecycleCoordinator extends Context.Service<
         const info = stackInfoFor(config);
         const enabledServices = enabledServicesForConfig(config);
         const stateRef = yield* SubscriptionRef.make(initialPublicStates(config));
+        const dormancyRevision = yield* SubscriptionRef.make(0);
         const phaseRef = yield* Ref.make<LifecyclePhase>("idle");
         const activatedServices = new Set<ServiceName>();
         const manuallyStoppedServices = new Set<ServiceName>();
@@ -522,17 +524,6 @@ export class StackLifecycleCoordinator extends Context.Service<
               },
             };
           });
-        const allStateChanges = () =>
-          SubscriptionRef.changes(stateRef).pipe(
-            Stream.mapAccum<
-              ReadonlyArray<StackServiceState> | undefined,
-              ReadonlyArray<StackServiceState>,
-              StackServiceState
-            >(
-              () => undefined,
-              (previous, current) => [current, changedStatesBetween(previous, current)],
-            ),
-          );
         const annotateDormancy = (state: StackServiceState): StackServiceState => {
           const service = SERVICE_NAMES.find((candidate) => candidate === state.name);
           const dormant =
@@ -544,7 +535,27 @@ export class StackLifecycleCoordinator extends Context.Service<
             !manuallyStoppedServices.has(service);
           return dormant ? new StackServiceState({ ...state, dormant: true }) : state;
         };
-        const publicAllStateChanges = () => allStateChanges().pipe(Stream.map(annotateDormancy));
+        const publishDormancyChange = SubscriptionRef.update(
+          dormancyRevision,
+          (value) => value + 1,
+        );
+        const publicAllStateChanges = () =>
+          Stream.merge(
+            SubscriptionRef.changes(stateRef),
+            SubscriptionRef.changes(dormancyRevision).pipe(
+              Stream.map(() => SubscriptionRef.getUnsafe(stateRef)),
+            ),
+          ).pipe(
+            Stream.map((states) => states.map(annotateDormancy)),
+            Stream.mapAccum<
+              ReadonlyArray<StackServiceState> | undefined,
+              ReadonlyArray<StackServiceState>,
+              StackServiceState
+            >(
+              () => undefined,
+              (previous, current) => [current, changedStatesBetween(previous, current)],
+            ),
+          );
         const publicServiceClosure = (
           runtime: RuntimeState,
           services: ReadonlyArray<ServiceName>,
@@ -610,6 +621,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                 for (const service of inactiveServiceClosure) {
                   activatedServices.add(service);
                 }
+                yield* publishDormancyChange;
                 yield* Effect.forEach(
                   inactiveServices,
                   (service) =>
@@ -625,10 +637,11 @@ export class StackLifecycleCoordinator extends Context.Service<
                   { discard: true },
                 ).pipe(
                   Effect.onError(() =>
-                    Effect.sync(() => {
+                    Effect.gen(function* () {
                       for (const service of inactiveServiceClosure) {
                         activatedServices.delete(service);
                       }
+                      yield* publishDormancyChange;
                     }),
                   ),
                 );
@@ -656,10 +669,11 @@ export class StackLifecycleCoordinator extends Context.Service<
               Effect.onError(() =>
                 withActivationLocks(
                   newlyActivated,
-                  Effect.sync(() => {
+                  Effect.gen(function* () {
                     for (const service of newlyActivated) {
                       activatedServices.delete(service);
                     }
+                    yield* publishDormancyChange;
                   }),
                 ),
               ),
@@ -768,6 +782,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                 yield* runtime.orchestrator.waitAllReady();
               }
               yield* Ref.set(phaseRef, "running");
+              yield* publishDormancyChange;
             }).pipe(
               Effect.onError(() => Ref.set(phaseRef, "stopped")),
               withLifecycleLock,
@@ -781,6 +796,7 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* Ref.set(phaseRef, "stopping");
               yield* withActivationLocks(SERVICE_NAMES, runtimeState.orchestrator.stop());
               yield* Ref.set(phaseRef, "stopped");
+              yield* publishDormancyChange;
             }).pipe(withLifecycleLock),
           dispose: disposeOnce,
           startService: (name) =>
@@ -831,6 +847,7 @@ export class StackLifecycleCoordinator extends Context.Service<
                       }
                     }
                   }
+                  yield* publishDormancyChange;
                 }),
               );
             }).pipe(withLifecycleLock),

--- a/packages/stack/src/StackServiceState.ts
+++ b/packages/stack/src/StackServiceState.ts
@@ -25,6 +25,8 @@ export class StackServiceState extends Data.Class<{
   readonly restartCount: number;
   readonly startedAt: number | null;
   readonly error: string | null;
+  /** True when a lazy service is intentionally idle and will activate on demand. */
+  readonly dormant?: boolean;
 }> {}
 
 export function fromRawServiceState(raw: RawServiceState): StackServiceState {

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Layer, Schema, Context } from "effect";
+import { Data, Effect, Layer, Schedule, Schema, Context } from "effect";
 import { FileSystem, Path } from "effect";
 import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
@@ -323,10 +323,14 @@ function makeWrite(deps: StateManagerDeps) {
     Effect.gen(function* () {
       const dir = deps.stackDir(state.name);
       yield* deps.fs.makeDirectory(dir, { recursive: true });
-      yield* writeFileAtomic(
-        deps.fs,
-        deps.stateFile(state.name),
-        encodePrettyJson(encodeStackState(state)),
+      yield* withStateLock(
+        deps,
+        state.name,
+        writeFileAtomic(
+          deps.fs,
+          deps.stateFile(state.name),
+          encodePrettyJson(encodeStackState(state)),
+        ),
       );
     }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
 }
@@ -440,7 +444,40 @@ function makeScanMetadata(deps: StateManagerDeps) {
     }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
 }
 
-function makeRemove(deps: StateManagerDeps) {
+function withStateLock<A, E, R>(
+  deps: StateManagerDeps,
+  name: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  const stateLockBusy = "StateLockBusy";
+  const lockPath = `${deps.stackDir(name)}.state.lock`;
+  const acquire = deps.fs.makeDirectory(lockPath).pipe(
+    Effect.result,
+    Effect.flatMap((result) => {
+      if (result._tag === "Success") return Effect.void;
+      return result.failure.reason._tag === "AlreadyExists"
+        ? Effect.fail(stateLockBusy)
+        : Effect.die(result.failure);
+    }),
+    Effect.retry({
+      while: (error) => error === stateLockBusy,
+      schedule: Schedule.spaced("10 millis"),
+    }),
+    Effect.orDie,
+  );
+  return deps.fs.makeDirectory(deps.stacksRoot, { recursive: true }).pipe(
+    Effect.orDie,
+    Effect.andThen(
+      Effect.acquireUseRelease(
+        acquire,
+        () => effect,
+        () => deps.fs.remove(lockPath, { recursive: true }).pipe(Effect.ignore),
+      ),
+    ),
+  );
+}
+
+function makeRemoveUnlocked(deps: StateManagerDeps) {
   return (name: string): Effect.Effect<void> =>
     Effect.gen(function* () {
       yield* deps.fs.remove(deps.stateFile(name)).pipe(Effect.ignore);
@@ -459,17 +496,30 @@ function makeRemove(deps: StateManagerDeps) {
     }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
 }
 
-function makeRemoveOwned(read: ReturnType<typeof makeRead>, remove: ReturnType<typeof makeRemove>) {
+function makeRemove(deps: StateManagerDeps) {
+  const remove = makeRemoveUnlocked(deps);
+  return (name: string): Effect.Effect<void> => withStateLock(deps, name, remove(name));
+}
+
+function makeRemoveOwned(
+  deps: StateManagerDeps,
+  read: ReturnType<typeof makeRead>,
+  remove: ReturnType<typeof makeRemoveUnlocked>,
+) {
   return (expected: StackState): Effect.Effect<void, InvalidStackStateError> =>
-    read(expected.name).pipe(
-      Effect.flatMap((current) =>
-        current.pid === expected.pid &&
-        current.startedAt === expected.startedAt &&
-        current.socketPath === expected.socketPath
-          ? remove(expected.name)
-          : Effect.void,
+    withStateLock(
+      deps,
+      expected.name,
+      read(expected.name).pipe(
+        Effect.flatMap((current) =>
+          current.pid === expected.pid &&
+          current.startedAt === expected.startedAt &&
+          current.socketPath === expected.socketPath
+            ? remove(expected.name)
+            : Effect.void,
+        ),
+        Effect.catchTag("StateNotFoundError", () => Effect.void),
       ),
-      Effect.catchTag("StateNotFoundError", () => Effect.void),
     );
 }
 
@@ -666,6 +716,7 @@ export class StateManager extends Context.Service<
           runtimeDir,
         };
         const read = makeRead(deps);
+        const removeUnlocked = makeRemoveUnlocked(deps);
         const remove = makeRemove(deps);
         const scan = makeScan(deps);
         const writeMetadata = makeWriteMetadata(deps);
@@ -686,7 +737,7 @@ export class StateManager extends Context.Service<
           readMetadata,
           scanMetadata: makeScanMetadata(deps),
           remove,
-          removeOwned: makeRemoveOwned(read, remove),
+          removeOwned: makeRemoveOwned(deps, read, removeUnlocked),
           deleteStack: makeDeleteStack(deps),
           resolve: makeResolve(path, scan),
           isAlive: makeIsAlive(),

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -41,7 +41,7 @@ export interface StackState {
   readonly services: PartialVersionManifest;
 }
 
-const StackStateSchema = Schema.Struct({
+export const StackStateSchema = Schema.Struct({
   pid: Schema.Number,
   name: Schema.String,
   projectDir: Schema.String,
@@ -459,6 +459,20 @@ function makeRemove(deps: StateManagerDeps) {
     }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
 }
 
+function makeRemoveOwned(read: ReturnType<typeof makeRead>, remove: ReturnType<typeof makeRemove>) {
+  return (expected: StackState): Effect.Effect<void, InvalidStackStateError> =>
+    read(expected.name).pipe(
+      Effect.flatMap((current) =>
+        current.pid === expected.pid &&
+        current.startedAt === expected.startedAt &&
+        current.socketPath === expected.socketPath
+          ? remove(expected.name)
+          : Effect.void,
+      ),
+      Effect.catchTag("StateNotFoundError", () => Effect.void),
+    );
+}
+
 function makeDeleteStack(deps: StateManagerDeps) {
   return (name: string): Effect.Effect<void> =>
     Effect.gen(function* () {
@@ -618,6 +632,7 @@ export class StateManager extends Context.Service<
       InvalidStackMetadataError | UnsupportedStackMetadataVersionError
     >;
     readonly remove: (name: string) => Effect.Effect<void>;
+    readonly removeOwned: (state: StackState) => Effect.Effect<void, InvalidStackStateError>;
     readonly deleteStack: (name: string) => Effect.Effect<void>;
     readonly resolve: (
       cwd: string,
@@ -650,6 +665,8 @@ export class StateManager extends Context.Service<
           metadataFile,
           runtimeDir,
         };
+        const read = makeRead(deps);
+        const remove = makeRemove(deps);
         const scan = makeScan(deps);
         const writeMetadata = makeWriteMetadata(deps);
         const readMetadata = makeReadMetadata(deps);
@@ -662,13 +679,14 @@ export class StateManager extends Context.Service<
           metadataFile,
           stackExists: makeStackExists(deps),
           write: makeWrite(deps),
-          read: makeRead(deps),
+          read,
           scan,
           writeMetadata,
           updateMetadata: makeUpdateMetadata(readMetadata, writeMetadata),
           readMetadata,
           scanMetadata: makeScanMetadata(deps),
-          remove: makeRemove(deps),
+          remove,
+          removeOwned: makeRemoveOwned(read, remove),
           deleteStack: makeDeleteStack(deps),
           resolve: makeResolve(path, scan),
           isAlive: makeIsAlive(),

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -1,8 +1,9 @@
-import { Data, Effect, Layer, Schedule, Schema, Context } from "effect";
+import { Data, Effect, Layer, Schema, Context } from "effect";
 import { FileSystem, Path } from "effect";
 import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { AllocatedPortsSchema, type AllocatedPorts } from "./PortAllocator.ts";
+import { acquireManagedPortLock, managedLockPath } from "./ManagedPortLock.ts";
 import {
   PartialVersionManifestSchema,
   STACK_METADATA_SCHEMA_VERSION,
@@ -449,31 +450,11 @@ function withStateLock<A, E, R>(
   name: string,
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> {
-  const stateLockBusy = "StateLockBusy";
-  const lockPath = `${deps.stackDir(name)}.state.lock`;
-  const acquire = deps.fs.makeDirectory(lockPath).pipe(
-    Effect.result,
-    Effect.flatMap((result) => {
-      if (result._tag === "Success") return Effect.void;
-      return result.failure.reason._tag === "AlreadyExists"
-        ? Effect.fail(stateLockBusy)
-        : Effect.die(result.failure);
-    }),
-    Effect.retry({
-      while: (error) => error === stateLockBusy,
-      schedule: Schedule.spaced("10 millis"),
-    }),
-    Effect.orDie,
-  );
-  return deps.fs.makeDirectory(deps.stacksRoot, { recursive: true }).pipe(
-    Effect.orDie,
-    Effect.andThen(
-      Effect.acquireUseRelease(
-        acquire,
-        () => effect,
-        () => deps.fs.remove(lockPath, { recursive: true }).pipe(Effect.ignore),
-      ),
-    ),
+  const lockPath = managedLockPath(`stack-state:${deps.stackDir(name)}`);
+  return Effect.acquireUseRelease(
+    Effect.promise((signal) => acquireManagedPortLock(lockPath, signal)),
+    () => effect,
+    (release) => Effect.promise(release),
   );
 }
 

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -3,7 +3,7 @@ import { FileSystem, Path } from "effect";
 import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { AllocatedPortsSchema, type AllocatedPorts } from "./PortAllocator.ts";
-import { acquireManagedPortLock, managedLockPath } from "./ManagedPortLock.ts";
+import { acquireManagedPortLock, privateManagedLockPath } from "./ManagedPortLock.ts";
 import {
   PartialVersionManifestSchema,
   STACK_METADATA_SCHEMA_VERSION,
@@ -450,7 +450,7 @@ function withStateLock<A, E, R>(
   name: string,
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> {
-  const lockPath = managedLockPath(`stack-state:${deps.stackDir(name)}`);
+  const lockPath = privateManagedLockPath(`stack-state:${deps.stackDir(name)}`);
   return Effect.acquireUseRelease(
     Effect.promise((signal) => acquireManagedPortLock(lockPath, signal)),
     () => effect,

--- a/packages/stack/src/StateManager.unit.test.ts
+++ b/packages/stack/src/StateManager.unit.test.ts
@@ -292,6 +292,37 @@ describe("StateManager", () => {
         yield* mgr.remove("nonexistent");
       }).pipe(Effect.provide(layer));
     });
+
+    it.live("removes state and runtime files when the owner matches", () => {
+      const { layer, dirs } = setup();
+      return Effect.gen(function* () {
+        const mgr = yield* StateManager;
+        const state = makeState();
+        yield* mgr.write(state);
+        dirs.add(mgr.runtimeDir(state.name));
+
+        yield* mgr.removeOwned(state);
+
+        expect(Exit.isFailure(yield* mgr.read(state.name).pipe(Effect.exit))).toBe(true);
+        expect(dirs.has(mgr.runtimeDir(state.name))).toBe(false);
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.live("preserves state and runtime files owned by a replacement daemon", () => {
+      const { layer, dirs } = setup();
+      return Effect.gen(function* () {
+        const mgr = yield* StateManager;
+        const previous = makeState();
+        const replacement = makeState({ pid: 67890, startedAt: "2026-03-04T10:01:00Z" });
+        yield* mgr.write(replacement);
+        dirs.add(mgr.runtimeDir(replacement.name));
+
+        yield* mgr.removeOwned(previous);
+
+        expect(yield* mgr.read(replacement.name)).toEqual(replacement);
+        expect(dirs.has(mgr.runtimeDir(replacement.name))).toBe(true);
+      }).pipe(Effect.provide(layer));
+    });
   });
 
   describe("deleteStack", () => {

--- a/packages/stack/src/daemon.ts
+++ b/packages/stack/src/daemon.ts
@@ -71,13 +71,20 @@ export async function runDaemon(
     // Build the stack (services are started later via POST /start)
     const localStack = await appRuntime.runPromise(Stack);
     const info = await appRuntime.runPromise(localStack.getInfo());
-    stateManager = await appRuntime.runPromise(StateManager);
+    const localStateManager = await appRuntime.runPromise(StateManager);
+    stateManager = localStateManager;
 
     // Build daemon management server on Unix socket
-    const daemonLayer = DaemonServer.layer.pipe(
+    const daemonLayer = DaemonServer.layerWithShutdown(
+      Effect.suspend(() =>
+        daemonState === undefined
+          ? Effect.void
+          : localStateManager.removeOwned(daemonState).pipe(Effect.ignore),
+      ),
+    ).pipe(
       Layer.provide(Layer.succeed(Stack, localStack)),
       Layer.provide(daemonServerFactory(socketPath)),
-    ) as unknown as Layer.Layer<DaemonServer, never, never>;
+    );
 
     daemonRuntime = ManagedRuntime.make(daemonLayer);
     await daemonRuntime.runPromise(DaemonServer);
@@ -103,7 +110,7 @@ export async function runDaemon(
       services: runningServiceVersionsForConfig(config),
     };
     daemonState = state;
-    await Effect.runPromise(stateManager.write(state));
+    await Effect.runPromise(localStateManager.write(state));
 
     const response: DaemonStartedMessage = { type: "started", state };
     process.send!(response);
@@ -163,6 +170,6 @@ async function shutdownDaemon(opts: {
   await opts.appRuntime?.dispose().catch(() => {});
 
   if (opts.stateManager != null && opts.daemonState != null) {
-    await Effect.runPromise(opts.stateManager.remove(opts.daemonState.name)).catch(() => {});
+    await Effect.runPromise(opts.stateManager.removeOwned(opts.daemonState)).catch(() => {});
   }
 }

--- a/packages/stack/src/daemon.ts
+++ b/packages/stack/src/daemon.ts
@@ -79,7 +79,7 @@ export async function runDaemon(
       Effect.suspend(() =>
         daemonState === undefined
           ? Effect.void
-          : localStateManager.removeOwned(daemonState).pipe(Effect.ignore),
+          : localStateManager.removeOwned(daemonState).pipe(Effect.catchCause(() => Effect.void)),
       ),
     ).pipe(
       Layer.provide(Layer.succeed(Stack, localStack)),

--- a/packages/stack/src/discovery.ts
+++ b/packages/stack/src/discovery.ts
@@ -212,7 +212,7 @@ export const stopDaemon = (opts: {
     }
 
     // Clean up any state the daemon did not remove for itself.
-    yield* stateManager.remove(state.name);
+    yield* stateManager.removeOwned(state);
   });
 
 export const deleteManagedStackPersistence = (opts: {

--- a/packages/stack/src/layers.ts
+++ b/packages/stack/src/layers.ts
@@ -1,11 +1,12 @@
 import { fork, type ChildProcess } from "node:child_process";
-import { Data, Effect, Layer, Option } from "effect";
+import { Data, Effect, Fiber, Layer, Option, Schema } from "effect";
 import { FileSystem, Path } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { ApiProxy, type ProxyConfig } from "./ApiProxy.ts";
 import { BinaryResolver } from "./BinaryResolver.ts";
 import type { PlatformFactory } from "./createStack.ts";
 import type { DaemonMessage, DaemonStartMessage } from "./daemon.ts";
+import { DaemonMessageSchema } from "./DaemonProtocol.ts";
 import type { PortLease } from "./PortAllocator.ts";
 import { RemoteStack } from "./RemoteStack.ts";
 import { StackServiceActivator } from "./ServiceActivation.ts";
@@ -239,9 +240,17 @@ export const daemonLayer = (
         projectDir: config.projectDir,
         socketPath,
       };
-      child.send(startMsg);
-
-      const response = yield* waitForDaemonResponse(child);
+      const responseFiber = yield* waitForDaemonResponse(child).pipe(
+        Effect.timeout("30 seconds"),
+        Effect.mapError((error) =>
+          error._tag === "DaemonStartError"
+            ? error
+            : new DaemonStartError({ message: "Timed out waiting for daemon startup" }),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* sendDaemonStart(child, startMsg);
+      const response = yield* Fiber.join(responseFiber);
 
       if (response.type === "error") {
         return yield* new DaemonStartError({ message: response.message });
@@ -282,6 +291,35 @@ const forkDaemon = (entryPoint: string): Effect.Effect<ChildProcess, DaemonStart
       }),
   });
 
+const sendDaemonStart = (
+  child: ChildProcess,
+  message: DaemonStartMessage,
+): Effect.Effect<void, DaemonStartError> =>
+  Effect.callback<void, DaemonStartError>((resume) => {
+    try {
+      child.send(message, (error) => {
+        if (error === null) {
+          resume(Effect.void);
+          return;
+        }
+        resume(
+          Effect.fail(
+            new DaemonStartError({ message: `Failed to send daemon config: ${error.message}` }),
+          ),
+        );
+      });
+    } catch (cause) {
+      resume(
+        Effect.fail(
+          new DaemonStartError({
+            message: `Failed to send daemon config: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
+        ),
+      );
+    }
+    return Effect.void;
+  });
+
 /** Wait for DaemonStartedMessage or DaemonErrorMessage from the child. */
 const waitForDaemonResponse = (
   child: ChildProcess,
@@ -289,7 +327,12 @@ const waitForDaemonResponse = (
   Effect.callback<DaemonMessage, DaemonStartError>((resume) => {
     const onMessage = (msg: unknown) => {
       cleanup();
-      resume(Effect.succeed(msg as DaemonMessage));
+      const decoded = Schema.decodeUnknownOption(DaemonMessageSchema)(msg);
+      resume(
+        Option.isSome(decoded)
+          ? Effect.succeed(decoded.value)
+          : Effect.fail(new DaemonStartError({ message: "Daemon sent an invalid IPC response" })),
+      );
     };
 
     const onError = (err: Error) => {

--- a/packages/stack/src/layers.ts
+++ b/packages/stack/src/layers.ts
@@ -1,4 +1,6 @@
 import { fork, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { Data, Effect, Fiber, Layer, Option, Schema } from "effect";
 import { FileSystem, Path } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
@@ -224,7 +226,10 @@ export const daemonLayer = (
     yield* fs
       .makeDirectory(runtimeDir, { recursive: true })
       .pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
-    const socketPath = stateManager.socketPath(config.name);
+    // A daemon generation owns its socket pathname for its entire lifetime.
+    // Reusing a fixed pathname lets a delayed shutdown unlink a replacement
+    // daemon's socket after the replacement has already bound it.
+    const socketPath = join(runtimeDir, `daemon-${randomUUID().slice(0, 12)}.sock`);
 
     // Clean up stale socket file if present
     yield* fs.remove(socketPath).pipe(Effect.ignore);


### PR DESCRIPTION
Stack layer 6 of 7, based on #6045.

Makes daemon-backed stacks preserve foreground lazy lifecycle semantics:

- tracks the real activated dependency closure and clears it across restarts
- fails readiness checks immediately outside the running phase or for dormant lazy services
- delegates remote readiness to dedicated daemon endpoints
- preserves typed lifecycle errors across the HTTP boundary
- validates and bounds the parent-child startup handshake