### PR TITLE
fix(cli): skip unmounted workdir

### DIFF
--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -14,6 +14,7 @@ import {
   mockLegacyTelemetryStateTracked,
   useLegacyTempWorkdir,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
+import { toDockerPath } from "../../../../shared/functions/deploy.ts";
 import {
   mockOutput,
   mockProcessControl,
@@ -488,6 +489,9 @@ describe("legacy functions serve integration", () => {
             value.endsWith(":/root/index.ts:ro,Z"),
           ),
         ).toBe(true);
+        expect(extractFlagValues(dockerRun.args, "--workdir")).toEqual([
+          toDockerPath(tempRoot.current),
+        ]);
         expect(dockerRun.args[dockerRun.args.length - 1]).toBe(
           "edge-runtime start --main-service=/root --port=8081 --policy=per_worker\n",
         );

--- a/apps/cli/src/legacy/commands/start/services/edge-runtime.service.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/edge-runtime.service.integration.test.ts
@@ -176,25 +176,68 @@ describe("legacyStartEdgeRuntimeContainer", () => {
       }),
   );
 
-  it.effect(
-    "sets --workdir and --ulimit nofile=65536:65536, matching Go's WorkingDir/Ulimits container.Config",
-    () =>
-      Effect.gen(function* () {
-        const mock = mockDockerSpawner();
-        const out = mockOutput();
+  it.effect("sets --ulimit nofile=65536:65536, matching Go's Ulimits container.Config", () =>
+    Effect.gen(function* () {
+      const mock = mockDockerSpawner();
+      const out = mockOutput();
 
-        yield* legacyStartEdgeRuntimeContainer(baseInput(tempWorkdir.current)).pipe(
-          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, mock.spawner),
-          Effect.provide(out.layer),
-        );
+      yield* legacyStartEdgeRuntimeContainer(baseInput(tempWorkdir.current)).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, mock.spawner),
+        Effect.provide(out.layer),
+      );
 
-        const runCall = mock.runCall!;
-        const workdirIndex = runCall.args.indexOf("--workdir");
-        expect(workdirIndex).toBeGreaterThanOrEqual(0);
-        expect(runCall.args[workdirIndex + 1]).toBe(tempWorkdir.current);
-        const ulimitIndex = runCall.args.indexOf("--ulimit");
-        expect(runCall.args[ulimitIndex + 1]).toBe("nofile=65536:65536");
-      }),
+      const runCall = mock.runCall!;
+      const ulimitIndex = runCall.args.indexOf("--ulimit");
+      expect(runCall.args[ulimitIndex + 1]).toBe("nofile=65536:65536");
+    }),
+  );
+
+  it.effect("sets --workdir once an enabled function mounts the project root (#6035)", () =>
+    Effect.gen(function* () {
+      const slug = "hello";
+      const entrypoint = join(tempWorkdir.current, "supabase", "functions", slug, "index.ts");
+      mkdirSync(join(tempWorkdir.current, "supabase", "functions", slug), { recursive: true });
+      writeFileSync(entrypoint, "Deno.serve(() => new Response('ok'));");
+
+      const fnConfig = {
+        enabled: true,
+        verify_jwt: true,
+        import_map: "",
+        entrypoint,
+        static_files: [],
+        env: {},
+      };
+      const mock = mockDockerSpawner();
+      const out = mockOutput();
+      const input = baseInput(tempWorkdir.current);
+
+      yield* legacyStartEdgeRuntimeContainer({
+        ...input,
+        configDeclaredFunctions: { [slug]: fnConfig },
+        configFunctions: { [slug]: fnConfig },
+        rawConfigFunctions: { [slug]: fnConfig },
+      }).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, mock.spawner),
+        Effect.provide(out.layer),
+      );
+
+      const args = mock.runCall!.args;
+      expect(args[args.indexOf("--workdir") + 1]).toBe(tempWorkdir.current);
+    }),
+  );
+
+  it.effect("omits --workdir when no bind mounts the project root into the container (#6035)", () =>
+    Effect.gen(function* () {
+      const mock = mockDockerSpawner();
+      const out = mockOutput();
+
+      yield* legacyStartEdgeRuntimeContainer(baseInput(tempWorkdir.current)).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, mock.spawner),
+        Effect.provide(out.layer),
+      );
+
+      expect(mock.runCall!.args).not.toContain("--workdir");
+    }),
   );
 
   it.effect(

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -298,10 +298,23 @@ function toBundledFileUrl(hostPath: string) {
   return url.toString();
 }
 
+const DOCKER_BIND_MODE_PATTERN = /:(?:ro|rw)(?:,[zZ])?$/;
+
 export function dockerBindHostPath(bind: string) {
-  const withoutMode = bind.replace(/:(?:ro|rw)$/, "");
+  const withoutMode = bind.replace(DOCKER_BIND_MODE_PATTERN, "");
   const separatorIndex = withoutMode.lastIndexOf(":");
   return separatorIndex === -1 ? withoutMode : withoutMode.slice(0, separatorIndex);
+}
+
+/**
+ * Container side of a `host:container[:mode]` bind. Unlike {@link dockerBindHostPath},
+ * a bind with no separator yields `""` rather than the whole string, so a malformed
+ * entry can never prefix-match a real container path.
+ */
+export function dockerBindContainerPath(bind: string) {
+  const withoutMode = bind.replace(DOCKER_BIND_MODE_PATTERN, "");
+  const separatorIndex = withoutMode.lastIndexOf(":");
+  return separatorIndex === -1 ? "" : withoutMode.slice(separatorIndex + 1);
 }
 
 function dockerNpmEnv(env: NodeJS.ProcessEnv = process.env): ReadonlyArray<string> {

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -49,6 +49,7 @@ import { ProcessControl } from "../runtime/process-control.service.ts";
 import {
   buildDockerBinds,
   discoverFunctionSlugs,
+  dockerBindContainerPath,
   dockerBindHostPath,
   dockerProjectLabels,
   dockerWorkdirLabel,
@@ -1063,6 +1064,22 @@ const loadServeProjectEnvironment = Effect.fnUntraced(function* (projectRoot: st
   return { paths, values, loadedPaths, sources } satisfies ProjectEnvironment;
 });
 
+/**
+ * Whether any bind mounts something at `containerPath` or below it, i.e. whether
+ * that path exists inside the container. Docker creates a missing `--workdir`,
+ * but Podman rejects the container outright (supabase/cli#6035), so the flag can
+ * only be set for a path a bind actually materializes.
+ */
+function hasBindUnder(binds: Iterable<string>, containerPath: string): boolean {
+  for (const bind of binds) {
+    const target = dockerBindContainerPath(bind);
+    if (target === containerPath || target.startsWith(`${containerPath}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function buildWatchSpecs(binds: ReadonlyArray<string>): Promise<ReadonlyArray<WatchSpec>> {
   const specs = new Map<string, WatchSpec>();
 
@@ -1617,6 +1634,7 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
       ).pipe(
         Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause)))),
       );
+      const containerProjectRoot = toDockerPath(input.projectRoot);
       const command = [
         "run",
         "-d",
@@ -1626,8 +1644,7 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
         networkMode,
         "--network-alias",
         "edge_runtime",
-        "--workdir",
-        toDockerPath(input.projectRoot),
+        ...(hasBindUnder(binds, containerProjectRoot) ? ["--workdir", containerProjectRoot] : []),
         "--ulimit",
         "nofile=65536:65536",
         "--label",

--- a/apps/cli/src/shared/functions/serve.unit.test.ts
+++ b/apps/cli/src/shared/functions/serve.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { bundleServeMainTemplate } from "./serve-main-bundler.ts";
+import { dockerBindContainerPath } from "./deploy.ts";
 import { buildServeEntrypointCommand } from "./serve.ts";
 
 describe("buildServeEntrypointCommand", () => {
@@ -20,5 +21,35 @@ describe("buildServeEntrypointCommand", () => {
     const script = buildServeEntrypointCommand(["edge-runtime", "start"]);
     expect(bundled.length).toBeGreaterThan(20_000);
     expect(script.length).toBeLessThan(128);
+  });
+});
+
+describe("dockerBindContainerPath", () => {
+  it("takes the container side of a posix bind", () => {
+    expect(
+      dockerBindContainerPath("/home/u/p/supabase/functions:/home/u/p/supabase/functions:ro"),
+    ).toBe("/home/u/p/supabase/functions");
+  });
+
+  it("takes the container side when the host path carries a Windows drive letter", () => {
+    // `split(":")[1]` returns the host-path tail here, which silently dropped
+    // `--workdir` for every Windows project that had functions.
+    expect(
+      dockerBindContainerPath(
+        "C:\\Users\\u\\p\\supabase\\functions:/Users/u/p/supabase/functions:ro",
+      ),
+    ).toBe("/Users/u/p/supabase/functions");
+  });
+
+  it("strips the SELinux relabel suffix this file emits", () => {
+    expect(dockerBindContainerPath("/tmp/x/main/index.ts:/root/index.ts:ro,Z")).toBe(
+      "/root/index.ts",
+    );
+  });
+
+  it("takes the container side of a named-volume bind", () => {
+    expect(dockerBindContainerPath("supabase_edge_runtime_x:/root/.cache/deno:rw")).toBe(
+      "/root/.cache/deno",
+    );
   });
 });


### PR DESCRIPTION
## TL;DR

Fixes `supabase start` failing on Podman with: `Error: workdir "/home/<user>/<project>" does not exist on container <id>`

 which was caused by the edge runtime container always being created with `--workdir <project root>` 
a path that only exists inside the container when a bind mounts something at or under it,
 so it's there for a project with functions and absent for one without. Docker quietly creates the missing directory,
Podman rejects the container outright. 
Now sorted by emitting `--workdir` only when a bind actually mounts that path, with tests around both directions...

No behaviour change for anyone already working: 
with ≥1 enabled function the flag is emitted exactly as before, on every runtime. A zero-function project simply stops getting an empty directory nothing ever read, the entrypoint is fully absolute (`--main-service=/root`)..

## refs

- closes supabase/cli#6035 
 the other 2/3 reported problems are already fixed: 
the SELinux relabel on the pgsodium secret bind by supabase/cli#6000 &
the volume already exists rejection by supabase/cli#6037