### PR TITLE
test(cli): resolve e2e images via the production resolver

### DIFF
--- a/apps/cli/src/legacy/commands/start/lib/image-prepull.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/lib/image-prepull.unit.test.ts
@@ -125,7 +125,7 @@ describe("legacyEnsureImagesCached", () => {
     }),
   );
 
-  // Every pull attempt fails, so this drives the real LEGACY_DOCKER_PULL_RETRY_DELAYS_MS
+  // Every pull attempt fails, so this drives the real DOCKER_PULL_RETRY_DELAYS_MS
   // backoff (4s + 8s) to exhaustion across all 3 registry candidates (~36s) —
   // needs more than Vitest's 5s default.
   it.live(

--- a/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
@@ -10,7 +10,15 @@ import { legacyGetRegistryImageUrlCandidates } from "./legacy-docker-registry.ts
 
 type Spawner = ChildProcessSpawner["Service"];
 
-export const LEGACY_DOCKER_PULL_RETRY_DELAYS_MS = [4_000, 8_000] as const;
+const DOCKER_PULL_RETRY_DELAYS_MS = [4_000, 8_000] as const;
+
+/**
+ * Distinguishes a deadline-bounded pull attempt expiring from a spawn failure:
+ * the loop below treats a failed `pullImage` EFFECT as "docker itself is
+ * broken" and aborts every remaining candidate, which is exactly wrong for a
+ * timeout — a slow registry is the one failure the next candidate can fix.
+ */
+const PULL_TIMED_OUT = Symbol("PULL_TIMED_OUT");
 
 const spawnError = () =>
   // Never embed the spawn error verbatim: it can leak the full argv and
@@ -45,7 +53,7 @@ const concat = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
  * unconditionally — Go retries on any non-nil error as long as the context
  * wasn't canceled, with no message-pattern gating — up to 2 times per
  * candidate (3 total attempts) with an escalating 4s/8s backoff
- * (`LEGACY_DOCKER_PULL_RETRY_DELAYS_MS`), matching Go's `2<<(i+1)` seconds for `i` in
+ * (`DOCKER_PULL_RETRY_DELAYS_MS`), matching Go's `2<<(i+1)` seconds for `i` in
  * `0,1`. A spawn failure (the Docker/Podman binary itself couldn't be run) is
  * a different, non-retryable case — see `spawnError` below. Used by both the
  * foreground `db dump`-style run-to-completion containers
@@ -62,7 +70,7 @@ const concat = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
 export function legacyMakeDockerImageResolver(
   spawner: Spawner,
   projectEnvValues?: Readonly<Record<string, string>>,
-): (image: string) => Effect.Effect<string, LegacyDockerRunError> {
+): (image: string, deadline?: number) => Effect.Effect<string, LegacyDockerRunError> {
   const hasLocalImage = (image: string): Effect.Effect<boolean, LegacyDockerRunError> =>
     Effect.gen(function* () {
       // `stdout: "ignore"`: `docker image inspect` writes the full image JSON
@@ -156,7 +164,7 @@ export function legacyMakeDockerImageResolver(
       };
     }).pipe(Effect.scoped);
 
-  return (image: string): Effect.Effect<string, LegacyDockerRunError> =>
+  return (image: string, deadline?: number): Effect.Effect<string, LegacyDockerRunError> =>
     Effect.gen(function* () {
       const candidates = legacyGetRegistryImageUrlCandidates(image, projectEnvValues);
       for (const candidate of candidates) {
@@ -166,24 +174,66 @@ export function legacyMakeDockerImageResolver(
       }
 
       const failures: Array<string> = [];
-      for (const candidate of candidates) {
+      for (const [candidateIndex, candidate] of candidates.entries()) {
+        // `deadline` (epoch ms) is opt-in and no production caller passes one:
+        // a human watching `supabase start` can Ctrl-C a slow pull, CI cannot,
+        // so only the e2e helper (`tests/helpers/docker-image.ts`) bounds the
+        // resolve. Remaining time is split across the candidates still to run
+        // — recomputed per candidate so a fast failure carries its unused
+        // share forward and the last candidate gets all remaining time — and
+        // a stalled registry can never starve the fallbacks behind it.
+        let candidateShareMs: number | undefined;
+        let candidateDeadline: number | undefined;
+        if (deadline !== undefined) {
+          candidateShareMs = Math.max(
+            1,
+            Math.floor((deadline - Date.now()) / (candidates.length - candidateIndex)),
+          );
+          candidateDeadline = Math.min(Date.now() + candidateShareMs, deadline);
+        }
+        // Whether the most recent failed attempt's teed output ended with a
+        // newline — read by the retry banner below, which runs outside the
+        // block the pull result is scoped to.
+        let lastPullEndedWithNewline = true;
         for (
           let attemptIndex = 0;
-          attemptIndex <= LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length;
+          attemptIndex <= DOCKER_PULL_RETRY_DELAYS_MS.length;
           attemptIndex += 1
         ) {
           const attempt = attemptIndex + 1;
-          const result = yield* Effect.exit(pullImage(candidate));
+          const remainingMs =
+            candidateDeadline === undefined ? undefined : candidateDeadline - Date.now();
+          if (remainingMs !== undefined && remainingMs <= 0) {
+            failures.push(
+              `${candidate} attempt ${attempt}: candidate budget exhausted (${candidateShareMs}ms share)`,
+            );
+            break;
+          }
+          const result = yield* Effect.exit(
+            remainingMs === undefined
+              ? pullImage(candidate)
+              : Effect.timeoutOrElse(pullImage(candidate), {
+                  duration: `${remainingMs} millis`,
+                  orElse: () => Effect.succeed(PULL_TIMED_OUT),
+                }),
+          );
           if (Exit.isSuccess(result)) {
-            if (result.value.exitCode === 0) {
+            if (result.value === PULL_TIMED_OUT) {
+              failures.push(`${candidate} attempt ${attempt}: timed out after ${remainingMs}ms`);
+              // The share is spent — move straight to the next candidate.
+              break;
+            }
+            const pulled = result.value;
+            lastPullEndedWithNewline = pulled.endedWithNewline;
+            if (pulled.exitCode === 0) {
               return candidate;
             }
             const message =
-              result.value.stderr.length > 0
-                ? result.value.stderr
-                : `docker pull exited with code ${result.value.exitCode}`;
+              pulled.stderr.length > 0
+                ? pulled.stderr
+                : `docker pull exited with code ${pulled.exitCode}`;
             failures.push(`${candidate} attempt ${attempt}: ${message}`);
-            if (attemptIndex === LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length) {
+            if (attemptIndex === DOCKER_PULL_RETRY_DELAYS_MS.length) {
               break;
             }
           } else {
@@ -197,8 +247,13 @@ export function legacyMakeDockerImageResolver(
             return yield* Effect.fail(spawnError());
           }
 
-          const delay = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
+          const delay = DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
           if (delay === undefined) {
+            break;
+          }
+          // Never sleep past this candidate's share — the backoff would spend
+          // budget the remaining registries still need.
+          if (candidateDeadline !== undefined && Date.now() + delay >= candidateDeadline) {
             break;
           }
           // Go prints a per-retry banner before sleeping (`docker.go:314`):
@@ -212,7 +267,7 @@ export function legacyMakeDockerImageResolver(
           // the banner would glue onto the error text where Go prints two
           // lines.
           yield* Effect.sync(() => {
-            if (!result.value.endedWithNewline) {
+            if (!lastPullEndedWithNewline) {
               globalThis.process.stderr.write("\n");
             }
             globalThis.process.stderr.write(`Retrying after ${delay / 1000}s: ${candidate}\n`);

--- a/apps/cli/src/legacy/shared/legacy-docker-image-resolve.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-image-resolve.unit.test.ts
@@ -274,6 +274,39 @@ describe("legacyMakeDockerImageResolver", () => {
       }),
   );
 
+  it.live("gives every registry candidate its share when a deadline is passed", () => {
+    // Fail-fast pulls with a small budget: each candidate still gets a turn
+    // (unused share carries forward), and the guarded backoff never sleeps a
+    // 4s retry into the next candidate's time — the test finishing in
+    // milliseconds rather than seconds is itself the assertion.
+    const mock = mockSpawner([
+      { exitCode: 1, stderr: "denied" },
+      { exitCode: 1, stderr: "denied" },
+      { exitCode: 1, stderr: "denied" },
+    ]);
+    const resolve = legacyMakeDockerImageResolver(mock.spawner);
+    return resolve("supabase/postgres:15", Date.now() + 500).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error).toBeInstanceOf(LegacyDockerRunError);
+        expect(mock.pulls.length).toBe(3);
+        expect(new Set(mock.pulls).size).toBe(3);
+      }),
+    );
+  });
+
+  it.live("reports exhausted candidate budgets instead of pulling past a spent deadline", () => {
+    const mock = mockSpawner([]);
+    const resolve = legacyMakeDockerImageResolver(mock.spawner);
+    return resolve("supabase/postgres:15", Date.now() - 1_000).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain("candidate budget exhausted");
+        expect(mock.pulls.length).toBe(0);
+      }),
+    );
+  });
+
   it.effect("prints no Retrying banner when the first pull attempt succeeds", () =>
     Effect.gen(function* () {
       const previousRegistry = process.env[REGISTRY_ENV];

--- a/apps/cli/tests/helpers/docker-image.ts
+++ b/apps/cli/tests/helpers/docker-image.ts
@@ -1,131 +1,141 @@
-import { spawnSync } from "node:child_process";
-import { setTimeout as sleep } from "node:timers/promises";
+import { BunServices } from "@effect/platform-bun";
+import { Cause, Duration, Effect, Layer } from "effect";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type { ChildProcessSpawner as ChildProcessSpawnerTag } from "effect/unstable/process/ChildProcessSpawner";
 
-import { LEGACY_DOCKER_PULL_RETRY_DELAYS_MS } from "../../src/legacy/shared/legacy-docker-image-resolve.ts";
-import { legacyGetRegistryImageUrlCandidates } from "../../src/legacy/shared/legacy-docker-registry.ts";
-import { legacyIsDockerDaemonUnreachable } from "../../src/legacy/shared/legacy-docker-suggest.ts";
+import { legacyMakeDockerImageResolver } from "../../src/legacy/shared/legacy-docker-image-resolve.ts";
 
-const INSPECT_TIMEOUT_MS = 15_000;
-const PULL_ATTEMPT_TIMEOUT_MS = 120_000;
+type Spawner = ChildProcessSpawnerTag["Service"];
+
 // Overall per-image ceiling. Deliberately BELOW the tightest e2e test budget
-// (120s): a stalled registry must leave the caller room to run its test body,
-// and vitest cannot preempt a blocked synchronous spawn to enforce that itself.
+// (120s): a stalled registry must leave the caller room to run its test body.
 export const RESOLVE_BUDGET_MS = 90_000;
-const PULL_MAX_BUFFER = 16 * 1024 * 1024;
-const PULL_ATTEMPTS = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS.length + 1;
 
 const resolvedImages = new Map<string, Promise<string>>();
 
 /**
- * Resolves an image for a raw e2e `docker run`/`docker pull` the same way the
- * production resolver does (`legacy-docker-image-resolve.ts`): any candidate
- * already in the local cache wins, otherwise each registry fallback
- * (ECR → GHCR → Docker Hub) is pulled explicitly with 4s/8s retries. A raw
- * `docker run` of an uncached image implicit-pulls from a single registry,
- * where CI regularly fails with `toomanyrequests: Rate exceeded`. Returns the
- * resolved reference the caller must use in its own docker argv. Results
- * (including failures) are memoized per process so parallel/subsequent tests
- * never re-pay the retry ladder. Every subprocess call is timeout-bounded —
- * vitest's own testTimeout cannot preempt a hung synchronous spawn.
+ * Serializes distinct-image resolution. The helper this replaced spawned
+ * synchronously, so a `Promise.all` over several images was serialized whether
+ * the caller meant it or not — and `serve-main-offline.e2e.test.ts` resolves
+ * two images exactly that way. Letting them run concurrently would put two cold
+ * pulls against the same registry at the same instant, which is the
+ * `toomanyrequests` failure this helper exists to avoid, so the old ordering is
+ * preserved deliberately rather than by accident.
  */
-export function ensureImage(image: string, deadline = resolveDeadline()): Promise<string> {
+let resolveQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Resolves an image for a raw e2e `docker run`/`docker pull` by running the
+ * PRODUCTION resolver (`legacyMakeDockerImageResolver`) against a real
+ * subprocess spawner — same candidate order, same local-cache-first check, same
+ * retry ladder the CLI itself uses, so this can never drift from it. A raw
+ * `docker run` of an uncached image implicit-pulls from a single registry,
+ * where CI regularly fails with `toomanyrequests: Rate exceeded`; resolving
+ * first lets the ECR → GHCR → Docker Hub fallback do its job.
+ *
+ * Returns the resolved reference the caller must use in its own docker argv.
+ * Results (including failures) are memoized per process so parallel/subsequent
+ * tests never re-pay the retry ladder.
+ *
+ * `deadline` bounds the resolve, but only for a subprocess that exits when
+ * asked: the spawner's release sends one SIGTERM and then awaits the child, and
+ * `forceKillAfter` does not change that — it races the signal call, not the
+ * wait. A `docker` CLI that ignored SIGTERM outright could still outlast the
+ * budget. Real ones don't, and the ceiling still covers what it was added for:
+ * a registry that is slow rather than wedged.
+ */
+export function ensureImage(
+  image: string,
+  deadline?: number,
+  // Injectable so the queue/memo behavior is unit-testable with a fake spawner;
+  // every e2e caller uses the real default.
+  services: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> = BunServices.layer,
+): Promise<string> {
   const memo = resolvedImages.get(image);
   if (memo !== undefined) return memo;
-  const resolving = resolveImage(image, deadline);
+  const resolving = resolveQueue.then(() =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      // A defaulted deadline is stamped when this image's turn STARTS, not when
+      // the caller enqueued it — otherwise time spent waiting behind another
+      // image's resolution would silently shrink this one's window. An explicit
+      // deadline is shared budget by contract and is left exactly as given.
+      return yield* resolveImage(spawner, image, deadline ?? resolveDeadline());
+    }).pipe(Effect.provide(services), Effect.runPromise),
+  );
+  // Both the queue link and the memo swallow nothing: callers still see the
+  // rejection, this only stops one failure from becoming an unhandled rejection
+  // or wedging the queue for the next image.
+  resolveQueue = resolving.catch(() => undefined);
+  resolving.catch(() => undefined);
   resolvedImages.set(image, resolving);
   return resolving;
 }
 
 /**
  * One deadline for a whole test's image setup: pass the same value to every
- * `ensureImage` call so multi-image tests pay at most one budget in total —
- * the synchronous spawns serialize regardless of Promise.all, so per-image
- * deadlines would otherwise stack beyond the test budget. Callers with roomier
- * test timeouts can size the budget to their own setup window.
+ * `ensureImage` call so multi-image tests pay at most one budget in total.
+ * Callers with roomier test timeouts can size the budget to their own setup
+ * window.
  */
 export function resolveDeadline(budgetMs = RESOLVE_BUDGET_MS): number {
   return Date.now() + budgetMs;
 }
 
-function spawnFailed(result: { error?: Error; signal: NodeJS.Signals | null }): boolean {
-  return result.error !== undefined && (result.signal === null || result.signal === undefined);
+/**
+ * The production resolver spawns through `spawnContainerCli`, which falls back
+ * to podman when docker is absent — but every caller then runs raw `docker`
+ * argv, so an image pulled by podman would be invisible to the command under
+ * test. Assert the docker CLI itself is present, turning that into one clear
+ * failure instead of a confusing "docker: command not found" several steps on.
+ * Deliberately a client-only probe: an unreachable daemon is a different
+ * condition that the resolver already reports with its own message.
+ */
+function requireDocker(spawner: Spawner): Effect.Effect<void, Error> {
+  return spawner.exitCode(ChildProcess.make("docker", ["--version"])).pipe(
+    Effect.mapError(() => new Error("docker is required for this test but could not be spawned")),
+    Effect.filterOrFail(
+      (exitCode) => Number(exitCode) === 0,
+      () => new Error("docker is required for this test but exited non-zero"),
+    ),
+    Effect.asVoid,
+  );
 }
 
-async function resolveImage(image: string, deadline: number): Promise<string> {
-  const candidates = legacyGetRegistryImageUrlCandidates(image);
-  for (const candidate of candidates) {
-    // Bounded by the shared deadline too: a cached hit still answers in
-    // milliseconds, but a stalled daemon can no longer stack 15s inspects
-    // past a budget an earlier image already consumed.
-    const inspect = spawnSync("docker", ["image", "inspect", candidate], {
-      encoding: "utf8",
-      stdio: ["ignore", "ignore", "pipe"],
-      timeout: Math.min(INSPECT_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
-      killSignal: "SIGKILL",
-    });
-    if (spawnFailed(inspect)) {
-      throw new Error(`failed to run docker: ${inspect.error?.message ?? "unknown spawn error"}`);
-    }
-    if (inspect.status === 0) return candidate;
-    const stderr = (inspect.stderr ?? "").trim();
-    if (legacyIsDockerDaemonUnreachable(stderr)) {
-      throw new Error(`docker daemon unreachable: ${stderr}`);
-    }
-  }
-
-  const failures: Array<string> = [];
-  for (const [candidateIndex, candidate] of candidates.entries()) {
-    // Recomputed per candidate: remaining time split across the candidates
-    // still to run. A stalled candidate can never starve the fallbacks after
-    // it, and a fast-failing one carries its unused budget forward — the last
-    // candidate gets all remaining time.
-    const candidateBudgetMs = Math.max(
-      1,
-      Math.floor((deadline - Date.now()) / (candidates.length - candidateIndex)),
-    );
-    const candidateDeadline = Math.min(Date.now() + candidateBudgetMs, deadline);
-    for (let attemptIndex = 0; attemptIndex < PULL_ATTEMPTS; attemptIndex += 1) {
-      const remainingMs = candidateDeadline - Date.now();
-      if (remainingMs <= 0) {
-        failures.push(`${candidate}: candidate budget exhausted (${candidateBudgetMs}ms)`);
-        break;
+/**
+ * The resolve itself, taking its spawner explicitly so unit tests can drive it
+ * with a fake instead of a real Docker daemon.
+ */
+export function resolveImage(
+  spawner: Spawner,
+  image: string,
+  deadline: number,
+): Effect.Effect<string, Error> {
+  const remainingMs = Math.max(1, deadline - Date.now());
+  return requireDocker(spawner).pipe(
+    // The deadline goes INTO the resolver, which divides it across the
+    // registry candidates — a stalled registry cannot starve the ECR → GHCR →
+    // Docker Hub fallbacks behind it, and an exhausted share is reported
+    // against the candidate that spent it. The outer timeout is only a
+    // backstop for the paths the resolver does not bound (a wedged daemon
+    // hanging `docker image inspect`); its 1s grace keeps the resolver's own
+    // richer per-candidate error winning every race it can.
+    Effect.andThen(() => legacyMakeDockerImageResolver(spawner)(image, deadline)),
+    Effect.timeout(Duration.millis(remainingMs + 1_000)),
+    Effect.mapError((cause) => {
+      if (Cause.isTimeoutError(cause)) {
+        return new Error(
+          `timed out resolving ${image} after ${remainingMs}ms — is the docker daemon responding?`,
+        );
       }
-      console.error(
-        `[ensureImage] pulling ${candidate} (attempt ${attemptIndex + 1}/${PULL_ATTEMPTS})`,
-      );
-      // stdout carries the (unbounded) layer-progress stream — ignore it so a
-      // large healthy pull can never die on ENOBUFS; docker writes errors to
-      // stderr, which stays small and is all the failure text needs.
-      const pull = spawnSync("docker", ["pull", candidate], {
-        encoding: "utf8",
-        stdio: ["ignore", "ignore", "pipe"],
-        timeout: Math.min(PULL_ATTEMPT_TIMEOUT_MS, remainingMs),
-        killSignal: "SIGKILL",
-        maxBuffer: PULL_MAX_BUFFER,
-      });
-      if (spawnFailed(pull)) {
-        throw new Error(`failed to run docker: ${pull.error?.message ?? "unknown spawn error"}`);
-      }
-      if (pull.status === 0) return candidate;
-      const output = (pull.stderr ?? "").trim();
-      const reason =
-        pull.signal !== null && pull.signal !== undefined
-          ? `killed by ${pull.signal} after ${PULL_ATTEMPT_TIMEOUT_MS}ms`
-          : output.length > 0
-            ? output
-            : `exit ${pull.status ?? "unknown"}`;
-      failures.push(`${candidate} attempt ${attemptIndex + 1}: ${reason}`);
-      const delay = LEGACY_DOCKER_PULL_RETRY_DELAYS_MS[attemptIndex];
-      if (delay === undefined) continue;
-      if (Date.now() + delay >= candidateDeadline) break;
-      await sleep(delay);
-    }
-  }
-  return allRegistriesFailed(image, failures);
-}
-
-function allRegistriesFailed(image: string, failures: ReadonlyArray<string>): never {
-  throw new Error(
-    `failed to pull ${image} from all registries (set SUPABASE_INTERNAL_IMAGE_REGISTRY to pin one):\n${failures.join("\n")}`,
+      // The registry-pin hint only helps when the registries themselves were
+      // the problem; gluing it onto a missing binary or an unreachable daemon
+      // would misdirect the CI triage this helper exists to speed up.
+      const hint = cause.message.includes("failed to pull docker image from all registries")
+        ? " (set SUPABASE_INTERNAL_IMAGE_REGISTRY to pin one)"
+        : "";
+      return new Error(`failed to resolve ${image}${hint}: ${cause.message}`);
+    }),
   );
 }

--- a/apps/cli/tests/helpers/docker-image.unit.test.ts
+++ b/apps/cli/tests/helpers/docker-image.unit.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Layer, PlatformError, Sink, Stream } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ensureImage, RESOLVE_BUDGET_MS, resolveDeadline, resolveImage } from "./docker-image.ts";
+
+/** Matches the standing `mockSpawner` shape in `image-prepull.unit.test.ts`. */
+function mockSpawner(
+  handler: (args: ReadonlyArray<string>) => {
+    exitCode: number;
+    stdout?: string;
+    stderr?: string;
+    hang?: boolean;
+  },
+) {
+  const encoder = new TextEncoder();
+  const spawned: Array<ReadonlyArray<string>> = [];
+
+  const spawner = ChildProcessSpawner.make((command) =>
+    Effect.gen(function* () {
+      const args = command._tag === "StandardCommand" ? command.args : [];
+      spawned.push(args);
+      const result = handler(args);
+
+      const exitDeferred = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+      // `hang: true` leaves the deferred unresolved, standing in for a child
+      // that never exits — the case the resolve deadline exists to bound.
+      if (result.hang !== true) {
+        yield* Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(result.exitCode));
+      }
+
+      return ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(1),
+        stdout: Stream.fromIterable(
+          result.stdout !== undefined ? [encoder.encode(result.stdout)] : [],
+        ),
+        stderr: Stream.fromIterable(
+          result.stderr !== undefined ? [encoder.encode(result.stderr)] : [],
+        ),
+        all: Stream.empty,
+        exitCode: Deferred.await(exitDeferred),
+        isRunning: Effect.succeed(false),
+        stdin: Sink.drain,
+        // A killed child exits: settle the deferred so an interrupt can finish.
+        // Without this the fake reproduces the very hang `forceKillAfter`
+        // guards against in the real spawner.
+        kill: () =>
+          Deferred.succeed(exitDeferred, ChildProcessSpawner.ExitCode(137)).pipe(Effect.asVoid),
+        unref: Effect.succeed(Effect.void),
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+      });
+    }),
+  );
+
+  return {
+    spawner,
+    get spawned() {
+      return spawned;
+    },
+  };
+}
+
+const IMAGE = "supabase/postgres:17";
+
+describe("resolveDeadline", () => {
+  it("defaults to the shared budget and accepts a caller-sized one", () => {
+    const before = Date.now();
+    expect(resolveDeadline()).toBeGreaterThanOrEqual(before + RESOLVE_BUDGET_MS - 50);
+    expect(resolveDeadline(1_000)).toBeLessThanOrEqual(Date.now() + 1_000);
+  });
+});
+
+describe("resolveImage", () => {
+  it.live("returns the first candidate already present in the local cache", () => {
+    // `image inspect` exits 0 -> cache hit, so no pull is ever attempted.
+    const mock = mockSpawner(() => ({ exitCode: 0 }));
+    return resolveImage(mock.spawner, IMAGE, resolveDeadline(5_000)).pipe(
+      Effect.map((resolved) => {
+        expect(resolved).toContain("supabase/postgres:17");
+        expect(mock.spawned.some((args) => args[0] === "pull")).toBe(false);
+      }),
+    );
+  });
+
+  it.live("fails clearly when docker itself cannot be spawned", () => {
+    // The production resolver would silently fall back to podman, but callers
+    // run raw `docker` argv — so a podman-resolved image would be invisible.
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.fail(
+        PlatformError.systemError({
+          _tag: "NotFound",
+          module: "ChildProcess",
+          method: "spawn",
+          description: "docker not found",
+        }),
+      ),
+    );
+    return resolveImage(spawner, IMAGE, resolveDeadline(5_000)).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain("docker is required");
+        expect(error.message).not.toContain("SUPABASE_INTERNAL_IMAGE_REGISTRY");
+      }),
+    );
+  });
+
+  it.live("fails when the docker CLI is present but exits non-zero", () => {
+    // Regression guard: `spawner.exitCode` SUCCEEDS with the code, so a probe
+    // that only maps spawn errors would wave a broken docker through.
+    const mock = mockSpawner((args) =>
+      args[0] === "--version" ? { exitCode: 1 } : { exitCode: 0 },
+    );
+    return resolveImage(mock.spawner, IMAGE, resolveDeadline(5_000)).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain("exited non-zero");
+        expect(error.message).not.toContain("SUPABASE_INTERNAL_IMAGE_REGISTRY");
+        expect(mock.spawned.some((args) => args[0] === "image")).toBe(false);
+      }),
+    );
+  });
+
+  it.live("keeps the resolver's own detail when it fails for a non-timeout reason", () => {
+    // Uses the daemon-unreachable path because it fails fast: the resolver's
+    // multi-candidate retry ladder really sleeps 4s+8s per candidate, and its
+    // aggregated "all registries" message is already covered by that module's
+    // own TestClock-driven test. What matters here is only that the wrapper
+    // forwards the resolver's message instead of flattening it.
+    const mock = mockSpawner((args) =>
+      args[0] === "--version"
+        ? { exitCode: 0 }
+        : {
+            exitCode: 1,
+            stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock.",
+          },
+    );
+    return resolveImage(mock.spawner, IMAGE, resolveDeadline(5_000)).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain(`failed to resolve ${IMAGE}`);
+        expect(error.message).toContain("Cannot connect to the Docker daemon");
+        // The registry-pin hint must NOT appear here: no registry pin can fix
+        // an unreachable daemon, and suggesting one misdirects CI triage.
+        expect(error.message).not.toContain("SUPABASE_INTERNAL_IMAGE_REGISTRY");
+        expect(mock.spawned.some((args) => args[0] === "pull")).toBe(false);
+      }),
+    );
+  });
+
+  it.live("moves to the next registry when a pull attempt outlives its share", () => {
+    // The point of handing the deadline INTO the resolver: one wedged
+    // candidate must not consume the budget the fallbacks behind it need.
+    const pulled: Array<string> = [];
+    const mock = mockSpawner((args) => {
+      if (args[0] === "--version") return { exitCode: 0 };
+      if (args[0] === "image") return { exitCode: 1, stderr: "no such image" };
+      pulled.push(args[1] ?? "");
+      // The first candidate's pull never exits; the rest fail fast.
+      return pulled.length === 1 ? { exitCode: 0, hang: true } : { exitCode: 1, stderr: "denied" };
+    });
+    return resolveImage(mock.spawner, IMAGE, resolveDeadline(600)).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(new Set(pulled).size).toBeGreaterThan(1);
+        expect(error.message).toContain("timed out after");
+        expect(error.message).toContain("denied");
+      }),
+    );
+  });
+
+  it.live("reports an exhausted share against the candidate that spent it", () => {
+    const mock = mockSpawner((args) => {
+      if (args[0] === "--version") return { exitCode: 0 };
+      return { exitCode: 1, stderr: "no such image" };
+    });
+    return resolveImage(mock.spawner, IMAGE, Date.now() - 10_000).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain("candidate budget exhausted");
+        expect(error.message).toContain("SUPABASE_INTERNAL_IMAGE_REGISTRY");
+      }),
+    );
+  });
+
+  it.live("falls back to the backstop message when the daemon itself hangs", () => {
+    // `docker image inspect` is not deadline-bounded inside the resolver, so a
+    // wedged daemon is caught by the helper's outer backstop instead.
+    const mock = mockSpawner((args) => {
+      if (args[0] === "--version") return { exitCode: 0 };
+      return { exitCode: 0, hang: true };
+    });
+    return resolveImage(mock.spawner, IMAGE, resolveDeadline(200)).pipe(
+      Effect.flip,
+      Effect.map((error) => {
+        expect(error.message).toContain(`timed out resolving ${IMAGE}`);
+        expect(error.message).toContain("daemon");
+      }),
+    );
+  });
+});
+
+describe("ensureImage", () => {
+  const layerFor = (mock: ReturnType<typeof mockSpawner>) =>
+    Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, mock.spawner);
+
+  it("memoizes per image, including across differing deadlines", async () => {
+    const mock = mockSpawner(() => ({ exitCode: 0 }));
+    const image = `memo-${Date.now()}-a`;
+    const first = await ensureImage(image, resolveDeadline(5_000), layerFor(mock));
+    const spawnsAfterFirst = mock.spawned.length;
+    const second = await ensureImage(image, resolveDeadline(60_000), layerFor(mock));
+    expect(second).toBe(first);
+    expect(mock.spawned.length).toBe(spawnsAfterFirst);
+  });
+
+  it("memoizes failures so the retry ladder is never re-paid", async () => {
+    const mock = mockSpawner((args) =>
+      args[0] === "--version" ? { exitCode: 0 } : { exitCode: 1, stderr: "no such image" },
+    );
+    const image = `memo-${Date.now()}-fail`;
+    await expect(ensureImage(image, Date.now() - 1_000, layerFor(mock))).rejects.toThrow();
+    const spawnsAfterFirst = mock.spawned.length;
+    await expect(ensureImage(image, Date.now() - 1_000, layerFor(mock))).rejects.toThrow();
+    expect(mock.spawned.length).toBe(spawnsAfterFirst);
+  });
+
+  it("serializes distinct images: the second never spawns before the first settles", async () => {
+    const firstSpawnCounts: Array<number> = [];
+    const mock = mockSpawner((args) => {
+      if (args[0] === "--version") return { exitCode: 0 };
+      return { exitCode: 1, stderr: "no such image" };
+    });
+    const imageA = `queue-${Date.now()}-a`;
+    const imageB = `queue-${Date.now()}-b`;
+    // Enqueue both before awaiting either; the queue must fully settle A
+    // (including its failure) before B's first spawn happens.
+    const a = ensureImage(imageA, Date.now() - 1_000, layerFor(mock)).catch(() => "a-done");
+    const spawnsWhenBEnqueued = mock.spawned.length;
+    const b = ensureImage(imageB, Date.now() - 1_000, layerFor(mock)).catch(() => "b-done");
+    expect(mock.spawned.length).toBe(spawnsWhenBEnqueued);
+    await a;
+    firstSpawnCounts.push(mock.spawned.length);
+    await b;
+    expect(firstSpawnCounts[0]).toBeLessThanOrEqual(mock.spawned.length);
+  });
+});


### PR DESCRIPTION
## TL;DR

Follow-up to the design note on #6030: `tests/helpers/docker-image.ts` hand-rolled ~130 lines of the candidate/cache-check/retry algorithm that already exists as `legacyMakeDockerImageResolver`, so the two could silently drift. The helper now
drives the production resolver through a real `ChildProcessSpawner`, and the one
piece that couldn't move, #6030's per-candidate budget split, which stops a stalled registry starving 
the ECR → GHCR → Docker Hub fallbacks, is ported into
the resolver as an opt-in `deadline`. One implementation of everything; nothing left to drift....

The deadline is inert in production: both callers pass one argument, every new path is gated on it, and the pre-existing resolver tests pass untouched — the only other production edit reverts #6030's export-widening of the retry
constant. The helper keeps only test policy (memoization, serialized resolves, a docker-CLI probe, a wedged-daemon backstop), with unit coverage it never had...

## Refs

- Follow-up to #6030
 <details>
<summary>basically fixes: (ss)</summary>

<img width="1736" height="1296" alt="image" src="https://github.com/user-attachments/assets/6361bebf-b1b1-4e2d-b976-af9204fff080" />

</details>
