### PR TITLE
test(stack): deflake parallel stacks

### DIFF
--- a/packages/stack/src/terminateChild.ts
+++ b/packages/stack/src/terminateChild.ts
@@ -1,9 +1,14 @@
 interface ChildLike {
   readonly pid?: number;
+  readonly exitCode?: number | null;
+  readonly signalCode?: NodeJS.Signals | null;
   kill: (signal?: NodeJS.Signals) => boolean | void;
   once: (event: "exit", listener: () => void) => void;
   off: (event: "exit", listener: () => void) => void;
 }
+
+const hasAlreadyExited = (child: ChildLike): boolean =>
+  child.exitCode != null || child.signalCode != null;
 
 export const terminateChildProcess = async (
   child: ChildLike,
@@ -12,6 +17,11 @@ export const terminateChildProcess = async (
   } = {},
 ): Promise<void> => {
   if (child.pid == null) {
+    return;
+  }
+  // An already-exited child never fires another `exit` event, so the waits
+  // below would burn their full SIGTERM + SIGKILL timeouts listening for one.
+  if (hasAlreadyExited(child)) {
     return;
   }
 
@@ -23,6 +33,9 @@ export const terminateChildProcess = async (
   } catch {}
 
   if (await termExit) {
+    return;
+  }
+  if (hasAlreadyExited(child)) {
     return;
   }
 

--- a/packages/stack/src/terminateChild.unit.test.ts
+++ b/packages/stack/src/terminateChild.unit.test.ts
@@ -10,6 +10,7 @@ interface ChildLike {
 
 class FakeChild implements ChildLike {
   readonly pid = 1234;
+  exitCode: number | null = null;
   readonly signals: Array<NodeJS.Signals> = [];
   #listeners = new Set<() => void>();
 
@@ -61,5 +62,32 @@ describe("terminateChildProcess", () => {
     await terminateChildProcess(child, { timeoutMs: 10 });
 
     expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+});
+
+describe("terminateChildProcess on an already-exited child", () => {
+  it("returns immediately instead of waiting out both signal timeouts", async () => {
+    // A dead ChildProcess never fires another `exit` event, so before this
+    // guard the call burned 2x timeoutMs listening for one — which turned a
+    // teardown sweep over dead children into the very afterAll hook timeout
+    // the sweep exists to prevent.
+    const child = new FakeChild();
+    child.exitCode = 0;
+    const started = Date.now();
+    await terminateChildProcess(child, { timeoutMs: 5_000 });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(child.signals).toEqual([]);
+  });
+
+  it("skips the SIGKILL wait when the child dies between checks", async () => {
+    const child = new FakeChild((signal, self) => {
+      if (signal === "SIGTERM") {
+        self.exitCode = 143;
+      }
+    });
+    const started = Date.now();
+    await terminateChildProcess(child, { timeoutMs: 300 });
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(child.signals).toEqual(["SIGTERM"]);
   });
 });

--- a/packages/stack/tests/helpers/spawn-stack.ts
+++ b/packages/stack/tests/helpers/spawn-stack.ts
@@ -1,0 +1,112 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { terminateChildProcess } from "../../src/terminateChild.ts";
+
+const STANDALONE_SCRIPT = resolve(import.meta.dirname, "standalone-stack.ts");
+const DEFAULT_READINESS_TIMEOUT_MS = 60_000;
+const OUTPUT_TAIL_CHARS = 2_000;
+
+export interface SpawnedStackInfo {
+  readonly url: string;
+  readonly dbUrl: string;
+  readonly process: ChildProcess;
+}
+
+export interface SpawnStandaloneStackOptions {
+  /** Overridable for unit tests only; the e2e suite always runs the real script. */
+  readonly command?: readonly [string, ...string[]];
+  readonly readinessTimeoutMs?: number;
+  /**
+   * Fired the moment the child exists, before readiness. Callers register the
+   * handle here so teardown can terminate every spawned child even when the
+   * readiness promise never resolved — a `Promise.all` that dies on one stack
+   * must not orphan its siblings.
+   */
+  readonly onSpawn?: (child: ChildProcess) => void;
+}
+
+/**
+ * Spawns one standalone stack subprocess and resolves when it reports
+ * readiness (a single JSON line on stdout). Unlike a bare spawn-and-parse,
+ * every way the child can fail settles the promise with the evidence attached:
+ *
+ * - exit before readiness — ANY code, including 0 — rejects with the code and
+ *   the child's stderr, so a stack that dies cleanly during bring-up cannot
+ *   turn into an opaque hook timeout with its error discarded;
+ * - readiness not reported within `readinessTimeoutMs` rejects with the
+ *   stdout/stderr collected so far and terminates the child, so a bring-up
+ *   that wedges (e.g. a port race) fails fast and names the last thing the
+ *   stack said instead of burning the whole hook budget.
+ */
+export function spawnStandaloneStack(
+  opts: SpawnStandaloneStackOptions = {},
+): Promise<SpawnedStackInfo> {
+  const [command, ...args] = opts.command ?? [
+    "bun",
+    "run",
+    STANDALONE_SCRIPT,
+    "--parent-pid",
+    String(process.pid),
+  ];
+  const readinessTimeoutMs = opts.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS;
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    opts.onSpawn?.(child);
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const settle = (outcome: { info?: SpawnedStackInfo; error?: Error }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(readinessTimer);
+      if (outcome.info !== undefined) resolvePromise(outcome.info);
+      else rejectPromise(outcome.error);
+    };
+
+    const outputTail = () =>
+      `stdout: ${stdout.slice(-OUTPUT_TAIL_CHARS) || "(none)"}\nstderr: ${
+        stderr.slice(-OUTPUT_TAIL_CHARS) || "(none)"
+      }`;
+
+    const readinessTimer = setTimeout(() => {
+      settle({
+        error: new Error(
+          `Stack did not report readiness within ${readinessTimeoutMs}ms\n${outputTail()}`,
+        ),
+      });
+      // Reclaim the unusable child; the 30s window matches the suite's own
+      // sweep so SIGKILL doesn't cut a wedged stack's dispose short.
+      void terminateChildProcess(child, { timeoutMs: 30_000 });
+    }, readinessTimeoutMs);
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const newline = stdout.indexOf("\n");
+      if (newline !== -1) {
+        try {
+          const info = JSON.parse(stdout.slice(0, newline));
+          settle({ info: { url: info.url, dbUrl: info.dbUrl, process: child } });
+        } catch {
+          settle({ error: new Error(`Failed to parse stack info: ${stdout.slice(0, newline)}`) });
+        }
+      }
+    });
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => settle({ error: err }));
+    // Any exit before readiness is a failure — including a clean 0.
+    child.on("exit", (code) => {
+      settle({
+        error: new Error(
+          `Stack process exited with code ${code} before readiness\n${outputTail()}`,
+        ),
+      });
+    });
+  });
+}

--- a/packages/stack/tests/helpers/spawn-stack.ts
+++ b/packages/stack/tests/helpers/spawn-stack.ts
@@ -100,8 +100,10 @@ export function spawnStandaloneStack(
     });
 
     child.on("error", (err) => settle({ error: err }));
-    // Any exit before readiness is a failure — including a clean 0.
-    child.on("exit", (code) => {
+    // Any exit before readiness is a failure — including a clean 0. `close`
+    // rather than `exit`: it waits for the stdio pipes to drain, so the tails
+    // below always carry whatever the child managed to say.
+    child.on("close", (code) => {
       settle({
         error: new Error(
           `Stack process exited with code ${code} before readiness\n${outputTail()}`,

--- a/packages/stack/tests/helpers/spawn-stack.unit.test.ts
+++ b/packages/stack/tests/helpers/spawn-stack.unit.test.ts
@@ -1,0 +1,122 @@
+import { type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+import { terminateChildProcess } from "../../src/terminateChild.ts";
+import { spawnStandaloneStack } from "./spawn-stack.ts";
+
+const dir = mkdtempSync(join(tmpdir(), "spawn-stack-unit-"));
+const children: ChildProcess[] = [];
+
+afterAll(() => {
+  for (const child of children) {
+    try {
+      child.kill("SIGKILL");
+    } catch {}
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function stub(name: string, source: string): readonly [string, ...string[]] {
+  const path = join(dir, name);
+  writeFileSync(path, source);
+  return ["bun", "run", path];
+}
+
+const track = (child: ChildProcess) => children.push(child);
+
+describe("spawnStandaloneStack", () => {
+  test("resolves with the reported url/dbUrl and a live process handle", async () => {
+    const command = stub(
+      "ok.ts",
+      `console.log(JSON.stringify({ url: "http://127.0.0.1:59991", dbUrl: "postgresql://127.0.0.1:59992/x" }));
+       setInterval(() => {}, 60_000);`,
+    );
+    const info = await spawnStandaloneStack({ command, onSpawn: track });
+    expect(info.url).toBe("http://127.0.0.1:59991");
+    expect(info.dbUrl).toBe("postgresql://127.0.0.1:59992/x");
+    expect(info.process.exitCode).toBeNull();
+  });
+
+  test("rejects with the exit code and stderr when the child dies cleanly before readiness", async () => {
+    // The pre-fix harness only rejected on a NON-zero exit, so this exact
+    // child left the promise pending until the 90s hook timeout, with the
+    // stderr below discarded — the opaque paired-timeout CI failure.
+    const command = stub(
+      "silent-exit0.ts",
+      `process.stderr.write("boot: port 54322 already bound, giving up\\n");
+       process.exit(0);`,
+    );
+    await expect(spawnStandaloneStack({ command, onSpawn: track })).rejects.toThrow(
+      /exited with code 0 before readiness[\s\S]*port 54322 already bound/,
+    );
+  });
+
+  test("rejects with collected output when readiness never arrives, and reclaims the child", async () => {
+    const command = stub(
+      "hang.ts",
+      `process.stderr.write("boot: waiting for postgres socket...\\n");
+       setInterval(() => {}, 60_000);`,
+    );
+    const spawned: ChildProcess[] = [];
+    await expect(
+      spawnStandaloneStack({
+        command,
+        readinessTimeoutMs: 1_500,
+        onSpawn: (child) => {
+          track(child);
+          spawned.push(child);
+        },
+      }),
+    ).rejects.toThrow(/did not report readiness within 1500ms[\s\S]*waiting for postgres socket/);
+    // The helper terminates its own unusable child rather than leaving an
+    // interval-driven zombie for suite teardown to hunt.
+    await expect.poll(() => spawned[0]?.exitCode !== null || spawned[0]?.killed).toBe(true);
+  });
+
+  test("rejects on an unparseable readiness line", async () => {
+    const command = stub("garbage.ts", `console.log("not json"); setInterval(() => {}, 60_000);`);
+    await expect(spawnStandaloneStack({ command, onSpawn: track })).rejects.toThrow(
+      /Failed to parse stack info: not json/,
+    );
+  });
+
+  test("registers every child via onSpawn before readiness, so a failed sibling cannot orphan a healthy one", async () => {
+    const okCommand = stub(
+      "ok-sibling.ts",
+      `console.log(JSON.stringify({ url: "http://127.0.0.1:59993", dbUrl: "postgresql://127.0.0.1:59994/x" }));
+       setInterval(() => {}, 60_000);`,
+    );
+    const badCommand = stub("bad-sibling.ts", `process.exit(0);`);
+
+    const registered: ChildProcess[] = [];
+    const results = await Promise.allSettled([
+      spawnStandaloneStack({ onSpawn: (c) => registered.push(c), command: okCommand }),
+      spawnStandaloneStack({ onSpawn: (c) => registered.push(c), command: badCommand }),
+    ]);
+    children.push(...registered);
+
+    expect(registered).toHaveLength(2);
+    expect(results.map((r) => r.status).sort()).toEqual(["fulfilled", "rejected"]);
+    // The healthy sibling's handle is reachable through the registry even
+    // though Promise.all-style consumption would have discarded its value.
+    const healthy = registered.find((c) => c.exitCode === null);
+    expect(healthy).toBeDefined();
+  });
+
+  test("teardown sweep over a dead child settles immediately, not after 2x the signal timeout", async () => {
+    // The incident replay: one sibling died before readiness, teardown then
+    // sweeps every registered child with a 30s timeout. Before the
+    // already-exited guard in terminateChildProcess this call burned 60s
+    // doing nothing — reproducing the afterAll hook timeout it was meant to
+    // prevent.
+    const command = stub("dead-sweep.ts", `process.exit(0);`);
+    const registered: ChildProcess[] = [];
+    await spawnStandaloneStack({ command, onSpawn: (c) => registered.push(c) }).catch(() => {});
+    await expect.poll(() => registered[0]?.exitCode !== null).toBe(true);
+    const started = Date.now();
+    await terminateChildProcess(registered[0]!, { timeoutMs: 30_000 });
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+});

--- a/packages/stack/tests/helpers/standalone-stack.ts
+++ b/packages/stack/tests/helpers/standalone-stack.ts
@@ -1,8 +1,30 @@
 import { createStack } from "../../src/node.ts";
 
+// Registered before any bring-up work: the spawning harness SIGTERMs a stack
+// that misses its readiness deadline, and without these the default signal
+// disposition kills the process mid-start with temp dirs and containers left
+// behind for the leak check to trip over. A pre-readiness signal is remembered
+// and honored at the next await boundary via a dispose-then-exit.
+let earlyShutdownRequested = false;
+const onEarlySignal = () => {
+  earlyShutdownRequested = true;
+};
+process.once("SIGINT", onEarlySignal);
+process.once("SIGTERM", onEarlySignal);
+
 const parentPid = readParentPid(process.argv.slice(2));
 const stack = await createStack();
+if (earlyShutdownRequested) {
+  await stack.dispose();
+  process.exit(0);
+}
 await stack.start();
+if (earlyShutdownRequested) {
+  await stack.dispose();
+  process.exit(0);
+}
+process.off("SIGINT", onEarlySignal);
+process.off("SIGTERM", onEarlySignal);
 
 // Signal readiness to parent process
 console.log(JSON.stringify({ url: stack.url, dbUrl: stack.dbUrl }));

--- a/packages/stack/tests/helpers/standalone-stack.ts
+++ b/packages/stack/tests/helpers/standalone-stack.ts
@@ -6,9 +6,16 @@ import { createStack } from "../../src/node.ts";
 // behind for the leak check to trip over. A pre-readiness signal is remembered
 // and honored at the next await boundary via a dispose-then-exit.
 let earlyShutdownRequested = false;
-const onEarlySignal = () => {
+let signalEarlyShutdown = () => {
   earlyShutdownRequested = true;
 };
+const earlyShutdown = new Promise<"early-shutdown">((resolveSignal) => {
+  signalEarlyShutdown = () => {
+    earlyShutdownRequested = true;
+    resolveSignal("early-shutdown");
+  };
+});
+const onEarlySignal = () => signalEarlyShutdown();
 process.once("SIGINT", onEarlySignal);
 process.once("SIGTERM", onEarlySignal);
 
@@ -18,7 +25,20 @@ if (earlyShutdownRequested) {
   await stack.dispose();
   process.exit(0);
 }
-await stack.start();
+// Raced rather than awaited directly: a signal during a HUNG start() must
+// still dispose whatever was already created — a flag alone can't run until
+// the await returns, which is exactly when it never will.
+const starting = stack.start().then(
+  () => "started" as const,
+  (error) => {
+    if (!earlyShutdownRequested) throw error;
+    return "start-failed" as const;
+  },
+);
+if ((await Promise.race([starting, earlyShutdown])) !== "started") {
+  await stack.dispose();
+  process.exit(0);
+}
 if (earlyShutdownRequested) {
   await stack.dispose();
   process.exit(0);

--- a/packages/stack/tests/parallelStacks.e2e.test.ts
+++ b/packages/stack/tests/parallelStacks.e2e.test.ts
@@ -1,6 +1,5 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { terminateChildProcess } from "../src/terminateChild.ts";
 import {
@@ -10,58 +9,17 @@ import {
   cleanupLeakArtifacts,
   type LeakSnapshot,
 } from "./helpers/leaks.ts";
+import { type SpawnedStackInfo, spawnStandaloneStack } from "./helpers/spawn-stack.ts";
 
 const STACK_COUNT = 2;
-const SCRIPT = resolve(import.meta.dirname, "helpers/standalone-stack.ts");
 const PARALLEL_STACK_TEST_TIMEOUT_MS = 5_000;
 
-interface StackInfo {
-  url: string;
-  dbUrl: string;
-  process: ChildProcess;
-}
-
-function spawnStack(): Promise<StackInfo> {
-  return new Promise((resolve, reject) => {
-    const child = spawn("bun", ["run", SCRIPT, "--parent-pid", String(process.pid)], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout!.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-      const newline = stdout.indexOf("\n");
-      if (newline !== -1) {
-        try {
-          const info = JSON.parse(stdout.slice(0, newline));
-          resolve({
-            url: info.url,
-            dbUrl: info.dbUrl,
-            process: child,
-          });
-        } catch {
-          reject(new Error(`Failed to parse stack info: ${stdout.slice(0, newline)}`));
-        }
-      }
-    });
-
-    child.stderr!.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-
-    child.on("error", (err) => reject(err));
-    child.on("exit", (code) => {
-      if (code !== 0) {
-        reject(new Error(`Stack process exited with code ${code}\nstderr: ${stderr}`));
-      }
-    });
-  });
-}
-
 describe("parallel stacks (multi-process)", () => {
-  const stacks: StackInfo[] = [];
+  const stacks: SpawnedStackInfo[] = [];
+  // Registered at spawn time, not readiness: when one stack fails bring-up,
+  // `Promise.all` discards its healthy siblings' values, so this list — not
+  // `stacks` — is what teardown owns.
+  const children: ChildProcess[] = [];
   let leakBaseline: LeakSnapshot;
 
   beforeAll(async () => {
@@ -69,13 +27,17 @@ describe("parallel stacks (multi-process)", () => {
       homeDir: homedir(),
       processNeedles: ["standalone-stack.ts"],
     });
-    const results = await Promise.all(Array.from({ length: STACK_COUNT }, () => spawnStack()));
+    const results = await Promise.all(
+      Array.from({ length: STACK_COUNT }, () =>
+        spawnStandaloneStack({ onSpawn: (child) => children.push(child) }),
+      ),
+    );
     stacks.push(...results);
   }, 90_000);
 
   afterAll(async () => {
     await Promise.allSettled(
-      stacks.map((s) => terminateChildProcess(s.process, { timeoutMs: 30_000 })),
+      children.map((child) => terminateChildProcess(child, { timeoutMs: 30_000 })),
     );
 
     const after = await waitForLeakSnapshot(


### PR DESCRIPTION
## TL;DR

Fixing the `parallelStacks.e2e.test.ts` flake that's hit CI three times now:
always the same pair of `90000ms` + `60000ms` hook timeouts with nothing useful in the log. Turns out the harness could hang three ways: 
a stack that died cleanly never settled its promise (the exit handler only checked for non-zero), stack that wedged had no timeout at all, and if one stack failed, its healthy sibling's handle got dropped 
so teardown killed nothing and the leak-check spun for 60s chasing a process it couldn't reach...

The spawn logic now lives in a small `spawnStandaloneStack` helper that settles on every path with the child's actual output attached, and teardown tracks children from the moment they spawn. 

Also fixed `terminateChildProcess` quietly burning 2×30s on an already-dead child, that alone would've recreated
the afterAll timeout. Repro'd all three failure modes with stubs first, each one has a pinning test, and the real suite ran green 6 times in a row....

## refs

- Deflakes the shard-1/3 failures from the #6038 and #6004 CI runs
-  Pairs with #6045 which fixes the underlying startup port race properly
