### PR TITLE
fix(cli): keep kong email templates

### DIFF
--- a/apps/cli-go/internal/db/reset/reset.go
+++ b/apps/cli-go/internal/db/reset/reset.go
@@ -295,7 +295,10 @@ func reloadKong(ctx context.Context) error {
 		return nil
 	}
 	var out bytes.Buffer
-	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload"}, &out, &out); err != nil {
+	// Reload re-renders nginx.conf from Kong's default template, so it needs the
+	// template bring-up wrote (start.go:589-592) handed back — otherwise it drops
+	// that template's email_templates server. https://github.com/supabase/cli/issues/6059
+	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload", "--nginx-conf", "/home/kong/custom_nginx.template"}, &out, &out); err != nil {
 		if msg := strings.TrimSpace(out.String()); len(msg) > 0 {
 			return suggestKongRecovery(errors.Errorf("failed to reload kong: %w:\n%s", err, msg))
 		}

--- a/apps/cli-go/internal/db/reset/reset_test.go
+++ b/apps/cli-go/internal/db/reset/reset_test.go
@@ -2,6 +2,7 @@ package reset
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -498,9 +499,23 @@ func TestRestartDatabase(t *testing.T) {
 		gock.New(utils.Docker.DaemonHost()).
 			Post("/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/exec").
 			Reply(http.StatusServiceUnavailable)
+		// The reload must carry bring-up's template — see reloadKong (#6059).
+		execPath := "/v" + utils.Docker.ClientVersion() + "/containers/" + utils.KongId + "/exec"
+		observed := 0
+		gock.Observe(func(r *http.Request, mock gock.Mock) {
+			if r.URL.Path != execPath {
+				return
+			}
+			observed += 1
+			var body container.ExecOptions
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, []string{"kong", "reload", "--nginx-conf", "/home/kong/custom_nginx.template"}, body.Cmd)
+		})
+		t.Cleanup(func() { gock.Observe(nil) })
 		// Run test
 		err := RestartDatabase(context.Background(), io.Discard)
 		// Check error
+		assert.Equal(t, 1, observed)
 		assert.ErrorContains(t, err, "failed to reload kong")
 		assert.Contains(t, utils.CmdSuggestion, "API routes may return 502")
 		assert.Contains(t, utils.CmdSuggestion, "docker restart test-kong")

--- a/apps/cli-go/internal/functions/serve/serve.go
+++ b/apps/cli-go/internal/functions/serve/serve.go
@@ -126,7 +126,7 @@ func restartEdgeRuntime(ctx context.Context, envFilePath string, noVerifyJWT *bo
 		return err
 	}
 	// 4. Reload Kong to refresh DNS cache for the new Edge Runtime container IP.
-	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload"}, os.Stderr, os.Stderr); err != nil {
+	if err := utils.DockerExecOnceWithStream(ctx, utils.KongId, "", nil, []string{"kong", "reload", "--nginx-conf", "/home/kong/custom_nginx.template"}, os.Stderr, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: failed to reload Kong:", err)
 	}
 	return nil

--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -518,17 +518,21 @@ describe("legacy functions serve integration", () => {
           },
         });
 
-        // Bare `kong reload`, matching Go's `restartEdgeRuntime`
-        // (`internal/functions/serve/serve.go:129`) — the `--nginx-conf`
-        // template argument belongs to `start`'s Kong bring-up, not reload.
+        // The reload must carry bring-up's `--nginx-conf`; a bare `kong reload`
+        // re-renders nginx.conf from Kong's default template and drops the
+        // `email_templates` server GoTrue fetches (issue #6059).
         expect(deployMockState.runCalls).toContainEqual({
           command: "docker",
-          args: ["exec", "supabase_kong_test-project", "kong", "reload"],
+          args: [
+            "exec",
+            "supabase_kong_test-project",
+            "kong",
+            "reload",
+            "--nginx-conf",
+            "/home/kong/custom_nginx.template",
+          ],
           options: { stdout: "ignore", stderr: "pipe" },
         });
-        expect(deployMockState.runCalls.some((call) => call.args.includes("--nginx-conf"))).toBe(
-          false,
-        );
 
         expect(childSpawner.spawned).toEqual([
           {

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -1337,17 +1337,14 @@ const bestEffortRemoveContainer = Effect.fnUntraced(function* (containerId: stri
 const reloadKong = Effect.fnUntraced(function* (projectId: string) {
   const output = yield* Output;
   const kongId = localDockerId("kong", projectId);
-  // Bare `kong reload`, exactly Go's `restartEdgeRuntime`
-  // (`internal/functions/serve/serve.go:129`). The `--nginx-conf
-  // /home/kong/custom_nginx.template` argument belongs to `start`'s Kong
-  // bring-up entrypoint (`internal/start/start.go:589-592`, mirrored by
-  // `legacy/commands/start/services/kong.service.ts`) — `kong reload` reuses
-  // the prefix configuration that bring-up already prepared, so passing the
-  // template again here is not part of Go's serve path.
-  const result = yield* runChildProcess("docker", ["exec", kongId, "kong", "reload"], {
-    stdout: "ignore",
-    stderr: "pipe",
-  }).pipe(Effect.catch(() => Effect.succeed({ exitCode: 1, stdout: "", stderr: "" })));
+  // Reload re-renders nginx.conf from Kong's default template, so it needs the
+  // template bring-up wrote (`kong.service.ts`, Go's `start.go:589-592`) handed
+  // back — otherwise it drops that template's `email_templates` server (#6059).
+  const result = yield* runChildProcess(
+    "docker",
+    ["exec", kongId, "kong", "reload", "--nginx-conf", "/home/kong/custom_nginx.template"],
+    { stdout: "ignore", stderr: "pipe" },
+  ).pipe(Effect.catch(() => Effect.succeed({ exitCode: 1, stdout: "", stderr: "" })));
 
   if (result.exitCode !== 0) {
     const suffix = result.stderr.trim().length > 0 ? ` ${result.stderr.trim()}` : "";


### PR DESCRIPTION
## TL;DR 

fixes custom auth email templates silently reverting to GoTrue's built-in defaults after `db reset`, `functions serve` (every hot reload) and 
`branch switch` `kong reload` re-renders nginx.conf from Kong's default template, dropping the `:8088`
 email-templates server that only bring-up's `--nginx-conf` defines. 
Every reload now hands that template back....

Third pass on this argument:
- PS: first complete one: #5906 added it to `functions serve`'s
reload #5976 reverted it for Go parity ("reload reuses the prefix bring-up prepared"
it doesn't) and
- #6017's new `db reset` reload (fixing issue #6016's 502s) shipped bare on the same assumption. 

Fixing Go's call sites too removes the parity argument,
 so this can't be reverted on parity grounds a fourth time. #6017's DNS re-resolution is unchanged. 
verified 502→200 on a rotated container IP with the new argv. 
Broken stacks self-heal on the next reset.
 A template-less container (only one never created by `supabase start`, written unconditionally since the start) now fails the reload loudly, fatal in `db reset`, stderr warning in `functions serve`/`branch switch`......

<details><summary>repro / before vs after</summary>

Real stack, kong's `StartedAt` never changes (container never restarted):

    0. after supabase start     listeners=[8000 8001 8088 8443 8444]  template=custom ✓
    1. after BASELINE db reset  listeners=[8000 8001      8443 8444]  template=REFUSED → built-in default
    2. after FIXED    db reset  listeners=[8000 8001 8088 8443 8444]  template=custom ✓

- #6016 non-regression: warm 200 → rotate auth IP → 502 502 502 → new reload → 200, :8088 intact.

</details>

## ref: 
- closes #6059
