### PR TITLE
fix(cli): relative declarative dir

### DIFF
--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.handler.ts
@@ -28,7 +28,10 @@ import {
   type LegacyDeclarativeRunContext,
   legacyGenerateDeclarativeOutput,
 } from "../declarative.orchestrate.ts";
-import { legacyWriteDeclarativeSchemas } from "../../../shared/legacy-pgdelta.write.ts";
+import {
+  legacyDeclarativeSchemaWrittenLine,
+  legacyWriteDeclarativeSchemas,
+} from "../../../shared/legacy-pgdelta.write.ts";
 import type { LegacyDbSchemaDeclarativeGenerateFlags } from "./generate.command.ts";
 import {
   type LegacyLocalConn,
@@ -114,14 +117,14 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
         }
       }
 
-      // `path.resolve` (not `path.join`) so an absolute `declarative_schema_path` is
-      // used as-is: Go's config resolver only prefixes the workdir onto a RELATIVE path
-      // (`config.resolve`), leaving an absolute path unchanged. `path.join(workdir, abs)`
-      // would mangle `/repo` + `/abs` into `/repo/abs`.
-      const declarativeDir = path.resolve(
-        cliConfig.workdir,
-        legacyResolveDeclarativeDir(path, toml.pgDelta),
-      );
+      // Go prints `utils.GetDeclarativeDir()` verbatim (`declarative.go:156`,
+      // `db_schema_declarative.go:268`) — the config value, relative unless a user
+      // configures an absolute `declarative_schema_path` — so user-facing renders use
+      // `declarativeDirRel`. File I/O needs the resolved dir: `path.resolve` (not
+      // `path.join`) so an absolute config value is used as-is, matching Go's
+      // `config.resolve`, which only prefixes the workdir onto a RELATIVE path.
+      const declarativeDirRel = legacyResolveDeclarativeDir(path, toml.pgDelta);
+      const declarativeDir = path.resolve(cliConfig.workdir, declarativeDirRel);
       const migrationsDir = path.join(cliConfig.workdir, "supabase", "migrations");
       const local: LegacyLocalConn = { port: toml.port, password: toml.password };
 
@@ -180,7 +183,7 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
             output,
             yes,
             `Declarative schema already exists at ${legacyBold(
-              declarativeDir,
+              declarativeDirRel,
             )}. Regenerate from database? This will overwrite existing files.`,
             false,
           );
@@ -272,7 +275,7 @@ export const legacyDbSchemaDeclarativeGenerate = Effect.fn("legacy.db.schema.dec
           ...(linkedProjectRef !== undefined ? { projectRef: linkedProjectRef } : {}),
         });
       }
-      yield* output.raw(`Declarative schema written to ${legacyBold(declarativeDir)}\n`, "stderr");
+      yield* output.raw(legacyDeclarativeSchemaWrittenLine(declarativeDirRel), "stderr");
     }).pipe(
       // Go's `ensureProjectGroupsCached` PersistentPostRun (`cmd/root.go:176,214-234`)
       // writes the linked-project cache (`GET /v1/projects/{ref}` →

--- a/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/generate/generate.integration.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
+import { stripAnsi } from "../../../../../../../tests/helpers/ansi.ts";
 
 import { mockOutput, mockStdin, mockTty } from "../../../../../../../tests/helpers/mocks.ts";
 import {
@@ -357,9 +358,15 @@ describe("legacy db schema declarative generate integration", () => {
         ),
       );
       expect(written).toBe("create table players ();");
-      expect(s.out.rawChunks.some((c) => c.text.includes("Declarative schema written to"))).toBe(
-        true,
-      );
+      // Go prints the relative `utils.GetDeclarativeDir()` verbatim
+      // (`declarative.go:156`) — never the resolved absolute dir.
+      expect(
+        s.out.rawChunks.map((c) => ({ text: stripAnsi(c.text), stream: c.stream })),
+      ).toContainEqual({
+        text: `Declarative schema written to ${join("supabase", "database")}\n`,
+        stream: "stderr",
+      });
+      expect(s.out.rawChunks.some((c) => c.text.includes(tmp.current))).toBe(false);
       // Go runs ensureLocalDatabaseStarted before generating from local.
       expect(s.ensureStartedCalls).toBe(1);
     }).pipe(Effect.provide(s.layer));
@@ -462,6 +469,13 @@ describe("legacy db schema declarative generate integration", () => {
       expect(
         readFileSync(join(absSchema, "schemas", "public", "tables", "players.sql"), "utf8"),
       ).toBe("create table players ();");
+      // Go prints the configured value verbatim — absolute here, never workdir-prefixed.
+      expect(
+        s.out.rawChunks.map((c) => ({ text: stripAnsi(c.text), stream: c.stream })),
+      ).toContainEqual({
+        text: `Declarative schema written to ${absSchema}\n`,
+        stream: "stderr",
+      });
       rmSync(absSchema, { recursive: true, force: true });
     }).pipe(Effect.provide(s.layer));
   });
@@ -646,9 +660,10 @@ describe("legacy db schema declarative generate integration", () => {
       yield* legacyDbSchemaDeclarativeGenerate(flags());
       expect(s.seamCalls).toEqual(["baseline", "declarative"]);
       // Go's PromptYesNo echoes the auto-accepted question to stderr under the
-      // global YES flag (`console.go:70-72`) — the echo must not be skipped.
-      expect(s.out.stderrText).toContain(
-        ". Regenerate from database? This will overwrite existing files. [y/N] y\n",
+      // global YES flag (`console.go:70-72`) — the echo must not be skipped, and
+      // the prompt renders the relative dir (`db_schema_declarative.go:268`).
+      expect(stripAnsi(s.out.stderrText)).toContain(
+        `Declarative schema already exists at ${join("supabase", "database")}. Regenerate from database? This will overwrite existing files. [y/N] y\n`,
       );
       expect(
         s.out.rawChunks.some((c) => c.text.includes("Skipped generating declarative schema")),
@@ -668,8 +683,8 @@ describe("legacy db schema declarative generate integration", () => {
     return Effect.gen(function* () {
       yield* legacyDbSchemaDeclarativeGenerate(flags());
       expect(s.seamCalls).toEqual(["baseline", "declarative"]);
-      expect(s.out.stderrText).toContain(
-        ". Regenerate from database? This will overwrite existing files. [y/N] y\n",
+      expect(stripAnsi(s.out.stderrText)).toContain(
+        `Declarative schema already exists at ${join("supabase", "database")}. Regenerate from database? This will overwrite existing files. [y/N] y\n`,
       );
     }).pipe(
       Effect.ensuring(

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -259,9 +259,7 @@ export const legacyDbSchemaDeclarativeSync = Effect.fn("legacy.db.schema.declara
         // both the interactive-accept and --yes/SUPABASE_YES bootstrap paths, and
         // regardless of --no-cache (the warm is skipped, the line is not). It prints
         // `utils.GetDeclarativeDir()` — the relative dir above, never a resolved
-        // absolute path, because Go chdirs into the workdir (CLI-1980). NOTE:
-        // `generate`'s port of this same Go line still prints the absolute dir
-        // today — a follow-up candidate for the same relative-dir treatment.
+        // absolute path, because Go chdirs into the workdir (CLI-1980).
         yield* output.raw(legacyDeclarativeSchemaWrittenLine(declarativeDirRel), "stderr");
       }
 

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.write.ts
@@ -7,10 +7,9 @@ import type { LegacyDeclarativeOutput } from "./legacy-pgdelta.ts";
 /**
  * Go's `declarative.Generate` / `pull.go`'s written-to line, printed by all three
  * declarative write paths (`generate`, `pull --declarative`, `sync`'s bootstrap).
- * Each caller passes its own dir rendering (`pull` and `sync` already print the
- * relative `GetDeclarativeDir()` value; `generate` still prints the resolved
- * absolute dir — a follow-up candidate for the same treatment) — this only pins
- * the shared message text in one place.
+ * Every caller passes the relative `GetDeclarativeDir()` value, never the resolved
+ * absolute dir (`generate` and `sync` route through this helper; `pull` still
+ * inlines the same template) — this pins the shared message text in one place.
  */
 export const legacyDeclarativeSchemaWrittenLine = (dir: string): string =>
   `Declarative schema written to ${legacyBold(dir)}\n`;


### PR DESCRIPTION
## TL;DR 

fixes db schema declarative generate printing the absolute `declarative` dir in
its written-to line and its overwrite prompt which worked in GO cause it chdirs into
the workdir and prints `GetDeclarativeDir()` verbatim,

 diverged in TS cause the handler resolves the dir against the workdir for file I/O and printed that same resolved value
while the tests only asserted a message prefix:
 now sorted cause we switch both renders to the config-verbatim `legacyResolveDeclarativeDir` value through the shared written-line helper exactly like pull and sync already do and is tested locally across
the generate sync and pull suites plus the full workspace....

## ref: 
- extends #5968 
 ( CLI-1978 )
