### PR TITLE
feat(stack): add lazy service lifecycle

### DIFF
--- a/apps/cli/src/next/commands/branches/switch/switch.handler.ts
+++ b/apps/cli/src/next/commands/branches/switch/switch.handler.ts
@@ -1,10 +1,4 @@
-import {
-  StateManager,
-  daemonLayer,
-  resolveDaemonConfig,
-  resolveManagedStack,
-  stopDaemon,
-} from "@supabase/stack/effect";
+import { StateManager, daemonLayer, resolveManagedStack, stopDaemon } from "@supabase/stack/effect";
 import { daemonEntryPoint } from "@supabase/stack";
 import { Effect, Option } from "effect";
 import { PlatformApi } from "../../../auth/platform-api.service.ts";
@@ -160,19 +154,15 @@ export const switchBranch = Effect.fn("branches.switch")(function* (opts: {
       },
     });
 
-    const resolvedConfig = yield* Effect.promise(() =>
-      resolveDaemonConfig({
+    const stackLayer = yield* daemonLayer(
+      {
         cacheRoot: cliConfig.supabaseHome,
         cwd: runtimeInfo.cwd,
         projectDir: projectHome.projectRoot,
         projectStateRoot: projectHome.projectHomeDir,
         name: stackState.name,
         ...launchConfig,
-      }),
-    );
-
-    const stackLayer = yield* daemonLayer(
-      { ...resolvedConfig, name: stackState.name, projectDir: projectHome.projectRoot },
+      },
       daemonEntryPoint,
     );
 

--- a/apps/cli/src/next/commands/functions/dev/functions-dev-runtime.ts
+++ b/apps/cli/src/next/commands/functions/dev/functions-dev-runtime.ts
@@ -2,7 +2,6 @@ import { daemonEntryPoint } from "@supabase/stack";
 import {
   connectLayer,
   daemonLayer,
-  resolveDaemonConfig,
   stackMetadata,
   Stack,
   StateManager,
@@ -69,8 +68,8 @@ const startFullStack = Effect.fnUntraced(function* (opts: FunctionsDevStackOptio
   yield* ensureProjectStateIgnored(projectHome.projectRoot);
 
   const serviceVersionContext = yield* resolveServiceVersionContext([], undefined);
-  const config = yield* Effect.promise(() =>
-    resolveDaemonConfig({
+  const stackLayer = yield* daemonLayer(
+    {
       cacheRoot: cliConfig.supabaseHome,
       cwd: runtimeInfo.cwd,
       projectDir: projectHome.projectRoot,
@@ -79,19 +78,20 @@ const startFullStack = Effect.fnUntraced(function* (opts: FunctionsDevStackOptio
       edgeRuntime: opts.edgeRuntime,
       functions: toStackFunctionsConfig(opts),
       ...versionsFromContext(serviceVersionContext),
-    }),
+    },
+    daemonEntryPoint,
   );
+  const state = yield* stateManager.read(opts.stack);
 
   yield* stateManager.writeMetadata(
     opts.stack,
     stackMetadata({
-      ports: config.ports,
+      ports: state.ports,
       services: serviceVersionContext.pinnedBaseline,
       launch: { mode: "auto", excludedServices: [] },
     }),
   );
 
-  const stackLayer = yield* daemonLayer(config, daemonEntryPoint);
   yield* startStackWithProgress().pipe(Effect.provide(stackLayer));
   const stack = yield* Stack.pipe(Effect.provide(stackLayer));
 

--- a/apps/cli/src/next/commands/start/start.command.ts
+++ b/apps/cli/src/next/commands/start/start.command.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_MANAGED_STACK_NAME,
   StateManager,
   daemonLayer,
-  resolveDaemonConfig,
   stackMetadata,
   type StackMetadata,
 } from "@supabase/stack/effect";
@@ -195,22 +194,24 @@ export const startCommand = Command.make("start", flags).pipe(
         ...baseStackConfig,
         postgres: { ...baseStackConfig.postgres, autoExposeNewTables },
       };
-      const resolvedConfig = yield* Effect.promise(() =>
-        resolveDaemonConfig({
+      yield* output.intro("Start local Supabase stack");
+      yield* ensureProjectStateIgnored(projectHome.projectRoot);
+
+      const stackLayer = yield* daemonLayer(
+        {
           cacheRoot: cliConfig.supabaseHome,
           cwd: runtimeInfo.cwd,
           projectDir: projectHome.projectRoot,
           projectStateRoot: projectHome.projectHomeDir,
           name: flags.stack,
           ...stackConfig,
-        }),
+        },
+        daemonEntryPoint,
       );
-
-      yield* output.intro("Start local Supabase stack");
-      yield* ensureProjectStateIgnored(projectHome.projectRoot);
+      const daemonState = yield* stateManager.read(flags.stack);
 
       const metadata = stackMetadata({
-        ports: resolvedConfig.ports,
+        ports: daemonState.ports,
         services: serviceVersionContext.pinnedBaseline,
         launch: { mode: flags.mode, excludedServices: flags.exclude },
         lastNotifiedUpdateFingerprint:
@@ -222,15 +223,6 @@ export const startCommand = Command.make("start", flags).pipe(
               }),
       });
       yield* stateManager.writeMetadata(flags.stack, metadata);
-
-      const stackLayer = yield* daemonLayer(
-        {
-          ...resolvedConfig,
-          name: flags.stack,
-          projectDir: projectHome.projectRoot,
-        },
-        daemonEntryPoint,
-      );
 
       return {
         stackLayer,

--- a/apps/cli/src/next/commands/start/start.integration.test.ts
+++ b/apps/cli/src/next/commands/start/start.integration.test.ts
@@ -171,9 +171,16 @@ function setupNonInteractive(
   opts: {
     info?: Partial<StackInfo>;
     stateChanges?: Array<{ name: string; status: StackServiceStatus }>;
+    startPending?: boolean;
+    liveStateChanges?: boolean;
   } = {},
 ) {
-  const stack = mockStack({ info: opts.info, stateChanges: opts.stateChanges });
+  const stack = mockStack({
+    info: opts.info,
+    stateChanges: opts.stateChanges,
+    startPending: opts.startPending,
+    liveStateChanges: opts.liveStateChanges,
+  });
   const analytics = mockAnalytics();
   const out = mockOutput({ format: "text", interactive: false });
   const ink = mockInk();
@@ -244,6 +251,39 @@ describe("start", () => {
       });
 
       expect(stack.started).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("completes startup progress for healthy and dormant services", () => {
+    const { layer, stack, out } = setupNonInteractive({
+      stateChanges: [
+        { name: "postgres", status: "Pending" },
+        { name: "studio", status: "Pending" },
+      ],
+      startPending: true,
+      liveStateChanges: true,
+    });
+    return Effect.gen(function* () {
+      const fiber = yield* start(backgroundFlags).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* waitFor(() => stack.started, "stack startup did not begin");
+
+      stack.emitStateChange({ name: "postgres", status: "Healthy" });
+      stack.emitStateChange({ name: "studio", status: "Dormant" });
+      stack.resolveStart();
+      yield* Fiber.join(fiber);
+
+      expect(
+        out.progressEvents
+          .filter((event) => event.type === "advance")
+          .reduce((sum, event) => sum + (event.step ?? 0), 0),
+      ).toBe(2);
+      expect(out.progressEvents).toContainEqual({
+        type: "advance",
+        step: 1,
+        message: "studio is dormant",
+      });
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/next/commands/status/status.handler.ts
+++ b/apps/cli/src/next/commands/status/status.handler.ts
@@ -14,8 +14,6 @@ import { Output } from "../../../shared/output/output.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
 import type { StatusFlags } from "./status.command.ts";
 
-const READY_STATUSES = new Set(["Healthy", "Running"]);
-
 function formatServiceStateLine(service: {
   readonly name: string;
   readonly status: string;
@@ -148,7 +146,9 @@ export const status = Effect.fnUntraced(function* (_flags: StatusFlags) {
       : fillServiceVersionManifest(managedStack.state.services),
   );
   const sortedServices = [...services].sort((a, b) => a.name.localeCompare(b.name));
-  const allReady = sortedServices.every((service) => READY_STATUSES.has(service.status));
+  const allReady = services.every((service) =>
+    ["Running", "Healthy", "Dormant"].includes(service.status),
+  );
   const message = allReady
     ? "Local Supabase stack is running."
     : "Local Supabase stack is running, but some services are not ready.";

--- a/apps/cli/src/next/commands/status/status.integration.test.ts
+++ b/apps/cli/src/next/commands/status/status.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { unixHttpClientLayer } from "@supabase/stack";
+import { StackServiceState } from "@supabase/stack/effect";
 import { Effect, Layer } from "effect";
 import { status } from "./status.handler.ts";
 import {
@@ -159,6 +160,165 @@ describe("status handler", () => {
           }),
         );
       }),
+  );
+
+  it.live("does not report dormant lazy services as unready", () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.acquireRelease(
+        Effect.promise(() =>
+          makeRunningStackFixture({
+            states: [
+              new StackServiceState({
+                name: "auth",
+                status: "Dormant",
+                pid: null,
+                exitCode: null,
+                restartCount: 0,
+                startedAt: null,
+                error: null,
+              }),
+            ],
+          }),
+        ),
+        (resource) => Effect.promise(() => resource.dispose()),
+      );
+      const out = mockOutput();
+      const layer = Layer.mergeAll(
+        fixture.baseLayer,
+        out.layer,
+        mockProjectLinkState(),
+        mockProjectLocalServiceVersions(),
+      );
+
+      yield* status({ stack: fixture.stackName }).pipe(Effect.provide(layer));
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({ type: "success", message: "Local Supabase stack is running." }),
+      );
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({ type: "info", message: "auth: Dormant" }),
+      );
+    }),
+  );
+
+  it.live("reports an activating pending service as unready", () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.acquireRelease(
+        Effect.promise(() =>
+          makeRunningStackFixture({
+            states: [
+              new StackServiceState({
+                name: "auth",
+                status: "Pending",
+                pid: null,
+                exitCode: null,
+                restartCount: 0,
+                startedAt: null,
+                error: null,
+              }),
+            ],
+          }),
+        ),
+        (resource) => Effect.promise(() => resource.dispose()),
+      );
+      const out = mockOutput();
+      const layer = Layer.mergeAll(
+        fixture.baseLayer,
+        out.layer,
+        mockProjectLinkState(),
+        mockProjectLocalServiceVersions(),
+      );
+
+      yield* status({ stack: fixture.stackName }).pipe(Effect.provide(layer));
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({
+          type: "warn",
+          message: "Local Supabase stack is running, but some services are not ready.",
+        }),
+      );
+    }),
+  );
+
+  it.live("reports a stopped service as unready", () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.acquireRelease(
+        Effect.promise(() =>
+          makeRunningStackFixture({
+            states: [
+              new StackServiceState({
+                name: "auth",
+                status: "Stopped",
+                pid: null,
+                exitCode: 0,
+                restartCount: 0,
+                startedAt: null,
+                error: null,
+              }),
+            ],
+          }),
+        ),
+        (resource) => Effect.promise(() => resource.dispose()),
+      );
+      const out = mockOutput();
+      const layer = Layer.mergeAll(
+        fixture.baseLayer,
+        out.layer,
+        mockProjectLinkState(),
+        mockProjectLocalServiceVersions(),
+      );
+
+      yield* status({ stack: fixture.stackName }).pipe(Effect.provide(layer));
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({
+          type: "warn",
+          message: "Local Supabase stack is running, but some services are not ready.",
+        }),
+      );
+    }),
+  );
+
+  it.live("reports transitional states without waiting for readiness", () =>
+    Effect.gen(function* () {
+      const starting = new StackServiceState({
+        name: "auth",
+        status: "Starting",
+        pid: 123,
+        exitCode: null,
+        restartCount: 0,
+        startedAt: Date.now(),
+        error: null,
+      });
+      const fixture = yield* Effect.acquireRelease(
+        Effect.promise(() =>
+          makeRunningStackFixture({
+            states: [starting],
+            waitAllReadyNever: true,
+          }),
+        ),
+        (resource) => Effect.promise(() => resource.dispose()),
+      );
+      const out = mockOutput();
+      const layer = Layer.mergeAll(
+        fixture.baseLayer,
+        out.layer,
+        mockProjectLinkState(),
+        mockProjectLocalServiceVersions(),
+      );
+
+      yield* status({ stack: fixture.stackName }).pipe(Effect.provide(layer));
+
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({
+          type: "warn",
+          message: "Local Supabase stack is running, but some services are not ready.",
+        }),
+      );
+      expect(out.messages).toContainEqual(
+        expect.objectContaining({ type: "info", message: "auth: Starting" }),
+      );
+    }).pipe(Effect.timeout("2 seconds")),
   );
 
   it.live("emits machine-readable available updates when the pinned stack is behind", () =>

--- a/apps/cli/src/next/stack/stack.shared.ts
+++ b/apps/cli/src/next/stack/stack.shared.ts
@@ -9,13 +9,18 @@ export const startStackWithProgress = Effect.fnUntraced(function* () {
   const initialStates = yield* stack.getAllStates();
   const stateNames = new Set(initialStates.map((state) => state.name));
   const statesByName = new Map(initialStates.map((state) => [state.name, state] as const));
-  const readyNames = new Set(
-    initialStates.filter((state) => state.status === "Healthy").map((state) => state.name),
+  const completedNames = new Set(
+    initialStates
+      .filter((state) => state.status === "Healthy" || state.status === "Dormant")
+      .map((state) => state.name),
   );
   const prog = yield* output.progress({ max: initialStates.length });
   yield* prog.start("Waiting for services...");
+  if (completedNames.size > 0) {
+    yield* prog.advance(completedNames.size, "Already ready");
+  }
 
-  const fiber = yield* Stream.runForEach(stack.allStateChanges(), (state) =>
+  const updateProgress = (state: (typeof initialStates)[number]) =>
     Effect.sync(() => {
       const previousState = statesByName.get(state.name);
       statesByName.set(state.name, state);
@@ -28,13 +33,18 @@ export const startStackWithProgress = Effect.fnUntraced(function* () {
         Effect.forEach(
           changedStates,
           (serviceState) => {
-            if (serviceState.status === "Healthy") {
-              if (readyNames.has(serviceState.name)) {
+            if (serviceState.status === "Healthy" || serviceState.status === "Dormant") {
+              if (completedNames.has(serviceState.name)) {
                 return Effect.void;
               }
 
-              readyNames.add(serviceState.name);
-              return prog.advance(1, `${serviceState.name} is ready`);
+              completedNames.add(serviceState.name);
+              return prog.advance(
+                1,
+                serviceState.status === "Dormant"
+                  ? `${serviceState.name} is dormant`
+                  : `${serviceState.name} is ready`,
+              );
             }
 
             return prog.message(`${serviceState.name}: ${serviceState.status}`);
@@ -42,13 +52,16 @@ export const startStackWithProgress = Effect.fnUntraced(function* () {
           { discard: true },
         ),
       ),
-    ),
-  ).pipe(
+    );
+
+  const fiber = yield* Stream.runForEach(stack.allStateChanges(), updateProgress).pipe(
     Effect.catch(() => Effect.void),
     Effect.forkChild({ startImmediately: true }),
   );
 
   yield* stack.start().pipe(Effect.ensuring(Fiber.interrupt(fiber)));
+  const finalStates = yield* stack.getAllStates();
+  yield* Effect.forEach(finalStates, updateProgress, { discard: true });
   yield* prog.stop("All services started");
 });
 

--- a/apps/cli/tests/helpers/mocks.ts
+++ b/apps/cli/tests/helpers/mocks.ts
@@ -692,15 +692,18 @@ export function mockStack(
           }),
         ),
       getAllStates: () => {
-        const serviceNames = opts.stateChanges
-          ? [...new Set(opts.stateChanges.map((s) => s.name))]
-          : ["postgres"];
+        const latestStates = new Map(
+          (stateHistory.length > 0
+            ? stateHistory
+            : [{ name: "postgres", status: "Pending" as const }]
+          ).map((state) => [state.name, state] as const),
+        );
         return Effect.succeed(
-          serviceNames.map(
-            (name) =>
+          [...latestStates.values()].map(
+            (state) =>
               new StackServiceState({
-                name,
-                status: "Pending",
+                name: state.name,
+                status: state.status,
                 pid: null,
                 exitCode: null,
                 restartCount: 0,
@@ -899,10 +902,13 @@ export function mockStateManager(
     stackDir: (name: string) => `/test/project/.supabase/stacks/${name}`,
     dataDir: (name: string) => `/test/project/.supabase/stacks/${name}/data`,
     runtimeDir: (name: string) => `/tmp/supabase/${name}`,
-    socketPath: (name: string) => `/tmp/supabase/${name}/daemon.sock`,
     metadataFile: (name: string) => `/test/project/.supabase/stacks/${name}/stack.json`,
     stackExists: (name: string) => Effect.succeed(states.has(name) || metadata.has(name)),
     write: (state: StackState) =>
+      Effect.sync(() => {
+        states.set(state.name, state);
+      }),
+    claim: (state: StackState) =>
       Effect.sync(() => {
         states.set(state.name, state);
       }),

--- a/apps/cli/tests/helpers/running-stack.ts
+++ b/apps/cli/tests/helpers/running-stack.ts
@@ -125,6 +125,7 @@ function makeProjectHome(projectRoot: string) {
 function makeStackLayer(opts: {
   info: StackInfo;
   states: ReadonlyArray<StackServiceState>;
+  waitAllReadyNever?: boolean;
   history: ReadonlyArray<LogEntry>;
   live: ReadonlyArray<LogEntry>;
   onStop?: () => void;
@@ -178,7 +179,7 @@ function makeStackLayer(opts: {
       opts.states.some((state) => state.name === name)
         ? Effect.void
         : Effect.fail(new ServiceNotFoundError({ name })),
-    waitAllReady: () => Effect.void,
+    waitAllReady: () => (opts.waitAllReadyNever ? Effect.never : Effect.void),
     subscribeLogs: (name: string) =>
       Stream.fromIterable(opts.live.filter((entry) => entry.service === name)),
     subscribeAllLogs: (services?: ReadonlyArray<string>) =>
@@ -238,6 +239,7 @@ export async function makeStackFixture(
     services?: PartialVersionManifest;
     metadata?: StackMetadata;
     states?: ReadonlyArray<StackServiceState>;
+    waitAllReadyNever?: boolean;
     history?: ReadonlyArray<LogEntry>;
     live?: ReadonlyArray<LogEntry>;
   } = {},
@@ -308,6 +310,7 @@ export async function makeStackFixture(
           makeStackLayer({
             info,
             states,
+            waitAllReadyNever: opts.waitAllReadyNever,
             history,
             live,
             onStop: () => {

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -524,6 +524,8 @@ export class Orchestrator extends Context.Service<
             while (shouldRestart(result) && (maxRestarts === 0 || restartCount < maxRestarts)) {
               restartCount++;
 
+              yield* sendEvent(def.name, { _tag: "RestartTriggered", restartCount });
+
               // The previous process scope has closed, so external resources can
               // be reserved safely for the duration of this restart's backoff.
               yield* prepareStart();
@@ -535,8 +537,6 @@ export class Orchestrator extends Context.Service<
                   `[restart] Service "${def.name}" is restarting after an unhealthy health check (no recent log output).`,
                 );
               }
-
-              yield* sendEvent(def.name, { _tag: "RestartTriggered", restartCount });
 
               // Exponential-ish backoff: min(30s, 2^(n-1) seconds)
               const backoffSeconds = Math.min(30, Math.pow(2, restartCount - 1));

--- a/packages/process-compose/src/Orchestrator.ts
+++ b/packages/process-compose/src/Orchestrator.ts
@@ -7,6 +7,7 @@ import {
   FiberMap,
   Layer,
   Context,
+  Semaphore,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -14,11 +15,16 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { buildGraph, type ResolvedGraph } from "./DependencyGraph.ts";
 import { type HealthProbeCallbacks, runHealthProbe } from "./HealthProbe.ts";
 import { LogBuffer } from "./LogBuffer.ts";
-import type { HookTrigger, OrchestratorConfig, RestartPolicy, ServiceDef } from "./ServiceDef.ts";
+import type {
+  HookTrigger,
+  OrchestratorConfig,
+  RestartPolicy,
+  ServiceDef,
+  ServiceStartOptions,
+} from "./ServiceDef.ts";
 import { defaults } from "./ServiceDef.ts";
-import { initial } from "./ServiceState.ts";
+import { initial, ServiceState, type ServiceDesiredState } from "./ServiceState.ts";
 import { makeSupervisedCommand, usesSupervisor } from "./Supervisor.ts";
-import type { ServiceState } from "./ServiceState.ts";
 import {
   CyclicDependencyError,
   MissingDependencyError,
@@ -42,11 +48,17 @@ const waitForProcessToStop = (handle: {
 export class Orchestrator extends Context.Service<
   Orchestrator,
   {
-    readonly start: () => Effect.Effect<void>;
-    readonly startService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
+    readonly start: (options?: ServiceStartOptions) => Effect.Effect<void>;
+    readonly startService: (
+      name: string,
+      options?: ServiceStartOptions,
+    ) => Effect.Effect<void, ServiceNotFoundError>;
     readonly stop: () => Effect.Effect<void>;
     readonly stopService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
-    readonly restartService: (name: string) => Effect.Effect<void, ServiceNotFoundError>;
+    readonly restartService: (
+      name: string,
+      options?: ServiceStartOptions,
+    ) => Effect.Effect<void, ServiceNotFoundError>;
     readonly updateServiceDefinition: (
       name: string,
       def: ServiceDef,
@@ -100,7 +112,8 @@ export class Orchestrator extends Context.Service<
           healthy: Deferred.Deferred<void>;
           completed: Deferred.Deferred<number>;
           stopped: Deferred.Deferred<void>;
-          stoppedByUser: boolean;
+          readonly readinessWaiters: Set<Deferred.Deferred<void>>;
+          readonly completionWaiters: Set<Deferred.Deferred<number>>;
         }
         const services = new Map<string, ServiceSignals>();
 
@@ -113,12 +126,14 @@ export class Orchestrator extends Context.Service<
             healthy: Deferred.makeUnsafe<void>(),
             completed: Deferred.makeUnsafe<number>(),
             stopped: Deferred.makeUnsafe<void>(),
-            stoppedByUser: false,
+            readinessWaiters: new Set(),
+            completionWaiters: new Set(),
           });
         }
 
         // FiberMap to track running service fibers — auto-interrupted on scope close
         const fibers = yield* FiberMap.make<string>();
+        const startServiceLock = Semaphore.makeUnsafe(1);
 
         // Helper: send a validated FSM event — only does the state transition
         const sendEvent = (
@@ -129,6 +144,21 @@ export class Orchestrator extends Context.Service<
           if (svc === undefined) return Effect.succeed(null);
           return transition(svc.state, event);
         };
+
+        const setDesired = (name: string, desired: ServiceDesiredState): Effect.Effect<void> => {
+          const svc = services.get(name);
+          if (svc === undefined) return Effect.void;
+          return SubscriptionRef.update(svc.state, (state) =>
+            state.desired === desired ? state : new ServiceState({ ...state, desired }),
+          );
+        };
+
+        const signalHealthy = (svc: ServiceSignals): Effect.Effect<void> =>
+          Effect.forEach(
+            [svc.healthy, ...svc.readinessWaiters],
+            (waiter) => Deferred.succeed(waiter, void 0),
+            { discard: true },
+          );
 
         // Helper: run all hooks for a given trigger in sequence
         const runHooks = (def: ServiceDef, trigger: HookTrigger): Effect.Effect<void> =>
@@ -165,11 +195,22 @@ export class Orchestrator extends Context.Service<
         const shouldRestartOnUnhealthy = (policy: RestartPolicy): boolean => policy !== "no";
 
         // The full lifecycle loop for a single service
-        const runService = (def: ServiceDef): Effect.Effect<void, SpawnError> =>
+        const runService = (
+          def: ServiceDef,
+          options?: ServiceStartOptions,
+        ): Effect.Effect<void, SpawnError> =>
           Effect.gen(function* () {
             let restartCount = 0;
             const maxRestarts = def.maxRestarts ?? defaults.maxRestarts;
             const restartPolicy = def.restart ?? defaults.restart;
+            const prepareStart = () =>
+              options
+                ?.beforeStart?.(def.name)
+                .pipe(
+                  Effect.mapError((cause) => new SpawnError({ service: def.command, cause })),
+                ) ?? Effect.void;
+
+            yield* prepareStart();
 
             // Re-create signals on each run (needed for restarts)
             const resetSignals = Effect.sync(() => {
@@ -236,6 +277,10 @@ export class Orchestrator extends Context.Service<
                         extendEnv: true,
                         stdin: "ignore",
                       });
+
+                  // Release external resources such as port reservations only
+                  // once dependencies are satisfied and spawning is imminent.
+                  yield* options?.beforeSpawn?.(def.name) ?? Effect.void;
 
                   // Spawn the process
                   const handle = yield* spawner
@@ -349,7 +394,7 @@ export class Orchestrator extends Context.Service<
                               yield* runHooks(def, "healthy");
                               const current = SubscriptionRef.getUnsafe(svcSig.state);
                               if (current.status !== "Failed") {
-                                yield* Deferred.succeed(svcSig.healthy, void 0);
+                                yield* signalHealthy(svcSig);
                               }
                             }
                           }
@@ -382,7 +427,7 @@ export class Orchestrator extends Context.Service<
                     if (svcSig) {
                       const current = SubscriptionRef.getUnsafe(svcSig.state);
                       if (current.status !== "Failed") {
-                        yield* Deferred.succeed(svcSig.healthy, void 0);
+                        yield* signalHealthy(svcSig);
                       }
                     }
                   }
@@ -441,8 +486,14 @@ export class Orchestrator extends Context.Service<
             const handleResult = (r: SpawnResult) =>
               Effect.gen(function* () {
                 if (r._tag === "Exited") {
-                  const completeSig = services.get(def.name)?.completed;
-                  if (completeSig) yield* Deferred.succeed(completeSig, r.exitCode);
+                  const service = services.get(def.name);
+                  if (service !== undefined) {
+                    yield* Effect.forEach(
+                      [service.completed, ...service.completionWaiters],
+                      (waiter) => Deferred.succeed(waiter, r.exitCode),
+                      { discard: true },
+                    );
+                  }
                   if (r.exitCode !== 0 && r.exitCode !== 143) {
                     yield* appendRecentServiceLogs(
                       def.name,
@@ -458,19 +509,24 @@ export class Orchestrator extends Context.Service<
 
             // Restart loop
             const shouldRestart = (r: SpawnResult): boolean => {
+              const svc = services.get(def.name);
+              if (svc === undefined || SubscriptionRef.getUnsafe(svc.state).desired !== "running") {
+                return false;
+              }
               if (r._tag === "UnhealthyRestart") return true;
               if (restartPolicy === "no") return false;
               if (restartPolicy === "always") return true;
-              if (restartPolicy === "unless-stopped") {
-                const svc = services.get(def.name);
-                return svc ? !svc.stoppedByUser : false;
-              }
+              if (restartPolicy === "unless-stopped") return true;
               if (restartPolicy === "on-failure") return r.exitCode !== 0;
               return false;
             };
 
             while (shouldRestart(result) && (maxRestarts === 0 || restartCount < maxRestarts)) {
               restartCount++;
+
+              // The previous process scope has closed, so external resources can
+              // be reserved safely for the duration of this restart's backoff.
+              yield* prepareStart();
 
               if (result._tag === "UnhealthyRestart") {
                 yield* appendRecentServiceLogs(
@@ -495,11 +551,11 @@ export class Orchestrator extends Context.Service<
             }
           });
 
-        const runServiceSafe = (def: ServiceDef) =>
-          runService(def).pipe(
+        const runServiceSafe = (def: ServiceDef, options?: ServiceStartOptions) =>
+          runService(def, options).pipe(
             Effect.catch((error) =>
               sendEvent(def.name, {
-                _tag: "DependencyFailed",
+                _tag: "SpawnFailed",
                 error: `Spawn failed: ${error.service} - ${String(error.cause)}`,
               }).pipe(Effect.asVoid),
             ),
@@ -512,12 +568,12 @@ export class Orchestrator extends Context.Service<
           Effect.gen(function* () {
             const svc = services.get(name);
             if (svc) {
-              yield* SubscriptionRef.set(svc.state, initial(name));
+              const desired = SubscriptionRef.getUnsafe(svc.state).desired;
+              yield* SubscriptionRef.set(svc.state, initial(name, desired));
               svc.started = Deferred.makeUnsafe<void>();
               svc.healthy = Deferred.makeUnsafe<void>();
               svc.completed = Deferred.makeUnsafe<number>();
               svc.stopped = Deferred.makeUnsafe<void>();
-              svc.stoppedByUser = false;
             }
           });
 
@@ -530,12 +586,24 @@ export class Orchestrator extends Context.Service<
 
         const restartClosureFor = (name: string): ReadonlyArray<ServiceDef> => {
           const names = new Set<string>([name]);
-          const collectDependents = (current: string): void => {
+          const visited = new Set<string>();
+          const collectDependents = (current: string): boolean => {
+            if (visited.has(current)) return names.has(current);
+            visited.add(current);
+            let hasActiveDependent = false;
             for (const dependent of graph.dependentsOf(current)) {
-              if (names.has(dependent.name)) continue;
-              names.add(dependent.name);
-              collectDependents(dependent.name);
+              const dependentService = services.get(dependent.name);
+              const dependentIsActive =
+                FiberMap.hasUnsafe(fibers, dependent.name) ||
+                (dependentService !== undefined &&
+                  SubscriptionRef.getUnsafe(dependentService.state).desired === "running");
+              const descendantIsActive = collectDependents(dependent.name);
+              if (dependentIsActive || descendantIsActive) {
+                names.add(dependent.name);
+                hasActiveDependent = true;
+              }
             }
+            return hasActiveDependent;
           };
           collectDependents(name);
           return graph.startOrder.filter((def) => names.has(def.name));
@@ -547,8 +615,18 @@ export class Orchestrator extends Context.Service<
             if (!svc) return Effect.void;
             const restartPolicy = def.restart ?? defaults.restart;
 
-            // Check if already failed
             const current = SubscriptionRef.getUnsafe(svc.state);
+            if (current.desired !== "running") {
+              return Effect.fail(
+                new ServiceReadyError({
+                  name: def.name,
+                  reason:
+                    current.desired === "inactive"
+                      ? "Service has not been started"
+                      : "Service was explicitly stopped",
+                }),
+              );
+            }
             if (current.status === "Failed") {
               return Effect.fail(
                 new ServiceReadyError({
@@ -559,8 +637,17 @@ export class Orchestrator extends Context.Service<
             }
 
             if (restartPolicy === "no") {
-              // One-shot: wait for completed, check exit code
-              return Deferred.await(svc.completed).pipe(
+              const completion = Deferred.makeUnsafe<number>();
+              svc.completionWaiters.add(completion);
+              return Deferred.isDone(svc.completed).pipe(
+                Effect.flatMap((alreadyCompleted) =>
+                  alreadyCompleted
+                    ? Deferred.await(svc.completed).pipe(
+                        Effect.flatMap((exitCode) => Deferred.succeed(completion, exitCode)),
+                      )
+                    : Effect.void,
+                ),
+                Effect.andThen(Deferred.await(completion)),
                 Effect.flatMap((exitCode) =>
                   exitCode === 0
                     ? Effect.void
@@ -572,68 +659,182 @@ export class Orchestrator extends Context.Service<
                         }),
                       ),
                 ),
+                Effect.ensuring(Effect.sync(() => svc.completionWaiters.delete(completion))),
               );
             }
 
-            // Long-running: race healthy vs failure
-            return Effect.race(
-              Deferred.await(svc.healthy),
-              SubscriptionRef.changes(svc.state).pipe(
-                Stream.filter((s) => s.status === "Failed"),
-                Stream.take(1),
-                Stream.runDrain,
-                Effect.andThen(
-                  Effect.gen(function* () {
-                    const current = SubscriptionRef.getUnsafe(svc.state);
-                    return yield* Effect.fail(
-                      new ServiceReadyError({
-                        name: def.name,
-                        reason: current.error ?? "Service entered Failed state",
-                      }),
-                    );
-                  }),
+            if (current.status === "Stopped") {
+              return Effect.fail(
+                new ServiceReadyError({
+                  name: def.name,
+                  reason: "Service stopped before becoming ready",
+                }),
+              );
+            }
+
+            // A waiter belongs to the readiness request, not to one service signal
+            // generation. Dependency retries may replace svc.healthy while this
+            // request is pending, so signal the stable waiter from any generation.
+            const readiness = Deferred.makeUnsafe<void>();
+            svc.readinessWaiters.add(readiness);
+            return Deferred.isDone(svc.healthy).pipe(
+              Effect.flatMap((alreadyHealthy) =>
+                alreadyHealthy ? Deferred.succeed(readiness, void 0) : Effect.void,
+              ),
+              Effect.andThen(
+                Effect.race(
+                  Deferred.await(readiness),
+                  SubscriptionRef.changes(svc.state).pipe(
+                    Stream.filter(
+                      (state) => state.status === "Failed" || state.status === "Stopped",
+                    ),
+                    Stream.take(1),
+                    Stream.runDrain,
+                    Effect.andThen(
+                      Deferred.isDone(readiness).pipe(
+                        Effect.flatMap((ready) => {
+                          if (ready) return Effect.void;
+                          const terminal = SubscriptionRef.getUnsafe(svc.state);
+                          return Effect.fail(
+                            new ServiceReadyError({
+                              name: def.name,
+                              reason:
+                                terminal.status === "Stopped"
+                                  ? "Service stopped before becoming ready"
+                                  : (terminal.error ?? "Service entered Failed state"),
+                            }),
+                          );
+                        }),
+                      ),
+                    ),
+                  ),
                 ),
               ),
+              Effect.ensuring(Effect.sync(() => svc.readinessWaiters.delete(readiness))),
             );
           });
 
         return {
-          start: () =>
+          start: (options) =>
             Effect.gen(function* () {
               for (const def of graph.startOrder) {
-                yield* FiberMap.run(fibers, def.name, runServiceSafe(def));
+                yield* setDesired(def.name, "running");
+                yield* FiberMap.run(fibers, def.name, runServiceSafe(def, options));
               }
             }),
 
-          startService: (name: string) =>
+          startService: (name: string, options) =>
             Effect.gen(function* () {
               const def = lookupDef(name);
               if (def === undefined) {
                 return yield* Effect.fail(new ServiceNotFoundError({ name }));
               }
               const order = graph.startOrderFor(name);
+              const orderNames = new Set(order.map((service) => service.name));
+              const resetNames = new Set<string>();
+              let dependencySignalsReset = false;
               for (const d of order) {
-                yield* FiberMap.run(fibers, d.name, runServiceSafe(d), { onlyIfMissing: true });
+                const service = services.get(d.name);
+                const state = service?.state;
+                const status =
+                  state === undefined ? undefined : SubscriptionRef.getUnsafe(state).status;
+                const restartPolicy = d.restart ?? defaults.restart;
+
+                // A successful one-shot remains a satisfied dependency after its
+                // process exits. Naturally stopped long-running services can be
+                // started again even when their restart policy did not relaunch them.
+                if (
+                  status === "Stopped" &&
+                  d.name !== name &&
+                  service !== undefined &&
+                  SubscriptionRef.getUnsafe(service.state).desired !== "stopped" &&
+                  restartPolicy === "no"
+                ) {
+                  continue;
+                }
+
+                if (status === "Failed") {
+                  // The failed fiber may still be unwinding its process scope.
+                  // Remove it before replacing the signals used by the retry.
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                  dependencySignalsReset = true;
+                } else if (status === "Stopped") {
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                  dependencySignalsReset = true;
+                } else if (dependencySignalsReset && status === "Pending") {
+                  // This fiber may be waiting on Deferreds replaced by a retried dependency.
+                  // Relaunch it so it observes the dependency's new signal generation.
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  resetNames.add(d.name);
+                }
+                yield* setDesired(d.name, "running");
+                yield* FiberMap.run(fibers, d.name, runServiceSafe(d, options), {
+                  onlyIfMissing: true,
+                });
               }
-            }),
+
+              // A caller may retry a dependency directly while dependents started by an
+              // earlier request are still waiting on its old Deferred generation.
+              for (const d of graph.startOrder) {
+                if (orderNames.has(d.name)) continue;
+                const dependsOnResetService = graph
+                  .startOrderFor(d.name)
+                  .some((dependency) => resetNames.has(dependency.name));
+                const service = services.get(d.name);
+                if (
+                  dependsOnResetService &&
+                  service !== undefined &&
+                  FiberMap.hasUnsafe(fibers, d.name) &&
+                  SubscriptionRef.getUnsafe(service.state).status === "Pending"
+                ) {
+                  yield* FiberMap.remove(fibers, d.name);
+                  yield* resetService(d.name);
+                  yield* setDesired(d.name, "running");
+                  yield* FiberMap.run(fibers, d.name, runServiceSafe(d, options), {
+                    onlyIfMissing: true,
+                  });
+                }
+              }
+            }).pipe(startServiceLock.withPermit),
 
           stop: () =>
             Effect.gen(function* () {
               const timeoutSecs = config?.shutdownTimeoutSeconds ?? defaults.shutdownTimeoutSeconds;
+              const desiredBeforeStop = new Map(
+                graph.startOrder.map((def) => {
+                  const svc = services.get(def.name);
+                  return [
+                    def.name,
+                    svc === undefined ? "inactive" : SubscriptionRef.getUnsafe(svc.state).desired,
+                  ] as const;
+                }),
+              );
+
+              yield* Effect.forEach(
+                graph.startOrder.filter((def) => desiredBeforeStop.get(def.name) === "running"),
+                (def) => setDesired(def.name, "stopped"),
+                { discard: true },
+              );
 
               const stopAll = Effect.gen(function* () {
                 const stopOne = (def: ServiceDef) =>
                   Effect.gen(function* () {
+                    if (desiredBeforeStop.get(def.name) === "inactive") {
+                      const inactiveSignal = services.get(def.name)?.stopped;
+                      if (inactiveSignal) yield* Deferred.succeed(inactiveSignal, void 0);
+                      return;
+                    }
                     // Wait for all dependents to be stopped first
                     const dependents = graph.dependentsOf(def.name);
                     for (const dep of dependents) {
                       const sig = services.get(dep.name)?.stopped;
                       if (sig) yield* Deferred.await(sig);
                     }
-
-                    // Mark as user-stopped so restart loop won't re-spawn
-                    const svc = services.get(def.name);
-                    if (svc) svc.stoppedByUser = true;
 
                     // Now safe to stop this service
                     yield* sendEvent(def.name, { _tag: "StopRequested" });
@@ -675,15 +876,16 @@ export class Orchestrator extends Context.Service<
               if (lookupDef(name) === undefined) {
                 return yield* Effect.fail(new ServiceNotFoundError({ name }));
               }
-              const svc = services.get(name);
-              if (svc) svc.stoppedByUser = true;
-              yield* sendEvent(name, { _tag: "StopRequested" });
-              yield* FiberMap.remove(fibers, name);
-              // Force Stopped if still in Stopping (fiber was interrupted before ProcessExited)
-              yield* sendEvent(name, { _tag: "ProcessExited", exitCode: 143 });
+              const affected = restartClosureFor(name);
+              for (const affectedDef of [...affected].reverse()) {
+                yield* setDesired(affectedDef.name, "stopped");
+                yield* sendEvent(affectedDef.name, { _tag: "StopRequested" });
+                yield* FiberMap.remove(fibers, affectedDef.name);
+                yield* sendEvent(affectedDef.name, { _tag: "ProcessExited", exitCode: 143 });
+              }
             }),
 
-          restartService: (name: string) =>
+          restartService: (name: string, options) =>
             Effect.gen(function* () {
               const def = lookupDef(name);
               if (def === undefined) {
@@ -696,9 +898,10 @@ export class Orchestrator extends Context.Service<
               }
               for (const affectedDef of affected) {
                 yield* resetService(affectedDef.name);
+                yield* setDesired(affectedDef.name, "running");
               }
               for (const affectedDef of affected) {
-                yield* FiberMap.run(fibers, affectedDef.name, runServiceSafe(affectedDef));
+                yield* FiberMap.run(fibers, affectedDef.name, runServiceSafe(affectedDef, options));
               }
             }),
 
@@ -760,9 +963,17 @@ export class Orchestrator extends Context.Service<
             }),
 
           waitAllReady: () =>
-            Effect.all(graph.startOrder.map(waitReadySingle), {
-              concurrency: "unbounded",
-            }).pipe(Effect.asVoid),
+            Effect.all(
+              graph.startOrder
+                .filter((def) => {
+                  const svc = services.get(def.name);
+                  return (
+                    svc !== undefined && SubscriptionRef.getUnsafe(svc.state).desired === "running"
+                  );
+                })
+                .map(waitReadySingle),
+              { concurrency: "unbounded" },
+            ).pipe(Effect.asVoid),
         };
       }),
     );

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -446,6 +446,31 @@ describe("Orchestrator", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.live("stopping a supervisor during its spawn handshake cleans it up", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("postgres", {
+          command: "docker",
+          args: ["run", "--rm", "postgres"],
+          supervision: {
+            orphanCleanup: [{ _tag: "DockerRemove", containerName: "supabase-postgres-test" }],
+          },
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("postgres", { beforeSpawn: () => Effect.void });
+      yield* proc.waitForSpawnCount(1);
+
+      yield* orc.stopService("postgres");
+      yield* proc.waitForKillCount(1);
+
+      expect(proc.killed[0]?.command).toBe(process.execPath);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.live("ServiceDef shutdown does not expose killMode", () => {
     const service: ServiceDef = {
       name: "a",
@@ -511,6 +536,308 @@ describe("Orchestrator", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.live("runs beforeSpawn for each service at its spawn boundary", () => {
+    const events: string[] = [];
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      {
+        exitDelay: "500 millis",
+        onSpawn: ({ command }) => events.push(`spawn:${command}`),
+      },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api", {
+        beforeSpawn: (name) => Effect.sync(() => events.push(`release:${name}`)),
+      });
+      yield* proc.waitForSpawnCount(2);
+
+      expect(events).toEqual(["release:db", "spawn:db", "release:api", "spawn:api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService restarts an explicitly requested dependency closure", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("web", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "500 millis" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("web");
+      yield* proc.waitForSpawnCount(2);
+      yield* orc.stopService("db");
+      yield* waitForStopped(orc, "db");
+
+      yield* orc.startService("web");
+      yield* proc.waitForSpawnCount(4);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "web", "db", "web"]);
+      expect((yield* orc.getState("db")).status).not.toBe("Stopped");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService preserves successful one-shot dependencies", () => {
+    const { layer, proc } = setupOrchestrator([
+      svc("setup", { restart: "no" }),
+      svc("api", {
+        dependencies: [{ service: "setup", condition: "completed" }],
+      }),
+      svc("worker", {
+        dependencies: [{ service: "setup", condition: "completed" }],
+      }),
+    ]);
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawnCount(2);
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.startService("worker");
+      yield* proc.waitForSpawnCount(3);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["setup", "api", "worker"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService reruns a directly requested successful one-shot", () => {
+    const { layer, proc } = setupOrchestrator([svc("setup", { restart: "no" })]);
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("setup");
+      yield* proc.waitForSpawn("setup");
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.startService("setup");
+      yield* proc.waitForSpawn("setup", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["setup", "setup"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService restarts a naturally stopped long-running service", () => {
+    const { layer, proc } = setupOrchestrator([svc("api", { restart: "on-failure" })], {
+      exitCode: 0,
+      exitDelay: "25 millis",
+    });
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api");
+      yield* waitForStopped(orc, "api");
+
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["api", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService replaces a failed fiber before retrying", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("api", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* waitForFailed(orc, "api");
+
+      yield* orc.startService("api");
+      yield* proc.waitForSpawn("api", 2);
+      yield* Effect.sleep(Duration.millis(25));
+
+      expect(attempts).toBe(2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService serializes concurrent retries of the same failed service", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("api", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+      ],
+      { exitDelay: "50 millis" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* waitForFailed(orc, "api");
+
+      yield* Effect.all([orc.startService("api"), orc.startService("api")], {
+        concurrency: "unbounded",
+      });
+      yield* orc.waitReady("api");
+
+      expect(attempts).toBe(2);
+      expect(proc.spawned.map((record) => record.command)).toEqual(["api", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService relaunches dependents waiting on a retried service", () => {
+    let attempts = 0;
+    const beforeSpawn: string[] = [];
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api", {
+        beforeSpawn: (name) => Effect.sync(() => beforeSpawn.push(name)),
+      });
+      yield* waitForFailed(orc, "db");
+      const ready = yield* orc.waitReady("api").pipe(Effect.forkScoped);
+
+      yield* orc.startService("db", {
+        beforeSpawn: (name) => Effect.sync(() => beforeSpawn.push(name)),
+      });
+      yield* proc.waitForSpawn("api");
+      yield* Fiber.join(ready);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db", "api"]);
+      expect(beforeSpawn).toEqual(["db", "db", "api"]);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("preserves one-shot readiness waiters when a dependency retry relaunches them", () => {
+    let attempts = 0;
+    const { layer } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("setup", {
+          restart: "no",
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "20 millis" },
+    );
+
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("setup");
+      yield* waitForFailed(orc, "db");
+      const ready = yield* orc.waitReady("setup").pipe(Effect.forkScoped);
+
+      yield* orc.startService("db");
+      yield* Fiber.join(ready);
+
+      expect(attempts).toBe(2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("startService leaves never-requested dependents pending when retrying a service", () => {
+    let attempts = 0;
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db", {
+          restart: "no",
+          hooks: [
+            {
+              on: "started",
+              run: () =>
+                Effect.suspend(() => {
+                  attempts++;
+                  return attempts === 1
+                    ? Effect.fail(new Error("first attempt failed"))
+                    : Effect.void;
+                }),
+            },
+          ],
+        }),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("db");
+      yield* waitForFailed(orc, "db");
+
+      yield* orc.startService("db");
+      yield* proc.waitForSpawn("db", 2);
+      yield* Effect.sleep(Duration.millis(25));
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db"]);
+      expect((yield* orc.getState("api")).status).toBe("Pending");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.live("restartService stops and restarts a service", () => {
     const { layer, proc } = setupOrchestrator([svc("a")], {
       exitDelay: "5 seconds",
@@ -560,6 +887,69 @@ describe("Orchestrator", () => {
         unrelated: 1,
         web: 2,
       });
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("restartService leaves never-started dependents pending", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("api", {
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+      ],
+      { exitDelay: "5 seconds" },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("db");
+      yield* proc.waitForSpawn("db");
+
+      yield* orc.restartService("db");
+      yield* proc.waitForSpawn("db", 2);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual(["db", "db"]);
+      expect((yield* orc.getState("api")).status).toBe("Pending");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.live("restartService replays completed dependencies of active dependents", () => {
+    const { layer, proc } = setupOrchestrator(
+      [
+        svc("db"),
+        svc("setup", {
+          restart: "no",
+          dependencies: [{ service: "db", condition: "started" }],
+        }),
+        svc("api", {
+          dependencies: [{ service: "setup", condition: "completed" }],
+        }),
+      ],
+      {
+        perService: {
+          db: { exitDelay: "5 seconds" },
+          setup: { exitDelay: "10 millis" },
+          api: { exitDelay: "5 seconds" },
+        },
+      },
+    );
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api");
+      yield* proc.waitForSpawnCount(3);
+      yield* waitForStopped(orc, "setup");
+
+      yield* orc.restartService("db");
+      yield* proc.waitForSpawnCount(6);
+
+      expect(proc.spawned.map((record) => record.command)).toEqual([
+        "db",
+        "setup",
+        "api",
+        "db",
+        "setup",
+        "api",
+      ]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
@@ -1223,9 +1613,28 @@ describe("Orchestrator", () => {
     });
   });
 
+  it.live("fails readiness when a pre-start hook fails", () => {
+    const { layer } = setupOrchestrator([svc("api")], { exitDelay: "5 seconds" });
+
+    return Effect.gen(function* () {
+      const orc = yield* Orchestrator;
+      yield* orc.startService("api", {
+        beforeStart: () => Effect.fail(new Error("port reservation failed")),
+      });
+
+      const error = yield* orc.waitReady("api").pipe(Effect.flip);
+      expect(error._tag).toBe("ServiceReadyError");
+      if (error._tag === "ServiceReadyError") {
+        expect(error.reason).toContain("port reservation failed");
+      }
+      expect((yield* orc.getState("api")).status).toBe("Failed");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   describe("unhealthy restart", () => {
     it.live("restarts service when it becomes unhealthy and restart policy allows", () => {
       let checkCalls = 0;
+      const prepared: string[] = [];
       const { layer, proc } = setupOrchestrator(
         [
           svc("a", {
@@ -1255,11 +1664,14 @@ describe("Orchestrator", () => {
       );
       return Effect.gen(function* () {
         const orc = yield* Orchestrator;
-        yield* orc.start();
+        yield* orc.start({
+          beforeStart: (name) => Effect.sync(() => prepared.push(name)),
+        });
         yield* proc.waitForSpawn("a", 2);
         // Should have spawned the main service twice (original + 1 restart)
         const mainSpawns = proc.spawned.filter((s) => s.command === "a");
         expect(mainSpawns.length).toBe(2);
+        expect(prepared).toEqual(["a", "a"]);
       }).pipe(Effect.provide(layer), Effect.scoped);
     });
 
@@ -1365,6 +1777,19 @@ describe("Orchestrator", () => {
       }).pipe(Effect.provide(layer), Effect.scoped);
     });
 
+    it.live("waitReady resolves after a one-shot service has already completed", () => {
+      const { layer } = setupOrchestrator([svc("a", { restart: "no" })], {
+        exitCode: 0,
+        exitDelay: "10 millis",
+      });
+      return Effect.gen(function* () {
+        const orc = yield* Orchestrator;
+        yield* orc.start();
+        yield* waitForStopped(orc, "a");
+        yield* orc.waitReady("a");
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    });
+
     it.live("waitReady fails when one-shot exits with non-zero code", () => {
       const { layer } = setupOrchestrator([svc("a", { restart: "no" })], {
         exitCode: 1,
@@ -1397,6 +1822,31 @@ describe("Orchestrator", () => {
         const orc = yield* Orchestrator;
         yield* orc.start();
         const exit = yield* orc.waitReady("a").pipe(Effect.exit);
+        expect(Exit.isFailure(exit)).toBe(true);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    });
+
+    it.live("waitReady fails when a starting service is stopped", () => {
+      const { layer, proc } = setupOrchestrator(
+        [
+          svc("a", {
+            healthCheck: {
+              probe: { _tag: "Exec", command: "true", args: [] },
+              initialDelaySeconds: 999,
+            },
+          }),
+        ],
+        { exitDelay: "5 seconds" },
+      );
+      return Effect.gen(function* () {
+        const orc = yield* Orchestrator;
+        yield* orc.start();
+        yield* proc.waitForSpawn("a");
+        const ready = yield* orc.waitReady("a").pipe(Effect.forkScoped);
+
+        yield* orc.stopService("a");
+
+        const exit = yield* Fiber.await(ready);
         expect(Exit.isFailure(exit)).toBe(true);
       }).pipe(Effect.provide(layer), Effect.scoped);
     });

--- a/packages/process-compose/src/Orchestrator.unit.test.ts
+++ b/packages/process-compose/src/Orchestrator.unit.test.ts
@@ -1675,6 +1675,57 @@ describe("Orchestrator", () => {
       }).pipe(Effect.provide(layer), Effect.scoped);
     });
 
+    it.live("fails readiness when unhealthy restart preparation fails", () => {
+      let checkCalls = 0;
+      let prepareCalls = 0;
+      const { layer } = setupOrchestrator(
+        [
+          svc("a", {
+            restart: "always",
+            maxRestarts: 1,
+            healthCheck: {
+              probe: { _tag: "Exec", command: "check", args: [] },
+              periodSeconds: 0.05,
+              successThreshold: 1,
+              failureThreshold: 2,
+            },
+          }),
+        ],
+        {
+          exitDelay: "5 seconds",
+          perService: {
+            check: {
+              exitDelay: "1 millis",
+              getExitCode: () => {
+                checkCalls++;
+                return checkCalls <= 1 ? 0 : 1;
+              },
+            },
+          },
+        },
+      );
+
+      return Effect.gen(function* () {
+        const orc = yield* Orchestrator;
+        yield* orc.start({
+          beforeStart: () =>
+            Effect.suspend(() => {
+              prepareCalls++;
+              return prepareCalls === 1
+                ? Effect.void
+                : Effect.fail(new Error("port reservation failed"));
+            }),
+        });
+
+        yield* waitForState(orc, "a", (state) => state.status === "Failed", "Failed");
+        const error = yield* orc.waitReady("a").pipe(Effect.flip);
+        expect(error._tag).toBe("ServiceReadyError");
+        if (error._tag === "ServiceReadyError") {
+          expect(error.reason).toContain("port reservation failed");
+        }
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    });
+
     it.live("does not restart unhealthy service when restart policy is no", () => {
       let checkCalls = 0;
       const { layer, proc } = setupOrchestrator(

--- a/packages/process-compose/src/ServiceDef.ts
+++ b/packages/process-compose/src/ServiceDef.ts
@@ -89,6 +89,13 @@ export interface OrchestratorConfig {
   readonly shutdownTimeoutSeconds?: number;
 }
 
+export interface ServiceStartOptions {
+  /** Runs when a service lifecycle starts and again after each process exit before backoff. */
+  readonly beforeStart?: (name: string) => Effect.Effect<void, unknown>;
+  /** Runs after dependencies are satisfied and immediately before each spawn. */
+  readonly beforeSpawn?: (name: string) => Effect.Effect<void>;
+}
+
 export const defaults = {
   healthCheck: {
     initialDelaySeconds: 0,

--- a/packages/process-compose/src/ServiceState.ts
+++ b/packages/process-compose/src/ServiceState.ts
@@ -11,6 +11,8 @@ export type ServiceStatus =
   | "Failed"
   | "Restarting";
 
+export type ServiceDesiredState = "inactive" | "running" | "stopped";
+
 export class ServiceState extends Data.Class<{
   readonly name: string;
   readonly status: ServiceStatus;
@@ -19,9 +21,11 @@ export class ServiceState extends Data.Class<{
   readonly restartCount: number;
   readonly startedAt: number | null;
   readonly error: string | null;
+  /** Caller-owned intent, independent of the current process transition. */
+  readonly desired: ServiceDesiredState;
 }> {}
 
-export const initial = (name: string): ServiceState =>
+export const initial = (name: string, desired: ServiceDesiredState = "inactive"): ServiceState =>
   new ServiceState({
     name,
     status: "Pending",
@@ -30,4 +34,5 @@ export const initial = (name: string): ServiceState =>
     restartCount: 0,
     startedAt: null,
     error: null,
+    desired,
   });

--- a/packages/process-compose/src/ServiceState.unit.test.ts
+++ b/packages/process-compose/src/ServiceState.unit.test.ts
@@ -11,6 +11,7 @@ describe("ServiceState", () => {
     expect(state.restartCount).toBe(0);
     expect(state.startedAt).toBeNull();
     expect(state.error).toBeNull();
+    expect(state.desired).toBe("inactive");
   });
 
   it("supports structural equality", () => {

--- a/packages/process-compose/src/ServiceTransition.ts
+++ b/packages/process-compose/src/ServiceTransition.ts
@@ -52,6 +52,7 @@ const allowed = new Set<`${ServiceStatus}:${ServiceEvent["_tag"]}`>([
   "Failed:RestartTriggered",
   "Unhealthy:RestartTriggered",
   "Restarting:StopRequested",
+  "Restarting:SpawnFailed",
   "Restarting:BackoffElapsed",
   "Running:HookFailed",
   "Healthy:HookFailed",

--- a/packages/process-compose/src/ServiceTransition.ts
+++ b/packages/process-compose/src/ServiceTransition.ts
@@ -8,6 +8,7 @@ import { ServiceState, type ServiceStatus } from "./ServiceState.ts";
 export type ServiceEvent =
   | { readonly _tag: "DependenciesSatisfied" }
   | { readonly _tag: "DependencyFailed"; readonly error: string }
+  | { readonly _tag: "SpawnFailed"; readonly error: string }
   | {
       readonly _tag: "ProcessSpawned";
       readonly pid: number;
@@ -31,8 +32,10 @@ export type ServiceEvent =
 const allowed = new Set<`${ServiceStatus}:${ServiceEvent["_tag"]}`>([
   "Pending:DependenciesSatisfied",
   "Pending:DependencyFailed",
+  "Pending:SpawnFailed",
   "Pending:StopRequested",
   "Starting:ProcessSpawned",
+  "Starting:SpawnFailed",
   "Starting:StopRequested",
   "Running:HealthCheckPassed",
   "Running:ProcessExited",
@@ -67,6 +70,7 @@ export const applyEvent = (state: ServiceState, event: ServiceEvent): ServiceSta
       return new ServiceState({ ...state, status: "Starting" });
 
     case "DependencyFailed":
+    case "SpawnFailed":
       return new ServiceState({
         ...state,
         status: "Failed",

--- a/packages/process-compose/src/ServiceTransition.unit.test.ts
+++ b/packages/process-compose/src/ServiceTransition.unit.test.ts
@@ -51,6 +51,24 @@ describe("ServiceTransition", () => {
       expect(next!.startedAt).toBe(1000);
     });
 
+    it("Starting + SpawnFailed → Failed with error", () => {
+      const result = applyEvent(make("db", { status: "Starting" }), {
+        _tag: "SpawnFailed",
+        error: "spawn gate failed",
+      });
+      expect(result?.status).toBe("Failed");
+      expect(result?.error).toBe("spawn gate failed");
+    });
+
+    it("Pending + SpawnFailed → Failed with error", () => {
+      const result = applyEvent(make("db"), {
+        _tag: "SpawnFailed",
+        error: "pre-start failed",
+      });
+      expect(result?.status).toBe("Failed");
+      expect(result?.error).toBe("pre-start failed");
+    });
+
     it("Running + HealthCheckPassed → Healthy", () => {
       const state = make("db", { status: "Running", pid: 1234 });
       const next = applyEvent(state, { _tag: "HealthCheckPassed" });

--- a/packages/process-compose/src/ServiceTransition.unit.test.ts
+++ b/packages/process-compose/src/ServiceTransition.unit.test.ts
@@ -69,6 +69,15 @@ describe("ServiceTransition", () => {
       expect(result?.error).toBe("pre-start failed");
     });
 
+    it("Restarting + SpawnFailed → Failed with error", () => {
+      const result = applyEvent(make("db", { status: "Restarting" }), {
+        _tag: "SpawnFailed",
+        error: "restart preparation failed",
+      });
+      expect(result?.status).toBe("Failed");
+      expect(result?.error).toBe("restart preparation failed");
+    });
+
     it("Running + HealthCheckPassed → Healthy", () => {
       const state = make("db", { status: "Running", pid: 1234 });
       const next = applyEvent(state, { _tag: "HealthCheckPassed" });

--- a/packages/process-compose/src/index.ts
+++ b/packages/process-compose/src/index.ts
@@ -11,11 +11,12 @@ export type {
   HookLog,
   LifecycleHook,
   OrchestratorConfig,
+  ServiceStartOptions,
   ServiceDef,
 } from "./ServiceDef.ts";
 export { defaults } from "./ServiceDef.ts";
 
-export type { ServiceStatus } from "./ServiceState.ts";
+export type { ServiceDesiredState, ServiceStatus } from "./ServiceState.ts";
 export { ServiceState, initial } from "./ServiceState.ts";
 
 export {

--- a/packages/process-compose/tests/helpers/mocks.ts
+++ b/packages/process-compose/tests/helpers/mocks.ts
@@ -1,4 +1,5 @@
 import { Deferred, Effect, Layer, Sink, Stream } from "effect";
+import { writeFileSync } from "node:fs";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 interface SpawnRecord {
@@ -8,11 +9,30 @@ interface SpawnRecord {
 
 const encoder = new TextEncoder();
 
+const signalSupervisorSpawnGate = (args: ReadonlyArray<string>): void => {
+  const encoded = args.at(-1);
+  if (encoded === undefined) return;
+  try {
+    const config: unknown = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+    if (typeof config !== "object" || config === null || !("spawnGate" in config)) return;
+    const gate = config.spawnGate;
+    if (
+      typeof gate === "object" &&
+      gate !== null &&
+      "requestPath" in gate &&
+      typeof gate.requestPath === "string"
+    ) {
+      writeFileSync(gate.requestPath, "ready", { flag: "wx" });
+    }
+  } catch {}
+};
+
 export function mockChildProcessSpawner(
   opts: {
     exitCode?: number;
     stdout?: string[];
     stderr?: string[];
+    beforeSpawn?: (record: SpawnRecord) => Effect.Effect<void>;
     onSpawn?: (record: SpawnRecord) => void;
   } = {},
 ) {
@@ -27,6 +47,8 @@ export function mockChildProcessSpawner(
           const cmd = command._tag === "StandardCommand" ? command.command : "";
           const args = command._tag === "StandardCommand" ? command.args : [];
           const record: SpawnRecord = { command: cmd, args };
+          signalSupervisorSpawnGate(args);
+          yield* opts.beforeSpawn?.(record) ?? Effect.void;
           spawned.push(record);
           opts.onSpawn?.(record);
 

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -7,8 +7,9 @@ Programmatic local Supabase stack for TypeScript. Create a local Supabase runtim
 - **Single entry point** -- `createStack()` resolves config and returns a handle; `start()` prepares assets, starts services, and waits for readiness
 - **Preparation-aware startup** -- cold-cache startup can surface `Downloading` before normal runtime states like `Starting`, `Initializing`, and `Healthy`
 - **Native binaries with Docker fallback** -- uses native services when available and falls back to Docker images automatically
-- **Automatic port allocation** -- all ports are optional and auto-assigned to avoid conflicts
+- **Leased port allocation** -- optional ports are auto-assigned and held until their service starts
 - **API proxy with opaque keys** -- SDKs use `publishableKey`/`secretKey` (like production), translated to JWTs internally
+- **Lazy HTTP services** -- opt into `startupMode: "lazy"` to start proxied HTTP services on first use while keeping direct listeners and Realtime reachable
 - **`AsyncDisposable` support** -- use `await using` for automatic cleanup
 - **Streaming logs and status** -- real-time `AsyncIterable` streams for service state changes and log output
 - **Per-service lifecycle control** -- start, stop, and restart individual services independently
@@ -75,13 +76,14 @@ await stack.dispose();
 
 ### Top-level settings
 
-| Field            | Type                             | Required | Default  | Description                                                                                                                                                     |
-| ---------------- | -------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`           | `"native" \| "auto" \| "docker"` | No       | `"auto"` | Resolution mode. `"native"` requires native binaries, `"auto"` tries native first and falls back to Docker, and `"docker"` uses Docker images for all services. |
-| `jwtSecret`      | `string`                         | No       |          | Secret for JWT signing (min 32 characters). Defaults to a well-known dev secret                                                                                 |
-| `port`           | `number`                         | No       |          | API proxy port (auto-allocated if omitted)                                                                                                                      |
-| `publishableKey` | `string`                         | No       |          | Custom opaque publishable key                                                                                                                                   |
-| `secretKey`      | `string`                         | No       |          | Custom opaque secret key                                                                                                                                        |
+| Field            | Type                             | Required | Default   | Description                                                                                                                                                     |
+| ---------------- | -------------------------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`           | `"native" \| "auto" \| "docker"` | No       | `"auto"`  | Resolution mode. `"native"` requires native binaries, `"auto"` tries native first and falls back to Docker, and `"docker"` uses Docker images for all services. |
+| `startupMode`    | `"eager" \| "lazy"`              | No       | `"eager"` | In lazy mode, proxied HTTP services start on first use. Direct listeners and Realtime start with the stack.                                                     |
+| `jwtSecret`      | `string`                         | No       |           | Secret for JWT signing (min 32 characters). Defaults to a well-known dev secret                                                                                 |
+| `port`           | `number`                         | No       |           | API proxy port (auto-allocated if omitted)                                                                                                                      |
+| `publishableKey` | `string`                         | No       |           | Custom opaque publishable key                                                                                                                                   |
+| `secretKey`      | `string`                         | No       |           | Custom opaque secret key                                                                                                                                        |
 
 ### `postgres`
 
@@ -181,6 +183,10 @@ await stack.startService("auth"); // Restart it (blocks until ready)
 await stack.restartService("auth"); // Stop + start in one call
 ```
 
+Service activation is dependency-aware. Starting Storage also starts imgproxy when enabled, and
+starting Analytics also starts Vector when enabled, so a public service never comes up without the
+companion it calls or feeds.
+
 Common service names include `"postgres"`, `"postgrest"`, `"auth"`, `"realtime"`, `"storage"`,
 `"imgproxy"`, `"mailpit"`, `"pgmeta"`, `"studio"`, `"analytics"`, `"vector"`, and `"pooler"`.
 
@@ -197,7 +203,11 @@ await stack.serviceReady("postgres"); // Wait for one service
 await stack.serviceReady("auth", { timeout: 10_000 });
 ```
 
-Note: `start()` already blocks until all services are ready. Use `ready()` and `serviceReady()` after manually starting individual services.
+In eager mode, `start()` blocks until every enabled service is ready. In lazy mode it waits only
+for direct listeners and services activated so far. Unrequested lazy services report `Dormant`.
+Calling `serviceReady()` for a dormant lazy
+service fails immediately; activate it through the proxy or call `startService()` first. Foreground
+and detached stacks use the same readiness rules.
 
 ### Status
 

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -239,12 +239,12 @@ flowchart LR
 
 **File:** `src/BinaryResolver.ts`
 
-`BinaryResolver` is the most complex piece of the package. Given a service name and version, it locates or downloads the correct binary for the current platform, verifies its integrity, and returns a path to the extracted directory.
+Given a service name and version, `BinaryResolver` asks the artifact catalog for a supported native release, reuses or downloads the corresponding binary for the current platform, verifies its integrity, and returns a path to the extracted directory.
 
 #### Service interface
 
 ```ts
-class BinaryResolver extends ServiceMap.Service<
+class BinaryResolver extends Context.Service<
   BinaryResolver,
   {
     readonly resolve: (
@@ -254,7 +254,7 @@ class BinaryResolver extends ServiceMap.Service<
 >()("local/BinaryResolver") {}
 
 interface BinarySpec {
-  readonly service: ServiceName; // "postgres" | "postgrest" | "auth"
+  readonly service: ServiceName;
   readonly version: string;
   readonly cacheDir?: string; // defaults to ~/.supabase/bin
 }
@@ -265,59 +265,63 @@ interface BinarySpec {
 ```mermaid
 flowchart TD
     A["resolve(spec)"] --> B["detectPlatform"]
-    B --> C{"assetName?"}
-    C -->|"null"| D["BinaryNotFoundError"]
-    C -->|"string"| E["construct cacheDir"]
-    E --> F2["sweep stale cacheDir.tmp-* siblings (best-effort, always runs)"]
-    F2 --> F{"fs.exists(cacheDir/.supabase-cache-complete)?"}
-    F -->|"yes"| G["return cacheDir (cache hit)"]
-    F -->|"no"| H["HttpClient.get tarball from GitHub"]
-    H -->|"network error"| I["DownloadError"]
-    H -->|"ok"| J{"checksumUrl?"}
-    J -->|"null"| L["skip verification"]
-    J -->|"string"| K["HttpClient.get .sha256 file"]
-    K --> M["verifyChecksum (SHA-256)"]
-    M -->|"mismatch"| N["ChecksumMismatchError"]
-    M -->|"ok"| L
-    L --> O["fs.makeDirectory tmpDir = cacheDir.tmp-«uuid»"]
-    O --> P["write _download-«uuid».tar/.zip into tmpDir"]
-    P --> Q["tar/unzip extract into tmpDir"]
-    Q -->|"exitCode != 0"| R["DownloadError"]
-    Q -->|"ok"| T["chmod +x, (macOS) codesign, write completion marker — all in tmpDir"]
-    T --> U["fs.rename(tmpDir, cacheDir)"]
-    U -->|"ok"| G
-    U -->|"rename fails, cacheDir has marker"| V["another process won — discard tmpDir, return cacheDir"]
-    U -->|"rename fails, no marker, attempts remain"| W["reclaim: remove broken/legacy cacheDir, retry rename"]
-    U -->|"rename fails, no marker, attempts exhausted"| X["DownloadError"]
-    W --> U
-    V --> G
+    B --> C{"native release in artifact catalog?"}
+    C -->|"no"| D["BinaryNotFoundError"]
+    C -->|"yes"| E["construct provider-scoped cacheDir"]
+    E --> F["sweep stale .partial-* siblings (best-effort)"]
+    F --> G{"cacheDir has .complete marker and payload?"}
+    G -->|"yes"| H["return cacheDir"]
+    G -->|"no"| I{"compatible legacy cache has expected executable?"}
+    I -->|"yes"| J["return legacy cacheDir"]
+    I -->|"no"| M["HttpClient.get release archive"]
+    M -->|"network error"| N["DownloadError"]
+    M -->|"ok"| O{"checksum URL?"}
+    O -->|"no"| Q["skip verification"]
+    O -->|"yes"| P["download and verify SHA-256"]
+    P -->|"mismatch"| R["ChecksumMismatchError"]
+    P -->|"ok"| Q
+    Q --> S["extract into unique .partial-* staging directory"]
+    S -->|"exitCode != 0"| T["DownloadError"]
+    S -->|"ok"| U["chmod, macOS codesign, write .complete marker"]
+    U --> V{"atomically rename staging to cacheDir"}
+    V -->|"won publication"| H
+    V -->|"destination exists"| W{"destination complete?"}
+    W -->|"yes"| H
+    W -->|"no"| N
 ```
 
-Note that a markerless `cacheDir` (e.g. a legacy binary from before this marker existed) is never removed upfront on the miss check — only `W`, at publish time, ever removes one, and only once a fully-staged replacement (`tmpDir`) is ready to take its place.
+A markerless provider-scoped `cacheDir` is not removed on the initial miss. It is replaced only after a complete artifact has been staged, so a failed download does not destroy the previous files.
 
 #### Cache layout
 
-The cache directory mirrors the logical identity of each binary: `<cacheDir>/<service>/<version>/<assetName>/`. Two versions of the same service coexist without conflict. The check is for a version-agnostic completion marker file (`.supabase-cache-complete`) inside `cacheDir`, not mere directory existence. A `cacheDir` that exists but lacks the marker can only be a broken or legacy leftover (e.g. from an older, pre-staging CLI version) — but it is left in place rather than removed on the miss check. Deleting it eagerly, before even attempting a download, would destroy a plausibly-still-usable binary before knowing whether a replacement can be produced (an offline machine or a GitHub outage would otherwise turn a would-have-been cache hit into both a failure and a lost cache). It's reclaimed later, only at publish time, once a fully-staged replacement is ready to atomically take its place.
+The cache identity is `<cacheDir>/<service>/<provider>/<version>/<assetName>/`. Including the provider prevents artifacts from different release sources from colliding when the catalog changes. A current cache entry is reusable only when it contains both the version-agnostic `.complete` marker and a payload file.
+
+The resolver also recognizes the previous `<cacheDir>/<service>/<version>/<assetName>/` layout for the four release providers supported by the old resolver. It reuses such an entry only when the service's expected executable exists. This keeps upgrades working offline without allowing a future provider change to inherit an artifact from an unrelated source.
 
 ```
 ~/.supabase/bin/
   postgres/
-    17.6.1.081-cli/
-      darwin-arm64/       <- extracted binary tree
-        start.sh
-        bin/
-          postgres
+    github.com_supabase_postgres/
+      17.6.1.081/
+        darwin-arm64/       <- extracted binary tree
+          .complete
+          bin/
+            postgres
   postgrest/
-    14.5/
-      macos-aarch64/
-        postgrest
+    github.com_PostgREST_postgrest/
+      14.5/
+        macos-aarch64/
+          .complete
+          postgrest
   auth/
-    2.187.0/
-      arm64/
-        auth
+    github.com_supabase_auth/
+      2.187.0/
+        arm64/
+          .complete
+          auth
 ```
 
-The cache path components — `<service>/<version>/<assetName>` — are exposed as static methods (`BinaryResolver.downloadUrl`, `BinaryResolver.checksumUrl`, `BinaryResolver.cachePath`) so they can be tested without constructing the full Effect service. These static helpers are the pure core; the Effect service wraps them with the actual I/O.
+`BinaryResolver.cachePath` exposes this path calculation for focused unit tests. Release URLs, archive formats, checksums, and provider identities come from `ServiceArtifacts` rather than resolver-specific static helpers.
 
 #### Checksum verification
 
@@ -325,22 +329,15 @@ Only postgres publishes SHA-256 checksums alongside its tarballs (as `<tarball-u
 
 #### Archive extraction
 
-To avoid corrupting `cacheDir` under concurrent invocations of the same spec, the download and extraction are staged in a per-invocation-unique sibling directory, `<cacheDir>.tmp-<uuid>`, never inside `cacheDir` itself. The archive is downloaded to a uniquely-named temp file inside that staging directory. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used with `--strip-components=1` to remove the top-level directory. For zip archives (PostgREST on Windows), `unzip` is used on Unix or `tar xf` on Windows. The `tar`/`unzip` subprocess is spawned via `ChildProcessSpawner` from `effect/unstable/process`.
+Each resolver extracts into a per-invocation-unique sibling directory named `.<assetName>.partial-*`, never inside `cacheDir` itself. For tarballs (`.tar.gz`, `.tar.xz`), `tar` is used and catalog metadata decides whether to strip the top-level directory. For zip archives, `unzip` is used on Unix or `tar xf` on Windows. The subprocess is spawned through `ChildProcessSpawner`.
 
-After extraction, permissions are restored (`chmod`) and, on macOS, executables are ad-hoc code-signed — all still scoped to the staging directory. A completion marker file (`.supabase-cache-complete`) is written into the staging directory last, so it travels with the payload.
+After extraction, permissions are restored (`chmod`) and, on macOS, executables are ad-hoc code-signed. The `.complete` marker is written last and records the provider, service, version, asset, and source URL. Publication is a single atomic rename into `cacheDir`: one concurrent resolver wins, while losers reuse the winner's complete entry. Existing incomplete destinations are preserved rather than destructively replaced.
 
-The staging directory is then published by an atomic `fs.rename` into `cacheDir`:
-
-- If another process already published a complete `cacheDir` first (detected via the marker, not mere existence), the losing process discards its own staged copy and resolves to the winner's `cacheDir` instead of failing.
-- If `cacheDir` exists but isn't a complete, marker-carrying entry — a broken/legacy leftover (this is the only place such a leftover is ever removed — see "Cache layout" above), or the rename failing for an unrelated reason — the current process treats it as reclaimable: it removes the leftover and retries the rename, up to a small bounded number of attempts. If a legitimate winner lands in the narrow gap between that reclaim and the retry, the retry's failure is re-checked against the marker on every attempt (including the last) and the winner is adopted immediately, regardless of how many reclaim attempts remain. Only the destructive reclaim-and-retry path is bounded: a rename that keeps failing for a reason unrelated to a competing destination (permissions, a read-only filesystem, disk I/O) can never succeed no matter how many times it's retried, so once attempts are exhausted the real rename error is surfaced as a `DownloadError` instead of retrying forever.
-
-The whole stage-and-publish sequence runs under a single `Effect.ensuring` finalizer that force-removes the staging directory on any exit path (success, failure, or interruption), and a best-effort sweep opportunistically reaps stale `.tmp-*` siblings older than 24 hours left behind by prior hard-killed processes. That sweep runs unconditionally before the cache-hit check, since once `cacheDir` becomes a complete cache hit, a sweep placed after the check would never run again for that entry's siblings.
+An `Effect.ensuring` finalizer force-removes the staging directory on success, failure, or interruption. A best-effort sweep also reaps `.partial-*` siblings older than 24 hours. The sweep runs before the cache-hit check so abandoned staging directories are eventually removed even when the final cache is already complete.
 
 #### Layer wiring
 
-`BinaryResolver` requires `FileSystem | Path | HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner` from the environment. The HOME directory is read via `Config.string("HOME")` rather than `process.env["HOME"]` directly.
-
-`BinaryResolver.layer` requires all four platform services from the environment. There is no `defaultLayer` — platform layers are provided at the entry point level (`bun.ts` / `node.ts`), not baked into `BinaryResolver`.
+`BinaryResolver.make(cacheRoot)` requires `FileSystem | Path | HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner` from the environment. Entry-point layers provide those platform services and use `defaultCacheRoot()` when the caller does not configure a cache root.
 
 ---
 
@@ -434,7 +431,7 @@ class JwtGenerator extends ServiceMap.Service<
 
 **File:** `src/PortAllocator.ts`
 
-`PortAllocator` resolves all port numbers before the stack starts. It supports two strategies: an explicit port requested by the caller, or a randomly assigned port from the OS.
+`PortAllocator` resolves all port numbers before the stack starts. It supports explicit caller ports and random OS-assigned ports. `createStack()` uses leased allocation: each selected port remains bound until the API proxy or corresponding service dependency closure is ready to bind it.
 
 #### Interface
 
@@ -461,16 +458,20 @@ export interface AllocatedPorts {
 export const allocatePorts = (
   input: PortInput,
 ): Effect.Effect<AllocatedPorts, PortAllocationError>;
+
+export const reservePorts = (
+  input: PortInput,
+): Effect.Effect<PortLease, PortAllocationError>;
 ```
 
 #### Two strategies
 
-- **Explicit port** (`input.apiPort !== undefined`) → `probeExactPort(port)`: binds the specific port on `127.0.0.1` to confirm it is available. Fails with `PortAllocationError` if the port is already in use.
-- **Omitted** → `probeRandomPort(exclude)`: binds port `0` on `127.0.0.1` so the OS assigns a free port, then closes the server immediately and returns the assigned port number.
+- **Explicit port** (`input.apiPort !== undefined`) binds the specific port on `127.0.0.1` and fails with `PortAllocationError` if it is already in use.
+- **Omitted** binds port `0` on `127.0.0.1`, allowing the OS to assign a free port.
 
 #### Collision avoidance
 
-Allocated ports are tracked in a `Set<number>`. When `probeRandomPort` returns a port already in the set (rare but possible under concurrent allocation), it retries automatically. This prevents two services from racing to the same port.
+Allocated ports are tracked in a `Set<number>` and OS listeners prevent concurrent stacks from receiving the same assignment. The API lease is released immediately before the central proxy binds. Backend leases remain active in lazy mode and are released only for the graph dependency closure being started. Any remaining listeners are closed during stack disposal. `allocatePorts()` remains available as a probe-only low-level API; stack construction uses `reservePorts()`.
 
 ---
 
@@ -708,6 +709,7 @@ public service projection metadata, and exact cleanup targets.
 
 ```ts
 interface ResolvedStackConfig {
+  readonly startupMode: "eager" | "lazy";
   readonly jwtSecret: string;
   readonly apiPort: number;
   readonly dbPort: number;
@@ -800,6 +802,30 @@ Before the orchestrator exists, it publishes synthetic service states derived fr
 why `getAllStates()` and `allStateChanges()` can surface `Downloading` during cold-cache startup
 even though no process has been spawned yet.
 
+`ServiceActivation.ts` is the declarative policy for startup and lifecycle ownership. It marks
+services as eager or lazy, declares activation companions, and declares owned companions. Storage
+activates and owns imgproxy; Analytics activates and owns Vector; Studio activates Analytics but
+does not own it. Process dependencies remain the responsibility of the process graph.
+
+The package defaults to `startupMode: "eager"`. In `"lazy"` mode, `start()` starts and waits only
+for direct listeners, Realtime, and Studio. Each HTTP proxy route activates its target service
+before it forwards the request, and concurrent activation remains single-flight in the
+orchestrator. Proxy
+requests made before startup or after shutdown receive `503 Service Unavailable`. `waitAllReady()`
+waits for services whose orchestrator desired state is `running`, rather than blocking on
+intentionally dormant ones. The public projection maps unrequested services to the explicit
+`Dormant` status. Readiness includes the process graph's dependency closure and fails immediately
+for dormant or explicitly stopped services. An explicit service stop remains `Stopped` across a
+whole-stack stop/start until that service is explicitly started again.
+
+Detached mode preserves these semantics instead of reconstructing readiness from status snapshots.
+The daemon exposes `/ready` and `/services/:name/ready`, both of which delegate to the lifecycle
+coordinator. Typed error discriminants preserve service-not-found, service-readiness, and stack-build
+failures across the HTTP boundary.
+
+Realtime starts eagerly because the HTTP proxy only owns ordinary request forwarding; WebSocket
+transport is not duplicated in platform-specific stack adapters.
+
 #### StackInfo
 
 ```ts
@@ -868,7 +894,7 @@ metadata persisted separately for crash recovery.
 
 **File:** `src/createStack.ts`
 
-`createStack` is the platform-agnostic core. It wires all layers, delegates to a `ManagedRuntime`, and returns a rich `Stack` interface. It takes a `PlatformFactory` parameter — a function `(apiPort: number) => PlatformLayer` — so the platform-specific HTTP server (Bun or Node.js) can be bound to the already-resolved port. Platform-specific layers (`BunHttpServer`, `NodeHttpServer`) are provided by the entry points (`bun.ts`, `node.ts`), not baked in.
+`createStack` is the platform-agnostic core. It wires all layers, delegates to a `ManagedRuntime`, and returns a rich `Stack` interface. It takes a `PlatformFactory` parameter — a function receiving `{ apiPort, releaseApiPort }` — so the platform-specific HTTP server (Bun or Node.js) can release the reserved API port immediately before binding it. Platform-specific HTTP layers (`BunHttpServer` and `NodeHttpServer`) are provided by the entry points (`bun.ts`, `node.ts`), not baked in.
 
 `createStack` also owns `resolveConfig()`, the internal async function that turns a raw
 `StackConfig` into a `ResolvedStackConfig`: it allocates ports via `PortAllocator`, generates JWTs
@@ -1097,18 +1123,19 @@ graph TB
 
 ### Test file table
 
-| File                                 | Type        | What it tests                                                                                                                |
-| ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `src/Platform.unit.test.ts`          | Unit        | `detectPlatform`, all three asset-name mapping functions                                                                     |
-| `src/BinaryResolver.unit.test.ts`    | Unit        | Static helpers: `downloadUrl`, `checksumUrl`, `cachePath`                                                                    |
-| `src/services/services.unit.test.ts` | Unit        | `makePostgresService`, `makePostgresServiceDocker`, `makePostgrestService`, `makeAuthServiceNative`, `makeAuthServiceDocker` |
-| `src/ApiProxy.unit.test.ts`          | Unit        | `transformAuthorization` key translation logic, CORS headers, route routing                                                  |
-| `src/StackBuilder.unit.test.ts`      | Unit        | `StackBuilder.build()` with prepared artifacts and mocked platform services                                                  |
-| `src/prefetch.unit.test.ts`          | Unit        | `StackPreparation` / `prefetch` cache hits, Docker fallback order, and pull behavior                                         |
-| `src/Stack.unit.test.ts`             | Integration | Public `Stack` facade over `StackLifecycleCoordinator`, including pre-start `Downloading` state publication                  |
-| `src/createStack.unit.test.ts`       | Unit        | Type shape assertions + missing `stackConfig` error                                                                          |
-| `tests/createStack.e2e.test.ts`      | E2e         | Full stack lifecycle: health checks, auth sign up/in/out, PostgREST CRUD                                                     |
-| `tests/parallelStacks.e2e.test.ts`   | E2e         | Concurrent stacks: port uniqueness, health check validation                                                                  |
+| File                                     | Type        | What it tests                                                                                                                |
+| ---------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `src/Platform.unit.test.ts`              | Unit        | `detectPlatform`, all three asset-name mapping functions                                                                     |
+| `src/BinaryResolver.unit.test.ts`        | Unit        | Native release descriptors and provider-scoped `cachePath`                                                                   |
+| `src/BinaryResolver.integration.test.ts` | Integration | Concurrent atomic cache publication, legacy-cache reuse, failed replacement preservation, and stale staging cleanup          |
+| `src/services/services.unit.test.ts`     | Unit        | `makePostgresService`, `makePostgresServiceDocker`, `makePostgrestService`, `makeAuthServiceNative`, `makeAuthServiceDocker` |
+| `src/ApiProxy.unit.test.ts`              | Unit        | `transformAuthorization` key translation logic, CORS headers, route routing                                                  |
+| `src/StackBuilder.unit.test.ts`          | Unit        | `StackBuilder.build()` with prepared artifacts and mocked platform services                                                  |
+| `src/prefetch.unit.test.ts`              | Unit        | `StackPreparation` / `prefetch` cache hits, Docker fallback order, and pull behavior                                         |
+| `src/Stack.unit.test.ts`                 | Integration | Public `Stack` facade over `StackLifecycleCoordinator`, including pre-start `Downloading` state publication                  |
+| `src/createStack.unit.test.ts`           | Unit        | Type shape assertions + missing `stackConfig` error                                                                          |
+| `tests/createStack.e2e.test.ts`          | E2e         | Full stack lifecycle: health checks, auth sign up/in/out, PostgREST CRUD                                                     |
+| `tests/parallelStacks.e2e.test.ts`       | E2e         | Concurrent stacks: port uniqueness, health check validation                                                                  |
 
 ### Mock patterns
 
@@ -1185,12 +1212,18 @@ spawner; the key idea is that tests compose `Stack.layer(config)` on top of a re
 function setupLayer(config: ResolvedStackConfig = defaultConfig) {
   const resolver = mockBinaryResolver();
   const spawner = mockChildProcessSpawner(); // from @supabase/process-compose mocks
+  const portLease: PortLease = {
+    ports: config.ports,
+    reserve: () => Effect.void,
+    release: () => Effect.void,
+    releaseAll: Effect.void,
+  };
 
   const preparationLayer = StackPreparation.layer.pipe(
     Layer.provide(resolver.layer),
     Layer.provide(spawner.layer),
   );
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(preparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
@@ -1200,6 +1233,9 @@ function setupLayer(config: ResolvedStackConfig = defaultConfig) {
   return { layer, resolver, spawner };
 }
 ```
+
+Production setup passes the real reserved `PortLease`; tests use the no-op lease above because
+their mocked processes do not bind the configured ports.
 
 The `mockChildProcessSpawner` is reused from `@supabase/process-compose`'s test helpers — it
 stubs process spawning without forking real OS processes, making `Stack` / coordinator tests fast

--- a/packages/stack/docs/detach-mode.md
+++ b/packages/stack/docs/detach-mode.md
@@ -201,8 +201,8 @@ wait healthy`, so detached mode exposes the same pre-runtime status behavior as 
 | `getState(name)`           | `GET /status` → `Effect` (filter by name)                      |
 | `allStateChanges()`        | `GET /status/stream` (SSE → `Stream`, including `Downloading`) |
 | `stateChanges(name)`       | `GET /status/stream` (SSE → `Stream`, filter by name)          |
-| `waitReady(name)`          | `GET /status/stream` (SSE → `Stream`, take until ready)        |
-| `waitAllReady()`           | `GET /status/stream` (SSE → `Stream`, take until all ready)    |
+| `waitReady(name)`          | `GET /services/:name/ready` → `Effect`                         |
+| `waitAllReady()`           | `GET /ready` → `Effect`                                        |
 | `subscribeAllLogs()`       | `GET /logs` (SSE → `Stream`)                                   |
 | `subscribeLogs(name)`      | `GET /logs/:name` (SSE → `Stream`)                             |
 | `logHistory(name, limit?)` | `GET /logs/:name/history?limit=N` → `Effect`                   |
@@ -233,9 +233,9 @@ Benefits of using Effect throughout:
 2. Build the foreground daemon layer (`StackPreparation` + `StackBuilder` + `StackLifecycleCoordinator` + `ApiProxy`)
 3. Call `stack.start()` which prepares assets first, then starts services
 4. Start management HTTP server on Unix socket
-5. Send IPC `{ type: "started", info: { url, dbUrl, ... } }` to parent
+5. Atomically claim `state.json`, then send IPC `{ type: "started", info: { url, dbUrl, ... } }` to parent
 6. Parent disconnects — daemon keeps running
-7. On SIGTERM/SIGINT or POST `/stop`: call `stack.dispose()`, clean up state files, exit
+7. On SIGTERM/SIGINT or POST `/stop`: call `stack.dispose()` and exit. The stopping client removes live state only after confirming process exit; later discovery removes crash-stale state.
 
 **IPC startup handshake:**
 
@@ -250,8 +250,9 @@ runtime-dispatch rationale.
 
 Parent and child send JSON messages via `process.send()` / `process.on("message")`.
 
-This channel is only used for the initial startup handshake — once the daemon confirms
-it's ready (or reports an error), the CLI disconnects the channel. All subsequent
+This channel is only used for the initial startup handshake. The parent validates the response and
+applies a bounded startup timeout. Once the daemon confirms it's ready (or reports an error), the
+CLI disconnects the channel. All subsequent
 communication (stop, status, logs) happens over the Unix socket HTTP API instead.
 
 ```
@@ -285,19 +286,25 @@ and the CLI displays the error and exits with a non-zero code.
 | Endpoint                 | Method | Description                                                                         |
 | ------------------------ | ------ | ----------------------------------------------------------------------------------- |
 | `/health`                | GET    | Liveness check (200 OK)                                                             |
+| `/ready`                 | GET    | Wait for all activated services using foreground lifecycle semantics                |
 | `/status`                | GET    | All service states + connection info (JSON)                                         |
 | `/status/stream`         | GET    | SSE stream of all service state changes, including `Downloading` during preparation |
 | `/stop`                  | POST   | Graceful shutdown → dispose + exit                                                  |
+| `/services/:name/ready`  | GET    | Wait for one activated service                                                      |
 | `/logs`                  | GET    | SSE stream of all logs                                                              |
 | `/logs/:service`         | GET    | SSE stream for one service                                                          |
 | `/logs/:service/history` | GET    | Recent log entries for one service (JSON, `?limit=N`)                               |
+
+Management errors include a stable discriminator. `RemoteStack` maps service-not-found,
+service-readiness, and stack-build responses back to the same typed failures exposed by a
+foreground stack.
 
 ### `supabase` — New/modified commands
 
 **Modified: `src/commands/start/`**
 
 - New flags: `--detach`, `--stack`
-- When `--detach`: fork daemon, wait for IPC "started", write state file, print connection info, exit
+- When `--detach`: fork daemon with unresolved port preferences, wait for IPC "started", print connection info, exit. The daemon allocates ports and atomically claims the live state file before acknowledging startup.
 - When foreground (default): unchanged behavior
 
 **New: `src/commands/stop/`**
@@ -370,7 +377,7 @@ within that project. This works from any nested directory inside the project.
 | Orphaned Docker containers              | `stack.dispose()` calls `dockerForceRemove()`. On crash, `stop` reads persisted cleanup metadata, then force-removes the exact known containers                                                                        |
 | Ctrl+C during `start --detach`          | If daemon hasn't started: kill child. If started: daemon keeps running                                                                                                                                                 |
 | Foreground start while detached running | `supabase start` (foreground) checks StateManager first. If a daemon is running for the same project, error with "Stack already running in detached mode. Use `supabase stop` first or `supabase logs` to see output." |
-| Detached start while foreground running | Port allocation will fail (ports already bound), daemon sends IPC error. No special detection needed — the existing port conflict handling covers this.                                                                |
+| Detached start while foreground running | The daemon owns port allocation and reports a conflict before acknowledging startup.                                                                                                                                   |
 
 ---
 

--- a/packages/stack/src/ApiProxy.ts
+++ b/packages/stack/src/ApiProxy.ts
@@ -9,6 +9,8 @@ import {
   HttpServerRequest,
   HttpServerResponse,
 } from "effect/unstable/http";
+import { StackServiceActivator } from "./ServiceActivation.ts";
+import type { ServiceName } from "./versions.ts";
 
 export interface ProxyConfig {
   readonly listenPort: number;
@@ -113,6 +115,7 @@ function addCorsHeaders(
 const COLD_START_RETRY_SCHEDULE = Schedule.spaced("250 millis").pipe(Schedule.upTo({ times: 8 }));
 
 interface ProxyHandlerOptions {
+  readonly service: ServiceName;
   readonly backendPort: number;
   readonly stripPrefix?: string;
   readonly backendPath?: string;
@@ -128,10 +131,19 @@ interface ProxyHandlerOptions {
 function makeProxyHandler(
   client: HttpClient.HttpClient,
   config: ProxyConfig,
+  activator: StackServiceActivator["Service"],
   opts: ProxyHandlerOptions,
 ) {
   return (req: HttpServerRequest.HttpServerRequest) =>
     Effect.gen(function* () {
+      const activation = yield* Effect.result(activator.activate(opts.service));
+      if (Result.isFailure(activation)) {
+        return HttpServerResponse.text("Service unavailable", {
+          status: 503,
+          headers: { "retry-after": "1" },
+        });
+      }
+
       let backendPath = opts.backendPath;
 
       if (backendPath === undefined) {
@@ -209,18 +221,24 @@ export class ApiProxy extends Context.Service<
 >()("local/ApiProxy") {
   static layer = (
     config: ProxyConfig,
-  ): Layer.Layer<ApiProxy, never, HttpServer.HttpServer | HttpClient.HttpClient> =>
+  ): Layer.Layer<
+    ApiProxy,
+    never,
+    HttpServer.HttpServer | HttpClient.HttpClient | StackServiceActivator
+  > =>
     Layer.effect(ApiProxy)(
       Effect.gen(function* () {
         const server = yield* HttpServer.HttpServer;
         const client = yield* HttpClient.HttpClient;
+        const activator = yield* StackServiceActivator;
 
         const routes = [
           HttpRouter.route("*", "/health", HttpServerResponse.text("OK", { status: 200 })),
           HttpRouter.route(
             "*",
             "/.well-known/oauth-authorization-server",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               backendPath: "/.well-known/oauth-authorization-server",
             }),
@@ -228,7 +246,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/verify",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -236,7 +255,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/callback",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -244,7 +264,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/authorize",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
             }),
@@ -252,7 +273,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/auth/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "auth",
               backendPort: config.gotruePort,
               stripPrefix: "/auth/v1",
               transformAuth: true,
@@ -261,7 +283,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/rest/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestPort,
               stripPrefix: "/rest/v1",
               transformAuth: true,
@@ -270,7 +293,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/rest-admin/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestAdminPort,
               stripPrefix: "/rest-admin/v1",
             }),
@@ -278,7 +302,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/graphql/v1",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "postgrest",
               backendPort: config.postgrestPort,
               backendPath: "/rpc/graphql",
               transformAuth: true,
@@ -288,7 +313,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/functions/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "edge-runtime",
               backendPort: config.edgeRuntimePort,
               stripPrefix: "/functions/v1",
               transformAuth: true,
@@ -299,7 +325,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/realtime/v1/api/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "realtime",
               backendPort: config.realtimePort,
               stripPrefix: "/realtime/v1",
               transformAuth: true,
@@ -308,7 +335,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/realtime/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "realtime",
               backendPort: config.realtimePort,
               stripPrefix: "/realtime/v1",
             }),
@@ -316,7 +344,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/storage/v1/s3/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "storage",
               backendPort: config.storagePort,
               stripPrefix: "/storage/v1",
             }),
@@ -324,7 +353,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/storage/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "storage",
               backendPort: config.storagePort,
               stripPrefix: "/storage/v1",
               transformAuth: true,
@@ -333,7 +363,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/pg/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "pgmeta",
               backendPort: config.pgmetaPort,
               stripPrefix: "/pg",
             }),
@@ -341,7 +372,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/analytics/v1/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "analytics",
               backendPort: config.analyticsPort,
               stripPrefix: "/analytics/v1",
             }),
@@ -349,7 +381,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/pooler/v2/*",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "pooler",
               backendPort: config.poolerPort,
               stripPrefix: "/pooler",
             }),
@@ -357,7 +390,8 @@ export class ApiProxy extends Context.Service<
           HttpRouter.route(
             "*",
             "/mcp",
-            makeProxyHandler(client, config, {
+            makeProxyHandler(client, config, activator, {
+              service: "studio",
               backendPort: config.studioPort,
               backendPath: "/api/mcp",
             }),

--- a/packages/stack/src/ApiProxy.unit.test.ts
+++ b/packages/stack/src/ApiProxy.unit.test.ts
@@ -1,10 +1,13 @@
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as http from "node:http";
 import { gzipSync } from "node:zlib";
-import { Layer, ManagedRuntime } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { ApiProxy, type ProxyConfig } from "./ApiProxy.ts";
+import { StackNotRunningError } from "./errors.ts";
+import { StackServiceActivator } from "./ServiceActivation.ts";
+import type { ServiceName } from "./versions.ts";
 
 interface EchoServer {
   readonly port: number;
@@ -102,18 +105,23 @@ function startFlakyBackend(opts: { failFirst: number; body: string }): Promise<F
 }
 
 // Builds the full proxy layer backed by a Node HTTP server.
-function buildProxyLayer(config: ProxyConfig): Layer.Layer<ApiProxy, never, never> {
+function buildProxyLayer(
+  config: ProxyConfig,
+  activatorLayer: Layer.Layer<StackServiceActivator> = StackServiceActivator.noop,
+): Layer.Layer<ApiProxy, never, never> {
   return ApiProxy.layer(config).pipe(
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
     Layer.provide(FetchHttpClient.layer),
+    Layer.provide(activatorLayer),
   ) as Layer.Layer<ApiProxy, never, never>;
 }
 
 // Spins up a proxy for an ad-hoc config and returns its URL plus a disposer.
 async function startProxy(
   config: ProxyConfig,
+  activatorLayer?: Layer.Layer<StackServiceActivator>,
 ): Promise<{ url: string; dispose: () => Promise<void> }> {
-  const proxyRuntime = ManagedRuntime.make(buildProxyLayer(config));
+  const proxyRuntime = ManagedRuntime.make(buildProxyLayer(config, activatorLayer));
   const proxy = await proxyRuntime.runPromise(ApiProxy);
   const addr = proxy.address;
   let url = "";
@@ -204,6 +212,38 @@ describe("ApiProxy", () => {
   test("non-OPTIONS responses include CORS headers", async () => {
     const res = await fetch(`${proxyUrl}/health`);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("activates the routed service before forwarding", async () => {
+    const activated: ServiceName[] = [];
+    const activatorLayer = Layer.succeed(StackServiceActivator, {
+      activate: (service) =>
+        Effect.sync(() => {
+          activated.push(service);
+        }),
+    });
+    const proxy = await startProxy(configForPort(echoServer.port), activatorLayer);
+    try {
+      const res = await fetch(`${proxy.url}/rest/v1/users`);
+      expect(res.status).toBe(200);
+      expect(activated).toEqual(["postgrest"]);
+    } finally {
+      await proxy.dispose();
+    }
+  });
+
+  test("returns 503 when the stack cannot activate a service", async () => {
+    const activatorLayer = Layer.succeed(StackServiceActivator, {
+      activate: () => Effect.fail(new StackNotRunningError({ phase: "idle" })),
+    });
+    const proxy = await startProxy(configForPort(echoServer.port), activatorLayer);
+    try {
+      const res = await fetch(`${proxy.url}/rest/v1/users`);
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+    } finally {
+      await proxy.dispose();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/stack/src/DaemonProtocol.ts
+++ b/packages/stack/src/DaemonProtocol.ts
@@ -1,0 +1,22 @@
+import { Schema } from "effect";
+import { StackStateSchema } from "./StateManager.ts";
+
+const DaemonErrorCodeSchema = Schema.Literals([
+  "SERVICE_NOT_FOUND",
+  "SERVICE_NOT_READY",
+  "STACK_BUILD_ERROR",
+]);
+
+export const DaemonErrorResponseSchema = Schema.Struct({
+  code: DaemonErrorCodeSchema,
+  error: Schema.String,
+  service: Schema.optionalKey(Schema.String),
+  exitCode: Schema.optionalKey(Schema.Number),
+});
+
+export type DaemonErrorResponse = typeof DaemonErrorResponseSchema.Type;
+
+export const DaemonMessageSchema = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("started"), state: StackStateSchema }),
+  Schema.Struct({ type: Schema.Literal("error"), message: Schema.String }),
+]);

--- a/packages/stack/src/DaemonServer.integration.test.ts
+++ b/packages/stack/src/DaemonServer.integration.test.ts
@@ -131,8 +131,9 @@ function mockStack() {
 
 function buildDaemonLayer(
   mock: ReturnType<typeof mockStack>,
+  beforeShutdown: Effect.Effect<void> = Effect.void,
 ): Layer.Layer<DaemonServer, never, never> {
-  return DaemonServer.layer.pipe(
+  return DaemonServer.layerWithShutdown(beforeShutdown).pipe(
     Layer.provide(mock.layer),
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
   ) as Layer.Layer<DaemonServer, never, never>;
@@ -353,6 +354,28 @@ describe("DaemonServer", () => {
     expect(mock.stopped).toBe(true);
   });
 
+  test("POST /stop unregisters the daemon before responding", async () => {
+    const freshMock = mockStack();
+    let registered = true;
+    const freshRuntime = ManagedRuntime.make(
+      buildDaemonLayer(
+        freshMock,
+        Effect.sync(() => {
+          registered = false;
+        }),
+      ),
+    );
+    try {
+      const daemon = await freshRuntime.runPromise(DaemonServer);
+      const res = await fetch(`${getUrl(daemon.address)}/stop`, { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(registered).toBe(false);
+    } finally {
+      await freshRuntime.dispose();
+    }
+  });
+
   test("POST /stop resolves awaitShutdown", async () => {
     // Use a fresh runtime so /stop hasn't been called yet
     const freshMock = mockStack();
@@ -368,6 +391,21 @@ describe("DaemonServer", () => {
       await fetch(`${freshUrl}/stop`, { method: "POST" });
 
       // awaitShutdown should resolve
+      await shutdownPromise;
+    } finally {
+      await freshRuntime.dispose();
+    }
+  });
+
+  test("POST /stop resolves awaitShutdown when cleanup defects", async () => {
+    const freshRuntime = ManagedRuntime.make(
+      buildDaemonLayer(mockStack(), Effect.die("state cleanup failed")),
+    );
+    try {
+      const daemon = await freshRuntime.runPromise(DaemonServer);
+      const shutdownPromise = freshRuntime.runPromise(daemon.awaitShutdown);
+
+      await fetch(`${getUrl(daemon.address)}/stop`, { method: "POST" });
       await shutdownPromise;
     } finally {
       await freshRuntime.dispose();

--- a/packages/stack/src/DaemonServer.ts
+++ b/packages/stack/src/DaemonServer.ts
@@ -7,6 +7,7 @@ import {
   HttpServerResponse,
 } from "effect/unstable/http";
 import * as Sse from "effect/unstable/encoding/Sse";
+import type { DaemonErrorResponse } from "./DaemonProtocol.ts";
 import { EdgeRuntimeReloadConfigSchema, Stack } from "./Stack.ts";
 
 // ---------------------------------------------------------------------------
@@ -20,253 +21,316 @@ export class DaemonServer extends Context.Service<
     readonly awaitShutdown: Effect.Effect<void>;
   }
 >()("stack/DaemonServer") {
-  static layer: Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> = Layer.effect(
-    this,
-    Effect.gen(function* () {
-      const stack = yield* Stack;
-      const server = yield* HttpServer.HttpServer;
-      const shutdownDeferred = yield* Deferred.make<void>();
-      const textEncoder = new TextEncoder();
+  static layerWithShutdown = (
+    beforeShutdown: Effect.Effect<void> = Effect.void,
+  ): Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> =>
+    Layer.effect(
+      this,
+      Effect.gen(function* () {
+        const stack = yield* Stack;
+        const server = yield* HttpServer.HttpServer;
+        const shutdownDeferred = yield* Deferred.make<void>();
+        const textEncoder = new TextEncoder();
+        const errorResponse = (body: DaemonErrorResponse, status: 404 | 500) =>
+          HttpServerResponse.jsonUnsafe(body, { status });
+        const notFoundResponse = (name: string) =>
+          errorResponse(
+            { code: "SERVICE_NOT_FOUND", error: `Service not found: ${name}`, service: name },
+            404,
+          );
+        const notReadyResponse = (name: string, reason: string, exitCode?: number) =>
+          errorResponse(
+            {
+              code: "SERVICE_NOT_READY",
+              error: reason,
+              service: name,
+              ...(exitCode === undefined ? {} : { exitCode }),
+            },
+            500,
+          );
+        const buildErrorResponse = (detail: string) =>
+          errorResponse({ code: "STACK_BUILD_ERROR", error: detail }, 500);
 
-      // Helper: wrap an Effect Stream as a text/event-stream response
-      const sseResponse = <A>(
-        stream: Stream.Stream<A>,
-        event: string,
-        toData: (a: A) => string,
-      ): HttpServerResponse.HttpServerResponse =>
-        HttpServerResponse.stream(
-          stream.pipe(
-            Stream.map((a) =>
-              textEncoder.encode(
-                Sse.encoder.write({ _tag: "Event", event, id: undefined, data: toData(a) }),
+        // Helper: wrap an Effect Stream as a text/event-stream response
+        const sseResponse = <A>(
+          stream: Stream.Stream<A>,
+          event: string,
+          toData: (a: A) => string,
+        ): HttpServerResponse.HttpServerResponse =>
+          HttpServerResponse.stream(
+            stream.pipe(
+              Stream.map((a) =>
+                textEncoder.encode(
+                  Sse.encoder.write({ _tag: "Event", event, id: undefined, data: toData(a) }),
+                ),
               ),
             ),
-          ),
-          {
-            status: 200,
-            contentType: "text/event-stream",
-            headers: Headers.fromInput({
-              "cache-control": "no-cache",
-              connection: "keep-alive",
+            {
+              status: 200,
+              contentType: "text/event-stream",
+              headers: Headers.fromInput({
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+              }),
+            },
+          );
+
+        const routes = [
+          // Health check
+          HttpRouter.route("GET", "/health", HttpServerResponse.text("OK", { status: 200 })),
+
+          // Status: connection info + all service states
+          HttpRouter.route(
+            "GET",
+            "/status",
+            Effect.gen(function* () {
+              const info = yield* stack.getInfo();
+              const services = yield* stack.getAllStates();
+              return HttpServerResponse.jsonUnsafe({ info, services });
             }),
-          },
-        );
-
-      const routes = [
-        // Health check
-        HttpRouter.route("GET", "/health", HttpServerResponse.text("OK", { status: 200 })),
-
-        // Status: connection info + all service states
-        HttpRouter.route(
-          "GET",
-          "/status",
-          Effect.gen(function* () {
-            const info = yield* stack.getInfo();
-            const services = yield* stack.getAllStates();
-            return HttpServerResponse.jsonUnsafe({ info, services });
-          }),
-        ),
-
-        // Status stream: SSE of service state changes
-        HttpRouter.route(
-          "GET",
-          "/status/stream",
-          Effect.sync(() =>
-            sseResponse(stack.allStateChanges(), "state", (s) => JSON.stringify(s)),
           ),
-        ),
 
-        // Start: begin service startup
-        HttpRouter.route(
-          "POST",
-          "/start",
-          Effect.gen(function* () {
-            yield* stack.start();
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }),
-        ),
+          // Status stream: SSE of service state changes
+          HttpRouter.route(
+            "GET",
+            "/status/stream",
+            Effect.sync(() =>
+              sseResponse(stack.allStateChanges(), "state", (s) => JSON.stringify(s)),
+            ),
+          ),
 
-        // Stop: graceful shutdown
-        HttpRouter.route(
-          "POST",
-          "/stop",
-          Effect.gen(function* () {
-            yield* stack.stop();
-            yield* Deferred.succeed(shutdownDeferred, void 0);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }),
-        ),
-
-        // Logs: SSE of all logs
-        HttpRouter.route(
-          "GET",
-          "/logs",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const services = parseServices(searchParams.service);
-            return sseResponse(stack.subscribeAllLogs(services), "log", (e) => JSON.stringify(e));
-          }),
-        ),
-
-        // Merged log history across all services
-        HttpRouter.route(
-          "GET",
-          "/logs/history",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const limit = parseLimit(searchParams.limit);
-            const services = parseServices(searchParams.service);
-            const entries = yield* stack.logHistoryAll(limit, services);
-            return HttpServerResponse.jsonUnsafe(entries);
-          }),
-        ),
-
-        // Log history for a service (registered before /logs/:service to avoid shadowing)
-        HttpRouter.route(
-          "GET",
-          "/logs/:service/history",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            const service = parseSingleParam(routeParams.service)!;
-            const limit = parseLimit(searchParams.limit);
-            const entries = yield* stack.logHistory(service, limit);
-            return HttpServerResponse.jsonUnsafe(entries);
-          }),
-        ),
-
-        // Logs for a specific service: SSE
-        HttpRouter.route(
-          "GET",
-          "/logs/:service",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            const service = parseSingleParam(routeParams.service)!;
-            return sseResponse(stack.subscribeLogs(service), "log", (e) => JSON.stringify(e));
-          }),
-        ),
-
-        // Per-service control
-        HttpRouter.route(
-          "POST",
-          "/services/:name/start",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.startService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          // Start: begin service startup
+          HttpRouter.route(
+            "POST",
+            "/start",
+            Effect.gen(function* () {
+              yield* stack.start();
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
-            ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
-          ),
-        ),
-
-        HttpRouter.route(
-          "POST",
-          "/services/:name/stop",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.stopService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/services/:name/restart",
-          Effect.gen(function* () {
-            const routeParams = yield* HttpRouter.params;
-            yield* stack.restartService(routeParams.name!);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          HttpRouter.route(
+            "GET",
+            "/ready",
+            stack.waitAllReady().pipe(
+              Effect.as(HttpServerResponse.jsonUnsafe({ ok: true })),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/functions/reload",
-          Effect.gen(function* () {
-            const searchParams = yield* HttpServerRequest.ParsedSearchParams;
-            yield* stack.reloadFunctions({
-              envFile: parseSingleParam(searchParams.envFile),
-              noVerifyJwt: parseBoolean(searchParams.noVerifyJwt),
-            });
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
+          // Stop: graceful shutdown
+          HttpRouter.route(
+            "POST",
+            "/stop",
+            Effect.gen(function* () {
+              yield* stack.stop();
+              yield* beforeShutdown.pipe(
+                Effect.ensuring(
+                  Deferred.succeed(shutdownDeferred, void 0).pipe(
+                    Effect.delay("25 millis"),
+                    Effect.forkDetach,
+                  ),
                 ),
+              );
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }),
+          ),
+
+          // Logs: SSE of all logs
+          HttpRouter.route(
+            "GET",
+            "/logs",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const services = parseServices(searchParams.service);
+              return sseResponse(stack.subscribeAllLogs(services), "log", (e) => JSON.stringify(e));
+            }),
+          ),
+
+          // Merged log history across all services
+          HttpRouter.route(
+            "GET",
+            "/logs/history",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const limit = parseLimit(searchParams.limit);
+              const services = parseServices(searchParams.service);
+              const entries = yield* stack.logHistoryAll(limit, services);
+              return HttpServerResponse.jsonUnsafe(entries);
+            }),
+          ),
+
+          // Log history for a service (registered before /logs/:service to avoid shadowing)
+          HttpRouter.route(
+            "GET",
+            "/logs/:service/history",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              const service = parseSingleParam(routeParams.service)!;
+              const limit = parseLimit(searchParams.limit);
+              const entries = yield* stack.logHistory(service, limit);
+              return HttpServerResponse.jsonUnsafe(entries);
+            }),
+          ),
+
+          // Logs for a specific service: SSE
+          HttpRouter.route(
+            "GET",
+            "/logs/:service",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              const service = parseSingleParam(routeParams.service)!;
+              return sseResponse(stack.subscribeLogs(service), "log", (e) => JSON.stringify(e));
+            }),
+          ),
+
+          // Per-service control
+          HttpRouter.route(
+            "POST",
+            "/services/:name/start",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.startService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
           ),
-        ),
 
-        HttpRouter.route(
-          "POST",
-          "/edge-runtime/reload",
-          Effect.gen(function* () {
-            const body = yield* HttpServerRequest.schemaBodyJson(EdgeRuntimeReloadConfigSchema);
-            yield* stack.reloadEdgeRuntime(body);
-            return HttpServerResponse.jsonUnsafe({ ok: true });
-          }).pipe(
-            Effect.catchTag("ServiceNotFoundError", (e) =>
-              Effect.succeed(
-                HttpServerResponse.jsonUnsafe(
-                  { error: `Service not found: ${e.name}` },
-                  { status: 404 },
-                ),
+          HttpRouter.route(
+            "GET",
+            "/services/:name/ready",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.waitReady(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
               ),
             ),
-            Effect.catchTag("ServiceReadyError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.reason }, { status: 500 })),
-            ),
-            Effect.catchTag("StackBuildError", (e) =>
-              Effect.succeed(HttpServerResponse.jsonUnsafe({ error: e.message }, { status: 500 })),
+          ),
+
+          HttpRouter.route(
+            "POST",
+            "/services/:name/stop",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.stopService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
             ),
           ),
-        ),
-      ];
 
-      const httpEffect = yield* HttpRouter.toHttpEffect(HttpRouter.addAll(routes));
-      yield* Effect.forkScoped(server.serve(httpEffect));
+          HttpRouter.route(
+            "POST",
+            "/services/:name/restart",
+            Effect.gen(function* () {
+              const routeParams = yield* HttpRouter.params;
+              yield* stack.restartService(routeParams.name!);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
 
-      return {
-        address: server.address,
-        awaitShutdown: Deferred.await(shutdownDeferred),
-      };
-    }),
-  );
+          HttpRouter.route(
+            "POST",
+            "/functions/reload",
+            Effect.gen(function* () {
+              const searchParams = yield* HttpServerRequest.ParsedSearchParams;
+              yield* stack.reloadFunctions({
+                envFile: parseSingleParam(searchParams.envFile),
+                noVerifyJwt: parseBoolean(searchParams.noVerifyJwt),
+              });
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
+
+          HttpRouter.route(
+            "POST",
+            "/edge-runtime/reload",
+            Effect.gen(function* () {
+              const body = yield* HttpServerRequest.schemaBodyJson(EdgeRuntimeReloadConfigSchema);
+              yield* stack.reloadEdgeRuntime(body);
+              return HttpServerResponse.jsonUnsafe({ ok: true });
+            }).pipe(
+              Effect.catchTag("ServiceNotFoundError", (e) =>
+                Effect.succeed(notFoundResponse(e.name)),
+              ),
+              Effect.catchTag("ServiceReadyError", (e) =>
+                Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
+              ),
+              Effect.catchTag("StackBuildError", (e) =>
+                Effect.succeed(buildErrorResponse(e.detail)),
+              ),
+            ),
+          ),
+        ];
+
+        const httpEffect = yield* HttpRouter.toHttpEffect(HttpRouter.addAll(routes));
+        yield* Effect.forkScoped(server.serve(httpEffect));
+
+        return {
+          address: server.address,
+          awaitShutdown: Deferred.await(shutdownDeferred),
+        };
+      }),
+    );
+
+  static layer: Layer.Layer<DaemonServer, never, Stack | HttpServer.HttpServer> =
+    this.layerWithShutdown();
 }
 
 function parseLimit(value: string | ReadonlyArray<string> | undefined): number | undefined {

--- a/packages/stack/src/PortAllocator.ts
+++ b/packages/stack/src/PortAllocator.ts
@@ -1,5 +1,5 @@
-import { createServer } from "node:net";
-import { Data, Effect, Schema } from "effect";
+import { createServer, type Server } from "node:net";
+import { Data, Effect, Schema, Semaphore } from "effect";
 
 export const DEFAULT_API_PORT = 54321;
 export const DEFAULT_DB_PORT = 54322;
@@ -101,7 +101,7 @@ export const PORT_FIELDS = [
   "poolerApiPort",
 ] as const satisfies ReadonlyArray<keyof AllocatedPorts>;
 
-type PortField = (typeof PORT_FIELDS)[number];
+export type PortField = (typeof PORT_FIELDS)[number];
 
 export const DEFAULT_PORTS: Partial<AllocatedPorts> = {
   apiPort: DEFAULT_API_PORT,
@@ -116,9 +116,12 @@ export const DEFAULT_PORTS: Partial<AllocatedPorts> = {
   edgeRuntimeInspectorPort: DEFAULT_EDGE_RUNTIME_INSPECTOR_PORT,
 };
 
-interface PortAllocationOptions {
+export interface PortSelectionOptions {
   readonly reserved?: ReadonlySet<number>;
   readonly preferred?: Partial<AllocatedPorts>;
+}
+
+interface PortAllocationOptions extends PortSelectionOptions {
   readonly probe?: PortProbe;
 }
 
@@ -184,6 +187,187 @@ const defaultPortProbe: PortProbe = {
   exact: probeExactPort,
   random: probeRandomPort,
 };
+
+const closeServer = (server: Server): Effect.Effect<void> =>
+  Effect.callback<void>((resume) => {
+    server.close(() => resume(Effect.void));
+    return Effect.void;
+  });
+
+interface BoundPort {
+  readonly port: number;
+  readonly server: Server;
+}
+
+const bindPort = (port: number): Effect.Effect<BoundPort, PortAllocationError> =>
+  Effect.callback<BoundPort, PortAllocationError>((resume) => {
+    const server = createServer((socket) => socket.destroy());
+    const onError = (cause: unknown) => {
+      resume(
+        Effect.fail(
+          new PortAllocationError({
+            detail:
+              port === 0 ? "Failed to reserve a random port" : `Port ${port} is not available`,
+            cause,
+          }),
+        ),
+      );
+    };
+    server.once("error", onError);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        void Effect.runPromise(closeServer(server));
+        resume(
+          Effect.fail(
+            new PortAllocationError({ detail: "Reserved TCP port has no numeric address" }),
+          ),
+        );
+        return;
+      }
+      resume(Effect.succeed({ port: address.port, server }));
+    });
+    return closeServer(server);
+  });
+
+export interface PortLease {
+  readonly ports: AllocatedPorts;
+  readonly reserve: (fields: ReadonlyArray<PortField>) => Effect.Effect<void, PortAllocationError>;
+  readonly release: (fields: ReadonlyArray<PortField>) => Effect.Effect<void>;
+  readonly releaseAll: Effect.Effect<void>;
+}
+
+const releaseReservations = (
+  reservations: Map<PortField, Server>,
+  fields: ReadonlyArray<PortField>,
+) =>
+  Effect.forEach(
+    fields,
+    (field) => {
+      const server = reservations.get(field);
+      if (server === undefined) {
+        return Effect.void;
+      }
+      reservations.delete(field);
+      return closeServer(server);
+    },
+    { discard: true },
+  );
+
+const reserveReservations = (
+  ports: AllocatedPorts,
+  reservations: Map<PortField, Server>,
+  fields: ReadonlyArray<PortField>,
+): Effect.Effect<void, PortAllocationError> =>
+  Effect.suspend(() => {
+    const acquired: Array<PortField> = [];
+    return Effect.forEach(
+      fields,
+      (field) => {
+        if (reservations.has(field)) return Effect.void;
+        return Effect.tap(bindPort(ports[field]), ({ server }) =>
+          Effect.sync(() => {
+            reservations.set(field, server);
+            acquired.push(field);
+          }),
+        );
+      },
+      { discard: true },
+    ).pipe(Effect.onError(() => releaseReservations(reservations, acquired)));
+  });
+
+const makePortLease = (ports: AllocatedPorts, reservations: Map<PortField, Server>): PortLease => {
+  const lock = Semaphore.makeUnsafe(1);
+  return {
+    ports,
+    reserve: (fields) => lock.withPermit(reserveReservations(ports, reservations, fields)),
+    release: (fields) => lock.withPermit(releaseReservations(reservations, fields)),
+    releaseAll: lock.withPermit(
+      Effect.suspend(() => releaseReservations(reservations, [...reservations.keys()])),
+    ),
+  };
+};
+
+const reserveRandomPort = (
+  exclude: ReadonlySet<number>,
+): Effect.Effect<BoundPort, PortAllocationError> =>
+  Effect.flatMap(bindPort(0), (bound) =>
+    exclude.has(bound.port)
+      ? closeServer(bound.server).pipe(Effect.andThen(reserveRandomPort(exclude)))
+      : Effect.succeed(bound),
+  );
+
+/**
+ * Allocate and keep every selected TCP port bound until its lease is released.
+ * This closes the probe-then-bind race for lazily started services.
+ */
+export const reservePorts = (
+  input: PortInput,
+  options: PortSelectionOptions = {},
+): Effect.Effect<PortLease, PortAllocationError> =>
+  Effect.suspend(() => {
+    const reservations = new Map<PortField, Server>();
+    const reserve = Effect.gen(function* () {
+      const reserved = options.reserved ?? new Set<number>();
+      const preferred = options.preferred ?? {};
+      const allocated = new Set<number>();
+      const partial: Partial<Record<PortField, number>> = {};
+
+      for (const field of PORT_FIELDS) {
+        const exclude = new Set([...reserved, ...allocated]);
+        const explicit = input[field];
+        const preferredPort = preferred[field];
+        let bound: BoundPort;
+
+        if (explicit !== undefined) {
+          if (exclude.has(explicit)) {
+            return yield* new PortAllocationError({ detail: `Port ${explicit} is not available` });
+          }
+          bound = yield* bindPort(explicit);
+        } else if (preferredPort !== undefined && !exclude.has(preferredPort)) {
+          bound = yield* bindPort(preferredPort).pipe(
+            Effect.catchTag("PortAllocationError", () => reserveRandomPort(exclude)),
+          );
+        } else {
+          bound = yield* reserveRandomPort(exclude);
+        }
+
+        allocated.add(bound.port);
+        reservations.set(field, bound.server);
+        partial[field] = bound.port;
+      }
+
+      return makePortLease(Schema.decodeUnknownSync(AllocatedPortsSchema)(partial), reservations);
+    });
+
+    return reserve.pipe(
+      Effect.onError(() => releaseReservations(reservations, [...reservations.keys()])),
+    );
+  });
+
+/** Reserve an already-resolved subset of ports, typically in a daemon process. */
+export const reserveAllocatedPorts = (
+  ports: AllocatedPorts,
+  fields: ReadonlyArray<PortField>,
+): Effect.Effect<PortLease, PortAllocationError> =>
+  Effect.suspend(() => {
+    const reservations = new Map<PortField, Server>();
+    const reserve = Effect.forEach(
+      fields,
+      (field) =>
+        Effect.tap(bindPort(ports[field]), ({ server }) =>
+          Effect.sync(() => {
+            reservations.set(field, server);
+          }),
+        ),
+      { discard: true },
+    ).pipe(Effect.as(makePortLease(ports, reservations)));
+
+    return reserve.pipe(
+      Effect.onError(() => releaseReservations(reservations, [...reservations.keys()])),
+    );
+  });
 
 export const allocatePorts = (
   input: PortInput,

--- a/packages/stack/src/PortAllocator.unit.test.ts
+++ b/packages/stack/src/PortAllocator.unit.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import { createServer } from "node:net";
 import type { Server } from "node:net";
 import { Effect } from "effect";
-import { allocatePorts, DEFAULT_PORTS, PortAllocationError } from "./PortAllocator.ts";
+import {
+  allocatePorts,
+  DEFAULT_PORTS,
+  PortAllocationError,
+  reservePorts,
+} from "./PortAllocator.ts";
 
 const listen = (port: number) =>
   Effect.callback<Server, Error>((resume) => {
@@ -123,6 +128,59 @@ describe("allocatePorts", () => {
     if (exit._tag === "Failure") {
       expect(JSON.stringify(exit.cause)).toContain("is not available");
     }
+  });
+
+  it("keeps allocated ports unavailable until their lease is released", async () => {
+    const lease = await Effect.runPromise(reservePorts({}));
+
+    try {
+      const occupied = await Effect.runPromise(
+        allocatePorts({ apiPort: lease.ports.apiPort }).pipe(Effect.exit),
+      );
+      expect(occupied._tag).toBe("Failure");
+
+      await Effect.runPromise(lease.release(["apiPort"]));
+      const available = await Effect.runPromise(allocatePorts({ apiPort: lease.ports.apiPort }));
+      expect(available.apiPort).toBe(lease.ports.apiPort);
+
+      await Effect.runPromise(lease.reserve(["apiPort"]));
+      const reservedAgain = await Effect.runPromise(
+        allocatePorts({ apiPort: lease.ports.apiPort }).pipe(Effect.exit),
+      );
+      expect(reservedAgain._tag).toBe("Failure");
+    } finally {
+      await Effect.runPromise(lease.releaseAll);
+    }
+  });
+
+  it("keeps concurrent port leases disjoint", async () => {
+    const [first, second] = await Promise.all([
+      Effect.runPromise(reservePorts({})),
+      Effect.runPromise(reservePorts({})),
+    ]);
+
+    try {
+      const firstPorts = new Set(Object.values(first.ports));
+      expect(Object.values(second.ports).every((port) => !firstPorts.has(port))).toBe(true);
+    } finally {
+      await Promise.all([
+        Effect.runPromise(first.releaseAll),
+        Effect.runPromise(second.releaseAll),
+      ]);
+    }
+  });
+
+  it("releases partial reservations when lease allocation fails", async () => {
+    const port = await Effect.runPromise(
+      Effect.scoped(Effect.map(occupyFreePort(), (occupied) => occupied.port)),
+    );
+    const failed = await Effect.runPromise(
+      reservePorts({ apiPort: port, dbPort: port }).pipe(Effect.exit),
+    );
+    expect(failed._tag).toBe("Failure");
+
+    const available = await Effect.runPromise(allocatePorts({ apiPort: port }));
+    expect(available.apiPort).toBe(port);
   });
 
   it("preferred ports are reused when available", async () => {

--- a/packages/stack/src/RemoteStack.integration.test.ts
+++ b/packages/stack/src/RemoteStack.integration.test.ts
@@ -1,11 +1,14 @@
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { ServiceNotFoundError, type LogEntry } from "@supabase/process-compose";
-import { Effect, Layer, ManagedRuntime, Stream } from "effect";
+import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabase/process-compose";
+import { Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect";
 import * as http from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { DaemonServer } from "./DaemonServer.ts";
+import { StackBuildError } from "./errors.ts";
+import { RemoteStack } from "./RemoteStack.ts";
 import { Stack, type StackInfo } from "./Stack.ts";
 import { StackServiceState } from "./StackServiceState.ts";
+import { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -53,7 +56,14 @@ const MOCK_LOGS: ReadonlyArray<LogEntry> = [
 // Mock Stack (server-side, backing the DaemonServer)
 // ---------------------------------------------------------------------------
 
-function mockStack() {
+function mockStack(
+  options: {
+    readonly startServiceBuildError?: string;
+    readonly startServiceReadyError?: string;
+    readonly waitReadyBuildError?: string;
+    readonly restartServiceReadyError?: string;
+  } = {},
+) {
   let stopped = false;
   const serviceCalls: string[] = [];
 
@@ -71,9 +81,18 @@ function mockStack() {
     startService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
-        : Effect.sync(() => {
-            serviceCalls.push(`start:${name}`);
-          }),
+        : options.startServiceBuildError !== undefined
+          ? Effect.fail(new StackBuildError({ detail: options.startServiceBuildError }))
+          : options.startServiceReadyError !== undefined
+            ? Effect.fail(
+                new ServiceReadyError({
+                  name,
+                  reason: options.startServiceReadyError,
+                }),
+              )
+            : Effect.sync(() => {
+                serviceCalls.push(`start:${name}`);
+              }),
     stopService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
@@ -83,9 +102,16 @@ function mockStack() {
     restartService: (name: string) =>
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
-        : Effect.sync(() => {
-            serviceCalls.push(`restart:${name}`);
-          }),
+        : options.restartServiceReadyError !== undefined
+          ? Effect.fail(
+              new ServiceReadyError({
+                name,
+                reason: options.restartServiceReadyError,
+              }),
+            )
+          : Effect.sync(() => {
+              serviceCalls.push(`restart:${name}`);
+            }),
     reloadFunctions: () =>
       Effect.sync(() => {
         serviceCalls.push("reload-functions");
@@ -108,9 +134,18 @@ function mockStack() {
     allStateChanges: () => Stream.fromIterable(MOCK_STATES),
     waitReady: (name: string) => {
       const match = MOCK_STATES.find((s) => s.name === name);
-      return match ? Effect.void : Effect.fail(new ServiceNotFoundError({ name }));
+      if (match === undefined) return Effect.fail(new ServiceNotFoundError({ name }));
+      if (options.waitReadyBuildError !== undefined) {
+        return Effect.fail(new StackBuildError({ detail: options.waitReadyBuildError }));
+      }
+      return Effect.sync(() => {
+        serviceCalls.push(`ready:${name}`);
+      });
     },
-    waitAllReady: () => Effect.void,
+    waitAllReady: () =>
+      Effect.sync(() => {
+        serviceCalls.push("ready:all");
+      }),
     subscribeLogs: (name: string) =>
       Stream.fromIterable(MOCK_LOGS.filter((l) => l.service === name)),
     subscribeAllLogs: (services?: ReadonlyArray<string>) =>
@@ -149,7 +184,18 @@ function buildServerLayer(
   return DaemonServer.layer.pipe(
     Layer.provide(mock.layer),
     Layer.provide(NodeHttpServer.layer(() => http.createServer(), { port: 0 }).pipe(Layer.orDie)),
-  ) as Layer.Layer<DaemonServer, never, never>;
+  );
+}
+
+function buildClientLayer(url: string): Layer.Layer<Stack, never, never> {
+  const clientLayer = Layer.succeed(UnixHttpClient, {
+    request: (socketPath, path, init) =>
+      Effect.tryPromise({
+        try: () => fetch(`${url}${path}`, init),
+        catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+      }),
+  });
+  return RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer));
 }
 
 // ---------------------------------------------------------------------------
@@ -166,123 +212,11 @@ describe("RemoteStack integration", () => {
     serverRuntime = ManagedRuntime.make(buildServerLayer(mock));
     const daemon = await serverRuntime.runPromise(DaemonServer);
 
-    // Build RemoteStack layer targeting the server's TCP address.
-    // RemoteStack uses Bun's `fetch({ unix })` but we test with TCP here
-    // since the HTTP behavior is identical.
     const addr = daemon.address;
     if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
     const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
-
-    // For TCP testing, we override the fetch helper by using a custom layer
-    // that patches the socket path to a TCP URL. Since RemoteStack uses
-    // `fetch("http://localhost/...", { unix })`, we can't directly test TCP.
-    //
-    // Instead, we'll test the RemoteStack methods via raw fetch to the TCP
-    // server, validating the HTTP contract that RemoteStack relies on.
-    // The DaemonServer integration tests already cover the HTTP endpoints.
-    //
-    // For a true end-to-end test, we'd need a Unix socket server.
-    // Here we verify the RemoteStack layer constructor + method wiring.
-
-    // Use the RemoteStack layer with a Unix socket path.
-    // Since we can't use Unix socket with the TCP test server,
-    // we test the layer construction only.
     const url = `http://${host}:${addr.port}`;
-
-    // Create a RemoteStack-like client that uses TCP instead of Unix socket
-    clientRuntime = ManagedRuntime.make(
-      Layer.succeed(Stack, {
-        getInfo: () =>
-          Effect.promise(async () => {
-            const res = await fetch(`${url}/status`);
-            const body = (await res.json()) as { info: StackInfo };
-            return body.info;
-          }),
-        start: () => Effect.void,
-        stop: () =>
-          Effect.promise(async () => {
-            await fetch(`${url}/stop`, { method: "POST" });
-          }),
-        dispose: () =>
-          Effect.promise(async () => {
-            await fetch(`${url}/stop`, { method: "POST" });
-          }),
-        startService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/start`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        stopService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/stop`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        restartService: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() =>
-              fetch(`${url}/services/${name}/restart`, { method: "POST" }),
-            );
-            if (res.status === 404) return yield* new ServiceNotFoundError({ name });
-          }),
-        reloadFunctions: () =>
-          Effect.gen(function* () {
-            yield* Effect.promise(() => fetch(`${url}/functions/reload`, { method: "POST" }));
-          }),
-        reloadEdgeRuntime: () =>
-          Effect.gen(function* () {
-            yield* Effect.promise(() =>
-              fetch(`${url}/edge-runtime/reload`, {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({ edgeRuntime: {} }),
-              }),
-            );
-          }),
-        getState: (name: string) =>
-          Effect.gen(function* () {
-            const res = yield* Effect.promise(() => fetch(`${url}/status`));
-            const body = (yield* Effect.promise(() => res.json())) as {
-              services: Array<StackServiceState>;
-            };
-            const s = body.services.find((s) => s.name === name);
-            if (!s) return yield* new ServiceNotFoundError({ name });
-            return new StackServiceState(s);
-          }),
-        getAllStates: () =>
-          Effect.promise(async () => {
-            const res = await fetch(`${url}/status`);
-            const body = (await res.json()) as { services: Array<StackServiceState> };
-            return body.services.map((s) => new StackServiceState(s));
-          }),
-        stateChanges: () => Effect.succeed(Stream.empty),
-        allStateChanges: () => Stream.empty,
-        waitReady: () => Effect.void,
-        waitAllReady: () => Effect.void,
-        subscribeLogs: () => Stream.empty,
-        subscribeAllLogs: () => Stream.empty,
-        logHistory: (name: string, limit?: number) =>
-          Effect.promise(async () => {
-            const query = limit !== undefined ? `?limit=${limit}` : "";
-            const res = await fetch(`${url}/logs/${name}/history${query}`);
-            return (await res.json()) as ReadonlyArray<LogEntry>;
-          }),
-        logHistoryAll: (limit?: number, services?: ReadonlyArray<string>) =>
-          Effect.promise(async () => {
-            const searchParams = new URLSearchParams();
-            if (limit !== undefined) searchParams.set("limit", String(limit));
-            for (const service of services ?? []) {
-              searchParams.append("service", service);
-            }
-            const query = searchParams.toString();
-            const res = await fetch(`${url}/logs/history${query.length > 0 ? `?${query}` : ""}`);
-            return (await res.json()) as ReadonlyArray<LogEntry>;
-          }),
-      }),
-    );
+    clientRuntime = ManagedRuntime.make(buildClientLayer(url));
   });
 
   afterAll(async () => {
@@ -331,6 +265,123 @@ describe("RemoteStack integration", () => {
       Effect.flatMap(Stack, (stack) => stack.startService("unknown")),
     );
     expect(exit._tag).toBe("Failure");
+  });
+
+  test("waitReady delegates to the daemon coordinator", async () => {
+    await clientRuntime.runPromise(Effect.flatMap(Stack, (stack) => stack.waitReady("auth")));
+    expect(mock.serviceCalls).toContain("ready:auth");
+  });
+
+  test("waitReady rejects dot path segments locally", async () => {
+    const error = await clientRuntime.runPromise(
+      Effect.flatMap(Stack, (stack) => stack.waitReady("..")).pipe(Effect.flip),
+    );
+    expect(error._tag).toBe("ServiceNotFoundError");
+    expect(mock.serviceCalls).not.toContain("ready:all");
+  });
+
+  test("waitAllReady delegates to the daemon coordinator", async () => {
+    await clientRuntime.runPromise(Effect.flatMap(Stack, (stack) => stack.waitAllReady()));
+    expect(mock.serviceCalls).toContain("ready:all");
+  });
+
+  test("interrupting waitReady aborts the daemon request", async () => {
+    let notifyRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      notifyRequestStarted = resolve;
+    });
+    let aborted = false;
+    const clientLayer = Layer.succeed(UnixHttpClient, {
+      request: (socketPath, path, init) =>
+        Effect.tryPromise({
+          try: () =>
+            new Promise<Response>((_resolve, reject) => {
+              notifyRequestStarted?.();
+              init?.signal?.addEventListener(
+                "abort",
+                () => {
+                  aborted = true;
+                  reject(new DOMException("Aborted", "AbortError"));
+                },
+                { once: true },
+              );
+            }),
+          catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+        }),
+    });
+    const runtime = ManagedRuntime.make(
+      RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer)),
+    );
+    try {
+      const fiber = runtime.runFork(Effect.flatMap(Stack, (stack) => stack.waitReady("auth")));
+      await requestStarted;
+      await runtime.runPromise(Fiber.interrupt(fiber));
+      expect(aborted).toBe(true);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  test("preserves StackBuildError across remote service operations", async () => {
+    const failingMock = mockStack({
+      restartServiceReadyError: "restart failed readiness",
+      startServiceBuildError: "stack is stopped",
+      waitReadyBuildError: "service has not been activated",
+    });
+    const failingServer = ManagedRuntime.make(buildServerLayer(failingMock));
+    let failingClient: ManagedRuntime.ManagedRuntime<Stack, never> | undefined;
+    try {
+      const daemon = await failingServer.runPromise(DaemonServer);
+      const addr = daemon.address;
+      if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
+      const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
+      failingClient = ManagedRuntime.make(buildClientLayer(`http://${host}:${addr.port}`));
+
+      const startError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.startService("auth")).pipe(Effect.flip),
+      );
+      expect(startError._tag).toBe("StackBuildError");
+
+      const readyError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.waitReady("auth")).pipe(Effect.flip),
+      );
+      expect(readyError._tag).toBe("StackBuildError");
+
+      const restartError = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.restartService("auth")).pipe(Effect.flip),
+      );
+      expect(restartError._tag).toBe("ServiceReadyError");
+      if (restartError._tag === "ServiceReadyError") {
+        expect(restartError.reason).toBe("restart failed readiness");
+      }
+    } finally {
+      await failingClient?.dispose();
+      await failingServer.dispose();
+    }
+  });
+
+  test("preserves ServiceReadyError from remote startService", async () => {
+    const failingMock = mockStack({ startServiceReadyError: "start failed readiness" });
+    const failingServer = ManagedRuntime.make(buildServerLayer(failingMock));
+    let failingClient: ManagedRuntime.ManagedRuntime<Stack, never> | undefined;
+    try {
+      const daemon = await failingServer.runPromise(DaemonServer);
+      const addr = daemon.address;
+      if (addr._tag !== "TcpAddress") throw new Error("Expected TcpAddress");
+      const host = addr.hostname === "0.0.0.0" ? "127.0.0.1" : addr.hostname;
+      failingClient = ManagedRuntime.make(buildClientLayer(`http://${host}:${addr.port}`));
+
+      const error = await failingClient.runPromise(
+        Effect.flatMap(Stack, (stack) => stack.startService("auth")).pipe(Effect.flip),
+      );
+      expect(error._tag).toBe("ServiceReadyError");
+      if (error._tag === "ServiceReadyError") {
+        expect(error.reason).toBe("start failed readiness");
+      }
+    } finally {
+      await failingClient?.dispose();
+      await failingServer.dispose();
+    }
   });
 
   test("stopService records the call", async () => {

--- a/packages/stack/src/RemoteStack.ts
+++ b/packages/stack/src/RemoteStack.ts
@@ -2,9 +2,12 @@ import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabas
 import { Effect, Layer, Schema, Stream } from "effect";
 import * as Sse from "effect/unstable/encoding/Sse";
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { DaemonErrorResponseSchema } from "./DaemonProtocol.ts";
+import { StackBuildError } from "./errors.ts";
 import { Stack, StackInfoSchema } from "./Stack.ts";
 import { StackServiceState, StackServiceStatusSchema } from "./StackServiceState.ts";
 import { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
+import { SERVICE_NAMES } from "./versions.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,10 +35,6 @@ const StatusResponseSchema = Schema.Struct({
   services: Schema.Array(StatusServiceSchema),
 });
 
-const ServiceErrorResponseSchema = Schema.Struct({
-  error: Schema.String,
-});
-
 const StatusServiceEventSchema = Schema.fromJsonString(StatusServiceSchema);
 const LogEntryEventSchema = Schema.fromJsonString(LogEntrySchema);
 const decodeStatusServiceEvent = Schema.decodeUnknownSync(StatusServiceEventSchema);
@@ -48,6 +47,13 @@ const decodeLogEntryEvent = Schema.decodeUnknownSync(LogEntryEventSchema);
 function requestHeaders(init?: RequestInit) {
   return Object.fromEntries(new Headers(init?.headers).entries());
 }
+
+const publicServicePath = (name: string): Effect.Effect<string, ServiceNotFoundError> => {
+  const service = SERVICE_NAMES.find((candidate) => candidate === name);
+  return service === undefined
+    ? Effect.fail(new ServiceNotFoundError({ name }))
+    : Effect.succeed(encodeURIComponent(service));
+};
 
 function makeRequest(path: string, init?: RequestInit) {
   const url = `http://localhost${path}`;
@@ -85,6 +91,46 @@ function unixResponse(socketPath: string, path: string, init?: RequestInit) {
     HttpClientResponse.fromWeb(request, response),
   );
 }
+
+function withAbortSignal<A, E, R>(
+  effect: (signal: AbortSignal) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => new AbortController()),
+    (controller) => effect(controller.signal),
+    (controller) => Effect.sync(() => controller.abort()),
+  );
+}
+
+const failDaemonResponse = (
+  response: HttpClientResponse.HttpClientResponse,
+  fallbackName: string,
+): Effect.Effect<never, ServiceNotFoundError | ServiceReadyError | StackBuildError> =>
+  Effect.gen(function* () {
+    const body = yield* HttpClientResponse.schemaBodyJson(DaemonErrorResponseSchema)(response).pipe(
+      Effect.orDie,
+    );
+    switch (body.code) {
+      case "SERVICE_NOT_FOUND":
+        return yield* new ServiceNotFoundError({ name: body.service ?? fallbackName });
+      case "SERVICE_NOT_READY":
+        return yield* new ServiceReadyError({
+          name: body.service ?? fallbackName,
+          reason: body.error,
+          ...(body.exitCode === undefined ? {} : { exitCode: body.exitCode }),
+        });
+      case "STACK_BUILD_ERROR":
+        return yield* new StackBuildError({ detail: body.error });
+    }
+  });
+
+const expectDaemonOk = (
+  response: HttpClientResponse.HttpClientResponse,
+  fallbackName: string,
+): Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError> =>
+  response.status >= 200 && response.status < 300
+    ? Effect.void
+    : failDaemonResponse(response, fallbackName);
 
 /** Fetch JSON from the daemon, dying on HTTP errors. */
 function fetchStatus(socketPath: string, path: string, method = "GET") {
@@ -213,7 +259,9 @@ export const RemoteStack = {
             withUnixHttpClient(
               Effect.gen(function* () {
                 const response = yield* unixResponse(socketPath, "/start", { method: "POST" });
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "stack").pipe(
+                  Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
+                );
               }),
             ),
 
@@ -236,45 +284,39 @@ export const RemoteStack = {
           startService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/start`, {
+                const servicePath = yield* publicServicePath(name);
+                const response = yield* unixResponse(socketPath, `/services/${servicePath}/start`, {
                   method: "POST",
                 });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({ name, reason: body.error });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, name);
               }),
             ),
 
           stopService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/stop`, {
+                const servicePath = yield* publicServicePath(name);
+                const response = yield* unixResponse(socketPath, `/services/${servicePath}/stop`, {
                   method: "POST",
                 });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, name).pipe(
+                  Effect.catchTag("ServiceReadyError", (error) => Effect.die(error)),
+                );
               }),
             ),
 
           restartService: (name: string) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, `/services/${name}/restart`, {
-                  method: "POST",
-                });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const servicePath = yield* publicServicePath(name);
+                const response = yield* unixResponse(
+                  socketPath,
+                  `/services/${servicePath}/restart`,
+                  {
+                    method: "POST",
+                  },
+                );
+                yield* expectDaemonOk(response, name);
               }),
             ),
 
@@ -290,19 +332,7 @@ export const RemoteStack = {
                   })}`,
                   { method: "POST" },
                 );
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name: "edge-runtime" });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({
-                    name: "edge-runtime",
-                    reason: body.error,
-                  });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "edge-runtime");
               }),
             ),
 
@@ -314,19 +344,7 @@ export const RemoteStack = {
                   headers: { "content-type": "application/json" },
                   body: JSON.stringify(opts),
                 });
-                if (response.status === 404) {
-                  return yield* new ServiceNotFoundError({ name: "edge-runtime" });
-                }
-                if (response.status === 500) {
-                  const body = yield* HttpClientResponse.schemaBodyJson(ServiceErrorResponseSchema)(
-                    response,
-                  ).pipe(Effect.orDie);
-                  return yield* new ServiceReadyError({
-                    name: "edge-runtime",
-                    reason: body.error,
-                  });
-                }
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                yield* expectDaemonOk(response, "edge-runtime");
               }),
             ),
 
@@ -376,67 +394,36 @@ export const RemoteStack = {
 
           waitReady: (name: string) =>
             withUnixHttpClient(
-              Effect.gen(function* () {
-                // Check current state first
-                const { services } = yield* fetchStatus(socketPath, "/status");
-                const match = services.find((s) => s.name === name);
-                if (!match) {
-                  return yield* new ServiceNotFoundError({ name });
-                }
-                if (match.status === "Healthy" || match.status === "Running") return;
-
-                // Wait for state change via SSE
-                yield* withUnixHttpClient(
-                  sseStream(socketPath, "/status/stream", (data) => {
-                    const raw = decodeStatusServiceEvent(data);
-                    return toServiceState(raw);
-                  }).pipe(
-                    Stream.filter((s) => s.name === name),
-                    Stream.takeUntil((s) => s.status === "Healthy" || s.status === "Running"),
-                    Stream.runDrain,
-                  ),
-                );
-              }),
+              withAbortSignal((signal) =>
+                Effect.gen(function* () {
+                  const servicePath = yield* publicServicePath(name);
+                  const response = yield* unixResponse(
+                    socketPath,
+                    `/services/${servicePath}/ready`,
+                    { signal },
+                  );
+                  yield* expectDaemonOk(response, name);
+                }),
+              ),
             ),
 
           waitAllReady: () =>
             withUnixHttpClient(
-              Effect.gen(function* () {
-                // Check current state first
-                const { services } = yield* fetchStatus(socketPath, "/status");
-                const allReady = services.every(
-                  (s) => s.status === "Healthy" || s.status === "Running",
-                );
-                if (allReady) return;
-
-                // Track service readiness via SSE
-                const readySet = new Set(
-                  services
-                    .filter((s) => s.status === "Healthy" || s.status === "Running")
-                    .map((s) => s.name),
-                );
-                const totalCount = services.length;
-
-                yield* withUnixHttpClient(
-                  sseStream(socketPath, "/status/stream", (data) => {
-                    const raw = decodeStatusServiceEvent(data);
-                    return toServiceState(raw);
-                  }).pipe(
-                    Stream.takeUntil((s) => {
-                      if (s.status === "Healthy" || s.status === "Running") {
-                        readySet.add(s.name);
-                      }
-                      return readySet.size >= totalCount;
-                    }),
-                    Stream.runDrain,
-                  ),
-                );
-              }),
+              withAbortSignal((signal) =>
+                Effect.gen(function* () {
+                  const response = yield* unixResponse(socketPath, "/ready", { signal });
+                  yield* expectDaemonOk(response, "stack").pipe(
+                    Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
+                  );
+                }),
+              ),
             ),
 
           subscribeLogs: (name: string) =>
             withUnixHttpClientStream(
-              sseStream<LogEntry>(socketPath, `/logs/${name}`, (data) => decodeLogEntryEvent(data)),
+              sseStream<LogEntry>(socketPath, `/logs/${encodeURIComponent(name)}`, (data) =>
+                decodeLogEntryEvent(data),
+              ),
             ),
 
           subscribeAllLogs: (services) => {
@@ -448,7 +435,9 @@ export const RemoteStack = {
 
           logHistory: (name: string, limit?: number) => {
             const query = limit !== undefined ? `?limit=${limit}` : "";
-            return withUnixHttpClient(fetchLogEntries(socketPath, `/logs/${name}/history${query}`));
+            return withUnixHttpClient(
+              fetchLogEntries(socketPath, `/logs/${encodeURIComponent(name)}/history${query}`),
+            );
           },
 
           logHistoryAll: (limit?: number, services?: ReadonlyArray<string>) => {

--- a/packages/stack/src/ServiceActivation.ts
+++ b/packages/stack/src/ServiceActivation.ts
@@ -1,0 +1,93 @@
+import { ServiceNotFoundError } from "@supabase/process-compose";
+import type { ServiceReadyError } from "@supabase/process-compose";
+import { Context, Effect, Layer } from "effect";
+import { StackBuildError, StackNotRunningError } from "./errors.ts";
+import type { ServiceName } from "./versions.ts";
+
+export interface ServiceActivationPolicy {
+  /** Whether the public service must already be running when lazy startup completes. */
+  readonly startup: "eager" | "lazy";
+  /** Other public services required when this service is activated. */
+  readonly activates?: ReadonlyArray<ServiceName>;
+  /** Private companions whose lifecycle is exclusively owned by this service. */
+  readonly owns?: ReadonlyArray<ServiceName>;
+}
+
+/**
+ * Central ownership map for lazy startup. Services with a direct TCP or HTTP
+ * endpoint must be running before that endpoint is published. Companion
+ * services are activated with the public service that consumes them.
+ */
+export const SERVICE_ACTIVATION_POLICY: Readonly<Record<ServiceName, ServiceActivationPolicy>> = {
+  postgres: { startup: "eager" },
+  postgrest: { startup: "lazy" },
+  auth: { startup: "lazy" },
+  "edge-runtime": { startup: "lazy" },
+  realtime: { startup: "eager" },
+  storage: { startup: "lazy", activates: ["imgproxy"], owns: ["imgproxy"] },
+  imgproxy: { startup: "lazy" },
+  mailpit: { startup: "eager" },
+  pgmeta: { startup: "lazy" },
+  studio: { startup: "eager", activates: ["analytics"] },
+  analytics: { startup: "lazy", activates: ["vector"], owns: ["vector"] },
+  vector: { startup: "lazy" },
+  pooler: { startup: "eager" },
+};
+
+export const eagerServices = (enabled: ReadonlyArray<ServiceName>): ReadonlyArray<ServiceName> =>
+  enabled.filter((service) => SERVICE_ACTIVATION_POLICY[service].startup === "eager");
+
+export const activationTargetsForService = (
+  enabledServices: ReadonlyArray<ServiceName>,
+  service: ServiceName,
+): ReadonlyArray<ServiceName> => {
+  const enabled = new Set(enabledServices);
+  const targets = new Set<ServiceName>();
+  const addWithCompanions = (target: ServiceName): void => {
+    if (!enabled.has(target) || targets.has(target)) return;
+    for (const activated of SERVICE_ACTIVATION_POLICY[target].activates ?? []) {
+      addWithCompanions(activated);
+    }
+    targets.add(target);
+  };
+  addWithCompanions(service);
+
+  return [...targets];
+};
+
+/** Services exclusively owned by a public service for stop/restart operations. */
+export const lifecycleTargetsForService = (
+  enabledServices: ReadonlyArray<ServiceName>,
+  service: ServiceName,
+): ReadonlyArray<ServiceName> => {
+  const enabled = new Set(enabledServices);
+  const targets: ServiceName[] = [];
+  const add = (target: ServiceName): void => {
+    if (enabled.has(target)) targets.push(target);
+  };
+
+  const addWithOwnedCompanions = (target: ServiceName): void => {
+    add(target);
+    for (const owned of SERVICE_ACTIVATION_POLICY[target].owns ?? []) {
+      addWithOwnedCompanions(owned);
+    }
+  };
+  addWithOwnedCompanions(service);
+  return targets;
+};
+
+export class StackServiceActivator extends Context.Service<
+  StackServiceActivator,
+  {
+    readonly activate: (
+      service: ServiceName,
+    ) => Effect.Effect<
+      void,
+      ServiceNotFoundError | ServiceReadyError | StackBuildError | StackNotRunningError
+    >;
+  }
+>()("stack/StackServiceActivator") {
+  static noop = Layer.succeed(this, {
+    activate: () => Effect.void,
+  });
+}

--- a/packages/stack/src/ServiceActivation.unit.test.ts
+++ b/packages/stack/src/ServiceActivation.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  activationTargetsForService,
+  eagerServices,
+  lifecycleTargetsForService,
+  SERVICE_ACTIVATION_POLICY,
+} from "./ServiceActivation.ts";
+import { SERVICE_NAMES } from "./versions.ts";
+
+describe("service activation", () => {
+  it("defines an access policy for every stack service", () => {
+    expect(Object.keys(SERVICE_ACTIVATION_POLICY).sort()).toEqual([...SERVICE_NAMES].sort());
+  });
+
+  it("starts direct endpoints eagerly", () => {
+    expect(eagerServices(SERVICE_NAMES)).toEqual([
+      "postgres",
+      "realtime",
+      "mailpit",
+      "studio",
+      "pooler",
+    ]);
+  });
+
+  it("activates service companions transitively", () => {
+    expect(activationTargetsForService(SERVICE_NAMES, "storage")).toEqual(["imgproxy", "storage"]);
+    expect(activationTargetsForService(SERVICE_NAMES, "analytics")).toEqual([
+      "vector",
+      "analytics",
+    ]);
+    expect(activationTargetsForService(SERVICE_NAMES, "studio")).toEqual([
+      "vector",
+      "analytics",
+      "studio",
+    ]);
+  });
+
+  it("omits disabled companions", () => {
+    const enabled = SERVICE_NAMES.filter(
+      (service) => service !== "imgproxy" && service !== "vector",
+    );
+    expect(activationTargetsForService(enabled, "storage")).toEqual(["storage"]);
+    expect(activationTargetsForService(enabled, "analytics")).toEqual(["analytics"]);
+    expect(activationTargetsForService(enabled, "studio")).toEqual(["analytics", "studio"]);
+  });
+
+  it("does not assign shared public dependencies to their consumers", () => {
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "storage")).toEqual(["storage", "imgproxy"]);
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "analytics")).toEqual(["analytics", "vector"]);
+    expect(lifecycleTargetsForService(SERVICE_NAMES, "studio")).toEqual(["studio"]);
+  });
+});

--- a/packages/stack/src/ServicePorts.ts
+++ b/packages/stack/src/ServicePorts.ts
@@ -1,0 +1,51 @@
+import type { PortField } from "./PortAllocator.ts";
+import type { ResolvedStackConfig } from "./StackBuilder.ts";
+
+export const allocatedPortFieldsForConfig = (
+  config: ResolvedStackConfig,
+): ReadonlyArray<PortField> => {
+  const fields: Array<PortField> = ["apiPort", "dbPort"];
+  if (config.postgrest !== false) fields.push("postgrestPort", "postgrestAdminPort");
+  if (config.auth !== false) fields.push("authPort");
+  if (config.edgeRuntime !== false) fields.push("edgeRuntimePort", "edgeRuntimeInspectorPort");
+  if (config.realtime !== false) fields.push("realtimePort");
+  if (config.storage !== false) fields.push("storagePort");
+  if (config.imgproxy !== false) fields.push("imgproxyPort");
+  if (config.mailpit !== false) fields.push("mailpitPort", "mailpitSmtpPort", "mailpitPop3Port");
+  if (config.pgmeta !== false) fields.push("pgmetaPort");
+  if (config.studio !== false) fields.push("studioPort");
+  if (config.analytics !== false) fields.push("analyticsPort");
+  if (config.pooler !== false) fields.push("poolerPort", "poolerApiPort");
+  return fields;
+};
+
+export const portFieldsForService = (name: string): ReadonlyArray<PortField> => {
+  switch (name) {
+    case "postgres":
+      return ["dbPort"];
+    case "postgrest":
+      return ["postgrestPort", "postgrestAdminPort"];
+    case "auth":
+      return ["authPort"];
+    case "edge-runtime":
+      return ["edgeRuntimePort", "edgeRuntimeInspectorPort"];
+    case "realtime":
+      return ["realtimePort"];
+    case "storage":
+      return ["storagePort"];
+    case "imgproxy":
+      return ["imgproxyPort"];
+    case "mailpit":
+      return ["mailpitPort", "mailpitSmtpPort", "mailpitPop3Port"];
+    case "pgmeta":
+      return ["pgmetaPort"];
+    case "studio":
+      return ["studioPort"];
+    case "analytics":
+      return ["analyticsPort"];
+    case "pooler":
+      return ["poolerPort", "poolerApiPort"];
+    default:
+      return [];
+  }
+};

--- a/packages/stack/src/Stack.ts
+++ b/packages/stack/src/Stack.ts
@@ -66,7 +66,7 @@ export class Stack extends Context.Service<
     ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
     readonly restartService: (
       name: string,
-    ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
+    ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
     readonly reloadFunctions: (
       opts?: FunctionsConfig,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;

--- a/packages/stack/src/Stack.unit.test.ts
+++ b/packages/stack/src/Stack.unit.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
 import { createHmac } from "node:crypto";
-import { Effect, Exit, Fiber, Layer, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Stream } from "effect";
 import { mockChildProcessSpawner } from "../../process-compose/tests/helpers/mocks.ts";
 import { mockBinaryResolver } from "../tests/helpers/mocks.ts";
 import { defaultPublishableKey, defaultSecretKey, generateJwt } from "./JwtGenerator.ts";
-import type { AllocatedPorts } from "./PortAllocator.ts";
+import type { AllocatedPorts, PortField, PortLease } from "./PortAllocator.ts";
 import { Stack } from "./Stack.ts";
 import { StackLifecycleCoordinator } from "./StackLifecycleCoordinator.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
@@ -43,6 +43,7 @@ const defaultConfig: ResolvedStackConfig = {
   runtimeRoot: "/tmp/supabase-runtime",
   projectDir: "/tmp/supabase-project",
   mode: "native",
+  startupMode: "eager",
   jwtSecret: testJwtSecret,
   ports: defaultPorts,
   apiPort: 54321,
@@ -99,23 +100,31 @@ const edgeRuntimeConfig: ResolvedStackConfig = {
   },
 };
 
-function setupLayer(config: ResolvedStackConfig = defaultConfig) {
+const noopPortLease = (ports: AllocatedPorts): PortLease => ({
+  ports,
+  reserve: () => Effect.void,
+  release: () => Effect.void,
+  releaseAll: Effect.void,
+});
+
+function setupLayer(
+  config: ResolvedStackConfig = defaultConfig,
+  portLease: PortLease = noopPortLease(config.ports),
+  spawner = mockChildProcessSpawner(),
+) {
   const resolver = mockBinaryResolver();
-  const spawner = mockChildProcessSpawner();
   const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
-  );
-
-  const layer = Stack.layer(config).pipe(
-    Layer.provide(coordinatorLayer),
     Layer.provide(spawner.layer),
     Layer.provide(BunServices.layer),
   );
 
-  return { layer, resolver, spawner };
+  const layer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+
+  return { coordinatorLayer, layer, resolver, spawner };
 }
 
 describe("Stack", () => {
@@ -128,6 +137,8 @@ describe("Stack", () => {
 
       expect(info.url).toBe("http://127.0.0.1:54321");
       expect(info.dbUrl).toBe("postgresql://postgres:postgres@127.0.0.1:54322/postgres");
+      expect(info.serviceEndpoints.auth).toBe("http://127.0.0.1:54321/auth/v1");
+      expect(info.serviceEndpoints.postgrest).toBe("http://127.0.0.1:54321/rest/v1");
     }).pipe(Effect.provide(layer));
   });
 
@@ -139,7 +150,7 @@ describe("Stack", () => {
       const info = yield* stack.getInfo();
 
       expect(info.serviceEndpoints.functions).toBe("http://127.0.0.1:54321/functions/v1");
-      expect(info.serviceEndpoints.edge_runtime).toBe("http://127.0.0.1:54325");
+      expect(info.serviceEndpoints.edge_runtime).toBe("http://127.0.0.1:54321/functions/v1");
     }).pipe(Effect.provide(layer));
   });
 
@@ -294,7 +305,10 @@ describe("Stack", () => {
     });
     const spawner = mockChildProcessSpawner();
     const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-    const coordinatorLayer = StackLifecycleCoordinator.layer(defaultConfig).pipe(
+    const coordinatorLayer = StackLifecycleCoordinator.layer(
+      defaultConfig,
+      noopPortLease(defaultConfig.ports),
+    ).pipe(
       Layer.provide(StackBuilder.layer),
       Layer.provide(stackPreparationLayer),
       Layer.provide(StackMetadataPersistence.noop),
@@ -376,7 +390,10 @@ describe("Stack", () => {
     const resolver = mockBinaryResolver({ failServices: ["postgres", "postgrest", "auth"] });
     const spawner = mockChildProcessSpawner({ exitCode: 1 });
     const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(resolver.layer));
-    const coordinatorLayer = StackLifecycleCoordinator.layer(defaultConfig).pipe(
+    const coordinatorLayer = StackLifecycleCoordinator.layer(
+      defaultConfig,
+      noopPortLease(defaultConfig.ports),
+    ).pipe(
       Layer.provide(StackBuilder.layer),
       Layer.provide(stackPreparationLayer),
       Layer.provide(StackMetadataPersistence.noop),
@@ -396,5 +413,291 @@ describe("Stack", () => {
       const startedContainers = spawner.spawned.filter((record) => record.args[0] === "run");
       expect(startedContainers).toEqual([]);
     }).pipe(Effect.provide(layer));
+  });
+
+  it.live("lazy startup starts direct services without starting HTTP backends", () => {
+    const { layer, spawner } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.start();
+      yield* stack.waitAllReady();
+
+      expect(
+        spawner.spawned.some((record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"bash"'),
+          ),
+        ),
+      ).toBe(true);
+      expect(spawner.spawned.some((record) => record.command.endsWith("/auth"))).toBe(false);
+      expect(spawner.spawned.some((record) => record.command.endsWith("/postgrest"))).toBe(false);
+
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy activation honors explicitly stopped transitive dependencies", () => {
+    const config: ResolvedStackConfig = {
+      ...defaultConfig,
+      mode: "auto",
+      startupMode: "lazy",
+      storage: {
+        port: defaultPorts.storagePort,
+        dataDir: "/tmp/supabase/storage",
+        fileSizeLimit: "50MiB",
+        s3ProtocolEnabled: true,
+        version: DEFAULT_VERSIONS.storage,
+      },
+      imgproxy: {
+        port: defaultPorts.imgproxyPort,
+        version: DEFAULT_VERSIONS.imgproxy,
+      },
+    };
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.stopService("imgproxy");
+
+      const error = yield* coordinator.activateService("storage").pipe(Effect.flip);
+
+      expect(error._tag).toBe("StackBuildError");
+      if (error._tag === "StackBuildError") {
+        expect(error.detail).toContain("imgproxy was explicitly stopped");
+      }
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy readiness includes an activation that is still starting", () =>
+    Effect.gen(function* () {
+      const spawnStarted = yield* Deferred.make<void>();
+      const spawner = mockChildProcessSpawner({
+        beforeSpawn: (record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          )
+            ? Deferred.succeed(spawnStarted, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.void,
+      });
+      const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+      const { coordinatorLayer } = setupLayer(config, noopPortLease(config.ports), spawner);
+
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        yield* coordinator.start();
+        expect((yield* coordinator.getState("auth")).status).toBe("Dormant");
+        const activeStateFiber = yield* coordinator.allStateChanges().pipe(
+          Stream.filter((state) => state.name === "auth" && state.status !== "Dormant"),
+          Stream.runHead,
+          Effect.forkChild({ startImmediately: true }),
+        );
+        const activationFiber = yield* coordinator
+          .activateService("auth")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(spawnStarted);
+        expect((yield* Fiber.join(activeStateFiber))._tag).toBe("Some");
+        expect((yield* coordinator.getState("auth")).status).not.toBe("Dormant");
+
+        const readyFiber = yield* coordinator
+          .waitAllReady()
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        expect(readyFiber.pollUnsafe()).toBeUndefined();
+
+        yield* coordinator.stop().pipe(Effect.timeout("1 second"));
+        yield* Fiber.interrupt(readyFiber);
+        yield* Fiber.interrupt(activationFiber);
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
+  );
+
+  it.live("dispose cancels an in-flight lazy activation", () =>
+    Effect.gen(function* () {
+      const spawnStarted = yield* Deferred.make<void>();
+      const allowSpawn = yield* Deferred.make<void>();
+      const spawner = mockChildProcessSpawner({
+        beforeSpawn: (record) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          )
+            ? Deferred.succeed(spawnStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(allowSpawn)),
+              )
+            : Effect.void,
+      });
+      const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+      const { coordinatorLayer } = setupLayer(config, noopPortLease(config.ports), spawner);
+
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        yield* coordinator.start();
+        const activationFiber = yield* coordinator
+          .activateService("auth")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(spawnStarted);
+
+        const disposeFiber = yield* coordinator
+          .dispose()
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Fiber.join(disposeFiber);
+        yield* Deferred.succeed(allowSpawn, undefined);
+        yield* Effect.sleep("20 millis");
+        yield* Fiber.interrupt(activationFiber);
+
+        expect(spawner.spawned.some((record) => record.command.endsWith("/auth"))).toBe(false);
+
+        const error = yield* coordinator.activateService("auth").pipe(Effect.flip);
+        expect(error._tag).toBe("StackNotRunningError");
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds")),
+  );
+
+  it.live("does not revive stopped lazy dependents when restarting a dependency", () => {
+    return Effect.gen(function* () {
+      const authHealthServer = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: () => new Response("ok"),
+          }),
+        ),
+        (server) => Effect.sync(() => server.stop(true)),
+      );
+      const authPort = authHealthServer.port;
+      if (authPort === undefined) {
+        throw new Error("Expected the auth health test server to bind a TCP port");
+      }
+      const authConfig = defaultConfig.auth;
+      if (authConfig === false) {
+        throw new Error("Expected auth to be enabled in the default test config");
+      }
+      const { coordinatorLayer, spawner } = setupLayer({
+        ...defaultConfig,
+        startupMode: "lazy",
+        ports: { ...defaultPorts, authPort },
+        auth: { ...authConfig, port: authPort },
+      });
+      yield* Effect.gen(function* () {
+        const coordinator = yield* StackLifecycleCoordinator;
+        const isAuthStart = (record: { readonly args: ReadonlyArray<string> }) =>
+          record.args.some((arg) =>
+            Buffer.from(arg, "base64url").toString().includes('"command":"/cache/auth/'),
+          );
+        yield* coordinator.start();
+        yield* coordinator.activateService("auth");
+        const initialAuthStarts = spawner.spawned.filter(isAuthStart).length;
+        expect(initialAuthStarts).toBeGreaterThan(0);
+
+        yield* coordinator.stopService("postgres");
+        yield* coordinator.restartService("postgres");
+        yield* coordinator.waitAllReady();
+
+        expect(spawner.spawned.filter(isAuthStart)).toHaveLength(initialAuthStarts);
+        expect((yield* coordinator.getState("auth")).status).toBe("Stopped");
+        yield* coordinator.stop();
+      }).pipe(Effect.provide(coordinatorLayer));
+    }).pipe(Effect.scoped, Effect.timeout("5 seconds"));
+  });
+
+  it.live("lazy readiness fails fast before a service is activated", () => {
+    const { layer } = setupLayer({ ...defaultConfig, startupMode: "lazy" });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const beforeStart = yield* stack.waitAllReady().pipe(Effect.flip);
+      expect(beforeStart._tag).toBe("StackBuildError");
+
+      yield* stack.start();
+      const authNotActivated = yield* stack.waitReady("auth").pipe(Effect.flip);
+      expect(authNotActivated._tag).toBe("ServiceReadyError");
+
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("keeps unactivated services dormant after a stop and start cycle", () => {
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      expect((yield* coordinator.getState("auth")).status).toBe("Dormant");
+
+      yield* coordinator.stop();
+      yield* coordinator.start();
+
+      expect((yield* coordinator.getState("auth")).status).toBe("Dormant");
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("rejects a cached activation after the stack has stopped", () => {
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.stop();
+
+      const error = yield* coordinator.activateService("postgres").pipe(Effect.flip);
+      expect(error._tag).toBe("StackNotRunningError");
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("preserves an explicitly stopped service across a stack restart", () => {
+    const config = { ...defaultConfig, startupMode: "lazy" } satisfies ResolvedStackConfig;
+    const { coordinatorLayer } = setupLayer(config);
+
+    return Effect.gen(function* () {
+      const coordinator = yield* StackLifecycleCoordinator;
+      yield* coordinator.start();
+      yield* coordinator.stopService("auth");
+      yield* Effect.sleep("20 millis");
+      expect((yield* coordinator.getState("auth")).status).toBe("Stopped");
+
+      yield* coordinator.stop();
+      yield* coordinator.start();
+
+      expect((yield* coordinator.getState("auth")).status).toBe("Stopped");
+      yield* coordinator.stop();
+    }).pipe(Effect.provide(coordinatorLayer), Effect.timeout("5 seconds"));
+  });
+
+  it.live("releases only the ports in a lazy service dependency closure", () => {
+    const released = new Set<PortField>();
+    const lease: PortLease = {
+      ports: defaultPorts,
+      reserve: () => Effect.void,
+      release: (fields) =>
+        Effect.sync(() => {
+          for (const field of fields) released.add(field);
+        }),
+      releaseAll: Effect.void,
+    };
+    const { layer } = setupLayer({ ...defaultConfig, startupMode: "lazy" }, lease);
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.start();
+
+      expect(released.has("dbPort")).toBe(true);
+      expect(released.has("authPort")).toBe(false);
+      expect(released.has("postgrestPort")).toBe(false);
+
+      const startFiber = yield* stack
+        .startService("auth")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Effect.sleep("50 millis");
+      expect(released.has("authPort")).toBe(true);
+      expect(released.has("postgrestPort")).toBe(false);
+
+      yield* Fiber.interrupt(startFiber);
+      yield* stack.stop();
+    }).pipe(Effect.provide(layer), Effect.timeout("5 seconds"));
   });
 });

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -148,6 +148,8 @@ export interface StackConfig {
   readonly runtimeRoot?: string;
   readonly projectDir?: string;
   readonly mode?: "native" | "auto" | "docker";
+  /** Start all services immediately, or defer proxied services until first use. */
+  readonly startupMode?: "eager" | "lazy";
   readonly jwtSecret?: string;
   readonly port?: number;
   readonly publishableKey?: string;
@@ -272,6 +274,7 @@ export interface ResolvedStackConfig {
   readonly runtimeRoot: string;
   readonly projectDir: string;
   readonly mode: "native" | "auto" | "docker";
+  readonly startupMode: "eager" | "lazy";
   readonly jwtSecret: string;
   readonly ports: AllocatedPorts;
   readonly apiPort: number;
@@ -892,7 +895,13 @@ export class StackBuilder extends Context.Service<
                 config.analytics !== false ? `http://${serviceHost}:${config.analytics.port}` : "",
               analyticsApiKey: config.analytics !== false ? config.analytics.apiKey : "api-key",
               networkArgs: dockerNetworkArgs(platform.os, [config.studio.port]),
-              dependencies: [{ service: "pgmeta", condition: "healthy" }],
+              dependencies:
+                config.analytics === false
+                  ? [{ service: "pgmeta", condition: "healthy" }]
+                  : [
+                      { service: "pgmeta", condition: "healthy" },
+                      { service: "analytics", condition: "healthy" },
+                    ],
             }),
             enabled: true,
           });

--- a/packages/stack/src/StackBuilder.unit.test.ts
+++ b/packages/stack/src/StackBuilder.unit.test.ts
@@ -42,6 +42,7 @@ const baseConfig: ResolvedStackConfig = {
   runtimeRoot: "/tmp/supabase-runtime",
   projectDir: "/tmp/supabase-project",
   mode: "auto",
+  startupMode: "eager",
   jwtSecret: testJwtSecret,
   ports: basePorts,
   apiPort: 3000,

--- a/packages/stack/src/StackLifecycleCoordinator.ts
+++ b/packages/stack/src/StackLifecycleCoordinator.ts
@@ -1,6 +1,6 @@
 import { LogBuffer, Orchestrator } from "@supabase/process-compose";
 import { ServiceNotFoundError } from "@supabase/process-compose";
-import type { LogEntry, ServiceReadyError } from "@supabase/process-compose";
+import type { LogEntry, ResolvedGraph, ServiceReadyError } from "@supabase/process-compose";
 import {
   Deferred,
   Effect,
@@ -8,6 +8,7 @@ import {
   Layer,
   Path,
   Ref,
+  Semaphore,
   Context,
   Stream,
   SubscriptionRef,
@@ -15,9 +16,16 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type { CleanupTargets } from "./CleanupTargets.ts";
 import { cleanupLocalStackResources } from "./cleanup.ts";
-import { StackBuildError } from "./errors.ts";
+import { StackBuildError, StackNotRunningError } from "./errors.ts";
 import { configureFunctionsRuntime, type FunctionsConfig } from "./functions.ts";
 import { detectPlatform, dockerHostAddress } from "./Platform.ts";
+import type { PortLease } from "./PortAllocator.ts";
+import {
+  activationTargetsForService,
+  eagerServices,
+  lifecycleTargetsForService,
+} from "./ServiceActivation.ts";
+import { portFieldsForService } from "./ServicePorts.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
 import { StackPreparation } from "./StackPreparation.ts";
 import type { PreparedStackArtifacts } from "./StackPreparation.ts";
@@ -31,6 +39,7 @@ import {
 import { changedProjectedStates, projectStackStates } from "./StackStateProjection.ts";
 import { StackServiceState } from "./StackServiceState.ts";
 import type { EdgeRuntimeReloadConfig, StackInfo } from "./Stack.ts";
+import { SERVICE_NAMES, type ServiceName } from "./versions.ts";
 
 type LifecyclePhase =
   | "idle"
@@ -43,6 +52,7 @@ type LifecyclePhase =
 
 interface RuntimeState {
   readonly orchestrator: Orchestrator["Service"];
+  readonly graph: ResolvedGraph;
   readonly cleanupTargets: CleanupTargets;
 }
 
@@ -69,52 +79,53 @@ const initialPublicStates = (config: ResolvedStackConfig): ReadonlyArray<StackSe
       }),
   );
 
-const stackInfoFor = (config: ResolvedStackConfig): StackInfo => ({
-  url: `http://127.0.0.1:${config.apiPort}`,
-  dbUrl: `postgresql://postgres:postgres@127.0.0.1:${config.dbPort}/postgres`,
-  publishableKey: config.publishableKey,
-  secretKey: config.secretKey,
-  anonJwt: config.anonJwt,
-  serviceRoleJwt: config.serviceRoleJwt,
-  serviceEndpoints: {
-    ...(config.auth === false ? {} : { auth: `http://127.0.0.1:${config.auth.port}` }),
-    ...(config.postgrest === false
-      ? {}
-      : { postgrest: `http://127.0.0.1:${config.postgrest.port}` }),
-    ...(config.edgeRuntime === false
-      ? {}
-      : {
-          functions: `http://127.0.0.1:${config.apiPort}/functions/v1`,
-          edge_runtime: `http://127.0.0.1:${config.edgeRuntime.port}`,
-        }),
-    ...(config.realtime === false ? {} : { realtime: `http://127.0.0.1:${config.realtime.port}` }),
-    ...(config.storage === false
-      ? {}
-      : {
-          storage: `http://127.0.0.1:${config.storage.port}`,
-          storage_s3: `http://127.0.0.1:${config.apiPort}/storage/v1/s3`,
-        }),
-    ...(config.imgproxy === false ? {} : { imgproxy: `http://127.0.0.1:${config.imgproxy.port}` }),
-    ...(config.mailpit === false
-      ? {}
-      : {
-          mailpit: `http://127.0.0.1:${config.mailpit.port}`,
-          mailpit_smtp: `smtp://127.0.0.1:${config.mailpit.smtpPort}`,
-          mailpit_pop3: `pop3://127.0.0.1:${config.mailpit.pop3Port}`,
-        }),
-    ...(config.pgmeta === false ? {} : { pgmeta: `http://127.0.0.1:${config.pgmeta.port}` }),
-    ...(config.studio === false ? {} : { studio: `http://127.0.0.1:${config.studio.port}` }),
-    ...(config.analytics === false
-      ? {}
-      : { analytics: `http://127.0.0.1:${config.analytics.port}` }),
-    ...(config.pooler === false
-      ? {}
-      : {
-          pooler: `postgresql://postgres:postgres@127.0.0.1:${config.pooler.port}/postgres`,
-          pooler_admin: `http://127.0.0.1:${config.pooler.apiPort}`,
-        }),
-  },
-});
+const stackInfoFor = (config: ResolvedStackConfig): StackInfo => {
+  const apiUrl = `http://127.0.0.1:${config.apiPort}`;
+  return {
+    url: apiUrl,
+    dbUrl: `postgresql://postgres:postgres@127.0.0.1:${config.dbPort}/postgres`,
+    publishableKey: config.publishableKey,
+    secretKey: config.secretKey,
+    anonJwt: config.anonJwt,
+    serviceRoleJwt: config.serviceRoleJwt,
+    serviceEndpoints: {
+      ...(config.auth === false ? {} : { auth: `${apiUrl}/auth/v1` }),
+      ...(config.postgrest === false ? {} : { postgrest: `${apiUrl}/rest/v1` }),
+      ...(config.edgeRuntime === false
+        ? {}
+        : {
+            functions: `${apiUrl}/functions/v1`,
+            edge_runtime: `${apiUrl}/functions/v1`,
+          }),
+      ...(config.realtime === false ? {} : { realtime: `${apiUrl}/realtime/v1` }),
+      ...(config.storage === false
+        ? {}
+        : {
+            storage: `${apiUrl}/storage/v1`,
+            storage_s3: `${apiUrl}/storage/v1/s3`,
+          }),
+      ...(config.imgproxy === false || config.startupMode === "lazy"
+        ? {}
+        : { imgproxy: `http://127.0.0.1:${config.imgproxy.port}` }),
+      ...(config.mailpit === false
+        ? {}
+        : {
+            mailpit: `http://127.0.0.1:${config.mailpit.port}`,
+            mailpit_smtp: `smtp://127.0.0.1:${config.mailpit.smtpPort}`,
+            mailpit_pop3: `pop3://127.0.0.1:${config.mailpit.pop3Port}`,
+          }),
+      ...(config.pgmeta === false ? {} : { pgmeta: `${apiUrl}/pg` }),
+      ...(config.studio === false ? {} : { studio: `http://127.0.0.1:${config.studio.port}` }),
+      ...(config.analytics === false ? {} : { analytics: `${apiUrl}/analytics/v1` }),
+      ...(config.pooler === false
+        ? {}
+        : {
+            pooler: `postgresql://postgres:postgres@127.0.0.1:${config.pooler.port}/postgres`,
+            pooler_admin: `http://127.0.0.1:${config.pooler.apiPort}`,
+          }),
+    },
+  };
+};
 
 const changedStatesBetween = (
   previous: ReadonlyArray<StackServiceState> | undefined,
@@ -139,12 +150,18 @@ export class StackLifecycleCoordinator extends Context.Service<
     readonly startService: (
       name: string,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
+    readonly activateService: (
+      name: ServiceName,
+    ) => Effect.Effect<
+      void,
+      ServiceNotFoundError | ServiceReadyError | StackBuildError | StackNotRunningError
+    >;
     readonly stopService: (
       name: string,
     ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
     readonly restartService: (
       name: string,
-    ) => Effect.Effect<void, ServiceNotFoundError | StackBuildError>;
+    ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
     readonly reloadFunctions: (
       opts?: FunctionsConfig,
     ) => Effect.Effect<void, ServiceNotFoundError | ServiceReadyError | StackBuildError>;
@@ -172,6 +189,7 @@ export class StackLifecycleCoordinator extends Context.Service<
 >()("stack/StackLifecycleCoordinator") {
   static layer = (
     config: ResolvedStackConfig,
+    portLease: PortLease,
   ): Layer.Layer<
     StackLifecycleCoordinator,
     StackBuildError,
@@ -194,8 +212,10 @@ export class StackLifecycleCoordinator extends Context.Service<
         const scope = yield* Effect.scope;
 
         const info = stackInfoFor(config);
+        const enabledServices = enabledServicesForConfig(config);
         const stateRef = yield* SubscriptionRef.make(initialPublicStates(config));
         const phaseRef = yield* Ref.make<LifecyclePhase>("idle");
+        const lifecycleLock = Semaphore.makeUnsafe(1);
 
         const logBufferServices = yield* Layer.buildWithScope(LogBuffer.layer, scope);
         const logBuffer = Context.get(logBufferServices, LogBuffer);
@@ -219,6 +239,17 @@ export class StackLifecycleCoordinator extends Context.Service<
               return yield* Effect.fail(new ServiceNotFoundError({ name }));
             }
             return match;
+          });
+        const requireKnownServiceName = (
+          name: string,
+        ): Effect.Effect<ServiceName, ServiceNotFoundError> =>
+          Effect.gen(function* () {
+            yield* requireKnownService(name);
+            const service = SERVICE_NAMES.find((candidate) => candidate === name);
+            if (service === undefined) {
+              return yield* Effect.fail(new ServiceNotFoundError({ name }));
+            }
+            return service;
           });
 
         let preparedArtifacts: PreparedStackArtifacts | undefined;
@@ -397,6 +428,7 @@ export class StackLifecycleCoordinator extends Context.Service<
 
             return {
               orchestrator,
+              graph,
               cleanupTargets,
             } satisfies RuntimeState;
           }).pipe(
@@ -484,7 +516,7 @@ export class StackLifecycleCoordinator extends Context.Service<
               },
             };
           });
-        const allStateChanges = () =>
+        const publicAllStateChanges = () =>
           SubscriptionRef.changes(stateRef).pipe(
             Stream.mapAccum<
               ReadonlyArray<StackServiceState> | undefined,
@@ -495,19 +527,112 @@ export class StackLifecycleCoordinator extends Context.Service<
               (previous, current) => [current, changedStatesBetween(previous, current)],
             ),
           );
+        const withLifecycleLock = lifecycleLock.withPermit;
+        const serviceStartOptions = {
+          beforeStart: (name: string) => portLease.reserve(portFieldsForService(name)),
+          beforeSpawn: (name: string) => portLease.release(portFieldsForService(name)),
+        };
+        const knownServiceError = (service: string, cause: ServiceNotFoundError) =>
+          new StackBuildError({
+            detail: `Prepared graph does not contain enabled service ${service}`,
+            cause,
+          });
+        const beginStartTargets = (
+          root: ServiceName,
+          allowExplicitlyStopped: ReadonlySet<ServiceName>,
+        ) =>
+          Effect.gen(function* () {
+            const runtime = yield* ensureRuntime;
+            const targets = activationTargetsForService(enabledServices, root);
+            const targetClosure = new Set(
+              targets.flatMap((target) =>
+                runtime.graph.startOrderFor(target).map((definition) => definition.name),
+              ),
+            );
+
+            for (const dependency of targetClosure) {
+              const state = yield* runtime.orchestrator
+                .getState(dependency)
+                .pipe(
+                  Effect.catchTag("ServiceNotFoundError", (cause) =>
+                    Effect.fail(knownServiceError(dependency, cause)),
+                  ),
+                );
+              const publicDependency = SERVICE_NAMES.find((candidate) => candidate === dependency);
+              if (
+                state.desired === "stopped" &&
+                publicDependency !== undefined &&
+                !allowExplicitlyStopped.has(publicDependency)
+              ) {
+                return yield* Effect.fail(
+                  new StackBuildError({
+                    detail: `Cannot activate ${root} because dependency ${dependency} was explicitly stopped`,
+                  }),
+                );
+              }
+            }
+
+            for (const target of targets) {
+              yield* runtime.orchestrator
+                .startService(target, serviceStartOptions)
+                .pipe(
+                  Effect.catchTag("ServiceNotFoundError", (cause) =>
+                    Effect.fail(knownServiceError(target, cause)),
+                  ),
+                );
+            }
+            return { runtime, targets };
+          });
+        const waitForTargets = ({
+          runtime,
+          targets,
+        }: {
+          readonly runtime: RuntimeState;
+          readonly targets: ReadonlyArray<ServiceName>;
+        }) =>
+          Effect.forEach(
+            targets,
+            (target) =>
+              runtime.orchestrator
+                .waitReady(target)
+                .pipe(
+                  Effect.catchTag("ServiceNotFoundError", (cause) =>
+                    Effect.fail(knownServiceError(target, cause)),
+                  ),
+                ),
+            { concurrency: "unbounded", discard: true },
+          );
+        const startTargets = (
+          root: ServiceName,
+          allowExplicitlyStopped: ReadonlySet<ServiceName>,
+        ) =>
+          Effect.gen(function* () {
+            const started = yield* beginStartTargets(root, allowExplicitlyStopped);
+            yield* waitForTargets(started);
+          });
+        const requireRunningPhase = Effect.gen(function* () {
+          const phase = yield* Ref.get(phaseRef);
+          if (phase !== "running") {
+            return yield* Effect.fail(new StackNotRunningError({ phase }));
+          }
+        });
         const disposeOnce = () =>
           Effect.gen(function* () {
             if (disposed) {
               return;
             }
             disposed = true;
+            yield* Ref.set(phaseRef, "stopping");
             yield* cleanupLocalStackResources({
               stop: () =>
                 runtimeState === undefined ? Effect.void : runtimeState.orchestrator.stop(),
               cleanupTargets: runtimeState?.cleanupTargets ?? { dockerContainerNames: [] },
               config,
-            });
-          });
+            }).pipe(
+              Effect.ensuring(portLease.releaseAll),
+              Effect.ensuring(Ref.set(phaseRef, "stopped")),
+            );
+          }).pipe(withLifecycleLock);
 
         yield* Effect.addFinalizer(disposeOnce);
 
@@ -520,10 +645,41 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* Ref.set(phaseRef, "starting");
               const runtime = yield* ensureRuntime;
               yield* configureFunctions(config);
-              yield* runtime.orchestrator.start();
-              yield* runtime.orchestrator.waitAllReady();
+
+              if (config.startupMode === "lazy") {
+                for (const service of eagerServices(enabledServices)) {
+                  yield* startTargets(
+                    service,
+                    new Set(lifecycleTargetsForService(enabledServices, service)),
+                  );
+                }
+                if (
+                  runtime.graph.startOrder.some((definition) => definition.name === "postgres-init")
+                ) {
+                  yield* runtime.orchestrator
+                    .startService("postgres-init", serviceStartOptions)
+                    .pipe(
+                      Effect.catchTag("ServiceNotFoundError", (cause) =>
+                        Effect.fail(knownServiceError("postgres-init", cause)),
+                      ),
+                    );
+                  yield* runtime.orchestrator
+                    .waitReady("postgres-init")
+                    .pipe(
+                      Effect.catchTag("ServiceNotFoundError", (cause) =>
+                        Effect.fail(knownServiceError("postgres-init", cause)),
+                      ),
+                    );
+                }
+              } else {
+                yield* runtime.orchestrator.start(serviceStartOptions);
+                yield* runtime.orchestrator.waitAllReady();
+              }
               yield* Ref.set(phaseRef, "running");
-            }),
+            }).pipe(
+              Effect.onError(() => Ref.set(phaseRef, "stopped")),
+              withLifecycleLock,
+            ),
           stop: () =>
             Effect.gen(function* () {
               if (runtimeState === undefined) {
@@ -533,35 +689,57 @@ export class StackLifecycleCoordinator extends Context.Service<
               yield* Ref.set(phaseRef, "stopping");
               yield* runtimeState.orchestrator.stop();
               yield* Ref.set(phaseRef, "stopped");
-            }),
+            }).pipe(withLifecycleLock),
           dispose: disposeOnce,
           startService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
-              const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.startService(name);
-              yield* runtime.orchestrator.waitReady(name);
+              const service = yield* requireKnownServiceName(name);
+              yield* startTargets(
+                service,
+                new Set(lifecycleTargetsForService(enabledServices, service)),
+              );
+            }).pipe(withLifecycleLock),
+          activateService: (name) =>
+            Effect.gen(function* () {
+              const started = yield* Effect.gen(function* () {
+                yield* requireRunningPhase;
+                const service = yield* requireKnownServiceName(name);
+                return yield* beginStartTargets(service, new Set());
+              }).pipe(withLifecycleLock);
+              yield* waitForTargets(started);
             }),
           stopService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
+              const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.stopService(name);
-            }),
+              for (const target of lifecycleTargetsForService(
+                enabledServices,
+                service,
+              ).toReversed()) {
+                yield* runtime.orchestrator.stopService(target);
+              }
+            }).pipe(withLifecycleLock),
           restartService: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
+              const service = yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
-              yield* runtime.orchestrator.restartService(name);
-            }),
+              yield* runtime.orchestrator.restartService(service, serviceStartOptions);
+              yield* runtime.orchestrator.waitReady(service);
+            }).pipe(withLifecycleLock),
           reloadFunctions: (opts) =>
             Effect.gen(function* () {
               yield* requireKnownService("edge-runtime");
-              const runtime = yield* ensureRuntime;
               yield* configureFunctions(configWithFunctionOptions(opts));
-              yield* runtime.orchestrator.restartService("edge-runtime");
-              yield* runtime.orchestrator.waitReady("edge-runtime");
-            }),
+              const runtime = yield* ensureRuntime;
+              const state = yield* runtime.orchestrator.getState("edge-runtime");
+              if (state.desired !== "running") {
+                yield* startTargets("edge-runtime", new Set(["edge-runtime"]));
+                return;
+              }
+              yield* runtime.orchestrator
+                .restartService("edge-runtime", serviceStartOptions)
+                .pipe(Effect.andThen(runtime.orchestrator.waitReady("edge-runtime")));
+            }).pipe(withLifecycleLock),
           reloadEdgeRuntime: (opts) =>
             Effect.gen(function* () {
               yield* requireKnownService("edge-runtime");
@@ -589,9 +767,15 @@ export class StackLifecycleCoordinator extends Context.Service<
                       }),
                   ),
                 );
-              yield* runtime.orchestrator.restartService("edge-runtime");
-              yield* runtime.orchestrator.waitReady("edge-runtime");
-            }),
+              const state = yield* runtime.orchestrator.getState("edge-runtime");
+              if (state.desired !== "running") {
+                yield* startTargets("edge-runtime", new Set(["edge-runtime"]));
+                return;
+              }
+              yield* runtime.orchestrator
+                .restartService("edge-runtime", serviceStartOptions)
+                .pipe(Effect.andThen(runtime.orchestrator.waitReady("edge-runtime")));
+            }).pipe(withLifecycleLock),
           getState: (name) =>
             Effect.gen(function* () {
               const currentStates = SubscriptionRef.getUnsafe(stateRef);
@@ -605,17 +789,33 @@ export class StackLifecycleCoordinator extends Context.Service<
           stateChanges: (name) =>
             Effect.gen(function* () {
               yield* requireKnownService(name);
-              return Stream.filter(allStateChanges(), (state) => state.name === name);
+              return Stream.filter(publicAllStateChanges(), (state) => state.name === name);
             }),
-          allStateChanges,
+          allStateChanges: publicAllStateChanges,
           waitReady: (name) =>
             Effect.gen(function* () {
-              yield* requireKnownService(name);
+              const phase = yield* Ref.get(phaseRef);
+              if (phase !== "running") {
+                return yield* Effect.fail(
+                  new StackBuildError({
+                    detail: `Cannot wait for service ${name} while the stack is ${phase}`,
+                  }),
+                );
+              }
+              yield* requireKnownServiceName(name);
               const runtime = yield* ensureRuntime;
               yield* runtime.orchestrator.waitReady(name);
             }),
           waitAllReady: () =>
             Effect.gen(function* () {
+              const phase = yield* Ref.get(phaseRef);
+              if (phase !== "running") {
+                return yield* Effect.fail(
+                  new StackBuildError({
+                    detail: `Cannot wait for stack readiness while the stack is ${phase}`,
+                  }),
+                );
+              }
               const runtime = yield* ensureRuntime;
               yield* runtime.orchestrator.waitAllReady();
             }),

--- a/packages/stack/src/StackServiceState.ts
+++ b/packages/stack/src/StackServiceState.ts
@@ -3,6 +3,7 @@ import type { ServiceState as RawServiceState } from "@supabase/process-compose"
 
 export const StackServiceStatusSchema = Schema.Union([
   Schema.Literal("Pending"),
+  Schema.Literal("Dormant"),
   Schema.Literal("Downloading"),
   Schema.Literal("Starting"),
   Schema.Literal("Running"),

--- a/packages/stack/src/StackStateProjection.ts
+++ b/packages/stack/src/StackStateProjection.ts
@@ -34,6 +34,10 @@ function projectPublicState(
   rawByName: ReadonlyMap<string, RawServiceState>,
   catalog: StackServiceProjectionCatalog,
 ): StackServiceState {
+  if (raw.desired === "inactive" && (raw.status === "Pending" || raw.status === "Stopped")) {
+    return new StackServiceState({ ...fromRawServiceState(raw), status: "Dormant" });
+  }
+
   const ownerHelpers = [...rawByName.values()].filter((candidate) => {
     const spec = catalog.get(candidate.name);
     return spec?.visibility === "internal" && spec.owner === raw.name;

--- a/packages/stack/src/StackStateProjection.unit.test.ts
+++ b/packages/stack/src/StackStateProjection.unit.test.ts
@@ -15,6 +15,7 @@ function rawState(name: string, status: ServiceState["status"], error: string | 
     restartCount: 0,
     startedAt: null,
     error,
+    desired: "running",
   });
 }
 

--- a/packages/stack/src/StateManager.integration.test.ts
+++ b/packages/stack/src/StateManager.integration.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { afterEach } from "vitest";
+import type { AllocatedPorts } from "./PortAllocator.ts";
+import {
+  StateClaimError,
+  StateManager,
+  singleStackStateManagerPaths,
+  type StackState,
+} from "./StateManager.ts";
+
+const tempRoots: string[] = [];
+
+const ports: AllocatedPorts = {
+  apiPort: 54321,
+  dbPort: 54322,
+  authPort: 54330,
+  postgrestPort: 54331,
+  postgrestAdminPort: 54332,
+  edgeRuntimePort: 54338,
+  edgeRuntimeInspectorPort: 54339,
+  realtimePort: 54333,
+  storagePort: 54334,
+  imgproxyPort: 54335,
+  mailpitPort: 54324,
+  mailpitSmtpPort: 54325,
+  mailpitPop3Port: 54326,
+  pgmetaPort: 54336,
+  studioPort: 54323,
+  analyticsPort: 54327,
+  poolerPort: 54329,
+  poolerApiPort: 54337,
+};
+
+const state = (pid: number): StackState => ({
+  pid,
+  name: "claim-test",
+  projectDir: "/project",
+  apiPort: ports.apiPort,
+  dbPort: ports.dbPort,
+  ports,
+  socketPath: "/runtime/daemon.sock",
+  startedAt: "2026-08-04T00:00:00.000Z",
+  url: "http://127.0.0.1:54321",
+  dbUrl: "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+  publishableKey: "publishable",
+  secretKey: "secret",
+  anonJwt: "anon",
+  serviceRoleJwt: "service-role",
+  serviceEndpoints: {},
+  services: {},
+});
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("StateManager claim", () => {
+  it.live("allows exactly one daemon generation to publish state", () => {
+    const root = mkdtempSync(join(tmpdir(), "stack-state-claim-"));
+    tempRoots.push(root);
+    const stackRoot = join(root, "stacks", "claim-test");
+    const layer = StateManager.make(
+      singleStackStateManagerPaths(stackRoot, join(root, "runtime"), "claim-test"),
+    ).pipe(Layer.provide(NodeServices.layer));
+
+    return Effect.gen(function* () {
+      const manager = yield* StateManager;
+      yield* manager.claim(state(100));
+
+      const error = yield* manager.claim(state(200)).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(StateClaimError);
+      expect((yield* manager.read("claim-test")).pid).toBe(100);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -1,7 +1,9 @@
 import { Data, Effect, Layer, Schema, Context } from "effect";
 import { FileSystem, Path } from "effect";
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
+import { link, unlink, writeFile } from "node:fs/promises";
 import { AllocatedPortsSchema, type AllocatedPorts } from "./PortAllocator.ts";
 import {
   PartialVersionManifestSchema,
@@ -14,7 +16,6 @@ import {
   defaultManagedProjectsRoot,
   defaultManagedProjectStacksRoot,
   defaultManagedRuntimeRoot,
-  socketPathForRuntimeRoot,
 } from "./paths.ts";
 import { basename, dirname, join } from "node:path";
 
@@ -41,7 +42,7 @@ export interface StackState {
   readonly services: PartialVersionManifest;
 }
 
-const StackStateSchema = Schema.Struct({
+export const StackStateSchema = Schema.Struct({
   pid: Schema.Number,
   name: Schema.String,
   projectDir: Schema.String,
@@ -125,6 +126,11 @@ export class StackAlreadyRunningError extends Data.TaggedError("StackAlreadyRunn
   readonly name: string;
   readonly pid: number;
   readonly message: string;
+}> {}
+
+export class StateClaimError extends Data.TaggedError("StateClaimError")<{
+  readonly name: string;
+  readonly path: string;
 }> {}
 
 interface StateManagerPaths {
@@ -331,6 +337,31 @@ function makeWrite(deps: StateManagerDeps) {
     }).pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
 }
 
+function makeClaim(deps: StateManagerDeps) {
+  return (state: StackState): Effect.Effect<void, StateClaimError> =>
+    Effect.gen(function* () {
+      const dir = deps.stackDir(state.name);
+      yield* deps.fs.makeDirectory(dir, { recursive: true });
+      const statePath = deps.stateFile(state.name);
+      const temporaryPath = `${statePath}.claim-${process.pid}-${randomUUID()}`;
+      yield* Effect.tryPromise({
+        try: async () => {
+          await writeFile(temporaryPath, encodePrettyJson(encodeStackState(state)), { flag: "wx" });
+          try {
+            await link(temporaryPath, statePath);
+          } finally {
+            await unlink(temporaryPath).catch(() => undefined);
+          }
+        },
+        catch: () => new StateClaimError({ name: state.name, path: statePath }),
+      });
+    }).pipe(
+      Effect.catchTag("PlatformError", () =>
+        Effect.fail(new StateClaimError({ name: state.name, path: deps.stateFile(state.name) })),
+      ),
+    );
+}
+
 function makeRead(deps: StateManagerDeps) {
   return (name: string): Effect.Effect<StackState, StateNotFoundError | InvalidStackStateError> =>
     Effect.gen(function* () {
@@ -441,6 +472,11 @@ function makeScanMetadata(deps: StateManagerDeps) {
 }
 
 function makeRemove(deps: StateManagerDeps) {
+  const remove = makeRemoveUnlocked(deps);
+  return (name: string): Effect.Effect<void> => remove(name);
+}
+
+function makeRemoveUnlocked(deps: StateManagerDeps) {
   return (name: string): Effect.Effect<void> =>
     Effect.gen(function* () {
       yield* deps.fs.remove(deps.stateFile(name)).pipe(Effect.ignore);
@@ -448,10 +484,7 @@ function makeRemove(deps: StateManagerDeps) {
 
       const dir = deps.stackDir(name);
       const exists = yield* deps.fs.exists(dir);
-      if (!exists) {
-        return;
-      }
-
+      if (!exists) return;
       const entries = yield* deps.fs.readDirectory(dir);
       if (entries.length === 0) {
         yield* deps.fs.remove(dir, { recursive: true }).pipe(Effect.ignore);
@@ -591,10 +624,10 @@ export class StateManager extends Context.Service<
     readonly stackDir: (name: string) => string;
     readonly dataDir: (name: string) => string;
     readonly runtimeDir: (name: string) => string;
-    readonly socketPath: (name: string) => string;
     readonly metadataFile: (name: string) => string;
     readonly stackExists: (name: string) => Effect.Effect<boolean>;
     readonly write: (state: StackState) => Effect.Effect<void>;
+    readonly claim: (state: StackState) => Effect.Effect<void, StateClaimError>;
     readonly read: (
       name: string,
     ) => Effect.Effect<StackState, StateNotFoundError | InvalidStackStateError>;
@@ -638,7 +671,6 @@ export class StateManager extends Context.Service<
         const stackDir = (name: string) => stackDirForName(name);
         const dataDir = (name: string) => path.join(stackDir(name), "data");
         const runtimeDir = (name: string) => paths.runtimeDirForStack(name);
-        const socketPath = (name: string) => socketPathForRuntimeRoot(runtimeDir(name));
         const stateFile = (name: string) => path.join(stackDir(name), "state.json");
         const metadataFile = (name: string) => path.join(stackDir(name), "stack.json");
 
@@ -650,6 +682,8 @@ export class StateManager extends Context.Service<
           metadataFile,
           runtimeDir,
         };
+        const read = makeRead(deps);
+        const remove = makeRemove(deps);
         const scan = makeScan(deps);
         const writeMetadata = makeWriteMetadata(deps);
         const readMetadata = makeReadMetadata(deps);
@@ -658,17 +692,17 @@ export class StateManager extends Context.Service<
           stackDir,
           dataDir,
           runtimeDir,
-          socketPath,
           metadataFile,
           stackExists: makeStackExists(deps),
           write: makeWrite(deps),
-          read: makeRead(deps),
+          claim: makeClaim(deps),
+          read,
           scan,
           writeMetadata,
           updateMetadata: makeUpdateMetadata(readMetadata, writeMetadata),
           readMetadata,
           scanMetadata: makeScanMetadata(deps),
-          remove: makeRemove(deps),
+          remove,
           deleteStack: makeDeleteStack(deps),
           resolve: makeResolve(path, scan),
           isAlive: makeIsAlive(),
@@ -677,5 +711,3 @@ export class StateManager extends Context.Service<
     );
   }
 }
-
-export type StateManagerService = typeof StateManager.Service;

--- a/packages/stack/src/StateManager.unit.test.ts
+++ b/packages/stack/src/StateManager.unit.test.ts
@@ -170,7 +170,6 @@ describe("StateManager", () => {
         expect(mgr.stackDir("my-project")).toBe("/persist/stacks/my-project");
         expect(mgr.dataDir("my-project")).toBe("/persist/stacks/my-project/data");
         expect(mgr.runtimeDir("my-project")).toBe("/tmp/supabase/custom");
-        expect(mgr.socketPath("my-project")).toBe("/tmp/supabase/custom/daemon.sock");
       }).pipe(Effect.provide(layer));
     });
   });

--- a/packages/stack/src/bun.ts
+++ b/packages/stack/src/bun.ts
@@ -42,8 +42,11 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
 // ---------------------------------------------------------------------------
 
 /** Bun platform factory for use with foregroundLayer / daemonLayer. */
-export const platformFactory: PlatformFactory = (apiPort) =>
-  Layer.mergeAll(BunServices.layer, BunHttpServer.layer({ port: apiPort }));
+export const platformFactory: PlatformFactory = ({ apiPort, releaseApiPort }) =>
+  Layer.mergeAll(
+    BunServices.layer,
+    Layer.unwrap(releaseApiPort.pipe(Effect.as(BunHttpServer.layer({ port: apiPort })))),
+  );
 
 /** Path to the Bun daemon entry point for use with daemonLayer. */
 export const daemonEntryPoint: string = fileURLToPath(new URL("./daemon-bun.ts", import.meta.url));

--- a/packages/stack/src/createStack.ts
+++ b/packages/stack/src/createStack.ts
@@ -30,7 +30,18 @@ import {
   defaultManagedStackRoot,
   shortTempPrefixRoot,
 } from "./paths.ts";
-import { allocatePorts, DEFAULT_PORTS, PORT_FIELDS, type AllocatedPorts } from "./PortAllocator.ts";
+import {
+  allocatePorts,
+  DEFAULT_PORTS,
+  PORT_FIELDS,
+  reservePorts,
+  type AllocatedPorts,
+  type PortInput,
+  type PortAllocationError,
+  type PortLease,
+  type PortSelectionOptions,
+} from "./PortAllocator.ts";
+import { allocatedPortFieldsForConfig } from "./ServicePorts.ts";
 import { StackMetadataSchema } from "./StackMetadata.ts";
 import { InvalidStackStateError, StackAlreadyRunningError } from "./StateManager.ts";
 import { Stack } from "./Stack.ts";
@@ -77,7 +88,13 @@ export type PlatformServices =
   | HttpServer.HttpServer;
 
 export type PlatformLayer = Layer.Layer<PlatformServices>;
-export type PlatformFactory = (apiPort: number) => PlatformLayer;
+/** Supplies the platform HTTP server used by the stack and HTTP proxy. */
+export interface PlatformFactoryOptions {
+  readonly apiPort: number;
+  readonly releaseApiPort: Effect.Effect<void>;
+}
+
+export type PlatformFactory = (options: PlatformFactoryOptions) => PlatformLayer;
 
 export interface ReadyOptions {
   readonly timeout?: number;
@@ -115,6 +132,10 @@ interface ResolveConfigOptions {
   readonly runtimeRoot?: string;
   readonly preferredPorts?: Partial<AllocatedPorts>;
   readonly reservedPorts?: ReadonlySet<number>;
+  readonly portAllocator?: (
+    input: PortInput,
+    options: PortSelectionOptions,
+  ) => Effect.Effect<AllocatedPorts, PortAllocationError>;
 }
 
 interface ResolvedRoots {
@@ -505,7 +526,7 @@ export async function resolveConfig(
   const postgresDataDir = resolveDataDir(postgresInput.dataDir, roots.stackRoot, "postgres");
 
   const ports = await Effect.runPromise(
-    allocatePorts(
+    (opts.portAllocator ?? allocatePorts)(
       {
         apiPort: config.port,
         dbPort: postgresInput.port,
@@ -545,6 +566,7 @@ export async function resolveConfig(
     runtimeRoot: roots.runtimeRoot,
     projectDir,
     mode: resolvedMode,
+    startupMode: config.startupMode ?? "eager",
     jwtSecret,
     ports,
     apiPort: ports.apiPort,
@@ -591,13 +613,16 @@ export async function resolveConfig(
   };
 }
 
+export type DaemonConfigInput = StackConfig & {
+  readonly cwd: string;
+  readonly name?: string;
+  readonly projectDir?: string;
+  readonly projectStateRoot?: string;
+};
+
 export async function resolveDaemonConfig(
-  input: StackConfig & {
-    readonly cwd: string;
-    readonly name?: string;
-    readonly projectDir?: string;
-    readonly projectStateRoot?: string;
-  },
+  input: DaemonConfigInput,
+  opts: Pick<ResolveConfigOptions, "portAllocator"> = {},
 ): Promise<DaemonConfig> {
   const { cwd, name, projectDir, projectStateRoot, ...stackConfig } = input;
   if (stackConfig.stackRoot !== undefined || stackConfig.runtimeRoot !== undefined) {
@@ -637,6 +662,7 @@ export async function resolveDaemonConfig(
       runtimeRoot,
       preferredPorts: savedPorts ?? DEFAULT_PORTS,
       reservedPorts,
+      portAllocator: opts.portAllocator,
     },
   );
   return {
@@ -659,19 +685,17 @@ export const projectDaemonLayer = (opts: {
   DaemonStartError | InvalidStackStateError | StackAlreadyRunningError,
   FileSystem.FileSystem | Path.Path | UnixHttpClient
 > =>
-  Effect.gen(function* () {
-    const config = yield* Effect.promise(() =>
-      resolveDaemonConfig({
-        cacheRoot: opts.cacheRoot,
-        cwd: opts.cwd,
-        projectDir: opts.projectDir,
-        projectStateRoot: opts.projectStateRoot,
-        name: opts.name,
-        ...opts.stackConfig,
-      }),
-    );
-    return yield* daemonLayer(config, opts.daemonEntryPoint);
-  });
+  daemonLayer(
+    {
+      cacheRoot: opts.cacheRoot,
+      cwd: opts.cwd,
+      projectDir: opts.projectDir,
+      projectStateRoot: opts.projectStateRoot,
+      name: opts.name,
+      ...opts.stackConfig,
+    },
+    opts.daemonEntryPoint,
+  );
 
 function possibleCleanupTargetsForConfig(config: ResolvedStackConfig): CleanupTargets {
   const dockerContainerNames = [`supabase-postgres-${config.apiPort}`];
@@ -695,67 +719,100 @@ export async function createStack(
   config: StackConfig | undefined,
   platformFactory: PlatformFactory,
 ): Promise<StackHandle> {
-  const resolved = await resolveConfig(config);
-  const fullLayer = foregroundLayer(resolved, platformFactory);
-  const runtime = ManagedRuntime.make(fullLayer);
+  let portLease: PortLease | undefined;
+  let resolved: ResolvedStackConfig;
+  try {
+    resolved = await resolveConfig(config, {
+      portAllocator: (input, options) =>
+        reservePorts(input, options).pipe(
+          Effect.tap((lease) =>
+            Effect.sync(() => {
+              portLease = lease;
+            }),
+          ),
+          Effect.map((lease) => lease.ports),
+        ),
+    });
+  } catch (error: unknown) {
+    if (portLease !== undefined) {
+      await Effect.runPromise(portLease.releaseAll);
+    }
+    throw error;
+  }
+
+  if (portLease === undefined) {
+    throw new Error("Stack port allocation completed without a port lease");
+  }
+
+  const activeFields = new Set(allocatedPortFieldsForConfig(resolved));
+  const unusedFields = PORT_FIELDS.filter((field) => !activeFields.has(field));
+  await Effect.runPromise(portLease.release(unusedFields));
 
   try {
-    const services = await runtime.context();
-    const localStack = await runtime.runPromise(
-      Effect.gen(function* () {
-        return yield* Stack;
-      }),
-    );
-    const info = await runtime.runPromise(localStack.getInfo());
+    const fullLayer = foregroundLayer(resolved, platformFactory, portLease);
+    const runtime = ManagedRuntime.make(fullLayer);
 
-    const run = <A>(effect: Effect.Effect<A, unknown>) =>
-      runtime.runPromise(effect).catch((error: unknown) => {
-        throw toStackError(error);
-      });
+    try {
+      const services = await runtime.context();
+      const localStack = await runtime.runPromise(
+        Effect.gen(function* () {
+          return yield* Stack;
+        }),
+      );
+      const info = await runtime.runPromise(localStack.getInfo());
 
-    const gracefulDispose = async () => {
+      const run = <A>(effect: Effect.Effect<A, unknown>) =>
+        runtime.runPromise(effect).catch((error: unknown) => {
+          throw toStackError(error);
+        });
+
+      const gracefulDispose = async () => {
+        await runtime.dispose().catch(() => {});
+      };
+
+      const stack: StackHandle = {
+        url: info.url,
+        dbUrl: info.dbUrl,
+        publishableKey: info.publishableKey,
+        secretKey: info.secretKey,
+        start: () => run(localStack.start()),
+        stop: () => run(localStack.stop()),
+        dispose: gracefulDispose,
+        startService: (name) => run(localStack.startService(name)),
+        stopService: (name) => run(localStack.stopService(name)),
+        restartService: (name) => run(localStack.restartService(name)),
+        reloadFunctions: (opts) => run(localStack.reloadFunctions(opts)),
+        reloadEdgeRuntime: (opts) => run(localStack.reloadEdgeRuntime(opts)),
+        ready: (opts) => {
+          const effect =
+            opts?.timeout != null
+              ? localStack.waitAllReady().pipe(Effect.timeout(Duration.millis(opts.timeout)))
+              : localStack.waitAllReady();
+          return run(effect);
+        },
+        serviceReady: (name, opts) => {
+          const effect =
+            opts?.timeout != null
+              ? localStack.waitReady(name).pipe(Effect.timeout(Duration.millis(opts.timeout)))
+              : localStack.waitReady(name);
+          return run(effect);
+        },
+        getStatus: () => run(localStack.getAllStates()),
+        getServiceStatus: (name) => run(localStack.getState(name)),
+        statusChanges: () => Stream.toAsyncIterableWith(localStack.allStateChanges(), services),
+        logs: () => Stream.toAsyncIterableWith(localStack.subscribeAllLogs(), services),
+        serviceLogs: (name) => Stream.toAsyncIterableWith(localStack.subscribeLogs(name), services),
+        logHistory: (name, limit) => run(localStack.logHistory(name, limit)),
+        [Symbol.asyncDispose]: gracefulDispose,
+      };
+
+      return stack;
+    } catch (error: unknown) {
       await runtime.dispose().catch(() => {});
-    };
-
-    const stack: StackHandle = {
-      url: info.url,
-      dbUrl: info.dbUrl,
-      publishableKey: info.publishableKey,
-      secretKey: info.secretKey,
-      start: () => run(localStack.start()),
-      stop: () => run(localStack.stop()),
-      dispose: gracefulDispose,
-      startService: (name) => run(localStack.startService(name)),
-      stopService: (name) => run(localStack.stopService(name)),
-      restartService: (name) => run(localStack.restartService(name)),
-      reloadFunctions: (opts) => run(localStack.reloadFunctions(opts)),
-      reloadEdgeRuntime: (opts) => run(localStack.reloadEdgeRuntime(opts)),
-      ready: (opts) => {
-        const effect =
-          opts?.timeout != null
-            ? localStack.waitAllReady().pipe(Effect.timeout(Duration.millis(opts.timeout)))
-            : localStack.waitAllReady();
-        return run(effect);
-      },
-      serviceReady: (name, opts) => {
-        const effect =
-          opts?.timeout != null
-            ? localStack.waitReady(name).pipe(Effect.timeout(Duration.millis(opts.timeout)))
-            : localStack.waitReady(name);
-        return run(effect);
-      },
-      getStatus: () => run(localStack.getAllStates()),
-      getServiceStatus: (name) => run(localStack.getState(name)),
-      statusChanges: () => Stream.toAsyncIterableWith(localStack.allStateChanges(), services),
-      logs: () => Stream.toAsyncIterableWith(localStack.subscribeAllLogs(), services),
-      serviceLogs: (name) => Stream.toAsyncIterableWith(localStack.subscribeLogs(name), services),
-      logHistory: (name, limit) => run(localStack.logHistory(name, limit)),
-      [Symbol.asyncDispose]: gracefulDispose,
-    };
-
-    return stack;
+      throw error;
+    }
   } catch (error: unknown) {
-    await runtime.dispose().catch(() => {});
+    await Effect.runPromise(portLease.releaseAll);
     dockerForceRemove(possibleCleanupTargetsForConfig(resolved).dockerContainerNames);
     cleanupAutoManagedPaths(resolved);
     throw toStackError(error);

--- a/packages/stack/src/createStack.unit.test.ts
+++ b/packages/stack/src/createStack.unit.test.ts
@@ -83,6 +83,7 @@ describe("createStack types", () => {
   it("StackConfig interface has expected shape", () => {
     const check = (_config: StackConfig) => {
       const _jwtSecret: string | undefined = _config.jwtSecret;
+      const _startupMode: "eager" | "lazy" | undefined = _config.startupMode;
       const _projectDir: string | undefined = _config.projectDir;
       const _functions = _config.functions;
       const _postgres: PostgresConfig | undefined = _config.postgres;
@@ -92,6 +93,7 @@ describe("createStack types", () => {
       const _publishableKey: string | undefined = _config.publishableKey;
       const _secretKey: string | undefined = _config.secretKey;
       void _jwtSecret;
+      void _startupMode;
       void _projectDir;
       void _functions;
       void _postgres;
@@ -235,5 +237,17 @@ describe("resolveConfig edge runtime defaults", () => {
         version: DEFAULT_VERSIONS["edge-runtime"],
       }),
     );
+  });
+});
+
+describe("resolveConfig startup mode", () => {
+  it("keeps eager startup as the package default", async () => {
+    const config = await resolveConfig();
+    expect(config.startupMode).toBe("eager");
+  });
+
+  it("preserves an explicit lazy startup mode", async () => {
+    const config = await resolveConfig({ startupMode: "lazy" });
+    expect(config.startupMode).toBe("lazy");
   });
 });

--- a/packages/stack/src/daemon-bun.ts
+++ b/packages/stack/src/daemon-bun.ts
@@ -1,11 +1,15 @@
 import { BunServices } from "@effect/platform-bun";
 import * as BunHttpServer from "@effect/platform-bun/BunHttpServer";
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import { runDaemon } from "./daemon.ts";
 
 export function runBunDaemon(): void {
   runDaemon(
-    (apiPort) => Layer.mergeAll(BunServices.layer, BunHttpServer.layer({ port: apiPort })),
+    ({ apiPort, releaseApiPort }) =>
+      Layer.mergeAll(
+        BunServices.layer,
+        Layer.unwrap(releaseApiPort.pipe(Effect.as(BunHttpServer.layer({ port: apiPort })))),
+      ),
     (socketPath) => BunHttpServer.layer({ idleTimeout: 0, unix: socketPath }),
   );
 }

--- a/packages/stack/src/daemon-node.ts
+++ b/packages/stack/src/daemon-node.ts
@@ -1,14 +1,20 @@
 import { NodeServices } from "@effect/platform-node";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { createServer } from "node:http";
-import { Layer } from "effect";
+import { Effect, Layer } from "effect";
 import { runDaemon } from "./daemon.ts";
 
 runDaemon(
-  (apiPort) =>
+  ({ apiPort, releaseApiPort }) =>
     Layer.mergeAll(
       NodeServices.layer,
-      NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+      Layer.unwrap(
+        releaseApiPort.pipe(
+          Effect.as(
+            NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+          ),
+        ),
+      ),
     ),
   (socketPath) =>
     NodeHttpServer.layer(() => createServer(), { path: socketPath }).pipe(Layer.orDie),

--- a/packages/stack/src/daemon.ts
+++ b/packages/stack/src/daemon.ts
@@ -1,12 +1,17 @@
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { HttpServer } from "effect/unstable/http";
-import type { PlatformFactory } from "./createStack.ts";
+import {
+  resolveDaemonConfig,
+  type DaemonConfigInput,
+  type PlatformFactory,
+} from "./createStack.ts";
 import { DaemonServer } from "./DaemonServer.ts";
+import { PORT_FIELDS, reservePorts, type PortLease } from "./PortAllocator.ts";
+import { allocatedPortFieldsForConfig } from "./ServicePorts.ts";
 import { runningServiceVersionsForConfig } from "./StackMetadata.ts";
 import { foregroundDaemonLayer } from "./layers.ts";
 import { Stack } from "./Stack.ts";
-import type { ResolvedStackConfig } from "./StackBuilder.ts";
-import { StateManager, type StackState, type StateManagerService } from "./StateManager.ts";
+import { StateManager, type StackState } from "./StateManager.ts";
 
 /** Factory for creating the daemon's Unix socket HTTP server (platform-specific). */
 export type DaemonHttpServerFactory = (socketPath: string) => Layer.Layer<HttpServer.HttpServer>;
@@ -17,9 +22,7 @@ export type DaemonHttpServerFactory = (socketPath: string) => Layer.Layer<HttpSe
 
 export interface DaemonStartMessage {
   readonly type: "start";
-  readonly config: ResolvedStackConfig;
-  readonly name: string;
-  readonly projectDir: string;
+  readonly config: DaemonConfigInput;
   readonly socketPath: string;
 }
 
@@ -44,39 +47,56 @@ export async function runDaemon(
   daemonServerFactory: DaemonHttpServerFactory,
 ): Promise<void> {
   const msg = await waitForMessage<DaemonStartMessage>();
-  const { config, name, projectDir, socketPath } = msg;
+  const { socketPath } = msg;
 
   let appRuntime: ManagedRuntime.ManagedRuntime<Stack | StateManager, never> | undefined;
   let daemonRuntime: ManagedRuntime.ManagedRuntime<DaemonServer, never> | undefined;
-  let stateManager: StateManagerService | undefined;
-  let daemonState: StackState | undefined;
+  let portLease: PortLease | undefined;
 
   try {
+    const config = await resolveDaemonConfig(msg.config, {
+      portAllocator: (input, options) =>
+        reservePorts(input, options).pipe(
+          Effect.tap((lease) =>
+            Effect.sync(() => {
+              portLease = lease;
+            }),
+          ),
+          Effect.map((lease) => lease.ports),
+        ),
+    });
+    if (portLease === undefined) {
+      throw new Error("Daemon port allocation completed without a port lease");
+    }
+    const activeFields = new Set(allocatedPortFieldsForConfig(config));
+    await Effect.runPromise(
+      portLease.release(PORT_FIELDS.filter((field) => !activeFields.has(field))),
+    );
+
     // Build the app layer (Stack + ApiProxy)
-    const appLayer = foregroundDaemonLayer({ ...config, name, projectDir }, platformFactory);
+    const appLayer = foregroundDaemonLayer(config, platformFactory, portLease);
 
     appRuntime = ManagedRuntime.make(appLayer);
 
     // Build the stack (services are started later via POST /start)
     const localStack = await appRuntime.runPromise(Stack);
     const info = await appRuntime.runPromise(localStack.getInfo());
-    stateManager = await appRuntime.runPromise(StateManager);
+    const localStateManager = await appRuntime.runPromise(StateManager);
 
     // Build daemon management server on Unix socket
     const daemonLayer = DaemonServer.layer.pipe(
       Layer.provide(Layer.succeed(Stack, localStack)),
       Layer.provide(daemonServerFactory(socketPath)),
-    ) as unknown as Layer.Layer<DaemonServer, never, never>;
+    );
 
     daemonRuntime = ManagedRuntime.make(daemonLayer);
     await daemonRuntime.runPromise(DaemonServer);
 
-    // Build state and signal success to parent.
-    // The parent (CLI) is responsible for writing the state file via StateManager.
+    // Claim live state before acknowledging startup to the parent.
     const state: StackState = {
       pid: process.pid,
-      name,
-      projectDir,
+      name: config.name,
+      projectDir: config.projectDir,
       apiPort: config.apiPort,
       dbPort: config.dbPort,
       ports: config.ports,
@@ -91,8 +111,7 @@ export async function runDaemon(
       serviceEndpoints: info.serviceEndpoints,
       services: runningServiceVersionsForConfig(config),
     };
-    daemonState = state;
-    await Effect.runPromise(stateManager.write(state));
+    await Effect.runPromise(localStateManager.claim(state));
 
     const response: DaemonStartedMessage = { type: "started", state };
     process.send!(response);
@@ -100,7 +119,7 @@ export async function runDaemon(
 
     const daemon = await daemonRuntime.runPromise(DaemonServer);
     await Promise.race([daemonRuntime.runPromise(daemon.awaitShutdown), waitForSignal()]);
-    await shutdownDaemon({ appRuntime, daemonRuntime, stateManager, daemonState });
+    await shutdownDaemon({ appRuntime, daemonRuntime });
     process.exit(0);
   } catch (err) {
     const errorMsg: DaemonErrorMessage = {
@@ -108,7 +127,10 @@ export async function runDaemon(
       message: err instanceof Error ? err.message : String(err),
     };
     process.send?.(errorMsg);
-    await shutdownDaemon({ appRuntime, daemonRuntime, stateManager, daemonState });
+    await shutdownDaemon({ appRuntime, daemonRuntime });
+    if (portLease !== undefined) {
+      await Effect.runPromise(portLease.releaseAll);
+    }
     process.exit(1);
   }
 }
@@ -142,13 +164,7 @@ function waitForSignal(): Promise<"SIGINT" | "SIGTERM"> {
 async function shutdownDaemon(opts: {
   readonly appRuntime?: ManagedRuntime.ManagedRuntime<Stack, never>;
   readonly daemonRuntime?: ManagedRuntime.ManagedRuntime<DaemonServer, never>;
-  readonly stateManager?: StateManagerService;
-  readonly daemonState?: StackState;
 }): Promise<void> {
   await opts.daemonRuntime?.dispose().catch(() => {});
   await opts.appRuntime?.dispose().catch(() => {});
-
-  if (opts.stateManager != null && opts.daemonState != null) {
-    await Effect.runPromise(opts.stateManager.remove(opts.daemonState.name)).catch(() => {});
-  }
 }

--- a/packages/stack/src/discovery.ts
+++ b/packages/stack/src/discovery.ts
@@ -153,8 +153,8 @@ export const resolveStackSummary = (opts: {
 /**
  * Stop a running daemon by name or working directory.
  * Sends POST /stop to the daemon's Unix socket and waits for it to exit.
- * The daemon owns its own state cleanup; this function only removes stale
- * state after confirming the process is no longer alive.
+ * Removes the live-state pointer only after confirming the process is no
+ * longer alive. Durable stack metadata is retained.
  */
 export const stopDaemon = (opts: {
   name?: string;
@@ -187,6 +187,7 @@ export const stopDaemon = (opts: {
         ),
         Effect.ignore,
       );
+      yield* stateManager.remove(state.name);
       return;
     }
 
@@ -211,7 +212,6 @@ export const stopDaemon = (opts: {
       return yield* new DaemonStillRunningError({ name: state.name, pid: state.pid });
     }
 
-    // Clean up any state the daemon did not remove for itself.
     yield* stateManager.remove(state.name);
   });
 

--- a/packages/stack/src/effect.ts
+++ b/packages/stack/src/effect.ts
@@ -41,17 +41,24 @@ export {
   JwtGenerator,
 } from "./JwtGenerator.ts";
 
-export type { AllocatedPorts, PortInput } from "./PortAllocator.ts";
+export type {
+  AllocatedPorts,
+  PortField,
+  PortInput,
+  PortLease,
+  PortSelectionOptions,
+} from "./PortAllocator.ts";
 export {
   allocatePorts,
   DEFAULT_API_PORT,
   DEFAULT_DB_PORT,
   PortAllocationError,
+  reserveAllocatedPorts,
+  reservePorts,
 } from "./PortAllocator.ts";
 
 export type { ProxyConfig } from "./ApiProxy.ts";
 export { ApiProxy } from "./ApiProxy.ts";
-
 export type {
   AnalyticsConfig,
   AuthConfig,
@@ -154,6 +161,7 @@ export { UnixHttpClient, UnixHttpClientError } from "./UnixHttpClient.ts";
 
 export type {
   PlatformFactory,
+  PlatformFactoryOptions,
   PlatformLayer,
   PlatformServices,
   ReadyOptions,

--- a/packages/stack/src/errors.ts
+++ b/packages/stack/src/errors.ts
@@ -27,6 +27,10 @@ export class StackBuildError extends Data.TaggedError("StackBuildError")<{
   readonly cause?: unknown;
 }> {}
 
+export class StackNotRunningError extends Data.TaggedError("StackNotRunningError")<{
+  readonly phase: string;
+}> {}
+
 export class PortConflictError extends Data.TaggedError("PortConflictError")<{
   readonly port: number;
   readonly service: string;
@@ -58,6 +62,12 @@ export function toStackError(err: unknown): StackError {
       case "StackBuildError":
         return new StackError({
           code: "BUILD_ERROR",
+          message: taggedMessage,
+          cause: err,
+        });
+      case "StackNotRunningError":
+        return new StackError({
+          code: "STACK_NOT_RUNNING",
           message: taggedMessage,
           cause: err,
         });

--- a/packages/stack/src/layers.ts
+++ b/packages/stack/src/layers.ts
@@ -1,12 +1,17 @@
 import { fork, type ChildProcess } from "node:child_process";
-import { Data, Effect, Layer, Option } from "effect";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { Data, Effect, Fiber, Layer, Option, Schema } from "effect";
 import { FileSystem, Path } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { ApiProxy, type ProxyConfig } from "./ApiProxy.ts";
 import { BinaryResolver } from "./BinaryResolver.ts";
-import type { PlatformFactory } from "./createStack.ts";
+import type { DaemonConfigInput, PlatformFactory } from "./createStack.ts";
 import type { DaemonMessage, DaemonStartMessage } from "./daemon.ts";
+import { DaemonMessageSchema } from "./DaemonProtocol.ts";
+import type { PortLease } from "./PortAllocator.ts";
 import { RemoteStack } from "./RemoteStack.ts";
+import { StackServiceActivator } from "./ServiceActivation.ts";
 import { Stack } from "./Stack.ts";
 import { StackLifecycleCoordinator } from "./StackLifecycleCoordinator.ts";
 import { StackMetadataPersistence } from "./StackMetadataPersistence.ts";
@@ -17,11 +22,16 @@ import {
   StackAlreadyRunningError,
   StateManager,
   singleStackStateManagerPaths,
-  type StateManagerService,
 } from "./StateManager.ts";
 import { StackBuilder, type ResolvedStackConfig } from "./StackBuilder.ts";
 import { UnixHttpClient } from "./UnixHttpClient.ts";
 import { resolveManagedStack } from "./managed-stack.ts";
+import {
+  DEFAULT_MANAGED_STACK_NAME,
+  defaultCacheRoot,
+  defaultManagedRuntimeRoot,
+  defaultManagedStackRoot,
+} from "./paths.ts";
 import { terminateChildProcess } from "./terminateChild.ts";
 
 /**
@@ -33,19 +43,29 @@ import { terminateChildProcess } from "./terminateChild.ts";
 export const foregroundLayer = (
   config: ResolvedStackConfig,
   platformFactory: PlatformFactory,
+  portLease: PortLease,
 ): Layer.Layer<Stack> => {
-  const platform = platformFactory(config.apiPort);
+  const platform = platformFactory({
+    apiPort: config.apiPort,
+    releaseApiPort: portLease.release(["apiPort"]),
+  });
 
   const binaryResolverLayer = BinaryResolver.make(config.cacheRoot).pipe(
     Layer.provide(FetchHttpClient.layer),
   );
   const stackPreparationLayer = StackPreparation.layer.pipe(Layer.provide(binaryResolverLayer));
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(StackMetadataPersistence.noop),
   );
-  const stackLayer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+  const stackLayer = Stack.layer(config);
+  const serviceActivatorLayer = Layer.effect(
+    StackServiceActivator,
+    Effect.map(StackLifecycleCoordinator, (coordinator) => ({
+      activate: coordinator.activateService,
+    })),
+  );
 
   const proxyConfig: ProxyConfig = {
     listenPort: config.apiPort,
@@ -64,9 +84,16 @@ export const foregroundLayer = (
     anonJwt: config.anonJwt,
     serviceRoleJwt: config.serviceRoleJwt,
   };
-  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(Layer.provide(FetchHttpClient.layer));
+  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(serviceActivatorLayer),
+  );
 
-  return Layer.mergeAll(stackLayer, apiProxyLayer).pipe(Layer.provide(platform), Layer.orDie);
+  return Layer.mergeAll(stackLayer, apiProxyLayer).pipe(
+    Layer.provide(coordinatorLayer),
+    Layer.provide(platform),
+    Layer.orDie,
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -89,8 +116,12 @@ export interface DaemonConfig extends ResolvedStackConfig {
 export const foregroundDaemonLayer = (
   config: DaemonConfig,
   platformFactory: PlatformFactory,
+  portLease: PortLease,
 ): Layer.Layer<Stack | StateManager> => {
-  const platform = platformFactory(config.apiPort);
+  const platform = platformFactory({
+    apiPort: config.apiPort,
+    releaseApiPort: portLease.release(["apiPort"]),
+  });
 
   const binaryResolverLayer = BinaryResolver.make(config.cacheRoot).pipe(
     Layer.provide(FetchHttpClient.layer),
@@ -112,7 +143,16 @@ export const foregroundDaemonLayer = (
     anonJwt: config.anonJwt,
     serviceRoleJwt: config.serviceRoleJwt,
   };
-  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(Layer.provide(FetchHttpClient.layer));
+  const serviceActivatorLayer = Layer.effect(
+    StackServiceActivator,
+    Effect.map(StackLifecycleCoordinator, (coordinator) => ({
+      activate: coordinator.activateService,
+    })),
+  );
+  const apiProxyLayer = ApiProxy.layer(proxyConfig).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(serviceActivatorLayer),
+  );
   const stateManagerLayer = StateManager.make(
     singleStackStateManagerPaths(config.stackRoot, config.runtimeRoot, config.name),
   );
@@ -120,14 +160,15 @@ export const foregroundDaemonLayer = (
   const metadataPersistenceLayer = StackMetadataPersistence.fromStateManager(config.name).pipe(
     Layer.provide(stateManagerLayer),
   );
-  const coordinatorLayer = StackLifecycleCoordinator.layer(config).pipe(
+  const coordinatorLayer = StackLifecycleCoordinator.layer(config, portLease).pipe(
     Layer.provide(StackBuilder.layer),
     Layer.provide(stackPreparationLayer),
     Layer.provide(metadataPersistenceLayer),
   );
-  const stackLayer = Stack.layer(config).pipe(Layer.provide(coordinatorLayer));
+  const stackLayer = Stack.layer(config);
 
   return Layer.mergeAll(stackLayer, apiProxyLayer, stateManagerLayer).pipe(
+    Layer.provide(coordinatorLayer),
     Layer.provide(platform),
     Layer.orDie,
   );
@@ -143,7 +184,7 @@ export const foregroundDaemonLayer = (
  * 5. Returns RemoteStack.layer(socketPath)
  */
 export const daemonLayer = (
-  config: DaemonConfig,
+  input: DaemonConfigInput,
   daemonEntryPoint: string,
 ): Effect.Effect<
   Layer.Layer<Stack>,
@@ -151,18 +192,33 @@ export const daemonLayer = (
   FileSystem.FileSystem | Path.Path | UnixHttpClient
 > =>
   Effect.gen(function* () {
+    if (input.stackRoot !== undefined || input.runtimeRoot !== undefined) {
+      return yield* new DaemonStartError({
+        message: "Managed daemon stacks derive stackRoot and runtimeRoot automatically",
+      });
+    }
+    const projectDir = input.projectDir ?? input.cwd;
+    const name = input.name ?? DEFAULT_MANAGED_STACK_NAME;
+    const cacheRoot = input.cacheRoot ?? defaultCacheRoot();
+    const stackRoot =
+      input.projectStateRoot !== undefined
+        ? join(input.projectStateRoot, "stacks", name)
+        : defaultManagedStackRoot(cacheRoot, projectDir, name);
+    const runtimeRoot = defaultManagedRuntimeRoot(stackRoot);
+    const config: DaemonConfigInput = {
+      ...input,
+      cacheRoot,
+      projectDir,
+      name,
+    };
     const fs = yield* FileSystem.FileSystem;
     const unixHttpClient = yield* UnixHttpClient;
     const stateManager = yield* StateManager.pipe(
-      Effect.provide(
-        StateManager.make(
-          singleStackStateManagerPaths(config.stackRoot, config.runtimeRoot, config.name),
-        ),
-      ),
+      Effect.provide(StateManager.make(singleStackStateManagerPaths(stackRoot, runtimeRoot, name))),
     );
 
     // Check if a stack with this name is already running
-    const existingState = yield* stateManager.read(config.name).pipe(
+    const existingState = yield* stateManager.read(name).pipe(
       Effect.map(Option.some),
       Effect.catchTag("StateNotFoundError", () => Effect.succeed(Option.none())),
     );
@@ -170,25 +226,28 @@ export const daemonLayer = (
       const alive = yield* stateManager.isAlive(existingState.value);
       if (alive) {
         return yield* new StackAlreadyRunningError({
-          name: config.name,
+          name,
           pid: existingState.value.pid,
           message: `A Supabase stack "${config.name}" is already running (PID ${existingState.value.pid}). Use "supabase stop" first.`,
         });
       }
       // Stale state from a dead daemon — clean up before proceeding
-      yield* stateManager.remove(config.name);
+      yield* stateManager.remove(name);
     }
 
     // Compute socket path via StateManager conventions
-    const dir = stateManager.stackDir(config.name);
+    const dir = stateManager.stackDir(name);
     yield* fs
       .makeDirectory(dir, { recursive: true })
       .pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
-    const runtimeDir = stateManager.runtimeDir(config.name);
+    const runtimeDir = stateManager.runtimeDir(name);
     yield* fs
       .makeDirectory(runtimeDir, { recursive: true })
       .pipe(Effect.catchTag("PlatformError", (e) => Effect.die(e)));
-    const socketPath = stateManager.socketPath(config.name);
+    // A daemon generation owns its socket pathname for its entire lifetime.
+    // Reusing a fixed pathname lets a delayed shutdown unlink a replacement
+    // daemon's socket after the replacement has already bound it.
+    const socketPath = join(runtimeDir, `daemon-${randomUUID().slice(0, 12)}.sock`);
 
     // Clean up stale socket file if present
     yield* fs.remove(socketPath).pipe(Effect.ignore);
@@ -200,13 +259,19 @@ export const daemonLayer = (
       const startMsg: DaemonStartMessage = {
         type: "start",
         config,
-        name: config.name,
-        projectDir: config.projectDir,
         socketPath,
       };
-      child.send(startMsg);
-
-      const response = yield* waitForDaemonResponse(child);
+      const responseFiber = yield* waitForDaemonResponse(child).pipe(
+        Effect.timeout("30 seconds"),
+        Effect.mapError((error) =>
+          error._tag === "DaemonStartError"
+            ? error
+            : new DaemonStartError({ message: "Timed out waiting for daemon startup" }),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* sendDaemonStart(child, startMsg);
+      const response = yield* Fiber.join(responseFiber);
 
       if (response.type === "error") {
         return yield* new DaemonStartError({ message: response.message });
@@ -217,15 +282,11 @@ export const daemonLayer = (
       child.unref();
       daemonRegistered = true;
 
-      return RemoteStack.layer(socketPath).pipe(
+      return RemoteStack.layer(response.state.socketPath).pipe(
         Layer.provide(Layer.succeed(UnixHttpClient, unixHttpClient)),
       );
     }).pipe(
-      Effect.onExit(() =>
-        daemonRegistered
-          ? Effect.void
-          : cleanupPendingDaemonStartup(child, stateManager, config.name),
-      ),
+      Effect.onExit(() => (daemonRegistered ? Effect.void : cleanupPendingDaemonStartup(child))),
     );
   });
 
@@ -247,6 +308,35 @@ const forkDaemon = (entryPoint: string): Effect.Effect<ChildProcess, DaemonStart
       }),
   });
 
+const sendDaemonStart = (
+  child: ChildProcess,
+  message: DaemonStartMessage,
+): Effect.Effect<void, DaemonStartError> =>
+  Effect.callback<void, DaemonStartError>((resume) => {
+    try {
+      child.send(message, (error) => {
+        if (error === null) {
+          resume(Effect.void);
+          return;
+        }
+        resume(
+          Effect.fail(
+            new DaemonStartError({ message: `Failed to send daemon config: ${error.message}` }),
+          ),
+        );
+      });
+    } catch (cause) {
+      resume(
+        Effect.fail(
+          new DaemonStartError({
+            message: `Failed to send daemon config: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
+        ),
+      );
+    }
+    return Effect.void;
+  });
+
 /** Wait for DaemonStartedMessage or DaemonErrorMessage from the child. */
 const waitForDaemonResponse = (
   child: ChildProcess,
@@ -254,7 +344,12 @@ const waitForDaemonResponse = (
   Effect.callback<DaemonMessage, DaemonStartError>((resume) => {
     const onMessage = (msg: unknown) => {
       cleanup();
-      resume(Effect.succeed(msg as DaemonMessage));
+      const decoded = Schema.decodeUnknownOption(DaemonMessageSchema)(msg);
+      resume(
+        Option.isSome(decoded)
+          ? Effect.succeed(decoded.value)
+          : Effect.fail(new DaemonStartError({ message: "Daemon sent an invalid IPC response" })),
+      );
     };
 
     const onError = (err: Error) => {
@@ -282,15 +377,8 @@ const waitForDaemonResponse = (
     return Effect.sync(cleanup);
   });
 
-const cleanupPendingDaemonStartup = (
-  child: ChildProcess,
-  stateManager: StateManagerService,
-  stackName: string,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    yield* Effect.promise(() => terminateChildProcess(child)).pipe(Effect.catch(() => Effect.void));
-    yield* stateManager.remove(stackName);
-  });
+const cleanupPendingDaemonStartup = (child: ChildProcess): Effect.Effect<void> =>
+  Effect.promise(() => terminateChildProcess(child)).pipe(Effect.catch(() => Effect.void));
 
 // ---------------------------------------------------------------------------
 // Connect mode

--- a/packages/stack/src/node.ts
+++ b/packages/stack/src/node.ts
@@ -118,10 +118,14 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
 // ---------------------------------------------------------------------------
 
 /** Node platform factory for use with foregroundLayer / daemonLayer. */
-export const platformFactory: PlatformFactory = (apiPort) =>
+export const platformFactory: PlatformFactory = ({ apiPort, releaseApiPort }) =>
   Layer.mergeAll(
     NodeServices.layer,
-    NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie),
+    Layer.unwrap(
+      releaseApiPort.pipe(
+        Effect.as(NodeHttpServer.layer(() => createServer(), { port: apiPort }).pipe(Layer.orDie)),
+      ),
+    ),
   );
 
 /** Path to the Node daemon entry point for use with daemonLayer. */

--- a/packages/stack/src/paths.ts
+++ b/packages/stack/src/paths.ts
@@ -37,7 +37,4 @@ const runtimeRootId = (stackRoot: string): string =>
 export const defaultManagedRuntimeRoot = (stackRoot: string): string =>
   join(defaultManagedRuntimeBaseRoot(), `s-${runtimeRootId(stackRoot)}`);
 
-export const socketPathForRuntimeRoot = (runtimeRoot: string): string =>
-  join(runtimeRoot, "daemon.sock");
-
 export const shortTempPrefixRoot = (): string => shortTempRoot();


### PR DESCRIPTION
Replacement stack 2 of 3, based on #6069.

Stack: #6069 → #6070 → #6071

Adds lazy startup around explicit ownership boundaries:

- gives `process-compose` sole ownership of desired service state and restart behavior
- declares eager startup, activation dependencies, and private companion ownership in one policy
- activates HTTP services at the existing proxy boundary while starting Realtime eagerly
- exposes `Dormant` as an explicit service state instead of parallel boolean bookkeeping
- lets the foreground stack and detached daemon reserve ports until their actual bind boundaries
- makes the daemon own allocation and atomically claim its live-state record

This deliberately omits the custom Realtime WebSocket bridge, managed port-lock protocol, and duplicate lifecycle intent sets from the previous stack.

Supersedes #6042
Supersedes #6043
Supersedes #6044
Supersedes #6045
Supersedes #6046