### PR TITLE
feat(cli): enable lazy local stack startup

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -123,7 +123,9 @@ Important areas:
 
 The local stack commands use `@supabase/stack` for lifecycle, daemon transport, status, and logs.
 That stack layer now has an explicit preparation phase, so foreground and detached `start` flows
-can surface `Downloading` before normal runtime states.
+can surface `Downloading` before normal runtime states. CLI-managed stacks use lazy service startup:
+direct listeners and Realtime start with the stack, while HTTP services activate on first proxied
+use. The package API itself keeps eager startup as its default.
 
 Useful companion docs:
 

--- a/apps/cli/src/legacy/commands/sso/update/update.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/update/update.integration.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Option, Redacted, Stdio } from "effect";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
-import { mockAnalytics, mockOutput } from "../../../../../tests/helpers/mocks.ts";
+import { mockAnalytics, mockOutput, mockRuntimeInfo } from "../../../../../tests/helpers/mocks.ts";
 import {
   buildLegacyTestRuntime,
   LEGACY_VALID_REF,
@@ -187,6 +187,7 @@ function setup(opts: SetupOpts = {}) {
       linkedProjectCache: cache.layer,
       analytics,
       goOutput: opts.goOutput === undefined ? Option.none() : Option.some(opts.goOutput),
+      runtimeInfo: mockRuntimeInfo({ homeDir: tempRoot.current }),
     }),
     Stdio.layerTest({
       args: Effect.succeed(opts.cliArgs ?? ["sso", "update", VALID_PROVIDER_ID]),
@@ -1684,6 +1685,15 @@ describe("legacy sso update integration", () => {
     const first = writeProfileYaml("first-notoken.yml", "http://first.example");
     const second = writeProfileYaml("second-notoken.yml", "http://second.example");
     const restoreEnv = withProfileEnv(undefined);
+    const previousNoKeyring = process.env["SUPABASE_NO_KEYRING"];
+    process.env["SUPABASE_NO_KEYRING"] = "1";
+    const restoreNoKeyring = Effect.sync(() => {
+      if (previousNoKeyring === undefined) {
+        delete process.env["SUPABASE_NO_KEYRING"];
+      } else {
+        process.env["SUPABASE_NO_KEYRING"] = previousNoKeyring;
+      }
+    });
     const { layer, api } = setup({
       accessToken: Option.none(),
       cliArgs: [
@@ -1710,7 +1720,7 @@ describe("legacy sso update integration", () => {
         expect(dump).toContain("Access token not provided. Supply an access token by running");
       }
       expect(api.requests).toHaveLength(0);
-    }).pipe(Effect.ensuring(restoreEnv), Effect.provide(layer));
+    }).pipe(Effect.ensuring(restoreNoKeyring), Effect.ensuring(restoreEnv), Effect.provide(layer));
   });
 
   it.live("profile emulation: the missing-token gate fires AFTER the mutex check, like Go", () => {

--- a/apps/cli/src/next/commands/start/start.live.test.ts
+++ b/apps/cli/src/next/commands/start/start.live.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, test } from "vitest";
+import { makeTempHome, makeTempStackProject } from "../../../../tests/helpers/cli.ts";
+import { describeLive, runSupabaseLive } from "../../../../tests/helpers/live.ts";
+
+const START_TIMEOUT_MS = 180_000;
+const COMMAND_OPTIONS = { entrypoint: "next" as const };
+const LIGHTWEIGHT_DOCKER_ARGS = [
+  "start",
+  "--detach",
+  "--mode",
+  "docker",
+  "--exclude",
+  "realtime",
+  "--exclude",
+  "storage",
+  "--exclude",
+  "imgproxy",
+  "--exclude",
+  "mailpit",
+  "--exclude",
+  "pgmeta",
+  "--exclude",
+  "studio",
+  "--exclude",
+  "analytics",
+  "--exclude",
+  "vector",
+  "--exclude",
+  "pooler",
+] as const;
+
+// Lazy service activation crosses the real proxy, daemon, Docker network, and
+// container lifecycle boundaries, so keep one gated golden-path live test.
+describeLive("supabase start lazy lifecycle (live)", () => {
+  let project: Awaited<ReturnType<typeof makeTempStackProject>> | undefined;
+  let home: ReturnType<typeof makeTempHome> | undefined;
+
+  afterEach(async () => {
+    if (project !== undefined && home !== undefined) {
+      await runSupabaseLive(["stop", "--no-backup"], {
+        ...COMMAND_OPTIONS,
+        cwd: project.dir,
+        home: home.dir,
+      }).catch(() => undefined);
+    }
+    await project?.cleanup();
+    home?.[Symbol.dispose]();
+    project = undefined;
+    home = undefined;
+  });
+
+  test(
+    "keeps an HTTP service dormant until its first proxied request",
+    { timeout: START_TIMEOUT_MS + 120_000 },
+    async () => {
+      project = await makeTempStackProject("supabase-lazy-start-live-");
+      home = makeTempHome();
+
+      const started = await runSupabaseLive([...LIGHTWEIGHT_DOCKER_ARGS], {
+        ...COMMAND_OPTIONS,
+        cwd: project.dir,
+        home: home.dir,
+        exitTimeoutMs: START_TIMEOUT_MS,
+      });
+      expect(started.exitCode, `stdout:\n${started.stdout}\nstderr:\n${started.stderr}`).toBe(0);
+
+      const before = await runSupabaseLive(["status"], {
+        ...COMMAND_OPTIONS,
+        cwd: project.dir,
+        home: home.dir,
+      });
+      expect(before.exitCode, `stdout:\n${before.stdout}\nstderr:\n${before.stderr}`).toBe(0);
+      expect(before.stdout).toContain("auth: Pending");
+
+      const response = await fetch(`http://127.0.0.1:${project.ports.apiPort}/auth/v1/health`, {
+        signal: AbortSignal.timeout(60_000),
+      });
+      expect(response.ok).toBe(true);
+
+      const after = await runSupabaseLive(["status"], {
+        ...COMMAND_OPTIONS,
+        cwd: project.dir,
+        home: home.dir,
+      });
+      expect(after.exitCode, `stdout:\n${after.stdout}\nstderr:\n${after.stderr}`).toBe(0);
+      expect(after.stdout).toContain("auth: Healthy");
+    },
+  );
+});

--- a/apps/cli/src/next/commands/start/ui/StartDashboard.tsx
+++ b/apps/cli/src/next/commands/start/ui/StartDashboard.tsx
@@ -9,8 +9,7 @@ export function StartDashboard({ model }: { model: StartDashboardModel }) {
   const states = useAtomValue(model.displayStatesAtom);
   const info = useAtomValue(model.stackInfoAtom);
   const phase = useAtomValue(model.phaseAtom);
-  const showConnectionInfo =
-    useAtomValue(model.allHealthyAtom) && info !== null && phase !== "failed";
+  const showConnectionInfo = useAtomValue(model.showConnectionInfoAtom);
   const statusLine = useAtomValue(model.statusLineAtom);
 
   return (

--- a/apps/cli/src/next/commands/start/ui/dashboard.model.ts
+++ b/apps/cli/src/next/commands/start/ui/dashboard.model.ts
@@ -26,6 +26,7 @@ export interface StartDashboardModel {
   readonly errorAtom: Atom.Writable<string | null>;
   readonly displayStatesAtom: Atom.Atom<ReadonlyArray<StackServiceState>>;
   readonly allHealthyAtom: Atom.Atom<boolean>;
+  readonly showConnectionInfoAtom: Atom.Atom<boolean>;
   readonly statusLineAtom: Atom.Atom<string>;
 }
 
@@ -68,6 +69,12 @@ export function createStartDashboardModel(
       get(displayStatesAtom).length > 0 &&
       get(displayStatesAtom).every((s) => s.status === "Healthy"),
   );
+  // Lazy stacks intentionally leave proxy-backed services Pending. A
+  // successful start phase, rather than universal health, makes connection
+  // details safe to display.
+  const showConnectionInfoAtom = Atom.make(
+    (get) => get(phaseAtom) === "running" && get(stackInfoAtom) !== null,
+  );
   const statusLineAtom = Atom.make((get) => {
     const phase = get(phaseAtom);
     const error = get(errorAtom);
@@ -97,6 +104,7 @@ export function createStartDashboardModel(
     errorAtom,
     displayStatesAtom,
     allHealthyAtom,
+    showConnectionInfoAtom,
     statusLineAtom,
   };
 }

--- a/apps/cli/src/next/commands/start/ui/dashboard.model.unit.test.ts
+++ b/apps/cli/src/next/commands/start/ui/dashboard.model.unit.test.ts
@@ -17,6 +17,15 @@ function state(name: string, status: StackServiceStatus) {
 }
 
 describe("createStartDashboardModel", () => {
+  const stackInfo: StackInfo = {
+    url: "http://127.0.0.1:54321",
+    dbUrl: "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+    publishableKey: "pk",
+    secretKey: "sk",
+    anonJwt: "anon",
+    serviceRoleJwt: "service-role",
+    serviceEndpoints: {},
+  };
   const dashboardStateLayer = Layer.effect(
     StartDashboardState,
     Effect.gen(function* () {
@@ -55,9 +64,12 @@ describe("createStartDashboardModel", () => {
       registry.get(model.displayStatesAtom).find((entry) => entry.name === "postgres")?.status,
     ).toBe("Initializing");
     expect(registry.get(model.allHealthyAtom)).toBe(false);
+    registry.set(model.stackInfoAtom, stackInfo);
+    expect(registry.get(model.showConnectionInfoAtom)).toBe(false);
 
     registry.set(model.phaseAtom, "running");
     expect(registry.get(model.statusLineAtom)).toContain("Interrupt to stop");
+    expect(registry.get(model.showConnectionInfoAtom)).toBe(true);
   });
 
   test("shows the foreground failure message when startup fails", async () => {

--- a/apps/cli/src/next/config/stack-config.ts
+++ b/apps/cli/src/next/config/stack-config.ts
@@ -25,6 +25,7 @@ export function toStartStackConfig(
   const excluded = new Set(exclude);
   return {
     mode,
+    startupMode: "lazy",
     realtime: excluded.has("realtime") ? false : {},
     storage: excluded.has("storage") ? false : {},
     imgproxy: excluded.has("imgproxy") || excluded.has("storage") ? false : {},

--- a/apps/cli/src/next/config/stack-config.unit.test.ts
+++ b/apps/cli/src/next/config/stack-config.unit.test.ts
@@ -2,10 +2,19 @@ import { describe, expect, it } from "vitest";
 import { toStartStackConfig, withServiceVersions } from "./stack-config.ts";
 
 describe("toStartStackConfig", () => {
-  it("sets the requested startup mode", () => {
-    expect(toStartStackConfig([], "auto")).toMatchObject({ mode: "auto" });
-    expect(toStartStackConfig([], "docker")).toMatchObject({ mode: "docker" });
-    expect(toStartStackConfig([], "native")).toMatchObject({ mode: "native" });
+  it("uses lazy service startup with the requested runtime mode", () => {
+    expect(toStartStackConfig([], "auto")).toMatchObject({
+      mode: "auto",
+      startupMode: "lazy",
+    });
+    expect(toStartStackConfig([], "docker")).toMatchObject({
+      mode: "docker",
+      startupMode: "lazy",
+    });
+    expect(toStartStackConfig([], "native")).toMatchObject({
+      mode: "native",
+      startupMode: "lazy",
+    });
   });
 
   it("dedupes excluded services when building stack config", () => {

--- a/apps/cli/src/next/stack/stack.shared.ts
+++ b/apps/cli/src/next/stack/stack.shared.ts
@@ -52,6 +52,7 @@ export const startStackWithProgress = Effect.fnUntraced(function* () {
           { discard: true },
         ),
       ),
+      Effect.uninterruptible,
     );
 
   const fiber = yield* Stream.runForEach(stack.allStateChanges(), updateProgress).pipe(


### PR DESCRIPTION
Replacement stack 3 of 3, based on #6070.

Stack: #6069 → #6070 → #6071

Makes lazy startup the policy for CLI-managed stacks while keeping the package default eager:

- maps CLI start, branch switching, and Functions development through the shared lazy stack configuration
- treats a completed lazy startup phase as sufficient to display connection details
- keeps one gated live test for the real daemon, proxy, Docker, and first-request activation boundary
- documents that Realtime remains eager while HTTP services activate through the proxy

The separate test-only commit isolates the legacy SSO integration suite from host keyring state discovered during the full regression run; it does not affect runtime behavior.

Supersedes #6047