### PR TITLE
chore(process-compose): classify Bun platform as test dependency

### DIFF
--- a/packages/process-compose/package.json
+++ b/packages/process-compose/package.json
@@ -13,10 +13,10 @@
     "fix:all": "nx run-many -t lint:fix fmt:fix knip:fix --projects=$npm_package_name"
   },
   "dependencies": {
-    "@effect/platform-bun": "catalog:",
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-bun": "catalog:",
     "@effect/vitest": "catalog:",
     "@tsconfig/bun": "catalog:",
     "@types/bun": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,13 +471,13 @@ importers:
 
   packages/process-compose:
     dependencies:
-      '@effect/platform-bun':
-        specifier: 'catalog:'
-        version: 4.0.0-beta.97(effect@4.0.0-beta.97)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.97
     devDependencies:
+      '@effect/platform-bun':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.97(effect@4.0.0-beta.97)(vitest@4.1.10)


### PR DESCRIPTION
Moves `@effect/platform-bun` from runtime dependencies into development dependencies for `@supabase/process-compose`.

The package uses this adapter only in Bun-backed tests, so keeping it in the runtime dependency set overstates the production contract and installs unused platform code for consumers.