### PR TITLE
fix(cli): exit analytics container when migrations fail

### DIFF
--- a/apps/cli/src/legacy/commands/start/services/logflare.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/logflare.service.ts
@@ -46,12 +46,16 @@ const LEGACY_LOGFLARE_API_KEY = "api-key";
 /**
  * Go's Logflare entrypoint script (`start.go:358-362`): the image's own
  * entrypoint conflicts with the container healthcheck due to a 15-second
- * sleep, so Go writes its own `run.sh` and runs that instead. Transcribed
- * byte-for-byte, including the trailing newline after `EOF` (Go's raw string
- * literal ends with a newline before the closing backtick).
+ * sleep, so Go writes its own `run.sh` and runs that instead.
+ *
+ * Deliberate divergence from Go, do not revert in a parity sweep (issue
+ * #6088): `migrate && start`, so a failed migrate exits the container and the
+ * `unless-stopped` restart policy retries until the db is ready — Go boots
+ * Logflare against the unmigrated database, where Oban dies on the missing
+ * `public.oban_jobs`.
  */
 const LEGACY_LOGFLARE_ENTRYPOINT_SCRIPT =
-  "cat <<'EOF' > run.sh && sh run.sh\n./logflare eval Logflare.Release.migrate\n./logflare start --sname logflare\nEOF\n";
+  "cat <<'EOF' > run.sh && sh run.sh\n./logflare eval Logflare.Release.migrate &&\n./logflare start --sname logflare\nEOF\n";
 
 export interface LegacyLogflareContainerSpecInput {
   /**

--- a/apps/cli/src/legacy/commands/start/services/logflare.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/logflare.service.unit.test.ts
@@ -32,7 +32,7 @@ describe("legacyBuildLogflareContainerSpec", () => {
     expect(spec.entrypoint).toBe("sh");
     expect(spec.cmd).toEqual([
       "-c",
-      "cat <<'EOF' > run.sh && sh run.sh\n./logflare eval Logflare.Release.migrate\n./logflare start --sname logflare\nEOF\n",
+      "cat <<'EOF' > run.sh && sh run.sh\n./logflare eval Logflare.Release.migrate &&\n./logflare start --sname logflare\nEOF\n",
     ]);
     expect(spec.exposedPorts).toEqual([{ containerPort: "4000" }]);
     expect(spec.ports).toEqual([{ hostPort: "54327", containerPort: "4000" }]);

--- a/packages/stack/src/services/analytics.ts
+++ b/packages/stack/src/services/analytics.ts
@@ -76,8 +76,10 @@ export const makeAnalyticsServiceDocker = (opts: DockerAnalyticsOptions): Servic
     entrypoint: "sh",
     cmd: [
       "-c",
+      // migrate && start: a failed migrate exits the container and the
+      // unless-stopped restart retries until the db is ready (supabase/cli#6088).
       `cat <<'EOF' > /tmp/run.sh && sh /tmp/run.sh
-./logflare eval Logflare.Release.migrate
+./logflare eval Logflare.Release.migrate &&
 ./logflare start --sname logflare
 EOF
 `,

--- a/packages/stack/src/services/services.unit.test.ts
+++ b/packages/stack/src/services/services.unit.test.ts
@@ -600,6 +600,9 @@ describe("docker-backed auxiliary services", () => {
     expect(args).toContain("PHX_HTTP_PORT=4000");
     expect(args).toContain("54328:4000");
     expect(args).toContain("LOGFLARE_NODE_HOST=0.0.0.0");
+    expect(args.at(-1)).toBe(
+      `cat <<'EOF' > /tmp/run.sh && sh /tmp/run.sh\n./logflare eval Logflare.Release.migrate &&\n./logflare start --sname logflare\nEOF\n`,
+    );
   });
 
   it("keeps analytics on its container port when Linux uses bridge networking", () => {


### PR DESCRIPTION
## TL;DR

fixes the analytics crashloop where a failed `Logflare.Release.migrate` got silently swallowed and 
Logflare booted against an unmigrated database killing 
Oban on the missing `public.oban_jobs`, by chaining `migrate && start` in the generated entrypoint
so a failed migrate now exits the container and the `unless-stopped` restart policy
just retries until the db is ready

already broken stacks need one `supabase stop && supabase start` after upgrading cause the new entrypoint only applies on container recreate. diverges from go (ts only)....

<details><summary>before vs after </summary>

    BEFORE (db refusing):  migrate fails, app boots anyway, zombie with exit 0
    AFTER  (db refusing):  app never boots, container exits and retries
    AFTER  (db appears):   migrations apply (37 tables + oban), boots clean

</details>

## ref: 
- closes #6088
