### PR TITLE
fix(cli): fail on unloadable --profile

### DIFF
--- a/apps/cli/src/legacy/commands/login/login.handler.ts
+++ b/apps/cli/src/legacy/commands/login/login.handler.ts
@@ -10,7 +10,7 @@ import {
   legacyPostLoginTelemetry,
 } from "../../shared/legacy-ensure-login.ts";
 import { CliArgs } from "../../../shared/cli/cli-args.service.ts";
-import { hasExplicitLongFlag } from "../../../shared/cli/cobra-flag-groups.ts";
+import { lastExplicitLongFlagValue } from "../../../shared/cli/cobra-flag-groups.ts";
 import { LegacyProfileFlag } from "../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
@@ -39,22 +39,25 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
   // Mirrors Go's login `PostRunE` (`cmd/login.go:42-48`): persist the chosen
   // profile to `<SUPABASE_HOME or ~/.supabase>/profile` on success. The raw
   // token is written so a YAML-path profile round-trips; a write failure is
-  // fatal. An explicitly passed flag counts even at its default value (pflag
-  // `Changed`, same argv scan as the config layer), so `login --profile
-  // supabase` persists "supabase" — shadowing SUPABASE_PROFILE and healing a
-  // stale profile file like Go, never re-persisting the shadowed env value.
+  // fatal. An explicitly passed flag counts even at its default value, and the
+  // LAST occurrence wins (pflag `Changed` + last-wins, same argv scan as the
+  // config layer), so `login --profile supabase` persists "supabase" —
+  // shadowing SUPABASE_PROFILE and healing a stale profile file like Go, never
+  // re-persisting the shadowed env value.
   const cliArgs = yield* Effect.serviceOption(CliArgs);
-  const profileFlagExplicit = Option.match(cliArgs, {
-    onNone: () => false,
-    onSome: ({ args }) => hasExplicitLongFlag(args, [], "profile"),
+  const explicitProfileFlag = Option.match(cliArgs, {
+    onNone: () => undefined,
+    onSome: ({ args }) => lastExplicitLongFlagValue(args, [], "profile"),
   });
   const envProfile = process.env["SUPABASE_PROFILE"];
   const profileToken =
-    profileFlagExplicit || profileFlag !== "supabase"
-      ? profileFlag
-      : envProfile !== undefined && envProfile.length > 0
-        ? envProfile
-        : undefined;
+    explicitProfileFlag !== undefined
+      ? explicitProfileFlag
+      : profileFlag !== "supabase"
+        ? profileFlag
+        : envProfile !== undefined && envProfile.length > 0
+          ? envProfile
+          : undefined;
   const saveProfileName =
     profileToken === undefined
       ? Effect.void

--- a/apps/cli/src/legacy/commands/login/login.handler.ts
+++ b/apps/cli/src/legacy/commands/login/login.handler.ts
@@ -9,6 +9,8 @@ import {
   legacyBrowserLogin,
   legacyPostLoginTelemetry,
 } from "../../shared/legacy-ensure-login.ts";
+import { CliArgs } from "../../../shared/cli/cli-args.service.ts";
+import { hasExplicitLongFlag } from "../../../shared/cli/cobra-flag-groups.ts";
 import { LegacyProfileFlag } from "../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
@@ -34,15 +36,21 @@ export const legacyLogin = Effect.fn("legacy.login")(function* (flags: LegacyLog
 
   const claudeHint = legacySuggestClaudePlugin({ stdoutIsTty: tty.stdoutIsTty });
 
-  // Mirrors Go's login `PostRunE` (`cmd/login.go:42-48`): when a profile was
-  // explicitly chosen (`--profile` over its default, else `SUPABASE_PROFILE`),
-  // persist it to `<SUPABASE_HOME or ~/.supabase>/profile` on success so later commands resolve the
-  // same profile. The raw token is written (Go's `viper.GetString("PROFILE")`),
-  // so a YAML-path profile round-trips. A write failure is fatal (Go: "Failure
-  // to save should block subsequent commands on CI").
+  // Mirrors Go's login `PostRunE` (`cmd/login.go:42-48`): persist the chosen
+  // profile to `<SUPABASE_HOME or ~/.supabase>/profile` on success. The raw
+  // token is written so a YAML-path profile round-trips; a write failure is
+  // fatal. An explicitly passed flag counts even at its default value (pflag
+  // `Changed`, same argv scan as the config layer), so `login --profile
+  // supabase` persists "supabase" — shadowing SUPABASE_PROFILE and healing a
+  // stale profile file like Go, never re-persisting the shadowed env value.
+  const cliArgs = yield* Effect.serviceOption(CliArgs);
+  const profileFlagExplicit = Option.match(cliArgs, {
+    onNone: () => false,
+    onSome: ({ args }) => hasExplicitLongFlag(args, [], "profile"),
+  });
   const envProfile = process.env["SUPABASE_PROFILE"];
   const profileToken =
-    profileFlag !== "supabase"
+    profileFlagExplicit || profileFlag !== "supabase"
       ? profileFlag
       : envProfile !== undefined && envProfile.length > 0
         ? envProfile

--- a/apps/cli/src/legacy/commands/login/login.integration.test.ts
+++ b/apps/cli/src/legacy/commands/login/login.integration.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "@effect/vitest";
@@ -13,6 +13,7 @@ import {
   mockStdin,
   mockTty,
 } from "../../../../tests/helpers/mocks.ts";
+import { CliArgs } from "../../../shared/cli/cli-args.service.ts";
 import { LegacyProfileFlag } from "../../../shared/legacy/global-flags.ts";
 import {
   LEGACY_VALID_TOKEN,
@@ -52,6 +53,8 @@ interface SetupOpts {
   readonly promptTextFail?: boolean;
   readonly profileFlag?: string;
   readonly homeDir?: string;
+  /** Raw argv for explicit `--profile` detection. */
+  readonly argv?: ReadonlyArray<string>;
 }
 
 function flags(overrides: Partial<LegacyLoginFlags> = {}): LegacyLoginFlags {
@@ -108,6 +111,7 @@ function setupLegacyLogin(opts: SetupOpts = {}) {
     mockStdin(isTTY, opts.pipedStdin),
     mockBrowser(),
     Layer.succeed(LegacyProfileFlag, opts.profileFlag ?? "supabase"),
+    ...(opts.argv !== undefined ? [Layer.succeed(CliArgs, { args: opts.argv })] : []),
   );
   return { layer, out, credentials, crypto, loginApi, telemetry, analytics };
 }
@@ -338,6 +342,43 @@ describe("legacy login integration", () => {
       const profilePath = join(tempRoot.current, ".supabase", "profile");
       expect(existsSync(profilePath)).toBe(true);
       expect(readFileSync(profilePath, "utf8")).toBe("supabase-staging");
+    }).pipe(Effect.provide(layer));
+  });
+
+  // The shadowed env value must never be re-persisted (Go: pflag `Changed`).
+  it.live("explicit --profile supabase persists 'supabase', shadowing SUPABASE_PROFILE", () => {
+    const prev = process.env["SUPABASE_PROFILE"];
+    process.env["SUPABASE_PROFILE"] = "rogue-profile";
+    const { layer } = setupLegacyLogin({
+      argv: ["login", "--profile", "supabase", "--token", LEGACY_VALID_TOKEN],
+      homeDir: tempRoot.current,
+    });
+    return Effect.gen(function* () {
+      yield* legacyLogin(flags({ token: Option.some(LEGACY_VALID_TOKEN) }));
+      const profilePath = join(tempRoot.current, ".supabase", "profile");
+      expect(readFileSync(profilePath, "utf8")).toBe("supabase");
+    }).pipe(
+      Effect.provide(layer),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (prev === undefined) delete process.env["SUPABASE_PROFILE"];
+          else process.env["SUPABASE_PROFILE"] = prev;
+        }),
+      ),
+    );
+  });
+
+  // Permanently heals a file persisted by an older lenient version (#6091).
+  it.live("explicit --profile supabase heals a stale persisted profile file", () => {
+    mkdirSync(join(tempRoot.current, ".supabase"), { recursive: true });
+    writeFileSync(join(tempRoot.current, ".supabase", "profile"), "resms");
+    const { layer } = setupLegacyLogin({
+      argv: ["login", "--profile=supabase"],
+      homeDir: tempRoot.current,
+    });
+    return Effect.gen(function* () {
+      yield* legacyLogin(flags({ token: Option.some(LEGACY_VALID_TOKEN) }));
+      expect(readFileSync(join(tempRoot.current, ".supabase", "profile"), "utf8")).toBe("supabase");
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
@@ -1,103 +1,51 @@
 import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
-import { parse as parseYaml } from "yaml";
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
+import { hasExplicitLongFlag } from "../../shared/cli/cobra-flag-groups.ts";
 import { CLI_VERSION } from "../../shared/cli/version.ts";
 import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
 import {
-  legacyApiUrl,
-  legacyDashboardUrl,
-  legacyIsBuiltinProfileName,
-  legacyPoolerHost,
-  legacyProjectHost,
-} from "../shared/legacy-profile.ts";
+  legacyLoadProfile,
+  type LegacyLoadedProfile,
+  type LegacyProfileLoadError,
+} from "../shared/legacy-profile-load.ts";
 import {
   LegacyDebugLogger,
   type LegacyDebugLoggerShape,
 } from "../shared/legacy-debug-logger.service.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
-import { LegacyCliConfig, type LegacyProfileName } from "./legacy-cli-config.service.ts";
+import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 import { legacyProfileFilePath } from "./legacy-profile-file.ts";
-
-interface ResolvedProfile {
-  readonly name: string;
-  readonly apiUrl: string;
-  readonly projectHost: string;
-  readonly poolerHost: string;
-  readonly dashboardUrl: string;
-}
-
-// All per-profile endpoints are sourced from `legacy-profile.ts` (the single
-// source of truth that mirrors Go's `allProfiles` table and is also consumed
-// by `branches get` and the sso pflag-profile reconciliation), so no mapping
-// is duplicated here.
-function resolvedBuiltin(name: LegacyProfileName): ResolvedProfile {
-  return {
-    name,
-    apiUrl: legacyApiUrl(name),
-    projectHost: legacyProjectHost(name),
-    poolerHost: legacyPoolerHost(name),
-    dashboardUrl: legacyDashboardUrl(name),
-  };
-}
-
-function safeParseYaml(text: string):
-  | {
-      name?: unknown;
-      api_url?: unknown;
-      project_host?: unknown;
-      pooler_host?: unknown;
-      dashboard_url?: unknown;
-    }
-  | undefined {
-  try {
-    const value = parseYaml(text);
-    return value !== null && typeof value === "object"
-      ? (value as {
-          name?: unknown;
-          api_url?: unknown;
-          project_host?: unknown;
-          pooler_host?: unknown;
-          dashboard_url?: unknown;
-        })
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 function unknownMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 /**
- * Resolves the profile that produces the API URL. Mirrors Go's `LoadProfile`
- * (`apps/cli-go/internal/utils/profile.go:96-118`):
+ * Mirrors Go's `getProfileName` precedence (`profile.go:121-136`) — explicit
+ * `--profile` flag → `SUPABASE_PROFILE` env → persisted `~/.supabase/profile`
+ * file → `supabase` — then loads the token via `legacyLoadProfile`, failing
+ * like Go's `LoadProfile` (`profile.go:94-118`) instead of falling back to
+ * the built-in `supabase` profile, which silently targeted the wrong keyring
+ * token and API (supabase/cli#6091).
  *
- * Profile-name precedence mirrors Go's `getProfileName` (`profile.go:121-136`):
- * `--profile` flag (when not the default) → `SUPABASE_PROFILE` env → the
- * persisted `~/.supabase/profile` file → `supabase`. The resolved token is then:
- *
- * 1. If the token matches a built-in profile name, use that.
- * 2. Otherwise treat the token as a path to a YAML config file with `api_url:`.
- * 3. Fall back to the `supabase` built-in if the file is missing or malformed.
- *
- * The cli-e2e harness depends on (2) — it writes a per-test YAML profile and
- * sets `SUPABASE_PROFILE=<that-path>` so both the Go and ts-legacy binaries
- * route requests to the local replay server. YAML profiles may also carry a
- * `project_host:` key (Go's `Profile.ProjectHost`; defaults to `supabase.co`) and
- * a `pooler_host:` key (Go's `Profile.PoolerHost`; `omitempty`, defaults to empty
- * which disables the linked pooler MITM domain assertion).
+ * `flagExplicit` mirrors pflag's `Changed`: an explicitly passed `--profile
+ * supabase` shadows env and file even at the default value, which the parsed
+ * value alone cannot detect. The persisted file's content is trimmed — a
+ * deliberate divergence from Go's raw bytes, compensated by the sso pflag
+ * reconciliation (`legacy-pflag-reconcile.ts`).
  */
 function resolveProfile(
   flagValue: string,
+  flagExplicit: boolean,
   envValue: string | undefined,
   fs: FileSystem.FileSystem,
   path: Path.Path,
   homeDir: string,
   debugLogger: LegacyDebugLoggerShape,
-): Effect.Effect<ResolvedProfile> {
+): Effect.Effect<LegacyLoadedProfile, LegacyProfileLoadError> {
   return Effect.gen(function* () {
     let token: string;
-    if (flagValue !== "supabase") {
+    if (flagValue !== "supabase" || flagExplicit) {
       yield* debugLogger.debug(`Loading profile from flag: ${flagValue}`);
       token = flagValue;
     } else if (envValue !== undefined && envValue.length > 0) {
@@ -125,36 +73,7 @@ function resolveProfile(
       });
     }
 
-    if (legacyIsBuiltinProfileName(token)) {
-      return resolvedBuiltin(token);
-    }
-
-    const content = yield* fs.readFileString(token).pipe(Effect.option);
-    if (Option.isNone(content)) return resolvedBuiltin("supabase");
-
-    const parsed = safeParseYaml(content.value);
-    if (parsed === undefined || typeof parsed.api_url !== "string") {
-      return resolvedBuiltin("supabase");
-    }
-    return {
-      name: typeof parsed.name === "string" ? parsed.name : "supabase",
-      apiUrl: parsed.api_url,
-      projectHost:
-        typeof parsed.project_host === "string"
-          ? parsed.project_host
-          : legacyProjectHost("supabase"),
-      // Go's `Profile.PoolerHost` is `omitempty` (`profile.go:23`): a YAML profile
-      // that omits `pooler_host:` yields an empty host, which disables the MITM
-      // domain assertion — it must NOT fall back to the production `supabase.com`.
-      poolerHost: typeof parsed.pooler_host === "string" ? parsed.pooler_host : "",
-      // Go's `Profile.DashboardURL` is `required` (`profile.go:20`); a YAML profile
-      // that omits it falls back to the built-in `supabase` dashboard here rather
-      // than erroring, since it only feeds the connect-failure suggestion text.
-      dashboardUrl:
-        typeof parsed.dashboard_url === "string"
-          ? parsed.dashboard_url
-          : legacyDashboardUrl("supabase"),
-    };
+    return yield* legacyLoadProfile(token, fs);
   });
 }
 
@@ -218,6 +137,14 @@ export const legacyCliConfigLayer = Layer.unwrap(
         const runtimeInfo = yield* RuntimeInfo;
         const env = process.env;
 
+        // `serviceOption`: tests without argv default to "not explicit". The
+        // empty command path scans all of argv up to `--`, like pflag.
+        const cliArgs = yield* Effect.serviceOption(CliArgs);
+        const profileFlagExplicit = Option.match(cliArgs, {
+          onNone: () => false,
+          onSome: ({ args }) => hasExplicitLongFlag(args, [], "profile"),
+        });
+
         const {
           name: profile,
           apiUrl,
@@ -226,6 +153,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
           dashboardUrl,
         } = yield* resolveProfile(
           profileFlag,
+          profileFlagExplicit,
           env["SUPABASE_PROFILE"],
           fs,
           path,

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.ts
@@ -1,6 +1,6 @@
 import { Effect, FileSystem, Layer, Option, Path, Redacted } from "effect";
 import { CliArgs } from "../../shared/cli/cli-args.service.ts";
-import { hasExplicitLongFlag } from "../../shared/cli/cobra-flag-groups.ts";
+import { lastExplicitLongFlagValue } from "../../shared/cli/cobra-flag-groups.ts";
 import { CLI_VERSION } from "../../shared/cli/version.ts";
 import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
 import {
@@ -28,15 +28,16 @@ function unknownMessage(error: unknown): string {
  * the built-in `supabase` profile, which silently targeted the wrong keyring
  * token and API (supabase/cli#6091).
  *
- * `flagExplicit` mirrors pflag's `Changed`: an explicitly passed `--profile
- * supabase` shadows env and file even at the default value, which the parsed
- * value alone cannot detect. The persisted file's content is trimmed — a
- * deliberate divergence from Go's raw bytes, compensated by the sso pflag
- * reconciliation (`legacy-pflag-reconcile.ts`).
+ * `explicitFlagValue` mirrors pflag: the LAST explicit `--profile` occurrence
+ * wins (the Effect parser is first-wins), and an explicit `--profile supabase`
+ * shadows env and file even at the default value, which the parsed value
+ * alone cannot detect. The persisted file's content is trimmed — a deliberate
+ * divergence from Go's raw bytes, compensated by the sso pflag reconciliation
+ * (`legacy-pflag-reconcile.ts`).
  */
 function resolveProfile(
   flagValue: string,
-  flagExplicit: boolean,
+  explicitFlagValue: string | undefined,
   envValue: string | undefined,
   fs: FileSystem.FileSystem,
   path: Path.Path,
@@ -45,9 +46,10 @@ function resolveProfile(
 ): Effect.Effect<LegacyLoadedProfile, LegacyProfileLoadError> {
   return Effect.gen(function* () {
     let token: string;
-    if (flagValue !== "supabase" || flagExplicit) {
-      yield* debugLogger.debug(`Loading profile from flag: ${flagValue}`);
-      token = flagValue;
+    if (explicitFlagValue !== undefined || flagValue !== "supabase") {
+      const flag = explicitFlagValue ?? flagValue;
+      yield* debugLogger.debug(`Loading profile from flag: ${flag}`);
+      token = flag;
     } else if (envValue !== undefined && envValue.length > 0) {
       // Go reads SUPABASE_PROFILE through viper's PROFILE key, so debug output
       // cannot distinguish env from an explicitly changed flag.
@@ -140,9 +142,9 @@ export const legacyCliConfigLayer = Layer.unwrap(
         // `serviceOption`: tests without argv default to "not explicit". The
         // empty command path scans all of argv up to `--`, like pflag.
         const cliArgs = yield* Effect.serviceOption(CliArgs);
-        const profileFlagExplicit = Option.match(cliArgs, {
-          onNone: () => false,
-          onSome: ({ args }) => hasExplicitLongFlag(args, [], "profile"),
+        const explicitProfileFlag = Option.match(cliArgs, {
+          onNone: () => undefined,
+          onSome: ({ args }) => lastExplicitLongFlagValue(args, [], "profile"),
         });
 
         const {
@@ -153,7 +155,7 @@ export const legacyCliConfigLayer = Layer.unwrap(
           dashboardUrl,
         } = yield* resolveProfile(
           profileFlag,
-          profileFlagExplicit,
+          explicitProfileFlag,
           env["SUPABASE_PROFILE"],
           fs,
           path,

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
@@ -4,9 +4,10 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
-import { Effect, Layer, Option, Redacted } from "effect";
+import { Cause, Effect, Exit, Layer, Option, Redacted } from "effect";
 import { afterEach, beforeEach, vi } from "vitest";
 
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
 import {
   LegacyDebugFlag,
   LegacyProfileFlag,
@@ -14,6 +15,7 @@ import {
 } from "../../shared/legacy/global-flags.ts";
 import { mockRuntimeInfo, processEnvLayer } from "../../../tests/helpers/mocks.ts";
 import { legacyDebugLoggerLayer } from "../shared/legacy-debug-logger.layer.ts";
+import { LegacyProfileLoadError } from "../shared/legacy-profile-load.ts";
 import { legacyCliConfigLayer } from "./legacy-cli-config.layer.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 
@@ -24,6 +26,8 @@ function makeLayer(opts: {
   cwd?: string;
   home?: string;
   debug?: boolean;
+  /** Raw argv for explicit `--profile` detection. */
+  argv?: ReadonlyArray<string>;
 }) {
   const profileFlag = opts.profileFlag ?? "supabase";
   const workdirFlag = opts.workdirFlag ?? Option.none<string>();
@@ -32,10 +36,31 @@ function makeLayer(opts: {
     Layer.provide(Layer.succeed(LegacyDebugFlag, opts.debug ?? false)),
     Layer.provide(Layer.succeed(LegacyProfileFlag, profileFlag)),
     Layer.provide(Layer.succeed(LegacyWorkdirFlag, workdirFlag)),
+    Layer.provide(Layer.succeed(CliArgs, { args: opts.argv ?? [] })),
     Layer.provide(mockRuntimeInfo({ cwd: opts.cwd ?? "/test/cwd", homeDir: opts.home })),
     Layer.provide(BunServices.layer),
     Layer.provide(processEnvLayer(opts.env ?? {})),
   );
+}
+
+// Profile load failures surface as layer-build failures (Go: PersistentPreRunE).
+function configExit(opts: Parameters<typeof makeLayer>[0]) {
+  return Effect.gen(function* () {
+    return yield* LegacyCliConfig;
+  }).pipe(Effect.provide(makeLayer(opts)), Effect.exit);
+}
+
+function expectProfileLoadFailure(exit: Exit.Exit<unknown, unknown>, ...fragments: string[]) {
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (Exit.isFailure(exit)) {
+    // A typed failure, not a defect — only expected errors render cleanly.
+    const error = exit.cause.reasons.find(Cause.isFailReason)?.error;
+    expect(error).toBeInstanceOf(LegacyProfileLoadError);
+    const message = (error as LegacyProfileLoadError).message;
+    for (const fragment of fragments) {
+      expect(message).toContain(fragment);
+    }
+  }
 }
 
 let tempRoot: string;
@@ -143,17 +168,65 @@ describe("legacyCliConfigLayer", () => {
     );
   });
 
+  // Go fails hard on an unloadable profile — never falls back to the built-in
+  // `supabase` profile and its keyring token (supabase/cli#6091).
   it.effect(
-    "falls back to supabase profile when SUPABASE_PROFILE is neither a known name nor a readable file",
+    "fails when SUPABASE_PROFILE is neither a known name nor a readable file — Go parity",
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* configExit({
+          env: { SUPABASE_PROFILE: "rogue-profile" },
+          cwd: tempRoot,
+        });
+        expectProfileLoadFailure(exit, "failed to read profile: Unsupported Config Type");
+      }),
+  );
+
+  it.effect("fails when --profile names a non-existent profile instead of falling back", () =>
+    Effect.gen(function* () {
+      const exit = yield* configExit({ profileFlag: "resms", cwd: tempRoot });
+      expectProfileLoadFailure(exit, "failed to read profile: Unsupported Config Type");
+    }),
+  );
+
+  it.effect("matches built-in profile names case-insensitively — Go strings.EqualFold", () =>
+    Effect.gen(function* () {
+      const config = yield* LegacyCliConfig;
+      expect(config.profile).toBe("supabase-staging");
+      expect(config.apiUrl).toBe("https://api.supabase.green");
+    }).pipe(Effect.provide(makeLayer({ profileFlag: "SUPABASE-STAGING", cwd: tempRoot }))),
+  );
+
+  // pflag `Changed`: an explicitly passed flag counts even at its default value.
+  it.effect(
+    "explicit --profile supabase shadows an unloadable SUPABASE_PROFILE — pflag Changed",
     () =>
       Effect.gen(function* () {
         const config = yield* LegacyCliConfig;
         expect(config.profile).toBe("supabase");
         expect(config.apiUrl).toBe("https://api.supabase.com");
       }).pipe(
-        Effect.provide(makeLayer({ env: { SUPABASE_PROFILE: "rogue-profile" }, cwd: tempRoot })),
+        Effect.provide(
+          makeLayer({
+            argv: ["link", "--profile", "supabase"],
+            env: { SUPABASE_PROFILE: "rogue-profile" },
+            cwd: tempRoot,
+          }),
+        ),
       ),
   );
+
+  it.effect("explicit --profile supabase shadows an unloadable persisted profile file", () => {
+    const home = join(tempRoot, "home");
+    mkdirSync(join(home, ".supabase"), { recursive: true });
+    writeFileSync(join(home, ".supabase", "profile"), "resms\n");
+    return Effect.gen(function* () {
+      const config = yield* LegacyCliConfig;
+      expect(config.profile).toBe("supabase");
+    }).pipe(
+      Effect.provide(makeLayer({ argv: ["login", "--profile=supabase"], home, cwd: tempRoot })),
+    );
+  });
 
   it.effect("loads api_url, name, pooler_host, and dashboard_url from a YAML profile file", () => {
     const profilePath = join(tempRoot, "profile.yaml");
@@ -179,45 +252,69 @@ describe("legacyCliConfigLayer", () => {
     }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_PROFILE: profilePath }, cwd: tempRoot })));
   });
 
-  it.effect("defaults project_host to supabase.co and pooler_host to empty when omitted", () => {
-    const profilePath = join(tempRoot, "no-host.yaml");
-    writeFileSync(profilePath, ["name: cli-e2e", 'api_url: "http://127.0.0.1:9999"'].join("\n"));
+  it.effect("keeps pooler_host empty when a YAML profile omits it — Go omitempty", () => {
+    const profilePath = join(tempRoot, "no-pooler.yaml");
+    writeFileSync(
+      profilePath,
+      [
+        "name: cli-e2e",
+        'api_url: "http://127.0.0.1:9999"',
+        'dashboard_url: "http://127.0.0.1:9999"',
+        "project_host: localhost",
+      ].join("\n"),
+    );
     return Effect.gen(function* () {
       const config = yield* LegacyCliConfig;
-      expect(config.projectHost).toBe("supabase.co");
+      expect(config.projectHost).toBe("localhost");
       // Go's Profile.PoolerHost is `omitempty`: an absent pooler_host disables the
       // MITM domain assertion rather than falling back to supabase.com.
       expect(config.poolerHost).toBe("");
-      // An omitted dashboard_url falls back to the built-in supabase dashboard.
-      expect(config.dashboardUrl).toBe("https://supabase.com/dashboard");
     }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_PROFILE: profilePath }, cwd: tempRoot })));
   });
 
-  it.effect(
-    "falls back to supabase profile when SUPABASE_PROFILE points to a non-existent file",
-    () =>
-      Effect.gen(function* () {
-        const config = yield* LegacyCliConfig;
-        expect(config.profile).toBe("supabase");
-        expect(config.apiUrl).toBe("https://api.supabase.com");
-      }).pipe(
-        Effect.provide(
-          makeLayer({
-            env: { SUPABASE_PROFILE: join(tempRoot, "missing.yaml") },
-            cwd: tempRoot,
-          }),
-        ),
-      ),
+  it.effect("fails when a YAML profile omits required keys — Go validator parity", () => {
+    const profilePath = join(tempRoot, "no-host.yaml");
+    writeFileSync(profilePath, ["name: cli-e2e", 'api_url: "http://127.0.0.1:9999"'].join("\n"));
+    return Effect.gen(function* () {
+      const exit = yield* configExit({ env: { SUPABASE_PROFILE: profilePath }, cwd: tempRoot });
+      expectProfileLoadFailure(
+        exit,
+        "invalid profile:",
+        "Field validation for 'DashboardURL' failed on the 'required' tag",
+        "Field validation for 'ProjectHost' failed on the 'required' tag",
+      );
+    });
+  });
+
+  it.effect("fails when SUPABASE_PROFILE points to a non-existent file — Go parity", () =>
+    Effect.gen(function* () {
+      const missingPath = join(tempRoot, "missing.yaml");
+      const exit = yield* configExit({ env: { SUPABASE_PROFILE: missingPath }, cwd: tempRoot });
+      expectProfileLoadFailure(
+        exit,
+        `failed to read profile: open ${missingPath}: no such file or directory`,
+      );
+    }),
   );
 
-  it.effect("falls back to supabase profile when SUPABASE_PROFILE points to malformed YAML", () => {
+  it.effect("fails when SUPABASE_PROFILE points to malformed YAML — Go parity", () => {
     const profilePath = join(tempRoot, "broken.yaml");
     writeFileSync(profilePath, "::: not yaml :::\n[unbalanced");
     return Effect.gen(function* () {
-      const config = yield* LegacyCliConfig;
-      expect(config.profile).toBe("supabase");
-      expect(config.apiUrl).toBe("https://api.supabase.com");
-    }).pipe(Effect.provide(makeLayer({ env: { SUPABASE_PROFILE: profilePath }, cwd: tempRoot })));
+      const exit = yield* configExit({ env: { SUPABASE_PROFILE: profilePath }, cwd: tempRoot });
+      expectProfileLoadFailure(exit, "failed to read profile: While parsing config:");
+    });
+  });
+
+  // Files written by older lenient versions still exist and must fail like Go.
+  it.effect("fails when the persisted profile file names an unloadable profile", () => {
+    const home = join(tempRoot, "home");
+    mkdirSync(join(home, ".supabase"), { recursive: true });
+    writeFileSync(join(home, ".supabase", "profile"), "resms\n");
+    return Effect.gen(function* () {
+      const exit = yield* configExit({ home, cwd: tempRoot });
+      expectProfileLoadFailure(exit, "failed to read profile: Unsupported Config Type");
+    });
   });
 
   it.effect("ignores SUPABASE_API_URL — Go parity", () =>

--- a/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-cli-config.layer.unit.test.ts
@@ -216,6 +216,33 @@ describe("legacyCliConfigLayer", () => {
       ),
   );
 
+  it.effect("resolves repeated --profile occurrences last-wins — pflag parity", () =>
+    Effect.gen(function* () {
+      // The Effect parser is first-wins ("rogue-profile"); pflag keeps the last.
+      const config = yield* LegacyCliConfig;
+      expect(config.profile).toBe("supabase");
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          argv: ["link", "--profile", "rogue-profile", "--profile", "supabase"],
+          profileFlag: "rogue-profile",
+          cwd: tempRoot,
+        }),
+      ),
+    ),
+  );
+
+  it.effect("fails when the last --profile occurrence is unloadable — pflag parity", () =>
+    Effect.gen(function* () {
+      const exit = yield* configExit({
+        argv: ["link", "--profile", "supabase", "--profile", "resms"],
+        profileFlag: "supabase",
+        cwd: tempRoot,
+      });
+      expectProfileLoadFailure(exit, "failed to read profile: Unsupported Config Type");
+    }),
+  );
+
   it.effect("explicit --profile supabase shadows an unloadable persisted profile file", () => {
     const home = join(tempRoot, "home");
     mkdirSync(join(home, ".supabase"), { recursive: true });

--- a/apps/cli/src/legacy/shared/legacy-db-config.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.layer.ts
@@ -3,6 +3,7 @@ import { BunServices } from "@effect/platform-bun";
 import { Duration, Effect, FileSystem, Layer, Option, Path } from "effect";
 
 import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api-factory.service.ts";
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
 import { LegacyCliConfig } from "../config/legacy-cli-config.service.ts";
 import {
   LegacyProjectRefResolver,
@@ -433,6 +434,13 @@ export const legacyDbConfigLayer = Layer.effect(
       // platform-API factory + linked-project cache (Go's single root-context
       // `sync.Once`). Provided to this layer by each command runtime.
       Layer.succeed(LegacyIdentityStitch, yield* LegacyIdentityStitch),
+      // Optional (absent in handler tests): the lazy rebuild of
+      // `legacyCliConfigLayer` reads it for explicit `--profile` detection, so
+      // the nested resolution matches the outer layer's.
+      Option.match(yield* Effect.serviceOption(CliArgs), {
+        onNone: () => Layer.empty,
+        onSome: (value) => Layer.succeed(CliArgs, value),
+      }),
       BunServices.layer,
     );
     // Compile-time guard: if `legacyLinkedDbResolverRuntimeLayer`'s requirements ever

--- a/apps/cli/src/legacy/shared/legacy-db-config.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.service.ts
@@ -5,6 +5,7 @@ import type {
   LegacyInvalidProjectRefError,
   LegacyProjectNotLinkedError,
 } from "../config/legacy-project-ref.errors.ts";
+import type { LegacyProfileLoadError } from "./legacy-profile-load.ts";
 import type { LegacyProjectRefReadError } from "./legacy-temp-paths.ts";
 import type { LegacyDbConnectError } from "./legacy-db-connection.errors.ts";
 import type {
@@ -46,7 +47,10 @@ export type LegacyDbConfigError =
   // auth-required / invalid-token / api-config errors surface from the resolver
   // effect — not a layer-build channel. `--linked --password` skips `make`
   // entirely and never raises these (Go's `NewDbConfigWithPassword`).
-  | LegacyPlatformApiFactoryError;
+  | LegacyPlatformApiFactoryError
+  // The lazy linked runtime rebuilds `legacyCliConfigLayer`, whose strict
+  // profile resolution can fail inside the resolver effect the same way.
+  | LegacyProfileLoadError;
 
 // The `--linked` path builds a lazy Management API runtime (so `--local` /
 // `--db-url` never resolve an access token) and provides ALL of its own

--- a/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
+++ b/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
@@ -1,6 +1,10 @@
 import { Data, Effect, FileSystem, Option, Path, Result } from "effect";
 
-import type { PflagArgvScan } from "../../shared/cli/cobra-flag-groups.ts";
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
+import {
+  lastExplicitLongFlagValue,
+  type PflagArgvScan,
+} from "../../shared/cli/cobra-flag-groups.ts";
 import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
 import { legacyProfileFilePath } from "../config/legacy-profile-file.ts";
@@ -261,16 +265,27 @@ export const legacyResolvePflagProfile = Effect.fnUntraced(function* (
   const env = process.env["SUPABASE_PROFILE"];
   const envProfile = env !== undefined && env.length > 0 ? env : undefined;
 
-  // viper-effective explicit token vs the config layer's explicit token
-  // (`resolveProfile`, `legacy-cli-config.layer.ts`: parsed flag ≠ default →
-  // env). When both agree on a non-empty explicit token, the layer resolved
-  // the exact same profile the Go binary would target.
+  // viper-effective explicit token vs the config layer's explicit token.
+  // The layer-model MUST mirror `resolveProfile` exactly (raw argv scan →
+  // parsed flag ≠ default → env): the layer's scan treats the last raw
+  // `--profile` occurrence as explicit even when pflag consumed it as another
+  // flag's value, so omitting it here would make the comparison miss a layer
+  // that shadowed the env and silently target the wrong host. When both agree
+  // on a non-empty explicit token, the layer resolved the exact same profile
+  // the Go binary would target.
+  const scanExplicit = Option.match(yield* Effect.serviceOption(CliArgs), {
+    onNone: () => undefined,
+    onSome: ({ args }) => lastExplicitLongFlagValue(args, [], "profile"),
+  });
   const goExplicit = legacyPflagProfileValue(scan, parsedProfile, envProfile);
-  const layerExplicit = Option.isSome(parsedProfile)
-    ? parsedProfile
-    : envProfile !== undefined
-      ? Option.some(envProfile)
-      : Option.none<string>();
+  const layerExplicit =
+    scanExplicit !== undefined
+      ? Option.some(scanExplicit)
+      : Option.isSome(parsedProfile)
+        ? parsedProfile
+        : envProfile !== undefined
+          ? Option.some(envProfile)
+          : Option.none<string>();
   if (
     Option.isSome(goExplicit) &&
     Option.isSome(layerExplicit) &&

--- a/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
+++ b/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
@@ -191,8 +191,9 @@ export const legacyValidatePflagWorkdir = Effect.fnUntraced(function* (
  * - otherwise the Effect-parsed value covers pre-command-path placement
  *   (`supabase --profile x sso add …`) the anchored scan cannot see. The
  *   parsed flag cannot distinguish an explicit `--profile supabase` from the
- *   flag's default, so that value is treated as unset — the same proxy the
- *   config layer uses (`legacy-cli-config.layer.ts`).
+ *   flag's default, so that value is treated as unset (the config layer
+ *   closes the same gap with its own argv scan,
+ *   `legacy-cli-config.layer.ts`).
  */
 export function legacyPflagProfileValue(
   scan: Pick<PflagArgvScan, "occurrences" | "consumedFlagNames" | "prePathOccurrences">,
@@ -241,9 +242,12 @@ export function legacyPflagProfileValue(
  * flag-shaped values, repeat resolution, explicit `--profile supabase`
  * shadowing the env, an untrimmed persisted-file token) — or when the token
  * is empty, which Go deterministically rejects. Where the two agree (every
- * normal invocation), the layer's resolution stands unchanged, including its
- * pre-existing lenient missing/malformed-file fallback, which predates this
- * PR and applies shell-wide (tracked separately from CLI-1982).
+ * normal invocation), the layer's resolution stands unchanged — it uses the
+ * same strict `legacyLoadProfile` and explicit-flag detection
+ * (supabase/cli#6091). Argv shapes where pflag's token consumption diverges
+ * from the Effect parser can still fail the layer build before this
+ * reconcile runs; those fail-closed on both sides, possibly with different
+ * detail text.
  *
  * `serviceOption` throughout: outside the real CLI tree (handler-level tests
  * provide argv via `Stdio.layerTest`) the flag settings and `RuntimeInfo`

--- a/apps/cli/src/legacy/shared/legacy-pflag-reconcile.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-pflag-reconcile.unit.test.ts
@@ -1,11 +1,20 @@
-import { describe, expect, it } from "@effect/vitest";
-import { Option, Result } from "effect";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { BunServices } from "@effect/platform-bun";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Result } from "effect";
+
+import { CliArgs } from "../../shared/cli/cli-args.service.ts";
+import { LegacyProfileFlag } from "../../shared/legacy/global-flags.ts";
+import { mockRuntimeInfo } from "../../../tests/helpers/mocks.ts";
 import {
   legacyPflagBoolValue,
   legacyPflagEnumValue,
   legacyPflagProfileValue,
   legacyPflagWorkdirValue,
+  legacyResolvePflagProfile,
 } from "./legacy-pflag-reconcile.ts";
 
 // Go's SAML `nameid-format` enum (`cmd/sso.go:157-158,176`), reused here only
@@ -344,5 +353,87 @@ describe("legacyPflagProfileValue", () => {
 
   it("treats an empty env var as unset", () => {
     expect(legacyPflagProfileValue(scan([]), Option.none(), "")).toEqual(Option.none());
+  });
+});
+
+describe("legacyResolvePflagProfile", () => {
+  const withEnvProfile = <A, E, R>(value: string, effect: Effect.Effect<A, E, R>) => {
+    const prev = process.env["SUPABASE_PROFILE"];
+    process.env["SUPABASE_PROFILE"] = value;
+    return effect.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (prev === undefined) delete process.env["SUPABASE_PROFILE"];
+          else process.env["SUPABASE_PROFILE"] = prev;
+        }),
+      ),
+    );
+  };
+
+  const services = (args: ReadonlyArray<string>, homeDir: string) =>
+    Layer.mergeAll(
+      BunServices.layer,
+      Layer.succeed(LegacyProfileFlag, "supabase"),
+      Layer.succeed(CliArgs, { args }),
+      mockRuntimeInfo({ homeDir }),
+    );
+
+  // `--domains --profile supabase`: pflag consumes the `--profile` token, so
+  // Go keeps SUPABASE_PROFILE — but the config layer's raw scan shadowed the
+  // env with the swallowed occurrence. The reconcile must see the mismatch and
+  // re-run LoadProfile on the env profile, not return none.
+  it.effect(
+    "re-loads the env profile when the layer's scan wrongly shadowed a consumed token",
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), "supabase-pflag-reconcile-"));
+      const profilePath = join(dir, "env.yml");
+      writeFileSync(
+        profilePath,
+        [
+          "name: harness",
+          "api_url: http://127.0.0.1:45555",
+          "dashboard_url: http://127.0.0.1:45555",
+          "project_host: localhost",
+        ].join("\n"),
+      );
+      return withEnvProfile(
+        profilePath,
+        Effect.gen(function* () {
+          const resolved = yield* legacyResolvePflagProfile({
+            occurrences: new Map(),
+            consumedFlagNames: new Set(["profile"]),
+            prePathOccurrences: new Map(),
+          });
+          expect(Option.isSome(resolved)).toBe(true);
+          if (Option.isSome(resolved)) {
+            expect(resolved.value.name).toBe("harness");
+            expect(resolved.value.apiUrl).toBe("http://127.0.0.1:45555");
+          }
+        }).pipe(
+          Effect.provide(
+            services(["sso", "add", "--type", "saml", "--domains", "--profile", "supabase"], dir),
+          ),
+          Effect.ensuring(Effect.sync(() => rmSync(dir, { recursive: true, force: true }))),
+        ),
+      );
+    },
+  );
+
+  it.effect("returns none when the scan and the layer agree on an explicit supabase", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supabase-pflag-reconcile-"));
+    return withEnvProfile(
+      "rogue-profile",
+      Effect.gen(function* () {
+        const resolved = yield* legacyResolvePflagProfile({
+          occurrences: new Map([["profile", ["supabase"]]]),
+          consumedFlagNames: new Set<string>(),
+          prePathOccurrences: new Map(),
+        });
+        expect(Option.isNone(resolved)).toBe(true);
+      }).pipe(
+        Effect.provide(services(["sso", "add", "--profile", "supabase"], dir)),
+        Effect.ensuring(Effect.sync(() => rmSync(dir, { recursive: true, force: true }))),
+      ),
+    );
   });
 });

--- a/apps/cli/src/legacy/shared/legacy-profile-load.ts
+++ b/apps/cli/src/legacy/shared/legacy-profile-load.ts
@@ -1,29 +1,34 @@
 import { Data, Effect, FileSystem } from "effect";
 import { parse as parseYaml } from "yaml";
 
-import { legacyApiUrl, legacyIsBuiltinProfileName } from "./legacy-profile.ts";
+import {
+  legacyApiUrl,
+  legacyDashboardUrl,
+  legacyIsBuiltinProfileName,
+  legacyPoolerHost,
+  legacyProjectHost,
+} from "./legacy-profile.ts";
 
 // Go's `LoadProfile` (`internal/utils/profile.go:94-118`), run from the root
 // `PersistentPreRunE` (`cmd/root.go:98-102`) immediately BEFORE
 // `ChangeWorkDir` — so a profile Go cannot load aborts before the workdir
 // check, `ValidateRequiredFlags`, `ValidateFlagGroups`, and `RunE`, with no
-// API call ever made. Emulated for the pflag/viper-effective `--profile`/
-// `SUPABASE_PROFILE` whenever it differs from the token the Effect config
-// layer resolved (PR #5974 review round 7). Shared across add + update;
-// message byte-matches Go for the deterministic failure classes (see
-// `legacy-profile-load.ts`).
+// API call ever made. Raised by `legacyCliConfigLayer` on every command's
+// profile resolution (supabase/cli#6091) and by the sso pflag reconciliation
+// (PR #5974 round 7). Message byte-matches Go for the deterministic failure
+// classes.
 export class LegacyProfileLoadError extends Data.TaggedError("LegacyProfileLoadError")<{
   readonly message: string;
 }> {}
 
 /**
  * Emulates Go's `LoadProfile` (`apps/cli-go/internal/utils/profile.go:94-118`)
- * for a viper-effective profile token, returning the profile's API URL or
- * failing exactly where — and, for the deterministic classes, byte-for-byte
- * how — the Go binary fails. Go runs this from the root `PersistentPreRunE`
- * (`cmd/root.go:98-102`) BEFORE `ChangeWorkDir`, so a load failure aborts the
- * command before the workdir check, the required-flag check, the mutex check,
- * and any API request.
+ * for a resolved profile token, returning the profile's endpoint set
+ * (`LegacyLoadedProfile`) or failing exactly where — and, for the
+ * deterministic classes, byte-for-byte how — the Go binary fails. Go runs
+ * this from the root `PersistentPreRunE` (`cmd/root.go:98-102`) BEFORE
+ * `ChangeWorkDir`, so a load failure aborts the command before the workdir
+ * check, the required-flag check, the mutex check, and any API request.
  *
  * Resolution, mirroring Go (binary-verified, PR #5974 review round 7):
  *
@@ -82,6 +87,15 @@ export interface LegacyLoadedProfile {
    * config layer's (review r3684153345).
    */
   readonly name: string;
+  /** Go's `Profile.ProjectHost` (`required`). */
+  readonly projectHost: string;
+  /**
+   * Go's `Profile.PoolerHost` (`omitempty`): "" when absent, disabling the
+   * linked pooler MITM domain assertion — never falls back to `supabase.com`.
+   */
+  readonly poolerHost: string;
+  /** Go's `Profile.DashboardURL` (`required`). */
+  readonly dashboardUrl: string;
 }
 
 export function legacyLoadProfile(
@@ -93,7 +107,13 @@ export function legacyLoadProfile(
     // ASCII lower-case, so folding is plain lower-casing here.
     const folded = token.toLowerCase();
     if (legacyIsBuiltinProfileName(folded)) {
-      return { apiUrl: legacyApiUrl(folded), name: folded };
+      return {
+        apiUrl: legacyApiUrl(folded),
+        name: folded,
+        projectHost: legacyProjectHost(folded),
+        poolerHost: legacyPoolerHost(folded),
+        dashboardUrl: legacyDashboardUrl(folded),
+      };
     }
 
     // viper `SetConfigFile("")` is a no-op, so `ReadInConfig` falls back to
@@ -190,9 +210,15 @@ export function legacyLoadProfile(
       return yield* fail(legacyPadGoErrorBlock(`invalid profile: ${validationErrors.join("\n")}`));
     }
 
-    // `api_url` and `name` both passed the `required` tag above, so they are
-    // present and non-empty.
-    return { apiUrl: values.get("api_url") ?? "", name: values.get("name") ?? "" };
+    // All `required` fields passed validation above; `pooler_host` stays ""
+    // when absent (omitempty).
+    return {
+      apiUrl: values.get("api_url") ?? "",
+      name: values.get("name") ?? "",
+      projectHost: values.get("project_host") ?? "",
+      poolerHost: values.get("pooler_host") ?? "",
+      dashboardUrl: values.get("dashboard_url") ?? "",
+    };
   });
 }
 

--- a/apps/cli/src/legacy/shared/legacy-profile-load.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-profile-load.unit.test.ts
@@ -126,6 +126,32 @@ describe("legacyLoadProfile", () => {
     }).pipe(Effect.provide(BunServices.layer)),
   );
 
+  it.effect("returns the full endpoint set for built-in and YAML profiles", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      // Built-in: endpoints come from the `allProfiles` table.
+      const builtin = yield* legacyLoadProfile("supabase-staging", fs);
+      expect(builtin.projectHost).toBe("supabase.red");
+      expect(builtin.poolerHost).toBe("supabase.green");
+      expect(builtin.dashboardUrl).toBe("https://supabase.green/dashboard");
+      // YAML: `project_host`/`dashboard_url` are required, `pooler_host` is
+      // `omitempty` and stays empty when absent (disables the MITM assertion).
+      const file = writeProfile(
+        "endpoints.yml",
+        [
+          "name: harness",
+          "api_url: http://127.0.0.1:44444",
+          "dashboard_url: http://127.0.0.1:44444/dashboard",
+          "project_host: example.test",
+        ].join("\n"),
+      );
+      const fromFile = yield* legacyLoadProfile(file, fs);
+      expect(fromFile.projectHost).toBe("example.test");
+      expect(fromFile.poolerHost).toBe("");
+      expect(fromFile.dashboardUrl).toBe("http://127.0.0.1:44444/dashboard");
+    }).pipe(Effect.provide(BunServices.layer)),
+  );
+
   it.effect("reports unknown keys LOWERCASED, like viper's pre-decode normalization", () =>
     Effect.gen(function* () {
       const file = writeProfile(

--- a/apps/cli/src/legacy/shared/legacy-profile.ts
+++ b/apps/cli/src/legacy/shared/legacy-profile.ts
@@ -5,9 +5,10 @@
  * `dashboard_url` (used by `legacySuggestUpgrade` to build the billing URL)
  * live here so we have a single source of truth.
  *
- * YAML-mode profiles do not currently carry `project_host` or `dashboard_url`
- * in the TS port; they fall back to the production endpoints, matching Go's
- * behavior when an external profile YAML omits those keys.
+ * YAML-mode profiles carry their own `project_host` and `dashboard_url`
+ * (both `required`, loaded by `legacyLoadProfile`). The `?? DEFAULT_ENDPOINTS`
+ * fallbacks below only serve callers that key a lookup on an already-resolved
+ * profile NAME, which for a YAML profile is its `name:` field, not a table key.
  */
 
 import type { LegacyProfileName } from "../config/legacy-cli-config.service.ts";

--- a/apps/cli/src/shared/cli/cobra-flag-groups.ts
+++ b/apps/cli/src/shared/cli/cobra-flag-groups.ts
@@ -29,6 +29,41 @@ export function hasExplicitLongFlag(
 }
 
 /**
+ * The LAST explicit `--<flagName>` occurrence's value in raw argv, matching
+ * pflag's last-wins resolution (`--profile a --profile b` → `b`), or
+ * `undefined` when the flag never appears. Like pflag, `--<flagName> <next>`
+ * consumes the following token verbatim; a trailing valueless occurrence is
+ * ignored (pflag would have aborted the parse before any resolution).
+ */
+export function lastExplicitLongFlagValue(
+  rawArgs: ReadonlyArray<string>,
+  commandPath: ReadonlyArray<string>,
+  flagName: string,
+): string | undefined {
+  const commandIndex = rawArgs.findIndex((_, index) =>
+    commandPath.every((segment, offset) => rawArgs[index + offset] === segment),
+  );
+  const start = commandIndex === -1 ? 0 : commandIndex + commandPath.length;
+  let value: string | undefined;
+  for (let index = start; index < rawArgs.length; index += 1) {
+    const token = rawArgs[index];
+    if (token === undefined || token === "--") {
+      break;
+    }
+    if (token === `--${flagName}`) {
+      const next = rawArgs[index + 1];
+      if (next !== undefined && next !== "--") {
+        value = next;
+        index += 1;
+      }
+    } else if (token.startsWith(`--${flagName}=`)) {
+      value = token.slice(flagName.length + 3);
+    }
+  }
+  return value;
+}
+
+/**
  * Value-taking long flags registered persistently on the Go root command
  * (`apps/cli-go/cmd/root.go:324-333`: `--workdir`, `--network-id`,
  * `--profile`, `--output`, `--dns-resolver`, `--agent`), plus the TS-only

--- a/apps/cli/src/shared/cli/cobra-flag-groups.unit.test.ts
+++ b/apps/cli/src/shared/cli/cobra-flag-groups.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   cobraMutuallyExclusiveErrorMessage,
   hasExplicitLongFlag,
+  lastExplicitLongFlagValue,
   PERSISTENT_VALUE_FLAG_NAMES,
   PERSISTENT_VALUE_FLAG_SHORTHANDS,
   pflagArgvScan,
@@ -47,6 +48,25 @@ describe("hasExplicitLongFlag", () => {
   test("falls back to a bare scan when the command path is not found", () => {
     expect(hasExplicitLongFlag(["--use-api"], COMMAND_PATH, "use-api")).toBe(true);
     expect(hasExplicitLongFlag(["--use-docker"], COMMAND_PATH, "use-api")).toBe(false);
+  });
+});
+
+describe("lastExplicitLongFlagValue", () => {
+  test("resolves repeated occurrences last-wins, like pflag", () => {
+    expect(
+      lastExplicitLongFlagValue(["link", "--profile", "a", "--profile", "b"], [], "profile"),
+    ).toBe("b");
+    expect(
+      lastExplicitLongFlagValue(["link", "--profile=a", "--profile", "b"], [], "profile"),
+    ).toBe("b");
+  });
+
+  test("reads inline and separate values, undefined when absent or valueless", () => {
+    expect(lastExplicitLongFlagValue(["--profile=x"], [], "profile")).toBe("x");
+    expect(lastExplicitLongFlagValue(["--profile="], [], "profile")).toBe("");
+    expect(lastExplicitLongFlagValue(["link"], [], "profile")).toBeUndefined();
+    expect(lastExplicitLongFlagValue(["link", "--profile"], [], "profile")).toBeUndefined();
+    expect(lastExplicitLongFlagValue(["--", "--profile", "x"], [], "profile")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# TL;DR

fixes `supabase link --profile <name>` failing with Authorization failed for 
the access token and project ref pair, 

which was caused by the legacy config layer silently falling back to the built in supabase profile and
 its keyring token whenever the profile was neither a built in name nor a readable YAML profile file,

 and is now fixed by resolving every command through the strict Go parity loader so an 
unloadable profile fails with the same failed to read profile error as the
 Go CLI before any API call. 
Commands run with a stale unloadable profile file now fail until rescued, and matching Go, 
an explicitly passed `--profile` supabase shadows `SUPABASE_PROFILE` and the persisted file, and login persists and heals the profile file the same way...

## ref:
- closes: https://github.com/supabase/cli/issues/6091
- extends: https://github.com/supabase/cli/pull/6040