### PR TITLE
chore(stack): sync service version manifest and fix sync workflow

### DIFF
--- a/.github/workflows/sync-stack-service-versions.yml
+++ b/.github/workflows/sync-stack-service-versions.yml
@@ -49,13 +49,13 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          if git diff --quiet -- packages/stack/src/versions.ts; then
+          if git diff --quiet -- packages/stack/src/ServiceCatalog.ts; then
             echo "Stack service versions are already synced."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/stack/src/versions.ts
+          git add packages/stack/src/ServiceCatalog.ts
           git commit -m "chore(stack): sync service version manifest"
           git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_HEAD_REF}"

--- a/packages/stack/src/ServiceCatalog.ts
+++ b/packages/stack/src/ServiceCatalog.ts
@@ -201,7 +201,7 @@ export const SERVICE_CATALOG = {
   realtime: {
     name: "realtime",
     configKey: "realtime",
-    defaultVersion: "2.123.1",
+    defaultVersion: "2.123.5",
     runtimeSupport: "docker-only",
     artifact: { docker: { ownership: "supabase", repository: "realtime", tagPrefix: "v" } },
     activation: { startup: "eager", activates: [], owns: [] },
@@ -210,7 +210,7 @@ export const SERVICE_CATALOG = {
   storage: {
     name: "storage",
     configKey: "storage",
-    defaultVersion: "1.68.1",
+    defaultVersion: "1.68.8",
     runtimeSupport: "docker-only",
     artifact: { docker: { ownership: "supabase", repository: "storage-api", tagPrefix: "v" } },
     activation: { startup: "lazy", activates: ["imgproxy"], owns: ["imgproxy"] },
@@ -237,7 +237,7 @@ export const SERVICE_CATALOG = {
   pgmeta: {
     name: "pgmeta",
     configKey: "pgmeta",
-    defaultVersion: "0.96.6",
+    defaultVersion: "0.96.8",
     runtimeSupport: "docker-only",
     artifact: {
       docker: { ownership: "supabase", repository: "postgres-meta", tagPrefix: "v" },
@@ -257,7 +257,7 @@ export const SERVICE_CATALOG = {
   analytics: {
     name: "analytics",
     configKey: "analytics",
-    defaultVersion: "1.49.2",
+    defaultVersion: "1.50.0",
     runtimeSupport: "docker-only",
     artifact: { docker: { ownership: "supabase", repository: "logflare" } },
     activation: { startup: "lazy", activates: ["vector"], owns: ["vector"] },


### PR DESCRIPTION
## What changed

The original pg-meta Dockerfile bump in this PR was superseded by dependabot's `docker-minor` group bump (#6107), which landed on `develop` first and already bumped `postgres-meta`, `realtime`, `storage-api`, and `logflare` in `apps/cli-go/pkg/config/templates/Dockerfile`.

That surfaced the real issue flagged in review: `packages/stack/src/ServiceCatalog.ts`'s `DEFAULT_VERSIONS` (used by the TS/`@supabase/stack` local runtime) had drifted from the Dockerfile for all 4 of those services, because `.github/workflows/sync-stack-service-versions.yml` still diffed/staged the pre-refactor `packages/stack/src/versions.ts` path instead of `ServiceCatalog.ts` (where `DEFAULT_VERSIONS` now lives), so it silently no-op'd instead of committing the sync after dependabot's PR.

This PR:
- Runs `pnpm sync:versions` to bring `ServiceCatalog.ts` back in sync with the Dockerfile (pgmeta, realtime, storage, analytics).
- Fixes the workflow to target `ServiceCatalog.ts` so future dependabot Dockerfile bumps sync correctly again.