### PR TITLE
fix(cli): skip function bundle chmod on windows

### DIFF
--- a/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/deploy/deploy.integration.test.ts
@@ -15,7 +15,10 @@ import {
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { mockOutput, mockRuntimeInfo } from "../../../../../tests/helpers/mocks.ts";
 import { mockChildProcessSpawner } from "../../../../../../../packages/process-compose/tests/helpers/mocks.ts";
-import { deployFunctions } from "../../../../shared/functions/deploy.ts";
+import {
+  deployFunctions,
+  shouldChmodBundleOutputDirectory,
+} from "../../../../shared/functions/deploy.ts";
 import {
   ConflictingFunctionDeployFlagsError,
   NoFunctionsToDeployError,
@@ -1123,6 +1126,16 @@ describe("legacy functions deploy", () => {
         ),
       );
     });
+  });
+
+  describe("Docker bundle output permissions", () => {
+    it.live("skips the POSIX chmod on Windows only", () =>
+      Effect.sync(() => {
+        expect(shouldChmodBundleOutputDirectory("win32")).toBe(false);
+        expect(shouldChmodBundleOutputDirectory("darwin")).toBe(true);
+        expect(shouldChmodBundleOutputDirectory("linux")).toBe(true);
+      }),
+    );
   });
 
   describe("no-functions error styling (Go parity: deploy.go:35; structured output stays plain)", () => {

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -45,6 +45,10 @@ const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:\//;
 const importPathPattern =
   /(?:import|export)\s+(?:type\s+)?(?:{[^{}]+}|.*?)\s*(?:from)?\s*['"](.*?)['"]|import\(\s*['"](.*?)['"]\)/gi;
 
+export function shouldChmodBundleOutputDirectory(platform: NodeJS.Platform) {
+  return platform !== "win32";
+}
+
 interface FunctionsDeployFlags {
   readonly functionNames: ReadonlyArray<string>;
   readonly projectRef: Option.Option<string>;
@@ -1414,7 +1418,14 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
     mkdtemp(join(outputRoot, `.supabase-output-${config.slug}-`)),
   );
   try {
-    yield* Effect.tryPromise(() => chmod(outputDir, 0o777));
+    // Go passes 0777 to MkdirAll, which Windows ignores. Calling chmod separately
+    // adds an NTFS WRITE_ATTRIBUTES requirement that the Go CLI does not have.
+    if (shouldChmodBundleOutputDirectory(process.platform)) {
+      yield* Effect.tryPromise({
+        try: () => chmod(outputDir, 0o777),
+        catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+      });
+    }
     const outputPath = join(outputDir, "output.eszip");
     const binds = yield* Effect.promise(() =>
       buildDockerBinds(projectId, functionsDir, outputDir, config),


### PR DESCRIPTION
## TL;DR

skips the POSIX-only bundle output `chmod` on Windows, matching the Go CLI's `MkdirAll(..., 0777)` behavior

the unconditional TypeScript chmod introduced an NTFS `WRITE_ATTRIBUTES` requirement that does not exist in the Go
when denied, deployment failed before Docker started and surfaced only `An error occurred in Effect.tryPromise`.

macOS and Linux retain the world-writable permission adjustment
while any chmod failure on those platforms now preserves the underlying filesystem error.

## ref

- closes #6104