### PR TITLE
test(process-compose): deflake the cleanup timeout test

### DIFF
--- a/packages/process-compose/src/SupervisorRuntime.unit.test.ts
+++ b/packages/process-compose/src/SupervisorRuntime.unit.test.ts
@@ -195,58 +195,65 @@ describe("supervisor-runtime", () => {
     expect(childEnv).toEqual({ KEEP_ME: "value" });
   });
 
-  test("bounds a cleanup command tree by its timeout and continues remaining cleanup", async () => {
-    const tempDir = mkdtempSync(path.join(tmpdir(), "process-compose-supervisor-timeout-"));
-    const cleanupDir = path.join(tempDir, "cleanup-dir");
-    const cleanupWorkerPidFile = path.join(tempDir, "cleanup-worker.pid");
-    const childScriptPath = path.join(tempDir, "child.mjs");
-    mkdirSync(cleanupDir);
-    writeFileSync(childScriptPath, "process.exit(0);\n");
-    const encodedConfig = Buffer.from(
-      JSON.stringify({
-        command: process.execPath,
-        args: [childScriptPath],
-        cleanup: [
-          {
-            _tag: "RunCommand",
-            executable: process.execPath,
-            args: [
-              "-e",
-              [
-                `const { spawn } = require("node:child_process");`,
-                `const { writeFileSync } = require("node:fs");`,
-                `const worker = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });`,
-                `writeFileSync(${JSON.stringify(cleanupWorkerPidFile)}, String(worker.pid));`,
-                `setInterval(() => {}, 1000);`,
-              ].join("\n"),
-            ],
-            // Budget starts at spawn, so it must outlast node booting, spawning
-            // the worker, and writing the pid file. 100ms lost that race on CI.
-            timeoutMs: 2_000,
-          },
-          { _tag: "RemovePath", path: cleanupDir, recursive: true },
-        ],
-      }),
-    ).toString("base64url");
-    const supervisor = spawnSupervisor("source path", encodedConfig);
+  test(
+    "bounds a cleanup command tree by its timeout and continues remaining cleanup",
+    { timeout: 12_000 },
+    async () => {
+      const tempDir = mkdtempSync(path.join(tmpdir(), "process-compose-supervisor-timeout-"));
+      const cleanupDir = path.join(tempDir, "cleanup-dir");
+      const cleanupWorkerPidFile = path.join(tempDir, "cleanup-worker.pid");
+      const childScriptPath = path.join(tempDir, "child.mjs");
+      mkdirSync(cleanupDir);
+      writeFileSync(childScriptPath, "process.exit(0);\n");
+      const encodedConfig = Buffer.from(
+        JSON.stringify({
+          command: process.execPath,
+          args: [childScriptPath],
+          cleanup: [
+            {
+              _tag: "RunCommand",
+              executable: process.execPath,
+              args: [
+                "-e",
+                [
+                  `const { spawn } = require("node:child_process");`,
+                  `const { writeFileSync } = require("node:fs");`,
+                  `const worker = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });`,
+                  `writeFileSync(${JSON.stringify(cleanupWorkerPidFile)}, String(worker.pid));`,
+                  `setInterval(() => {}, 1000);`,
+                ].join("\n"),
+              ],
+              // Budget starts at spawn, so it must outlast node booting, spawning
+              // the worker, and writing the pid file. 100ms lost that race on CI.
+              timeoutMs: 2_000,
+            },
+            { _tag: "RemovePath", path: cleanupDir, recursive: true },
+          ],
+        }),
+      ).toString("base64url");
+      const supervisor = spawnSupervisor("source path", encodedConfig);
 
-    try {
-      await waitFor(() => supervisor.exitCode != null);
-      expect(supervisor.exitCode).toBe(0);
-      expect(existsSync(cleanupDir)).toBe(false);
-      const cleanupWorkerPid = Number.parseInt(readFileSync(cleanupWorkerPidFile, "utf8"), 10);
-      expect(Number.isSafeInteger(cleanupWorkerPid)).toBe(true);
-      await waitFor(() => !isPidAlive(cleanupWorkerPid));
-    } finally {
-      supervisor.kill("SIGKILL");
-      if (existsSync(cleanupWorkerPidFile)) {
-        try {
-          process.kill(Number.parseInt(readFileSync(cleanupWorkerPidFile, "utf8"), 10), "SIGKILL");
-        } catch {}
+      try {
+        await waitFor(() => supervisor.exitCode != null, { timeoutMs: 10_000 });
+        expect(supervisor.exitCode).toBe(0);
+        expect(existsSync(cleanupDir)).toBe(false);
+        const cleanupWorkerPid = Number.parseInt(readFileSync(cleanupWorkerPidFile, "utf8"), 10);
+        expect(Number.isSafeInteger(cleanupWorkerPid)).toBe(true);
+        await waitFor(() => !isPidAlive(cleanupWorkerPid), { timeoutMs: 10_000 });
+      } finally {
+        supervisor.kill("SIGKILL");
+        if (existsSync(cleanupWorkerPidFile)) {
+          try {
+            process.kill(
+              Number.parseInt(readFileSync(cleanupWorkerPidFile, "utf8"), 10),
+              "SIGKILL",
+            );
+          } catch {}
+        }
+        rmSync(tempDir, { recursive: true, force: true });
       }
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   test("bounds a cleanup command when no timeout is configured", { timeout: 12_000 }, async () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), "process-compose-supervisor-timeout-"));

--- a/packages/process-compose/src/SupervisorRuntime.unit.test.ts
+++ b/packages/process-compose/src/SupervisorRuntime.unit.test.ts
@@ -220,7 +220,9 @@ describe("supervisor-runtime", () => {
                 `setInterval(() => {}, 1000);`,
               ].join("\n"),
             ],
-            timeoutMs: 100,
+            // Budget starts at spawn, so it must outlast node booting, spawning
+            // the worker, and writing the pid file. 100ms lost that race on CI.
+            timeoutMs: 2_000,
           },
           { _tag: "RemovePath", path: cleanupDir, recursive: true },
         ],


### PR DESCRIPTION


## TL;DR

`SupervisorRuntime.unit.test.ts` intermittently fails on CI with `ENOENT … cleanup-worker.pid`:

<img width="731" height="520" alt="image" src="https://github.com/user-attachments/assets/08fae2db-d372-4c27-aa72-a4e56c7ac1ee" />

the cleanup command's timeout budget starts at spawn, 
so `100ms` had to cover node booting, spawning the worker and writing the pid file. 
lose that race and the tree gets killed before the write lands. raised to 2s, any value bounds the tree, so what the test asserts is unchanged....

## ref:
- seen on: https://github.com/supabase/cli/actions/runs/31211231481/job/92974279931
