### PR TITLE
fix(cli): skip redundant network create

### DIFF
--- a/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.integration.test.ts
@@ -368,6 +368,7 @@ function defaultLocalResetRoute(opts: DefaultRouteOpts = {}) {
     if (args[0] === "context" && args[1] === "inspect") return { exitCode: 1 };
     if (args[0] === "container" && args[1] === "rm") return { exitCode: 0 };
     if (args[0] === "volume" && args[1] === "rm") return { exitCode: 0 };
+    if (args[0] === "network" && args[1] === "inspect") return { exitCode: 1 };
     if (args[0] === "network" && args[1] === "create") return { exitCode: 0 };
     if (args[0] === "volume" && args[1] === "create") return { exitCode: 0 };
     if (args[0] === "create") {

--- a/apps/cli/src/legacy/commands/db/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/start/start.integration.test.ts
@@ -154,6 +154,7 @@ function defaultRoute(opts: { readonly neverHealthy?: boolean } = {}) {
   const created = new Set<string>();
   return (args: ReadonlyArray<string>): RouteResult => {
     if (args[0] === "image" && args[1] === "inspect") return { exitCode: 0 };
+    if (args[0] === "network" && args[1] === "inspect") return { exitCode: 1 };
     if (args[0] === "network" && args[1] === "create") return { exitCode: 0 };
     if (args[0] === "volume" && args[1] === "inspect") return { exitCode: 0 };
     if (args[0] === "volume" && args[1] === "create") return { exitCode: 0 };

--- a/apps/cli/src/legacy/commands/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.integration.test.ts
@@ -242,6 +242,7 @@ function defaultRoute(opts: { readonly neverHealthy?: ReadonlySet<string> } = {}
   const created = new Set<string>();
   return (args: ReadonlyArray<string>): RouteResult => {
     if (args[0] === "image" && args[1] === "inspect") return { exitCode: 0 };
+    if (args[0] === "network" && args[1] === "inspect") return { exitCode: 1 };
     if (args[0] === "network" && args[1] === "create") return { exitCode: 0 };
     if (args[0] === "volume" && args[1] === "create") return { exitCode: 0 };
     if (args[0] === "context" && args[1] === "inspect") return { exitCode: 1 };
@@ -3629,6 +3630,29 @@ content_path = "./templates/custom_notice.html"
         );
         const networkFlagIndex = kongCreate?.args.indexOf("--network") ?? -1;
         expect(kongCreate?.args[networkFlagIndex + 1]).toBe("custom-net");
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.live("never spawns a create for a pre-created --network-id network", () => {
+      const base = defaultRoute();
+      const route = (args: ReadonlyArray<string>): RouteResult => {
+        if (args[0] === "network" && args[1] === "inspect") return { exitCode: 0 };
+        if (args[0] === "network" && args[1] === "create") {
+          return { exitCode: 1, stderr: ["error during connect: write: broken pipe"] };
+        }
+        return base(args);
+      };
+      const { layer, child } = setup({ networkId: Option.some("custom-net"), route });
+      return Effect.gen(function* () {
+        yield* legacyStart(flags());
+        expect(child.spawned.some((s) => s.args[0] === "network" && s.args[1] === "create")).toBe(
+          false,
+        );
+        expect(
+          child.spawned.some(
+            (s) => s.args[0] === "network" && s.args[1] === "inspect" && s.args[2] === "custom-net",
+          ),
+        ).toBe(true);
       }).pipe(Effect.provide(layer));
     });
 

--- a/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.ts
@@ -22,6 +22,7 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 
 import {
   collectText,
+  containerCliExitCode,
   legacyDescribeContainerCliFailure,
   runContainerCliExpectSuccess,
   spawnContainerCli,
@@ -234,6 +235,14 @@ export function legacyEnsureNetwork(
   }
   return Effect.scoped(
     Effect.gen(function* () {
+      const inspectExitCode = yield* containerCliExitCode(
+        spawner,
+        ["network", "inspect", networkId],
+        { stdin: "ignore", stdout: "ignore", stderr: "ignore" },
+      ).pipe(Effect.orElseSucceed(() => 1));
+      if (inspectExitCode === 0) {
+        return;
+      }
       const args = [
         "network",
         "create",

--- a/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.unit.test.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.unit.test.ts
@@ -694,14 +694,19 @@ describe("legacyCreateContainer secretFiles", () => {
 });
 
 describe("legacyEnsureNetwork", () => {
-  it.live("creates the network with labels", () => {
-    const mock = mockSpawner(() => ({ exitCode: 0 }));
+  it.live("creates the network with labels when it does not exist yet", () => {
+    const mock = mockSpawner((args) =>
+      args[1] === "inspect"
+        ? { exitCode: 1, stderr: "Error: No such network: supabase_network_proj\n" }
+        : { exitCode: 0 },
+    );
     return legacyEnsureNetwork(mock.spawner, "supabase_network_proj", {
       "com.supabase.cli.project": "proj",
       "com.docker.compose.project": "proj",
     }).pipe(
       Effect.map(() => {
         expect(mock.spawned).toEqual([
+          ["network", "inspect", "supabase_network_proj"],
           [
             "network",
             "create",
@@ -712,6 +717,21 @@ describe("legacyEnsureNetwork", () => {
             "supabase_network_proj",
           ],
         ]);
+      }),
+    );
+  });
+
+  it.live("never spawns a create for an already-existing network", () => {
+    const mock = mockSpawner((args) =>
+      args[1] === "inspect"
+        ? { exitCode: 0 }
+        : { exitCode: 1, stderr: "error during connect: write: broken pipe\n" },
+    );
+    return legacyEnsureNetwork(mock.spawner, "supabase_network_proj", {
+      "com.supabase.cli.project": "proj",
+    }).pipe(
+      Effect.map(() => {
+        expect(mock.spawned).toEqual([["network", "inspect", "supabase_network_proj"]]);
       }),
     );
   });


### PR DESCRIPTION
## TL;DR

fixes `supabase start --network-id` failing with `failed to create docker network`
 when the network already exists but the create request dies in transit, for example an EPIPE through a docker socket forwarder. 

was caused by `legacyEnsureNetwork` always spawning a `docker network create` that is a guaranteed conflict for an existing network, and is now fixed by:
probing `docker network inspect` first and only creating on a miss, the same shape `ensureDockerNetwork` already uses. The shared bootstrap path also covers `db start` and `db reset`....

## ref:
- closes: CLI-2151
- closes: https://github.com/supabase/cli/issues/6127
