### PR TITLE
chore(cli): define error taxonomy

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-access-token.ts
+++ b/apps/cli/src/legacy/auth/legacy-access-token.ts
@@ -27,9 +27,13 @@ const LEGACY_INVALID_ACCESS_TOKEN_MESSAGE =
  */
 export const validateLegacyAccessToken = (
   token: string,
+  source?: "env" | "stored",
 ): Effect.Effect<string, LegacyInvalidAccessTokenError> =>
   LEGACY_ACCESS_TOKEN_PATTERN.test(token)
     ? Effect.succeed(token)
     : Effect.fail(
-        new LegacyInvalidAccessTokenError({ message: LEGACY_INVALID_ACCESS_TOKEN_MESSAGE }),
+        new LegacyInvalidAccessTokenError({
+          message: LEGACY_INVALID_ACCESS_TOKEN_MESSAGE,
+          source,
+        }),
       );

--- a/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-credentials.layer.ts
@@ -483,14 +483,14 @@ const makeLegacyCredentials = Effect.gen(function* () {
       // Env takes precedence (matches access_token.go:38).
       if (Option.isSome(cliConfig.accessToken)) {
         yield* debugLogger.debug("Using access token from env var...");
-        yield* validateLegacyAccessToken(Redacted.value(cliConfig.accessToken.value));
+        yield* validateLegacyAccessToken(Redacted.value(cliConfig.accessToken.value), "env");
         return Option.some(cliConfig.accessToken.value);
       }
 
       // Keyring (profile key, then legacy key). Skipped on WSL.
       const keyringValue = yield* readKeyring;
       if (Option.isSome(keyringValue)) {
-        yield* validateLegacyAccessToken(keyringValue.value);
+        yield* validateLegacyAccessToken(keyringValue.value, "stored");
         return Option.some(Redacted.make(keyringValue.value));
       }
 
@@ -498,7 +498,7 @@ const makeLegacyCredentials = Effect.gen(function* () {
       const fileValue = yield* readFile;
       if (Option.isSome(fileValue)) {
         yield* debugLogger.debug(`Using access token from file: ${fallbackPath}`);
-        yield* validateLegacyAccessToken(fileValue.value);
+        yield* validateLegacyAccessToken(fileValue.value, "stored");
         return Option.some(Redacted.make(fileValue.value));
       }
 

--- a/apps/cli/src/legacy/auth/legacy-errors.ts
+++ b/apps/cli/src/legacy/auth/legacy-errors.ts
@@ -1,16 +1,37 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 export class LegacyInvalidAccessTokenError extends Data.TaggedError(
   "LegacyInvalidAccessTokenError",
 )<{
   readonly message: string;
-}> {}
+  /**
+   * Where the malformed token was read from. An env-var token
+   * (`SUPABASE_ACCESS_TOKEN`) takes precedence over stored credentials, so
+   * `supabase login` cannot fix it — the remediation is to correct the env
+   * var. A stored (keyring/file) token, or an unknown source, is fixable by
+   * logging in again.
+   */
+  readonly source?: "env" | "stored";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.source === "env" ? actionability.authToken : actionability.authLogin;
+  }
+}
 
 export class LegacyPlatformAuthRequiredError extends Data.TaggedError(
   "LegacyPlatformAuthRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 /**
  * Raised by `deleteProjectCredential` when removing a stored database-password
@@ -21,7 +42,11 @@ export class LegacyPlatformAuthRequiredError extends Data.TaggedError(
  */
 export class LegacyCredentialDeleteError extends Data.TaggedError("LegacyCredentialDeleteError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Raised by `deleteAccessToken` when there is no access token to delete, i.e.
@@ -33,7 +58,11 @@ export class LegacyCredentialDeleteError extends Data.TaggedError("LegacyCredent
  */
 export class LegacyNotLoggedInError extends Data.TaggedError("LegacyNotLoggedInError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 /**
  * Raised by `deleteAccessToken` when removing the token fails for a real reason
@@ -44,4 +73,8 @@ export class LegacyNotLoggedInError extends Data.TaggedError("LegacyNotLoggedInE
  */
 export class LegacyDeleteTokenError extends Data.TaggedError("LegacyDeleteTokenError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
+++ b/apps/cli/src/legacy/auth/legacy-platform-api.layer.ts
@@ -47,7 +47,7 @@ export const legacyMakePlatformApi = Effect.gen(function* () {
       // already validates the keyring/file paths; validate the env token here too so
       // a malformed SUPABASE_ACCESS_TOKEN fails with the invalid-token error rather
       // than being sent to the API.
-      yield* validateLegacyAccessToken(Redacted.value(configuredToken.value));
+      yield* validateLegacyAccessToken(Redacted.value(configuredToken.value), "env");
       return configuredToken;
     }
     return yield* credentials.getAccessToken;

--- a/apps/cli/src/legacy/commands/backups/backups.errors.ts
+++ b/apps/cli/src/legacy/commands/backups/backups.errors.ts
@@ -1,8 +1,21 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyBackupListNetworkError extends Data.TaggedError("LegacyBackupListNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBackupListUnexpectedStatusError extends Data.TaggedError(
   "LegacyBackupListUnexpectedStatusError",
@@ -10,13 +23,24 @@ export class LegacyBackupListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyBackupRestoreNetworkError extends Data.TaggedError(
   "LegacyBackupRestoreNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBackupRestoreUnexpectedStatusError extends Data.TaggedError(
   "LegacyBackupRestoreUnexpectedStatusError",
@@ -24,4 +48,8 @@ export class LegacyBackupRestoreUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}

--- a/apps/cli/src/legacy/commands/backups/backups.errors.ts
+++ b/apps/cli/src/legacy/commands/backups/backups.errors.ts
@@ -25,7 +25,7 @@ export class LegacyBackupListUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -50,6 +50,6 @@ export class LegacyBackupRestoreUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 // ---------------------------------------------------------------------------
 // Bootstrap-specific tagged errors. Each maps to a Go `errors.New` / failure
@@ -12,21 +18,33 @@ export class LegacyBootstrapInvalidTemplateError extends Data.TaggedError(
   "LegacyBootstrapInvalidTemplateError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** GitHub samples listing failure — Go's `failed to list samples` (`bootstrap.go:ListSamples`). */
 export class LegacyBootstrapTemplateListError extends Data.TaggedError(
   "LegacyBootstrapTemplateListError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 /** Reading the target workdir failed — Go's `failed to read workdir: %w` (`bootstrap.go:44`). */
 export class LegacyBootstrapWorkdirReadError extends Data.TaggedError(
   "LegacyBootstrapWorkdirReadError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * User declined the overwrite prompt — Go returns `errors.New(context.Canceled)`
@@ -36,14 +54,22 @@ export class LegacyBootstrapOverwriteDeclinedError extends Data.TaggedError(
   "LegacyBootstrapOverwriteDeclinedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}
 
 /** Template download failure — Go's `failed to download template: %w` (`bootstrap.go:downloadSample`). */
 export class LegacyBootstrapTemplateDownloadError extends Data.TaggedError(
   "LegacyBootstrapTemplateDownloadError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 /**
  * Project health probe failed — Go's `Error status %d: %s` (non-200) or
@@ -51,4 +77,25 @@ export class LegacyBootstrapTemplateDownloadError extends Data.TaggedError(
  */
 export class LegacyBootstrapHealthError extends Data.TaggedError("LegacyBootstrapHealthError")<{
   readonly message: string;
-}> {}
+  /** Set when the health poll itself failed with a non-200; absent when the
+   * service reported unhealthy. */
+  readonly status?: number;
+  /** Set when the health poll's response came back with a 200 the generated
+   * client could not decode (`SchemaError`/`HttpBodyError`) — an API-response
+   * problem, not a transport failure. */
+  readonly decode?: boolean;
+  /** Set when the health poll failed without any HTTP response (DNS, TLS,
+   * timeout) — a network failure, not an API status. */
+  readonly transport?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.status !== undefined) return statusCodeActionability(this.status);
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    if (this.transport === true) {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+    }
+    return actionability.apiStatus;
+  }
+}

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.errors.ts
@@ -81,7 +81,7 @@ export class LegacyBootstrapHealthError extends Data.TaggedError("LegacyBootstra
    * service reported unhealthy. */
   readonly status?: number;
   /** Set when the health poll's response came back with a 200 the generated
-   * client could not decode (`SchemaError`/`HttpBodyError`) — an API-response
+   * client could not decode (`SchemaError`) — an API-response
    * problem, not a transport failure. */
   readonly decode?: boolean;
   /** Set when the health poll failed without any HTTP response (DNS, TLS,

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
@@ -423,14 +423,14 @@ export const legacyBootstrap = Effect.fn("legacy.bootstrap")(function* (
   );
 });
 
-// Whether `cause` is the generated client's `SchemaError`/`HttpBodyError` — a
-// 200 response the client could not decode, as opposed to a transport
-// failure (DNS, TLS, timeout).
+// Whether `cause` is the generated client's `SchemaError` — a 200 response the
+// client could not decode, as opposed to a transport failure (DNS, TLS,
+// timeout).
 function isDecodeFailureCause(cause: unknown): boolean {
   if (typeof cause !== "object" || cause === null || !("_tag" in cause)) {
     return false;
   }
-  return cause._tag === "SchemaError" || cause._tag === "HttpBodyError";
+  return cause._tag === "SchemaError";
 }
 
 // Mirrors Go's `checkProjectHealth` non-200 branch: `Error status %d: %s`.

--- a/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
+++ b/apps/cli/src/legacy/commands/bootstrap/bootstrap.handler.ts
@@ -423,6 +423,16 @@ export const legacyBootstrap = Effect.fn("legacy.bootstrap")(function* (
   );
 });
 
+// Whether `cause` is the generated client's `SchemaError`/`HttpBodyError` — a
+// 200 response the client could not decode, as opposed to a transport
+// failure (DNS, TLS, timeout).
+function isDecodeFailureCause(cause: unknown): boolean {
+  if (typeof cause !== "object" || cause === null || !("_tag" in cause)) {
+    return false;
+  }
+  return cause._tag === "SchemaError" || cause._tag === "HttpBodyError";
+}
+
 // Mirrors Go's `checkProjectHealth` non-200 branch: `Error status %d: %s`.
 const mapHealthError = (cause: unknown): Effect.Effect<never, LegacyBootstrapHealthError> => {
   if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
@@ -431,9 +441,15 @@ const mapHealthError = (cause: unknown): Effect.Effect<never, LegacyBootstrapHea
       Effect.orElseSucceed(() => ""),
       Effect.map(sanitizeLegacyErrorBody),
       Effect.flatMap((body) =>
-        Effect.fail(new LegacyBootstrapHealthError({ message: `Error status ${status}: ${body}` })),
+        Effect.fail(
+          new LegacyBootstrapHealthError({ message: `Error status ${status}: ${body}`, status }),
+        ),
       ),
     );
   }
-  return Effect.fail(new LegacyBootstrapHealthError({ message: `Error status 0: ${cause}` }));
+  return Effect.fail(
+    isDecodeFailureCause(cause)
+      ? new LegacyBootstrapHealthError({ message: `Error status 0: ${cause}`, decode: true })
+      : new LegacyBootstrapHealthError({ message: `Error status 0: ${cause}`, transport: true }),
+  );
 };

--- a/apps/cli/src/legacy/commands/branches/branches.errors.ts
+++ b/apps/cli/src/legacy/commands/branches/branches.errors.ts
@@ -1,4 +1,11 @@
 import { Data } from "effect";
+import {
+  actionability,
+  CliSuggestionType,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 // ---------------------------------------------------------------------------
 // HTTP-bound errors — one (Network + UnexpectedStatus) pair per Go errorf site.
@@ -10,7 +17,14 @@ export class LegacyBranchesListNetworkError extends Data.TaggedError(
   "LegacyBranchesListNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesListUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesListUnexpectedStatusError",
@@ -18,13 +32,24 @@ export class LegacyBranchesListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesCreateNetworkError extends Data.TaggedError(
   "LegacyBranchesCreateNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesCreateUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesCreateUnexpectedStatusError",
@@ -32,14 +57,37 @@ export class LegacyBranchesCreateUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // A non-gated 409 on `branches create` means the branch name already
+    // exists (the next shell maps this endpoint's 409 to
+    // BranchAlreadyExistsError) — user input, not a raw API status. The gate
+    // guard stays ahead so a confirmed plan-limited 409 still classifies as
+    // plan_limit via the shared policy.
+    if (this.upgradeSuggested !== true && this.status === 409) {
+      return { ...actionability.invalidInput, fingerprint_suffix: "conflict" };
+    }
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: true,
+    });
+  }
+}
 
 // Lookup phase of `branches get` (only runs when input is not UUID / not ref).
 export class LegacyBranchesFindNetworkError extends Data.TaggedError(
   "LegacyBranchesFindNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesFindUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesFindUnexpectedStatusError",
@@ -47,7 +95,11 @@ export class LegacyBranchesFindUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 // `branches get` detail phase + the resolver's UUID branch (both use
 // V1GetABranchConfig; Go shares the same error template).
@@ -55,7 +107,14 @@ export class LegacyBranchesGetNetworkError extends Data.TaggedError(
   "LegacyBranchesGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesGetUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesGetUnexpectedStatusError",
@@ -63,13 +122,24 @@ export class LegacyBranchesGetUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesApiKeysNetworkError extends Data.TaggedError(
   "LegacyBranchesApiKeysNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesApiKeysUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesApiKeysUnexpectedStatusError",
@@ -77,13 +147,24 @@ export class LegacyBranchesApiKeysUnexpectedStatusError extends Data.TaggedError
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesPoolerNetworkError extends Data.TaggedError(
   "LegacyBranchesPoolerNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesPoolerUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesPoolerUnexpectedStatusError",
@@ -91,19 +172,36 @@ export class LegacyBranchesPoolerUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesPrimaryNotFoundError extends Data.TaggedError(
   "LegacyBranchesPrimaryNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // A successful pooler-config response with no PRIMARY entry — an API
+    // response problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 export class LegacyBranchesUpdateNetworkError extends Data.TaggedError(
   "LegacyBranchesUpdateNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesUpdateUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesUpdateUnexpectedStatusError",
@@ -111,13 +209,28 @@ export class LegacyBranchesUpdateUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: true,
+    });
+  }
+}
 
 export class LegacyBranchesPauseNetworkError extends Data.TaggedError(
   "LegacyBranchesPauseNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesPauseUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesPauseUnexpectedStatusError",
@@ -125,13 +238,24 @@ export class LegacyBranchesPauseUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesUnpauseNetworkError extends Data.TaggedError(
   "LegacyBranchesUnpauseNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesUnpauseUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesUnpauseUnexpectedStatusError",
@@ -139,13 +263,24 @@ export class LegacyBranchesUnpauseUnexpectedStatusError extends Data.TaggedError
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesDeleteNetworkError extends Data.TaggedError(
   "LegacyBranchesDeleteNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesDeleteUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesDeleteUnexpectedStatusError",
@@ -153,13 +288,24 @@ export class LegacyBranchesDeleteUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 export class LegacyBranchesDisableNetworkError extends Data.TaggedError(
   "LegacyBranchesDisableNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyBranchesDisableUnexpectedStatusError extends Data.TaggedError(
   "LegacyBranchesDisableUnexpectedStatusError",
@@ -167,7 +313,11 @@ export class LegacyBranchesDisableUnexpectedStatusError extends Data.TaggedError
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pure-path errors (validation, prompt-time semantics, user cancellation).
@@ -177,19 +327,31 @@ export class LegacyBranchesEnvNotSupportedError extends Data.TaggedError(
   "LegacyBranchesEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacyBranchesCreateCancelledError extends Data.TaggedError(
   "LegacyBranchesCreateCancelledError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}
 
 export class LegacyBranchesBranchNameEmptyError extends Data.TaggedError(
   "LegacyBranchesBranchNameEmptyError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyBranchesBranchingDisabledError extends Data.TaggedError(
   "LegacyBranchesBranchingDisabledError",
@@ -201,4 +363,13 @@ export class LegacyBranchesBranchingDisabledError extends Data.TaggedError(
    * `normalizeCliError` and printed after the error message in text mode.
    */
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return {
+      ...actionability.invalidInput,
+      has_suggestion: true,
+      suggestion_type: CliSuggestionType.RunCommand,
+      suggested_command: "supabase branches create",
+    };
+  }
+}

--- a/apps/cli/src/legacy/commands/branches/branches.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/branches/branches.errors.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import {
+  LegacyBranchesCreateUnexpectedStatusError,
+  LegacyBranchesDeleteUnexpectedStatusError,
+  LegacyBranchesPauseUnexpectedStatusError,
+  LegacyBranchesUnpauseUnexpectedStatusError,
+  LegacyBranchesUpdateUnexpectedStatusError,
+} from "./branches.errors.ts";
+
+const body = { body: "not found", message: "boom" };
+
+describe("branch operation 404s classify as invalid input", () => {
+  it("pause 404 → invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesPauseUnexpectedStatusError({ status: 404, ...body }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe("tag:LegacyBranchesPauseUnexpectedStatusError:not_found");
+  });
+
+  it("unpause 404 → invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesUnpauseUnexpectedStatusError({ status: 404, ...body }),
+    );
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe(
+      "tag:LegacyBranchesUnpauseUnexpectedStatusError:not_found",
+    );
+  });
+
+  it("delete 404 → invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesDeleteUnexpectedStatusError({ status: 404, ...body }),
+    );
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe(
+      "tag:LegacyBranchesDeleteUnexpectedStatusError:not_found",
+    );
+  });
+
+  it("a non-404 status stays on the status policy", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesPauseUnexpectedStatusError({ status: 500, ...body }),
+    );
+    expect(result.error_category).toBe("api_status");
+  });
+});
+
+describe("gated branch operation 404s", () => {
+  it("update 404 without an upgrade gate → invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesUpdateUnexpectedStatusError({ status: 404, ...body }),
+    );
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.suggestion_type).toBe("none");
+  });
+
+  it("create 404 without an upgrade gate → invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesCreateUnexpectedStatusError({ status: 404, ...body }),
+    );
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.suggestion_type).toBe("none");
+  });
+
+  it("update: a confirmed plan gate is not shadowed by the 404 branch", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesUpdateUnexpectedStatusError({
+        status: 404,
+        ...body,
+        upgradeSuggested: true,
+      }),
+    );
+    expect(result.error_category).toBe("plan_limit");
+    expect(result.suggestion_type).toBe("upgrade_plan");
+  });
+
+  it("create: a confirmed plan gate is not shadowed by the 404 branch", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesCreateUnexpectedStatusError({
+        status: 404,
+        ...body,
+        upgradeSuggested: true,
+      }),
+    );
+    expect(result.error_category).toBe("plan_limit");
+    expect(result.suggestion_type).toBe("upgrade_plan");
+  });
+});
+
+describe("branches create 409 = duplicate branch name", () => {
+  it("create 409 without an upgrade gate → invalid input (conflict)", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesCreateUnexpectedStatusError({ status: 409, ...body }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe("tag:LegacyBranchesCreateUnexpectedStatusError:conflict");
+  });
+
+  it("create: a confirmed plan gate is not shadowed by the 409 branch", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBranchesCreateUnexpectedStatusError({
+        status: 409,
+        ...body,
+        upgradeSuggested: true,
+      }),
+    );
+    expect(result.error_category).toBe("plan_limit");
+    expect(result.suggestion_type).toBe("upgrade_plan");
+  });
+});

--- a/apps/cli/src/legacy/commands/branches/branches.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/branches/branches.errors.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
 import {
+  LegacyBranchesBranchingDisabledError,
   LegacyBranchesCreateUnexpectedStatusError,
   LegacyBranchesDeleteUnexpectedStatusError,
   LegacyBranchesPauseUnexpectedStatusError,
@@ -111,4 +112,15 @@ describe("branches create 409 = duplicate branch name", () => {
     expect(result.error_category).toBe("plan_limit");
     expect(result.suggestion_type).toBe("upgrade_plan");
   });
+});
+
+it("classifies the branching-disabled remediation as running the suggested command", () => {
+  const result = classifyCliErrorActionability(
+    new LegacyBranchesBranchingDisabledError({
+      message: "Preview branching is disabled.",
+      suggestion: "Create your first branch with: supabase branches create",
+    }),
+  );
+  expect(result.suggestion_type).toBe("run_command");
+  expect(result.suggested_command).toBe("supabase branches create");
 });

--- a/apps/cli/src/legacy/commands/branches/create/create.handler.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.handler.ts
@@ -20,6 +20,7 @@ import { mapLegacyHttpError } from "../../../shared/legacy-http-errors.ts";
 import { legacyGateMapError } from "../../../shared/legacy-upgrade-suggest.ts";
 import { LEGACY_GO_BRANCH_RESPONSE } from "../branches.go-payload.ts";
 import {
+  LegacyBranchesBranchNameEmptyError,
   LegacyBranchesCreateCancelledError,
   LegacyBranchesCreateNetworkError,
   LegacyBranchesCreateUnexpectedStatusError,
@@ -84,6 +85,12 @@ export const legacyBranchesCreate = Effect.fn("legacy.branches.create")(function
     }
   }
 
+  if (branchName.length === 0) {
+    return yield* new LegacyBranchesBranchNameEmptyError({
+      message: "branch name cannot be empty",
+    });
+  }
+
   const ref = yield* resolver.resolve(flags.projectRef);
 
   yield* Effect.gen(function* () {
@@ -107,7 +114,24 @@ export const legacyBranchesCreate = Effect.fn("legacy.branches.create")(function
         // Mirror Go's `create.go:34-37`: on any non-201 status (including
         // gated 4xx), run the plan-gate check before mapping the error.
         Effect.catch(
-          legacyGateMapError({ projectRef: ref, featureKey: "branching_limit" }, mapCreateErrorRaw),
+          legacyGateMapError(
+            { projectRef: ref, featureKey: "branching_limit" },
+            (cause, upgradeSuggested) =>
+              Effect.gen(function* () {
+                const mapped = yield* Effect.flip(mapCreateErrorRaw(cause));
+                if (mapped._tag === "LegacyBranchesCreateUnexpectedStatusError") {
+                  return yield* Effect.fail(
+                    new LegacyBranchesCreateUnexpectedStatusError({
+                      status: mapped.status,
+                      body: mapped.body,
+                      message: mapped.message,
+                      upgradeSuggested,
+                    }),
+                  );
+                }
+                return yield* Effect.fail(mapped);
+              }),
+          ),
         ),
       );
     yield* creating?.clear() ?? Effect.void;

--- a/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
+++ b/apps/cli/src/legacy/commands/branches/create/create.integration.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { legacyBranchesCreateCommand, type LegacyBranchesCreateFlags } from "./create.command.ts";
 import { legacyBranchesCreate } from "./create.handler.ts";
+import { classifyCliCauseActionability } from "../../../../shared/telemetry/error-actionability.ts";
 
 type CreatedBranch = typeof V1CreateABranchOutput.Type;
 
@@ -217,6 +218,33 @@ describe("legacy branches create integration", () => {
         git_branch: "feature/login-page",
       });
     }).pipe(Effect.provide(layer));
+  });
+
+  it.live("reports a missing name before contacting the API outside a git repository", () => {
+    const previousHead = process.env["GITHUB_HEAD_REF"];
+    delete process.env["GITHUB_HEAD_REF"];
+    const { layer, api } = setup();
+    return Effect.gen(function* () {
+      const exit = yield* legacyBranchesCreate(baseFlags).pipe(Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("LegacyBranchesBranchNameEmptyError");
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_kind: "user_actionable",
+          error_category: "invalid_input",
+          suggestion_type: "provide_flags",
+        });
+      }
+      expect(api.requests).toHaveLength(0);
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (previousHead === undefined) delete process.env["GITHUB_HEAD_REF"];
+          else process.env["GITHUB_HEAD_REF"] = previousHead;
+        }),
+      ),
+      Effect.provide(layer),
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/cli/src/legacy/commands/branches/update/update.handler.ts
+++ b/apps/cli/src/legacy/commands/branches/update/update.handler.ts
@@ -74,7 +74,21 @@ export const legacyBranchesUpdate = Effect.fn("legacy.branches.update")(function
         Effect.catch(
           legacyGateMapError(
             { projectRef: branchRef, featureKey: "branching_persistent" },
-            mapUpdateError,
+            (cause, upgradeSuggested) =>
+              Effect.gen(function* () {
+                const mapped = yield* Effect.flip(mapUpdateError(cause));
+                if (mapped._tag === "LegacyBranchesUpdateUnexpectedStatusError") {
+                  return yield* Effect.fail(
+                    new LegacyBranchesUpdateUnexpectedStatusError({
+                      status: mapped.status,
+                      body: mapped.body,
+                      message: mapped.message,
+                      upgradeSuggested,
+                    }),
+                  );
+                }
+                return yield* Effect.fail(mapped);
+              }),
           ),
         ),
       );

--- a/apps/cli/src/legacy/commands/config/push/push.cost-matrix.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.cost-matrix.ts
@@ -72,6 +72,7 @@ export const getCostMatrix = Effect.fn("legacy.config.push.cost-matrix")(functio
     catch: (cause) =>
       new LegacyConfigPushListAddonsNetworkError({
         message: `failed to list addons: ${String(cause)}`,
+        decode: true,
       }),
   });
 

--- a/apps/cli/src/legacy/commands/config/push/push.errors.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Tagged errors for `supabase config push`, one per Go error path
@@ -20,6 +26,17 @@ interface NetworkErrorArgs {
   readonly message: string;
 }
 
+/**
+ * A network-error shape that may instead represent a 200-response body decode
+ * failure (`SchemaError` / `HttpBodyError` folded in by `mapLegacyHttpError`).
+ * `decode: true` reclassifies the failure as an API-response problem rather
+ * than a transport/network problem.
+ */
+interface DecodableNetworkErrorArgs {
+  readonly message: string;
+  readonly decode?: boolean;
+}
+
 interface StatusErrorArgs {
   readonly status: number;
   readonly body: string;
@@ -29,113 +46,258 @@ interface StatusErrorArgs {
 /** TOML parse failure (rewraps the packages/config parse error). Aborts before any network call. */
 export class LegacyConfigPushLoadConfigError extends Data.TaggedError(
   "LegacyConfigPushLoadConfigError",
-)<NetworkErrorArgs> {}
+)<NetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 // --- cost matrix (list addons) ---------------------------------------------
 
 export class LegacyConfigPushListAddonsNetworkError extends Data.TaggedError(
   "LegacyConfigPushListAddonsNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyConfigPushListAddonsStatusError extends Data.TaggedError(
   "LegacyConfigPushListAddonsStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- api --------------------------------------------------------------------
 
 export class LegacyConfigPushApiReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushApiReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushApiReadStatusError extends Data.TaggedError(
   "LegacyConfigPushApiReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushApiUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushApiUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushApiUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushApiUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- db.settings ------------------------------------------------------------
 
 export class LegacyConfigPushDbReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushDbReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushDbReadStatusError extends Data.TaggedError(
   "LegacyConfigPushDbReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushDbUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushDbUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushDbUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushDbUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- db.network_restrictions ------------------------------------------------
 
 export class LegacyConfigPushNetworkRestrictionsReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushNetworkRestrictionsReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushNetworkRestrictionsReadStatusError extends Data.TaggedError(
   "LegacyConfigPushNetworkRestrictionsReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushNetworkRestrictionsUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushNetworkRestrictionsUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushNetworkRestrictionsUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushNetworkRestrictionsUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- db.ssl_enforcement -----------------------------------------------------
 
 export class LegacyConfigPushSslEnforcementReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushSslEnforcementReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushSslEnforcementReadStatusError extends Data.TaggedError(
   "LegacyConfigPushSslEnforcementReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushSslEnforcementUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushSslEnforcementUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushSslEnforcementUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushSslEnforcementUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- auth -------------------------------------------------------------------
 
 export class LegacyConfigPushAuthReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushAuthReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushAuthReadStatusError extends Data.TaggedError(
   "LegacyConfigPushAuthReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushAuthUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushAuthUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushAuthUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushAuthUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- storage ----------------------------------------------------------------
 
 export class LegacyConfigPushStorageReadNetworkError extends Data.TaggedError(
   "LegacyConfigPushStorageReadNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushStorageReadStatusError extends Data.TaggedError(
   "LegacyConfigPushStorageReadStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 export class LegacyConfigPushStorageUpdateNetworkError extends Data.TaggedError(
   "LegacyConfigPushStorageUpdateNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushStorageUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushStorageUpdateStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // --- experimental.webhooks --------------------------------------------------
 
 export class LegacyConfigPushEnableWebhookNetworkError extends Data.TaggedError(
   "LegacyConfigPushEnableWebhookNetworkError",
-)<NetworkErrorArgs> {}
+)<DecodableNetworkErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 export class LegacyConfigPushEnableWebhookStatusError extends Data.TaggedError(
   "LegacyConfigPushEnableWebhookStatusError",
-)<StatusErrorArgs> {}
+)<StatusErrorArgs> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}

--- a/apps/cli/src/legacy/commands/config/push/push.errors.ts
+++ b/apps/cli/src/legacy/commands/config/push/push.errors.ts
@@ -28,7 +28,7 @@ interface NetworkErrorArgs {
 
 /**
  * A network-error shape that may instead represent a 200-response body decode
- * failure (`SchemaError` / `HttpBodyError` folded in by `mapLegacyHttpError`).
+ * failure (`SchemaError` folded in by `mapLegacyHttpError`).
  * `decode: true` reclassifies the failure as an API-response problem rather
  * than a transport/network problem.
  */
@@ -69,7 +69,7 @@ export class LegacyConfigPushListAddonsStatusError extends Data.TaggedError(
   "LegacyConfigPushListAddonsStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -88,7 +88,7 @@ export class LegacyConfigPushApiReadStatusError extends Data.TaggedError(
   "LegacyConfigPushApiReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushApiUpdateNetworkError extends Data.TaggedError(
@@ -104,7 +104,7 @@ export class LegacyConfigPushApiUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushApiUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -123,7 +123,7 @@ export class LegacyConfigPushDbReadStatusError extends Data.TaggedError(
   "LegacyConfigPushDbReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushDbUpdateNetworkError extends Data.TaggedError(
@@ -139,7 +139,7 @@ export class LegacyConfigPushDbUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushDbUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -158,7 +158,7 @@ export class LegacyConfigPushNetworkRestrictionsReadStatusError extends Data.Tag
   "LegacyConfigPushNetworkRestrictionsReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushNetworkRestrictionsUpdateNetworkError extends Data.TaggedError(
@@ -174,7 +174,7 @@ export class LegacyConfigPushNetworkRestrictionsUpdateStatusError extends Data.T
   "LegacyConfigPushNetworkRestrictionsUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -193,7 +193,7 @@ export class LegacyConfigPushSslEnforcementReadStatusError extends Data.TaggedEr
   "LegacyConfigPushSslEnforcementReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushSslEnforcementUpdateNetworkError extends Data.TaggedError(
@@ -209,7 +209,7 @@ export class LegacyConfigPushSslEnforcementUpdateStatusError extends Data.Tagged
   "LegacyConfigPushSslEnforcementUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -228,7 +228,7 @@ export class LegacyConfigPushAuthReadStatusError extends Data.TaggedError(
   "LegacyConfigPushAuthReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushAuthUpdateNetworkError extends Data.TaggedError(
@@ -244,7 +244,7 @@ export class LegacyConfigPushAuthUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushAuthUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -263,7 +263,7 @@ export class LegacyConfigPushStorageReadStatusError extends Data.TaggedError(
   "LegacyConfigPushStorageReadStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 export class LegacyConfigPushStorageUpdateNetworkError extends Data.TaggedError(
@@ -279,7 +279,7 @@ export class LegacyConfigPushStorageUpdateStatusError extends Data.TaggedError(
   "LegacyConfigPushStorageUpdateStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -298,6 +298,6 @@ export class LegacyConfigPushEnableWebhookStatusError extends Data.TaggedError(
   "LegacyConfigPushEnableWebhookStatusError",
 )<StatusErrorArgs> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }

--- a/apps/cli/src/legacy/commands/db/advisors/advisors.errors.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.errors.ts
@@ -112,7 +112,7 @@ export class LegacyDbAdvisorsSecurityStatusError extends Data.TaggedError(
   "LegacyDbAdvisorsSecurityStatusError",
 )<{ readonly status: number; readonly body: string; readonly message: string }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -137,7 +137,7 @@ export class LegacyDbAdvisorsPerformanceStatusError extends Data.TaggedError(
   "LegacyDbAdvisorsPerformanceStatusError",
 )<{ readonly status: number; readonly body: string; readonly message: string }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/db/advisors/advisors.errors.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Tagged errors for `db advisors`, one per Go failure path
@@ -13,7 +19,11 @@ import { Data } from "effect";
 /** cobra `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` (`db.go`). */
 export class LegacyDbAdvisorsMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyDbAdvisorsMutuallyExclusiveFlagsError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--linked` PreRunE: no access token. Message is Go's `utils.ErrMissingToken`;
@@ -22,7 +32,11 @@ export class LegacyDbAdvisorsMutuallyExclusiveFlagsError extends Data.TaggedErro
  */
 export class LegacyDbAdvisorsNotLoggedInError extends Data.TaggedError(
   "LegacyDbAdvisorsNotLoggedInError",
-)<{ readonly message: string; readonly suggestion: string }> {}
+)<{ readonly message: string; readonly suggestion: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 /**
  * `--linked` PreRunE: the resolved access token is malformed. Message is Go's
@@ -33,44 +47,105 @@ export class LegacyDbAdvisorsNotLoggedInError extends Data.TaggedError(
  */
 export class LegacyDbAdvisorsInvalidTokenError extends Data.TaggedError(
   "LegacyDbAdvisorsInvalidTokenError",
-)<{ readonly message: string; readonly suggestion: string }> {}
+)<{
+  readonly message: string;
+  readonly suggestion: string;
+  /**
+   * Copied from the wrapped `LegacyInvalidAccessTokenError`: an env-var token
+   * (`SUPABASE_ACCESS_TOKEN`) takes precedence over stored credentials, so
+   * `supabase login` cannot fix it — the remediation is to correct the env
+   * var. A stored (keyring/file) token, or an unknown source, is fixable by
+   * logging in again.
+   */
+  readonly source?: "env" | "stored";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.source === "env" ? actionability.authToken : actionability.authLogin;
+  }
+}
 
 /** `failed to begin transaction: %w` (`advisors.go:105`). */
 export class LegacyDbAdvisorsBeginTxError extends Data.TaggedError("LegacyDbAdvisorsBeginTxError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /** `failed to prepare lint session: %w` (`advisors.go:115`). */
 export class LegacyDbAdvisorsSetupError extends Data.TaggedError("LegacyDbAdvisorsSetupError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /** `failed to query lints: %w` (`advisors.go:120`). */
 export class LegacyDbAdvisorsQueryError extends Data.TaggedError("LegacyDbAdvisorsQueryError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
-/** `failed to fetch security advisors: %w` (`advisors.go:165`). */
+/**
+ * `failed to fetch security advisors: %w` (`advisors.go:165`). Go folds a
+ * decode error into the same message path as a transport failure — `decode`
+ * distinguishes them for actionability so a 200-response decode failure
+ * classifies as an API response problem instead of a network problem.
+ */
 export class LegacyDbAdvisorsSecurityNetworkError extends Data.TaggedError(
   "LegacyDbAdvisorsSecurityNetworkError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string; readonly decode?: boolean }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /** `unexpected security advisors status %d: %s` (`advisors.go:168`). */
 export class LegacyDbAdvisorsSecurityStatusError extends Data.TaggedError(
   "LegacyDbAdvisorsSecurityStatusError",
-)<{ readonly status: number; readonly body: string; readonly message: string }> {}
+)<{ readonly status: number; readonly body: string; readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
-/** `failed to fetch performance advisors: %w` (`advisors.go:176`). */
+/**
+ * `failed to fetch performance advisors: %w` (`advisors.go:176`). Go folds a
+ * decode error into the same message path as a transport failure — `decode`
+ * distinguishes them for actionability so a 200-response decode failure
+ * classifies as an API response problem instead of a network problem.
+ */
 export class LegacyDbAdvisorsPerformanceNetworkError extends Data.TaggedError(
   "LegacyDbAdvisorsPerformanceNetworkError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string; readonly decode?: boolean }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /** `unexpected performance advisors status %d: %s` (`advisors.go:179`). */
 export class LegacyDbAdvisorsPerformanceStatusError extends Data.TaggedError(
   "LegacyDbAdvisorsPerformanceStatusError",
-)<{ readonly status: number; readonly body: string; readonly message: string }> {}
+)<{ readonly status: number; readonly body: string; readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /** `fail-on is set to %s, non-zero exit` (`advisors.go:257`). */
 export class LegacyDbAdvisorsFailOnError extends Data.TaggedError("LegacyDbAdvisorsFailOnError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/advisors/advisors.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.errors.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
+import { LegacyDbAdvisorsInvalidTokenError } from "./advisors.errors.ts";
+
+describe("LegacyDbAdvisorsInvalidTokenError actionability", () => {
+  const build = (source?: "env" | "stored") =>
+    new LegacyDbAdvisorsInvalidTokenError({
+      message: "Invalid access token format. Must be like `sbp_0102...1920`.",
+      suggestion: "Run supabase login first.",
+      source,
+    });
+
+  it("classifies an env-provided malformed token as a set-env-var remediation", () => {
+    const result = classifyCliErrorActionability(build("env"));
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("auth");
+    expect(result.suggestion_type).toBe("set_env_var");
+    expect(result.error_fingerprint).toBe("tag:LegacyDbAdvisorsInvalidTokenError");
+  });
+
+  it("classifies a stored malformed token as a re-login remediation", () => {
+    const result = classifyCliErrorActionability(build("stored"));
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("auth");
+    expect(result.suggestion_type).toBe("login");
+    expect(result.suggested_command).toBe("supabase login");
+  });
+
+  it("defaults to a re-login remediation when the source is unknown", () => {
+    const result = classifyCliErrorActionability(build());
+    expect(result.suggestion_type).toBe("login");
+    expect(result.suggested_command).toBe("supabase login");
+  });
+});

--- a/apps/cli/src/legacy/commands/db/advisors/advisors.handler.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.handler.ts
@@ -154,6 +154,9 @@ const runLinked = Effect.fnUntraced(function* (
           new LegacyDbAdvisorsInvalidTokenError({
             message: cause.message,
             suggestion: loginSuggestion(),
+            // Preserve the token source so an env-provided malformed token keeps
+            // its `set_env_var` remediation instead of degrading to `supabase login`.
+            source: cause.source,
           }),
         ),
       ),

--- a/apps/cli/src/legacy/commands/db/advisors/advisors.linked.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.linked.ts
@@ -18,8 +18,15 @@ import { apiResponseToLegacyAdvisorLints } from "./advisors.format.ts";
 
 interface AdvisorEndpoint {
   readonly path: "security" | "performance";
-  /** Builds the network/parse failure (Go's `failed to fetch … advisors: %w`). */
-  readonly network: (message: string) => LegacyAdvisorNetworkError;
+  /**
+   * Builds the network/parse failure (Go's `failed to fetch … advisors: %w`).
+   * `decode: true` marks a 200-response body decode failure rather than a
+   * transport failure, even though Go folds both into the same message path.
+   */
+  readonly network: (
+    message: string,
+    opts?: { readonly decode?: boolean },
+  ) => LegacyAdvisorNetworkError;
   /** Builds the non-200 failure (Go's `unexpected … advisors status %d: %s`). */
   readonly status: (status: number, body: string) => LegacyAdvisorStatusError;
 }
@@ -92,7 +99,7 @@ const fetchAdvisors = Effect.fnUntraced(function* (
   // `apiResponseToLegacyAdvisorLints`) to the endpoint's network error.
   return yield* Effect.try({
     try: () => apiResponseToLegacyAdvisorLints(JSON.parse(rawBody) as unknown),
-    catch: (cause) => endpoint.network(String(cause)),
+    catch: (cause) => endpoint.network(String(cause), { decode: true }),
   });
 });
 
@@ -101,9 +108,10 @@ export const legacyFetchSecurityAdvisors = (ref: string, stitch: LegacyStitchFn)
     ref,
     {
       path: "security",
-      network: (message) =>
+      network: (message, opts) =>
         new LegacyDbAdvisorsSecurityNetworkError({
           message: `failed to fetch security advisors: ${message}`,
+          decode: opts?.decode,
         }),
       status: (status, body) =>
         new LegacyDbAdvisorsSecurityStatusError({
@@ -120,9 +128,10 @@ export const legacyFetchPerformanceAdvisors = (ref: string, stitch: LegacyStitch
     ref,
     {
       path: "performance",
-      network: (message) =>
+      network: (message, opts) =>
         new LegacyDbAdvisorsPerformanceNetworkError({
           message: `failed to fetch performance advisors: ${message}`,
+          decode: opts?.decode,
         }),
       status: (status, body) =>
         new LegacyDbAdvisorsPerformanceStatusError({

--- a/apps/cli/src/legacy/commands/db/diff/diff.errors.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Conflicting database-target flags. Reproduces cobra's
@@ -7,7 +12,11 @@ import { Data } from "effect";
  */
 export class LegacyDbDiffTargetFlagsError extends Data.TaggedError("LegacyDbDiffTargetFlagsError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Conflicting diff-engine flags. Reproduces cobra's
@@ -18,7 +27,11 @@ export class LegacyDbDiffEngineConflictError extends Data.TaggedError(
   "LegacyDbDiffEngineConflictError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Only one of `--from` / `--to` was set in explicit diff mode. Byte-matches Go's
@@ -29,7 +42,11 @@ export class LegacyDbDiffExplicitFlagsError extends Data.TaggedError(
   "LegacyDbDiffExplicitFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * An explicit `--from`/`--to` ref was neither `local`/`linked`/`migrations` nor a
@@ -41,7 +58,11 @@ export class LegacyDbDiffUnknownTargetError extends Data.TaggedError(
   "LegacyDbDiffUnknownTargetError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Writing the diff output failed — a `--file` migration, or an explicit-mode
@@ -49,4 +70,8 @@ export class LegacyDbDiffUnknownTargetError extends Data.TaggedError(
  */
 export class LegacyDbDiffWriteError extends Data.TaggedError("LegacyDbDiffWriteError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/dump/dump.errors.ts
+++ b/apps/cli/src/legacy/commands/db/dump/dump.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * `--use-copy` / `--exclude` were passed without `--data-only`. Reproduces
@@ -9,7 +14,11 @@ export class LegacyDbDumpRequiresDataOnlyError extends Data.TaggedError(
   "LegacyDbDumpRequiresDataOnlyError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Two mutually exclusive flags were set together. Reproduces cobra's
@@ -20,7 +29,11 @@ export class LegacyDbDumpMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyDbDumpMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Failed to open the `--file` output path. Byte-matches Go's
@@ -28,7 +41,11 @@ export class LegacyDbDumpMutuallyExclusiveFlagsError extends Data.TaggedError(
  */
 export class LegacyDbDumpOpenFileError extends Data.TaggedError("LegacyDbDumpOpenFileError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * The pg_dump container exited non-zero. Byte-matches Go's
@@ -41,4 +58,8 @@ export class LegacyDbDumpRunError extends Data.TaggedError("LegacyDbDumpRunError
   // transaction-pooler guidance. `Output.fail` prints it bare on stderr after the
   // error message, mirroring Go's `recoverAndExit`.
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/dump/dump.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/dump/dump.integration.test.ts
@@ -112,7 +112,11 @@ function mockDockerRun(opts: {
       allOpts.push(runOpts);
       if (opts.runFails === true) {
         return Effect.fail(
-          new LegacyDockerRunError({ message: "failed to run docker: not found" }),
+          new LegacyDockerRunError({
+            message: "failed to run docker: not found",
+            reason: "spawn",
+            daemonDown: false,
+          }),
         );
       }
       const next = queue.shift();
@@ -130,7 +134,11 @@ function mockDockerRun(opts: {
         allOpts.push(runOpts);
         if (opts.runFails === true) {
           return yield* Effect.fail(
-            new LegacyDockerRunError({ message: "failed to run docker: not found" }),
+            new LegacyDockerRunError({
+              message: "failed to run docker: not found",
+              reason: "spawn",
+              daemonDown: false,
+            }),
           );
         }
         const next = queue.shift();

--- a/apps/cli/src/legacy/commands/db/lint/lint.errors.ts
+++ b/apps/cli/src/legacy/commands/db/lint/lint.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Tagged errors for `db lint`, one per Go failure path
  * (`internal/db/lint/lint.go`). The `message` byte-matches Go's `errors.Errorf`
@@ -12,34 +18,62 @@ import { Data } from "effect";
 /** cobra `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` (`db.go`). */
 export class LegacyDbLintMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyDbLintMutuallyExclusiveFlagsError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** `failed to begin transaction: %w` (`lint.go:111`). */
 export class LegacyDbLintBeginTxError extends Data.TaggedError("LegacyDbLintBeginTxError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /** `failed to list schemas: %w` (`drop.go:46`, via `ListUserSchemas`). */
 export class LegacyDbLintListSchemasError extends Data.TaggedError("LegacyDbLintListSchemasError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** `failed to enable pgsql_check: %w` (`lint.go:126`). */
 export class LegacyDbLintEnableCheckError extends Data.TaggedError("LegacyDbLintEnableCheckError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** `failed to query rows: %w` (`lint.go:140`). */
 export class LegacyDbLintQueryError extends Data.TaggedError("LegacyDbLintQueryError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** `failed to marshal json: %w` (`lint.go:151`). */
 export class LegacyDbLintMalformedJsonError extends Data.TaggedError(
   "LegacyDbLintMalformedJsonError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** `fail-on is set to %s, non-zero exit` (`lint.go:72`). */
 export class LegacyDbLintFailOnError extends Data.TaggedError("LegacyDbLintFailOnError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/pull/pull.errors.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Conflicting database-target flags. Reproduces cobra's
  * `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` error byte-for-byte
@@ -7,7 +13,11 @@ import { Data } from "effect";
  */
 export class LegacyDbPullTargetFlagsError extends Data.TaggedError("LegacyDbPullTargetFlagsError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--declarative` / `--use-pg-delta` combined with `--diff-engine`. Reproduces
@@ -18,7 +28,11 @@ export class LegacyDbPullEngineConflictError extends Data.TaggedError(
   "LegacyDbPullEngineConflictError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * The remote migration history does not match local files. Byte-matches Go's
@@ -30,7 +44,11 @@ export class LegacyDbPullMigrationConflictError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.migrationDrift;
+  }
+}
 
 /**
  * The diff produced no schema changes. Byte-matches Go's `errInSync`
@@ -40,7 +58,11 @@ export class LegacyDbPullMigrationConflictError extends Data.TaggedError(
  */
 export class LegacyDbPullInSyncError extends Data.TaggedError("LegacyDbPullInSyncError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Writing the migration file / updating the remote migration-history table failed.
@@ -48,7 +70,11 @@ export class LegacyDbPullInSyncError extends Data.TaggedError("LegacyDbPullInSyn
  */
 export class LegacyDbPullWriteError extends Data.TaggedError("LegacyDbPullWriteError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * The initial-pull pg_dump container exited non-zero. Go's `dumpRemoteSchema`
@@ -60,4 +86,15 @@ export class LegacyDbPullWriteError extends Data.TaggedError("LegacyDbPullWriteE
 export class LegacyDbPullDumpError extends Data.TaggedError("LegacyDbPullDumpError")<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+  /**
+   * Set when the failure is opening/truncating the local migration file before
+   * any pg_dump attempt — a filesystem permission problem, not a database
+   * connection failure. The actual pg_dump-run failures leave it unset and keep
+   * the `dbConnection` classification.
+   */
+  readonly fileOpen?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.fileOpen === true ? actionability.permission : actionability.dbConnection;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/pull/pull.errors.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.errors.ts
@@ -95,6 +95,8 @@ export class LegacyDbPullDumpError extends Data.TaggedError("LegacyDbPullDumpErr
   readonly fileOpen?: boolean;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return this.fileOpen === true ? actionability.permission : actionability.dbConnection;
+    return this.fileOpen === true
+      ? { ...actionability.permission, fingerprint_suffix: "filesystem" }
+      : { ...actionability.dbConnection, fingerprint_suffix: "connect" };
   }
 }

--- a/apps/cli/src/legacy/commands/db/pull/pull.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.errors.unit.test.ts
@@ -12,7 +12,7 @@ describe("LegacyDbPullDumpError actionability", () => {
     );
     expect(result.error_kind).toBe("user_actionable");
     expect(result.error_category).toBe("permission");
-    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError");
+    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError:filesystem");
   });
 
   it("classifies a pg_dump-run failure as a db-connection problem", () => {
@@ -21,6 +21,6 @@ describe("LegacyDbPullDumpError actionability", () => {
     );
     expect(result.error_kind).toBe("user_actionable");
     expect(result.error_category).toBe("db_connection");
-    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError");
+    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError:connect");
   });
 });

--- a/apps/cli/src/legacy/commands/db/pull/pull.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.errors.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
+import { LegacyDbPullDumpError } from "./pull.errors.ts";
+
+describe("LegacyDbPullDumpError actionability", () => {
+  it("classifies a local migration-file open failure as a permission problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyDbPullDumpError({
+        message: "failed to open dump file: permission denied",
+        fileOpen: true,
+      }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("permission");
+    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError");
+  });
+
+  it("classifies a pg_dump-run failure as a db-connection problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyDbPullDumpError({ message: "error running container: exit 1" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("db_connection");
+    expect(result.error_fingerprint).toBe("tag:LegacyDbPullDumpError");
+  });
+});

--- a/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
@@ -536,7 +536,10 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
             columnInsert: false,
           };
           const toDumpOpenError = (cause: { readonly message: string }) =>
-            new LegacyDbPullDumpError({ message: `failed to open dump file: ${cause.message}` });
+            new LegacyDbPullDumpError({
+              message: `failed to open dump file: ${cause.message}`,
+              fileOpen: true,
+            });
           // Stream pg_dump → migration file, (re)truncating per attempt so a pooler
           // retry leaves only the successful attempt's bytes (Go's `resetOutput`).
           const runSchemaDump = (target: LegacyPgConnInput) => {

--- a/apps/cli/src/legacy/commands/db/push/push.errors.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Conflicting database-target flags. Reproduces cobra's
@@ -7,7 +12,11 @@ import { Data } from "effect";
  */
 export class LegacyDbPushTargetFlagsError extends Data.TaggedError("LegacyDbPushTargetFlagsError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Remote migration versions are missing from the local directory. Byte-matches
@@ -19,7 +28,11 @@ export class LegacyDbPushMissingLocalError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.migrationDrift;
+  }
+}
 
 /**
  * Local migration files are ordered before the remote head and `--include-all`
@@ -31,7 +44,11 @@ export class LegacyDbPushMissingRemoteError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.migrationDrift;
+  }
+}
 
 /**
  * The user declined a confirmation prompt. Go returns `errors.New(context.Canceled)`
@@ -39,12 +56,20 @@ export class LegacyDbPushMissingRemoteError extends Data.TaggedError(
  */
 export class LegacyDbPushCancelledError extends Data.TaggedError("LegacyDbPushCancelledError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}
 
 /** Locating `supabase/roles.sql` failed (Go's `failed to find custom roles: %w`). */
 export class LegacyDbPushRolesError extends Data.TaggedError("LegacyDbPushRolesError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * A migration / seed / globals / vault statement failed while applying. Carries
@@ -53,4 +78,8 @@ export class LegacyDbPushRolesError extends Data.TaggedError("LegacyDbPushRolesE
  */
 export class LegacyDbPushApplyError extends Data.TaggedError("LegacyDbPushApplyError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/query/query.errors.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.errors.ts
@@ -104,6 +104,6 @@ export class LegacyDbQueryUnexpectedStatusError extends Data.TaggedError(
     if (this.status === 400) {
       return { ...actionability.dbFinding, fingerprint_suffix: "query" };
     }
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }

--- a/apps/cli/src/legacy/commands/db/query/query.errors.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * No SQL was provided by any source. Byte-matches Go's
@@ -7,17 +13,29 @@ import { Data } from "effect";
  */
 export class LegacyDbQueryNoSqlError extends Data.TaggedError("LegacyDbQueryNoSqlError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** Stdin was piped but empty. Byte-matches Go's `"no SQL provided via stdin"`. */
 export class LegacyDbQueryNoStdinSqlError extends Data.TaggedError("LegacyDbQueryNoStdinSqlError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** `--file` could not be read. Byte-matches Go's `"failed to read SQL file: " + err`. */
 export class LegacyDbQueryReadFileError extends Data.TaggedError("LegacyDbQueryReadFileError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--linked` was used without an access token. Mirrors Go's PreRunE, which
@@ -29,12 +47,30 @@ export class LegacyDbQueryLoginRequiredError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 /** Query execution failed. Byte-matches Go's `"failed to execute query: " + err`. */
 export class LegacyDbQueryExecError extends Data.TaggedError("LegacyDbQueryExecError")<{
   readonly message: string;
-}> {}
+  /**
+   * Set when this failure came from the linked path's HTTP transport
+   * (`httpClient.execute`/body read against `/v1/projects/{ref}/database/query`)
+   * rather than the user's SQL failing to execute.
+   */
+  readonly transport?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.transport === true) {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+    }
+    // The user's own SQL failed — same bucket as every sibling exec error.
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * More than one of `--db-url` / `--linked` / `--local` was set. Reproduces
@@ -46,7 +82,11 @@ export class LegacyDbQueryMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyDbQueryMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * The linked Management API returned a non-201 status. Byte-matches Go's
@@ -55,5 +95,15 @@ export class LegacyDbQueryMutuallyExclusiveFlagsError extends Data.TaggedError(
 export class LegacyDbQueryUnexpectedStatusError extends Data.TaggedError(
   "LegacyDbQueryUnexpectedStatusError",
 )<{
+  readonly status: number;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The endpoint executes the user's SQL: a 400 is the remote twin of the
+    // local LegacyDbQueryExecError (syntax/constraint failures in user SQL).
+    if (this.status === 400) {
+      return { ...actionability.dbFinding, fingerprint_suffix: "query" };
+    }
+    return statusCodeActionability(this.status);
+  }
+}

--- a/apps/cli/src/legacy/commands/db/query/query.handler.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.handler.ts
@@ -200,12 +200,17 @@ export const legacyDbQuery = Effect.fn("legacy.db.query")(function* (flags: Lega
         return { status: response.status, body: text };
       }).pipe(
         Effect.mapError(
-          (cause) => new LegacyDbQueryExecError({ message: `failed to execute query: ${cause}` }),
+          (cause) =>
+            new LegacyDbQueryExecError({
+              message: `failed to execute query: ${cause}`,
+              transport: true,
+            }),
         ),
       );
       if (status !== 201) {
         return yield* Effect.fail(
           new LegacyDbQueryUnexpectedStatusError({
+            status,
             message: `unexpected status ${status}: ${body}`,
           }),
         );

--- a/apps/cli/src/legacy/commands/db/reset/reset.errors.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Conflicting database-target flags. Reproduces cobra's
  * `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` (`cmd/db.go:573`).
@@ -8,7 +14,11 @@ export class LegacyDbResetTargetFlagsError extends Data.TaggedError(
   "LegacyDbResetTargetFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--version` and `--last` together. Reproduces cobra's
@@ -18,7 +28,11 @@ export class LegacyDbResetVersionFlagsError extends Data.TaggedError(
   "LegacyDbResetVersionFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--version` is not a valid integer. Byte-matches Go's bare
@@ -30,7 +44,11 @@ export class LegacyDbResetInvalidVersionError extends Data.TaggedError(
   "LegacyDbResetInvalidVersionError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * No migration file matches `--version`. Byte-matches Go's
@@ -41,7 +59,11 @@ export class LegacyDbResetMigrationFileError extends Data.TaggedError(
   "LegacyDbResetMigrationFileError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * The user declined the reset confirmation. Go returns
@@ -49,12 +71,20 @@ export class LegacyDbResetMigrationFileError extends Data.TaggedError(
  */
 export class LegacyDbResetCancelledError extends Data.TaggedError("LegacyDbResetCancelledError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}
 
 /** A drop / migrate / seed / vault statement failed during the remote reset. */
 export class LegacyDbResetApplyError extends Data.TaggedError("LegacyDbResetApplyError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * `--last` was given a negative value. Go declares `--last` as an unsigned flag
@@ -63,7 +93,11 @@ export class LegacyDbResetApplyError extends Data.TaggedError("LegacyDbResetAppl
  */
 export class LegacyDbResetLastFlagError extends Data.TaggedError("LegacyDbResetLastFlagError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Invalid `--sql-paths` usage. Byte-matches Go's `validateDbResetSeedFlags`
@@ -77,4 +111,8 @@ export class LegacyDbResetSeedFlagsError extends Data.TaggedError("LegacyDbReset
    * `validateDbResetSeedFlags` `utils.CmdSuggestion` (`cmd/db.go`).
    */
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/schema/declarative/declarative.errors.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/declarative.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Declarative commands were invoked without `--experimental` and without
  * `[experimental.pgdelta] enabled = true`. Byte-matches Go's gate error
@@ -12,7 +18,11 @@ export class LegacyDeclarativeNotEnabledError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * A target could not be resolved in non-interactive mode. Byte-matches Go's
@@ -24,7 +34,11 @@ export class LegacyDeclarativeNonInteractiveError extends Data.TaggedError(
   "LegacyDeclarativeNonInteractiveError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * A mutually-exclusive flag group was violated. Reproduces cobra's
@@ -37,7 +51,11 @@ export class LegacyDeclarativeMutuallyExclusiveFlagsError extends Data.TaggedErr
   "LegacyDeclarativeMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * The interactive custom-database-URL prompt was empty or unparseable. Byte-matches
@@ -48,7 +66,11 @@ export class LegacyDeclarativeInvalidDbUrlError extends Data.TaggedError(
   "LegacyDeclarativeInvalidDbUrlError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `db schema declarative generate` ran but produced no declarative files (sync's
@@ -59,7 +81,11 @@ export class LegacyDeclarativeNoFilesGeneratedError extends Data.TaggedError(
   "LegacyDeclarativeNoFilesGeneratedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Diffing declarative schema to migrations failed. Wraps
@@ -69,7 +95,11 @@ export class LegacyDeclarativeNoFilesGeneratedError extends Data.TaggedError(
  */
 export class LegacyDeclarativeDiffError extends Data.TaggedError("LegacyDeclarativeDiffError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Applying the generated migration to the local database failed. Wraps Go's
@@ -79,7 +109,19 @@ export class LegacyDeclarativeDiffError extends Data.TaggedError("LegacyDeclarat
  */
 export class LegacyDeclarativeApplyError extends Data.TaggedError("LegacyDeclarativeApplyError")<{
   readonly message: string;
-}> {}
+  /**
+   * Set when this failure came from connecting to the local Postgres instance
+   * (`dbConnection.connect`) rather than the migration SQL failing to apply.
+   */
+  readonly connect?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.connect === true) {
+      return { ...actionability.dbConnection, fingerprint_suffix: "connect" };
+    }
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Materializing the declarative export on disk failed. Byte-matches Go's

--- a/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
+++ b/apps/cli/src/legacy/commands/db/schema/declarative/sync/sync.handler.ts
@@ -492,7 +492,9 @@ const applyMigrationToLocal = (
         { isLocal: true, dnsResolver: local.dnsResolver },
       )
       .pipe(
-        Effect.mapError((error) => new LegacyDeclarativeApplyError({ message: error.message })),
+        Effect.mapError(
+          (error) => new LegacyDeclarativeApplyError({ message: error.message, connect: true }),
+        ),
       );
     yield* legacyApplyMigrationFile(
       session,

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migra.errors.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migra.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * The migra diff failed (edge-runtime run, or the OOM bash fallback in the
  * `supabase/migra` Docker image). Byte-matches Go's
@@ -8,7 +14,25 @@ import { Data } from "effect";
  */
 export class LegacyMigraDiffError extends Data.TaggedError("LegacyMigraDiffError")<{
   readonly message: string;
-}> {}
+  /**
+   * Threaded from a wrapped `LegacyDockerRunError` in the OOM bash fallback so a
+   * docker-boundary failure (docker daemon down or registry pull) does not
+   * misclassify as a user-SQL (`dbFinding`) failure. `daemon` maps to
+   * docker-not-running, `pull` to an external network problem. `undefined` for
+   * genuine diff/script failures, which keep the user-SQL classification.
+   */
+  readonly docker?: "daemon" | "pull";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.docker === "daemon") {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    if (this.docker === "pull") {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+    }
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Loading the target's user-defined schemas for the migra bash fallback failed.
@@ -18,4 +42,8 @@ export class LegacyMigraDiffError extends Data.TaggedError("LegacyMigraDiffError
  */
 export class LegacyMigraSchemaLoadError extends Data.TaggedError("LegacyMigraSchemaLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migra.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migra.errors.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
+import { LegacyMigraDiffError } from "./legacy-migra.errors.ts";
+
+describe("LegacyMigraDiffError actionability", () => {
+  it("classifies a docker-daemon failure as docker-not-running", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyMigraDiffError({ message: "error diffing schema: ...", docker: "daemon" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("docker_not_running");
+    expect(result.suggestion_type).toBe("start_docker");
+    expect(result.error_fingerprint).toBe("tag:LegacyMigraDiffError:docker_not_running");
+  });
+
+  it("classifies a registry-pull failure as an external network problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyMigraDiffError({ message: "error diffing schema: ...", docker: "pull" }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("network");
+    expect(result.error_fingerprint).toBe("tag:LegacyMigraDiffError:registry_pull");
+  });
+
+  it("classifies a non-docker diff failure as a user db finding", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyMigraDiffError({ message: "error diffing schema:\n..." }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.has_suggestion).toBe(false);
+    expect(result.error_fingerprint).toBe("tag:LegacyMigraDiffError");
+  });
+});

--- a/apps/cli/src/legacy/commands/db/shared/legacy-migra.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-migra.ts
@@ -225,7 +225,14 @@ const diffMigraBash = Effect.fnUntraced(function* (params: {
     })
     .pipe(
       Effect.mapError(
-        (cause) => new LegacyMigraDiffError({ message: `error diffing schema: ${cause.message}` }),
+        (cause) =>
+          new LegacyMigraDiffError({
+            message: `error diffing schema: ${cause.message}`,
+            // Thread the docker discriminant so a daemon-down / registry-pull
+            // failure at the docker boundary is not misclassified as user SQL,
+            // mirroring the edge-runtime-script fix.
+            docker: cause.reason === "spawn" || cause.daemonDown ? "daemon" : "pull",
+          }),
       ),
     );
   if (result.exitCode !== 0) {

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta-migrations.write.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta-migrations.write.ts
@@ -1,5 +1,10 @@
 import { Data, Effect, type FileSystem, type Path } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 import { legacyMakeDir } from "../../../shared/legacy-make-dir.ts";
 import {
   legacyFormatMigrationTimestamp,
@@ -20,7 +25,11 @@ export class LegacyPgDeltaMigrationWriteError extends Data.TaggedError(
   "LegacyPgDeltaMigrationWriteError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Bounds the base-timestamp bump retry so a directory already full of same-second

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.errors.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * The pg-delta edge-runtime script failed. Byte-matches Go's
  * `"<errPrefix>: <err>:\n<stderr>"` wrapping in `RunEdgeRuntimeScript`
@@ -11,7 +17,21 @@ export class LegacyDeclarativeEdgeRuntimeError extends Data.TaggedError(
   "LegacyDeclarativeEdgeRuntimeError",
 )<{
   readonly message: string;
-}> {}
+  readonly docker?: "daemon" | "inspect" | "pull";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.docker === "daemon") {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    if (this.docker === "pull") {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+    }
+    if (this.docker === "inspect") {
+      return { ...actionability.invalidConfig, fingerprint_suffix: "image_inspect" };
+    }
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * Setting up / connecting to / migrating the throwaway shadow database failed.
@@ -23,7 +43,14 @@ export class LegacyDeclarativeShadowDbError extends Data.TaggedError(
   "LegacyDeclarativeShadowDbError",
 )<{
   readonly message: string;
-}> {}
+  readonly docker?: "daemon";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.docker === "daemon"
+      ? { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" }
+      : actionability.startStack;
+  }
+}
 
 /**
  * Exporting declarative schema produced no output. Byte-matches Go's
@@ -35,7 +62,11 @@ export class LegacyDeclarativeEmptyOutputError extends Data.TaggedError(
   "LegacyDeclarativeEmptyOutputError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.impossibleState;
+  }
+}
 
 /**
  * Parsing the declarative export envelope failed. Byte-matches Go's
@@ -46,7 +77,11 @@ export class LegacyDeclarativeParseOutputError extends Data.TaggedError(
   "LegacyDeclarativeParseOutputError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.impossibleState;
+  }
+}
 
 /**
  * Parsing the pg-delta diff envelope failed. Byte-matches Go's
@@ -55,7 +90,11 @@ export class LegacyDeclarativeParseOutputError extends Data.TaggedError(
  */
 export class LegacyPgDeltaDiffParseError extends Data.TaggedError("LegacyPgDeltaDiffParseError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.impossibleState;
+  }
+}
 
 /**
  * Materializing the declarative export on disk failed. Byte-matches Go's
@@ -66,4 +105,8 @@ export class LegacyPgDeltaDiffParseError extends Data.TaggedError("LegacyPgDelta
  */
 export class LegacyDeclarativeWriteError extends Data.TaggedError("LegacyDeclarativeWriteError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.errors.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
+import {
+  LegacyDeclarativeEdgeRuntimeError,
+  LegacyDeclarativeShadowDbError,
+} from "./legacy-pgdelta.errors.ts";
+
+describe("pg-delta error actionability", () => {
+  it.each([
+    ["daemon", "user_actionable", "docker_not_running", "docker_not_running"],
+    ["pull", "external_service", "network", "registry_pull"],
+    ["inspect", "user_actionable", "invalid_config", "image_inspect"],
+  ] as const)("classifies edge-runtime docker %s failures", (docker, kind, category, suffix) => {
+    const result = classifyCliErrorActionability(
+      new LegacyDeclarativeEdgeRuntimeError({ message: "redacted", docker }),
+    );
+    expect(result.error_kind).toBe(kind);
+    expect(result.error_category).toBe(category);
+    expect(result.error_fingerprint).toBe(`tag:LegacyDeclarativeEdgeRuntimeError:${suffix}`);
+  });
+
+  it("keeps non-docker edge-runtime failures in the database family", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyDeclarativeEdgeRuntimeError({ message: "redacted" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("tag:LegacyDeclarativeEdgeRuntimeError");
+  });
+
+  it("distinguishes an unreachable Docker daemon from a missing shadow stack", () => {
+    const daemon = classifyCliErrorActionability(
+      new LegacyDeclarativeShadowDbError({ message: "redacted", docker: "daemon" }),
+    );
+    expect(daemon.error_category).toBe("docker_not_running");
+    expect(daemon.error_fingerprint).toBe("tag:LegacyDeclarativeShadowDbError:docker_not_running");
+
+    const missingStack = classifyCliErrorActionability(
+      new LegacyDeclarativeShadowDbError({ message: "redacted" }),
+    );
+    expect(missingStack.error_category).toBe("invalid_config");
+    expect(missingStack.suggested_command).toBe("supabase start");
+    expect(missingStack.error_fingerprint).toBe("tag:LegacyDeclarativeShadowDbError");
+  });
+});

--- a/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.seam.layer.ts
+++ b/apps/cli/src/legacy/commands/db/shared/legacy-pgdelta.seam.layer.ts
@@ -9,6 +9,7 @@ import { containerCliExitCode, spawnContainerCli } from "../../../shared/legacy-
 import { legacyResolveDbImage } from "../../../shared/legacy-db-image.ts";
 import { legacyReadDbToml } from "../../../shared/legacy-db-config.toml-read.ts";
 import { legacyGetRegistryImageUrl } from "../../../shared/legacy-docker-registry.ts";
+import { legacyIsDockerDaemonUnreachable } from "../../../shared/legacy-docker-suggest.ts";
 import {
   legacyResolveLocalProjectId,
   localDbContainerId,
@@ -16,6 +17,11 @@ import {
 import { LegacyDeclarativeShadowDbError } from "./legacy-pgdelta.errors.ts";
 import { LegacyDeclarativeSeam, type LegacyShadowSource } from "./legacy-pgdelta.seam.service.ts";
 import { legacyInjectPostgresPassword } from "./legacy-pgdelta.seam.url.ts";
+
+const legacyShadowDockerCause = (
+  stderr: string,
+): { readonly docker: "daemon" } | Record<never, never> =>
+  legacyIsDockerDaemonUnreachable(stderr) ? { docker: "daemon" } : {};
 
 /**
  * Real `LegacyDeclarativeSeam`: runs the bundled `supabase-go`'s hidden
@@ -154,7 +160,11 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
               extendEnv: true,
             }).pipe(
               Effect.mapError(
-                () => new LegacyDeclarativeShadowDbError({ message: "failed to inspect service" }),
+                () =>
+                  new LegacyDeclarativeShadowDbError({
+                    message: "failed to inspect service",
+                    docker: "daemon",
+                  }),
               ),
             );
             const stderrChunks: Array<Uint8Array> = [];
@@ -164,13 +174,21 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
               }),
             ).pipe(
               Effect.mapError(
-                () => new LegacyDeclarativeShadowDbError({ message: "failed to inspect service" }),
+                () =>
+                  new LegacyDeclarativeShadowDbError({
+                    message: "failed to inspect service",
+                    docker: "daemon",
+                  }),
               ),
             );
             const inspectExit = yield* child.exitCode.pipe(
               Effect.map(Number),
               Effect.mapError(
-                () => new LegacyDeclarativeShadowDbError({ message: "failed to inspect service" }),
+                () =>
+                  new LegacyDeclarativeShadowDbError({
+                    message: "failed to inspect service",
+                    docker: "daemon",
+                  }),
               ),
             );
             if (inspectExit === 0) return; // already running
@@ -200,6 +218,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                     stderr.length > 0
                       ? `failed to inspect service: ${stderr}`
                       : "failed to inspect service",
+                  ...legacyShadowDockerCause(stderr),
                 }),
               );
             }
@@ -284,6 +303,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                 () =>
                   new LegacyDeclarativeShadowDbError({
                     message: "failed to inspect local Postgres container.",
+                    docker: "daemon",
                   }),
               ),
             );
@@ -298,6 +318,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                 () =>
                   new LegacyDeclarativeShadowDbError({
                     message: "failed to inspect local Postgres container.",
+                    docker: "daemon",
                   }),
               ),
             );
@@ -310,6 +331,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                 () =>
                   new LegacyDeclarativeShadowDbError({
                     message: "failed to inspect local Postgres container.",
+                    docker: "daemon",
                   }),
               ),
             );
@@ -319,6 +341,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                 () =>
                   new LegacyDeclarativeShadowDbError({
                     message: "failed to inspect local Postgres container.",
+                    docker: "daemon",
                   }),
               ),
             );
@@ -342,6 +365,7 @@ export const legacyDeclarativeSeamLayer = Layer.effect(
                     stderr.length > 0
                       ? `failed to inspect local Postgres container: ${stderr}`
                       : "failed to inspect local Postgres container.",
+                  ...legacyShadowDockerCause(stderr),
                 }),
               );
             }

--- a/apps/cli/src/legacy/commands/domains/domains.cname.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.cname.ts
@@ -12,6 +12,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Internal discriminated failure for the CNAME verification pipeline:
+ * `transport: true` for resolver failures (fetch error, non-200, timeout),
+ * `transport: false` for a genuine finding about the user's DNS records
+ * (no CNAME answer). Consumed exclusively by {@link verifyLegacyCname}, which
+ * folds it into `LegacyDomainsCnameError` so telemetry can tell a Cloudflare
+ * DoH outage apart from a misconfigured record.
+ */
+export interface LegacyCnameFailure {
+  readonly transport: boolean;
+  readonly detail: string;
+}
+
+/**
  * Extract the first CNAME answer's `data` from a Cloudflare DNS-over-HTTPS JSON
  * response. Mirrors Go's `utils.ResolveCNAME`
  * (`apps/cli-go/internal/utils/api.go:60-79`): scan `Answer` for the first entry
@@ -20,7 +33,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * answers instead of Go's actual (uncapped, `%+v`-on-`[]byte`) dump — see the
  * NOTE at the failure site below for why those don't byte-match.
  */
-export function parseFirstCname(payload: unknown, host: string): Effect.Effect<string, Error> {
+export function parseFirstCname(
+  payload: unknown,
+  host: string,
+): Effect.Effect<string, LegacyCnameFailure> {
   const answers = isRecord(payload) && Array.isArray(payload["Answer"]) ? payload["Answer"] : [];
   for (const answer of answers) {
     if (isRecord(answer) && answer["type"] === CNAME_TYPE && typeof answer["data"] === "string") {
@@ -38,21 +54,27 @@ export function parseFirstCname(payload: unknown, host: string): Effect.Effect<s
   // array, not the JSON text itself; empirically verified by compiling Go).
   const dump = JSON.stringify(answers, null, 4);
   const capped = dump.length > 1024 ? `${dump.slice(0, 1024)}…` : dump;
-  return Effect.fail(
-    new Error(`failed to locate appropriate CNAME record for ${host}; resolves to ${capped}`),
-  );
+  return Effect.fail({
+    transport: false,
+    detail: `failed to locate appropriate CNAME record for ${host}; resolves to ${capped}`,
+  });
 }
 
 /**
  * Render the `%w`-wrapped cause string for the "failed to resolve" CNAME error.
- * Transport / timeout / parse failures and the locate error all flow through
- * here so the outer message stays Go-shaped without leaking object internals.
+ * Transport / timeout / parse failures all flow through here so the outer
+ * message stays Go-shaped without leaking object internals.
  */
 export function formatCnameCause(cause: unknown): string {
   if (cause instanceof Error) return cause.message;
   if (isRecord(cause) && typeof cause["message"] === "string") return cause["message"];
   return String(cause);
 }
+
+const transportFailure = (cause: unknown): LegacyCnameFailure => ({
+  transport: true,
+  detail: formatCnameCause(cause),
+});
 
 /**
  * Verify that `customHostname` has a CNAME record pointing at the project's
@@ -77,20 +99,29 @@ export const verifyLegacyCname = Effect.fnUntraced(function* (args: {
   );
 
   const resolved = yield* Effect.gen(function* () {
-    const response = yield* args.httpClient.execute(request);
+    const response = yield* args.httpClient
+      .execute(request)
+      .pipe(Effect.mapError(transportFailure));
     if (response.status !== 200) {
-      return yield* Effect.fail(new Error(`unexpected DNS query status ${response.status}`));
+      return yield* Effect.fail<LegacyCnameFailure>({
+        transport: true,
+        detail: `unexpected DNS query status ${response.status}`,
+      });
     }
-    const payload = yield* response.json;
+    const payload = yield* response.json.pipe(Effect.mapError(transportFailure));
     return yield* parseFirstCname(payload, args.customHostname);
   }).pipe(
     Effect.timeout("10 seconds"),
-    Effect.mapError(
-      (cause) =>
-        new LegacyDomainsCnameError({
-          message: `expected custom hostname '${args.customHostname}' to have a CNAME record pointing to your project at '${expected}', but it failed to resolve: ${formatCnameCause(cause)}`,
-        }),
-    ),
+    Effect.mapError((cause) => {
+      const failure: LegacyCnameFailure =
+        typeof cause === "object" && cause !== null && "transport" in cause
+          ? cause
+          : transportFailure(cause);
+      return new LegacyDomainsCnameError({
+        message: `expected custom hostname '${args.customHostname}' to have a CNAME record pointing to your project at '${expected}', but it failed to resolve: ${failure.detail}`,
+        transport: failure.transport,
+      });
+    }),
   );
 
   if (resolved !== expected) {

--- a/apps/cli/src/legacy/commands/domains/domains.cname.unit.test.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.cname.unit.test.ts
@@ -33,11 +33,12 @@ describe("parseFirstCname", () => {
     expect(Exit.isFailure(exit)).toBe(true);
   });
 
-  it("fails with a locate error when no CNAME answer is present", () => {
-    const error = Effect.runSync(
+  it("fails with a non-transport locate failure when no CNAME answer is present", () => {
+    const failure = Effect.runSync(
       Effect.flip(parseFirstCname({ Answer: [{ type: 1, data: "1.2.3.4" }] }, "host.example.com")),
     );
-    expect(error.message).toContain(
+    expect(failure.transport).toBe(false);
+    expect(failure.detail).toContain(
       "failed to locate appropriate CNAME record for host.example.com",
     );
   });

--- a/apps/cli/src/legacy/commands/domains/domains.errors.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.errors.ts
@@ -37,6 +37,9 @@ export class LegacyDomainsUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The gated create/get/activate/reverify wrappers currently do not retain
+    // the entitlement check's boolean on this shared error. Keep 404 on the
+    // conservative API-status policy until that typed signal is threaded.
     return statusCodeActionability(this.status);
   }
 }

--- a/apps/cli/src/legacy/commands/domains/domains.errors.ts
+++ b/apps/cli/src/legacy/commands/domains/domains.errors.ts
@@ -1,28 +1,45 @@
 import { Data } from "effect";
 
 import { mapLegacyHttpError } from "../../shared/legacy-http-errors.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Transport-level failure talking to the Management API custom-hostname
  * endpoints. Mirrors Go's `errors.Errorf("failed to <verb> custom hostname: %w", err)`
  * (`apps/cli-go/internal/hostnames/*`).
  */
-class LegacyDomainsNetworkError extends Data.TaggedError("LegacyDomainsNetworkError")<{
+export class LegacyDomainsNetworkError extends Data.TaggedError("LegacyDomainsNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /**
  * The custom-hostname endpoint returned a status the Go CLI does not treat as
  * success (201 for create/reverify/activate, 200 for get/delete). Mirrors Go's
  * `errors.Errorf("unexpected <verb> hostname status %d: %s", code, body)`.
  */
-class LegacyDomainsUnexpectedStatusError extends Data.TaggedError(
+export class LegacyDomainsUnexpectedStatusError extends Data.TaggedError(
   "LegacyDomainsUnexpectedStatusError",
 )<{
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /**
  * The CNAME pre-check in `domains create` failed — either the DNS lookup did
@@ -31,7 +48,20 @@ class LegacyDomainsUnexpectedStatusError extends Data.TaggedError(
  */
 export class LegacyDomainsCnameError extends Data.TaggedError("LegacyDomainsCnameError")<{
   readonly message: string;
-}> {}
+  /**
+   * Set when the DNS-over-HTTPS resolver call itself failed (timeout,
+   * non-200, or fetch failure against the 1.1.1.1 resolver) rather than the
+   * CNAME being missing or pointing at the wrong host.
+   */
+  readonly transport?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.transport === true) {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+    }
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Build the network/status error mapper for a custom-hostname subcommand. The

--- a/apps/cli/src/legacy/commands/encryption/encryption.errors.ts
+++ b/apps/cli/src/legacy/commands/encryption/encryption.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { mapLegacyHttpError } from "../../shared/legacy-http-errors.ts";
 
 /**
@@ -7,22 +13,33 @@ import { mapLegacyHttpError } from "../../shared/legacy-http-errors.ts";
  * Mirrors Go's `errors.Errorf("failed to <verb> pgsodium config: %w", err)`
  * (`apps/cli-go/internal/encryption/{get,update}`).
  */
-class LegacyEncryptionNetworkError extends Data.TaggedError("LegacyEncryptionNetworkError")<{
+export class LegacyEncryptionNetworkError extends Data.TaggedError("LegacyEncryptionNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /**
  * The pgsodium endpoint returned a status the Go CLI does not treat as success
  * (it only accepts `JSON200`). Mirrors Go's
  * `errors.Errorf("unexpected <verb> pgsodium config status %d: %s", code, body)`.
  */
-class LegacyEncryptionUnexpectedStatusError extends Data.TaggedError(
+export class LegacyEncryptionUnexpectedStatusError extends Data.TaggedError(
   "LegacyEncryptionUnexpectedStatusError",
 )<{
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /**
  * Build the network/status error mapper for an encryption subcommand. Go uses

--- a/apps/cli/src/legacy/commands/encryption/encryption.errors.ts
+++ b/apps/cli/src/legacy/commands/encryption/encryption.errors.ts
@@ -37,7 +37,7 @@ export class LegacyEncryptionUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/functions/list/list.errors.ts
+++ b/apps/cli/src/legacy/commands/functions/list/list.errors.ts
@@ -1,10 +1,23 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyFunctionsListNetworkError extends Data.TaggedError(
   "LegacyFunctionsListNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyFunctionsListUnexpectedStatusError extends Data.TaggedError(
   "LegacyFunctionsListUnexpectedStatusError",
@@ -12,10 +25,18 @@ export class LegacyFunctionsListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyFunctionsEnvNotSupportedError extends Data.TaggedError(
   "LegacyFunctionsEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}

--- a/apps/cli/src/legacy/commands/functions/list/list.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/functions/list/list.errors.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
+import { LegacyFunctionsListUnexpectedStatusError } from "./list.errors.ts";
+
+describe("LegacyFunctionsListUnexpectedStatusError actionability", () => {
+  it("keeps collection-level 404s on the API-status policy", () => {
+    expect(
+      classifyCliErrorActionability(
+        new LegacyFunctionsListUnexpectedStatusError({
+          status: 404,
+          body: "not found",
+          message: "unexpected list functions status 404: not found",
+        }),
+      ),
+    ).toMatchObject({
+      error_kind: "external_service",
+      error_category: "api_status",
+      error_fingerprint: "tag:LegacyFunctionsListUnexpectedStatusError:api_status",
+    });
+  });
+});

--- a/apps/cli/src/legacy/commands/functions/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/functions/list/list.handler.ts
@@ -88,6 +88,7 @@ export const legacyFunctionsList = Effect.fn("legacy.functions.list")(function* 
       yield* fetching?.fail() ?? Effect.void;
       return yield* new LegacyFunctionsListNetworkError({
         message: decodedFunctions.message,
+        decode: true,
       });
     }
     yield* fetching?.clear() ?? Effect.void;

--- a/apps/cli/src/legacy/commands/functions/new/new.errors.ts
+++ b/apps/cli/src/legacy/commands/functions/new/new.errors.ts
@@ -1,11 +1,20 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyFunctionsNewInvalidSlugError extends Data.TaggedError(
   "LegacyFunctionsNewInvalidSlugError",
 )<{
   readonly message: string;
   readonly detail: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyFunctionsNewFileExistsError extends Data.TaggedError(
   "LegacyFunctionsNewFileExistsError",
@@ -13,12 +22,20 @@ export class LegacyFunctionsNewFileExistsError extends Data.TaggedError(
   readonly path: string;
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyFunctionsNewWriteError extends Data.TaggedError("LegacyFunctionsNewWriteError")<{
   readonly path: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Maps an arbitrary thrown cause from a filesystem write to a typed

--- a/apps/cli/src/legacy/commands/gen/bearer-jwt/bearer-jwt.errors.ts
+++ b/apps/cli/src/legacy/commands/gen/bearer-jwt/bearer-jwt.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Extracts a display message from a thrown `cause`. Every `Effect.try` catch in this
  * command's handler/signing-key resolver wraps a function that only ever throws a real
@@ -28,26 +34,42 @@ export class LegacyGenBearerJwtRoleRequiredError extends Data.TaggedError(
   "LegacyGenBearerJwtRoleRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** `supabase/config.toml` itself is malformed. Mirrors `gen signing-key`'s own error shape. */
 export class LegacyGenBearerJwtConfigParseError extends Data.TaggedError(
   "LegacyGenBearerJwtConfigParseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /** `[auth].signing_keys_path` is configured but the file could not be read. */
 export class LegacyGenBearerJwtReadError extends Data.TaggedError("LegacyGenBearerJwtReadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /** `[auth].signing_keys_path`'s file is not valid JSON / not a JWK array. */
 export class LegacyGenBearerJwtDecodeError extends Data.TaggedError(
   "LegacyGenBearerJwtDecodeError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Go's `getSigningKey` Branch A (`bearerjwt.go:46-50`): the pasted stdin JWK is not
@@ -57,7 +79,11 @@ export class LegacyGenBearerJwtKeyParseError extends Data.TaggedError(
   "LegacyGenBearerJwtKeyParseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 /**
  * Go's `getSigningKey` Branch B (`bearerjwt.go:67`): the entered kid matched no
@@ -67,7 +93,11 @@ export class LegacyGenBearerJwtKeyNotFoundError extends Data.TaggedError(
   "LegacyGenBearerJwtKeyNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 /**
  * Go's `getSigningKey` Branch C (`bearerjwt.go:70-79`): the TTY key picker
@@ -80,7 +110,11 @@ export class LegacyGenBearerJwtKeyPickerAbortedError extends Data.TaggedError(
   "LegacyGenBearerJwtKeyPickerAbortedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}
 
 /**
  * Go's `parseClaims` payload merge (`cmd/gen.go:209-211`). Byte-matches
@@ -90,7 +124,11 @@ export class LegacyGenBearerJwtPayloadError extends Data.TaggedError(
   "LegacyGenBearerJwtPayloadError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 /**
  * Go's `config.GenerateAsymmetricJWT` (`pkg/config/apikeys.go:88-113`) — unsupported
@@ -100,4 +138,8 @@ export class LegacyGenBearerJwtPayloadError extends Data.TaggedError(
  */
 export class LegacyGenBearerJwtSignError extends Data.TaggedError("LegacyGenBearerJwtSignError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}

--- a/apps/cli/src/legacy/commands/gen/signing-key/signing-key.errors.ts
+++ b/apps/cli/src/legacy/commands/gen/signing-key/signing-key.errors.ts
@@ -1,35 +1,64 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyGenSigningKeyConfigParseError extends Data.TaggedError(
   "LegacyGenSigningKeyConfigParseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 export class LegacyGenSigningKeyGenerateError extends Data.TaggedError(
   "LegacyGenSigningKeyGenerateError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.internalPanic;
+  }
+}
 
 export class LegacyGenSigningKeyReadError extends Data.TaggedError("LegacyGenSigningKeyReadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 export class LegacyGenSigningKeyDecodeError extends Data.TaggedError(
   "LegacyGenSigningKeyDecodeError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 export class LegacyGenSigningKeyWriteError extends Data.TaggedError(
   "LegacyGenSigningKeyWriteError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 export class LegacyGenSigningKeyCancelledError extends Data.TaggedError(
   "LegacyGenSigningKeyCancelledError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/legacy/commands/gen/types/types.errors.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.errors.ts
@@ -25,7 +25,7 @@ export class LegacyGenTypesUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/gen/types/types.errors.ts
+++ b/apps/cli/src/legacy/commands/gen/types/types.errors.ts
@@ -1,8 +1,21 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyGenTypesNetworkError extends Data.TaggedError("LegacyGenTypesNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyGenTypesUnexpectedStatusError extends Data.TaggedError(
   "LegacyGenTypesUnexpectedStatusError",
@@ -10,16 +23,28 @@ export class LegacyGenTypesUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyInvalidGenTypesDurationError extends Data.TaggedError(
   "LegacyInvalidGenTypesDurationError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyInvalidGenTypesDatabaseUrlError extends Data.TaggedError(
   "LegacyInvalidGenTypesDatabaseUrlError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/init/init.errors.ts
+++ b/apps/cli/src/legacy/commands/init/init.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * `supabase/config.toml` already exists and `--force` was not set. Reproduces
  * Go's wrapped `O_EXCL` open error from `utils.InitConfig`
@@ -16,7 +22,11 @@ import { Data } from "effect";
 export class LegacyInitConfigExistsError extends Data.TaggedError("LegacyInitConfigExistsError")<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--use-orioledb` without `--experimental`. Reproduces cobra's
@@ -30,4 +40,8 @@ export class LegacyInitExperimentalRequiredError extends Data.TaggedError(
   "LegacyInitExperimentalRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/inspect/db/legacy-inspect-query.ts
+++ b/apps/cli/src/legacy/commands/inspect/db/legacy-inspect-query.ts
@@ -3,6 +3,11 @@ import { Data, Effect, Option } from "effect";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
 import { LegacyDnsResolverFlag } from "../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 import { renderGlamourTable } from "../../../output/legacy-glamour-table.ts";
 import { LegacyDbConfigResolver } from "../../../shared/legacy-db-config.service.ts";
 import type { LegacyResolvedDbConfig } from "../../../shared/legacy-db-config.types.ts";
@@ -60,7 +65,11 @@ export interface LegacyInspectQuerySpec {
  */
 export class LegacyInspectMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyInspectMutuallyExclusiveFlagsError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Cell formatters — pure, exported, unit-tested. Each reproduces a Go `fmt`

--- a/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
@@ -1,4 +1,9 @@
 import { Option } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * A bounded, hand-written evaluator for the subset of the csvq SQL dialect that
@@ -48,6 +53,10 @@ import { Option } from "effect";
 /** Thrown for grammar or evaluation outside the supported csvq subset. */
 export class LegacyInspectCsvqError extends Error {
   override readonly name = "LegacyInspectCsvqError";
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.impossibleState;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/legacy/commands/inspect/report/report.errors.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Creating the dated `<output-dir>/<YYYY-MM-DD>/` directory failed. Mirrors Go's
@@ -7,7 +12,11 @@ import { Data } from "effect";
  */
 export class LegacyInspectReportMkdirError extends Data.TaggedError(
   "LegacyInspectReportMkdirError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Writing one of the report CSV files failed. Mirrors Go's `copyToCSV`
@@ -18,4 +27,8 @@ export class LegacyInspectReportMkdirError extends Data.TaggedError(
  */
 export class LegacyInspectReportWriteError extends Data.TaggedError(
   "LegacyInspectReportWriteError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/link/link.errors.ts
+++ b/apps/cli/src/legacy/commands/link/link.errors.ts
@@ -9,15 +9,15 @@ import {
   statusCodeActionability,
 } from "../../../shared/telemetry/error-actionability.ts";
 
-/** Transport (or body-decode) failure while fetching `GET /v1/projects/{ref}`. */
+/** Transport (or response-decode) failure while fetching `GET /v1/projects/{ref}`. */
 export class LegacyLinkProjectStatusNetworkError extends Data.TaggedError(
   "LegacyLinkProjectStatusNetworkError",
 )<{
   readonly message: string;
   /**
    * Set when the failure was the generated client rejecting the response body
-   * (`SchemaError` / `HttpBodyError`) rather than a transport failure — an API
-   * response problem instead of a network one.
+   * (`SchemaError`) rather than a transport failure — an API response problem
+   * instead of a network one.
    */
   readonly decode?: boolean;
 }> {
@@ -91,7 +91,7 @@ export class LegacyLinkAuthTokenError extends Data.TaggedError("LegacyLinkAuthTo
     // The shared mapper wraps any non-200 in this tag; the status policy maps
     // 401 → re-login, 404 → user-supplied ref not found, everything else →
     // API status.
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -103,6 +103,6 @@ export class LegacyLinkMissingKeyError extends Data.TaggedError("LegacyLinkMissi
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.permission;
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
   }
 }

--- a/apps/cli/src/legacy/commands/link/link.errors.ts
+++ b/apps/cli/src/legacy/commands/link/link.errors.ts
@@ -1,11 +1,32 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  CliErrorCategory,
+  CliErrorKind,
+  CliSuggestionType,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
-/** Transport failure while fetching `GET /v1/projects/{ref}`. */
+/** Transport (or body-decode) failure while fetching `GET /v1/projects/{ref}`. */
 export class LegacyLinkProjectStatusNetworkError extends Data.TaggedError(
   "LegacyLinkProjectStatusNetworkError",
 )<{
   readonly message: string;
-}> {}
+  /**
+   * Set when the failure was the generated client rejecting the response body
+   * (`SchemaError` / `HttpBodyError`) rather than a transport failure — an API
+   * response problem instead of a network one.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /**
  * `GET /v1/projects/{ref}` returned a non-200, non-404 status. Byte-matches Go's
@@ -15,7 +36,11 @@ export class LegacyLinkProjectStatusError extends Data.TaggedError("LegacyLinkPr
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /**
  * The remote project is paused (`status == INACTIVE`). Message `"project is paused"`
@@ -25,14 +50,32 @@ export class LegacyLinkProjectStatusError extends Data.TaggedError("LegacyLinkPr
 export class LegacyProjectPausedError extends Data.TaggedError("LegacyProjectPausedError")<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The rendered remediation is "unpause it from the Supabase dashboard" —
+    // remote project state, not local config and not an entitlement failure.
+    return {
+      error_kind: CliErrorKind.UserActionable,
+      error_category: CliErrorCategory.ProjectPaused,
+      has_suggestion: true,
+      suggestion_type: CliSuggestionType.OpenDashboard,
+    };
+  }
+}
 
 /** Transport failure while fetching `GET /v1/projects/{ref}/api-keys`. */
 export class LegacyLinkApiKeysNetworkError extends Data.TaggedError(
   "LegacyLinkApiKeysNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /**
  * `GET /v1/projects/{ref}/api-keys` returned a non-200 status. Byte-matches Go's
@@ -43,7 +86,14 @@ export class LegacyLinkAuthTokenError extends Data.TaggedError("LegacyLinkAuthTo
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The shared mapper wraps any non-200 in this tag; the status policy maps
+    // 401 → re-login, 404 → user-supplied ref not found, everything else →
+    // API status.
+    return statusCodeActionability(this.status);
+  }
+}
 
 /**
  * The api-keys response contained no usable anon/service-role key. Byte-matches
@@ -51,4 +101,8 @@ export class LegacyLinkAuthTokenError extends Data.TaggedError("LegacyLinkAuthTo
  */
 export class LegacyLinkMissingKeyError extends Data.TaggedError("LegacyLinkMissingKeyError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/link/link.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/link/link.errors.unit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
-import { LegacyLinkProjectStatusNetworkError } from "./link.errors.ts";
+import {
+  LegacyLinkAuthTokenError,
+  LegacyLinkMissingKeyError,
+  LegacyLinkProjectStatusError,
+  LegacyLinkProjectStatusNetworkError,
+} from "./link.errors.ts";
 
 describe("LegacyLinkProjectStatusNetworkError actionability", () => {
   it("classifies a body-decode failure as an API response problem", () => {
@@ -17,5 +22,34 @@ describe("LegacyLinkProjectStatusNetworkError actionability", () => {
       new LegacyLinkProjectStatusNetworkError({ message: "boom" }),
     );
     expect(result.error_category).toBe("network");
+  });
+});
+
+describe("link response actionability", () => {
+  it("classifies a missing selected project from the api-keys request as invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLinkAuthTokenError({ status: 404, body: "ignored", message: "ignored" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe("tag:LegacyLinkAuthTokenError:not_found");
+  });
+
+  it("keeps the project-status fallback 404 on the API-status policy", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLinkProjectStatusError({ status: 404, body: "ignored", message: "ignored" }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyLinkProjectStatusError:api_status");
+  });
+
+  it("classifies a successful api-keys response missing both keys as an API response failure", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLinkMissingKeyError({ message: "Anon key not found." }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyLinkMissingKeyError:api_response");
   });
 });

--- a/apps/cli/src/legacy/commands/link/link.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/link/link.errors.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import { LegacyLinkProjectStatusNetworkError } from "./link.errors.ts";
+
+describe("LegacyLinkProjectStatusNetworkError actionability", () => {
+  it("classifies a body-decode failure as an API response problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLinkProjectStatusNetworkError({ message: "boom", decode: true }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyLinkProjectStatusNetworkError:api_response");
+  });
+
+  it("classifies a transport failure as network", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLinkProjectStatusNetworkError({ message: "boom" }),
+    );
+    expect(result.error_category).toBe("network");
+  });
+});

--- a/apps/cli/src/legacy/commands/link/link.handler.ts
+++ b/apps/cli/src/legacy/commands/link/link.handler.ts
@@ -65,9 +65,13 @@ const classifyProjectError = (
       ),
     );
   }
+  // Everything else: a transport `HttpClientError` (no response) is a network
+  // failure; a non-`HttpClientError` (the generated client's `SchemaError` /
+  // `HttpBodyError` rejecting the response body) is an API response problem.
   return Effect.fail(
     new LegacyLinkProjectStatusNetworkError({
       message: `failed to retrieve remote project status: ${String(cause)}`,
+      decode: !HttpClientError.isHttpClientError(cause),
     }),
   );
 };

--- a/apps/cli/src/legacy/commands/link/link.handler.ts
+++ b/apps/cli/src/legacy/commands/link/link.handler.ts
@@ -66,8 +66,8 @@ const classifyProjectError = (
     );
   }
   // Everything else: a transport `HttpClientError` (no response) is a network
-  // failure; a non-`HttpClientError` (the generated client's `SchemaError` /
-  // `HttpBodyError` rejecting the response body) is an API response problem.
+  // failure; a non-`HttpClientError` (the generated client's `SchemaError`
+  // rejecting the response body) is an API response problem.
   return Effect.fail(
     new LegacyLinkProjectStatusNetworkError({
       message: `failed to retrieve remote project status: ${String(cause)}`,

--- a/apps/cli/src/legacy/commands/login/login.errors.ts
+++ b/apps/cli/src/legacy/commands/login/login.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Go's `ErrMissingToken` (`apps/cli-go/cmd/login.go:16`). Go Aqua-styles the
  * `--token` / `SUPABASE_ACCESS_TOKEN` substrings, but the legacy port renders
@@ -9,15 +15,29 @@ export const LEGACY_LOGIN_MISSING_TOKEN_MESSAGE =
   `Cannot use automatic login flow inside non-TTY environments. ` +
   `Please provide --token flag or set the SUPABASE_ACCESS_TOKEN environment variable.`;
 
-/** Token-path save failure — Go's `cannot save provided token: %w` (`login.go:171`). */
+/**
+ * Token-path save failure — Go's `cannot save provided token: %w`
+ * (`login.go:171`). Only ever constructed on the provided-token paths (`--token`
+ * / `SUPABASE_ACCESS_TOKEN` / piped stdin); the browser flow saves via the raw
+ * `credentials.saveAccessToken`. A malformed provided token is not fixable by
+ * `supabase login`, so the remediation is to correct that input.
+ */
 export class LegacyLoginSaveTokenError extends Data.TaggedError("LegacyLoginSaveTokenError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authToken;
+  }
+}
 
 /** Non-TTY environment with no token supplied (`login.go:34-35`). */
 export class LegacyLoginMissingTokenError extends Data.TaggedError("LegacyLoginMissingTokenError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authToken;
+  }
+}
 
 /**
  * A single login-session poll/parse failure. Carries the underlying message so
@@ -27,19 +47,68 @@ export class LegacyLoginMissingTokenError extends Data.TaggedError("LegacyLoginM
  */
 export class LegacyLoginVerificationError extends Data.TaggedError("LegacyLoginVerificationError")<{
   readonly message: string;
-}> {}
+  /** HTTP status of a non-200 poll response, when one was received. */
+  readonly statusCode?: number;
+  /** Set when the poll failed at the transport layer (connection/timeout). */
+  readonly network?: boolean;
+  /**
+   * Set when the poll response arrived but its body could not be decoded — an
+   * API response problem rather than a transport (network) one.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
-/** All verification retries exhausted (`login.go:214-216`). */
+/**
+ * All verification retries exhausted (`login.go:214-216`). Carries the LAST
+ * poll failure's discriminant so classification distinguishes "the user never
+ * completed the browser flow" (the endpoint keeps returning a pending 4xx, or
+ * no signal) from a genuine platform problem (5xx / transport). See the Go
+ * poll protocol: `pollForAccessToken` treats every non-200 as a retryable
+ * error (`login.go:132-157`, `pkg/fetcher/http.go:102-113`).
+ */
 export class LegacyLoginFailedError extends Data.TaggedError("LegacyLoginFailedError")<{
   readonly message: string;
-}> {}
+  readonly statusCode?: number;
+  readonly network?: boolean;
+  /**
+   * Set when the last poll response arrived but its body could not be decoded —
+   * an API response problem rather than a transport (network) one or an
+   * incomplete browser flow.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    if (this.network === true) {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+    }
+    if (this.statusCode !== undefined && this.statusCode >= 500) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_status" };
+    }
+    return actionability.authLogin;
+  }
+}
 
 /** ECDH / AES-GCM decryption failure — Go's `cannot decrypt access token` (`login.go:47`). */
 export class LegacyLoginDecryptError extends Data.TaggedError("LegacyLoginDecryptError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 /** ECDH keypair generation failure — Go's `cannot generate crypto keys` (`login.go:66`). */
 export class LegacyLoginCryptoError extends Data.TaggedError("LegacyLoginCryptoError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.internalPanic;
+  }
+}

--- a/apps/cli/src/legacy/commands/login/login.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/login/login.errors.unit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import { LegacyLoginFailedError, LegacyLoginSaveTokenError } from "./login.errors.ts";
+
+describe("LegacyLoginFailedError actionability", () => {
+  it("classifies a decoded-body poll failure as an API response problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLoginFailedError({ message: "boom", decode: true }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyLoginFailedError:api_response");
+  });
+
+  it("prefers the decode signal over a transport one", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLoginFailedError({ message: "boom", network: true, decode: true }),
+    );
+    expect(result.error_fingerprint).toBe("tag:LegacyLoginFailedError:api_response");
+  });
+
+  it("classifies a transport failure as network", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLoginFailedError({ message: "boom", network: true }),
+    );
+    expect(result.error_category).toBe("network");
+    expect(result.error_fingerprint).toBe("tag:LegacyLoginFailedError:network");
+  });
+
+  it("classifies a 5xx poll status as an API status problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLoginFailedError({ message: "boom", statusCode: 503 }),
+    );
+    expect(result.error_fingerprint).toBe("tag:LegacyLoginFailedError:api_status");
+  });
+
+  it("treats an incomplete browser flow (no signal / pending 4xx) as auth login", () => {
+    expect(
+      classifyCliErrorActionability(new LegacyLoginFailedError({ message: "boom" })).error_category,
+    ).toBe("auth");
+    expect(
+      classifyCliErrorActionability(
+        new LegacyLoginFailedError({ message: "boom", statusCode: 400 }),
+      ).error_category,
+    ).toBe("auth");
+  });
+});
+
+describe("LegacyLoginSaveTokenError actionability", () => {
+  it("classifies a provided-token save failure as a token problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyLoginSaveTokenError({ message: "cannot save provided token: bad" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("auth");
+    expect(result.suggestion_type).toBe("set_env_var");
+  });
+});

--- a/apps/cli/src/legacy/commands/logout/logout.errors.ts
+++ b/apps/cli/src/legacy/commands/logout/logout.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Raised when the user declines the logout confirmation prompt. Go returns
@@ -12,4 +17,8 @@ import { Data } from "effect";
  */
 export class LegacyLogoutCancelledError extends Data.TaggedError("LegacyLogoutCancelledError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/down/down.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/down/down.errors.ts
@@ -1,9 +1,18 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /** `--last 0`. Byte-matches Go's `--last must be greater than 0` (`down.go:21`). */
 export class LegacyMigrationLastZeroError extends Data.TaggedError("LegacyMigrationLastZeroError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--last` >= the number of applied migrations. Byte-matches Go's
@@ -15,4 +24,8 @@ export class LegacyMigrationLastTooLargeError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/fetch/fetch.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/fetch/fetch.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Writing a fetched migration file failed. Byte-matches Go's
  * `failed to write migration: %w` (`internal/migration/fetch/fetch.go:38`).
@@ -8,4 +14,8 @@ export class LegacyMigrationFetchWriteError extends Data.TaggedError(
   "LegacyMigrationFetchWriteError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/migration.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/migration.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Conflicting database-target flags. Reproduces cobra's
  * `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` error byte-for-byte
@@ -10,7 +16,11 @@ export class LegacyMigrationTargetFlagsError extends Data.TaggedError(
   "LegacyMigrationTargetFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--db-url` combined with `--password`/`-p`. Reproduces cobra's
@@ -20,7 +30,11 @@ export class LegacyMigrationPasswordFlagsError extends Data.TaggedError(
   "LegacyMigrationPasswordFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * A positional version argument is not a valid integer. Byte-matches Go's
@@ -30,7 +44,11 @@ export class LegacyMigrationInvalidVersionError extends Data.TaggedError(
   "LegacyMigrationInvalidVersionError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * No local migration file matched the requested version glob. Byte-matches Go's
@@ -41,7 +59,11 @@ export class LegacyMigrationFileNotFoundError extends Data.TaggedError(
   "LegacyMigrationFileNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * The user declined a confirmation prompt (overwrite / repair-all / revert).
@@ -50,4 +72,8 @@ export class LegacyMigrationFileNotFoundError extends Data.TaggedError(
  */
 export class LegacyOperationCanceledError extends Data.TaggedError("LegacyOperationCanceledError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/new/new.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/new/new.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Creating the migrations directory or writing the new migration file failed.
@@ -7,4 +12,8 @@ import { Data } from "effect";
  */
 export class LegacyMigrationNewWriteError extends Data.TaggedError("LegacyMigrationNewWriteError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/repair/repair.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/repair/repair.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Applying the repair batch (TRUNCATE / UPSERT / DELETE) failed. Byte-matches
@@ -9,4 +14,8 @@ export class LegacyMigrationRepairUpdateError extends Data.TaggedError(
   "LegacyMigrationRepairUpdateError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}

--- a/apps/cli/src/legacy/commands/migration/up/up.errors.ts
+++ b/apps/cli/src/legacy/commands/migration/up/up.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * A remote migration version is not present in the local migrations directory.
@@ -10,7 +15,11 @@ export class LegacyMigrationMissingLocalError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.migrationDrift;
+  }
+}
 
 /**
  * Out-of-order local migrations exist before the last remote migration, and
@@ -23,4 +32,8 @@ export class LegacyMigrationMissingRemoteError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.migrationDrift;
+  }
+}

--- a/apps/cli/src/legacy/commands/network-bans/network-bans.errors.ts
+++ b/apps/cli/src/legacy/commands/network-bans/network-bans.errors.ts
@@ -1,10 +1,24 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 export class LegacyNetworkBansGetNetworkError extends Data.TaggedError(
   "LegacyNetworkBansGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyNetworkBansGetUnexpectedStatusError extends Data.TaggedError(
   "LegacyNetworkBansGetUnexpectedStatusError",
@@ -12,13 +26,24 @@ export class LegacyNetworkBansGetUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyNetworkBansRemoveNetworkError extends Data.TaggedError(
   "LegacyNetworkBansRemoveNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyNetworkBansRemoveUnexpectedStatusError extends Data.TaggedError(
   "LegacyNetworkBansRemoveUnexpectedStatusError",
@@ -26,13 +51,21 @@ export class LegacyNetworkBansRemoveUnexpectedStatusError extends Data.TaggedErr
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyNetworkBansEnvNotSupportedError extends Data.TaggedError(
   "LegacyNetworkBansEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacyNetworkBansInvalidIpError extends Data.TaggedError(
   "LegacyNetworkBansInvalidIpError",
@@ -42,5 +75,9 @@ export class LegacyNetworkBansInvalidIpError extends Data.TaggedError(
 }> {
   constructor(args: { readonly input: string }) {
     super({ input: args.input, message: `invalid IP address: ${args.input}` });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
   }
 }

--- a/apps/cli/src/legacy/commands/network-bans/network-bans.errors.ts
+++ b/apps/cli/src/legacy/commands/network-bans/network-bans.errors.ts
@@ -28,7 +28,7 @@ export class LegacyNetworkBansGetUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -53,7 +53,7 @@ export class LegacyNetworkBansRemoveUnexpectedStatusError extends Data.TaggedErr
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/network-restrictions/network-restrictions.errors.ts
+++ b/apps/cli/src/legacy/commands/network-restrictions/network-restrictions.errors.ts
@@ -1,10 +1,23 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyNetworkRestrictionsGetNetworkError extends Data.TaggedError(
   "LegacyNetworkRestrictionsGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyNetworkRestrictionsGetUnexpectedStatusError extends Data.TaggedError(
   "LegacyNetworkRestrictionsGetUnexpectedStatusError",
@@ -12,13 +25,24 @@ export class LegacyNetworkRestrictionsGetUnexpectedStatusError extends Data.Tagg
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyNetworkRestrictionsUpdateNetworkError extends Data.TaggedError(
   "LegacyNetworkRestrictionsUpdateNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyNetworkRestrictionsUpdateUnexpectedStatusError extends Data.TaggedError(
   "LegacyNetworkRestrictionsUpdateUnexpectedStatusError",
@@ -26,7 +50,11 @@ export class LegacyNetworkRestrictionsUpdateUnexpectedStatusError extends Data.T
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyNetworkRestrictionsInvalidCidrError extends Data.TaggedError(
   "LegacyNetworkRestrictionsInvalidCidrError",
@@ -37,6 +65,10 @@ export class LegacyNetworkRestrictionsInvalidCidrError extends Data.TaggedError(
   constructor(args: { readonly input: string }) {
     // Verbatim Go string from `apps/cli-go/internal/restrictions/update/update.go:23`.
     super({ input: args.input, message: `failed to parse IP: ${args.input}` });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
   }
 }
 
@@ -49,5 +81,9 @@ export class LegacyNetworkRestrictionsPrivateIpError extends Data.TaggedError(
   constructor(args: { readonly input: string }) {
     // Verbatim Go string from `apps/cli-go/internal/restrictions/update/update.go:26`.
     super({ input: args.input, message: `private IP provided: ${args.input}` });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
   }
 }

--- a/apps/cli/src/legacy/commands/network-restrictions/network-restrictions.errors.ts
+++ b/apps/cli/src/legacy/commands/network-restrictions/network-restrictions.errors.ts
@@ -27,7 +27,7 @@ export class LegacyNetworkRestrictionsGetUnexpectedStatusError extends Data.Tagg
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -52,7 +52,7 @@ export class LegacyNetworkRestrictionsUpdateUnexpectedStatusError extends Data.T
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/orgs/orgs.errors.ts
+++ b/apps/cli/src/legacy/commands/orgs/orgs.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 // ---------------------------------------------------------------------------
 // HTTP-bound errors — one (Network + UnexpectedStatus) pair per Go errorf site
@@ -7,7 +13,14 @@ import { Data } from "effect";
 
 export class LegacyOrgsListNetworkError extends Data.TaggedError("LegacyOrgsListNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyOrgsListUnexpectedStatusError extends Data.TaggedError(
   "LegacyOrgsListUnexpectedStatusError",
@@ -15,11 +28,22 @@ export class LegacyOrgsListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyOrgsCreateNetworkError extends Data.TaggedError("LegacyOrgsCreateNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyOrgsCreateUnexpectedStatusError extends Data.TaggedError(
   "LegacyOrgsCreateUnexpectedStatusError",
@@ -27,7 +51,11 @@ export class LegacyOrgsCreateUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pure-path error — `orgs list --output env` is explicitly rejected by the Go
@@ -40,4 +68,8 @@ export class LegacyOrgsEnvNotSupportedError extends Data.TaggedError(
   "LegacyOrgsEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}

--- a/apps/cli/src/legacy/commands/postgres-config/postgres-config.errors.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/postgres-config.errors.ts
@@ -24,7 +24,7 @@ export class LegacyPostgresConfigGetUnexpectedStatusError extends Data.TaggedErr
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -58,7 +58,7 @@ export class LegacyPostgresConfigUpdateUnexpectedStatusError extends Data.Tagged
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -102,7 +102,7 @@ export class LegacyPostgresConfigDeleteUnexpectedStatusError extends Data.Tagged
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/postgres-config/postgres-config.errors.ts
+++ b/apps/cli/src/legacy/commands/postgres-config/postgres-config.errors.ts
@@ -1,10 +1,20 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyPostgresConfigGetNetworkError extends Data.TaggedError(
   "LegacyPostgresConfigGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyPostgresConfigGetUnexpectedStatusError extends Data.TaggedError(
   "LegacyPostgresConfigGetUnexpectedStatusError",
@@ -12,19 +22,33 @@ export class LegacyPostgresConfigGetUnexpectedStatusError extends Data.TaggedErr
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyPostgresConfigGetUnmarshalError extends Data.TaggedError(
   "LegacyPostgresConfigGetUnmarshalError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Constructed only after a 200 status check when `parseJsonObject` fails —
+    // an API response problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 export class LegacyPostgresConfigUpdateNetworkError extends Data.TaggedError(
   "LegacyPostgresConfigUpdateNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyPostgresConfigUpdateUnexpectedStatusError extends Data.TaggedError(
   "LegacyPostgresConfigUpdateUnexpectedStatusError",
@@ -32,25 +56,43 @@ export class LegacyPostgresConfigUpdateUnexpectedStatusError extends Data.Tagged
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyPostgresConfigUpdateUnmarshalError extends Data.TaggedError(
   "LegacyPostgresConfigUpdateUnmarshalError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Constructed only after a 200 status check when `parseJsonObject` fails —
+    // an API response problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 export class LegacyPostgresConfigUpdateSerializeError extends Data.TaggedError(
   "LegacyPostgresConfigUpdateSerializeError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyPostgresConfigDeleteNetworkError extends Data.TaggedError(
   "LegacyPostgresConfigDeleteNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyPostgresConfigDeleteUnexpectedStatusError extends Data.TaggedError(
   "LegacyPostgresConfigDeleteUnexpectedStatusError",
@@ -58,19 +100,33 @@ export class LegacyPostgresConfigDeleteUnexpectedStatusError extends Data.Tagged
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyPostgresConfigDeleteUnmarshalError extends Data.TaggedError(
   "LegacyPostgresConfigDeleteUnmarshalError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Constructed only after a 200 status check when `parseJsonObject` fails —
+    // an API response problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 export class LegacyPostgresConfigDeleteSerializeError extends Data.TaggedError(
   "LegacyPostgresConfigDeleteSerializeError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyPostgresConfigInvalidConfigValueError extends Data.TaggedError(
   "LegacyPostgresConfigInvalidConfigValueError",
@@ -83,5 +139,9 @@ export class LegacyPostgresConfigInvalidConfigValueError extends Data.TaggedErro
       input: args.input,
       message: `expected config value in key:value format, received: '${args.input}'`,
     });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }

--- a/apps/cli/src/legacy/commands/projects/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/projects/list/list.handler.ts
@@ -114,6 +114,7 @@ export const legacyProjectsList = Effect.fn("legacy.projects.list")(function* (
             status: response.status,
             body: "",
             message: `Unexpected error retrieving projects: ${cause}`,
+            decode: true,
           }),
       ),
     );
@@ -123,6 +124,7 @@ export const legacyProjectsList = Effect.fn("legacy.projects.list")(function* (
         status: response.status,
         body: "",
         message: "Unexpected error retrieving projects: response was not an array",
+        decode: true,
       });
     }
     yield* fetching?.clear() ?? Effect.void;

--- a/apps/cli/src/legacy/commands/projects/projects.errors.ts
+++ b/apps/cli/src/legacy/commands/projects/projects.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 // ---------------------------------------------------------------------------
 // HTTP-bound errors — one (Network + UnexpectedStatus) pair per Go errorf site.
@@ -10,7 +16,11 @@ export class LegacyProjectsListNetworkError extends Data.TaggedError(
   "LegacyProjectsListNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyProjectsListUnexpectedStatusError extends Data.TaggedError(
   "LegacyProjectsListUnexpectedStatusError",
@@ -18,13 +28,30 @@ export class LegacyProjectsListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  /**
+   * Set when the failure is a 200 response whose body could not be decoded
+   * (unparseable JSON / not an array) rather than a genuine non-200 status —
+   * an API response problem, not a bad status code.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyProjectsCreateNetworkError extends Data.TaggedError(
   "LegacyProjectsCreateNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacyProjectsCreateUnexpectedStatusError extends Data.TaggedError(
   "LegacyProjectsCreateUnexpectedStatusError",
@@ -32,7 +59,11 @@ export class LegacyProjectsCreateUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // Interactive org list fetched by `create` when `--org-id` is omitted
 // (`create.go:97-105`).
@@ -40,7 +71,14 @@ export class LegacyProjectsOrgsListNetworkError extends Data.TaggedError(
   "LegacyProjectsOrgsListNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyProjectsOrgsListUnexpectedStatusError extends Data.TaggedError(
   "LegacyProjectsOrgsListUnexpectedStatusError",
@@ -48,13 +86,24 @@ export class LegacyProjectsOrgsListUnexpectedStatusError extends Data.TaggedErro
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyProjectsDeleteNetworkError extends Data.TaggedError(
   "LegacyProjectsDeleteNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyProjectsDeleteUnexpectedStatusError extends Data.TaggedError(
   "LegacyProjectsDeleteUnexpectedStatusError",
@@ -62,20 +111,35 @@ export class LegacyProjectsDeleteUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // 404 branch of `delete.Run` (`delete.go:37-38`): "Project does not exist:<ref>".
 export class LegacyProjectsDeleteNotFoundError extends Data.TaggedError(
   "LegacyProjectsDeleteNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacyProjectsApiKeysNetworkError extends Data.TaggedError(
   "LegacyProjectsApiKeysNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyProjectsApiKeysUnexpectedStatusError extends Data.TaggedError(
   "LegacyProjectsApiKeysUnexpectedStatusError",
@@ -83,7 +147,11 @@ export class LegacyProjectsApiKeysUnexpectedStatusError extends Data.TaggedError
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pure-path errors (validation, prompt-time semantics, user cancellation).
@@ -94,7 +162,11 @@ export class LegacyProjectsEnvNotSupportedError extends Data.TaggedError(
   "LegacyProjectsEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 // Non-interactive `create` missing required params — mirrors Go's PreRunE
 // marking `--org-id`, `--db-password`, `--region` required + ExactArgs(1)
@@ -103,14 +175,22 @@ export class LegacyProjectsCreateMissingArgError extends Data.TaggedError(
   "LegacyProjectsCreateMissingArgError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // Interactive `create` name prompt returned blank (`create.go:94`).
 export class LegacyProjectsCreateNameEmptyError extends Data.TaggedError(
   "LegacyProjectsCreateNameEmptyError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // `delete` non-interactive with no positional ref — mirrors Go's
 // `cobra.ExactArgs(1)` on a non-TTY (`projects.go:109-113`).
@@ -118,7 +198,11 @@ export class LegacyProjectsDeleteRefRequiredError extends Data.TaggedError(
   "LegacyProjectsDeleteRefRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // User declined the delete confirmation prompt (`delete.go:24-25`,
 // `errors.New(context.Canceled)`).
@@ -126,4 +210,8 @@ export class LegacyProjectsDeleteCancelledError extends Data.TaggedError(
   "LegacyProjectsDeleteCancelledError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/legacy/commands/projects/projects.errors.ts
+++ b/apps/cli/src/legacy/commands/projects/projects.errors.ts
@@ -149,7 +149,7 @@ export class LegacyProjectsApiKeysUnexpectedStatusError extends Data.TaggedError
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/secrets/secrets.errors.ts
+++ b/apps/cli/src/legacy/commands/secrets/secrets.errors.ts
@@ -1,5 +1,12 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 // ---------------------------------------------------------------------------
 // HTTP-bound errors (network + unexpected-status pairs)
 // ---------------------------------------------------------------------------
@@ -8,7 +15,14 @@ export class LegacySecretsListNetworkError extends Data.TaggedError(
   "LegacySecretsListNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySecretsListUnexpectedStatusError extends Data.TaggedError(
   "LegacySecretsListUnexpectedStatusError",
@@ -16,11 +30,22 @@ export class LegacySecretsListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacySecretsSetNetworkError extends Data.TaggedError("LegacySecretsSetNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySecretsSetUnexpectedStatusError extends Data.TaggedError(
   "LegacySecretsSetUnexpectedStatusError",
@@ -28,13 +53,24 @@ export class LegacySecretsSetUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacySecretsUnsetNetworkError extends Data.TaggedError(
   "LegacySecretsUnsetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySecretsUnsetUnexpectedStatusError extends Data.TaggedError(
   "LegacySecretsUnsetUnexpectedStatusError",
@@ -42,7 +78,11 @@ export class LegacySecretsUnsetUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pure-path errors (validation, file I/O, user cancellation)
@@ -52,33 +92,57 @@ export class LegacySecretsEnvFileOpenError extends Data.TaggedError(
   "LegacySecretsEnvFileOpenError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacySecretsEnvFileParseError extends Data.TaggedError(
   "LegacySecretsEnvFileParseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacyInvalidSecretPairError extends Data.TaggedError("LegacyInvalidSecretPairError")<{
   readonly pair: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacySecretsNoArgumentsError extends Data.TaggedError(
   "LegacySecretsNoArgumentsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacySecretsEnvNotSupportedError extends Data.TaggedError(
   "LegacySecretsEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacySecretsUnsetCancelledError extends Data.TaggedError(
   "LegacySecretsUnsetCancelledError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/legacy/commands/secrets/secrets.errors.ts
+++ b/apps/cli/src/legacy/commands/secrets/secrets.errors.ts
@@ -32,7 +32,7 @@ export class LegacySecretsListUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -55,7 +55,7 @@ export class LegacySecretsSetUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -80,7 +80,7 @@ export class LegacySecretsUnsetUnexpectedStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -92,15 +92,30 @@ export class LegacySecretsEnvFileOpenError extends Data.TaggedError(
   "LegacySecretsEnvFileOpenError",
 )<{
   readonly message: string;
+  readonly reason: "not_found" | "permission" | "other";
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.provideFlags;
+    if (this.reason === "not_found") {
+      return { ...actionability.provideFlags, fingerprint_suffix: "not_found" };
+    }
+    if (this.reason === "permission") {
+      return { ...actionability.permission, fingerprint_suffix: "filesystem" };
+    }
+    return { ...actionability.unknown, fingerprint_suffix: "platform_error" };
   }
 }
 
 export class LegacySecretsEnvFileParseError extends Data.TaggedError(
   "LegacySecretsEnvFileParseError",
 )<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+export class LegacySecretsSetInputError extends Data.TaggedError("LegacySecretsSetInputError")<{
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {

--- a/apps/cli/src/legacy/commands/secrets/set/set.handler.ts
+++ b/apps/cli/src/legacy/commands/secrets/set/set.handler.ts
@@ -23,6 +23,7 @@ import {
   LegacySecretsEnvFileOpenError,
   LegacySecretsEnvFileParseError,
   LegacySecretsNoArgumentsError,
+  LegacySecretsSetInputError,
   LegacySecretsSetNetworkError,
   LegacySecretsSetUnexpectedStatusError,
 } from "../secrets.errors.ts";
@@ -323,6 +324,12 @@ export const legacySecretsSet = Effect.fn("legacy.secrets.set")(function* (
           (cause) =>
             new LegacySecretsEnvFileOpenError({
               message: `failed to open env file: ${String(cause)}`,
+              reason:
+                cause.reason._tag === "NotFound"
+                  ? "not_found"
+                  : cause.reason._tag === "PermissionDenied"
+                    ? "permission"
+                    : "other",
             }),
         ),
       );
@@ -391,13 +398,18 @@ export const legacySecretsSet = Effect.fn("legacy.secrets.set")(function* (
     // cap) before sending any request. Without this, a schema-invalid entry in a
     // later batch would only surface after earlier batches had already been
     // uploaded, leaving the project partially updated. Decoding fails with the
-    // same `SchemaError` `bulkCreateSecrets` raises, so `mapSetError` keeps the
-    // error surface identical to the previous single-call path.
+    // same `SchemaError` `bulkCreateSecrets` raises. This validation is wholly
+    // user-derived, so keep it distinct from response-schema decode failures.
     yield* Effect.forEach(
       batches,
       (batch) => Schema.decodeUnknownEffect(V1BulkCreateSecretsInput)({ ref, body: batch }),
       { discard: true },
-    ).pipe(Effect.catch(mapSetError));
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new LegacySecretsSetInputError({ message: `failed to set secrets: ${String(cause)}` }),
+      ),
+    );
 
     const setting = output.format === "text" ? yield* output.task("Setting secrets...") : undefined;
     yield* Effect.forEach(batches, (batch) => api.v1.bulkCreateSecrets({ ref, body: batch }), {

--- a/apps/cli/src/legacy/commands/secrets/set/set.integration.test.ts
+++ b/apps/cli/src/legacy/commands/secrets/set/set.integration.test.ts
@@ -1,8 +1,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, Layer, Option } from "effect";
+import { Effect, Exit, FileSystem, Layer, Option, PlatformError } from "effect";
 
 import {
   mockOutput,
@@ -17,6 +18,7 @@ import {
   useLegacyTempWorkdir,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { LegacyDebugLogger } from "../../../shared/legacy-debug-logger.service.ts";
+import { classifyCliCauseActionability } from "../../../../shared/telemetry/error-actionability.ts";
 import { legacySecretsSet } from "./set.handler.ts";
 
 function mockLegacyDebugLoggerTracked() {
@@ -31,6 +33,28 @@ function mockLegacyDebugLoggerTracked() {
       http: () => Effect.void,
     }),
   };
+}
+
+function permissionDeniedReadLayer(target: string) {
+  return Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(FileSystem.FileSystem, (real) =>
+      FileSystem.FileSystem.of({
+        ...real,
+        readFileString: (path, encoding) =>
+          path === target
+            ? Effect.fail(
+                PlatformError.systemError({
+                  _tag: "PermissionDenied",
+                  module: "FileSystem",
+                  method: "readFileString",
+                  pathOrDescriptor: path,
+                }),
+              )
+            : real.readFileString(path, encoding),
+      }),
+    ),
+  ).pipe(Layer.provide(BunServices.layer));
 }
 
 // ---------------------------------------------------------------------------
@@ -178,6 +202,12 @@ describe("legacy secrets set integration", () => {
           }),
         );
         expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(JSON.stringify(exit.cause)).toContain("LegacySecretsSetInputError");
+          const classified = classifyCliCauseActionability(exit.cause);
+          expect(classified.error_kind).toBe("user_actionable");
+          expect(classified.error_category).toBe("invalid_input");
+        }
         expect(api.requests).toHaveLength(0);
       }).pipe(Effect.provide(layer));
     },
@@ -423,7 +453,37 @@ FOO = "literal-foo"
         const errJson = JSON.stringify(exit.cause);
         expect(errJson).toContain("LegacySecretsEnvFileOpenError");
         expect(errJson).toContain("failed to open env file");
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_category: "invalid_input",
+          suggestion_type: "provide_flags",
+          error_fingerprint: "tag:LegacySecretsEnvFileOpenError:not_found",
+        });
       }
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("classifies an unreadable env file as a permission failure", () => {
+    const envPath = join(tempRoot.current, "private.env");
+    const { layer: baseLayer, api } = setup();
+    const layer = Layer.mergeAll(baseLayer, permissionDeniedReadLayer(envPath));
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        legacySecretsSet({
+          projectRef: Option.none(),
+          envFile: Option.some(envPath),
+          secrets: [],
+        }),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_kind: "user_actionable",
+          error_category: "permission",
+          suggestion_type: "none",
+          error_fingerprint: "tag:LegacySecretsEnvFileOpenError:filesystem",
+        });
+      }
+      expect(api.requests).toHaveLength(0);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/commands/seed/buckets/buckets.errors.ts
+++ b/apps/cli/src/legacy/commands/seed/buckets/buckets.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Domain errors specific to `supabase seed buckets`.
@@ -18,7 +23,11 @@ import { Data } from "effect";
  */
 export class LegacySeedConfigLoadError extends Data.TaggedError("LegacySeedConfigLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Raised when `--local` and `--linked` are both passed, reproducing cobra's
@@ -28,4 +37,8 @@ export class LegacySeedMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacySeedMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/services/services.errors.ts
+++ b/apps/cli/src/legacy/commands/services/services.errors.ts
@@ -1,7 +1,16 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacyServicesEnvNotSupportedError extends Data.TaggedError(
   "LegacyServicesEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}

--- a/apps/cli/src/legacy/commands/snippets/download/download.handler.ts
+++ b/apps/cli/src/legacy/commands/snippets/download/download.handler.ts
@@ -203,6 +203,9 @@ export const legacySnippetsDownload = Effect.fn("legacy.snippets.download")(func
           (cause) =>
             new LegacySnippetsDownloadNetworkError({
               message: `failed to download snippet: ${String(cause)}`,
+              // 200-response body decode failure — an API-response problem, not
+              // a transport/network failure.
+              decode: true,
             }),
         ),
       );

--- a/apps/cli/src/legacy/commands/snippets/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/snippets/list/list.handler.ts
@@ -185,6 +185,9 @@ export const legacySnippetsList = Effect.fn("legacy.snippets.list")(function* (
           (cause) =>
             new LegacySnippetsListNetworkError({
               message: `failed to list snippets: ${String(cause)}`,
+              // 200-response body decode failure — an API-response problem, not
+              // a transport/network failure.
+              decode: true,
             }),
         ),
       );

--- a/apps/cli/src/legacy/commands/snippets/snippets.errors.ts
+++ b/apps/cli/src/legacy/commands/snippets/snippets.errors.ts
@@ -1,10 +1,23 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacySnippetsListNetworkError extends Data.TaggedError(
   "LegacySnippetsListNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySnippetsListUnexpectedStatusError extends Data.TaggedError(
   "LegacySnippetsListUnexpectedStatusError",
@@ -12,7 +25,11 @@ export class LegacySnippetsListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // Mirrors Go's `utils.ErrEnvNotSupported` ("--output env is not supported"),
 // returned from `list.Run` when `OutputFormat.Value == OutputEnv`.
@@ -20,7 +37,11 @@ export class LegacySnippetsEnvNotSupportedError extends Data.TaggedError(
   "LegacySnippetsEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 // Mirrors Go's `utils.EncodeOutput` TOML failure: `snippets list -o toml`
 // fails whenever a snippet carries a `description`, because BurntSushi
@@ -30,19 +51,34 @@ export class LegacySnippetsTomlEncodeError extends Data.TaggedError(
   "LegacySnippetsTomlEncodeError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.internalPanic;
+  }
+}
 
 // Wraps `uuid.Parse` failure in `download.Run`; message preserves Go's
 // `invalid snippet ID: <cause>` prefix so callers see the same string.
 export class LegacySnippetsInvalidIdError extends Data.TaggedError("LegacySnippetsInvalidIdError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacySnippetsDownloadNetworkError extends Data.TaggedError(
   "LegacySnippetsDownloadNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySnippetsDownloadUnexpectedStatusError extends Data.TaggedError(
   "LegacySnippetsDownloadUnexpectedStatusError",
@@ -50,4 +86,8 @@ export class LegacySnippetsDownloadUnexpectedStatusError extends Data.TaggedErro
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}

--- a/apps/cli/src/legacy/commands/ssl-enforcement/ssl-enforcement.errors.ts
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/ssl-enforcement.errors.ts
@@ -1,10 +1,23 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class LegacySslEnforcementGetNetworkError extends Data.TaggedError(
   "LegacySslEnforcementGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySslEnforcementGetUnexpectedStatusError extends Data.TaggedError(
   "LegacySslEnforcementGetUnexpectedStatusError",
@@ -12,13 +25,24 @@ export class LegacySslEnforcementGetUnexpectedStatusError extends Data.TaggedErr
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacySslEnforcementUpdateNetworkError extends Data.TaggedError(
   "LegacySslEnforcementUpdateNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySslEnforcementUpdateUnexpectedStatusError extends Data.TaggedError(
   "LegacySslEnforcementUpdateUnexpectedStatusError",
@@ -26,7 +50,11 @@ export class LegacySslEnforcementUpdateUnexpectedStatusError extends Data.Tagged
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 // Verbatim Go string from `apps/cli-go/internal/ssl_enforcement/update/update.go:27`.
 export class LegacySslEnforcementNoEnableDisableFlagError extends Data.TaggedError(
@@ -36,6 +64,10 @@ export class LegacySslEnforcementNoEnableDisableFlagError extends Data.TaggedErr
 }> {
   constructor() {
     super({ message: "enable/disable not specified" });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 
@@ -52,5 +84,9 @@ export class LegacySslEnforcementMutuallyExclusiveFlagsError extends Data.Tagged
       message:
         "if any flags in the group [enable-db-ssl-enforcement disable-db-ssl-enforcement] are set none of the others can be",
     });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }

--- a/apps/cli/src/legacy/commands/ssl-enforcement/ssl-enforcement.errors.ts
+++ b/apps/cli/src/legacy/commands/ssl-enforcement/ssl-enforcement.errors.ts
@@ -27,7 +27,7 @@ export class LegacySslEnforcementGetUnexpectedStatusError extends Data.TaggedErr
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -52,7 +52,7 @@ export class LegacySslEnforcementUpdateUnexpectedStatusError extends Data.Tagged
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/commands/sso/add/add.handler.ts
+++ b/apps/cli/src/legacy/commands/sso/add/add.handler.ts
@@ -60,7 +60,8 @@ const SAML_DISABLED_MESSAGE =
 
 const readMetadata = readMetadataFile({
   openError: (args) => new LegacySsoAddMetadataFileError(args),
-  nonUtf8Error: (args) => new LegacySsoAddMetadataFileError({ message: args.message }),
+  nonUtf8Error: (args) =>
+    new LegacySsoAddMetadataFileError({ message: args.message, reason: "invalid_content" }),
 });
 
 const readAttributeMapping = readAttributeMappingFile({
@@ -306,6 +307,7 @@ export const legacySsoAdd = Effect.fn("legacy.sso.add")(function* (flags: Legacy
               (cause) =>
                 new LegacySsoAddMetadataFileError({
                   message: `${cause.message} Use --skip-url-validation to suppress this error`,
+                  reason: "invalid_url",
                 }),
             ),
           );
@@ -370,7 +372,7 @@ export const legacySsoAdd = Effect.fn("legacy.sso.add")(function* (flags: Legacy
         // mapper uses (`mapLegacyHttpError`) so error output stays bounded and
         // shell-safe — the raw-HTTP path must not skip these defences.
         const bodyText = sanitizeLegacyErrorBody(rawBody);
-        yield* legacySuggestUpgrade({
+        const upgradeSuggested = yield* legacySuggestUpgrade({
           projectRef: ref,
           featureKey: "auth.saml_2",
           statusCode: response.status,
@@ -383,7 +385,7 @@ export const legacySsoAdd = Effect.fn("legacy.sso.add")(function* (flags: Legacy
         yield* creating?.fail() ?? Effect.void;
         if (response.status === 404) {
           return yield* Effect.fail(
-            new LegacySsoAddSamlDisabledError({ message: SAML_DISABLED_MESSAGE }),
+            new LegacySsoAddSamlDisabledError({ message: SAML_DISABLED_MESSAGE, upgradeSuggested }),
           );
         }
         return yield* Effect.fail(
@@ -391,6 +393,7 @@ export const legacySsoAdd = Effect.fn("legacy.sso.add")(function* (flags: Legacy
             status: response.status,
             body: bodyText,
             message: `Unexpected error adding identity provider: ${bodyText}`,
+            upgradeSuggested,
           }),
         );
       }

--- a/apps/cli/src/legacy/commands/sso/add/add.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/add/add.integration.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { LegacyProfileFlag } from "../../../../shared/legacy/global-flags.ts";
 import { EventUpgradeSuggested } from "../../../../shared/telemetry/event-catalog.ts";
+import { classifyCliCauseActionability } from "../../../../shared/telemetry/error-actionability.ts";
 import { legacySsoAdd } from "./add.handler.ts";
 
 const RESPONSE_PROVIDER = {
@@ -921,6 +922,11 @@ describe("legacy sso add integration", () => {
         const dump = JSON.stringify(exit.cause);
         expect(dump).toContain("only HTTPS Metadata URLs are supported");
         expect(dump).toContain("Use --skip-url-validation to suppress this error");
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_category: "invalid_input",
+          suggestion_type: "provide_flags",
+          error_fingerprint: "tag:LegacySsoAddMetadataFileError:invalid_url",
+        });
       }
     }).pipe(Effect.provide(layer));
   });

--- a/apps/cli/src/legacy/commands/sso/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/sso/list/list.handler.ts
@@ -41,7 +41,7 @@ const handleListError = (ref: string, cause: SupabaseApiError) =>
   Effect.gen(function* () {
     const mapped = yield* Effect.flip(mapStatusOrNetwork(cause));
     if (mapped._tag === "LegacySsoListUnexpectedStatusError") {
-      yield* legacySuggestUpgrade({
+      const upgradeSuggested = yield* legacySuggestUpgrade({
         projectRef: ref,
         featureKey: "auth.saml_2",
         statusCode: mapped.status,
@@ -49,9 +49,17 @@ const handleListError = (ref: string, cause: SupabaseApiError) =>
       });
       if (mapped.status === 404) {
         return yield* Effect.fail(
-          new LegacySsoListSamlDisabledError({ message: SAML_DISABLED_MESSAGE }),
+          new LegacySsoListSamlDisabledError({ message: SAML_DISABLED_MESSAGE, upgradeSuggested }),
         );
       }
+      return yield* Effect.fail(
+        new LegacySsoListUnexpectedStatusError({
+          status: mapped.status,
+          body: mapped.body,
+          message: mapped.message,
+          upgradeSuggested,
+        }),
+      );
     }
     return yield* Effect.fail(mapped);
   });

--- a/apps/cli/src/legacy/commands/sso/remove/remove.handler.ts
+++ b/apps/cli/src/legacy/commands/sso/remove/remove.handler.ts
@@ -38,7 +38,7 @@ const handleRemoveError = (ref: string, providerId: string, cause: SupabaseApiEr
   Effect.gen(function* () {
     const mapped = yield* Effect.flip(mapStatusOrNetwork(cause));
     if (mapped._tag === "LegacySsoRemoveUnexpectedStatusError") {
-      yield* legacySuggestUpgrade({
+      const upgradeSuggested = yield* legacySuggestUpgrade({
         projectRef: ref,
         featureKey: "auth.saml_2",
         statusCode: mapped.status,
@@ -48,9 +48,18 @@ const handleRemoveError = (ref: string, providerId: string, cause: SupabaseApiEr
         return yield* Effect.fail(
           new LegacySsoRemoveNotFoundError({
             message: `An identity provider with ID ${JSON.stringify(providerId)} could not be found.`,
+            upgradeSuggested,
           }),
         );
       }
+      return yield* Effect.fail(
+        new LegacySsoRemoveUnexpectedStatusError({
+          status: mapped.status,
+          body: mapped.body,
+          message: mapped.message,
+          upgradeSuggested,
+        }),
+      );
     }
     return yield* Effect.fail(mapped);
   });

--- a/apps/cli/src/legacy/commands/sso/sso.errors.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.errors.ts
@@ -1,4 +1,46 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  planLimitGatedActionability,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
+import type { LegacySsoFileErrorReason } from "./sso.saml.ts";
+
+function ssoFileActionability(reason: LegacySsoFileErrorReason): CliErrorActionabilityDeclaration {
+  if (reason === "not_found") {
+    return { ...actionability.provideFlags, fingerprint_suffix: "not_found" };
+  }
+  if (reason === "permission") {
+    return { ...actionability.permission, fingerprint_suffix: "filesystem" };
+  }
+  if (reason === "invalid_content") {
+    return { ...actionability.invalidInput, fingerprint_suffix: "invalid_content" };
+  }
+  if (reason === "invalid_url") {
+    return { ...actionability.provideFlags, fingerprint_suffix: "invalid_url" };
+  }
+  return { ...actionability.unknown, fingerprint_suffix: "platform_error" };
+}
+
+/**
+ * The SAML feature is entitlement-gated: handlers thread the typed result of
+ * `legacySuggestUpgrade` (`upgradeSuggested`) into these errors so telemetry
+ * can distinguish plan-gated failures from ordinary API failures without
+ * sniffing message text.
+ */
+const samlDisabledActionability = (
+  upgradeSuggested: boolean | undefined,
+): CliErrorActionabilityDeclaration =>
+  upgradeSuggested === true
+    ? planLimitGatedActionability
+    : { ...actionability.invalidConfig, fingerprint_suffix: "saml_disabled" };
+
+const gatedNotFoundActionability = (
+  upgradeSuggested: boolean | undefined,
+): CliErrorActionabilityDeclaration =>
+  upgradeSuggested === true ? planLimitGatedActionability : actionability.invalidInput;
 
 // Shared across show / update / remove: Go's `uuid.Parse` failure.
 // Message intentionally diverges from Go's verbose `failed to parse provider ID: invalid UUID …`
@@ -7,7 +49,11 @@ import { Data } from "effect";
 export class LegacySsoInvalidUuidError extends Data.TaggedError("LegacySsoInvalidUuidError")<{
   readonly providerId: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 // Shared across list / show: mirrors Go's `utils.EncodeOutput` TOML failure
 // ("failed to output toml: %w") — reachable when an `attribute_mapping`
@@ -15,18 +61,34 @@ export class LegacySsoInvalidUuidError extends Data.TaggedError("LegacySsoInvali
 // element).
 export class LegacySsoTomlEncodeError extends Data.TaggedError("LegacySsoTomlEncodeError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.internalPanic;
+  }
+}
 
 // `sso list`
 export class LegacySsoListNetworkError extends Data.TaggedError("LegacySsoListNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySsoListSamlDisabledError extends Data.TaggedError(
   "LegacySsoListSamlDisabledError",
 )<{
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return samlDisabledActionability(this.upgradeSuggested);
+  }
+}
 
 export class LegacySsoListUnexpectedStatusError extends Data.TaggedError(
   "LegacySsoListUnexpectedStatusError",
@@ -34,18 +96,32 @@ export class LegacySsoListUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { upgradeSuggested: this.upgradeSuggested });
+  }
+}
 
 // `sso add`
 export class LegacySsoAddNetworkError extends Data.TaggedError("LegacySsoAddNetworkError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class LegacySsoAddSamlDisabledError extends Data.TaggedError(
   "LegacySsoAddSamlDisabledError",
 )<{
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return samlDisabledActionability(this.upgradeSuggested);
+  }
+}
 
 export class LegacySsoAddUnexpectedStatusError extends Data.TaggedError(
   "LegacySsoAddUnexpectedStatusError",
@@ -53,23 +129,42 @@ export class LegacySsoAddUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { upgradeSuggested: this.upgradeSuggested });
+  }
+}
 
 export class LegacySsoAddMetadataFileError extends Data.TaggedError(
   "LegacySsoAddMetadataFileError",
 )<{
   readonly message: string;
-}> {}
+  readonly reason: LegacySsoFileErrorReason;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return ssoFileActionability(this.reason);
+  }
+}
 
 export class LegacySsoAddAttributeMappingFileError extends Data.TaggedError(
   "LegacySsoAddAttributeMappingFileError",
 )<{
   readonly message: string;
-}> {}
+  readonly reason: LegacySsoFileErrorReason;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return ssoFileActionability(this.reason);
+  }
+}
 
 export class LegacySsoMutexFlagError extends Data.TaggedError("LegacySsoMutexFlagError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 // pflag's `ValueRequiredError` (`errors.go:63-78`), emulated for the case the
 // Effect parser accepts but pflag rejects: a bare value-taking flag as the
@@ -81,7 +176,11 @@ export class LegacySsoFlagNeedsArgumentError extends Data.TaggedError(
   "LegacySsoFlagNeedsArgumentError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // pflag's `InvalidValueError` (`errors.go:32-48`, raised when a flag's
 // `Value.Set` rejects an occurrence), emulated for values the Effect parser
@@ -96,7 +195,11 @@ export class LegacySsoInvalidFlagValueError extends Data.TaggedError(
   "LegacySsoInvalidFlagValueError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // cobra's `ValidateRequiredFlags` (`command.go:1007`), emulated for the case
 // the Effect parser cannot see: pflag consumed the required flag's own token
@@ -106,35 +209,66 @@ export class LegacySsoAddRequiredFlagError extends Data.TaggedError(
   "LegacySsoAddRequiredFlagError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // Shared across add + update — metadata URL validation.
 export class LegacySsoMetadataUrlInvalidError extends Data.TaggedError(
   "LegacySsoMetadataUrlInvalidError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacySsoMetadataUrlNetworkError extends Data.TaggedError(
   "LegacySsoMetadataUrlNetworkError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Fired only during preflight validation of the USER-SUPPLIED
+    // `--metadata-url` (a third-party SAML IDP endpoint), never a Supabase
+    // service — a bad URL that times out / non-200s / is too large is user
+    // input, like its `MetadataUrlInvalid` / `NonUtf8` siblings.
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacySsoMetadataUrlNonUtf8Error extends Data.TaggedError(
   "LegacySsoMetadataUrlNonUtf8Error",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 // `sso show`
 export class LegacySsoShowNetworkError extends Data.TaggedError("LegacySsoShowNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySsoShowNotFoundError extends Data.TaggedError("LegacySsoShowNotFoundError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 export class LegacySsoShowUnexpectedStatusError extends Data.TaggedError(
   "LegacySsoShowUnexpectedStatusError",
@@ -142,13 +276,21 @@ export class LegacySsoShowUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacySsoShowEnvNotSupportedError extends Data.TaggedError(
   "LegacySsoShowEnvNotSupportedError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 // `sso update`
 // cobra's `ValidateArgs` / `ExactArgs(1)` (`command.go:968`, `cmd/sso.go:87`),
@@ -158,15 +300,31 @@ export class LegacySsoShowEnvNotSupportedError extends Data.TaggedError(
 // (CLI-1982). Message byte-matches cobra's `ExactArgs` template.
 export class LegacySsoUpdateArityError extends Data.TaggedError("LegacySsoUpdateArityError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacySsoUpdateNetworkError extends Data.TaggedError("LegacySsoUpdateNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySsoUpdateNotFoundError extends Data.TaggedError("LegacySsoUpdateNotFoundError")<{
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return gatedNotFoundActionability(this.upgradeSuggested);
+  }
+}
 
 export class LegacySsoUpdateUnexpectedStatusError extends Data.TaggedError(
   "LegacySsoUpdateUnexpectedStatusError",
@@ -174,28 +332,58 @@ export class LegacySsoUpdateUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: true,
+    });
+  }
+}
 
 export class LegacySsoUpdateMetadataFileError extends Data.TaggedError(
   "LegacySsoUpdateMetadataFileError",
 )<{
   readonly message: string;
-}> {}
+  readonly reason: LegacySsoFileErrorReason;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return ssoFileActionability(this.reason);
+  }
+}
 
 export class LegacySsoUpdateAttributeMappingFileError extends Data.TaggedError(
   "LegacySsoUpdateAttributeMappingFileError",
 )<{
   readonly message: string;
-}> {}
+  readonly reason: LegacySsoFileErrorReason;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return ssoFileActionability(this.reason);
+  }
+}
 
 // `sso remove`
 export class LegacySsoRemoveNetworkError extends Data.TaggedError("LegacySsoRemoveNetworkError")<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacySsoRemoveNotFoundError extends Data.TaggedError("LegacySsoRemoveNotFoundError")<{
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return gatedNotFoundActionability(this.upgradeSuggested);
+  }
+}
 
 export class LegacySsoRemoveUnexpectedStatusError extends Data.TaggedError(
   "LegacySsoRemoveUnexpectedStatusError",
@@ -203,7 +391,12 @@ export class LegacySsoRemoveUnexpectedStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { upgradeSuggested: this.upgradeSuggested });
+  }
+}
 
 /**
  * Go's `GetSupabase` token gate (`internal/utils/api.go:119-124`):
@@ -213,4 +406,8 @@ export class LegacySsoRemoveUnexpectedStatusError extends Data.TaggedError(
  */
 export class LegacySsoAccessTokenError extends Data.TaggedError("LegacySsoAccessTokenError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}

--- a/apps/cli/src/legacy/commands/sso/sso.errors.unit.test.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.errors.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import {
+  LegacySsoAddAttributeMappingFileError,
+  LegacySsoAddMetadataFileError,
+  LegacySsoMetadataUrlNetworkError,
+  LegacySsoUpdateAttributeMappingFileError,
+  LegacySsoUpdateMetadataFileError,
+} from "./sso.errors.ts";
+import type { LegacySsoFileErrorReason } from "./sso.saml.ts";
+
+describe("LegacySsoMetadataUrlNetworkError actionability", () => {
+  it("classifies a failed user-supplied --metadata-url as a flag input problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacySsoMetadataUrlNetworkError({ message: "failed to fetch metadata url: timeout" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.suggestion_type).toBe("provide_flags");
+  });
+});
+
+describe("SSO file error actionability", () => {
+  const factories: ReadonlyArray<(reason: LegacySsoFileErrorReason) => Error> = [
+    (reason) => new LegacySsoAddMetadataFileError({ message: "file error", reason }),
+    (reason) => new LegacySsoAddAttributeMappingFileError({ message: "file error", reason }),
+    (reason) => new LegacySsoUpdateMetadataFileError({ message: "file error", reason }),
+    (reason) => new LegacySsoUpdateAttributeMappingFileError({ message: "file error", reason }),
+  ];
+
+  it("distinguishes missing, unreadable, invalid, URL, and ambiguous failures", () => {
+    for (const makeError of factories) {
+      expect(classifyCliErrorActionability(makeError("not_found"))).toMatchObject({
+        error_category: "invalid_input",
+        suggestion_type: "provide_flags",
+        error_fingerprint: expect.stringContaining(":not_found"),
+      });
+      expect(classifyCliErrorActionability(makeError("permission"))).toMatchObject({
+        error_category: "permission",
+        suggestion_type: "none",
+        error_fingerprint: expect.stringContaining(":filesystem"),
+      });
+      expect(classifyCliErrorActionability(makeError("invalid_content"))).toMatchObject({
+        error_category: "invalid_input",
+        suggestion_type: "none",
+        error_fingerprint: expect.stringContaining(":invalid_content"),
+      });
+      expect(classifyCliErrorActionability(makeError("invalid_url"))).toMatchObject({
+        error_category: "invalid_input",
+        suggestion_type: "provide_flags",
+        error_fingerprint: expect.stringContaining(":invalid_url"),
+      });
+      expect(classifyCliErrorActionability(makeError("other"))).toMatchObject({
+        error_kind: "unknown",
+        error_category: "unknown",
+        suggestion_type: "none",
+        error_fingerprint: expect.stringContaining(":platform_error"),
+      });
+    }
+  });
+});

--- a/apps/cli/src/legacy/commands/sso/sso.saml.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.saml.ts
@@ -1,4 +1,18 @@
 import { Effect, FileSystem } from "effect";
+import type { PlatformError } from "effect/PlatformError";
+
+export type LegacySsoFileErrorReason =
+  | "not_found"
+  | "permission"
+  | "invalid_content"
+  | "invalid_url"
+  | "other";
+
+function fileErrorReason(cause: PlatformError): LegacySsoFileErrorReason {
+  if (cause.reason._tag === "NotFound") return "not_found";
+  if (cause.reason._tag === "PermissionDenied") return "permission";
+  return "other";
+}
 
 /**
  * The `--name-id-format` value set, shared by `sso add` and `sso update`
@@ -51,7 +65,10 @@ export function validateMetadataXmlBytes<E>(
  */
 export const readMetadataFile =
   <Eopen, Eutf>(factory: {
-    readonly openError: (args: { readonly message: string }) => Eopen;
+    readonly openError: (args: {
+      readonly message: string;
+      readonly reason: LegacySsoFileErrorReason;
+    }) => Eopen;
     readonly nonUtf8Error: (args: { readonly source: string; readonly message: string }) => Eutf;
   }) =>
   (path: string): Effect.Effect<string, Eopen | Eutf, FileSystem.FileSystem> =>
@@ -61,13 +78,14 @@ export const readMetadataFile =
       // single error branch here (any open / read failure surfaces as
       // `failed to open metadata file:` to match the externally observable
       // string for the common case — missing file).
-      const bytes = yield* fs
-        .readFile(path)
-        .pipe(
-          Effect.mapError((cause) =>
-            factory.openError({ message: `failed to open metadata file: ${String(cause)}` }),
-          ),
-        );
+      const bytes = yield* fs.readFile(path).pipe(
+        Effect.mapError((cause) =>
+          factory.openError({
+            message: `failed to open metadata file: ${String(cause)}`,
+            reason: fileErrorReason(cause),
+          }),
+        ),
+      );
       yield* validateMetadataXmlBytes(bytes, path, factory.nonUtf8Error);
       return new TextDecoder("utf-8").decode(bytes);
     });
@@ -78,21 +96,30 @@ export const readMetadataFile =
  * `default` that aren't in the generated `attribute_mapping` schema.
  */
 export const readAttributeMappingFile =
-  <E>(factory: { readonly openError: (args: { readonly message: string }) => E }) =>
+  <E>(factory: {
+    readonly openError: (args: {
+      readonly message: string;
+      readonly reason: LegacySsoFileErrorReason;
+    }) => E;
+  }) =>
   (path: string): Effect.Effect<unknown, E, FileSystem.FileSystem> =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const content = yield* fs
-        .readFileString(path)
-        .pipe(
-          Effect.mapError((cause) =>
-            factory.openError({ message: `failed to open attribute mapping: ${String(cause)}` }),
-          ),
-        );
+      const content = yield* fs.readFileString(path).pipe(
+        Effect.mapError((cause) =>
+          factory.openError({
+            message: `failed to open attribute mapping: ${String(cause)}`,
+            reason: fileErrorReason(cause),
+          }),
+        ),
+      );
       const parsed = yield* Effect.try({
         try: () => JSON.parse(content) as unknown,
         catch: (cause) =>
-          factory.openError({ message: `failed to parse attribute mapping: ${String(cause)}` }),
+          factory.openError({
+            message: `failed to parse attribute mapping: ${String(cause)}`,
+            reason: "invalid_content",
+          }),
       });
       return parsed;
     });

--- a/apps/cli/src/legacy/commands/sso/sso.saml.unit.test.ts
+++ b/apps/cli/src/legacy/commands/sso/sso.saml.unit.test.ts
@@ -3,16 +3,25 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "@effect/vitest";
 import { BunServices } from "@effect/platform-bun";
-import { Data, Effect, Exit } from "effect";
+import { Data, Effect, Exit, FileSystem, PlatformError } from "effect";
 
 import { useLegacyTempWorkdir } from "../../../../tests/helpers/legacy-mocks.ts";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
 import {
+  LegacySsoAddMetadataFileError,
+  LegacySsoUpdateAttributeMappingFileError,
+} from "./sso.errors.ts";
+import {
+  type LegacySsoFileErrorReason,
   readAttributeMappingFile,
   readMetadataFile,
   validateMetadataXmlBytes,
 } from "./sso.saml.ts";
 
-class TestOpenError extends Data.TaggedError("TestOpenError")<{ readonly message: string }> {}
+class TestOpenError extends Data.TaggedError("TestOpenError")<{
+  readonly message: string;
+  readonly reason: LegacySsoFileErrorReason;
+}> {}
 class TestNonUtf8Error extends Data.TaggedError("TestNonUtf8Error")<{
   readonly source: string;
   readonly message: string;
@@ -26,6 +35,15 @@ const readMetadata = readMetadataFile({
 const readAttrMapping = readAttributeMappingFile({
   openError: (args) => new TestOpenError(args),
 });
+
+function permissionDenied(method: "readFile" | "readFileString") {
+  return PlatformError.systemError({
+    _tag: "PermissionDenied",
+    module: "FileSystem",
+    method,
+    pathOrDescriptor: "/private/file",
+  });
+}
 
 const tempRoot = useLegacyTempWorkdir("sso-saml-unit-");
 
@@ -48,6 +66,29 @@ describe("readMetadataFile", () => {
         expect(JSON.stringify(exit.cause)).toContain("TestOpenError");
       }
     }).pipe(Effect.provide(BunServices.layer));
+  });
+
+  it.effect("preserves a metadata file permission failure", () => {
+    const read = readMetadataFile({
+      openError: (args) => new LegacySsoAddMetadataFileError(args),
+      nonUtf8Error: (args) =>
+        new LegacySsoAddMetadataFileError({ message: args.message, reason: "invalid_content" }),
+    });
+    return Effect.gen(function* () {
+      const error = yield* read("/private/metadata.xml").pipe(Effect.flip);
+      expect(classifyCliErrorActionability(error)).toMatchObject({
+        error_kind: "user_actionable",
+        error_category: "permission",
+        suggestion_type: "none",
+        error_fingerprint: "tag:LegacySsoAddMetadataFileError:filesystem",
+      });
+    }).pipe(
+      Effect.provide(
+        FileSystem.layerNoop({
+          readFile: () => Effect.fail(permissionDenied("readFile")),
+        }),
+      ),
+    );
   });
 
   it.live("fails with TestNonUtf8Error on invalid UTF-8 bytes", () => {
@@ -96,6 +137,27 @@ describe("readAttributeMappingFile", () => {
         expect(dump).toContain("failed to open attribute mapping");
       }
     }).pipe(Effect.provide(BunServices.layer));
+  });
+
+  it.effect("preserves an attribute mapping permission failure", () => {
+    const read = readAttributeMappingFile({
+      openError: (args) => new LegacySsoUpdateAttributeMappingFileError(args),
+    });
+    return Effect.gen(function* () {
+      const error = yield* read("/private/mapping.json").pipe(Effect.flip);
+      expect(classifyCliErrorActionability(error)).toMatchObject({
+        error_kind: "user_actionable",
+        error_category: "permission",
+        suggestion_type: "none",
+        error_fingerprint: "tag:LegacySsoUpdateAttributeMappingFileError:filesystem",
+      });
+    }).pipe(
+      Effect.provide(
+        FileSystem.layerNoop({
+          readFileString: () => Effect.fail(permissionDenied("readFileString")),
+        }),
+      ),
+    );
   });
 });
 

--- a/apps/cli/src/legacy/commands/sso/update/update.handler.ts
+++ b/apps/cli/src/legacy/commands/sso/update/update.handler.ts
@@ -63,7 +63,8 @@ import type { LegacySsoUpdateFlags } from "./update.command.ts";
 
 const readMetadata = readMetadataFile({
   openError: (args) => new LegacySsoUpdateMetadataFileError(args),
-  nonUtf8Error: (args) => new LegacySsoUpdateMetadataFileError({ message: args.message }),
+  nonUtf8Error: (args) =>
+    new LegacySsoUpdateMetadataFileError({ message: args.message, reason: "invalid_content" }),
 });
 
 const readAttributeMapping = readAttributeMappingFile({
@@ -122,7 +123,7 @@ const handleGetError = (ref: string, providerId: string, cause: SupabaseApiError
   Effect.gen(function* () {
     const mapped = yield* Effect.flip(mapGetStatusOrNetwork(cause));
     if (mapped._tag === "LegacySsoUpdateUnexpectedStatusError") {
-      yield* legacySuggestUpgrade({
+      const upgradeSuggested = yield* legacySuggestUpgrade({
         projectRef: ref,
         featureKey: "auth.saml_2",
         statusCode: mapped.status,
@@ -132,9 +133,18 @@ const handleGetError = (ref: string, providerId: string, cause: SupabaseApiError
         return yield* Effect.fail(
           new LegacySsoUpdateNotFoundError({
             message: `An identity provider with ID ${JSON.stringify(providerId)} could not be found.`,
+            upgradeSuggested,
           }),
         );
       }
+      return yield* Effect.fail(
+        new LegacySsoUpdateUnexpectedStatusError({
+          status: mapped.status,
+          body: mapped.body,
+          message: mapped.message,
+          upgradeSuggested,
+        }),
+      );
     }
     return yield* Effect.fail(mapped);
   });
@@ -442,6 +452,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
             return yield* Effect.fail(
               new LegacySsoUpdateNetworkError({
                 message: `failed to get sso provider: ${cause instanceof Error ? cause.message : String(cause)}`,
+                decode: true,
               }),
             );
           }
@@ -452,7 +463,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
         // gate check, then 404 / unexpected-status.
         yield* fetching?.fail() ?? Effect.void;
         const bodyText = sanitizeLegacyErrorBody(rawBody);
-        yield* legacySuggestUpgrade({
+        const upgradeSuggested = yield* legacySuggestUpgrade({
           projectRef: ref,
           featureKey: "auth.saml_2",
           statusCode: response.status,
@@ -466,6 +477,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
           return yield* Effect.fail(
             new LegacySsoUpdateNotFoundError({
               message: `An identity provider with ID ${JSON.stringify(providerId)} could not be found.`,
+              upgradeSuggested,
             }),
           );
         }
@@ -474,6 +486,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
             status: response.status,
             body: bodyText,
             message: `unexpected error fetching identity provider: ${bodyText}`,
+            upgradeSuggested,
           }),
         );
       });
@@ -502,6 +515,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
               (cause) =>
                 new LegacySsoUpdateMetadataFileError({
                   message: `${cause.message} Use --skip-url-validation to suppress this error.`,
+                  reason: "invalid_url",
                 }),
             ),
           );
@@ -569,7 +583,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
         // Cap + sanitise to match `mapLegacyHttpError`'s defences — see add handler
         // for the rationale; the raw-HTTP path must not bypass these.
         const bodyText = sanitizeLegacyErrorBody(rawBody);
-        yield* legacySuggestUpgrade({
+        const upgradeSuggested = yield* legacySuggestUpgrade({
           projectRef: ref,
           featureKey: "auth.saml_2",
           statusCode: response.status,
@@ -586,6 +600,7 @@ export const legacySsoUpdate = Effect.fn("legacy.sso.update")(function* (
             status: response.status,
             body: bodyText,
             message: `unexpected error fetching identity provider: ${bodyText}`,
+            upgradeSuggested,
           }),
         );
       }

--- a/apps/cli/src/legacy/commands/sso/update/update.integration.test.ts
+++ b/apps/cli/src/legacy/commands/sso/update/update.integration.test.ts
@@ -18,6 +18,7 @@ import {
 import { LegacyProfileFlag } from "../../../../shared/legacy/global-flags.ts";
 import { LegacyIdentityStitch } from "../../../shared/legacy-identity-stitch.ts";
 import { EventUpgradeSuggested } from "../../../../shared/telemetry/event-catalog.ts";
+import { classifyCliCauseActionability } from "../../../../shared/telemetry/error-actionability.ts";
 import { legacySsoUpdate } from "./update.handler.ts";
 
 const VALID_PROVIDER_ID = "b5ae62f9-ef1d-4f11-a02b-731c8bbb11e8";
@@ -1471,6 +1472,11 @@ describe("legacy sso update integration", () => {
         // Per Go's `update.go:69`: error tail is `… Use --skip-url-validation to suppress this error.`
         // (trailing period).
         expect(dump).toContain("Use --skip-url-validation to suppress this error.");
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_category: "invalid_input",
+          suggestion_type: "provide_flags",
+          error_fingerprint: "tag:LegacySsoUpdateMetadataFileError:invalid_url",
+        });
       }
     }).pipe(Effect.provide(layer));
   });
@@ -1835,6 +1841,10 @@ describe("legacy sso update integration", () => {
           const dump = JSON.stringify(exit.cause);
           expect(dump).toContain("LegacySsoUpdateNetworkError");
           expect(dump).toContain("failed to get sso provider:");
+          const classified = classifyCliCauseActionability(exit.cause);
+          expect(classified.error_kind).toBe("external_service");
+          expect(classified.error_category).toBe("api_status");
+          expect(classified.error_fingerprint).toBe("tag:LegacySsoUpdateNetworkError:api_response");
         }
         expect(api.requests.some((r) => r.method === "PUT")).toBe(false);
       }).pipe(Effect.ensuring(restoreEnv), Effect.provide(layer));
@@ -1887,6 +1897,12 @@ describe("legacy sso update integration", () => {
       return Effect.gen(function* () {
         const exit = yield* Effect.exit(legacySsoUpdate(defaultFlags));
         expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const classified = classifyCliCauseActionability(exit.cause);
+          expect(classified.error_kind).toBe("user_actionable");
+          expect(classified.error_category).toBe("plan_limit");
+          expect(classified.suggestion_type).toBe("upgrade_plan");
+        }
         const project = api.requests.find((r) =>
           r.url.endsWith(`/v1/projects/${LEGACY_VALID_REF}`),
         );

--- a/apps/cli/src/legacy/commands/start/start.errors.ts
+++ b/apps/cli/src/legacy/commands/start/start.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * An explicit `--workdir`/`SUPABASE_WORKDIR` path doesn't exist or isn't a
  * directory. Mirrors Go's `ChangeWorkDir` (`apps/cli-go/internal/utils/misc.go:
@@ -10,12 +16,20 @@ import { Data } from "effect";
  */
 export class LegacyStartWorkdirError extends Data.TaggedError("LegacyStartWorkdirError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** Loading `config.toml` failed for a reason other than the file being absent (malformed TOML). */
 export class LegacyStartConfigLoadError extends Data.TaggedError("LegacyStartConfigLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * `config.toml` resolved to a value `Config.Validate` would reject before
@@ -26,4 +40,8 @@ export class LegacyStartInvalidConfigError extends Data.TaggedError(
   "LegacyStartInvalidConfigError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}

--- a/apps/cli/src/legacy/commands/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/start/start.integration.test.ts
@@ -24,6 +24,7 @@ import {
   useLegacyTempWorkdir,
 } from "../../../../tests/helpers/legacy-mocks.ts";
 import { CliArgs } from "../../../shared/cli/cli-args.service.ts";
+import { classifyCliCauseActionability } from "../../../shared/telemetry/error-actionability.ts";
 import {
   LegacyDebugFlag,
   LegacyExperimentalFlag,
@@ -1290,6 +1291,11 @@ describe("legacy start integration", () => {
             const serialized = JSON.stringify(exit.cause);
             expect(serialized).toContain("LegacyDockerLifecycleInspectError");
             expect(serialized).toContain("docker: command not found (podman also not found)");
+            expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+              error_kind: "user_actionable",
+              error_category: "docker_not_running",
+              error_fingerprint: "tag:LegacyDockerLifecycleInspectError:docker_not_running",
+            });
           }
         }).pipe(Effect.provide(layer));
       },

--- a/apps/cli/src/legacy/commands/stop/stop.errors.ts
+++ b/apps/cli/src/legacy/commands/stop/stop.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 /**
  * An explicit `--workdir`/`SUPABASE_WORKDIR` path doesn't exist or isn't a
@@ -10,7 +15,11 @@ import { Data } from "effect";
  */
 export class LegacyStopWorkdirError extends Data.TaggedError("LegacyStopWorkdirError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `--project-id` and `--all` were both set. Best-effort match of cobra's
@@ -23,12 +32,20 @@ export class LegacyStopMutuallyExclusiveError extends Data.TaggedError(
   "LegacyStopMutuallyExclusiveError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** Loading `config.toml` failed for a reason other than the file being absent (malformed TOML). */
 export class LegacyStopConfigLoadError extends Data.TaggedError("LegacyStopConfigLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Listing containers to stop failed. `stop`-specific wrapper over
@@ -37,26 +54,46 @@ export class LegacyStopConfigLoadError extends Data.TaggedError("LegacyStopConfi
  */
 export class LegacyStopListError extends Data.TaggedError("LegacyStopListError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /** Stopping one or more containers failed (`DockerRemoveAll`'s `WaitAll` step). */
 export class LegacyStopContainerError extends Data.TaggedError("LegacyStopContainerError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /** `docker container prune` failed. */
 export class LegacyStopContainerPruneError extends Data.TaggedError(
   "LegacyStopContainerPruneError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /** `docker volume prune` failed (only run when `--no-backup`/`--backup=false`). */
 export class LegacyStopVolumePruneError extends Data.TaggedError("LegacyStopVolumePruneError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /** `docker network prune` failed. */
 export class LegacyStopNetworkPruneError extends Data.TaggedError("LegacyStopNetworkPruneError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}

--- a/apps/cli/src/legacy/commands/storage/storage.errors.ts
+++ b/apps/cli/src/legacy/commands/storage/storage.errors.ts
@@ -1,5 +1,10 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyAqua } from "../../shared/legacy-colors.ts";
 import { legacyGoQuote } from "../../shared/legacy-go-quote.ts";
 
@@ -22,6 +27,10 @@ export class LegacyStorageInvalidUrlError extends Data.TaggedError("LegacyStorag
   constructor() {
     super({ message: "URL must match pattern ss:///bucket/[prefix]" });
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
 }
 
 /**
@@ -31,7 +40,11 @@ export class LegacyStorageInvalidUrlError extends Data.TaggedError("LegacyStorag
  */
 export class LegacyStorageUrlParseError extends Data.TaggedError("LegacyStorageUrlParseError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `cp`'s local→local branch (`internal/storage/cp/cp.go:59-60`). Go sets
@@ -49,6 +62,10 @@ export class LegacyStorageUnsupportedOperationError extends Data.TaggedError(
       message: "Unsupported operation",
       suggestion: `Run ${legacyAqua("cp -r <src> <dst>")} to copy between local directories.`,
     });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 
@@ -82,6 +99,10 @@ export class LegacyStorageCopyBetweenBucketsError extends Data.TaggedError(
   constructor() {
     super({ message: "Copying between buckets is not supported" });
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
 }
 
 /** `mv`'s cross-bucket branch (`internal/storage/mv/mv.go:19,38`). */
@@ -92,6 +113,10 @@ export class LegacyStorageUnsupportedMoveError extends Data.TaggedError(
 }> {
   constructor() {
     super({ message: "Moving between buckets is unsupported" });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 
@@ -104,6 +129,10 @@ export class LegacyStorageMissingPathError extends Data.TaggedError(
   constructor() {
     super({ message: "You must specify an object path" });
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
 }
 
 /** `rm`'s root-arg branch (`internal/storage/rm/rm.go:21,41`). */
@@ -115,6 +144,10 @@ export class LegacyStorageMissingBucketError extends Data.TaggedError(
   constructor() {
     super({ message: "You must specify a bucket to delete." });
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
 }
 
 /** `rm`'s directory-without-`-r` branch (`internal/storage/rm/rm.go:22,44,53`). */
@@ -125,6 +158,10 @@ export class LegacyStorageMissingFlagError extends Data.TaggedError(
 }> {
   constructor() {
     super({ message: "You must specify -r flag to delete directories." });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 
@@ -141,12 +178,20 @@ export class LegacyStorageObjectNotFoundError extends Data.TaggedError(
   constructor(path: string) {
     super({ message: `Object not found: ${path}` });
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
 }
 
 /** `failed to read file:` / `failed to create file:` (`pkg/storage/objects.go`). */
 export class LegacyStorageFileError extends Data.TaggedError("LegacyStorageFileError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Both `--linked` and `--local` set, reproducing cobra's
@@ -156,4 +201,8 @@ export class LegacyStorageMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyStorageMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/commands/test/new/new.errors.ts
+++ b/apps/cli/src/legacy/commands/test/new/new.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
+
 /**
  * The target test file already exists. Byte-matches Go's
  * `errors.New(path + " already exists.")` (`apps/cli-go/internal/test/new/new.go:26`).
@@ -7,7 +13,11 @@ import { Data } from "effect";
 export class LegacyTestNewFileExistsError extends Data.TaggedError("LegacyTestNewFileExistsError")<{
   readonly path: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Writing the test file failed (e.g. permission denied). Mirrors Go's
@@ -16,4 +26,8 @@ export class LegacyTestNewFileExistsError extends Data.TaggedError("LegacyTestNe
 export class LegacyTestNewWriteError extends Data.TaggedError("LegacyTestNewWriteError")<{
   readonly path: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/unlink/unlink.errors.ts
+++ b/apps/cli/src/legacy/commands/unlink/unlink.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * Reading `supabase/.temp/project-ref` failed for a reason other than the file
  * being absent (which maps to `LegacyProjectNotLinkedError`). Byte-matches Go's
@@ -7,7 +13,11 @@ import { Data } from "effect";
  */
 export class LegacyUnlinkRefReadError extends Data.TaggedError("LegacyUnlinkRefReadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 /**
  * Removing the `supabase/.temp` directory failed. Byte-matches Go's
@@ -15,4 +25,8 @@ export class LegacyUnlinkRefReadError extends Data.TaggedError("LegacyUnlinkRefR
  */
 export class LegacyUnlinkTempRemovalError extends Data.TaggedError("LegacyUnlinkTempRemovalError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/commands/vanity-subdomains/activate/activate.handler.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/activate/activate.handler.ts
@@ -80,12 +80,20 @@ export const legacyVanitySubdomainsActivate = Effect.fn("legacy.vanity-subdomain
                 // tagged error before deciding whether to suggest an upgrade, then re-fail.
                 const mapped = yield* Effect.flip(mapActivateError(cause));
                 if (mapped._tag === "LegacyVanitySubdomainsActivateUnexpectedStatusError") {
-                  yield* legacySuggestUpgrade({
+                  const upgradeSuggested = yield* legacySuggestUpgrade({
                     projectRef: ref,
                     featureKey: "vanity_subdomain",
                     statusCode: mapped.status,
                     response: legacyGateResponse(cause),
                   });
+                  return yield* Effect.fail(
+                    new LegacyVanitySubdomainsActivateUnexpectedStatusError({
+                      status: mapped.status,
+                      body: mapped.body,
+                      message: mapped.message,
+                      upgradeSuggested,
+                    }),
+                  );
                 }
                 return yield* Effect.fail(mapped);
               }),

--- a/apps/cli/src/legacy/commands/vanity-subdomains/check-availability/check-availability.handler.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/check-availability/check-availability.handler.ts
@@ -83,13 +83,21 @@ export const legacyVanitySubdomainsCheckAvailability = Effect.fn(
               if (mapped._tag === "LegacyVanitySubdomainsCheckUnexpectedStatusError") {
                 // Go's check command calls SuggestUpgradeOnError without a following
                 // TrackUpgradeSuggested, so suppress the analytics event for parity.
-                yield* legacySuggestUpgrade({
+                const upgradeSuggested = yield* legacySuggestUpgrade({
                   projectRef: ref,
                   featureKey: "vanity_subdomain",
                   statusCode: mapped.status,
                   response: legacyGateResponse(cause),
                   trackAnalytics: false,
                 });
+                return yield* Effect.fail(
+                  new LegacyVanitySubdomainsCheckUnexpectedStatusError({
+                    status: mapped.status,
+                    body: mapped.body,
+                    message: mapped.message,
+                    upgradeSuggested,
+                  }),
+                );
               }
               return yield* Effect.fail(mapped);
             }),

--- a/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.errors.ts
+++ b/apps/cli/src/legacy/commands/vanity-subdomains/vanity-subdomains.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 /**
  * Raised by the `activate` and `check-availability` handlers when
@@ -14,13 +20,24 @@ export class LegacyDesiredSubdomainRequiredError extends Data.TaggedError(
   "LegacyDesiredSubdomainRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class LegacyVanitySubdomainsGetNetworkError extends Data.TaggedError(
   "LegacyVanitySubdomainsGetNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyVanitySubdomainsGetUnexpectedStatusError extends Data.TaggedError(
   "LegacyVanitySubdomainsGetUnexpectedStatusError",
@@ -28,13 +45,26 @@ export class LegacyVanitySubdomainsGetUnexpectedStatusError extends Data.TaggedE
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Unlike check/activate, this gated wrapper does not yet retain the typed
+    // entitlement result. Keep 404 conservative rather than masking a plan gate.
+    return statusCodeActionability(this.status);
+  }
+}
 
 export class LegacyVanitySubdomainsCheckNetworkError extends Data.TaggedError(
   "LegacyVanitySubdomainsCheckNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyVanitySubdomainsCheckUnexpectedStatusError extends Data.TaggedError(
   "LegacyVanitySubdomainsCheckUnexpectedStatusError",
@@ -42,13 +72,28 @@ export class LegacyVanitySubdomainsCheckUnexpectedStatusError extends Data.Tagge
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: true,
+    });
+  }
+}
 
 export class LegacyVanitySubdomainsActivateNetworkError extends Data.TaggedError(
   "LegacyVanitySubdomainsActivateNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyVanitySubdomainsActivateUnexpectedStatusError extends Data.TaggedError(
   "LegacyVanitySubdomainsActivateUnexpectedStatusError",
@@ -56,13 +101,28 @@ export class LegacyVanitySubdomainsActivateUnexpectedStatusError extends Data.Ta
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+  readonly upgradeSuggested?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: true,
+    });
+  }
+}
 
 export class LegacyVanitySubdomainsDeleteNetworkError extends Data.TaggedError(
   "LegacyVanitySubdomainsDeleteNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyVanitySubdomainsDeleteUnexpectedStatusError extends Data.TaggedError(
   "LegacyVanitySubdomainsDeleteUnexpectedStatusError",
@@ -70,4 +130,8 @@ export class LegacyVanitySubdomainsDeleteUnexpectedStatusError extends Data.Tagg
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
+  }
+}

--- a/apps/cli/src/legacy/config/legacy-profile-file.ts
+++ b/apps/cli/src/legacy/config/legacy-profile-file.ts
@@ -1,5 +1,10 @@
 import { Data, Effect, FileSystem, Path } from "effect";
 import { resolveSupabaseHome } from "../../shared/config/supabase-home.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Helpers for the persisted profile-name file under the global Supabase home,
@@ -29,7 +34,11 @@ export function legacySupabaseHome(
  * (`apps/cli-go/cmd/login.go:42-46`). */
 export class LegacyProfileSaveError extends Data.TaggedError("LegacyProfileSaveError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 export function legacyProfileFilePath(
   path: Path.Path,

--- a/apps/cli/src/legacy/config/legacy-project-ref.errors.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.errors.ts
@@ -1,13 +1,27 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 export class LegacyProjectNotLinkedError extends Data.TaggedError("LegacyProjectNotLinkedError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.projectNotLinked;
+  }
+}
 
 export class LegacyInvalidProjectRefError extends Data.TaggedError("LegacyInvalidProjectRefError")<{
   readonly ref: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 /**
  * Raised by `resolveForLink` on a non-TTY when neither `--project-ref` nor
@@ -19,4 +33,8 @@ export class LegacyProjectRefRequiredError extends Data.TaggedError(
   "LegacyProjectRefRequiredError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.missingProjectRef;
+  }
+}

--- a/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/container-lifecycle.ts
@@ -21,6 +21,11 @@ import { Data, Effect } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
 import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+import {
   collectText,
   containerCliExitCode,
   legacyDescribeContainerCliFailure,
@@ -32,6 +37,7 @@ import {
   legacyIsBindMountSource,
 } from "../legacy-docker-bind-classify.ts";
 import { LEGACY_CLI_PROJECT_LABEL, LEGACY_CLI_WORKDIR_LABEL } from "../legacy-docker-ids.ts";
+import { legacyIsDockerDaemonUnreachable } from "../legacy-docker-suggest.ts";
 import { isUserDefinedDockerNetwork } from "../../../shared/functions/deploy.ts";
 import {
   legacyBuildStartContainerCreateArgs,
@@ -62,24 +68,65 @@ type Spawner = ChildProcessSpawner["Service"];
  */
 export const LEGACY_COMPOSE_PROJECT_LABEL = "com.docker.compose.project";
 
+type LegacyContainerOperationReason = "runtime" | "configuration" | "filesystem" | "port_conflict";
+
+function legacyContainerOperationActionability(
+  reason: LegacyContainerOperationReason | undefined,
+): CliErrorActionabilityDeclaration {
+  switch (reason) {
+    case "runtime":
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    case "filesystem":
+      return { ...actionability.permission, fingerprint_suffix: "filesystem" };
+    case "port_conflict":
+      return { ...actionability.invalidConfig, fingerprint_suffix: "port_conflict" };
+    default:
+      return { ...actionability.invalidConfig, fingerprint_suffix: "container_configuration" };
+  }
+}
+
+function legacyContainerCliReason(message: string): "runtime" | "configuration" {
+  return legacyIsDockerDaemonUnreachable(message) ? "runtime" : "configuration";
+}
+
 /** `docker network create --label ...`/`docker volume create --label ...` failed. */
 export class LegacyNetworkCreateError extends Data.TaggedError("LegacyNetworkCreateError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 export class LegacyVolumeCreateError extends Data.TaggedError("LegacyVolumeCreateError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 /** `docker create` failed. */
 export class LegacyContainerCreateError extends Data.TaggedError("LegacyContainerCreateError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration" | "filesystem";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 /** `docker start` failed — see {@link legacyPortConflictSuggestion} for the port-already-allocated case. */
 export class LegacyContainerStartError extends Data.TaggedError("LegacyContainerStartError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration" | "port_conflict";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 /** Every failure {@link legacyCreateContainer} itself can produce (network creation is separate, see {@link legacyEnsureNetwork}). */
 export type LegacyContainerError =
@@ -258,6 +305,7 @@ export function legacyEnsureNetwork(
           (cause) =>
             new LegacyNetworkCreateError({
               message: `failed to create docker network: ${legacyDescribeContainerCliFailure(cause)}`,
+              reason: "runtime",
             }),
         ),
       );
@@ -266,7 +314,11 @@ export function legacyEnsureNetwork(
         { concurrency: "unbounded" },
       ).pipe(
         Effect.mapError(
-          () => new LegacyNetworkCreateError({ message: "failed to create docker network" }),
+          () =>
+            new LegacyNetworkCreateError({
+              message: "failed to create docker network",
+              reason: "runtime",
+            }),
         ),
       );
       if (exitCode !== 0 && !legacyIsNetworkAlreadyExistsError(stderr)) {
@@ -277,6 +329,7 @@ export function legacyEnsureNetwork(
               message.length > 0
                 ? `failed to create docker network: ${message}`
                 : "failed to create docker network",
+            reason: legacyContainerCliReason(message),
           }),
         );
       }
@@ -327,6 +380,7 @@ export function legacyEnsureVolume(
           (cause) =>
             new LegacyVolumeCreateError({
               message: `failed to create volume: ${legacyDescribeContainerCliFailure(cause)}`,
+              reason: "runtime",
             }),
         ),
       );
@@ -334,7 +388,13 @@ export function legacyEnsureVolume(
         [child.exitCode.pipe(Effect.map(Number)), collectText(child.stderr)],
         { concurrency: "unbounded" },
       ).pipe(
-        Effect.mapError(() => new LegacyVolumeCreateError({ message: "failed to create volume" })),
+        Effect.mapError(
+          () =>
+            new LegacyVolumeCreateError({
+              message: "failed to create volume",
+              reason: "runtime",
+            }),
+        ),
       );
       if (exitCode !== 0 && !legacyIsVolumeAlreadyExistsError(stderr)) {
         const message = stderr.trim();
@@ -344,6 +404,7 @@ export function legacyEnsureVolume(
               message.length > 0
                 ? `failed to create volume: ${message}`
                 : "failed to create volume",
+            reason: legacyContainerCliReason(message),
           }),
         );
       }
@@ -354,7 +415,11 @@ export function legacyEnsureVolume(
 /** `docker volume inspect` failed to spawn at all (no docker/podman binary). */
 export class LegacyVolumeInspectError extends Data.TaggedError("LegacyVolumeInspectError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /** Docker's/Podman's "no such volume" stderr shape for `volume inspect`. */
 function isVolumeNotFoundMessage(message: string): boolean {
@@ -421,7 +486,12 @@ export function legacyVolumeExists(
 /** `docker container rm -f <id>` (or `docker rm -f`) failed. */
 export class LegacyContainerRemoveError extends Data.TaggedError("LegacyContainerRemoveError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 /**
  * Port of Go's `db reset`-only `Docker.ContainerRemove(ctx, DbId,
@@ -441,14 +511,20 @@ export function legacyRemoveContainer(
     spawner,
     ["container", "rm", "-f", containerId],
     "remove container",
-    (message) => new LegacyContainerRemoveError({ message }),
+    (message) =>
+      new LegacyContainerRemoveError({ message, reason: legacyContainerCliReason(message) }),
   );
 }
 
 /** `docker volume rm -f <name>` failed. */
 export class LegacyVolumeRemoveError extends Data.TaggedError("LegacyVolumeRemoveError")<{
   readonly message: string;
-}> {}
+  readonly reason: "runtime" | "configuration";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return legacyContainerOperationActionability(this.reason);
+  }
+}
 
 /**
  * Port of Go's `db reset`-only `Docker.VolumeRemove(ctx, DbId, true)`
@@ -466,7 +542,8 @@ export function legacyRemoveVolume(
     spawner,
     ["volume", "rm", "-f", volumeName],
     "remove volume",
-    (message) => new LegacyVolumeRemoveError({ message }),
+    (message) =>
+      new LegacyVolumeRemoveError({ message, reason: legacyContainerCliReason(message) }),
   );
 }
 
@@ -505,6 +582,7 @@ function legacyDockerCreateContainer(
           (cause) =>
             new LegacyContainerCreateError({
               message: `failed to create docker container: ${legacyDescribeContainerCliFailure(cause)}`,
+              reason: "runtime",
             }),
         ),
       );
@@ -517,7 +595,11 @@ function legacyDockerCreateContainer(
         { concurrency: "unbounded" },
       ).pipe(
         Effect.mapError(
-          () => new LegacyContainerCreateError({ message: "failed to create docker container" }),
+          () =>
+            new LegacyContainerCreateError({
+              message: "failed to create docker container",
+              reason: "runtime",
+            }),
         ),
       );
       if (exitCode !== 0) {
@@ -528,6 +610,7 @@ function legacyDockerCreateContainer(
               message.length > 0
                 ? `failed to create docker container: ${message}`
                 : "failed to create docker container",
+            reason: legacyContainerCliReason(message),
           }),
         );
       }
@@ -552,6 +635,7 @@ function legacyDockerStartContainer(
           (cause) =>
             new LegacyContainerStartError({
               message: `failed to start docker container "${spec.containerName}": ${legacyDescribeContainerCliFailure(cause)}`,
+              reason: "runtime",
             }),
         ),
       );
@@ -563,6 +647,7 @@ function legacyDockerStartContainer(
           () =>
             new LegacyContainerStartError({
               message: `failed to start docker container "${spec.containerName}"`,
+              reason: "runtime",
             }),
         ),
       );
@@ -573,12 +658,18 @@ function legacyDockerStartContainer(
         }`;
         const hostPort = legacyParsePortBindError(trimmed);
         if (hostPort === undefined) {
-          return yield* Effect.fail(new LegacyContainerStartError({ message: base }));
+          return yield* Effect.fail(
+            new LegacyContainerStartError({
+              message: base,
+              reason: legacyContainerCliReason(trimmed),
+            }),
+          );
         }
         const serviceLabel = spec.networkAliases?.[0] ?? spec.containerName;
         return yield* Effect.fail(
           new LegacyContainerStartError({
             message: `${base}${legacyPortConflictSuggestion(hostPort, serviceLabel)}`,
+            reason: "port_conflict",
           }),
         );
       }
@@ -613,6 +704,7 @@ function legacyDockerCopyIntoContainer(
           (cause) =>
             new LegacyContainerCreateError({
               message: `failed to create docker container: failed to copy secret file into container: ${legacyDescribeContainerCliFailure(cause)}`,
+              reason: "runtime",
             }),
         ),
       );
@@ -625,6 +717,7 @@ function legacyDockerCopyIntoContainer(
             new LegacyContainerCreateError({
               message:
                 "failed to create docker container: failed to copy secret file into container",
+              reason: "runtime",
             }),
         ),
       );
@@ -636,6 +729,7 @@ function legacyDockerCopyIntoContainer(
               message.length > 0
                 ? `failed to create docker container: failed to copy secret file into container: ${message}`
                 : "failed to create docker container: failed to copy secret file into container",
+            reason: legacyContainerCliReason(message),
           }),
         );
       }
@@ -683,6 +777,7 @@ function legacyCopyStartSecretFileIntoContainer(
         message: `failed to create docker container: failed to stage container secret file: ${
           cause instanceof Error ? cause.message : String(cause)
         }`,
+        reason: "filesystem",
       }),
   }).pipe(
     Effect.flatMap((dir) => {
@@ -699,6 +794,7 @@ function legacyCopyStartSecretFileIntoContainer(
             message: `failed to create docker container: failed to stage container secret file: ${
               cause instanceof Error ? cause.message : String(cause)
             }`,
+            reason: "filesystem",
           }),
       }).pipe(
         Effect.flatMap(() =>

--- a/apps/cli/src/legacy/shared/db-bootstrap/db-bootstrap-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/db-bootstrap-errors.unit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import {
+  LegacyContainerCreateError,
+  LegacyContainerStartError,
+  LegacyNetworkCreateError,
+} from "./container-lifecycle.ts";
+import { LegacyDbSetupError } from "./db-setup.ts";
+import { LegacyImagePrepullError } from "./image-prepull.ts";
+import { LegacyLocalDbRunningError } from "./local-db-running.ts";
+import { LegacyResetReplicationSlotsError } from "./recreate-local-database.ts";
+
+const classify = (error: unknown) => classifyCliErrorActionability(error);
+
+describe("db bootstrap error actionability discriminants", () => {
+  it("distinguishes container-runtime, configuration, filesystem, and port failures", () => {
+    expect(
+      classify(new LegacyNetworkCreateError({ message: "ignored", reason: "runtime" })),
+    ).toMatchObject({ error_category: "docker_not_running" });
+    expect(
+      classify(new LegacyNetworkCreateError({ message: "ignored", reason: "configuration" })),
+    ).toMatchObject({ error_category: "invalid_config" });
+    expect(
+      classify(new LegacyContainerCreateError({ message: "ignored", reason: "filesystem" })),
+    ).toMatchObject({ error_category: "permission" });
+    expect(
+      classify(new LegacyContainerStartError({ message: "ignored", reason: "port_conflict" })),
+    ).toMatchObject({
+      error_category: "invalid_config",
+      error_fingerprint: "tag:LegacyContainerStartError:port_conflict",
+    });
+  });
+
+  it("keeps database setup causes in separate KPI families", () => {
+    expect(
+      classify(new LegacyDbSetupError({ message: "ignored", reason: "database" })),
+    ).toMatchObject({ error_category: "invalid_config" });
+    expect(
+      classify(new LegacyDbSetupError({ message: "ignored", reason: "filesystem" })),
+    ).toMatchObject({ error_category: "permission" });
+    expect(
+      classify(new LegacyDbSetupError({ message: "ignored", reason: "docker_daemon" })),
+    ).toMatchObject({ error_category: "docker_not_running" });
+    expect(
+      classify(new LegacyDbSetupError({ message: "ignored", reason: "registry_pull" })),
+    ).toMatchObject({ error_kind: "external_service", error_category: "network" });
+    expect(
+      classify(new LegacyDbSetupError({ message: "ignored", reason: "image_inspect" })),
+    ).toMatchObject({ error_category: "invalid_config" });
+  });
+
+  it("distinguishes an active replication slot from a failed slot query", () => {
+    expect(
+      classify(new LegacyResetReplicationSlotsError({ message: "ignored", retryable: true })),
+    ).toMatchObject({
+      error_category: "invalid_config",
+      error_fingerprint: "tag:LegacyResetReplicationSlotsError:replication_slots_active",
+    });
+    expect(
+      classify(new LegacyResetReplicationSlotsError({ message: "ignored", retryable: false })),
+    ).toMatchObject({
+      error_category: "db_connection",
+      error_fingerprint: "tag:LegacyResetReplicationSlotsError:replication_slots_query",
+    });
+  });
+
+  it("distinguishes an unavailable daemon from another local DB inspect failure", () => {
+    expect(
+      classify(new LegacyLocalDbRunningError({ message: "ignored", daemonDown: true })),
+    ).toMatchObject({ error_category: "docker_not_running" });
+    expect(classify(new LegacyLocalDbRunningError({ message: "ignored" }))).toMatchObject({
+      error_category: "invalid_config",
+      suggested_command: "supabase start",
+    });
+  });
+
+  it("distinguishes daemon, registry, and image-inspection prepull failures", () => {
+    expect(
+      classify(new LegacyImagePrepullError({ message: "ignored", reason: "docker_daemon" })),
+    ).toMatchObject({ error_category: "docker_not_running" });
+    expect(
+      classify(new LegacyImagePrepullError({ message: "ignored", reason: "registry_pull" })),
+    ).toMatchObject({ error_kind: "external_service", error_category: "network" });
+    expect(
+      classify(new LegacyImagePrepullError({ message: "ignored", reason: "image_inspect" })),
+    ).toMatchObject({ error_category: "invalid_config" });
+  });
+});

--- a/apps/cli/src/legacy/shared/db-bootstrap/db-setup.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/db-setup.ts
@@ -114,6 +114,11 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 import type { LocalServiceVersionOverrides } from "../../../shared/services/services.shared.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { LegacyDbConnection, type LegacyDbSession } from "../legacy-db-connection.service.ts";
 import type { LegacyDbConnectError } from "../legacy-db-connection.errors.ts";
 import { LegacyDbConfigLoadError } from "../legacy-db-config.errors.ts";
@@ -173,7 +178,40 @@ alter default privileges for role postgres in schema public
  */
 export class LegacyDbSetupError extends Data.TaggedError("LegacyDbSetupError")<{
   readonly message: string;
-}> {}
+  readonly reason:
+    | "database"
+    | "filesystem"
+    | "invalid_config"
+    | "docker_daemon"
+    | "registry_pull"
+    | "image_inspect";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    switch (this.reason) {
+      case "database":
+        return { ...actionability.dbFinding, fingerprint_suffix: "database" };
+      case "filesystem":
+        return { ...actionability.permission, fingerprint_suffix: "filesystem" };
+      case "docker_daemon":
+        return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+      case "registry_pull":
+        return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+      case "image_inspect":
+        return { ...actionability.invalidConfig, fingerprint_suffix: "image_inspect" };
+      default:
+        return { ...actionability.invalidConfig, fingerprint_suffix: "invalid_config" };
+    }
+  }
+}
+
+function legacyDbSetupDockerReason(
+  reason: "spawn" | "inspect" | "pull",
+  daemonDown: boolean,
+): LegacyDbSetupError["reason"] {
+  if (reason === "spawn" || daemonDown) return "docker_daemon";
+  if (reason === "pull") return "registry_pull";
+  return "image_inspect";
+}
 
 /** Every failure {@link legacyStartSetupLocalDatabase} can produce. */
 export type LegacyStartSetupLocalDatabaseError =
@@ -376,6 +414,7 @@ const legacyExecSqlConstant = Effect.fnUntraced(function* (
       (error) =>
         new LegacyDbSetupError({
           message: `failed to write ${filename}: ${errMessage(error)}`,
+          reason: "filesystem",
         }),
     ),
   );
@@ -384,7 +423,7 @@ const legacyExecSqlConstant = Effect.fnUntraced(function* (
     fs,
     path,
     filePath,
-    (message) => new LegacyDbSetupError({ message }),
+    (message) => new LegacyDbSetupError({ message, reason: "database" }),
   );
 });
 
@@ -519,10 +558,21 @@ const legacyRunStartMigrateJob = Effect.fnUntraced(function* (
   // (review: Codex, PR #6022).
   const result = yield* docker
     .runStream(runOpts, { onStdout: () => Effect.void, teeStderr: opts.debug })
-    .pipe(Effect.mapError((cause) => new LegacyDbSetupError({ message: cause.message })));
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new LegacyDbSetupError({
+            message: cause.message,
+            reason: legacyDbSetupDockerReason(cause.reason, cause.daemonDown),
+          }),
+      ),
+    );
   if (result.exitCode !== 0) {
     return yield* Effect.fail(
-      new LegacyDbSetupError({ message: `error running container: exit ${result.exitCode}` }),
+      new LegacyDbSetupError({
+        message: `error running container: exit ${result.exitCode}`,
+        reason: "database",
+      }),
     );
   }
 });
@@ -651,6 +701,7 @@ const legacyStartInitSchema15 = Effect.fnUntraced(function* (
       catch: (cause) =>
         new LegacyDbSetupError({
           message: `invalid config for storage: ${errMessage(cause)}`,
+          reason: "invalid_config",
         }),
     });
     yield* legacyRunStartMigrateJob(spawner, {
@@ -762,6 +813,7 @@ export const legacyStartInitCurrentBranch = Effect.fnUntraced(function* (
       (error) =>
         new LegacyDbSetupError({
           message: `failed init current branch: ${errMessage(error)}`,
+          reason: "filesystem",
         }),
     ),
   );
@@ -771,6 +823,7 @@ export const legacyStartInitCurrentBranch = Effect.fnUntraced(function* (
       (error) =>
         new LegacyDbSetupError({
           message: `failed init current branch: ${errMessage(error)}`,
+          reason: "filesystem",
         }),
     ),
   );
@@ -785,6 +838,7 @@ export const legacyStartInitCurrentBranch = Effect.fnUntraced(function* (
       (error) =>
         new LegacyDbSetupError({
           message: `failed init current branch: ${errMessage(error)}`,
+          reason: "filesystem",
         }),
     ),
   );
@@ -843,6 +897,7 @@ export const legacyStartSetupLocalDatabase = (
               (error) =>
                 new LegacyDbSetupError({
                   message: `failed to create temp directory: ${errMessage(error)}`,
+                  reason: "filesystem",
                 }),
             ),
           );
@@ -879,6 +934,7 @@ export const legacyStartSetupLocalDatabase = (
         (error) =>
           new LegacyDbSetupError({
             message: `failed to check roles.sql: ${errMessage(error)}`,
+            reason: "filesystem",
           }),
       ),
     );
@@ -888,7 +944,7 @@ export const legacyStartSetupLocalDatabase = (
         fs,
         path,
         customRolesPath,
-        (message) => new LegacyDbSetupError({ message }),
+        (message) => new LegacyDbSetupError({ message, reason: "database" }),
       );
     }
 

--- a/apps/cli/src/legacy/shared/db-bootstrap/db-setup.unit.test.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/db-setup.unit.test.ts
@@ -124,9 +124,30 @@ function mockAlwaysCachedSpawner(): ChildProcessSpawner.ChildProcessSpawner["Ser
 
 function mockDockerRunFails() {
   const layer = Layer.succeed(LegacyDockerRun, {
-    run: () => Effect.fail(new LegacyDockerRunError({ message: "failed to run docker" })),
-    runCapture: () => Effect.fail(new LegacyDockerRunError({ message: "failed to run docker" })),
-    runStream: () => Effect.fail(new LegacyDockerRunError({ message: "failed to run docker" })),
+    run: () =>
+      Effect.fail(
+        new LegacyDockerRunError({
+          message: "failed to run docker",
+          reason: "spawn",
+          daemonDown: false,
+        }),
+      ),
+    runCapture: () =>
+      Effect.fail(
+        new LegacyDockerRunError({
+          message: "failed to run docker",
+          reason: "spawn",
+          daemonDown: false,
+        }),
+      ),
+    runStream: () =>
+      Effect.fail(
+        new LegacyDockerRunError({
+          message: "failed to run docker",
+          reason: "spawn",
+          daemonDown: false,
+        }),
+      ),
   });
   return { layer };
 }

--- a/apps/cli/src/legacy/shared/db-bootstrap/health-check.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/health-check.ts
@@ -16,6 +16,11 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
 import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+import {
   legacySpawnContainerCliWithRuntime,
   type LegacyContainerRuntime,
 } from "../legacy-container-cli.ts";
@@ -62,10 +67,14 @@ export interface LegacyHealthCheckFailure {
   readonly reason: string;
 }
 
-/** Internal-only: one probe round's failures, narrowing which containers are still watched next round. */
-class LegacyHealthCheckProbeError extends Data.TaggedError("LegacyHealthCheckProbeError")<{
+/** Runtime-internal probe sentinel; exported only for the exhaustive actionability guard. */
+export class LegacyHealthCheckProbeError extends Data.TaggedError("LegacyHealthCheckProbeError")<{
   readonly failures: ReadonlyArray<LegacyHealthCheckFailure>;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /**
  * The retry loop's final, and only surfaced, failure — mirrors Go returning
@@ -83,7 +92,11 @@ export class LegacyHealthCheckTimeoutError extends Data.TaggedError(
    * pointing at an HTTP request logger is a non-sequitur (as in CLI-1973).
    */
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /**
  * PostgREST's local Kong gateway coordinates, mirroring Go's

--- a/apps/cli/src/legacy/shared/db-bootstrap/image-prepull.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/image-prepull.ts
@@ -19,6 +19,11 @@
 import { Data, Effect, Result } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyMakeDockerImageResolver } from "../legacy-docker-image-resolve.ts";
 import {
   LEGACY_SUGGEST_DOCKER_INSTALL,
@@ -35,7 +40,19 @@ type Spawner = ChildProcessSpawner["Service"];
  */
 export class LegacyImagePrepullError extends Data.TaggedError("LegacyImagePrepullError")<{
   readonly message: string;
-}> {}
+  readonly reason: "docker_daemon" | "registry_pull" | "image_inspect";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    switch (this.reason) {
+      case "docker_daemon":
+        return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+      case "registry_pull":
+        return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+      default:
+        return { ...actionability.invalidConfig, fingerprint_suffix: "image_inspect" };
+    }
+  }
+}
 
 /**
  * Resolves every image in `images` concurrently (Go's `utils.WaitAll` —
@@ -66,10 +83,19 @@ export function legacyEnsureImagesCached(
 
     const resolved = new Map<string, string>();
     const failures: Array<string> = [];
+    let failureReason: LegacyImagePrepullError["reason"] = "image_inspect";
     for (const [index, image] of uniqueImages.entries()) {
       const result = results[index];
       if (result === undefined || Result.isFailure(result)) {
         failures.push(result === undefined ? `${image}: unknown error` : result.failure.message);
+        if (result !== undefined) {
+          const failure = result.failure;
+          if (failure.reason === "spawn" || failure.daemonDown) {
+            failureReason = "docker_daemon";
+          } else if (failure.reason === "pull" && failureReason !== "docker_daemon") {
+            failureReason = "registry_pull";
+          }
+        }
         continue;
       }
       resolved.set(image, result.success);
@@ -86,7 +112,10 @@ export function legacyEnsureImagesCached(
         ? `\n\n${LEGACY_SUGGEST_DOCKER_INSTALL}`
         : "";
       return yield* Effect.fail(
-        new LegacyImagePrepullError({ message: `${failures.join("\n")}${hint}` }),
+        new LegacyImagePrepullError({
+          message: `${failures.join("\n")}${hint}`,
+          reason: failureReason,
+        }),
       );
     }
 

--- a/apps/cli/src/legacy/shared/db-bootstrap/local-db-running.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/local-db-running.ts
@@ -1,6 +1,11 @@
 import { Data, Effect, type FileSystem, Option, type Path, Stream } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyIsContainerNotFoundMessage, spawnContainerCli } from "../legacy-container-cli.ts";
 import { legacyReadDbToml } from "../legacy-db-config.toml-read.ts";
 import { legacyResolveLocalProjectId, localDbContainerId } from "../legacy-docker-ids.ts";
@@ -14,9 +19,18 @@ type Spawner = ChildProcessSpawner["Service"];
 /** `docker container inspect` failed for a reason other than "the container doesn't exist". */
 export class LegacyLocalDbRunningError extends Data.TaggedError("LegacyLocalDbRunningError")<{
   readonly message: string;
+  /** Classified at the container-runtime boundary; never inferred from `message` by telemetry. */
+  readonly daemonDown?: boolean;
   /** Set when the failure is a daemon-connection error, mirroring `utils.CmdSuggestion`. */
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.daemonDown === true) {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    return actionability.startStack;
+  }
+}
 
 const decodeChunks = (chunks: ReadonlyArray<Uint8Array>): string => {
   const total = chunks.reduce((size, chunk) => size + chunk.length, 0);
@@ -90,7 +104,11 @@ export function legacyIsLocalDbRunning(
         extendEnv: true,
       }).pipe(
         Effect.mapError(
-          () => new LegacyLocalDbRunningError({ message: "failed to inspect service" }),
+          () =>
+            new LegacyLocalDbRunningError({
+              message: "failed to inspect service",
+              daemonDown: true,
+            }),
         ),
       );
       const stderrChunks: Array<Uint8Array> = [];
@@ -122,15 +140,15 @@ export function legacyIsLocalDbRunning(
         // Go's `AssertServiceIsRunning` sets `CmdSuggestion = suggestDockerInstall`
         // on a daemon-connection failure (`misc.go:148-154`), so a down daemon
         // still surfaces the actionable Docker Desktop hint, not just raw stderr.
+        const daemonDown = legacyIsDockerDaemonUnreachable(stderr);
         return yield* Effect.fail(
           new LegacyLocalDbRunningError({
             message:
               stderr.length > 0
                 ? `failed to inspect service: ${stderr}`
                 : "failed to inspect service",
-            ...(legacyIsDockerDaemonUnreachable(stderr)
-              ? { suggestion: LEGACY_SUGGEST_DOCKER_INSTALL }
-              : {}),
+            daemonDown,
+            ...(daemonDown ? { suggestion: LEGACY_SUGGEST_DOCKER_INSTALL } : {}),
           }),
         );
       }

--- a/apps/cli/src/legacy/shared/db-bootstrap/recreate-local-database.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/recreate-local-database.ts
@@ -84,6 +84,11 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 
 import { Output } from "../../../shared/output/output.service.ts";
 import type { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyIsSqlState } from "../legacy-connect-errors.ts";
 import { legacyCheckDbToml } from "../legacy-db-config.toml-read.ts";
 import { LegacyDbConnection, type LegacyDbSession } from "../legacy-db-connection.service.ts";
@@ -145,17 +150,23 @@ const errMessage = (e: unknown): string =>
  * One or more replication slots are still active (retryable — the WAL sender
  * that owns the slot may still be tearing down), OR counting them failed
  * outright (permanent — Go's `backoff.PermanentError`, `reset.go:236-238`:
- * a query-execution failure is never retried, only "count > 0" is). Not
- * exported outside this module — callers discriminate this via the
- * {@link LegacyRecreateLocalDatabaseError} union's `_tag`, never by importing
- * the class itself (same pattern as `legacy-docker-remove-all.ts`).
+ * a query-execution failure is never retried, only "count > 0" is). Exported
+ * only so the exhaustive actionability guard can inspect its
+ * declaration; runtime callers discriminate it through the
+ * {@link LegacyRecreateLocalDatabaseError} union's `_tag`.
  */
-class LegacyResetReplicationSlotsError extends Data.TaggedError(
+export class LegacyResetReplicationSlotsError extends Data.TaggedError(
   "LegacyResetReplicationSlotsError",
 )<{
   readonly message: string;
   readonly retryable: boolean;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.retryable
+      ? { ...actionability.dbFinding, fingerprint_suffix: "replication_slots_active" }
+      : { ...actionability.dbConnection, fingerprint_suffix: "replication_slots_query" };
+  }
+}
 
 /** Every failure the PG14/PG15 `db reset` recreate composition can produce. */
 export type LegacyRecreateLocalDatabaseError =
@@ -256,6 +267,7 @@ export const legacyResetDisconnectClients = Effect.fnUntraced(function* (session
       return yield* Effect.fail(
         new LegacyDbSetupError({
           message: `failed to disconnect clients: ${failure.message}`,
+          reason: "database",
         }),
       );
     }
@@ -427,6 +439,7 @@ const legacyRecreateLocalDatabase14 = <E>(
               (error) =>
                 new LegacyDbSetupError({
                   message: `failed to create temp directory: ${errMessage(error)}`,
+                  reason: "filesystem",
                 }),
             ),
           );

--- a/apps/cli/src/legacy/shared/db-bootstrap/reset-local-database.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/reset-local-database.ts
@@ -48,6 +48,11 @@ import {
 } from "../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyAqua, legacyYellow } from "../legacy-colors.ts";
 import { LegacyCliConfig } from "../../config/legacy-cli-config.service.ts";
 import { legacyCheckDbToml, legacyLoadProjectEnv } from "../legacy-db-config.toml-read.ts";
@@ -61,16 +66,19 @@ import { legacyRecreateLocalDatabase } from "./recreate-local-database.ts";
  * The local database container is not running. Byte-matches Go's
  * `utils.ErrNotRunning` (`internal/utils/misc.go:116`), `"<aqua>supabase start</aqua>
  * is not running."`, returned by `AssertSupabaseDbIsRunning` before the local
- * reset (`internal/db/reset/reset.go:57`). Not exported outside this module —
- * callers discriminate this via the failure's own message, never by importing the
- * class itself (same pattern as `recreate-local-database.ts`'s own
- * `LegacyResetReplicationSlotsError`).
+ * reset (`internal/db/reset/reset.go:57`). Exported only so the exhaustive
+ * actionability guard can inspect its declaration; runtime callers consume the
+ * enclosing effect rather than importing this class.
  */
-class LegacyResetLocalDbNotRunningError extends Data.TaggedError(
+export class LegacyResetLocalDbNotRunningError extends Data.TaggedError(
   "LegacyResetLocalDbNotRunningError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /** Go's `toLogMessage` (`internal/db/reset/reset.go:88-91`). */
 const toLogMessage = (version: string): string =>

--- a/apps/cli/src/legacy/shared/db-bootstrap/restart-services.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/restart-services.ts
@@ -12,6 +12,11 @@
 import { Data, Effect, Option, Result } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyAqua } from "../legacy-colors.ts";
 import {
   collectText,
@@ -28,7 +33,11 @@ type Spawner = ChildProcessSpawner["Service"];
 /** `docker restart <id>` (the db container itself) failed — used only by PG14's `RestartDatabase`. */
 export class LegacyContainerRestartError extends Data.TaggedError("LegacyContainerRestartError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /**
  * Port of Go's `Docker.ContainerRestart(ctx, utils.DbId, container.StopOptions{})`
@@ -94,7 +103,11 @@ const legacyRestartSatelliteService = (
 /** One or more satellite-service restarts failed. Messages are newline-joined, matching Go's `errors.Join`. */
 export class LegacyRestartServicesError extends Data.TaggedError("LegacyRestartServicesError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /**
  * Port of Go's `restartServices` restart half (`reset.go:259-271`): restarts
@@ -146,7 +159,11 @@ function legacyKongRecoverySuggestion(kongId: string): string {
 export class LegacyKongReloadError extends Data.TaggedError("LegacyKongReloadError")<{
   readonly message: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /** `docker exec <id> <cmd...>`, combined stdout+stderr into one buffer — mirrors Go's shared `io.Writer` in `DockerExecOnceWithStream(ctx, KongId, "", nil, cmd, &out, &out)`. Never fails the Effect itself: a spawn failure (no docker/podman) folds into `exitCode: 1`. */
 function legacyExecCaptureCombined(

--- a/apps/cli/src/legacy/shared/db-bootstrap/start-database.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/start-database.ts
@@ -53,6 +53,11 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 
 import { Output } from "../../../shared/output/output.service.ts";
 import type { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { legacyAqua } from "../legacy-colors.ts";
 import { LegacyDbConnection } from "../legacy-db-connection.service.ts";
 import type { LegacyDbConnectError } from "../legacy-db-connection.errors.ts";
@@ -101,15 +106,19 @@ type Spawner = ChildProcessSpawner["Service"];
  * has) — Go refuses outright rather than guessing which the caller wants. Raised BEFORE any
  * container is created (no `docker create`/`docker start` happens on this path). Only ever
  * reachable via `db start` (the sole caller that ever sets `postgresSpec.fromBackup`).
- * Not exported outside this module — callers only ever observe it through the
- * {@link LegacyStartDatabaseError} union and its `_tag`, never by importing the class.
+ * Exported only so the exhaustive actionability guard can inspect its declaration;
+ * runtime callers observe it through {@link LegacyStartDatabaseError}.
  */
-class LegacyStartBackupVolumeExistsError extends Data.TaggedError(
+export class LegacyStartBackupVolumeExistsError extends Data.TaggedError(
   "LegacyStartBackupVolumeExistsError",
 )<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.stopStack;
+  }
+}
 
 /** Every failure {@link legacyStartDatabase} itself can produce, independent of the caller's own `E`. */
 export type LegacyStartDatabaseError =

--- a/apps/cli/src/legacy/shared/legacy-config-validate.ts
+++ b/apps/cli/src/legacy/shared/legacy-config-validate.ts
@@ -1,5 +1,10 @@
 import { isAbsolute, join } from "node:path";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { legacyGoUrlParse } from "./legacy-storage-url.ts";
 
 /**
@@ -161,7 +166,11 @@ export function legacyParseGoBool(value: string): boolean | undefined {
  * `.toThrow("substring")`), so swapping their inline `throw new Error(...)` calls for this class
  * is a byte-identical, purely internal refactor.
  */
-export class LegacyConfigValidateError extends Error {}
+export class LegacyConfigValidateError extends Error {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /** One `[api.tls]` section, post-env-override. See {@link LegacyConfigValidationInput}. */
 export interface LegacyApiInput {

--- a/apps/cli/src/legacy/shared/legacy-container-cli.ts
+++ b/apps/cli/src/legacy/shared/legacy-container-cli.ts
@@ -2,6 +2,12 @@ import { Data, Effect, Stream } from "effect";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Container CLIs tried in order: Docker is preferred, Podman is the fallback
  * for Docker-less hosts (e.g. Podman-only Linux setups).
@@ -17,16 +23,21 @@ type Spawner = ChildProcessSpawner["Service"];
 /**
  * Raised when neither `docker` nor `podman` can be spawned at all (e.g. neither
  * is installed or on `PATH`) — distinct from a spawned process exiting non-zero.
- * Not exported: callers never need to match on this type directly, they fold it
- * into their own tagged error via {@link legacyDescribeContainerCliFailure} so
- * the "no runtime found" root cause survives instead of collapsing into a
- * generic "failed to ..." message.
+ * Callers never need to match on this type directly, they fold it into their
+ * own tagged error via {@link legacyDescribeContainerCliFailure} so the "no
+ * runtime found" root cause survives instead of collapsing into a generic
+ * "failed to ..." message. Exported only so the coverage test can verify its
+ * own actionability declaration.
  */
-class LegacyContainerRuntimeNotFoundError extends Data.TaggedError(
+export class LegacyContainerRuntimeNotFoundError extends Data.TaggedError(
   "LegacyContainerRuntimeNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /**
  * Exported so `legacy-docker-suggest.ts`'s daemon-unreachable matcher can test

--- a/apps/cli/src/legacy/shared/legacy-db-config.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.errors.ts
@@ -56,7 +56,7 @@ export class LegacyDbConfigLoginRoleStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -80,7 +80,7 @@ export class LegacyDbConfigListBansStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 
@@ -104,7 +104,7 @@ export class LegacyDbConfigUnbanStatusError extends Data.TaggedError(
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-db-config.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.errors.ts
@@ -1,4 +1,11 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  CliSuggestionType,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * `--db-url` could not be parsed as a Postgres connection string. Mirrors Go's
@@ -7,7 +14,11 @@ import { Data } from "effect";
  */
 export class LegacyDbConfigParseUrlError extends Data.TaggedError("LegacyDbConfigParseUrlError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * `supabase/config.toml` exists but could not be read or parsed. Mirrors Go's
@@ -19,12 +30,22 @@ export class LegacyDbConfigParseUrlError extends Data.TaggedError("LegacyDbConfi
  */
 export class LegacyDbConfigLoadError extends Data.TaggedError("LegacyDbConfigLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /** Transport failure creating a temporary login role (`V1CreateLoginRole`). */
 export class LegacyDbConfigLoginRoleNetworkError extends Data.TaggedError(
   "LegacyDbConfigLoginRoleNetworkError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string; readonly decode?: boolean }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /** Non-201 status creating a temporary login role (`V1CreateLoginRole`). */
 export class LegacyDbConfigLoginRoleStatusError extends Data.TaggedError(
@@ -33,12 +54,22 @@ export class LegacyDbConfigLoginRoleStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /** Transport failure listing network bans (`V1ListAllNetworkBans`). */
 export class LegacyDbConfigListBansNetworkError extends Data.TaggedError(
   "LegacyDbConfigListBansNetworkError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string; readonly decode?: boolean }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /** Non-2xx status listing network bans (`V1ListAllNetworkBans`). */
 export class LegacyDbConfigListBansStatusError extends Data.TaggedError(
@@ -47,12 +78,22 @@ export class LegacyDbConfigListBansStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /** Transport failure removing network bans (`V1DeleteNetworkBans`). */
 export class LegacyDbConfigUnbanNetworkError extends Data.TaggedError(
   "LegacyDbConfigUnbanNetworkError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string; readonly decode?: boolean }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /** Non-2xx status removing network bans (`V1DeleteNetworkBans`). */
 export class LegacyDbConfigUnbanStatusError extends Data.TaggedError(
@@ -61,7 +102,11 @@ export class LegacyDbConfigUnbanStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}
 
 /**
  * The linked project's direct database host is unreachable (IPv6-only) and no
@@ -72,7 +117,18 @@ export class LegacyDbConfigUnbanStatusError extends Data.TaggedError(
 export class LegacyDbConfigIpv6Error extends Data.TaggedError("LegacyDbConfigIpv6Error")<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The rendered remediation is "Run supabase link --project-ref <ref> to
+    // setup IPv4 connection", so the suggestion is link-shaped even though the
+    // category stays db_connection.
+    return {
+      ...actionability.dbConnection,
+      suggestion_type: CliSuggestionType.LinkProject,
+      suggested_command: "supabase link",
+    };
+  }
+}
 
 /**
  * Failed to connect to the linked project as the temporary login role after the
@@ -84,7 +140,11 @@ export class LegacyDbConfigConnectTempRoleError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /**
  * The configured pooler connection string does not match the linked project ref
@@ -97,4 +157,8 @@ export class LegacyDbConfigPoolerLoginError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-db-config.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.service.ts
@@ -1,4 +1,6 @@
 import { Context, type Effect, type Option } from "effect";
+import type { SupabaseApiInputError } from "@supabase/api/effect";
+import type * as HttpBody from "effect/unstable/http/HttpBody";
 import type { LegacyPlatformApiFactoryError } from "../auth/legacy-platform-api-factory.service.ts";
 import type { LegacyPgConnInput } from "./legacy-db-connection.service.ts";
 import type {
@@ -38,6 +40,8 @@ export type LegacyDbConfigError =
   | LegacyDbConfigListBansStatusError
   | LegacyDbConfigUnbanNetworkError
   | LegacyDbConfigUnbanStatusError
+  | SupabaseApiInputError
+  | HttpBody.HttpBodyError
   | LegacyDbConfigIpv6Error
   | LegacyDbConfigConnectTempRoleError
   | LegacyDbConfigPoolerLoginError

--- a/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Opening a Postgres connection failed. Mirrors Go's `pgx`/`pgconn` connect
@@ -9,7 +14,11 @@ import { Data } from "effect";
 export class LegacyDbConnectError extends Data.TaggedError("LegacyDbConnectError")<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /**
  * Executing a SQL statement against an open connection failed. Mirrors the Go
@@ -38,7 +47,11 @@ export class LegacyDbExecError extends Data.TaggedError("LegacyDbExecError")<{
    * caret under the error position (`pkg/migration/file.go:98`, `markError`).
    */
   readonly position?: number;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * A server-side `COPY (...) TO STDOUT` stream failed. Mirrors Go's
@@ -57,4 +70,8 @@ export class LegacyDbExecError extends Data.TaggedError("LegacyDbExecError")<{
  */
 export class LegacyDbCopyError extends Data.TaggedError("LegacyDbCopyError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-image-resolve.ts
@@ -26,6 +26,8 @@ const spawnError = () =>
   // credential-free message that still points at the likely cause.
   new LegacyDockerRunError({
     message: `failed to run docker. ${LEGACY_SUGGEST_DOCKER_INSTALL}`,
+    reason: "spawn",
+    daemonDown: false,
   });
 
 /**
@@ -121,12 +123,13 @@ export function legacyMakeDockerImageResolver(
       // aggregate. So this must default to failing, and only treat a confirmed not-found as a
       // cache miss — the inverse of the daemon-unreachable-only gate this replaced.
       if (isImageNotFoundMessage(stderr)) return false;
-      const hint = legacyIsDockerDaemonUnreachable(stderr)
-        ? `\n\n${LEGACY_SUGGEST_DOCKER_INSTALL}`
-        : "";
+      const daemonDown = legacyIsDockerDaemonUnreachable(stderr);
+      const hint = daemonDown ? `\n\n${LEGACY_SUGGEST_DOCKER_INSTALL}` : "";
       return yield* Effect.fail(
         new LegacyDockerRunError({
           message: `failed to inspect docker image: ${stderr}${hint}`,
+          reason: "inspect",
+          daemonDown,
         }),
       );
     }).pipe(Effect.scoped);
@@ -303,6 +306,8 @@ export function legacyMakeDockerImageResolver(
       return yield* Effect.fail(
         new LegacyDockerRunError({
           message: `failed to pull docker image from all registries: ${failures.join("; ")}`,
+          reason: "pull",
+          daemonDown: failures.some(legacyIsDockerDaemonUnreachable),
         }),
       );
     });

--- a/apps/cli/src/legacy/shared/legacy-docker-lifecycle.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-lifecycle.ts
@@ -1,7 +1,17 @@
+import { isDockerDaemonDownMessage } from "@supabase/stack/effect";
 import { Data, Effect, Stream } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
-import { legacyDescribeContainerCliFailure, spawnContainerCli } from "./legacy-container-cli.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+import {
+  LegacyContainerRuntimeNotFoundError,
+  legacyDescribeContainerCliFailure,
+  spawnContainerCli,
+} from "./legacy-container-cli.ts";
 import { LEGACY_CLI_WORKDIR_LABEL } from "./legacy-docker-ids.ts";
 
 type Spawner = ChildProcessSpawner["Service"];
@@ -16,14 +26,43 @@ export class LegacyDockerLifecycleListError extends Data.TaggedError(
   "LegacyDockerLifecycleListError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  // `docker ps`/`docker volume ls` never fail because nothing matches the
+  // label filter — an empty match is a successful, empty result. Every real
+  // failure here is therefore a container-runtime problem: neither
+  // docker/podman could be spawned, or the daemon itself rejected the call.
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
-/** Inspecting a single container's state failed for a reason other than "not found". */
+/**
+ * Inspecting a single container's state failed for a reason other than "not
+ * found" — except Go's `assertContainerHealthy` (and this port, matching it,
+ * see `status.handler.ts`) never special-cases a missing container either: an
+ * absent container is just another non-zero `docker container inspect` exit,
+ * which is by far the dominant real trigger of this error (the user hasn't
+ * run `supabase start` yet) — same fix as the other "stack isn't running"
+ * errors elsewhere in this codebase.
+ */
 export class LegacyDockerLifecycleInspectError extends Data.TaggedError(
   "LegacyDockerLifecycleInspectError",
 )<{
   readonly message: string;
-}> {}
+  /**
+   * Set at the container boundary when neither runtime can be spawned or the
+   * daemon is unreachable. Every other inspect failure (the dominant "stack
+   * isn't running yet" case) keeps the `startStack` classification.
+   */
+  readonly daemonDown?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.daemonDown === true) {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    return actionability.startStack;
+  }
+}
 
 function collectByteStream(stream: Stream.Stream<Uint8Array, unknown>) {
   const decoder = new TextDecoder();
@@ -201,12 +240,15 @@ export const legacyInspectContainerState = (spawner: Spawner, containerId: strin
           stderr: "pipe",
         },
       ).pipe(
-        Effect.mapError(
-          (cause) =>
-            new LegacyDockerLifecycleInspectError({
-              message: `failed to inspect container health: ${legacyDescribeContainerCliFailure(cause)}`,
-            }),
-        ),
+        Effect.mapError((cause) => {
+          const description = legacyDescribeContainerCliFailure(cause);
+          return new LegacyDockerLifecycleInspectError({
+            message: `failed to inspect container health: ${description}`,
+            daemonDown:
+              cause instanceof LegacyContainerRuntimeNotFoundError ||
+              isDockerDaemonDownMessage(description),
+          });
+        }),
       );
       // Concurrency is required, not cosmetic — see the matching comment in
       // `legacyListContainersByLabel` above.
@@ -233,6 +275,7 @@ export const legacyInspectContainerState = (spawner: Spawner, containerId: strin
               message.length > 0
                 ? `failed to inspect container health: ${message}`
                 : "failed to inspect container health",
+            daemonDown: isDockerDaemonDownMessage(message),
           }),
         );
       }

--- a/apps/cli/src/legacy/shared/legacy-docker-lifecycle.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-lifecycle.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Sink, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
 import {
   LegacyDockerLifecycleInspectError,
   LegacyDockerLifecycleListError,
@@ -290,6 +291,10 @@ describe("legacyInspectContainerState", () => {
           expect(error.message).toBe(
             "failed to inspect container health: Error response from daemon: No such container: supabase_db_my-app",
           );
+          // The dominant "stack isn't running yet" case: not daemon-down, so it
+          // keeps the start-stack classification.
+          expect(error.daemonDown).toBeFalsy();
+          expect(classifyCliErrorActionability(error).error_category).toBe("invalid_config");
         }),
       );
     },
@@ -303,6 +308,14 @@ describe("legacyInspectContainerState", () => {
         expect(error).toBeInstanceOf(LegacyDockerLifecycleInspectError);
         expect(error.message).toBe(
           "failed to inspect container health: Cannot connect to the Docker daemon",
+        );
+        // A daemon-down stderr flips the discriminant so the failure classifies
+        // as docker-not-running instead of a broken running stack.
+        expect(error.daemonDown).toBe(true);
+        const result = classifyCliErrorActionability(error);
+        expect(result.error_category).toBe("docker_not_running");
+        expect(result.error_fingerprint).toBe(
+          "tag:LegacyDockerLifecycleInspectError:docker_not_running",
         );
       }),
     );

--- a/apps/cli/src/legacy/shared/legacy-docker-remove-all.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-remove-all.ts
@@ -2,6 +2,11 @@ import { Data, Effect, Result } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
 import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+import {
   containerCliExitCode,
   legacyContainerCliExitCodeAndStdout,
   legacyDescribeContainerCliFailure,
@@ -19,34 +24,58 @@ type Spawner = ChildProcessSpawner["Service"];
  * cause carrying only a `.message` — same generalization pattern as `legacy-docker-lifecycle.ts`'s
  * `LegacyDockerLifecycleListError`/`LegacyDockerLifecycleInspectError`. Callers (`stop.handler.ts`
  * via `Effect.catchTags`; `legacy/shared/db-bootstrap/rollback.ts` via a blanket swallow) discriminate/consume these by
- * their string `_tag`, never by importing the classes themselves, so only the union below is
- * exported — matching every constructor's actual usage (confirmed via `knip`).
+ * their string `_tag`, never by importing the classes themselves. The classes
+ * are exported so the exhaustive telemetry guard can verify their declarations.
  */
-class LegacyDockerRemoveAllListError extends Data.TaggedError("LegacyDockerRemoveAllListError")<{
+export class LegacyDockerRemoveAllListError extends Data.TaggedError(
+  "LegacyDockerRemoveAllListError",
+)<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
-class LegacyDockerRemoveAllStopError extends Data.TaggedError("LegacyDockerRemoveAllStopError")<{
+export class LegacyDockerRemoveAllStopError extends Data.TaggedError(
+  "LegacyDockerRemoveAllStopError",
+)<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
-class LegacyDockerRemoveAllContainerPruneError extends Data.TaggedError(
+export class LegacyDockerRemoveAllContainerPruneError extends Data.TaggedError(
   "LegacyDockerRemoveAllContainerPruneError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
-class LegacyDockerRemoveAllVolumePruneError extends Data.TaggedError(
+export class LegacyDockerRemoveAllVolumePruneError extends Data.TaggedError(
   "LegacyDockerRemoveAllVolumePruneError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
-class LegacyDockerRemoveAllNetworkPruneError extends Data.TaggedError(
+export class LegacyDockerRemoveAllNetworkPruneError extends Data.TaggedError(
   "LegacyDockerRemoveAllNetworkPruneError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /**
  * Extracts the deleted-object IDs/names from `docker`/`podman` `… prune`

--- a/apps/cli/src/legacy/shared/legacy-docker-run.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-run.errors.ts
@@ -1,6 +1,32 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /** Spawning or running the `docker` CLI failed (binary missing, daemon down, non-spawn failure). */
 export class LegacyDockerRunError extends Data.TaggedError("LegacyDockerRunError")<{
   readonly message: string;
-}> {}
+  /**
+   * Structured discriminant set at the docker boundary: `spawn` when the
+   * container runtime could not be executed, `inspect` when image inspection
+   * failed, and `pull` when every registry candidate failed.
+   */
+  readonly reason: "spawn" | "inspect" | "pull";
+  /**
+   * Whether runtime output indicates the daemon itself is unreachable,
+   * detected where docker's output is produced so consumers never inspect
+   * `message` text.
+   */
+  readonly daemonDown: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.reason === "spawn" || this.daemonDown) {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    return this.reason === "pull"
+      ? { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" }
+      : { ...actionability.invalidConfig, fingerprint_suffix: "image_inspect" };
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-docker-run.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-run.layer.ts
@@ -28,6 +28,8 @@ export const legacyDockerRunLayer: Layer.Layer<
       // credential-free message that still points at the likely cause.
       new LegacyDockerRunError({
         message: `failed to run docker. ${LEGACY_SUGGEST_DOCKER_INSTALL}`,
+        reason: "spawn",
+        daemonDown: false,
       });
 
     const concat = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
@@ -181,6 +183,8 @@ export const legacyDockerRunLayer: Layer.Layer<
                 () =>
                   new LegacyDockerRunError({
                     message: `failed to run docker. ${LEGACY_SUGGEST_DOCKER_INSTALL}`,
+                    reason: "spawn",
+                    daemonDown: false,
                   }),
               ),
             );

--- a/apps/cli/src/legacy/shared/legacy-drop-objects.ts
+++ b/apps/cli/src/legacy/shared/legacy-drop-objects.ts
@@ -1,11 +1,20 @@
 import { Data, Effect } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 
 /** Dropping the user schemas failed (Go's `DropUserSchemas` error). */
 export class LegacyMigrationDropError extends Data.TaggedError("LegacyMigrationDropError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * The embedded `DO $$ ... $$` block from Go's `pkg/migration/queries/drop.sql`,

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Running a TypeScript program inside the edge-runtime container failed (non-zero
@@ -10,4 +15,22 @@ import { Data } from "effect";
  */
 export class LegacyEdgeRuntimeScriptError extends Data.TaggedError("LegacyEdgeRuntimeScriptError")<{
   readonly message: string;
-}> {}
+  /**
+   * Threaded from a wrapped `LegacyDockerRunError` so a docker-boundary failure
+   * (docker daemon down or registry pull) does not misclassify as a user-SQL
+   * (`dbFinding`) failure. `daemon` maps to docker-not-running, `pull` to an
+   * external network problem. `undefined` for genuine script/config failures,
+   * which keep the user-SQL classification.
+   */
+  readonly docker?: "daemon" | "pull";
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.docker === "daemon") {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    if (this.docker === "pull") {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+    }
+    return actionability.dbFinding;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.ts
@@ -22,7 +22,7 @@ export class LegacyEdgeRuntimeScriptError extends Data.TaggedError("LegacyEdgeRu
    * external network problem. `undefined` for genuine script/config failures,
    * which keep the user-SQL classification.
    */
-  readonly docker?: "daemon" | "pull";
+  readonly docker?: "daemon" | "inspect" | "pull";
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     if (this.docker === "daemon") {
@@ -30,6 +30,9 @@ export class LegacyEdgeRuntimeScriptError extends Data.TaggedError("LegacyEdgeRu
     }
     if (this.docker === "pull") {
       return { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" };
+    }
+    if (this.docker === "inspect") {
+      return { ...actionability.invalidConfig, fingerprint_suffix: "image_inspect" };
     }
     return actionability.dbFinding;
   }

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
+import { LegacyEdgeRuntimeScriptError } from "./legacy-edge-runtime-script.errors.ts";
+
+describe("LegacyEdgeRuntimeScriptError actionability", () => {
+  it("classifies a docker-daemon failure as docker-not-running", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyEdgeRuntimeScriptError({ message: "error diffing schema: ...", docker: "daemon" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("docker_not_running");
+    expect(result.suggestion_type).toBe("start_docker");
+    expect(result.error_fingerprint).toBe("tag:LegacyEdgeRuntimeScriptError:docker_not_running");
+  });
+
+  it("classifies a registry-pull failure as an external network problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyEdgeRuntimeScriptError({ message: "error diffing schema: ...", docker: "pull" }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("network");
+    expect(result.error_fingerprint).toBe("tag:LegacyEdgeRuntimeScriptError:registry_pull");
+  });
+
+  it("classifies a non-docker script failure as a user db finding", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyEdgeRuntimeScriptError({ message: "error diffing schema: exit 1:\n..." }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.has_suggestion).toBe(false);
+    expect(result.error_fingerprint).toBe("tag:LegacyEdgeRuntimeScriptError");
+  });
+});

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.errors.unit.test.ts
@@ -22,6 +22,15 @@ describe("LegacyEdgeRuntimeScriptError actionability", () => {
     expect(result.error_fingerprint).toBe("tag:LegacyEdgeRuntimeScriptError:registry_pull");
   });
 
+  it("classifies an image-inspect failure as invalid config", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyEdgeRuntimeScriptError({ message: "error diffing schema: ...", docker: "inspect" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("tag:LegacyEdgeRuntimeScriptError:image_inspect");
+  });
+
   it("classifies a non-docker script failure as a user db finding", () => {
     const result = classifyCliErrorActionability(
       new LegacyEdgeRuntimeScriptError({ message: "error diffing schema: exit 1:\n..." }),

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.layer.ts
@@ -136,7 +136,12 @@ export const legacyEdgeRuntimeScriptLayer = Layer.effect(
                 (cause) =>
                   new LegacyEdgeRuntimeScriptError({
                     message: `${opts.errPrefix}: ${cause.message}`,
-                    docker: cause.reason === "spawn" || cause.daemonDown ? "daemon" : "pull",
+                    docker:
+                      cause.reason === "spawn" || cause.daemonDown
+                        ? "daemon"
+                        : cause.reason === "pull"
+                          ? "pull"
+                          : "inspect",
                   }),
               ),
             );

--- a/apps/cli/src/legacy/shared/legacy-edge-runtime-script.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-edge-runtime-script.layer.ts
@@ -129,11 +129,14 @@ export const legacyEdgeRuntimeScriptLayer = Layer.effect(
             })
             // A spawn failure (e.g. Docker not installed) carries no container
             // stderr; wrap it with the caller's prefix like Go's `%s: %w`.
+            // Thread the docker discriminant so a daemon-down / registry-pull
+            // failure at the docker boundary is not misclassified as user SQL.
             .pipe(
               Effect.mapError(
                 (cause) =>
                   new LegacyEdgeRuntimeScriptError({
                     message: `${opts.errPrefix}: ${cause.message}`,
+                    docker: cause.reason === "spawn" || cause.daemonDown ? "daemon" : "pull",
                   }),
               ),
             );

--- a/apps/cli/src/legacy/shared/legacy-ensure-login.ts
+++ b/apps/cli/src/legacy/shared/legacy-ensure-login.ts
@@ -137,7 +137,14 @@ export const legacyBrowserLogin = Effect.fnUntraced(function* (opts: LegacyBrows
         Effect.gen(function* () {
           const failures = failuresSoFar + 1;
           if (failures > MAX_LOGIN_RETRIES) {
-            return yield* Effect.fail(new LegacyLoginFailedError({ message: err.message }));
+            return yield* Effect.fail(
+              new LegacyLoginFailedError({
+                message: err.message,
+                statusCode: err.statusCode,
+                network: err.network,
+                decode: err.decode,
+              }),
+            );
           }
           yield* output.raw(`${err.message}\nRetry (${failures}/${MAX_LOGIN_RETRIES}): `, "stderr");
           return yield* verifyWithRetries(failures);

--- a/apps/cli/src/legacy/shared/legacy-experimental-gate.ts
+++ b/apps/cli/src/legacy/shared/legacy-experimental-gate.ts
@@ -1,5 +1,10 @@
 import { Data, Effect } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { legacyResolveExperimental } from "../../shared/legacy/global-flags.ts";
 
 /**
@@ -34,6 +39,10 @@ export class LegacyExperimentalRequiredError extends Data.TaggedError(
 }> {
   constructor() {
     super({ message: "must set the --experimental flag to run this command" });
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-go-output-flag.ts
+++ b/apps/cli/src/legacy/shared/legacy-go-output-flag.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Per-command `--output`/`-o` enums, mirroring Go. Go registers `--output` per
@@ -25,7 +30,11 @@ export const LEGACY_QUERY_OUTPUT_FORMATS = ["json", "table", "csv"] as const;
  */
 export class LegacyInvalidOutputFormatError extends Data.TaggedError(
   "LegacyInvalidOutputFormatError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
 
 /** Go's `must be one of [ a | b | c ]` (`enum.go:23`, joined with `" | "`). */
 export function legacyOutputFormatEnumMessage(allowed: ReadonlyArray<string>): string {

--- a/apps/cli/src/legacy/shared/legacy-go-struct-output.encoders.ts
+++ b/apps/cli/src/legacy/shared/legacy-go-struct-output.encoders.ts
@@ -1,3 +1,9 @@
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Byte-faithful reproductions of the Go CLI's `-o yaml` / `-o toml` output for
  * **struct** payloads (CLI-1975).
@@ -1065,6 +1071,10 @@ export class LegacyGoTomlEncodeError extends Error {
   constructor(message = "toml: cannot encode a map with non-string key type") {
     super(message);
     this.name = "LegacyGoTomlEncodeError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.internalPanic;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-http-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-http-errors.ts
@@ -1,5 +1,6 @@
-import type { SupabaseApiError } from "@supabase/api/effect";
+import { SupabaseApiInputError, type SupabaseApiError } from "@supabase/api/effect";
 import { Effect } from "effect";
+import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 
 // HttpClientError reasons that indicate the server returned an actual response (vs a transport
@@ -72,9 +73,17 @@ export function mapLegacyHttpError<N, S>(opts: {
   readonly statusError: StatusErrorFactory<S>;
   readonly networkMessage: (cause: string) => string;
   readonly statusMessage: (status: number, body: string) => string;
-}): (cause: SupabaseApiError) => Effect.Effect<never, N | S> {
+}): (
+  cause: SupabaseApiError,
+) => Effect.Effect<never, N | S | SupabaseApiInputError | HttpBody.HttpBodyError> {
   return (cause) =>
     Effect.gen(function* () {
+      if (cause instanceof SupabaseApiInputError || cause instanceof HttpBody.HttpBodyError) {
+        // These failures occur while the generated client validates or builds
+        // the request. Keep their identity because this generic mapper cannot
+        // safely infer user provenance or reclassify them as response errors.
+        return yield* Effect.fail(cause);
+      }
       if (HttpClientError.isHttpClientError(cause)) {
         if (RESPONSE_ERROR_TAGS.has(cause.reason._tag) && cause.response !== undefined) {
           const status = cause.response.status;
@@ -95,10 +104,10 @@ export function mapLegacyHttpError<N, S>(opts: {
           new opts.networkError({ message: opts.networkMessage(description) }),
         );
       }
-      // SchemaError or HttpBodyError — the server returned a response whose
-      // body failed schema decoding (a 200 the generated client could not
-      // parse). This is not a transport failure, so flag `decode` to classify
-      // it as an API-response problem rather than a network problem.
+      // SchemaError — the server returned a response whose body failed schema
+      // decoding (a 200 the generated client could not parse). This is not a
+      // transport failure, so flag `decode` to classify it as an API-response
+      // problem rather than a network problem.
       return yield* Effect.fail(
         new opts.networkError({ message: opts.networkMessage(String(cause)), decode: true }),
       );

--- a/apps/cli/src/legacy/shared/legacy-http-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-http-errors.ts
@@ -47,7 +47,10 @@ function sanitizeErrorBody(input: string): string {
   return out;
 }
 
-export type NetworkErrorFactory<E> = new (args: { readonly message: string }) => E;
+export type NetworkErrorFactory<E> = new (args: {
+  readonly message: string;
+  readonly decode?: boolean;
+}) => E;
 
 export type StatusErrorFactory<E> = new (args: {
   readonly status: number;
@@ -92,9 +95,12 @@ export function mapLegacyHttpError<N, S>(opts: {
           new opts.networkError({ message: opts.networkMessage(description) }),
         );
       }
-      // SchemaError or HttpBodyError — treat as transport-level network error.
+      // SchemaError or HttpBodyError — the server returned a response whose
+      // body failed schema decoding (a 200 the generated client could not
+      // parse). This is not a transport failure, so flag `decode` to classify
+      // it as an API-response problem rather than a network problem.
       return yield* Effect.fail(
-        new opts.networkError({ message: opts.networkMessage(String(cause)) }),
+        new opts.networkError({ message: opts.networkMessage(String(cause)), decode: true }),
       );
     });
 }

--- a/apps/cli/src/legacy/shared/legacy-http-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-http-errors.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@effect/vitest";
+import { SupabaseApiInputError } from "@supabase/api/effect";
+import { Data, Effect } from "effect";
+import * as HttpBody from "effect/unstable/http/HttpBody";
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
+
+import { mapLegacyHttpError } from "./legacy-http-errors.ts";
+
+class TestNetworkError extends Data.TaggedError("TestNetworkError")<{
+  readonly message: string;
+  readonly decode?: boolean;
+}> {}
+
+class TestStatusError extends Data.TaggedError("TestStatusError")<{
+  readonly status: number;
+  readonly body: string;
+  readonly message: string;
+}> {}
+
+const mapError = mapLegacyHttpError({
+  networkError: TestNetworkError,
+  statusError: TestStatusError,
+  networkMessage: (cause) => cause,
+  statusMessage: (status, body) => `${status}: ${body}`,
+});
+
+describe("mapLegacyHttpError", () => {
+  it.effect("preserves generated API input errors", () =>
+    Effect.gen(function* () {
+      const inputError = new SupabaseApiInputError("invalid request input");
+
+      const error = yield* mapError(inputError).pipe(Effect.flip);
+
+      expect(error).toBe(inputError);
+      expect(inputError.source).toBe("generated_client");
+      expect(classifyCliErrorActionability(error)).toMatchObject({
+        error_kind: "internal_bug",
+        error_category: "impossible_state",
+        error_fingerprint: "tag:SupabaseApiInputError:request_encoding",
+      });
+    }),
+  );
+
+  it.effect("preserves request-body construction errors", () =>
+    Effect.gen(function* () {
+      const bodyError = new HttpBody.HttpBodyError({
+        reason: { _tag: "JsonError" },
+        cause: new Error("body read failed"),
+      });
+
+      const error = yield* mapError(bodyError).pipe(Effect.flip);
+
+      expect(error).toBe(bodyError);
+      expect(classifyCliErrorActionability(error)).toMatchObject({
+        error_kind: "internal_bug",
+        error_category: "impossible_state",
+        error_fingerprint: "tag:HttpBodyError:request_encoding",
+      });
+    }),
+  );
+});

--- a/apps/cli/src/legacy/shared/legacy-local-config-values.ts
+++ b/apps/cli/src/legacy/shared/legacy-local-config-values.ts
@@ -12,6 +12,11 @@ import {
   toPublicJwk,
   type ThirdPartyProvidersLike,
 } from "../../shared/auth/jwks.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { legacyResolveApiExternalUrl } from "./legacy-api-url.ts";
 import { legacySanitizeProjectId } from "./legacy-docker-ids.ts";
 import {
@@ -170,6 +175,9 @@ export class LegacyInvalidJwtSecretError extends Error {
     super("Invalid config for auth.jwt_secret. Must be at least 16 characters");
     this.name = "LegacyInvalidJwtSecretError";
   }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
 }
 
 /** Go's minimum `auth.jwt_secret` length (`pkg/config/apikeys.go:46`). */
@@ -191,6 +199,9 @@ export class LegacyInvalidPortEnvOverrideError extends Error {
   constructor(dottedFieldPath: string, value: string) {
     super(`Invalid config for ${dottedFieldPath}: cannot parse "${value}" as a port`);
     this.name = "LegacyInvalidPortEnvOverrideError";
+  }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }
 
@@ -289,6 +300,9 @@ export class LegacyInvalidBoolEnvOverrideError extends Error {
     super(`Invalid config for ${dottedFieldPath}: cannot parse "${value}" as a bool`);
     this.name = "LegacyInvalidBoolEnvOverrideError";
   }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
 }
 
 /**
@@ -344,6 +358,9 @@ export class LegacyInvalidAnalyticsBackendEnvOverrideError extends Error {
     );
     this.name = "LegacyInvalidAnalyticsBackendEnvOverrideError";
   }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
 }
 
 /**
@@ -386,6 +403,10 @@ export class LegacyInvalidRealtimeIpVersionEnvOverrideError extends Error {
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "IPv4", "IPv6"`,
     );
     this.name = "LegacyInvalidRealtimeIpVersionEnvOverrideError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }
 
@@ -446,6 +467,10 @@ export class LegacyInvalidPoolModeEnvOverrideError extends Error {
     );
     this.name = "LegacyInvalidPoolModeEnvOverrideError";
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
 }
 
 /**
@@ -479,6 +504,10 @@ export class LegacyInvalidEdgeRuntimePolicyEnvOverrideError extends Error {
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "per_worker", "oneshot"`,
     );
     this.name = "LegacyInvalidEdgeRuntimePolicyEnvOverrideError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }
 
@@ -1276,6 +1305,10 @@ export class LegacyInvalidSessionReplicationRoleEnvOverrideError extends Error {
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "origin", "replica", "local"`,
     );
     this.name = "LegacyInvalidSessionReplicationRoleEnvOverrideError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-login-api.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-login-api.layer.ts
@@ -11,6 +11,12 @@ import { LegacyLoginVerificationError } from "../commands/login/login.errors.ts"
 
 const POLL_TIMEOUT = "10 seconds";
 
+// HttpClientError reasons that mean the response arrived but its body could not
+// be decoded (including a 2xx whose body isn't valid JSON). These are API
+// response problems, not transport ones, so they classify by `decode` rather
+// than as a network failure. Mirrors `next/auth/api.layer.ts`.
+const BODY_DECODE_REASONS = new Set<string>(["DecodeError", "EmptyBodyError"]);
+
 function readString(obj: unknown, key: string): string {
   if (typeof obj === "object" && obj !== null && key in obj) {
     const value = (obj as Record<string, unknown>)[key];
@@ -38,6 +44,7 @@ export const legacyLoginApiLayer = Layer.effect(
             return yield* Effect.fail(
               new LegacyLoginVerificationError({
                 message: `Error status ${response.status}: ${body}`,
+                statusCode: response.status,
               }),
             );
           }
@@ -51,12 +58,20 @@ export const legacyLoginApiLayer = Layer.effect(
         }).pipe(
           // Map transport / JSON-decode failures to the retry-driving error.
           // The explicit non-200 `LegacyLoginVerificationError` above passes
-          // through untouched (it is not an `HttpClientError`).
+          // through untouched (it is not an `HttpClientError`). A body-decode
+          // reason means the response arrived but its body was unparseable — an
+          // API response problem (`decode`), not a transport (`network`) one.
           Effect.catchTag("HttpClientError", (cause) =>
             Effect.fail(
-              new LegacyLoginVerificationError({
-                message: `failed to execute http request: ${cause.message}`,
-              }),
+              BODY_DECODE_REASONS.has(cause.reason._tag)
+                ? new LegacyLoginVerificationError({
+                    message: `failed to execute http request: ${cause.message}`,
+                    decode: true,
+                  })
+                : new LegacyLoginVerificationError({
+                    message: `failed to execute http request: ${cause.message}`,
+                    network: true,
+                  }),
             ),
           ),
           Effect.timeoutOrElse({
@@ -65,6 +80,7 @@ export const legacyLoginApiLayer = Layer.effect(
               Effect.fail(
                 new LegacyLoginVerificationError({
                   message: "failed to execute http request: request timed out",
+                  network: true,
                 }),
               ),
           }),

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.ts
@@ -2,6 +2,11 @@ import { Data, Effect, type FileSystem, type Path } from "effect";
 
 import { Output } from "../../shared/output/output.service.ts";
 import type { LegacyDbExecError } from "./legacy-db-connection.errors.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
   INSERT_MIGRATION_VERSION,
@@ -22,7 +27,11 @@ import { legacySplitAndTrim } from "./legacy-sql-split.ts";
 export class LegacyMigrationApplyError extends Data.TaggedError("LegacyMigrationApplyError")<{
   readonly message: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 // Byte order mark (U+FEFF) — stripped from the head of a statement like Go does.
 const BOM_CODE_POINT = 0xfeff;

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
@@ -6,6 +6,11 @@ import { describe, expect, it } from "@effect/vitest";
 import { Data, Effect, Exit, FileSystem, Path } from "effect";
 
 import { mockOutput } from "../../../tests/helpers/mocks.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
   legacyApplyMigrationFile,
@@ -21,7 +26,11 @@ class FakeExecError extends Data.TaggedError("LegacyDbExecError")<{
   readonly code?: string;
   readonly detail?: string;
   readonly position?: number;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 function fakeSession(
   opts: {

--- a/apps/cli/src/legacy/shared/legacy-migration.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Listing or reading migrations failed for a reason other than the directory
@@ -13,4 +18,8 @@ import { Data } from "effect";
  */
 export class LegacyMigrationsReadError extends Data.TaggedError("LegacyMigrationsReadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
+++ b/apps/cli/src/legacy/shared/legacy-pflag-reconcile.ts
@@ -7,6 +7,11 @@ import {
 } from "../../shared/cli/cobra-flag-groups.ts";
 import { LegacyProfileFlag, LegacyWorkdirFlag } from "../../shared/legacy/global-flags.ts";
 import { RuntimeInfo } from "../../shared/runtime/runtime-info.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { legacyProfileFilePath } from "../config/legacy-profile-file.ts";
 import { legacyLoadProfile, type LegacyLoadedProfile } from "./legacy-profile-load.ts";
 import { legacyParseStringSliceFlag } from "./legacy-string-slice-flag.ts";
@@ -37,7 +42,11 @@ import { legacyValidateWorkdirIsDirectory } from "./legacy-workdir-validation.ts
  */
 export class LegacyPflagWorkdirError extends Data.TaggedError("LegacyPflagWorkdirError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Reconciles an Effect-parsed option flag with pflag semantics

--- a/apps/cli/src/legacy/shared/legacy-pgdelta-ssl-probe.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-pgdelta-ssl-probe.service.ts
@@ -1,4 +1,9 @@
 import { Context, Data, type Effect } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * A live TLS-capability probe for pg-delta SOURCE/TARGET endpoints, mirroring Go's
@@ -33,7 +38,11 @@ export interface LegacyPgDeltaSslProbeShape {
 export class LegacyPgDeltaSslProbeError extends Data.TaggedError("LegacyPgDeltaSslProbeError")<{
   readonly message: string;
   readonly cause?: unknown;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 export class LegacyPgDeltaSslProbe extends Context.Service<
   LegacyPgDeltaSslProbe,

--- a/apps/cli/src/legacy/shared/legacy-pgdelta.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-pgdelta.integration.test.ts
@@ -27,13 +27,25 @@ const CTX: LegacyPgDeltaContext = {
   denoVersion: 2,
 };
 
-function fakeEdgeRuntime(outcome: { stdout?: string; stderr?: string; fail?: string } = {}) {
+function fakeEdgeRuntime(
+  outcome: {
+    stdout?: string;
+    stderr?: string;
+    fail?: string;
+    docker?: "daemon" | "inspect" | "pull";
+  } = {},
+) {
   const calls: LegacyEdgeRuntimeRunOpts[] = [];
   const layer = Layer.succeed(LegacyEdgeRuntimeScript, {
     run: (opts: LegacyEdgeRuntimeRunOpts) => {
       calls.push(opts);
       if (outcome.fail !== undefined) {
-        return Effect.fail(new LegacyEdgeRuntimeScriptError({ message: outcome.fail }));
+        return Effect.fail(
+          new LegacyEdgeRuntimeScriptError({
+            message: outcome.fail,
+            ...(outcome.docker !== undefined ? { docker: outcome.docker } : {}),
+          }),
+        );
       }
       return Effect.succeed({
         stdout: outcome.stdout ?? "",
@@ -150,6 +162,30 @@ describe("legacyDiffPgDelta", () => {
           expect((failError(exit) as { message: string }).message).toBe(
             "error diffing schema: boom",
           );
+        }),
+      ),
+      Effect.provide(Layer.mergeAll(edge.layer, probe, BunServices.layer)),
+    );
+  });
+
+  it.effect("preserves docker failure classification through the pg-delta wrapper", () => {
+    const edge = fakeEdgeRuntime({
+      fail: "error diffing schema: docker unavailable",
+      docker: "daemon",
+    });
+    return legacyDiffPgDelta(CTX, {
+      targetRef: "postgresql://t",
+      sourceRef: "",
+      schema: [],
+      formatOptions: "",
+    }).pipe(
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          expect(failError(exit)).toMatchObject({
+            _tag: "LegacyDeclarativeEdgeRuntimeError",
+            docker: "daemon",
+          });
         }),
       ),
       Effect.provide(Layer.mergeAll(edge.layer, probe, BunServices.layer)),

--- a/apps/cli/src/legacy/shared/legacy-pgdelta.ts
+++ b/apps/cli/src/legacy/shared/legacy-pgdelta.ts
@@ -179,8 +179,14 @@ const buildDiffEnv = Effect.fnUntraced(function* (
   return env;
 });
 
-const toDeclarativeEdgeRuntimeError = (error: { readonly message: string }) =>
-  new LegacyDeclarativeEdgeRuntimeError({ message: error.message });
+const toDeclarativeEdgeRuntimeError = (error: {
+  readonly message: string;
+  readonly docker?: "daemon" | "inspect" | "pull";
+}) =>
+  new LegacyDeclarativeEdgeRuntimeError({
+    message: error.message,
+    ...(error.docker !== undefined ? { docker: error.docker } : {}),
+  });
 
 /**
  * Diffs SOURCE → TARGET via the pg-delta diff script. Mirrors Go's

--- a/apps/cli/src/legacy/shared/legacy-profile-load.ts
+++ b/apps/cli/src/legacy/shared/legacy-profile-load.ts
@@ -2,6 +2,11 @@ import { Data, Effect, FileSystem } from "effect";
 import { parse as parseYaml } from "yaml";
 
 import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+import {
   legacyApiUrl,
   legacyDashboardUrl,
   legacyIsBuiltinProfileName,
@@ -19,7 +24,11 @@ import {
 // classes.
 export class LegacyProfileLoadError extends Data.TaggedError("LegacyProfileLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Emulates Go's `LoadProfile` (`apps/cli-go/internal/utils/profile.go:94-118`)

--- a/apps/cli/src/legacy/shared/legacy-seed.ts
+++ b/apps/cli/src/legacy/shared/legacy-seed.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { Data, Effect, FileSystem, Path, Result } from "effect";
 
 import { Output } from "../../shared/output/output.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 import { legacyGlobPattern, legacyResolveUnderWorkdir, legacyWalkSqlFiles } from "./legacy-glob.ts";
 import {
@@ -15,7 +20,11 @@ import { legacySplitAndTrim } from "./legacy-sql-split.ts";
 /** Applying a seed file failed (Go's `SeedData` / `ExecBatchWithCache` errors). */
 export class LegacyMigrationSeedError extends Data.TaggedError("LegacyMigrationSeedError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** `[db.seed]` config: `enabled` + the (supabase-prefixed) `sql_paths` glob list. */
 export interface LegacySeedConfig {

--- a/apps/cli/src/legacy/shared/legacy-status-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-status-errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * An explicit `--workdir`/`SUPABASE_WORKDIR` path doesn't exist or isn't a
@@ -10,41 +15,76 @@ import { Data } from "effect";
  */
 export class LegacyStatusWorkdirError extends Data.TaggedError("LegacyStatusWorkdirError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /** `loadProjectConfig` rejected `supabase/config.toml` (malformed TOML/JSON). */
 export class LegacyStatusConfigLoadError extends Data.TaggedError("LegacyStatusConfigLoadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /** A `--override-name KEY=VALUE` entry did not parse, mirroring `env.EnvironToEnvSet`. */
 export class LegacyStatusOverrideParseError extends Data.TaggedError(
   "LegacyStatusOverrideParseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
-/** Inspecting the db container failed for a reason other than "not found". */
+/**
+ * Inspecting the db container failed for a reason other than "not found" —
+ * except Go's `assertContainerHealthy` never special-cases a missing
+ * container (see `status.handler.ts`'s step-5 comment): an absent container
+ * is just another non-zero inspect exit, so the dominant real trigger of this
+ * error is "the local stack was never started", same fix as
+ * {@link LegacyStatusDbNotRunningError}.
+ */
 export class LegacyStatusDbInspectError extends Data.TaggedError("LegacyStatusDbInspectError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /** The db container is absent or present but not in the `running` state. */
 export class LegacyStatusDbNotRunningError extends Data.TaggedError(
   "LegacyStatusDbNotRunningError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /** The db container is running but its Docker health check is not `healthy`. */
 export class LegacyStatusDbNotReadyError extends Data.TaggedError("LegacyStatusDbNotReadyError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.startStack;
+  }
+}
 
 /** Listing running containers by label failed. */
 export class LegacyStatusListError extends Data.TaggedError("LegacyStatusListError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dockerNotRunning;
+  }
+}
 
 /**
  * `config.toml` resolved to a value `Config.Validate` would reject before status
@@ -55,4 +95,8 @@ export class LegacyStatusInvalidConfigError extends Data.TaggedError(
   "LegacyStatusInvalidConfigError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-storage-credentials.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-credentials.errors.ts
@@ -71,6 +71,6 @@ export class LegacyStorageAuthTokenError extends Data.TaggedError("LegacyStorage
     // The shared mapper wraps any non-200 in this tag; the status policy maps
     // 401 → re-login, 404 → user-supplied ref not found, everything else →
     // API status.
-    return statusCodeActionability(this.status);
+    return statusCodeActionability(this.status, { notFoundIsInvalidInput: true });
   }
 }

--- a/apps/cli/src/legacy/shared/legacy-storage-credentials.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-credentials.errors.ts
@@ -1,5 +1,12 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Errors raised while deriving Storage connection credentials, shared by
  * `seed buckets` and `storage ls/cp/mv/rm`.
@@ -11,7 +18,11 @@ import { Data } from "effect";
  */
 export class LegacyStorageConfigError extends Data.TaggedError("LegacyStorageConfigError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 /**
  * Raised on `--linked` when the project's api-keys response yields no keys,
@@ -23,14 +34,27 @@ export class LegacyStorageMissingApiKeyError extends Data.TaggedError(
   "LegacyStorageMissingApiKeyError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // A 200 api-keys response with no usable key — an API response problem, not
+    // a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 /** Transport failure fetching the project's api-keys (`failed to get api keys: <cause>`). */
 export class LegacyStorageApiKeysNetworkError extends Data.TaggedError(
   "LegacyStorageApiKeysNetworkError",
 )<{
   readonly message: string;
-}> {}
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 /**
  * `GET /v1/projects/{ref}/api-keys?reveal=true` returned a non-200 on a
@@ -42,4 +66,11 @@ export class LegacyStorageAuthTokenError extends Data.TaggedError("LegacyStorage
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The shared mapper wraps any non-200 in this tag; the status policy maps
+    // 401 → re-login, 404 → user-supplied ref not found, everything else →
+    // API status.
+    return statusCodeActionability(this.status);
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-storage-gateway.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-gateway.errors.ts
@@ -47,10 +47,10 @@ export class LegacyStorageGatewayStatusError extends Data.TaggedError(
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     // The tenant Storage gateway is not the Management API: a 401/403 here
     // means stale local service keys, which `supabase login` cannot fix, so
-    // the Management-API auth/permission policy must not apply. A 404 is a
-    // user-supplied ss:///bucket/path that matched nothing (the friendly
-    // bucket-not-found cases are intercepted by the handlers before this error
-    // propagates), which the status policy classifies as user input.
+    // the Management-API auth/permission policy must not apply. This tag also
+    // spans collection and capability-probe routes (including unsupported
+    // vector routes returning 404), so it cannot safely opt every 404 into the
+    // named-resource policy.
     if (this.status === 401 || this.status === 403) {
       return { ...actionability.apiStatus, fingerprint_suffix: "gateway_auth" };
     }

--- a/apps/cli/src/legacy/shared/legacy-storage-gateway.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-gateway.errors.ts
@@ -1,4 +1,10 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * Errors for the Supabase Storage **service gateway** (Kong), shared by every
@@ -17,7 +23,19 @@ export class LegacyStorageGatewayNetworkError extends Data.TaggedError(
   "LegacyStorageGatewayNetworkError",
 )<{
   readonly message: string;
-}> {}
+  /**
+   * Set when this failure is a 200-response body that failed to decode
+   * (`failParse`) rather than a transport failure — so a malformed-body decode
+   * classifies as an API response problem instead of a network problem.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.decode === true
+      ? { ...actionability.apiStatus, fingerprint_suffix: "api_response" }
+      : actionability.externalNetwork;
+  }
+}
 
 export class LegacyStorageGatewayStatusError extends Data.TaggedError(
   "LegacyStorageGatewayStatusError",
@@ -25,7 +43,20 @@ export class LegacyStorageGatewayStatusError extends Data.TaggedError(
   readonly status: number;
   readonly body: string;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // The tenant Storage gateway is not the Management API: a 401/403 here
+    // means stale local service keys, which `supabase login` cannot fix, so
+    // the Management-API auth/permission policy must not apply. A 404 is a
+    // user-supplied ss:///bucket/path that matched nothing (the friendly
+    // bucket-not-found cases are intercepted by the handlers before this error
+    // propagates), which the status policy classifies as user input.
+    if (this.status === 401 || this.status === 403) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "gateway_auth" };
+    }
+    return statusCodeActionability(this.status);
+  }
+}
 
 export type LegacyStorageGatewayError =
   | LegacyStorageGatewayNetworkError

--- a/apps/cli/src/legacy/shared/legacy-storage-gateway.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-gateway.ts
@@ -136,6 +136,7 @@ export interface LegacyStorageGateway {
 function failParse(detail: string): LegacyStorageGatewayNetworkError {
   return new LegacyStorageGatewayNetworkError({
     message: `failed to parse response body: ${detail}`,
+    decode: true,
   });
 }
 

--- a/apps/cli/src/legacy/shared/legacy-storage-gateway.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-gateway.unit.test.ts
@@ -5,6 +5,8 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
+import { LegacyStorageGatewayStatusError } from "./legacy-storage-gateway.errors.ts";
 import { legacyBucketBody, legacyMakeStorageGateway } from "./legacy-storage-gateway.ts";
 
 describe("legacyBucketBody", () => {
@@ -34,6 +36,17 @@ describe("legacyBucketBody", () => {
         allowedMimeTypes: ["image/png"],
       }),
     ).toEqual({ public: false, file_size_limit: 52_428_800, allowed_mime_types: ["image/png"] });
+  });
+});
+
+describe("LegacyStorageGatewayStatusError actionability", () => {
+  it("keeps a shared gateway 404 on API status because the tag also wraps capability probes", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyStorageGatewayStatusError({ status: 404, body: "ignored", message: "ignored" }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyStorageGatewayStatusError:api_status");
   });
 });
 

--- a/apps/cli/src/legacy/shared/legacy-storage-url.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-url.ts
@@ -1,3 +1,9 @@
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Storage URL parsing, ported 1:1 from Go's `internal/storage/client/scheme.go`
  * plus the slices of `net/url` that `url.Parse` exercises for the `ss://` scheme.
@@ -32,6 +38,10 @@ export class LegacyGoUrlParseError extends Error {
     super(`parse "${rawURL}": ${inner}`);
     this.name = "LegacyGoUrlParseError";
   }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
 }
 
 /**
@@ -44,6 +54,10 @@ export class LegacyStorageUrlPatternError extends Error {
   constructor() {
     super(LEGACY_STORAGE_INVALID_URL_MESSAGE);
     this.name = "LegacyStorageUrlPatternError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
+++ b/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
@@ -1,3 +1,9 @@
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Parses a pflag `StringSliceVar` flag: CSV-splits each occurrence via
  * `encoding/csv` and accumulates across repeats, matching `readAsCSV` in
@@ -55,6 +61,10 @@ export class LegacyStringSliceFlagParseError extends Error {
   /** Mirrors pflag propagating `io.EOF` (value is nothing but blank lines). */
   static eof(value: string): LegacyStringSliceFlagParseError {
     return new LegacyStringSliceFlagParseError(value, "EOF");
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-temp-paths.ts
+++ b/apps/cli/src/legacy/shared/legacy-temp-paths.ts
@@ -16,7 +16,7 @@ export class LegacyProjectRefReadError extends Data.TaggedError("LegacyProjectRe
   readonly message: string;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.relinkProject;
+    return actionability.permission;
   }
 }
 

--- a/apps/cli/src/legacy/shared/legacy-temp-paths.ts
+++ b/apps/cli/src/legacy/shared/legacy-temp-paths.ts
@@ -1,4 +1,9 @@
 import { Data, Effect, FileSystem, Option, type Path } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * A real failure reading `<workdir>/supabase/.temp/project-ref` (e.g. the path is a
@@ -9,7 +14,11 @@ import { Data, Effect, FileSystem, Option, type Path } from "effect";
  */
 export class LegacyProjectRefReadError extends Data.TaggedError("LegacyProjectRefReadError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.relinkProject;
+  }
+}
 
 /**
  * Absolute paths to the files the Go CLI writes under `<workdir>/supabase/.temp/`.

--- a/apps/cli/src/legacy/shared/legacy-temp-paths.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-temp-paths.unit.test.ts
@@ -5,7 +5,12 @@ import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, FileSystem, Option, Path } from "effect";
 
-import { legacyReadProjectRefFile, legacyTempPaths } from "./legacy-temp-paths.ts";
+import { classifyCliErrorActionability } from "../../shared/telemetry/error-actionability.ts";
+import {
+  LegacyProjectRefReadError,
+  legacyReadProjectRefFile,
+  legacyTempPaths,
+} from "./legacy-temp-paths.ts";
 
 const readRef = (workdir: string) =>
   Effect.gen(function* () {
@@ -111,5 +116,16 @@ describe("legacyReadProjectRefFile", () => {
         }),
       ),
     );
+  });
+
+  it("classifies an unreadable ref file as permission without an unrelated command", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyProjectRefReadError({ message: "failed to load project ref: permission denied" }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("permission");
+    expect(result.has_suggestion).toBe(false);
+    expect(result.suggestion_type).toBe("none");
+    expect(result.suggested_command).toBeUndefined();
   });
 });

--- a/apps/cli/src/legacy/shared/legacy-test-db.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.errors.ts
@@ -1,12 +1,22 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * `create extension if not exists pgtap` failed. Byte-matches Go's
  * `"failed to enable pgTAP: " + err` (`apps/cli-go/internal/db/test/test.go:70`).
  */
 export class LegacyTestDbEnablePgtapError extends Data.TaggedError("LegacyTestDbEnablePgtapError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbConnection;
+  }
+}
 
 /**
  * `pg_prove` exited non-zero (test failures or a container error). Byte-matches
@@ -15,7 +25,11 @@ export class LegacyTestDbEnablePgtapError extends Data.TaggedError("LegacyTestDb
  */
 export class LegacyTestDbRunError extends Data.TaggedError("LegacyTestDbRunError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /**
  * More than one of `--db-url` / `--linked` / `--local` was set. Reproduces
@@ -26,4 +40,8 @@ export class LegacyTestDbMutuallyExclusiveFlagsError extends Data.TaggedError(
   "LegacyTestDbMutuallyExclusiveFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
@@ -105,19 +105,37 @@ function mockDockerRun(opts: { exitCode?: number; runFails?: boolean }) {
     run: (runOpts) => {
       lastOpts = runOpts;
       return opts.runFails === true
-        ? Effect.fail(new LegacyDockerRunError({ message: "failed to run docker: not found" }))
+        ? Effect.fail(
+            new LegacyDockerRunError({
+              message: "failed to run docker: not found",
+              reason: "spawn",
+              daemonDown: false,
+            }),
+          )
         : Effect.succeed(opts.exitCode ?? 0);
     },
     runCapture: (runOpts) => {
       lastOpts = runOpts;
       return opts.runFails === true
-        ? Effect.fail(new LegacyDockerRunError({ message: "failed to run docker: not found" }))
+        ? Effect.fail(
+            new LegacyDockerRunError({
+              message: "failed to run docker: not found",
+              reason: "spawn",
+              daemonDown: false,
+            }),
+          )
         : Effect.succeed({ exitCode: opts.exitCode ?? 0, stdout: new Uint8Array(0), stderr: "" });
     },
     runStream: (runOpts) => {
       lastOpts = runOpts;
       return opts.runFails === true
-        ? Effect.fail(new LegacyDockerRunError({ message: "failed to run docker: not found" }))
+        ? Effect.fail(
+            new LegacyDockerRunError({
+              message: "failed to run docker: not found",
+              reason: "spawn",
+              daemonDown: false,
+            }),
+          )
         : Effect.succeed({ exitCode: opts.exitCode ?? 0, stderr: "" });
     },
   });

--- a/apps/cli/src/legacy/shared/legacy-upgrade-suggest.ts
+++ b/apps/cli/src/legacy/shared/legacy-upgrade-suggest.ts
@@ -59,18 +59,18 @@ export function legacyGateResponse(
 export const legacyGateMapError =
   <E, R2>(
     opts: { readonly projectRef: string; readonly featureKey?: string },
-    mapError: (cause: SupabaseApiError) => Effect.Effect<never, E, R2>,
+    mapError: (cause: SupabaseApiError, upgradeSuggested: boolean) => Effect.Effect<never, E, R2>,
   ) =>
   (cause: SupabaseApiError) =>
     Effect.gen(function* () {
       const response = legacyGateResponse(cause);
-      yield* legacySuggestUpgrade({
+      const upgradeSuggested = yield* legacySuggestUpgrade({
         projectRef: opts.projectRef,
         featureKey: opts.featureKey,
         statusCode: response?.status ?? 0,
         response,
       });
-      return yield* mapError(cause);
+      return yield* mapError(cause, upgradeSuggested);
     });
 
 /**
@@ -79,6 +79,8 @@ export const legacyGateMapError =
  * The fallback bypasses the typed API client: its strict response schemas
  * reject the cli-e2e replay fixtures' placeholder refs (same workaround as
  * `legacy-linked-project-cache.layer.ts`).
+ * Returns whether the feature was confirmed plan-gated so callers can carry
+ * that typed result into their error classification.
  */
 export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
   readonly projectRef: string;
@@ -117,7 +119,7 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
   readonly trackAnalytics?: boolean;
 }) {
   if (opts.statusCode < 400 || opts.statusCode >= 500) {
-    return;
+    return false;
   }
 
   const output = yield* Output;
@@ -143,7 +145,7 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
 
   if (gate === undefined) {
     if (opts.featureKey === undefined || opts.featureKey === "") {
-      return;
+      return false;
     }
 
     const tokenOpt = opts.accessToken ?? (yield* resolveLegacyAccessToken);
@@ -160,15 +162,15 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
     );
     const projectResp = yield* httpClient.execute(projectReq).pipe(Effect.option);
     if (projectResp._tag === "None" || projectResp.value.status !== 200) {
-      return;
+      return false;
     }
     const projectBody = yield* projectResp.value.json.pipe(Effect.option);
     if (projectBody._tag === "None") {
-      return;
+      return false;
     }
     const orgSlug = readString(projectBody.value, "organization_slug");
     if (orgSlug.length === 0) {
-      return;
+      return false;
     }
 
     const entReq = HttpClientRequest.get(`${apiUrl}/v1/organizations/${orgSlug}/entitlements`).pipe(
@@ -177,15 +179,15 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
     );
     const entResp = yield* httpClient.execute(entReq).pipe(Effect.option);
     if (entResp._tag === "None" || entResp.value.status !== 200) {
-      return;
+      return false;
     }
     const entBody = yield* entResp.value.json.pipe(Effect.option);
     if (entBody._tag === "None") {
-      return;
+      return false;
     }
     const entitlements = (entBody.value as { entitlements?: unknown }).entitlements;
     if (!Array.isArray(entitlements)) {
-      return;
+      return false;
     }
 
     const gated = entitlements.some((entry: unknown) => {
@@ -197,7 +199,7 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
       return key === opts.featureKey && hasAccess === false;
     });
     if (!gated) {
-      return;
+      return false;
     }
 
     gate = {
@@ -219,4 +221,6 @@ export const legacySuggestUpgrade = Effect.fnUntraced(function* (opts: {
       [PropOrgSlug]: gate.orgSlug,
     });
   }
+
+  return true;
 });

--- a/apps/cli/src/legacy/shared/legacy-vault.ts
+++ b/apps/cli/src/legacy/shared/legacy-vault.ts
@@ -1,12 +1,21 @@
 import { Data, Effect } from "effect";
 
 import { Output } from "../../shared/output/output.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import type { LegacyDbSession } from "./legacy-db-connection.service.ts";
 
 /** Reading or updating `vault.secrets` failed (Go's `UpsertVaultSecrets` errors). */
 export class LegacyMigrationVaultError extends Data.TaggedError("LegacyMigrationVaultError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
 
 /** A resolved `[db.vault]` secret. `resolved` mirrors Go's `len(SHA256) > 0` gate. */
 export interface LegacyVaultSecret {

--- a/apps/cli/src/legacy/shared/legacy-workdir-validation.ts
+++ b/apps/cli/src/legacy/shared/legacy-workdir-validation.ts
@@ -1,13 +1,27 @@
 import { Data, Effect, FileSystem } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+
 /**
  * Raised by {@link legacyValidateWorkdirIsDirectory} when the target path
  * doesn't exist or isn't a directory. Callers map this into their own
- * command-specific error type.
+ * command-specific error type. Only reachable when the user explicitly set
+ * `--workdir`/`SUPABASE_WORKDIR` to a bad path — the default walk-up
+ * resolution can never fail this check (see the doc comment on
+ * {@link legacyValidateWorkdirIsDirectory} below) — so the fix is always
+ * "pass a different `--workdir`/`SUPABASE_WORKDIR`".
  */
 export class LegacyWorkdirValidationError extends Data.TaggedError("LegacyWorkdirValidationError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 /**
  * Validates that `workdir` exists and is a directory, the way Go's

--- a/apps/cli/src/next/auth/api.layer.ts
+++ b/apps/cli/src/next/auth/api.layer.ts
@@ -10,18 +10,42 @@ import {
 import { ApiError } from "./errors.ts";
 import { Api, type LoginSessionResponse } from "./api.service.ts";
 
-function mapHttpClientError(
-  error: HttpClientError.HttpClientError,
-): Effect.Effect<never, ApiError> {
-  if (error.response !== undefined) {
-    return Effect.fail(
-      new ApiError({
-        statusCode: error.response.status,
-        detail: `${error.response.status} ${error.message}`,
-      }),
-    );
+// HttpClientError reasons that mean the response arrived but its body could not
+// be decoded (including a 2xx whose body isn't valid JSON). These are API
+// response problems, not transport ones, so they classify by `decode` rather
+// than a status code.
+const BODY_DECODE_REASONS = new Set<string>(["DecodeError", "EmptyBodyError"]);
+
+/**
+ * Maps any fetcher failure to an {@link ApiError}, preserving the classification
+ * signal:
+ * - a received status → `statusCode` (transport error → status-less, classified
+ *   as network);
+ * - a body/schema decode failure — whether an `HttpClientError` decode reason or
+ *   a non-`HttpClientError` thrown while decoding — → `decode: true`, classified
+ *   as an API response problem instead of network.
+ */
+function mapToApiError(error: unknown): Effect.Effect<never, ApiError> {
+  if (HttpClientError.isHttpClientError(error)) {
+    if (BODY_DECODE_REASONS.has(error.reason._tag)) {
+      return Effect.fail(new ApiError({ detail: error.message, decode: true }));
+    }
+    if (error.response !== undefined) {
+      return Effect.fail(
+        new ApiError({
+          statusCode: error.response.status,
+          detail: `${error.response.status} ${error.message}`,
+        }),
+      );
+    }
+    return Effect.fail(new ApiError({ detail: error.message }));
   }
-  return Effect.fail(new ApiError({ detail: error.message }));
+  return Effect.fail(
+    new ApiError({
+      detail: error instanceof Error ? error.message : String(error),
+      decode: true,
+    }),
+  );
 }
 
 export const makeApi = Effect.gen(function* () {
@@ -36,7 +60,7 @@ export const makeApi = Effect.gen(function* () {
         const response = yield* httpClient.execute(HttpClientRequest.get(url));
         return (yield* response.json) as LoginSessionResponse;
       },
-      (effect) => effect.pipe(Effect.catch(mapHttpClientError)),
+      (effect) => effect.pipe(Effect.catch(mapToApiError)),
     ),
     fetchProfile: Effect.fnUntraced(
       function* (apiUrl, accessToken) {
@@ -47,19 +71,7 @@ export const makeApi = Effect.gen(function* () {
         }).pipe(Effect.provide(httpClientLayer));
         return yield* api.v1.getProfile();
       },
-      (effect) =>
-        effect.pipe(
-          Effect.catch((error) => {
-            if (HttpClientError.isHttpClientError(error)) {
-              return mapHttpClientError(error);
-            }
-            return Effect.fail(
-              new ApiError({
-                detail: error instanceof Error ? error.message : String(error),
-              }),
-            );
-          }),
-        ),
+      (effect) => effect.pipe(Effect.catch(mapToApiError)),
     ),
   });
 });

--- a/apps/cli/src/next/auth/errors.ts
+++ b/apps/cli/src/next/auth/errors.ts
@@ -1,25 +1,58 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../../shared/telemetry/error-actionability.ts";
 
-function CliError<Tag extends string>(tag: Tag) {
-  return class extends Data.TaggedError(tag)<{
-    readonly detail: string;
-    readonly suggestion: string;
-  }> {
-    override get message() {
-      return `${this.detail}\n  Suggestion: ${this.suggestion}`;
-    }
-  };
+export class InvalidTokenError extends Data.TaggedError("InvalidTokenError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+  /**
+   * Where the malformed token came from. Direct-input tokens (`--token` flag,
+   * `SUPABASE_ACCESS_TOKEN`, piped stdin) cannot be fixed by `supabase login`,
+   * so their remediation is to correct that input. A token from the browser
+   * flow (no source) is fixable by logging in again.
+   */
+  readonly source?: "env" | "flag" | "stdin";
+}> {
+  override get message() {
+    return `${this.detail}\n  Suggestion: ${this.suggestion}`;
+  }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.source === undefined ? actionability.authLogin : actionability.authToken;
+  }
 }
-
-export class InvalidTokenError extends CliError("InvalidTokenError") {}
 
 export class ApiError extends Data.TaggedError("ApiError")<{
   readonly statusCode?: number;
   readonly detail: string;
-}> {}
+  /**
+   * Set when this error represents a body/schema decode failure on an
+   * otherwise-successful response (no status code to classify by), rather
+   * than a transport failure — so it classifies as an API response problem
+   * instead of a network problem.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.statusCode !== undefined) {
+      return statusCodeActionability(this.statusCode);
+    }
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    return statusCodeActionability(undefined);
+  }
+}
 
 export class PlatformAuthRequiredError extends Data.TaggedError("PlatformAuthRequiredError")<{
   readonly message: string;
   readonly detail?: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}

--- a/apps/cli/src/next/auth/token.ts
+++ b/apps/cli/src/next/auth/token.ts
@@ -3,11 +3,15 @@ import { InvalidTokenError } from "./errors.ts";
 
 const TOKEN_PATTERN = /^sbp_(oauth_)?[a-f0-9]{40}$/;
 
-export const validateToken = Effect.fnUntraced(function* (token: string) {
+export const validateToken = Effect.fnUntraced(function* (
+  token: string,
+  source?: "env" | "flag" | "stdin",
+) {
   if (!TOKEN_PATTERN.test(token)) {
     return yield* new InvalidTokenError({
       detail: "Invalid access token format",
       suggestion: "Generate a token at https://supabase.com/dashboard/account/tokens",
+      source,
     });
   }
 });

--- a/apps/cli/src/next/commands/branches/create/create.handler.ts
+++ b/apps/cli/src/next/commands/branches/create/create.handler.ts
@@ -13,6 +13,12 @@ import { BranchAlreadyExistsError, NoBranchNameError } from "../errors.ts";
 
 const resolveBranchName = Effect.fnUntraced(function* (nameOpt: Option.Option<string>) {
   if (Option.isSome(nameOpt)) {
+    if (nameOpt.value.length === 0) {
+      return yield* new NoBranchNameError({
+        detail: "Branch name cannot be empty.",
+        suggestion: "Provide a branch name: `supabase branches create <name>`",
+      });
+    }
     return { branchName: nameOpt.value, gitBranch: Option.none<string>() };
   }
 

--- a/apps/cli/src/next/commands/branches/create/create.handler.ts
+++ b/apps/cli/src/next/commands/branches/create/create.handler.ts
@@ -50,6 +50,7 @@ const resolveBranchName = Effect.fnUntraced(function* (nameOpt: Option.Option<st
       new NoBranchNameError({
         detail: "Branch creation cancelled.",
         suggestion: "Provide a branch name: `supabase branches create <name>`",
+        cancelled: true,
       }),
     );
   }

--- a/apps/cli/src/next/commands/branches/create/create.integration.test.ts
+++ b/apps/cli/src/next/commands/branches/create/create.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { makeApiClient, V1CreateABranchOutput } from "@supabase/api/effect";
-import { Effect, Layer, Option } from "effect";
+import { Effect, Exit, Layer, Option } from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
@@ -8,6 +8,7 @@ import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import { PlatformApi } from "../../../auth/platform-api.service.ts";
 import { ProjectLinkState } from "../../../config/project-link-state.service.ts";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { classifyCliCauseActionability } from "../../../../shared/telemetry/error-actionability.ts";
 import {
   emptyEnv,
   mockOutput,
@@ -192,6 +193,26 @@ describe("branches create handler", () => {
             m.message.includes("created and set as active"),
         ),
       ).toBe(true);
+    }),
+  );
+
+  it.live("rejects an explicit empty name before contacting the API", () =>
+    Effect.gen(function* () {
+      const { layer, api } = setup({ env: { GITHUB_HEAD_REF: "fallback-branch" } });
+      const exit = yield* create({ ...BASE_FLAGS, name: Option.some("") }).pipe(
+        Effect.provide(layer),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(classifyCliCauseActionability(exit.cause)).toMatchObject({
+          error_kind: "user_actionable",
+          error_category: "invalid_input",
+          suggestion_type: "provide_flags",
+        });
+      }
+      expect(api.capturedInput).toBeUndefined();
     }),
   );
 

--- a/apps/cli/src/next/commands/branches/errors.ts
+++ b/apps/cli/src/next/commands/branches/errors.ts
@@ -26,7 +26,9 @@ export class NoBranchNameError extends Data.TaggedError("NoBranchNameError")<{
   readonly cancelled?: boolean;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return this.cancelled === true ? actionability.cancelled : actionability.provideFlags;
+    return this.cancelled === true
+      ? { ...actionability.cancelled, fingerprint_suffix: "cancelled" }
+      : actionability.provideFlags;
   }
 }
 

--- a/apps/cli/src/next/commands/branches/errors.ts
+++ b/apps/cli/src/next/commands/branches/errors.ts
@@ -1,16 +1,40 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class BranchNotFoundError extends Data.TaggedError("BranchNotFoundError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class NoBranchNameError extends Data.TaggedError("NoBranchNameError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+  /**
+   * Set when the user declined the "create branch named …?" prompt: the
+   * failure is a deliberate cancellation, not missing input. Left unset for
+   * the genuine "no name and no way to obtain one" paths, which stay
+   * `provideFlags`.
+   */
+  readonly cancelled?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return this.cancelled === true ? actionability.cancelled : actionability.provideFlags;
+  }
+}
 
 export class BranchAlreadyExistsError extends Data.TaggedError("BranchAlreadyExistsError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/next/commands/branches/errors.unit.test.ts
+++ b/apps/cli/src/next/commands/branches/errors.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import { NoBranchNameError } from "./errors.ts";
+
+describe("NoBranchNameError actionability", () => {
+  it("classifies a declined-prompt cancellation as user-cancelled", () => {
+    const result = classifyCliErrorActionability(
+      new NoBranchNameError({
+        detail: "Branch creation cancelled.",
+        suggestion: "Provide a branch name: `supabase branches create <name>`",
+        cancelled: true,
+      }),
+    );
+    expect(result.error_kind).toBe("user_cancelled");
+    expect(result.error_category).toBe("cancelled");
+    expect(result.error_fingerprint).toBe("tag:NoBranchNameError");
+  });
+
+  it("classifies a genuinely missing branch name as provide-flags", () => {
+    const result = classifyCliErrorActionability(
+      new NoBranchNameError({
+        detail: "No branch name provided and no git branch detected.",
+        suggestion: "Provide a branch name: `supabase branches create <name>`",
+      }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.suggestion_type).toBe("provide_flags");
+    expect(result.error_fingerprint).toBe("tag:NoBranchNameError");
+  });
+});

--- a/apps/cli/src/next/commands/branches/errors.unit.test.ts
+++ b/apps/cli/src/next/commands/branches/errors.unit.test.ts
@@ -13,7 +13,7 @@ describe("NoBranchNameError actionability", () => {
     );
     expect(result.error_kind).toBe("user_cancelled");
     expect(result.error_category).toBe("cancelled");
-    expect(result.error_fingerprint).toBe("tag:NoBranchNameError");
+    expect(result.error_fingerprint).toBe("tag:NoBranchNameError:cancelled");
   });
 
   it("classifies a genuinely missing branch name as provide-flags", () => {

--- a/apps/cli/src/next/commands/functions/delete/delete.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/delete/delete.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { makeApiClient } from "@supabase/api/effect";
+import { makeApiClient, SupabaseApiInputError } from "@supabase/api/effect";
 import { Effect, Layer, Option } from "effect";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
@@ -20,6 +20,7 @@ import {
   InvalidFunctionSlugError,
 } from "../../../../shared/functions/delete.errors.ts";
 import { functionsDelete } from "./delete.handler.ts";
+import { classifyCliErrorActionability } from "../../../../shared/telemetry/error-actionability.ts";
 
 const PROJECT_REF = "abcdefghijklmnopqrst";
 const BRANCH_REF = "branchrefabcdefghij";
@@ -186,6 +187,29 @@ describe("functions delete", () => {
       }).pipe(Effect.provide(layer), Effect.flip);
 
       expect(error).toBeInstanceOf(InvalidFunctionSlugError);
+      expect(api.requests).toHaveLength(0);
+    }),
+  );
+
+  it.live("marks a rejected project ref as user input without sending a request", () =>
+    Effect.gen(function* () {
+      const { layer, api } = setup({ linked: false });
+
+      const error = yield* functionsDelete({
+        slug: "hello-world",
+        projectRef: Option.some("invalid-ref"),
+      }).pipe(Effect.provide(layer), Effect.flip);
+
+      expect(error).toBeInstanceOf(SupabaseApiInputError);
+      if (!(error instanceof SupabaseApiInputError)) {
+        return yield* Effect.die("expected SupabaseApiInputError");
+      }
+      expect(error.source).toBe("user_input");
+      expect(classifyCliErrorActionability(error)).toMatchObject({
+        error_kind: "user_actionable",
+        error_category: "invalid_input",
+        error_fingerprint: "tag:SupabaseApiInputError:request_input",
+      });
       expect(api.requests).toHaveLength(0);
     }),
   );

--- a/apps/cli/src/next/commands/functions/dev/functions-dev-edge-runtime-config.ts
+++ b/apps/cli/src/next/commands/functions/dev/functions-dev-edge-runtime-config.ts
@@ -7,6 +7,11 @@ import {
 import type { EdgeRuntimeConfig } from "@supabase/stack/effect";
 import { Data, Effect, Redacted } from "effect";
 import { ProjectHome } from "../../../config/project-home.service.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 type ResolvedSecretValue = string | Redacted.Redacted<string>;
 type EdgeRuntimePolicy = "oneshot" | "per_worker";
@@ -26,6 +31,10 @@ export class FunctionsDevEdgeRuntimeDisabledError extends Data.TaggedError(
 }> {
   override get message() {
     return `${this.detail}\n  Suggestion: ${this.suggestion}`;
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }
 

--- a/apps/cli/src/next/commands/functions/new/new.errors.ts
+++ b/apps/cli/src/next/commands/functions/new/new.errors.ts
@@ -1,18 +1,35 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../../shared/telemetry/error-actionability.ts";
 
 export class InvalidFunctionSlugError extends Data.TaggedError("InvalidFunctionSlugError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class MissingFunctionSlugError extends Data.TaggedError("MissingFunctionSlugError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class FunctionEntrypointExistsError extends Data.TaggedError(
   "FunctionEntrypointExistsError",
 )<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/next/commands/init/init.errors.ts
+++ b/apps/cli/src/next/commands/init/init.errors.ts
@@ -1,5 +1,11 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 /**
  * `--use-orioledb` without `--experimental`. The next shell deliberately keeps
  * this friendlier wording; the legacy shell byte-matches Go's cobra
@@ -14,5 +20,9 @@ export class InitExperimentalRequiredError extends Data.TaggedError(
 }> {
   override get message() {
     return "The --use-orioledb flag requires --experimental.";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }

--- a/apps/cli/src/next/commands/link/link.errors.ts
+++ b/apps/cli/src/next/commands/link/link.errors.ts
@@ -1,11 +1,24 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class ProjectRefRequiredError extends Data.TaggedError("ProjectRefRequiredError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.missingProjectRef;
+  }
+}
 
 export class NoAccessibleProjectsError extends Data.TaggedError("NoAccessibleProjectsError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.accountAccess;
+  }
+}

--- a/apps/cli/src/next/commands/login/login.errors.ts
+++ b/apps/cli/src/next/commands/login/login.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 function LoginError<Tag extends string>(tag: Tag) {
   return class extends Data.TaggedError(tag)<{
@@ -11,5 +16,42 @@ function LoginError<Tag extends string>(tag: Tag) {
   };
 }
 
-export class NoTtyError extends LoginError("NoTtyError") {}
-export class LoginFailedError extends LoginError("LoginFailedError") {}
+export class NoTtyError extends LoginError("NoTtyError") {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authToken;
+  }
+}
+/**
+ * All browser-login verification retries exhausted. Carries the LAST poll
+ * failure's discriminant so classification distinguishes "the user never
+ * completed the browser flow" (a pending 4xx, or no signal) from a genuine
+ * platform problem (5xx / transport).
+ */
+export class LoginFailedError extends Data.TaggedError("LoginFailedError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+  readonly statusCode?: number;
+  readonly network?: boolean;
+  /**
+   * Set when the last poll failed decoding an otherwise-received response body
+   * (no status code to classify by) — an API response problem rather than a
+   * transport (network) one or an incomplete browser flow.
+   */
+  readonly decode?: boolean;
+}> {
+  override get message() {
+    return `${this.detail}\n  Suggestion: ${this.suggestion}`;
+  }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    if (this.network === true) {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+    }
+    if (this.statusCode !== undefined && this.statusCode >= 500) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_status" };
+    }
+    return actionability.authLogin;
+  }
+}

--- a/apps/cli/src/next/commands/login/login.errors.unit.test.ts
+++ b/apps/cli/src/next/commands/login/login.errors.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../../../shared/telemetry/error-actionability.ts";
+import { LoginFailedError } from "./login.errors.ts";
+
+const base = { detail: "Login failed after maximum retries", suggestion: "Try again" };
+
+describe("LoginFailedError actionability", () => {
+  it("classifies a decoded-body poll failure as an API response problem", () => {
+    const result = classifyCliErrorActionability(new LoginFailedError({ ...base, decode: true }));
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LoginFailedError:api_response");
+  });
+
+  it("prefers the decode signal over a transport one", () => {
+    const result = classifyCliErrorActionability(
+      new LoginFailedError({ ...base, network: true, decode: true }),
+    );
+    expect(result.error_fingerprint).toBe("tag:LoginFailedError:api_response");
+  });
+
+  it("classifies a transport failure as network", () => {
+    const result = classifyCliErrorActionability(new LoginFailedError({ ...base, network: true }));
+    expect(result.error_category).toBe("network");
+    expect(result.error_fingerprint).toBe("tag:LoginFailedError:network");
+  });
+
+  it("classifies a 5xx poll status as an API status problem", () => {
+    const result = classifyCliErrorActionability(
+      new LoginFailedError({ ...base, statusCode: 502 }),
+    );
+    expect(result.error_fingerprint).toBe("tag:LoginFailedError:api_status");
+  });
+
+  it("treats an incomplete browser flow (no signal / pending 4xx) as auth login", () => {
+    expect(classifyCliErrorActionability(new LoginFailedError(base)).error_category).toBe("auth");
+    expect(
+      classifyCliErrorActionability(new LoginFailedError({ ...base, statusCode: 400 }))
+        .error_category,
+    ).toBe("auth");
+  });
+});

--- a/apps/cli/src/next/commands/login/login.handler.ts
+++ b/apps/cli/src/next/commands/login/login.handler.ts
@@ -18,14 +18,23 @@ import {
 } from "../../../shared/telemetry/identity.ts";
 import { Analytics } from "../../../shared/telemetry/analytics.service.ts";
 import { withAnalyticsContext } from "../../../shared/telemetry/analytics-context.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 import { TelemetryRuntime } from "../../../shared/telemetry/runtime.service.ts";
 import type { NonInteractiveError } from "../../../shared/output/errors.ts";
 import { LoginFailedError, NoTtyError } from "./login.errors.ts";
 import type { LoginFlags } from "./login.command.ts";
 
-class LoginVerificationError extends Data.TaggedError("LoginVerificationError")<{
+export class LoginVerificationError extends Data.TaggedError("LoginVerificationError")<{
   cause: ApiError;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 const MAX_LOGIN_VERIFICATION_RETRIES = 2;
 
@@ -89,34 +98,48 @@ const captureLoginCompleted = Effect.fnUntraced(function* (
   );
 });
 
-const saveDirectToken = Effect.fnUntraced(function* (token: Redacted.Redacted<string>) {
+const saveDirectToken = Effect.fnUntraced(function* (
+  token: Redacted.Redacted<string>,
+  source: "env" | "flag" | "stdin",
+) {
   const credentials = yield* Credentials;
   const output = yield* Output;
-  yield* validateToken(revealToken(token));
+  yield* validateToken(revealToken(token), source);
   yield* credentials.saveAccessToken(token);
   const distinctId = yield* resolveAuthenticatedDistinctId(token);
   yield* output.success("Logged in successfully.", { command: "login" });
   yield* captureLoginCompleted({ login_method: "token" }, distinctId);
 });
 
+interface ResolvedToken {
+  readonly token: Redacted.Redacted<string>;
+  readonly source: "env" | "flag" | "stdin";
+}
+
 // Token resolution priority: --token flag > SUPABASE_ACCESS_TOKEN env > piped stdin > interactive browser flow
 const resolveToken = Effect.fnUntraced(function* (tokenFlag: Option.Option<string>) {
-  if (Option.isSome(tokenFlag)) return Option.some(Redacted.make(tokenFlag.value));
+  if (Option.isSome(tokenFlag)) {
+    return Option.some<ResolvedToken>({ token: Redacted.make(tokenFlag.value), source: "flag" });
+  }
 
   const cliConfig = yield* CliConfig;
-  if (Option.isSome(cliConfig.accessToken)) return cliConfig.accessToken;
+  if (Option.isSome(cliConfig.accessToken)) {
+    return Option.some<ResolvedToken>({ token: cliConfig.accessToken.value, source: "env" });
+  }
 
   const stdin = yield* Stdin;
   if (!stdin.isTTY) {
     const piped = yield* stdin.readPipedText;
-    if (Option.isSome(piped)) return Option.some(Redacted.make(piped.value));
+    if (Option.isSome(piped)) {
+      return Option.some<ResolvedToken>({ token: Redacted.make(piped.value), source: "stdin" });
+    }
     return yield* new NoTtyError({
       detail: "Cannot prompt for token in non-interactive mode",
       suggestion: "Pass --token or set SUPABASE_ACCESS_TOKEN",
     });
   }
 
-  return Option.none();
+  return Option.none<ResolvedToken>();
 });
 
 // ---------------------------------------------------------------------------
@@ -187,14 +210,23 @@ const browserOAuthFlow = Effect.fnUntraced(function* (flags: LoginFlags) {
     remainingRetries: number,
   ): Effect.Effect<LoginSessionResponse, LoginFailedError | NonInteractiveError> =>
     verifyCode.pipe(
-      Effect.catchTag("LoginVerificationError", () =>
+      Effect.catchTag("LoginVerificationError", (err) =>
         Effect.gen(function* () {
           yield* output.error("Verification failed");
           if (remainingRetries <= 0) {
+            // Thread the last poll failure's discriminant: a received status
+            // classifies by code (5xx → platform outage), a status-less/decode
+            // failure means transport (network) unless it carried a decoded
+            // body, and a pending 4xx / no signal stays "run supabase login".
+            const { statusCode, decode } = err.cause;
+            const network = statusCode === undefined && decode !== true;
             return yield* Effect.fail(
               new LoginFailedError({
                 detail: "Login failed after maximum retries",
                 suggestion: "Try running `supabase login` again",
+                statusCode,
+                network,
+                decode,
               }),
             );
           }
@@ -239,7 +271,7 @@ export const login = Effect.fnUntraced(function* (flags: LoginFlags) {
 
   const resolved = yield* resolveToken(flags.token);
   if (Option.isSome(resolved)) {
-    return yield* saveDirectToken(resolved.value);
+    return yield* saveDirectToken(resolved.value.token, resolved.value.source);
   }
   return yield* browserOAuthFlow(flags);
 });

--- a/apps/cli/src/next/commands/logs/logs.errors.ts
+++ b/apps/cli/src/next/commands/logs/logs.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
 
 export class UnsupportedLogsOutputFormatError extends Data.TaggedError(
   "UnsupportedLogsOutputFormatError",
@@ -8,5 +13,9 @@ export class UnsupportedLogsOutputFormatError extends Data.TaggedError(
 }> {
   override get message() {
     return `${this.detail}\n  Suggestion: ${this.suggestion}`;
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }

--- a/apps/cli/src/next/commands/platform/platform.errors.ts
+++ b/apps/cli/src/next/commands/platform/platform.errors.ts
@@ -1,24 +1,46 @@
 import { Data } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../../shared/telemetry/error-actionability.ts";
+
 export class PlatformInputError extends Data.TaggedError("PlatformInputError")<{
   readonly message: string;
   readonly detail?: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class PlatformMetadataError extends Data.TaggedError("PlatformMetadataError")<{
   readonly message: string;
   readonly detail?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.impossibleState;
+  }
+}
 
 export class PlatformRouteNotFoundError extends Data.TaggedError("PlatformRouteNotFoundError")<{
   readonly message: string;
   readonly detail?: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class PlatformMethodSelectionError extends Data.TaggedError("PlatformMethodSelectionError")<{
   readonly message: string;
   readonly detail?: string;
   readonly suggestion?: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}

--- a/apps/cli/src/next/config/project-link-remote.layer.ts
+++ b/apps/cli/src/next/config/project-link-remote.layer.ts
@@ -1,5 +1,10 @@
 import { Data, Duration, Effect, Exit, Layer } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { PlatformApi } from "../auth/platform-api.service.ts";
 import { CliConfig } from "./cli-config.service.ts";
 import {
@@ -10,13 +15,23 @@ import {
 } from "./project-link-remote.service.ts";
 import type { LinkedServiceVersions } from "./project-link-state.service.ts";
 
-class ServiceVersionNotFoundError extends Data.TaggedError("ServiceVersionNotFoundError")<{
+export class ServiceVersionNotFoundError extends Data.TaggedError("ServiceVersionNotFoundError")<{
   readonly service: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
-class NoProjectApiKeyError extends Data.TaggedError("NoProjectApiKeyError")<{
+export class NoProjectApiKeyError extends Data.TaggedError("NoProjectApiKeyError")<{
   readonly projectRef: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // A successful api-keys response with no usable key — an API response
+    // problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 type ProjectApiKey = {
   readonly name: string;

--- a/apps/cli/src/next/config/project-link-state.service.ts
+++ b/apps/cli/src/next/config/project-link-state.service.ts
@@ -1,5 +1,10 @@
 import type { Effect, Option } from "effect";
 import { Data, Schema, Context } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 const LinkedServiceVersionsSchema = Schema.Struct({
   postgres: Schema.optionalKey(Schema.String),
@@ -37,12 +42,20 @@ export type ProjectLinkStateValue = Schema.Schema.Type<typeof ProjectLinkStateVa
 export class InvalidProjectLinkStateError extends Data.TaggedError("InvalidProjectLinkStateError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.relinkProject;
+  }
+}
 
 export class ProjectNotLinkedError extends Data.TaggedError("ProjectNotLinkedError")<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.projectNotLinked;
+  }
+}
 
 interface ProjectLinkStateShape {
   readonly load: Effect.Effect<Option.Option<ProjectLinkStateValue>, InvalidProjectLinkStateError>;

--- a/apps/cli/src/next/config/project-local-service-versions.service.ts
+++ b/apps/cli/src/next/config/project-local-service-versions.service.ts
@@ -1,5 +1,10 @@
 import type { Effect, Option } from "effect";
 import { Data, Schema, Context } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 const LocalServiceVersionsSchema = Schema.Struct({
   postgres: Schema.optionalKey(Schema.String),
@@ -28,7 +33,11 @@ export class InvalidLocalServiceVersionsStateError extends Data.TaggedError(
 )<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
 
 interface ProjectLocalServiceVersionsShape {
   readonly load: Effect.Effect<

--- a/apps/cli/src/next/config/service-version-resolution.ts
+++ b/apps/cli/src/next/config/service-version-resolution.ts
@@ -6,17 +6,26 @@ import {
   SERVICE_NAMES,
 } from "@supabase/stack/effect";
 import { Data, Effect, Option } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 import { ProjectLocalServiceVersions } from "./project-local-service-versions.service.ts";
 import { ProjectLinkState } from "./project-link-state.service.ts";
 
 export type ResolvedServiceVersionContext = StackVersionPlan;
 
-class InvalidServiceVersionOverrideError extends Data.TaggedError(
+export class InvalidServiceVersionOverrideError extends Data.TaggedError(
   "InvalidServiceVersionOverrideError",
 )<{
   readonly detail: string;
   readonly suggestion: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 function isServiceName(value: string): value is ServiceName {
   return (SERVICE_NAMES as ReadonlyArray<string>).includes(value);

--- a/apps/cli/src/shared/functions/delete.errors.ts
+++ b/apps/cli/src/shared/functions/delete.errors.ts
@@ -1,19 +1,42 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../telemetry/error-actionability.ts";
 
 export class InvalidFunctionSlugError extends Data.TaggedError("InvalidFunctionSlugError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class FunctionNotFoundError extends Data.TaggedError("FunctionNotFoundError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class DeleteFunctionNetworkError extends Data.TaggedError("DeleteFunctionNetworkError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
 
 export class DeleteFunctionUnexpectedStatusError extends Data.TaggedError(
   "DeleteFunctionUnexpectedStatusError",
 )<{
+  readonly status: number;
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status);
+  }
+}

--- a/apps/cli/src/shared/functions/delete.ts
+++ b/apps/cli/src/shared/functions/delete.ts
@@ -1,4 +1,9 @@
-import { operationDefinitions, type ApiClient } from "@supabase/api/effect";
+import {
+  markSupabaseApiInputErrorAsUserInput,
+  operationDefinitions,
+  SupabaseApiInputError,
+  type ApiClient,
+} from "@supabase/api/effect";
 import { Effect, type Option } from "effect";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import { Output } from "../output/output.service.ts";
@@ -54,6 +59,11 @@ export function deleteFunction<ResolveError, ResolveRequirements>(
       })
       .pipe(
         Effect.mapError((error) => {
+          if (error instanceof SupabaseApiInputError) {
+            // This operation's complete input is the resolved ref and the
+            // prevalidated slug, so a schema rejection is user-derived.
+            return markSupabaseApiInputErrorAsUserInput(error);
+          }
           if (HttpClientError.isHttpClientError(error)) {
             const description = error.reason.description ?? error.reason._tag;
             return new DeleteFunctionNetworkError({

--- a/apps/cli/src/shared/functions/delete.ts
+++ b/apps/cli/src/shared/functions/delete.ts
@@ -79,6 +79,7 @@ export function deleteFunction<ResolveError, ResolveRequirements>(
         const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
         return yield* Effect.fail(
           new DeleteFunctionUnexpectedStatusError({
+            status: response.status,
             message: `unexpected delete function status ${response.status}: ${body}`,
           }),
         );

--- a/apps/cli/src/shared/functions/deploy.errors.ts
+++ b/apps/cli/src/shared/functions/deploy.errors.ts
@@ -1,21 +1,42 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
 
 export class ConflictingFunctionDeployFlagsError extends Data.TaggedError(
   "ConflictingFunctionDeployFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class InvalidFunctionDeploySlugError extends Data.TaggedError(
   "InvalidFunctionDeploySlugError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class NoFunctionsToDeployError extends Data.TaggedError("NoFunctionsToDeployError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class FunctionDeployCancelledError extends Data.TaggedError("FunctionDeployCancelledError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -2,7 +2,12 @@ import { brotliCompressSync, constants as zlibConstants } from "node:zlib";
 import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { URL } from "node:url";
-import { FunctionResponse, operationDefinitions, type ApiClient } from "@supabase/api/effect";
+import {
+  FunctionResponse,
+  operationDefinitions,
+  SupabaseApiInputError,
+  type ApiClient,
+} from "@supabase/api/effect";
 import {
   inferFunctionsManifest,
   loadProjectConfig,
@@ -33,6 +38,7 @@ import {
   InvalidFunctionDeploySlugError,
   NoFunctionsToDeployError,
 } from "./deploy.errors.ts";
+import { FunctionsApiStatusError, FunctionsApiTransportError } from "./functions-api.errors.ts";
 
 const COMPRESSED_ESZIP_MAGIC = "EZBR";
 const DENO1_EDGE_RUNTIME_VERSION = "1.68.4";
@@ -171,17 +177,42 @@ function decodeFunctionListResponse(value: unknown): ReadonlyArray<RemoteFunctio
   return decodeFunctionListResponseSchema(normalized);
 }
 
-function mapTransportError(prefix: string, error: unknown): Error {
+// Format a raw response body for an unexpected-status error message. When the
+// body is JSON, re-stringify it so the message stays byte-identical to the
+// previous `JSON.stringify(parsedBody)` form; otherwise fall back to the raw
+// text (a non-JSON body was previously impossible because the response was
+// eagerly JSON-decoded before the status check).
+function formatUnexpectedStatusBody(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text));
+  } catch {
+    return text;
+  }
+}
+
+function mapTransportError(
+  prefix: string,
+  error: unknown,
+): FunctionsApiTransportError | SupabaseApiInputError {
+  // The generated client's input schema rejected the request before any
+  // request was sent (e.g. a user-supplied ref failing the `ref` pattern).
+  // That is an input-phase failure, not a transport failure — pass it through
+  // unchanged so the actionability adapter classifies it as invalid input
+  // instead of network.
+  if (error instanceof SupabaseApiInputError) {
+    return error;
+  }
+
   if (HttpClientError.isHttpClientError(error)) {
     const description = error.reason.description ?? error.reason._tag;
-    return new Error(`${prefix}: ${description}`);
+    return new FunctionsApiTransportError({ message: `${prefix}: ${description}` });
   }
 
   if (error instanceof Error) {
-    return new Error(`${prefix}: ${error.message}`);
+    return new FunctionsApiTransportError({ message: `${prefix}: ${error.message}` });
   }
 
-  return new Error(`${prefix}: ${String(error)}`);
+  return new FunctionsApiTransportError({ message: `${prefix}: ${String(error)}` });
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -1514,7 +1545,7 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
 });
 
 const listRemoteFunctions = Effect.fnUntraced(function* (api: ApiClient, projectRef: string) {
-  let lastError: Error | undefined;
+  let lastError: Error | FunctionsApiStatusError | undefined;
   for (let attempt = 0; attempt <= 3; attempt += 1) {
     const result = yield* api
       .executeRaw(operationDefinitions.v1ListAllFunctions, { ref: projectRef })
@@ -1531,15 +1562,23 @@ const listRemoteFunctions = Effect.fnUntraced(function* (api: ApiClient, project
     if (result.success) {
       const body = yield* result.response.text.pipe(Effect.orElseSucceed(() => ""));
       if (result.response.status === 200) {
+        // A 200 whose body is not the expected JSON is an API-response problem,
+        // not a transport failure — surface it via FunctionsApiStatusError so it
+        // classifies as api_status rather than network.
         return yield* Effect.try({
           try: () => decodeFunctionListResponse(JSON.parse(body)),
           catch: (error) =>
-            new Error(
-              `failed to read functions list: ${error instanceof Error ? error.message : String(error)}`,
-            ),
+            new FunctionsApiStatusError({
+              status: result.response.status,
+              message: `failed to read functions list: ${error instanceof Error ? error.message : String(error)}`,
+              decode: true,
+            }),
         });
       }
-      lastError = new Error(`unexpected list functions status ${result.response.status}: ${body}`);
+      lastError = new FunctionsApiStatusError({
+        status: result.response.status,
+        message: `unexpected list functions status ${result.response.status}: ${body}`,
+      });
       if (result.response.status < 500 && result.response.status !== 429) {
         return yield* Effect.fail(lastError);
       }
@@ -1645,12 +1684,14 @@ const uploadFunctionSource = Effect.fnUntraced(function* (
         },
       })
       .pipe(
+        // Read the body as text (never failing) so the status check below wins:
+        // a non-201 with a non-JSON body, or a 201 with malformed JSON, must
+        // classify as a status/response problem — not fall through
+        // `mapTransportError` as a network failure.
         Effect.map((raw) => ({
           status: raw.status,
           headers: raw.headers,
-          body: raw.json.pipe(
-            Effect.mapError((error) => mapTransportError("failed to deploy function", error)),
-          ),
+          body: raw.text.pipe(Effect.orElseSucceed(() => "")),
         })),
         Effect.mapError((error) => mapTransportError("failed to deploy function", error)),
       ),
@@ -1658,15 +1699,23 @@ const uploadFunctionSource = Effect.fnUntraced(function* (
   const body = yield* response.body;
   if (response.status !== 201) {
     return yield* Effect.fail(
-      new Error(`unexpected deploy status ${response.status}: ${JSON.stringify(body)}`),
+      new FunctionsApiStatusError({
+        status: response.status,
+        message: `unexpected deploy status ${response.status}: ${formatUnexpectedStatusBody(body)}`,
+      }),
     );
   }
+  // A 201 whose body is not the expected JSON is an API-response problem, not a
+  // transport failure — surface it via FunctionsApiStatusError so it classifies
+  // as api_status rather than network.
   return yield* Effect.try({
-    try: () => decodeDeployFunctionResponse(body),
+    try: () => decodeDeployFunctionResponse(JSON.parse(body)),
     catch: (error) =>
-      new Error(
-        `failed to read deploy response: ${error instanceof Error ? error.message : String(error)}`,
-      ),
+      new FunctionsApiStatusError({
+        status: response.status,
+        message: `failed to read deploy response: ${error instanceof Error ? error.message : String(error)}`,
+        decode: true,
+      }),
   });
 });
 
@@ -1691,7 +1740,7 @@ const bulkUpdateRemoteFunctions = Effect.fnUntraced(function* (
   projectRef: string,
   functions: ReadonlyArray<BulkUpdateFunction>,
 ) {
-  let lastError: Error | undefined;
+  let lastError: Error | FunctionsApiStatusError | undefined;
   for (let attempt = 0; attempt <= 3; attempt += 1) {
     const result = yield* rateLimitedRequest("bulk updating functions", () =>
       api
@@ -1700,12 +1749,12 @@ const bulkUpdateRemoteFunctions = Effect.fnUntraced(function* (
           body: functions.map(toBulkUpdateItem),
         })
         .pipe(
+          // Read the body as text (never failing) so the status check wins even
+          // if the body cannot be read.
           Effect.map((raw) => ({
             status: raw.status,
             headers: raw.headers,
-            body: raw.text.pipe(
-              Effect.mapError((error) => mapTransportError("failed to bulk update", error)),
-            ),
+            body: raw.text.pipe(Effect.orElseSucceed(() => "")),
           })),
           Effect.mapError((error) => mapTransportError("failed to bulk update", error)),
         ),
@@ -1724,7 +1773,10 @@ const bulkUpdateRemoteFunctions = Effect.fnUntraced(function* (
       if (result.response.status === 200) {
         return;
       }
-      lastError = new Error(`unexpected bulk update status ${result.response.status}: ${body}`);
+      lastError = new FunctionsApiStatusError({
+        status: result.response.status,
+        message: `unexpected bulk update status ${result.response.status}: ${body}`,
+      });
       if (result.response.status < 500) {
         return yield* Effect.fail(lastError);
       }
@@ -1746,7 +1798,7 @@ const upsertBundledFunction = Effect.fnUntraced(function* (
   exists: boolean,
 ) {
   let shouldUpdate = exists;
-  let lastError: Error | undefined;
+  let lastError: Error | FunctionsApiStatusError | undefined;
 
   for (let attempt = 0; attempt <= 3; attempt += 1) {
     const action = shouldUpdate ? "update" : "create";
@@ -1786,19 +1838,29 @@ const upsertBundledFunction = Effect.fnUntraced(function* (
     if (response.success) {
       const expectedStatus = shouldUpdate ? 200 : 201;
       if (response.value.status === expectedStatus) {
-        const body = yield* response.value.json.pipe(
-          Effect.mapError((error) => mapTransportError("failed to read function response", error)),
-        );
-        return decodeDeployFunctionResponse(body);
+        // A success status with a malformed / unexpected JSON body is an
+        // API-response problem, not a transport failure — surface it via
+        // FunctionsApiStatusError so it classifies as api_status not network.
+        const body = yield* response.value.text.pipe(Effect.orElseSucceed(() => ""));
+        return yield* Effect.try({
+          try: () => decodeDeployFunctionResponse(JSON.parse(body)),
+          catch: (error) =>
+            new FunctionsApiStatusError({
+              status: response.value.status,
+              message: `failed to read function response: ${error instanceof Error ? error.message : String(error)}`,
+              decode: true,
+            }),
+        });
       }
 
       const body = yield* response.value.text.pipe(Effect.orElseSucceed(() => ""));
       if (!shouldUpdate && body.includes("Duplicated function slug")) {
         shouldUpdate = true;
       }
-      lastError = new Error(
-        `unexpected ${action} function status ${response.value.status}: ${body}`,
-      );
+      lastError = new FunctionsApiStatusError({
+        status: response.value.status,
+        message: `unexpected ${action} function status ${response.value.status}: ${body}`,
+      });
     } else {
       lastError = response.error;
     }
@@ -1828,7 +1890,10 @@ const deleteRemoteFunction = Effect.fnUntraced(function* (
   }
   const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
   return yield* Effect.fail(
-    new Error(`unexpected delete function status ${response.status}: ${body}`),
+    new FunctionsApiStatusError({
+      status: response.status,
+      message: `unexpected delete function status ${response.status}: ${body}`,
+    }),
   );
 });
 

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -14,8 +14,9 @@ import {
   type ResolvedFunctionConfig as ManifestFunctionConfig,
 } from "@supabase/config";
 import { Duration, Effect, Option, Schema, Stream } from "effect";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import { legacyPromptYesNo } from "../legacy/legacy-prompt-yes-no.ts";
 import { CONTEXT_CANCELED_MESSAGE } from "../output/errors.ts";
 import { Output } from "../output/output.service.ts";
@@ -193,13 +194,10 @@ function formatUnexpectedStatusBody(text: string): string {
 function mapTransportError(
   prefix: string,
   error: unknown,
-): FunctionsApiTransportError | SupabaseApiInputError {
-  // The generated client's input schema rejected the request before any
-  // request was sent (e.g. a user-supplied ref failing the `ref` pattern).
-  // That is an input-phase failure, not a transport failure — pass it through
-  // unchanged so the actionability adapter classifies it as invalid input
-  // instead of network.
-  if (error instanceof SupabaseApiInputError) {
+): FunctionsApiTransportError | SupabaseApiInputError | HttpBody.HttpBodyError {
+  // The request mixes user input with CLI-generated bundle metadata. Preserve
+  // validation/build failures so their provenance is not inferred from text.
+  if (error instanceof SupabaseApiInputError || error instanceof HttpBody.HttpBodyError) {
     return error;
   }
 
@@ -1860,6 +1858,7 @@ const upsertBundledFunction = Effect.fnUntraced(function* (
       lastError = new FunctionsApiStatusError({
         status: response.value.status,
         message: `unexpected ${action} function status ${response.value.status}: ${body}`,
+        notFoundIsInvalidInput: shouldUpdate,
       });
     } else {
       lastError = response.error;

--- a/apps/cli/src/shared/functions/download.errors.ts
+++ b/apps/cli/src/shared/functions/download.errors.ts
@@ -1,29 +1,66 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
 
 export class InvalidFunctionSlugError extends Data.TaggedError("InvalidFunctionSlugError")<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class ConflictingFunctionDownloadFlagsError extends Data.TaggedError(
   "ConflictingFunctionDownloadFlagsError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class FunctionDownloadNotFoundError extends Data.TaggedError(
   "FunctionDownloadNotFoundError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 export class InvalidFunctionDownloadResponseError extends Data.TaggedError(
   "InvalidFunctionDownloadResponseError",
 )<{
   readonly message: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    // Every construction is a 200-response whose multipart/metadata/list body
+    // failed to decode — an API response problem, not a raw status failure.
+    return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+  }
+}
 
 export class UnsafeFunctionDownloadPathError extends Data.TaggedError(
   "UnsafeFunctionDownloadPathError",
 )<{
   readonly message: string;
-}> {}
+  /**
+   * True when a 200 response's multipart filename/metadata entrypoint
+   * resolved outside `supabase/functions` — an API response problem, not a
+   * local write/rename failure (the other construction sites, which keep the
+   * default `permission` classification).
+   */
+  readonly unsafeResponsePath?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.unsafeResponsePath === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    return actionability.permission;
+  }
+}

--- a/apps/cli/src/shared/functions/download.errors.unit.test.ts
+++ b/apps/cli/src/shared/functions/download.errors.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../telemetry/error-actionability.ts";
+import { UnsafeFunctionDownloadPathError } from "./download.errors.ts";
+
+describe("UnsafeFunctionDownloadPathError actionability", () => {
+  it("classifies a response-derived unsafe path as an API response problem", () => {
+    const result = classifyCliErrorActionability(
+      new UnsafeFunctionDownloadPathError({
+        message: "refusing to extract Function file outside supabase/functions: ../evil",
+        unsafeResponsePath: true,
+      }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:UnsafeFunctionDownloadPathError:api_response");
+  });
+
+  it("keeps a local temp-file write/rename failure on the permission policy", () => {
+    const result = classifyCliErrorActionability(
+      new UnsafeFunctionDownloadPathError({
+        message: "failed to write Function file: index.ts: EACCES",
+      }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("permission");
+    expect(result.error_fingerprint).toBe("tag:UnsafeFunctionDownloadPathError");
+  });
+
+  it("keeps an explicitly-false unsafeResponsePath on the permission policy", () => {
+    const result = classifyCliErrorActionability(
+      new UnsafeFunctionDownloadPathError({
+        message: "failed to create temporary Function file while extracting index.ts: EACCES",
+        unsafeResponsePath: false,
+      }),
+    );
+    expect(result.error_category).toBe("permission");
+  });
+});

--- a/apps/cli/src/shared/functions/download.ts
+++ b/apps/cli/src/shared/functions/download.ts
@@ -1,4 +1,4 @@
-import { operationDefinitions, type ApiClient } from "@supabase/api/effect";
+import { operationDefinitions, SupabaseApiInputError, type ApiClient } from "@supabase/api/effect";
 import { randomUUID } from "node:crypto";
 import { open, rename, rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
@@ -23,6 +23,7 @@ import {
   InvalidFunctionSlugError,
   UnsafeFunctionDownloadPathError,
 } from "./download.errors.ts";
+import { FunctionsApiStatusError, FunctionsApiTransportError } from "./functions-api.errors.ts";
 
 const legacyEntrypointPath = "file:///src/index.ts";
 
@@ -149,17 +150,29 @@ function validateDownloadFlags(
       );
 }
 
-function mapTransportError(prefix: string, error: unknown): Error {
+function mapTransportError(
+  prefix: string,
+  error: unknown,
+): FunctionsApiTransportError | SupabaseApiInputError {
+  // The generated client's input schema rejected the request before any
+  // request was sent (e.g. a user-supplied ref failing the `ref` pattern).
+  // That is an input-phase failure, not a transport failure — pass it through
+  // unchanged so the actionability adapter classifies it as invalid input
+  // instead of network.
+  if (error instanceof SupabaseApiInputError) {
+    return error;
+  }
+
   if (HttpClientError.isHttpClientError(error)) {
     const description = error.reason.description ?? error.reason._tag;
-    return new Error(`${prefix}: ${description}`);
+    return new FunctionsApiTransportError({ message: `${prefix}: ${description}` });
   }
 
   if (error instanceof Error) {
-    return new Error(`${prefix}: ${error.message}`);
+    return new FunctionsApiTransportError({ message: `${prefix}: ${error.message}` });
   }
 
-  return new Error(`${prefix}: ${String(error)}`);
+  return new FunctionsApiTransportError({ message: `${prefix}: ${String(error)}` });
 }
 
 function hasEntrypointPath(metadata: DownloadMetadata | undefined): metadata is {
@@ -523,6 +536,7 @@ function resolveDownloadDestination(
   return Effect.fail(
     new UnsafeFunctionDownloadPathError({
       message: `refusing to extract Function file outside ${functionsRoot}: ${partPath}`,
+      unsafeResponsePath: true,
     }),
   );
 }
@@ -535,6 +549,7 @@ function ensureContainedPath(root: string, candidate: string, sourcePath: string
   return Effect.fail(
     new UnsafeFunctionDownloadPathError({
       message: `refusing to extract Function file outside ${root}: ${sourcePath}`,
+      unsafeResponsePath: true,
     }),
   );
 }
@@ -589,7 +604,10 @@ const listRemoteFunctionSlugs = Effect.fnUntraced(function* (api: ApiClient, pro
   const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
   if (response.status !== 200) {
     return yield* Effect.fail(
-      new Error(`unexpected list functions status ${response.status}: ${body}`),
+      new FunctionsApiStatusError({
+        status: response.status,
+        message: `unexpected list functions status ${response.status}: ${body}`,
+      }),
     );
   }
 
@@ -635,7 +653,10 @@ const getRemoteFunction = Effect.fnUntraced(function* (
       );
     default:
       return yield* Effect.fail(
-        new Error(`Failed to download Function ${slug} on the Supabase project: ${body}`),
+        new FunctionsApiStatusError({
+          status: response.status,
+          message: `Failed to download Function ${slug} on the Supabase project: ${body}`,
+        }),
       );
   }
 
@@ -675,7 +696,12 @@ const downloadBody = Effect.fnUntraced(function* (
   }
 
   const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
-  return yield* Effect.fail(new Error(`Error status ${response.status}: ${body}`));
+  return yield* Effect.fail(
+    new FunctionsApiStatusError({
+      status: response.status,
+      message: `Error status ${response.status}: ${body}`,
+    }),
+  );
 });
 
 const downloadSingle = Effect.fnUntraced(function* (

--- a/apps/cli/src/shared/functions/download.ts
+++ b/apps/cli/src/shared/functions/download.ts
@@ -4,6 +4,7 @@ import { open, rename, rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Effect, FileSystem, Option } from "effect";
+import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import { Output } from "../output/output.service.ts";
@@ -153,13 +154,10 @@ function validateDownloadFlags(
 function mapTransportError(
   prefix: string,
   error: unknown,
-): FunctionsApiTransportError | SupabaseApiInputError {
-  // The generated client's input schema rejected the request before any
-  // request was sent (e.g. a user-supplied ref failing the `ref` pattern).
-  // That is an input-phase failure, not a transport failure — pass it through
-  // unchanged so the actionability adapter classifies it as invalid input
-  // instead of network.
-  if (error instanceof SupabaseApiInputError) {
+): FunctionsApiTransportError | SupabaseApiInputError | HttpBody.HttpBodyError {
+  // This mapper is shared by requests with different input ownership. Preserve
+  // validation/build failures so their provenance is not inferred from text.
+  if (error instanceof SupabaseApiInputError || error instanceof HttpBody.HttpBodyError) {
     return error;
   }
 
@@ -700,6 +698,7 @@ const downloadBody = Effect.fnUntraced(function* (
     new FunctionsApiStatusError({
       status: response.status,
       message: `Error status ${response.status}: ${body}`,
+      notFoundIsInvalidInput: true,
     }),
   );
 });

--- a/apps/cli/src/shared/functions/functions-api.errors.ts
+++ b/apps/cli/src/shared/functions/functions-api.errors.ts
@@ -1,0 +1,55 @@
+import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "../telemetry/error-actionability.ts";
+
+/**
+ * Shared error for a non-OK Management API response where an HTTP status
+ * code is available, used by both `deploy.ts` and `download.ts`. Keeping one
+ * class here (rather than duplicating it per file) lets both call sites
+ * classify identically via {@link statusCodeActionability} instead of
+ * falling back to a plain `Error` (which reports as `unknown` in the error
+ * actionability KPI).
+ */
+export class FunctionsApiStatusError extends Data.TaggedError("FunctionsApiStatusError")<{
+  readonly status: number;
+  readonly message: string;
+  /** The request path names a user-selected function slug. */
+  readonly notFoundIsInvalidInput?: boolean;
+  /**
+   * Set when the failure is a successful-status response whose body could not
+   * be decoded (status is 200/201 but the JSON is malformed / unexpected).
+   * That is an API-response problem, not a raw status failure, so it classifies
+   * as `api_status` with the `api_response` fingerprint ahead of the
+   * status-code policy.
+   */
+  readonly decode?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    if (this.decode === true) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    return statusCodeActionability(this.status, {
+      notFoundIsInvalidInput: this.notFoundIsInvalidInput,
+    });
+  }
+}
+
+/**
+ * Shared error for a Management API request that failed before a response
+ * was received (DNS, connection reset, timeout, ...), used by both
+ * `deploy.ts` and `download.ts`'s `mapTransportError`. Keeping one class here
+ * (rather than duplicating it per file) lets both call sites classify
+ * identically as a network failure instead of falling back to a plain
+ * `Error` (which reports as `unknown` in the error actionability KPI).
+ */
+export class FunctionsApiTransportError extends Data.TaggedError("FunctionsApiTransportError")<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+  }
+}

--- a/apps/cli/src/shared/functions/functions-api.errors.unit.test.ts
+++ b/apps/cli/src/shared/functions/functions-api.errors.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { classifyCliErrorActionability } from "../telemetry/error-actionability.ts";
+import { FunctionsApiStatusError } from "./functions-api.errors.ts";
+
+describe("FunctionsApiStatusError actionability", () => {
+  it("keeps a collection-level 404 on the API-status policy", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({ status: 404, message: "not found" }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:FunctionsApiStatusError:api_status");
+  });
+
+  it("classifies a user-selected function slug 404 as invalid input", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({
+        status: 404,
+        message: "not found",
+        notFoundIsInvalidInput: true,
+      }),
+    );
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_input");
+    expect(result.error_fingerprint).toBe("tag:FunctionsApiStatusError:not_found");
+  });
+
+  it("keeps a 401 on the auth-login policy", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({ status: 401, message: "unauthorized" }),
+    );
+    expect(result.error_category).toBe("auth");
+  });
+
+  it("keeps a 5xx on the API status policy", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({ status: 500, message: "server error" }),
+    );
+    expect(result.error_category).toBe("api_status");
+  });
+
+  it("classifies a successful-status decode failure as an api-response problem", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({
+        status: 201,
+        message: "failed to read deploy response: unexpected token",
+        decode: true,
+      }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:FunctionsApiStatusError:api_response");
+  });
+
+  it("classifies a 200 list-functions decode failure as an api-response problem", () => {
+    const result = classifyCliErrorActionability(
+      new FunctionsApiStatusError({
+        status: 200,
+        message: "failed to read functions list: unexpected token",
+        decode: true,
+      }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:FunctionsApiStatusError:api_response");
+  });
+});

--- a/apps/cli/src/shared/init/project-init.errors.ts
+++ b/apps/cli/src/shared/init/project-init.errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
 
 export class InitParseSettingsError extends Data.TaggedError("InitParseSettingsError")<{
   readonly detail: string;
@@ -6,5 +11,9 @@ export class InitParseSettingsError extends Data.TaggedError("InitParseSettingsE
 }> {
   override get message() {
     return "Failed to parse existing IDE settings file.";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
   }
 }

--- a/apps/cli/src/shared/legacy/legacy-go-child-exit.error.ts
+++ b/apps/cli/src/shared/legacy/legacy-go-child-exit.error.ts
@@ -1,5 +1,11 @@
 import { Data, Runtime } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+
 /**
  * A spawned `supabase-go` child process — via `LegacyGoProxy.exec`/`execCapture`, or
  * (historically, before CLI-1955 removed it) the hidden `db __db-bootstrap` seam —
@@ -52,4 +58,8 @@ export class LegacyGoChildExitError extends Data.TaggedError("LegacyGoChildExitE
   readonly message: string;
 }> {
   override readonly [Runtime.errorExitCode] = this.exitCode;
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.unknown;
+  }
 }

--- a/apps/cli/src/shared/output/errors.ts
+++ b/apps/cli/src/shared/output/errors.ts
@@ -1,4 +1,9 @@
 import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
 
 /**
  * Byte-for-byte render of Go's `context.Canceled` sentinel.
@@ -32,5 +37,9 @@ export class NonInteractiveError extends Data.TaggedError("NonInteractiveError")
 }> {
   override get message() {
     return `${this.detail}\n  Suggestion: ${this.suggestion}`;
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
   }
 }

--- a/apps/cli/src/shared/runtime/file-watcher.service.ts
+++ b/apps/cli/src/shared/runtime/file-watcher.service.ts
@@ -1,6 +1,12 @@
 import type { Stream } from "effect";
 import { Data, Context } from "effect";
 
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+
 type FileWatchEventType = "create" | "update" | "delete";
 
 export interface FileWatchEvent {
@@ -15,7 +21,11 @@ export interface FileWatchOptions {
 export class FileWatcherError extends Data.TaggedError("FileWatcherError")<{
   readonly path: string;
   readonly cause: unknown;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
 
 interface FileWatcherShape {
   readonly watch: (

--- a/apps/cli/src/shared/services/services.shared.ts
+++ b/apps/cli/src/shared/services/services.shared.ts
@@ -5,6 +5,11 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import { renderGlamourTable } from "../../legacy/output/legacy-glamour-table.ts";
 import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+import {
   dockerfileServiceImages,
   parseDockerfileServiceImages,
   type DockerfileImageSpec,
@@ -197,9 +202,14 @@ export interface ServiceFetchConfig {
   readonly tenantBaseUrlOverride?: string;
 }
 
-class ServiceVersionNotFoundError extends Data.TaggedError("ServiceVersionNotFoundError")<{
+/** @public */
+export class ServiceVersionNotFoundError extends Data.TaggedError("ServiceVersionNotFoundError")<{
   readonly service: string;
-}> {}
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
 
 function fieldValue(value: unknown, key: string): unknown {
   if (typeof value !== "object" || value === null) {

--- a/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Vitest (via Vite) provides `import.meta.glob` at runtime; the workspace
+// tsconfig does not load `vite/client`, so declare the one member we use.
+declare global {
+  interface ImportMeta {
+    readonly glob: (patterns: ReadonlyArray<string>) => Record<string, () => Promise<unknown>>;
+  }
+}
+import {
+  CliErrorCategory,
+  CliErrorKind,
+  CliSuggestionType,
+  ErrorActionabilityId,
+  isClassifiedExternalErrorTag,
+} from "./error-actionability.ts";
+
+/**
+ * Drift guard for the error actionability taxonomy: every error class defined
+ * in `apps/cli/src` must declare its own classification under
+ * {@link ErrorActionabilityId}, and every error tag defined in the workspace
+ * packages that can surface through CLI commands must have an external
+ * adapter. A new error type failing here is the feature — `unknown` in
+ * production telemetry must mean "genuinely unforeseen failure", never "we
+ * forgot to classify".
+ */
+
+// Matches every way an error class is defined in this workspace: direct
+// `Data.TaggedError("Tag")`, any local `*Error(...)` factory whose heritage
+// call carries the tag literal (`CliError("Tag")`, `LoginError("Tag")`, ...),
+// and plain `extends Error` classes (identified by class name). Error
+// factories must therefore be named `<Something>Error` to stay guarded —
+// which also keeps `Data.TaggedClass` event types out of the scan.
+const ERROR_DEFINITION_PATTERN =
+  /TaggedError\(\s*"([A-Za-z0-9_]+)"|class\s+[A-Za-z0-9_]+\s+extends\s+[A-Za-z0-9_.]*Error\(\s*"([A-Za-z0-9_]+)"|class\s+([A-Za-z0-9_]+)\s+extends\s+Error\b/gs;
+
+function scanErrorTags(root: string): Map<string, Array<string>> {
+  const tagsByFile = new Map<string, Array<string>>();
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!path.endsWith(".ts") || path.endsWith(".test.ts")) continue;
+      const tags = [...readFileSync(path, "utf8").matchAll(ERROR_DEFINITION_PATTERN)].map(
+        (match) => match[1] ?? match[2] ?? match[3] ?? "",
+      );
+      if (tags.length > 0) tagsByFile.set(path, tags);
+    }
+  };
+  walk(root);
+  return tagsByFile;
+}
+
+const kindValues = new Set<string>(Object.values(CliErrorKind));
+const categoryValues = new Set<string>(Object.values(CliErrorCategory));
+const suggestionValues = new Set<string>(Object.values(CliSuggestionType));
+
+interface DeclaredErrorClass {
+  readonly exportName: string;
+  readonly tag: string;
+  readonly prototype: object;
+}
+
+function collectErrorClasses(module: Record<string, unknown>): Array<DeclaredErrorClass> {
+  const classes: Array<DeclaredErrorClass> = [];
+  for (const [exportName, value] of Object.entries(module)) {
+    if (typeof value !== "function") continue;
+    const prototype: unknown = value.prototype;
+    if (typeof prototype !== "object" || prototype === null) continue;
+    if (!(prototype instanceof Error)) continue;
+    // effect V4 assigns `_tag` per instance, so probe with an empty props bag.
+    // Plain `extends Error` classes have no `_tag`; identify them by class name.
+    let tag: unknown;
+    try {
+      tag = Reflect.get(Reflect.construct(value, [{}]), "_tag");
+    } catch {
+      tag = undefined;
+    }
+    classes.push({ exportName, tag: typeof tag === "string" ? tag : exportName, prototype });
+  }
+  return classes;
+}
+
+const srcRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(import.meta.dirname, "../../../../..");
+
+const moduleLoaders = new Map(
+  Object.entries(import.meta.glob(["../../**/*.ts", "!**/*.test.ts"])).map(([key, loader]) => [
+    resolve(import.meta.dirname, key),
+    loader,
+  ]),
+);
+
+describe("apps/cli error classes declare their actionability", () => {
+  const tagsByFile = scanErrorTags(srcRoot);
+
+  it("finds the error definition surface", () => {
+    expect(tagsByFile.size).toBeGreaterThan(50);
+  });
+
+  for (const [file, tags] of tagsByFile) {
+    const relativePath = file.slice(srcRoot.length + 1);
+    // Importing a command module can pull in a large transitive graph on first
+    // load; give these dynamic-import tests more headroom than the default 5s.
+    it(relativePath, { timeout: 30_000 }, async () => {
+      const loader = moduleLoaders.get(file);
+      expect(loader, `no module loader for ${relativePath}`).toBeDefined();
+      const module = await loader?.();
+      expect(typeof module).toBe("object");
+      const classes = collectErrorClasses(Object(module));
+
+      const exportedTags = new Set(classes.map((cls) => cls.tag));
+      for (const tag of tags) {
+        expect(
+          exportedTags.has(tag),
+          `error "${tag}" is defined in ${relativePath} but not exported — export it so its actionability declaration is verifiable`,
+        ).toBe(true);
+      }
+
+      for (const { exportName, tag, prototype } of classes) {
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, ErrorActionabilityId);
+        expect(
+          typeof descriptor?.get,
+          `${exportName} ("${tag}") does not declare an own [ErrorActionabilityId] getter — add one returning its CliErrorActionabilityDeclaration`,
+        ).toBe("function");
+
+        // Evaluate the getter against a field-less probe: instance-dependent
+        // declarations must degrade to a valid declaration when fields are
+        // absent, and static ones are checked directly.
+        const probe: object = Object.create(prototype);
+        const declaration: unknown = Reflect.get(probe, ErrorActionabilityId);
+        expect(
+          typeof declaration === "object" && declaration !== null,
+          `${exportName} ("${tag}") declaration is not an object`,
+        ).toBe(true);
+        const record: Record<string, unknown> = Object(declaration);
+        expect(kindValues.has(String(record["error_kind"]))).toBe(true);
+        expect(categoryValues.has(String(record["error_category"]))).toBe(true);
+        expect(typeof record["has_suggestion"]).toBe("boolean");
+        expect(suggestionValues.has(String(record["suggestion_type"]))).toBe(true);
+      }
+    });
+  }
+});
+
+describe("workspace package error tags have external adapters", () => {
+  const packageRoots = [
+    "packages/api/src",
+    "packages/stack/src",
+    "packages/config/src",
+    "packages/process-compose/src",
+  ];
+
+  for (const packageRoot of packageRoots) {
+    it(packageRoot, () => {
+      const tagsByFile = scanErrorTags(resolve(repoRoot, packageRoot));
+      expect(tagsByFile.size).toBeGreaterThan(0);
+      for (const [file, tags] of tagsByFile) {
+        for (const tag of tags) {
+          expect(
+            isClassifiedExternalErrorTag(tag),
+            `"${tag}" (${file.slice(repoRoot.length + 1)}) has no external adapter in error-actionability.ts`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});

--- a/apps/cli/src/shared/telemetry/error-actionability.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.ts
@@ -1,0 +1,1031 @@
+import { Cause, Option } from "effect";
+
+/**
+ * CLI error actionability taxonomy for KPI reporting (CLI-1560).
+ *
+ * Classification is declared where each error is defined: every error class in
+ * `apps/cli/src` exposes a {@link CliErrorActionabilityDeclaration} under the
+ * {@link ErrorActionabilityId} symbol (enforced by
+ * `error-actionability-coverage.unit.test.ts`). Errors originating outside the
+ * CLI workspace (`@supabase/stack`, `@supabase/config`,
+ * `@supabase/process-compose`, `effect` cli/http) are classified by the
+ * structural adapters at the bottom of this module, which are themselves
+ * exhaustiveness-checked against those packages' sources.
+ *
+ * Everything emitted from here is sanitized by construction: kinds, categories,
+ * suggestion types, and fingerprints are closed enums or `tag:`-prefixed safe
+ * identifiers — never raw error text or user-specific data.
+ */
+
+export const CliErrorKind = {
+  UserActionable: "user_actionable",
+  InternalBug: "internal_bug",
+  ExternalService: "external_service",
+  UserCancelled: "user_cancelled",
+  Unknown: "unknown",
+} as const;
+
+export type CliErrorKind = (typeof CliErrorKind)[keyof typeof CliErrorKind];
+
+export const CliErrorCategory = {
+  Auth: "auth",
+  MissingProjectRef: "missing_project_ref",
+  ProjectNotLinked: "project_not_linked",
+  DockerNotRunning: "docker_not_running",
+  InvalidConfig: "invalid_config",
+  DbConnection: "db_connection",
+  MigrationDrift: "migration_drift",
+  Permission: "permission",
+  PlanLimit: "plan_limit",
+  ProjectPaused: "project_paused",
+  InvalidInput: "invalid_input",
+  Network: "network",
+  ApiStatus: "api_status",
+  Cancelled: "cancelled",
+  Panic: "panic",
+  ImpossibleState: "impossible_state",
+  Unknown: "unknown",
+} as const;
+
+export type CliErrorCategory = (typeof CliErrorCategory)[keyof typeof CliErrorCategory];
+
+export const CliSuggestionType = {
+  Login: "login",
+  LinkProject: "link_project",
+  StartDocker: "start_docker",
+  ProvideFlags: "provide_flags",
+  SetEnvVar: "set_env_var",
+  RepairMigration: "repair_migration",
+  UpdateConfig: "update_config",
+  RunCommand: "run_command",
+  UpgradePlan: "upgrade_plan",
+  RerunDebug: "rerun_debug",
+  OpenDashboard: "open_dashboard",
+  None: "none",
+} as const;
+
+export type CliSuggestionType = (typeof CliSuggestionType)[keyof typeof CliSuggestionType];
+
+const CLI_SUGGESTED_COMMANDS = [
+  "supabase branches create",
+  "supabase link",
+  "supabase login",
+  "supabase start",
+  "supabase stop",
+] as const;
+
+type CliSuggestedCommand = (typeof CLI_SUGGESTED_COMMANDS)[number];
+
+const CLI_ERROR_FINGERPRINT_SUFFIXES = [
+  "api_response",
+  "api_status",
+  "asset_checksum",
+  "asset_preparation",
+  "auth",
+  "bad_argument",
+  "conflict",
+  "cancelled",
+  "connect",
+  "container_configuration",
+  "daemon_start",
+  "daemon_protocol",
+  "daemon_status",
+  "daemon_transport",
+  "database",
+  "docker_not_running",
+  "filesystem",
+  "forbidden",
+  "gateway_auth",
+  "image_inspect",
+  "invalid_content",
+  "invalid_url",
+  "internal_build",
+  "invalid_config",
+  "network",
+  "not_found",
+  "plan_limit",
+  "platform_error",
+  "port_allocation",
+  "port_conflict",
+  "query",
+  "registry_pull",
+  "replication_slots_active",
+  "replication_slots_query",
+  "request_encoding",
+  "request_input",
+  "saml_disabled",
+] as const;
+
+type CliErrorFingerprintSuffix = (typeof CLI_ERROR_FINGERPRINT_SUFFIXES)[number];
+
+type UserActionableErrorCategory =
+  | typeof CliErrorCategory.Auth
+  | typeof CliErrorCategory.MissingProjectRef
+  | typeof CliErrorCategory.ProjectNotLinked
+  | typeof CliErrorCategory.DockerNotRunning
+  | typeof CliErrorCategory.InvalidConfig
+  | typeof CliErrorCategory.DbConnection
+  | typeof CliErrorCategory.MigrationDrift
+  | typeof CliErrorCategory.Permission
+  | typeof CliErrorCategory.PlanLimit
+  | typeof CliErrorCategory.ProjectPaused
+  | typeof CliErrorCategory.InvalidInput;
+
+type CliErrorKindCategory =
+  | {
+      readonly error_kind: typeof CliErrorKind.UserActionable;
+      readonly error_category: UserActionableErrorCategory;
+    }
+  | {
+      readonly error_kind: typeof CliErrorKind.InternalBug;
+      readonly error_category:
+        | typeof CliErrorCategory.Panic
+        | typeof CliErrorCategory.ImpossibleState;
+    }
+  | {
+      readonly error_kind: typeof CliErrorKind.ExternalService;
+      readonly error_category: typeof CliErrorCategory.Network | typeof CliErrorCategory.ApiStatus;
+    }
+  | {
+      readonly error_kind: typeof CliErrorKind.UserCancelled;
+      readonly error_category: typeof CliErrorCategory.Cancelled;
+    }
+  | {
+      readonly error_kind: typeof CliErrorKind.Unknown;
+      readonly error_category: typeof CliErrorCategory.Unknown;
+    };
+
+type CliErrorSuggestion =
+  | {
+      readonly has_suggestion: false;
+      readonly suggestion_type: typeof CliSuggestionType.None;
+      readonly suggested_command?: never;
+    }
+  | {
+      readonly has_suggestion: true;
+      readonly suggestion_type: typeof CliSuggestionType.Login;
+      readonly suggested_command?: "supabase login";
+    }
+  | {
+      readonly has_suggestion: true;
+      readonly suggestion_type: typeof CliSuggestionType.LinkProject;
+      readonly suggested_command?: "supabase link";
+    }
+  | {
+      readonly has_suggestion: true;
+      readonly suggestion_type: typeof CliSuggestionType.RunCommand;
+      readonly suggested_command?: "supabase branches create" | "supabase start" | "supabase stop";
+    }
+  | {
+      readonly has_suggestion: true;
+      readonly suggestion_type: Exclude<
+        CliSuggestionType,
+        | typeof CliSuggestionType.None
+        | typeof CliSuggestionType.Login
+        | typeof CliSuggestionType.LinkProject
+        | typeof CliSuggestionType.RunCommand
+      >;
+      readonly suggested_command?: never;
+    };
+
+/** Q2 KPI metric definitions, kept next to the taxonomy they consume. */
+export const CliErrorActionabilityMetricDefinitions = {
+  strictRecovery: {
+    id: "same_command_success_same_session",
+    event: "cli_command_executed",
+    partition_by: ["device_id", "$session_id", "command"],
+    command_identity:
+      "Exact equality of the command property, which is the normalized command path emitted by CLI instrumentation without argument values.",
+    order_by: "event timestamp ascending",
+    eligible_failure: "exit_code != 0 AND error_kind = 'user_actionable'",
+    recovered_when:
+      "For eligible failure F, there exists event S with S.timestamp > F.timestamp, S.exit_code = 0, and S.device_id = F.device_id, S.$session_id = F.$session_id, and S.command = F.command. Intervening events do not change the result.",
+    reset_when:
+      "The observation window ends with the $session_id. A success with a different device_id, $session_id, or command never counts.",
+    description:
+      "A user-actionable failure is recovered only when the same normalized command later succeeds for the same device_id and $session_id.",
+  },
+  repeatError: {
+    id: "same_command_same_error_same_session_before_success",
+    event: "cli_command_executed",
+    partition_by: ["device_id", "$session_id", "command"],
+    command_identity:
+      "Exact equality of the command property, which is the normalized command path emitted by CLI instrumentation without argument values.",
+    order_by: "event timestamp ascending",
+    eligible_failure: "exit_code != 0 AND error_fingerprint IS NOT NULL",
+    repeated_when:
+      "Failed event F is a repeat when an earlier failed event P in the same partition has P.error_fingerprint = F.error_fingerprint and no event S in that partition has P.timestamp < S.timestamp < F.timestamp and S.exit_code = 0.",
+    reset_when:
+      "Any exit_code = 0 event in the partition clears every prior fingerprint for that command. A different $session_id starts a new partition; successes for other commands do not reset it.",
+    description:
+      "The second and each later occurrence of the same error_fingerprint is a repeat until that normalized command succeeds or the session changes.",
+  },
+  internalUnknownBugRate: {
+    id: "failed_commands_internal_bug_or_unknown",
+    event: "cli_command_executed",
+    denominator: "count where exit_code != 0",
+    numerator: "count where exit_code != 0 AND error_kind IN ('internal_bug', 'unknown')",
+    description:
+      "Internal/unknown bug failure rate is the share of failed commands classified as internal_bug or unknown.",
+  },
+} as const;
+
+/**
+ * Symbol under which CLI error classes declare their own actionability.
+ * It is intentionally absent from the global symbol registry, so errors from
+ * dependencies cannot impersonate a CLI-owned declaration.
+ *
+ * Declare it as a getter so it lives on the prototype (visible to the coverage
+ * test without instantiating the class) and can branch on instance fields:
+ *
+ * ```ts
+ * class MyStatusError extends Data.TaggedError(tag)<{ status: number }> {
+ *   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+ *     return statusCodeActionability(this.status);
+ *   }
+ * }
+ * ```
+ */
+export const ErrorActionabilityId: unique symbol = Symbol(
+  "@supabase/cli/telemetry/ErrorActionability",
+);
+
+/**
+ * Closed metadata declared by each error class. `has_suggestion` describes a
+ * canonical remediation; raw instance suggestion text is never inspected.
+ */
+export type CliErrorActionabilityDeclaration = CliErrorKindCategory &
+  CliErrorSuggestion & {
+    /**
+     * Distinguishes branches of instance-dependent declarations in the repeat
+     * fingerprint, so e.g. a registry pull failure and a daemon-down failure of
+     * the same wrapper tag never count as repeats of one another. Must be a
+     * static safe identifier, never derived from error text.
+     */
+    readonly fingerprint_suffix?: CliErrorFingerprintSuffix;
+  };
+
+/** Sanitized classification emitted with failed `cli_command_executed` events. */
+export type CliErrorActionability = CliErrorKindCategory &
+  CliErrorSuggestion & {
+    readonly error_fingerprint: string;
+  };
+
+/** Shared declarations for the recurring classification shapes. */
+export const actionability = {
+  authLogin: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.Auth,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.Login,
+    suggested_command: "supabase login",
+  },
+  authToken: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.Auth,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.SetEnvVar,
+  },
+  provideFlags: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidInput,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.ProvideFlags,
+  },
+  invalidInput: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidInput,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+  invalidConfig: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidConfig,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.UpdateConfig,
+  },
+  /**
+   * A database operation failed because of the user's own SQL, schema, or
+   * data — actionable, but the CLI has no generic remediation to suggest.
+   */
+  dbFinding: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidConfig,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+  dbConnection: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.DbConnection,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.UpdateConfig,
+  },
+  migrationDrift: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.MigrationDrift,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RepairMigration,
+  },
+  permission: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.Permission,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+  accountAccess: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.Permission,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.Login,
+    suggested_command: "supabase login",
+  },
+  planLimit: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.PlanLimit,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.UpgradePlan,
+  },
+  projectNotLinked: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.ProjectNotLinked,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.LinkProject,
+    suggested_command: "supabase link",
+  },
+  missingProjectRef: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.MissingProjectRef,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.LinkProject,
+    suggested_command: "supabase link",
+  },
+  /** Local link state exists but is unusable — re-linking repairs it. */
+  relinkProject: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidConfig,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.LinkProject,
+    suggested_command: "supabase link",
+  },
+  dockerNotRunning: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.DockerNotRunning,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.StartDocker,
+  },
+  startStack: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidConfig,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RunCommand,
+    suggested_command: "supabase start",
+  },
+  stopStack: {
+    error_kind: CliErrorKind.UserActionable,
+    error_category: CliErrorCategory.InvalidConfig,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RunCommand,
+    suggested_command: "supabase stop",
+  },
+  externalNetwork: {
+    error_kind: CliErrorKind.ExternalService,
+    error_category: CliErrorCategory.Network,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RerunDebug,
+  },
+  apiStatus: {
+    error_kind: CliErrorKind.ExternalService,
+    error_category: CliErrorCategory.ApiStatus,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+  cancelled: {
+    error_kind: CliErrorKind.UserCancelled,
+    error_category: CliErrorCategory.Cancelled,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+  internalPanic: {
+    error_kind: CliErrorKind.InternalBug,
+    error_category: CliErrorCategory.Panic,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RerunDebug,
+  },
+  impossibleState: {
+    error_kind: CliErrorKind.InternalBug,
+    error_category: CliErrorCategory.ImpossibleState,
+    has_suggestion: true,
+    suggestion_type: CliSuggestionType.RerunDebug,
+  },
+  unknown: {
+    error_kind: CliErrorKind.Unknown,
+    error_category: CliErrorCategory.Unknown,
+    has_suggestion: false,
+    suggestion_type: CliSuggestionType.None,
+  },
+} as const satisfies Record<string, CliErrorActionabilityDeclaration>;
+
+/**
+ * The declaration for a failure confirmed plan-gated by the entitlement
+ * check (`legacySuggestUpgrade`). Shared so every gated surface groups under
+ * the same fingerprint family.
+ */
+export const planLimitGatedActionability: CliErrorActionabilityDeclaration = {
+  ...actionability.planLimit,
+  fingerprint_suffix: "plan_limit",
+};
+
+/**
+ * Classification policy for errors that carry a Management API status code.
+ * `upgradeSuggested` is the typed result of the entitlement gate
+ * (`legacySuggestUpgrade`) threaded through the error constructor — never
+ * inferred from message text.
+ *
+ * A 404 is user-actionable only when the caller knows the endpoint names a
+ * user-selected resource. List and discovery endpoints can also return 404,
+ * so the default remains an API-status failure. The entitlement-gate branch
+ * stays ahead of that opt-in so a confirmed plan-limited 404 still classifies
+ * as `plan_limit`.
+ */
+export function statusCodeActionability(
+  status: number | undefined,
+  opts: {
+    readonly upgradeSuggested?: boolean;
+    readonly notFoundIsInvalidInput?: boolean;
+  } = {},
+): CliErrorActionabilityDeclaration {
+  if (status === 401) {
+    return { ...actionability.authLogin, fingerprint_suffix: "auth" };
+  }
+  if (opts.upgradeSuggested === true && status !== undefined && status >= 400 && status < 500) {
+    return planLimitGatedActionability;
+  }
+  if (status === 403) {
+    return { ...actionability.accountAccess, fingerprint_suffix: "forbidden" };
+  }
+  if (status === 404 && opts.notFoundIsInvalidInput === true) {
+    return { ...actionability.invalidInput, fingerprint_suffix: "not_found" };
+  }
+  if (status === undefined) {
+    return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+  }
+  return { ...actionability.apiStatus, fingerprint_suffix: "api_status" };
+}
+
+type ErrorRecord = Record<PropertyKey, unknown>;
+
+function isErrorRecord(value: unknown): value is ErrorRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: ErrorRecord, key: string): string | undefined {
+  const field = value[key];
+  return typeof field === "string" && field.trim().length > 0 ? field.trim() : undefined;
+}
+
+function readNumber(value: ErrorRecord, key: string): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+const suggestedCommandValues = new Set<string>(CLI_SUGGESTED_COMMANDS);
+const fingerprintSuffixValues = new Set<string>(CLI_ERROR_FINGERPRINT_SUFFIXES);
+
+function isUserActionableCategory(value: unknown): value is UserActionableErrorCategory {
+  return (
+    value === CliErrorCategory.Auth ||
+    value === CliErrorCategory.MissingProjectRef ||
+    value === CliErrorCategory.ProjectNotLinked ||
+    value === CliErrorCategory.DockerNotRunning ||
+    value === CliErrorCategory.InvalidConfig ||
+    value === CliErrorCategory.DbConnection ||
+    value === CliErrorCategory.MigrationDrift ||
+    value === CliErrorCategory.Permission ||
+    value === CliErrorCategory.PlanLimit ||
+    value === CliErrorCategory.ProjectPaused ||
+    value === CliErrorCategory.InvalidInput
+  );
+}
+
+function sanitizeKindCategory(kind: unknown, category: unknown): CliErrorKindCategory | undefined {
+  if (kind === CliErrorKind.UserActionable && isUserActionableCategory(category)) {
+    return { error_kind: kind, error_category: category };
+  }
+  if (
+    kind === CliErrorKind.InternalBug &&
+    (category === CliErrorCategory.Panic || category === CliErrorCategory.ImpossibleState)
+  ) {
+    return { error_kind: kind, error_category: category };
+  }
+  if (
+    kind === CliErrorKind.ExternalService &&
+    (category === CliErrorCategory.Network || category === CliErrorCategory.ApiStatus)
+  ) {
+    return { error_kind: kind, error_category: category };
+  }
+  if (kind === CliErrorKind.UserCancelled && category === CliErrorCategory.Cancelled) {
+    return { error_kind: kind, error_category: category };
+  }
+  if (kind === CliErrorKind.Unknown && category === CliErrorCategory.Unknown) {
+    return { error_kind: kind, error_category: category };
+  }
+  return undefined;
+}
+
+function isSuggestionWithRemediation(
+  value: unknown,
+): value is Exclude<CliSuggestionType, typeof CliSuggestionType.None> {
+  return (
+    value === CliSuggestionType.Login ||
+    value === CliSuggestionType.LinkProject ||
+    value === CliSuggestionType.StartDocker ||
+    value === CliSuggestionType.ProvideFlags ||
+    value === CliSuggestionType.SetEnvVar ||
+    value === CliSuggestionType.RepairMigration ||
+    value === CliSuggestionType.UpdateConfig ||
+    value === CliSuggestionType.RunCommand ||
+    value === CliSuggestionType.UpgradePlan ||
+    value === CliSuggestionType.RerunDebug ||
+    value === CliSuggestionType.OpenDashboard
+  );
+}
+
+function isSuggestedCommand(value: unknown): value is CliSuggestedCommand {
+  return typeof value === "string" && suggestedCommandValues.has(value);
+}
+
+function sanitizeSuggestion(
+  hasSuggestion: unknown,
+  suggestionType: unknown,
+  suggestedCommand: unknown,
+): CliErrorSuggestion | undefined {
+  if (
+    hasSuggestion === false &&
+    suggestionType === CliSuggestionType.None &&
+    suggestedCommand === undefined
+  ) {
+    return { has_suggestion: false, suggestion_type: suggestionType };
+  }
+  if (hasSuggestion !== true || !isSuggestionWithRemediation(suggestionType)) {
+    return undefined;
+  }
+  if (suggestedCommand === undefined) {
+    return { has_suggestion: true, suggestion_type: suggestionType };
+  }
+  if (!isSuggestedCommand(suggestedCommand)) return undefined;
+  if (suggestionType === CliSuggestionType.Login && suggestedCommand === "supabase login") {
+    return {
+      has_suggestion: true,
+      suggestion_type: suggestionType,
+      suggested_command: suggestedCommand,
+    };
+  }
+  if (suggestionType === CliSuggestionType.LinkProject && suggestedCommand === "supabase link") {
+    return {
+      has_suggestion: true,
+      suggestion_type: suggestionType,
+      suggested_command: suggestedCommand,
+    };
+  }
+  if (
+    suggestionType === CliSuggestionType.RunCommand &&
+    (suggestedCommand === "supabase branches create" ||
+      suggestedCommand === "supabase start" ||
+      suggestedCommand === "supabase stop")
+  ) {
+    return {
+      has_suggestion: true,
+      suggestion_type: suggestionType,
+      suggested_command: suggestedCommand,
+    };
+  }
+  return undefined;
+}
+
+function isFingerprintSuffix(value: unknown): value is CliErrorFingerprintSuffix {
+  return typeof value === "string" && fingerprintSuffixValues.has(value);
+}
+
+function sanitizeDeclaration(value: unknown): CliErrorActionabilityDeclaration | undefined {
+  if (!isErrorRecord(value)) return undefined;
+  const kindCategory = sanitizeKindCategory(value["error_kind"], value["error_category"]);
+  if (kindCategory === undefined) return undefined;
+  const suggestion = sanitizeSuggestion(
+    value["has_suggestion"],
+    value["suggestion_type"],
+    value["suggested_command"],
+  );
+  if (suggestion === undefined) return undefined;
+  const fingerprintSuffix = value["fingerprint_suffix"];
+  if (fingerprintSuffix === undefined) return { ...kindCategory, ...suggestion };
+  if (!isFingerprintSuffix(fingerprintSuffix)) return undefined;
+  return { ...kindCategory, ...suggestion, fingerprint_suffix: fingerprintSuffix };
+}
+
+function readDeclaration(error: unknown): CliErrorActionabilityDeclaration | undefined {
+  if (!(error instanceof Error)) return undefined;
+  try {
+    const prototype = Object.getPrototypeOf(error);
+    if (!isErrorRecord(prototype)) return undefined;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, ErrorActionabilityId);
+    if (descriptor?.get === undefined) return undefined;
+    return sanitizeDeclaration(Reflect.apply(descriptor.get, error, []));
+  } catch {
+    return undefined;
+  }
+}
+
+function safeIdentifier(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return /^[A-Za-z][A-Za-z0-9_]*$/.test(value) ? value : undefined;
+}
+
+function readErrorTag(error: unknown): string | undefined {
+  if (!isErrorRecord(error)) return undefined;
+  return safeIdentifier(readString(error, "_tag"));
+}
+
+function readErrorName(error: unknown): string | undefined {
+  if (error instanceof Error) return safeIdentifier(error.name);
+  if (!isErrorRecord(error)) return undefined;
+  return safeIdentifier(readString(error, "name"));
+}
+
+function readDeclaredErrorConstructorName(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const prototype = Object.getPrototypeOf(error);
+  if (!isErrorRecord(prototype)) return undefined;
+  const constructor = prototype["constructor"];
+  if (typeof constructor !== "function") return undefined;
+  const name = safeIdentifier(constructor.name);
+  return name === "Error" ? undefined : name;
+}
+
+function fingerprint(
+  prefix: "error" | "string" | "tag",
+  identifier: string | undefined,
+  suffix?: CliErrorFingerprintSuffix,
+): string {
+  const base = identifier === undefined ? `${prefix}:unknown` : `${prefix}:${identifier}`;
+  return suffix === undefined ? base : `${base}:${suffix}`;
+}
+
+function toActionability(
+  declaration: CliErrorActionabilityDeclaration,
+  fingerprintPrefix: "error" | "string" | "tag",
+  identifier: string | undefined,
+): CliErrorActionability {
+  const { fingerprint_suffix, ...metadata } = declaration;
+  return {
+    ...metadata,
+    error_fingerprint: fingerprint(fingerprintPrefix, identifier, fingerprint_suffix),
+  };
+}
+
+/**
+ * Adapters for errors defined outside `apps/cli`, keyed by `_tag`. Kept
+ * exhaustive against those packages' sources by
+ * `error-actionability-coverage.unit.test.ts`. Everything defined inside
+ * `apps/cli` must declare {@link ErrorActionabilityId} instead of being
+ * added here.
+ */
+const externalActionabilityByTag: Record<
+  string,
+  (error: ErrorRecord) => CliErrorActionabilityDeclaration
+> = {
+  // effect/unstable/cli parser failures (ShowHelp and UserError recurse in
+  // classifyCliErrorActionability instead of mapping here)
+  MissingOption: () => actionability.invalidInput,
+  MissingArgument: () => actionability.invalidInput,
+  DuplicateOption: () => actionability.invalidInput,
+  InvalidValue: () => actionability.invalidInput,
+  UnknownSubcommand: () => actionability.invalidInput,
+  UnrecognizedOption: () => actionability.invalidInput,
+
+  // effect PlatformError — OS/filesystem operations. `reason` is
+  // `BadArgument | SystemError`; BadArgument means the CLI itself passed a
+  // rejected argument (internal bug). Only the closed PermissionDenied and
+  // NotFound reasons have context-independent user-actionable meanings.
+  PlatformError: (error) => {
+    const reason = error["reason"];
+    const reasonTag = isErrorRecord(reason)
+      ? safeIdentifier(readString(reason, "_tag"))
+      : undefined;
+    if (reasonTag === "BadArgument") {
+      return { ...actionability.impossibleState, fingerprint_suffix: "bad_argument" };
+    }
+    if (reasonTag === "PermissionDenied") {
+      return { ...actionability.permission, fingerprint_suffix: "filesystem" };
+    }
+    if (reasonTag === "NotFound") {
+      return { ...actionability.invalidInput, fingerprint_suffix: "not_found" };
+    }
+    // The remaining closed SystemError reasons are context-dependent. Keep
+    // them unknown until a command boundary supplies a more specific wrapper
+    // instead of misreporting every local I/O failure as a permission issue.
+    return { ...actionability.unknown, fingerprint_suffix: "platform_error" };
+  },
+  BadArgument: () => ({ ...actionability.impossibleState, fingerprint_suffix: "bad_argument" }),
+
+  // @supabase/config
+  ProjectConfigParseError: () => actionability.invalidConfig,
+  ProjectEnvParseError: () => actionability.invalidConfig,
+  MissingProjectConfigValueError: () => actionability.invalidConfig,
+  DuplicateRemoteProjectIdError: () => actionability.invalidConfig,
+  InvalidRemoteProjectIdError: () => actionability.invalidConfig,
+
+  // @supabase/api — client construction failed before any request (missing
+  // access token / bad configuration); remediation is the token env var.
+  SupabaseApiConfigError: () => actionability.authToken,
+
+  // @supabase/api — the generated client's input schema rejected a request
+  // before it was sent. Treat it as an internal request-construction failure
+  // unless the command boundary explicitly marked the whole request as
+  // user-derived; never infer provenance from the schema error message.
+  SupabaseApiInputError: (error) =>
+    readString(error, "source") === "user_input"
+      ? { ...actionability.invalidInput, fingerprint_suffix: "request_input" }
+      : { ...actionability.impossibleState, fingerprint_suffix: "request_encoding" },
+
+  // effect/unstable/http — generated Management API client transport/decoding
+  HttpClientError: (error) => {
+    const reason = error["reason"];
+    const reasonTag = isErrorRecord(reason) ? readString(reason, "_tag") : undefined;
+    const response = error["response"];
+    const status = isErrorRecord(response) ? readNumber(response, "status") : undefined;
+    if (reasonTag === "DecodeError" || reasonTag === "EmptyBodyError") {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_response" };
+    }
+    if (status === 401) return { ...actionability.authLogin, fingerprint_suffix: "auth" };
+    if (status === 403) return { ...actionability.accountAccess, fingerprint_suffix: "forbidden" };
+    if (reasonTag === "StatusCodeError" || isErrorRecord(response)) {
+      return { ...actionability.apiStatus, fingerprint_suffix: "api_status" };
+    }
+    return { ...actionability.externalNetwork, fingerprint_suffix: "network" };
+  },
+  // Request-body construction failed before the HTTP request was sent. The
+  // generated client owns this encoding boundary, so it is an impossible
+  // state rather than an API-response failure.
+  HttpBodyError: () => ({
+    ...actionability.impossibleState,
+    fingerprint_suffix: "request_encoding",
+  }),
+  SchemaError: () => ({ ...actionability.apiStatus, fingerprint_suffix: "api_response" }),
+
+  // @supabase/stack — StackError is a plain Error subclass matched by `name`
+  // in classifyCliErrorActionability, with a structured `code` field.
+  StackError: (error) =>
+    readString(error, "code") === "PORT_ALLOCATION"
+      ? { ...actionability.invalidConfig, fingerprint_suffix: "port_allocation" }
+      : actionability.unknown,
+  BinaryNotFoundError: () => actionability.invalidConfig,
+  DownloadError: () => actionability.externalNetwork,
+  ChecksumMismatchError: () => ({
+    ...actionability.externalNetwork,
+    fingerprint_suffix: "asset_checksum",
+  }),
+  DockerPullError: (error) =>
+    error["daemonDown"] === true
+      ? { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" }
+      : { ...actionability.externalNetwork, fingerprint_suffix: "registry_pull" },
+  StackBuildError: (error) => {
+    const reason = readString(error, "reason");
+    if (reason === "invalid_config") {
+      return { ...actionability.invalidConfig, fingerprint_suffix: "invalid_config" };
+    }
+    if (reason === "docker_not_running") {
+      return { ...actionability.dockerNotRunning, fingerprint_suffix: "docker_not_running" };
+    }
+    if (reason === "asset_preparation") {
+      return { ...actionability.externalNetwork, fingerprint_suffix: "asset_preparation" };
+    }
+    return { ...actionability.impossibleState, fingerprint_suffix: "internal_build" };
+  },
+  PortConflictError: () => ({
+    ...actionability.invalidConfig,
+    fingerprint_suffix: "port_conflict",
+  }),
+  PortAllocationError: () => ({
+    ...actionability.invalidConfig,
+    fingerprint_suffix: "port_allocation",
+  }),
+  StateNotFoundError: () => actionability.startStack,
+  StateClaimError: (error) =>
+    readString(error, "reason") === "already-claimed"
+      ? { ...actionability.stopStack, fingerprint_suffix: "conflict" }
+      : { ...actionability.permission, fingerprint_suffix: "filesystem" },
+  StackNotRunningError: () => actionability.startStack,
+  StackReadinessError: () => actionability.startStack,
+  StackMetadataNotFoundError: () => actionability.startStack,
+  InvalidStackStateError: () => actionability.invalidConfig,
+  InvalidStackMetadataError: () => actionability.invalidConfig,
+  UnsupportedStackMetadataVersionError: () => actionability.invalidConfig,
+  NoRunningStackError: () => actionability.startStack,
+  StackAlreadyRunningError: () => actionability.stopStack,
+  DaemonStartError: () => actionability.unknown,
+  DaemonStillRunningError: () => actionability.stopStack,
+  // Transport failures retain the existing stack-recovery policy. An HTTP
+  // status or protocol failure came from the CLI-owned daemon itself and is
+  // therefore an internal invariant failure, not user configuration.
+  UnixHttpClientError: (error) => {
+    const reason = readString(error, "reason");
+    if (reason === "protocol") {
+      return { ...actionability.impossibleState, fingerprint_suffix: "daemon_protocol" };
+    }
+    if (reason === "status") {
+      return { ...actionability.impossibleState, fingerprint_suffix: "daemon_status" };
+    }
+    if (reason !== "transport") return actionability.unknown;
+    const path = readString(error, "path");
+    if (path !== undefined && path.startsWith("/start")) {
+      return { ...actionability.startStack, fingerprint_suffix: "daemon_start" };
+    }
+    return { ...actionability.stopStack, fingerprint_suffix: "daemon_transport" };
+  },
+
+  // @supabase/process-compose — the CLI generates the process graph, so graph
+  // invariants are internal bugs; runtime service failures are stack-state
+  // problems the user resolves by restarting the stack.
+  CyclicDependencyError: () => actionability.impossibleState,
+  MissingDependencyError: () => actionability.impossibleState,
+  ServiceNotFoundError: () => actionability.impossibleState,
+  SpawnError: () => actionability.startStack,
+  ShutdownTimeoutError: () => actionability.stopStack,
+  ServiceReadyError: () => actionability.startStack,
+};
+
+/**
+ * Whether a tag defined outside `apps/cli` has an external adapter. Used by
+ * the coverage test to keep {@link externalActionabilityByTag} exhaustive
+ * against the workspace packages.
+ */
+export function isClassifiedExternalErrorTag(tag: string): boolean {
+  return Object.hasOwn(externalActionabilityByTag, tag);
+}
+
+/**
+ * A wrapper's preserved `cause`, but only when classifying it cannot degrade
+ * the result: the cause must carry its own declaration or a known external
+ * adapter tag, otherwise the wrapper's own classification is more truthful.
+ */
+function classifiableCause(error: ErrorRecord): ErrorRecord | undefined {
+  const cause = error["cause"];
+  if (!isErrorRecord(cause)) return undefined;
+  if (readDeclaration(cause) !== undefined) return cause;
+  const causeTag = readErrorTag(cause);
+  if (causeTag !== undefined && Object.hasOwn(externalActionabilityByTag, causeTag)) return cause;
+  return undefined;
+}
+
+function classifyShowHelp(error: ErrorRecord, depth: number): CliErrorActionability | undefined {
+  const errors = error["errors"];
+  if (!Array.isArray(errors)) return undefined;
+  if (errors.length === 1) return classifyAtDepth(errors[0], depth + 1);
+  return toActionability(actionability.invalidInput, "tag", "ShowHelp");
+}
+
+function isNativeJsExceptionName(name: string | undefined): boolean {
+  return (
+    name === "TypeError" ||
+    name === "ReferenceError" ||
+    name === "RangeError" ||
+    name === "SyntaxError" ||
+    name === "EvalError" ||
+    name === "URIError" ||
+    name === "AggregateError"
+  );
+}
+
+/**
+ * Hard cap on cause-chain recursion (ShowHelp, UserError, and stack wrapper
+ * causes). Real chains are 1-2 deep; the cap exists so a cyclic or
+ * adversarial cause chain can never stack-overflow the failure-telemetry
+ * path itself.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+export function classifyCliErrorActionability(error: unknown): CliErrorActionability {
+  try {
+    return classifyAtDepth(error, 0);
+  } catch {
+    return toActionability(actionability.unknown, "error", "ClassificationFailure");
+  }
+}
+
+function classifyAtDepth(error: unknown, depth: number): CliErrorActionability {
+  if (depth >= MAX_CAUSE_DEPTH) {
+    return toActionability(actionability.unknown, "error", "CauseChainLimit");
+  }
+  const declared = readDeclaration(error);
+  if (declared !== undefined) {
+    const constructorName = readDeclaredErrorConstructorName(error);
+    const tag = readErrorTag(error);
+    if (tag !== undefined && tag === constructorName) {
+      return toActionability(declared, "tag", tag);
+    }
+    return toActionability(declared, "error", constructorName);
+  }
+
+  const tag = readErrorTag(error);
+
+  if (tag === "ShowHelp" && isErrorRecord(error)) {
+    const classified = classifyShowHelp(error, depth);
+    if (classified !== undefined) return classified;
+  }
+
+  // effect cli wraps handler failures in UserError({ cause }) — classify the
+  // actual failure instead of the wrapper.
+  if (tag === "UserError" && isErrorRecord(error) && error["cause"] !== undefined) {
+    return classifyAtDepth(error["cause"], depth + 1);
+  }
+
+  // @supabase/stack wrapper errors preserve the underlying tagged failure in
+  // `cause`; classify it when it is more specific than the wrapper (e.g. a
+  // daemon-down DockerPullError inside an asset-preparation StackBuildError,
+  // or a user's ProjectConfigParseError inside a reason-less StackBuildError).
+  // Explicit `invalid_config` StackBuildErrors are deliberate user-facing
+  // config verdicts and are never overridden by their cause.
+  if (
+    isErrorRecord(error) &&
+    tag === "StackBuildError" &&
+    readString(error, "reason") !== "invalid_config"
+  ) {
+    const cause = classifiableCause(error);
+    if (cause !== undefined) {
+      return classifyAtDepth(cause, depth + 1);
+    }
+  }
+
+  // DownloadError recurses ONLY into local filesystem causes (PlatformError:
+  // unwritable cache, extraction failure). HTTP causes stay on the wrapper —
+  // the HttpClientError adapter's 401/403 → auth/permission policy is
+  // Management-API-specific and must not apply to GitHub/CDN asset downloads.
+  if (isErrorRecord(error) && tag === "DownloadError") {
+    const cause = error["cause"];
+    if (isErrorRecord(cause) && readErrorTag(cause) === "PlatformError") {
+      return classifyAtDepth(cause, depth + 1);
+    }
+  }
+
+  if (tag !== undefined && isErrorRecord(error)) {
+    // Own-property lookup: a sanitized tag like "constructor" must not pick
+    // up Object.prototype members as adapters.
+    if (Object.hasOwn(externalActionabilityByTag, tag)) {
+      const external = externalActionabilityByTag[tag];
+      if (external !== undefined) {
+        return toActionability(external(error), "tag", tag);
+      }
+    }
+    return toActionability(actionability.unknown, "tag", undefined);
+  }
+
+  if (isErrorRecord(error) && readErrorName(error) === "StackError") {
+    // The public Stack promise API wraps tagged failures via `toStackError`,
+    // preserving the original in `cause` — classify that instead of the
+    // wrapper whenever it is itself classifiable.
+    const cause = classifiableCause(error);
+    if (cause !== undefined) {
+      return classifyAtDepth(cause, depth + 1);
+    }
+    // toStackError wraps arbitrary thrown errors with code "UNKNOWN"; a
+    // native JS exception cause is a stack-internal crash and must land in
+    // the internal-bug bucket, matching the top-level native-exception rule.
+    if (isNativeJsExceptionName(readErrorName(error["cause"]))) {
+      return classifyAtDepth(error["cause"], depth + 1);
+    }
+    const classify = externalActionabilityByTag["StackError"];
+    if (classify !== undefined) {
+      return toActionability(classify(error), "error", "StackError");
+    }
+  }
+
+  if (typeof error === "string") {
+    return toActionability(actionability.unknown, "string", undefined);
+  }
+
+  const name = readErrorName(error);
+  if (isNativeJsExceptionName(name)) {
+    return toActionability(actionability.internalPanic, "error", name);
+  }
+
+  return toActionability(actionability.unknown, "error", undefined);
+}
+
+export function classifyCliCauseActionability(cause: Cause.Cause<unknown>): CliErrorActionability {
+  let firstKnownDefect: CliErrorActionability | undefined;
+  let hasUnknownDefect = false;
+  for (const reason of cause.reasons) {
+    if (!Cause.isDieReason(reason)) continue;
+    const classified = classifyCliErrorActionability(reason.defect);
+    if (classified.error_kind === CliErrorKind.InternalBug) return classified;
+    if (classified.error_kind === CliErrorKind.Unknown) hasUnknownDefect = true;
+    else firstKnownDefect ??= classified;
+  }
+  if (hasUnknownDefect) return toActionability(actionability.internalPanic, "error", "Defect");
+  if (firstKnownDefect !== undefined) return firstKnownDefect;
+  if (Cause.hasInterruptsOnly(cause)) {
+    return toActionability(actionability.cancelled, "error", "Interrupt");
+  }
+  const error = Option.getOrElse(Cause.findErrorOption(cause), () => Cause.squash(cause));
+  return classifyCliErrorActionability(error);
+}

--- a/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
@@ -1,0 +1,926 @@
+import { Cause, Data } from "effect";
+import { describe, expect, it } from "vitest";
+import { markSupabaseApiInputErrorAsUserInput, SupabaseApiInputError } from "@supabase/api/effect";
+import { LegacyBootstrapHealthError } from "../../legacy/commands/bootstrap/bootstrap.errors.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  classifyCliCauseActionability,
+  classifyCliErrorActionability,
+  CliErrorActionabilityMetricDefinitions,
+  ErrorActionabilityId,
+  statusCodeActionability,
+} from "./error-actionability.ts";
+
+class DeclaredError extends Data.TaggedError("DeclaredError")<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
+
+class DeclaredStatusError extends Data.TaggedError("DeclaredStatusError")<{
+  readonly status: number;
+  readonly upgradeSuggested?: boolean;
+  readonly notFoundIsInvalidInput?: boolean;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return statusCodeActionability(this.status, {
+      upgradeSuggested: this.upgradeSuggested,
+      notFoundIsInvalidInput: this.notFoundIsInvalidInput,
+    });
+  }
+}
+
+class UndeclaredError extends Data.TaggedError("UndeclaredError")<{
+  readonly message: string;
+}> {}
+
+class DeclaredNoSuggestionError extends Data.TaggedError("DeclaredNoSuggestionError")<{
+  readonly message: string;
+  readonly suggestion?: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.dbFinding;
+  }
+}
+
+class PlainDeclaredError extends Error {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
+
+class DeclarationCarrierError extends Error {
+  readonly _tag: string;
+  readonly declaration: Record<string, unknown>;
+
+  constructor(tag: string, declaration: Record<string, unknown>) {
+    super(tag);
+    this._tag = tag;
+    this.declaration = declaration;
+  }
+
+  get [ErrorActionabilityId](): Record<string, unknown> {
+    return this.declaration;
+  }
+}
+
+function declarationCarrier(tag: string, declaration: Record<string, unknown>) {
+  return new DeclarationCarrierError(tag, declaration);
+}
+
+describe("classifyCliErrorActionability", () => {
+  it("uses the declaration co-located on the error class", () => {
+    expect(
+      classifyCliErrorActionability(new DeclaredError({ message: "raw secret text" })),
+    ).toEqual({
+      error_kind: "user_actionable",
+      error_category: "auth",
+      error_fingerprint: "tag:DeclaredError",
+      has_suggestion: true,
+      suggestion_type: "login",
+      suggested_command: "supabase login",
+    });
+  });
+
+  it("uses a declared Error subclass constructor for an untagged fingerprint", () => {
+    const result = classifyCliErrorActionability(new PlainDeclaredError("private path"));
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("error:PlainDeclaredError");
+  });
+
+  it("does not claim a generic remediation for local permission failures", () => {
+    expect(actionability.permission).toEqual({
+      error_kind: "user_actionable",
+      error_category: "permission",
+      has_suggestion: false,
+      suggestion_type: "none",
+    });
+  });
+
+  it("lets instance-dependent declarations branch on typed fields", () => {
+    const auth = classifyCliErrorActionability(new DeclaredStatusError({ status: 401 }));
+    expect(auth.error_category).toBe("auth");
+    expect(auth.error_fingerprint).toBe("tag:DeclaredStatusError:auth");
+
+    const gated = classifyCliErrorActionability(
+      new DeclaredStatusError({ status: 404, upgradeSuggested: true }),
+    );
+    expect(gated.error_category).toBe("plan_limit");
+    expect(gated.suggestion_type).toBe("upgrade_plan");
+    expect(gated.error_fingerprint).toBe("tag:DeclaredStatusError:plan_limit");
+
+    const notFound = classifyCliErrorActionability(new DeclaredStatusError({ status: 404 }));
+    expect(notFound.error_kind).toBe("external_service");
+    expect(notFound.error_category).toBe("api_status");
+    expect(notFound.error_fingerprint).toBe("tag:DeclaredStatusError:api_status");
+
+    const namedResourceNotFound = classifyCliErrorActionability(
+      new DeclaredStatusError({ status: 404, notFoundIsInvalidInput: true }),
+    );
+    expect(namedResourceNotFound.error_kind).toBe("user_actionable");
+    expect(namedResourceNotFound.error_category).toBe("invalid_input");
+    expect(namedResourceNotFound.error_fingerprint).toBe("tag:DeclaredStatusError:not_found");
+
+    const status = classifyCliErrorActionability(new DeclaredStatusError({ status: 500 }));
+    expect(status.error_kind).toBe("external_service");
+    expect(status.error_category).toBe("api_status");
+    expect(status.error_fingerprint).toBe("tag:DeclaredStatusError:api_status");
+  });
+
+  it("classifies undeclared tagged errors as unknown with a sanitized fingerprint", () => {
+    const result = classifyCliErrorActionability(new UndeclaredError({ message: "boom" }));
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_fingerprint).toBe("tag:unknown");
+  });
+
+  it.each([
+    ["user_actionable", "auth"],
+    ["user_actionable", "missing_project_ref"],
+    ["user_actionable", "project_not_linked"],
+    ["user_actionable", "docker_not_running"],
+    ["user_actionable", "invalid_config"],
+    ["user_actionable", "db_connection"],
+    ["user_actionable", "migration_drift"],
+    ["user_actionable", "permission"],
+    ["user_actionable", "plan_limit"],
+    ["user_actionable", "project_paused"],
+    ["user_actionable", "invalid_input"],
+    ["internal_bug", "panic"],
+    ["internal_bug", "impossible_state"],
+    ["external_service", "network"],
+    ["external_service", "api_status"],
+    ["user_cancelled", "cancelled"],
+    ["unknown", "unknown"],
+  ])("accepts the valid %s and %s taxonomy pair", (errorKind, errorCategory) => {
+    const result = classifyCliErrorActionability(
+      declarationCarrier("MatrixError", {
+        error_kind: errorKind,
+        error_category: errorCategory,
+        has_suggestion: false,
+        suggestion_type: "none",
+      }),
+    );
+    expect(result.error_kind).toBe(errorKind);
+    expect(result.error_category).toBe(errorCategory);
+  });
+
+  it.each([
+    ["user_actionable", "panic"],
+    ["internal_bug", "invalid_input"],
+    ["external_service", "auth"],
+    ["user_cancelled", "unknown"],
+    ["unknown", "cancelled"],
+  ])("rejects the invalid %s and %s taxonomy pair", (errorKind, errorCategory) => {
+    const result = classifyCliErrorActionability(
+      declarationCarrier("InvalidMatrixError", {
+        error_kind: errorKind,
+        error_category: errorCategory,
+        has_suggestion: false,
+        suggestion_type: "none",
+      }),
+    );
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_fingerprint).toBe("tag:unknown");
+  });
+
+  it("accepts a closed command remediation", () => {
+    const result = classifyCliErrorActionability(
+      declarationCarrier("RunCommandError", {
+        error_kind: "user_actionable",
+        error_category: "invalid_config",
+        has_suggestion: true,
+        suggestion_type: "run_command",
+        suggested_command: "supabase start",
+      }),
+    );
+    expect(result.suggestion_type).toBe("run_command");
+    expect(result.suggested_command).toBe("supabase start");
+  });
+
+  it.each([
+    [false, "login", undefined],
+    [true, "none", undefined],
+    [false, "none", "supabase login"],
+  ])(
+    "rejects inconsistent suggestion metadata (%s, %s, %s)",
+    (hasSuggestion, suggestionType, suggestedCommand) => {
+      const result = classifyCliErrorActionability(
+        declarationCarrier("InvalidSuggestionError", {
+          error_kind: "user_actionable",
+          error_category: "auth",
+          has_suggestion: hasSuggestion,
+          suggestion_type: suggestionType,
+          suggested_command: suggestedCommand,
+        }),
+      );
+      expect(result.error_kind).toBe("unknown");
+      expect(result).not.toHaveProperty("suggested_command");
+    },
+  );
+
+  it("ignores a declaration whose symbol getter throws", () => {
+    const secret = "token-from-throwing-getter";
+    class ThrowingDeclarationError extends Error {
+      readonly _tag = "ThrowingDeclarationError";
+
+      get [ErrorActionabilityId]() {
+        throw new Error(secret);
+      }
+    }
+    const error = new ThrowingDeclarationError();
+    const result = classifyCliErrorActionability(error);
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_fingerprint).toBe("tag:unknown");
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("falls back safely when even structural property access throws", () => {
+    const secret = "token-from-hostile-proxy";
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(secret);
+        },
+      },
+    );
+    const result = classifyCliErrorActionability(hostile);
+    expect(result).toEqual({
+      error_kind: "unknown",
+      error_category: "unknown",
+      has_suggestion: false,
+      suggestion_type: "none",
+      error_fingerprint: "error:ClassificationFailure",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("rejects arbitrary declaration commands and fingerprint suffixes", () => {
+    const commandSecret = "supabase login --token user-secret-token";
+    const unsafeCommand = classifyCliErrorActionability(
+      declarationCarrier("UnsafeCommandError", {
+        error_kind: "user_actionable",
+        error_category: "auth",
+        has_suggestion: true,
+        suggestion_type: "login",
+        suggested_command: commandSecret,
+      }),
+    );
+    expect(unsafeCommand.error_kind).toBe("unknown");
+    expect(JSON.stringify(unsafeCommand)).not.toContain(commandSecret);
+
+    const suffixSecret = "customer_project_reference";
+    const unsafeSuffix = classifyCliErrorActionability(
+      declarationCarrier("UnsafeSuffixError", {
+        error_kind: "user_actionable",
+        error_category: "invalid_input",
+        has_suggestion: false,
+        suggestion_type: "none",
+        fingerprint_suffix: suffixSecret,
+      }),
+    );
+    expect(unsafeSuffix.error_fingerprint).toBe("tag:unknown");
+    expect(JSON.stringify(unsafeSuffix)).not.toContain(suffixSecret);
+  });
+
+  it("rejects a closed command paired with the wrong suggestion type", () => {
+    const result = classifyCliErrorActionability(
+      declarationCarrier("MismatchedSuggestionError", {
+        error_kind: "user_actionable",
+        error_category: "auth",
+        has_suggestion: true,
+        suggestion_type: "login",
+        suggested_command: "supabase stop",
+      }),
+    );
+    expect(result.error_kind).toBe("unknown");
+    expect(result).not.toHaveProperty("suggested_command");
+  });
+
+  it("snapshots validated declaration fields before emitting them", () => {
+    const secret = "supabase login --token later-secret";
+    let reads = 0;
+    const declaration = {
+      error_kind: "user_actionable",
+      error_category: "auth",
+      has_suggestion: true,
+      suggestion_type: "login",
+      get suggested_command() {
+        reads += 1;
+        return reads === 1 ? "supabase login" : secret;
+      },
+    };
+    const result = classifyCliErrorActionability(
+      declarationCarrier("ChangingDeclarationError", declaration),
+    );
+    expect(result.suggested_command).toBe("supabase login");
+    expect(reads).toBe(1);
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("does not include sensitive error fields in classification output", () => {
+    const secrets = [
+      "/Users/alice/private/project/config.toml",
+      "select * from private_table",
+      "abcdefghijklmnopqrst",
+      "db.customer.internal",
+      "user-specific-project-ref",
+    ];
+    const result = classifyCliErrorActionability({
+      _tag: "UndeclaredSensitiveError",
+      message: secrets[0],
+      sql: secrets[1],
+      token: secrets[2],
+      hostname: secrets[3],
+      projectRef: secrets[4],
+    });
+    const encoded = JSON.stringify(result);
+    for (const secret of secrets) expect(encoded).not.toContain(secret);
+  });
+
+  it("does not fingerprint an unknown tag that looks like an identifier", () => {
+    const secret = "CustomerSecret123";
+    const result = classifyCliErrorActionability({ _tag: secret });
+    expect(result.error_fingerprint).toBe("tag:unknown");
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("does not trust an arbitrary declaration carrier as a fingerprint authority", () => {
+    const secret = "CustomerProjectRef123";
+    const plainResult = classifyCliErrorActionability({
+      _tag: secret,
+      [ErrorActionabilityId]: actionability.invalidInput,
+    });
+    expect(plainResult.error_fingerprint).toBe("tag:unknown");
+
+    const errorResult = classifyCliErrorActionability(
+      declarationCarrier(secret, actionability.invalidInput),
+    );
+    expect(errorResult.error_fingerprint).toBe("error:DeclarationCarrierError");
+    expect(JSON.stringify([plainResult, errorResult])).not.toContain(secret);
+  });
+
+  it("does not accept declarations through the global symbol registry", () => {
+    const secret = "CustomerProjectRef123";
+    const globalDeclarationKey = Symbol.for("@supabase/cli/telemetry/ErrorActionability");
+    class HostileDeclaredError extends Error {
+      readonly _tag = secret;
+
+      get [globalDeclarationKey](): CliErrorActionabilityDeclaration {
+        return actionability.invalidInput;
+      }
+    }
+    Object.defineProperty(HostileDeclaredError, "name", { value: secret });
+
+    const result = classifyCliErrorActionability(new HostileDeclaredError(secret));
+    expect(result.error_fingerprint).toBe("tag:unknown");
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("classifies external stack build errors by structured reason", () => {
+    const invalidConfig = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "imgproxy requires storage to be enabled",
+      reason: "invalid_config",
+    });
+    expect(invalidConfig.error_category).toBe("invalid_config");
+    expect(invalidConfig.error_fingerprint).toBe("tag:StackBuildError:invalid_config");
+
+    const assetPreparation = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "Failed to prepare stack assets",
+      reason: "asset_preparation",
+    });
+    expect(assetPreparation.error_kind).toBe("external_service");
+    expect(assetPreparation.error_fingerprint).toBe("tag:StackBuildError:asset_preparation");
+
+    const dockerNotRunning = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "Failed to prepare stack assets",
+      reason: "docker_not_running",
+    });
+    expect(dockerNotRunning.error_category).toBe("docker_not_running");
+    expect(dockerNotRunning.error_fingerprint).toBe("tag:StackBuildError:docker_not_running");
+
+    const internal = classifyCliErrorActionability({ _tag: "StackBuildError", detail: "bug" });
+    expect(internal.error_kind).toBe("internal_bug");
+    expect(internal.error_category).toBe("impossible_state");
+    expect(internal.error_fingerprint).toBe("tag:StackBuildError:internal_build");
+  });
+
+  it("classifies stack readiness and state-claim failures without reading details", () => {
+    const readiness = classifyCliErrorActionability({
+      _tag: "StackReadinessError",
+      target: "auth",
+      timeoutMs: 10,
+      detail: "private runtime detail",
+    });
+    expect(readiness.error_category).toBe("invalid_config");
+    expect(readiness.suggestion_type).toBe("run_command");
+    expect(readiness.suggested_command).toBe("supabase start");
+
+    const claimed = classifyCliErrorActionability({
+      _tag: "StateClaimError",
+      reason: "already-claimed",
+      path: "/private/state.json",
+    });
+    expect(claimed.suggested_command).toBe("supabase stop");
+    expect(claimed.suggestion_type).toBe("run_command");
+    expect(claimed.error_fingerprint).toBe("tag:StateClaimError:conflict");
+
+    const filesystem = classifyCliErrorActionability({
+      _tag: "StateClaimError",
+      reason: "io-error",
+      path: "/private/state.json",
+    });
+    expect(filesystem.error_category).toBe("permission");
+    expect(filesystem.has_suggestion).toBe(false);
+    expect(filesystem.error_fingerprint).toBe("tag:StateClaimError:filesystem");
+  });
+
+  it("splits docker pull failures from a stopped docker daemon", () => {
+    const daemonDown = classifyCliErrorActionability({
+      _tag: "DockerPullError",
+      image: "postgres",
+      daemonDown: true,
+    });
+    expect(daemonDown.error_category).toBe("docker_not_running");
+    expect(daemonDown.suggestion_type).toBe("start_docker");
+
+    const pull = classifyCliErrorActionability({ _tag: "DockerPullError", image: "postgres" });
+    expect(pull.error_kind).toBe("external_service");
+    expect(pull.error_fingerprint).toBe("tag:DockerPullError:registry_pull");
+  });
+
+  it("classifies http client errors by response presence and status", () => {
+    const auth = classifyCliErrorActionability({
+      _tag: "HttpClientError",
+      response: { status: 401 },
+    });
+    expect(auth.error_category).toBe("auth");
+
+    const notFound = classifyCliErrorActionability({
+      _tag: "HttpClientError",
+      response: { status: 404 },
+    });
+    expect(notFound.error_kind).toBe("external_service");
+    expect(notFound.error_category).toBe("api_status");
+    expect(notFound.error_fingerprint).toBe("tag:HttpClientError:api_status");
+
+    const status = classifyCliErrorActionability({
+      _tag: "HttpClientError",
+      response: { status: 503 },
+    });
+    expect(status.error_category).toBe("api_status");
+
+    const transport = classifyCliErrorActionability({
+      _tag: "HttpClientError",
+      reason: { _tag: "TransportError" },
+    });
+    expect(transport.error_category).toBe("network");
+
+    for (const reason of ["DecodeError", "EmptyBodyError"]) {
+      const decode = classifyCliErrorActionability({
+        _tag: "HttpClientError",
+        reason: { _tag: reason },
+        response: { status: 200 },
+      });
+      expect(decode.error_category).toBe("api_status");
+      expect(decode.error_fingerprint).toBe("tag:HttpClientError:api_response");
+    }
+  });
+
+  it("classifies a stopped external stack through its static adapter", () => {
+    const result = classifyCliErrorActionability({
+      _tag: "StackNotRunningError",
+      statePath: "/private/project/.temp/stack.json",
+    });
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.suggested_command).toBe("supabase start");
+    expect(JSON.stringify(result)).not.toContain("/private/project");
+  });
+
+  it("recurses into single-error ShowHelp wrappers", () => {
+    const single = classifyCliErrorActionability({
+      _tag: "ShowHelp",
+      errors: [new DeclaredError({ message: "inner" })],
+    });
+    expect(single.error_fingerprint).toBe("tag:DeclaredError");
+
+    const multiple = classifyCliErrorActionability({
+      _tag: "ShowHelp",
+      errors: [{ _tag: "MissingOption" }, { _tag: "MissingOption" }],
+    });
+    expect(multiple.error_category).toBe("invalid_input");
+    expect(multiple.error_fingerprint).toBe("tag:ShowHelp");
+  });
+
+  it("classifies StackError port allocation failures", () => {
+    const error = new Error("no free port");
+    error.name = "StackError";
+    Object.defineProperty(error, "code", { value: "PORT_ALLOCATION" });
+    const result = classifyCliErrorActionability(error);
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("error:StackError:port_allocation");
+
+    const other = new Error("other");
+    other.name = "StackError";
+    expect(classifyCliErrorActionability(other).error_kind).toBe("unknown");
+  });
+
+  it("classifies the preserved tagged cause of a StackError wrapper", () => {
+    const wrapped = new Error("stack failure");
+    wrapped.name = "StackError";
+    Object.defineProperty(wrapped, "code", { value: "BUILD_ERROR" });
+    Object.defineProperty(wrapped, "cause", {
+      value: { _tag: "StackBuildError", detail: "x", reason: "invalid_config" },
+    });
+    const result = classifyCliErrorActionability(wrapped);
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("tag:StackBuildError:invalid_config");
+  });
+
+  it("classifies a native exception wrapped by StackError as an internal bug", () => {
+    const wrapped = new Error("boom");
+    wrapped.name = "StackError";
+    Object.defineProperty(wrapped, "code", { value: "UNKNOWN" });
+    Object.defineProperty(wrapped, "cause", { value: new TypeError("x is not a function") });
+    const result = classifyCliErrorActionability(wrapped);
+    expect(result.error_kind).toBe("internal_bug");
+    expect(result.error_category).toBe("panic");
+    expect(result.error_fingerprint).toBe("error:TypeError");
+  });
+
+  it("treats forbidden API statuses as account permission failures", () => {
+    const forbidden = classifyCliErrorActionability(new DeclaredStatusError({ status: 403 }));
+    expect(forbidden.error_kind).toBe("user_actionable");
+    expect(forbidden.error_category).toBe("permission");
+    expect(forbidden.error_fingerprint).toBe("tag:DeclaredStatusError:forbidden");
+
+    const gated = classifyCliErrorActionability(
+      new DeclaredStatusError({ status: 403, upgradeSuggested: true }),
+    );
+    expect(gated.error_category).toBe("plan_limit");
+
+    const http = classifyCliErrorActionability({
+      _tag: "HttpClientError",
+      response: { status: 403 },
+    });
+    expect(http.error_category).toBe("permission");
+  });
+
+  it("classifies the preserved cause of stack wrapper errors", () => {
+    const daemonDown = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "Failed to prepare stack assets",
+      reason: "asset_preparation",
+      cause: { _tag: "DockerPullError", image: "postgres", daemonDown: true },
+    });
+    expect(daemonDown.error_category).toBe("docker_not_running");
+    expect(daemonDown.error_fingerprint).toBe("tag:DockerPullError:docker_not_running");
+
+    const localFs = classifyCliErrorActionability({
+      _tag: "DownloadError",
+      url: "filesystem error for /cache",
+      cause: { _tag: "PlatformError", reason: { _tag: "PermissionDenied" } },
+    });
+    expect(localFs.error_kind).toBe("user_actionable");
+    expect(localFs.error_category).toBe("permission");
+
+    // An unclassifiable cause keeps the wrapper's own bucket.
+    const opaque = classifyCliErrorActionability({
+      _tag: "DownloadError",
+      url: "https://example.com",
+      cause: new Error("boom"),
+    });
+    expect(opaque.error_kind).toBe("external_service");
+    expect(opaque.error_category).toBe("network");
+  });
+
+  it.each([
+    ["PermissionDenied", "user_actionable", "permission", "tag:PlatformError:filesystem"],
+    ["NotFound", "user_actionable", "invalid_input", "tag:PlatformError:not_found"],
+    ["TimedOut", "unknown", "unknown", "tag:PlatformError:platform_error"],
+    ["Unknown", "unknown", "unknown", "tag:PlatformError:platform_error"],
+  ])(
+    "classifies PlatformError reason %s without conflating it with permissions",
+    (reason, errorKind, errorCategory, errorFingerprint) => {
+      const result = classifyCliErrorActionability({
+        _tag: "PlatformError",
+        reason: { _tag: reason },
+      });
+      expect(result.error_kind).toBe(errorKind);
+      expect(result.error_category).toBe(errorCategory);
+      expect(result.error_fingerprint).toBe(errorFingerprint);
+    },
+  );
+
+  it("splits daemon start failures from other daemon RPC failures", () => {
+    const start = classifyCliErrorActionability({
+      _tag: "UnixHttpClientError",
+      socketPath: "/tmp/daemon.sock",
+      path: "/start",
+      reason: "transport",
+    });
+    expect(start.error_category).toBe("invalid_config");
+    expect(start.suggested_command).toBe("supabase start");
+    expect(start.error_fingerprint).toBe("tag:UnixHttpClientError:daemon_start");
+
+    const status = classifyCliErrorActionability({
+      _tag: "UnixHttpClientError",
+      socketPath: "/tmp/daemon.sock",
+      path: "/status",
+      reason: "transport",
+    });
+    expect(status.error_category).toBe("invalid_config");
+    expect(status.suggested_command).toBe("supabase stop");
+    expect(status.error_fingerprint).toBe("tag:UnixHttpClientError:daemon_transport");
+  });
+
+  it("keeps daemon status and protocol failures in the internal-bug bucket", () => {
+    for (const [reason, suffix] of [
+      ["status", "daemon_status"],
+      ["protocol", "daemon_protocol"],
+    ] as const) {
+      const result = classifyCliErrorActionability({
+        _tag: "UnixHttpClientError",
+        path: "/status",
+        reason,
+      });
+      expect(result.error_kind).toBe("internal_bug");
+      expect(result.error_category).toBe("impossible_state");
+      expect(result.error_fingerprint).toBe(`tag:UnixHttpClientError:${suffix}`);
+    }
+  });
+
+  it("does not claim daemon startup failures are recoverable stack config", () => {
+    const result = classifyCliErrorActionability({ _tag: "DaemonStartError" });
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_category).toBe("unknown");
+  });
+
+  it("classifies API client configuration failures as token problems", () => {
+    const result = classifyCliErrorActionability({
+      _tag: "SupabaseApiConfigError",
+      message: "Missing access token.",
+    });
+    expect(result.error_category).toBe("auth");
+    expect(result.suggestion_type).toBe("set_env_var");
+  });
+
+  it("classifies API input-schema rejections from typed provenance", () => {
+    const generated = new SupabaseApiInputError("private generated schema details");
+    const generatedResult = classifyCliErrorActionability(generated);
+    expect(generatedResult.error_kind).toBe("internal_bug");
+    expect(generatedResult.error_category).toBe("impossible_state");
+    expect(generatedResult.error_fingerprint).toBe("tag:SupabaseApiInputError:request_encoding");
+    expect(JSON.stringify(generatedResult)).not.toContain("private generated schema details");
+
+    const userInput = new SupabaseApiInputError("private user schema details");
+    expect(markSupabaseApiInputErrorAsUserInput(userInput)).toBe(userInput);
+    const userResult = classifyCliErrorActionability(userInput);
+    expect(userResult.error_kind).toBe("user_actionable");
+    expect(userResult.error_category).toBe("invalid_input");
+    expect(userResult.error_fingerprint).toBe("tag:SupabaseApiInputError:request_input");
+    expect(JSON.stringify(userResult)).not.toContain("private user schema details");
+  });
+
+  it("caps cause-chain recursion instead of overflowing on cycles", () => {
+    const a: Record<string, unknown> = {
+      _tag: "StackBuildError",
+      detail: "x",
+      reason: "asset_preparation",
+    };
+    const b: Record<string, unknown> = {
+      _tag: "StackBuildError",
+      detail: "y",
+      reason: "asset_preparation",
+      cause: a,
+    };
+    a["cause"] = b;
+    const result = classifyCliErrorActionability(a);
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_fingerprint).toBe("error:CauseChainLimit");
+
+    const self: Record<string, unknown> = { _tag: "UserError" };
+    self["cause"] = self;
+    expect(classifyCliErrorActionability(self).error_fingerprint).toBe("error:CauseChainLimit");
+  });
+
+  it("classifies the user config cause of a reason-less StackBuildError", () => {
+    const result = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "Failed to configure Edge Functions",
+      cause: { _tag: "ProjectConfigParseError", path: "supabase/config.toml" },
+    });
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("tag:ProjectConfigParseError");
+  });
+
+  it("keeps a local stack schema failure in the invalid-config bucket", () => {
+    const result = classifyCliErrorActionability({
+      _tag: "StackBuildError",
+      detail: "Invalid Edge Functions bundle",
+      reason: "invalid_config",
+      cause: { _tag: "SchemaError", issue: "private local config details" },
+    });
+    expect(result.error_kind).toBe("user_actionable");
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("tag:StackBuildError:invalid_config");
+  });
+
+  it("keeps HTTP download causes in the download bucket", () => {
+    // GitHub/CDN 401/403 during asset download must NOT hit the
+    // Management-API auth/permission policy of the HttpClientError adapter.
+    const forbidden = classifyCliErrorActionability({
+      _tag: "DownloadError",
+      url: "https://github.com/releases/x",
+      cause: { _tag: "HttpClientError", response: { status: 403 } },
+    });
+    expect(forbidden.error_kind).toBe("external_service");
+    expect(forbidden.error_category).toBe("network");
+    expect(forbidden.error_fingerprint).toBe("tag:DownloadError");
+
+    const localFs = classifyCliErrorActionability({
+      _tag: "DownloadError",
+      url: "filesystem error for /cache",
+      cause: { _tag: "PlatformError", reason: { _tag: "PermissionDenied" } },
+    });
+    expect(localFs.error_category).toBe("permission");
+  });
+
+  it("does not treat Object.prototype members as external adapters", () => {
+    const result = classifyCliErrorActionability({ _tag: "constructor" });
+    expect(result.error_kind).toBe("unknown");
+    expect(result.error_fingerprint).toBe("tag:unknown");
+  });
+
+  it("buckets native JS exceptions as internal panics", () => {
+    const result = classifyCliErrorActionability(new TypeError("x is not a function"));
+    expect(result.error_kind).toBe("internal_bug");
+    expect(result.error_category).toBe("panic");
+    expect(result.error_fingerprint).toBe("error:TypeError");
+  });
+
+  it("does not inspect raw instance-level suggestion text", () => {
+    const secret = "run --token user-secret-token";
+    const withSuggestion = classifyCliErrorActionability(
+      new DeclaredNoSuggestionError({ message: "bad row", suggestion: secret }),
+    );
+    expect(withSuggestion.has_suggestion).toBe(false);
+    expect(withSuggestion.suggestion_type).toBe("none");
+    expect(JSON.stringify(withSuggestion)).not.toContain(secret);
+
+    const withoutSuggestion = classifyCliErrorActionability(
+      new DeclaredNoSuggestionError({ message: "bad row" }),
+    );
+    expect(withoutSuggestion.has_suggestion).toBe(false);
+  });
+
+  it("never leaks raw text into fingerprints for unknown failures", () => {
+    expect(classifyCliErrorActionability("raw failure text").error_fingerprint).toBe(
+      "string:unknown",
+    );
+    const named = new Error("boom");
+    named.name = "CustomerSecret123";
+    expect(classifyCliErrorActionability(named).error_fingerprint).toBe("error:unknown");
+  });
+});
+
+describe("metric definitions", () => {
+  it("keeps the Q2 baseline definitions stable for reporting queries", () => {
+    // These ids are referenced by the PostHog reporting built in CLI-1562;
+    // changing them invalidates the Q2 baseline and must be deliberate.
+    expect(CliErrorActionabilityMetricDefinitions.strictRecovery.id).toBe(
+      "same_command_success_same_session",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.repeatError.id).toBe(
+      "same_command_same_error_same_session_before_success",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.internalUnknownBugRate.id).toBe(
+      "failed_commands_internal_bug_or_unknown",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.strictRecovery.partition_by).toEqual([
+      "device_id",
+      "$session_id",
+      "command",
+    ]);
+    expect(CliErrorActionabilityMetricDefinitions.strictRecovery.eligible_failure).toBe(
+      "exit_code != 0 AND error_kind = 'user_actionable'",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.strictRecovery.recovered_when).toContain(
+      "S.device_id = F.device_id, S.$session_id = F.$session_id, and S.command = F.command",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.repeatError.partition_by).toEqual([
+      "device_id",
+      "$session_id",
+      "command",
+    ]);
+    expect(CliErrorActionabilityMetricDefinitions.repeatError.eligible_failure).toBe(
+      "exit_code != 0 AND error_fingerprint IS NOT NULL",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.repeatError.repeated_when).toContain(
+      "P.error_fingerprint = F.error_fingerprint",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.repeatError.reset_when).toContain(
+      "clears every prior fingerprint",
+    );
+  });
+});
+
+describe("classifyCliCauseActionability", () => {
+  it("classifies the typed failure inside a cause", () => {
+    const cause = Cause.fail(new DeclaredError({ message: "inner" }));
+    expect(classifyCliCauseActionability(cause).error_category).toBe("auth");
+  });
+
+  it("classifies defects", () => {
+    const cause = Cause.die(new TypeError("boom"));
+    expect(classifyCliCauseActionability(cause).error_category).toBe("panic");
+  });
+
+  it("gives defects precedence over typed failures in a combined cause", () => {
+    const cause = Cause.combine(
+      Cause.fail(new DeclaredError({ message: "recoverable" })),
+      Cause.die(new TypeError("boom")),
+    );
+    expect(classifyCliCauseActionability(cause)).toMatchObject({
+      error_kind: "internal_bug",
+      error_category: "panic",
+      error_fingerprint: "error:TypeError",
+    });
+  });
+
+  it("preserves a known tagged defect's structured classification", () => {
+    const cause = Cause.die({
+      _tag: "UnixHttpClientError",
+      path: "/status",
+      reason: "protocol",
+    });
+    expect(classifyCliCauseActionability(cause)).toMatchObject({
+      error_kind: "internal_bug",
+      error_category: "impossible_state",
+      error_fingerprint: "tag:UnixHttpClientError:daemon_protocol",
+    });
+  });
+
+  it("does not let an earlier known defect hide a later panic", () => {
+    const cause = Cause.combine(
+      Cause.die({ _tag: "UnixHttpClientError", path: "/start", reason: "transport" }),
+      Cause.die(new TypeError("boom")),
+    );
+    expect(classifyCliCauseActionability(cause)).toMatchObject({
+      error_kind: "internal_bug",
+      error_category: "panic",
+      error_fingerprint: "error:TypeError",
+    });
+  });
+
+  it("classifies interrupt-only causes as user cancellation", () => {
+    expect(classifyCliCauseActionability(Cause.interrupt(42))).toEqual({
+      error_kind: "user_cancelled",
+      error_category: "cancelled",
+      has_suggestion: false,
+      suggestion_type: "none",
+      error_fingerprint: "error:Interrupt",
+    });
+  });
+});
+
+describe("LegacyBootstrapHealthError actionability", () => {
+  it("classifies a non-200 health poll on the status-code policy", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBootstrapHealthError({ message: "Error status 500: boom", status: 500 }),
+    );
+    expect(result.error_category).toBe("api_status");
+  });
+
+  it("classifies a 200 the generated client could not decode as an api-response problem", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBootstrapHealthError({ message: "Error status 0: boom", decode: true }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("api_status");
+    expect(result.error_fingerprint).toBe("tag:LegacyBootstrapHealthError:api_response");
+  });
+
+  it("classifies a responseless health poll failure as network", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBootstrapHealthError({ message: "Error status 0: boom", transport: true }),
+    );
+    expect(result.error_kind).toBe("external_service");
+    expect(result.error_category).toBe("network");
+    expect(result.error_fingerprint).toBe("tag:LegacyBootstrapHealthError:network");
+  });
+
+  it("falls back to the api-status policy for an unhealthy service report", () => {
+    const result = classifyCliErrorActionability(
+      new LegacyBootstrapHealthError({ message: "Service not healthy: db (unhealthy)" }),
+    );
+    expect(result.error_category).toBe("api_status");
+  });
+});

--- a/packages/api/src/effect.ts
+++ b/packages/api/src/effect.ts
@@ -11,8 +11,16 @@ import {
   versionedEffectOperations,
 } from "./generated/effect-client.ts";
 
-export type { SupabaseApiError, SupabaseApiRetryOptions } from "./internal/client.ts";
-export { SupabaseApiConfigError } from "./internal/client.ts";
+export type {
+  SupabaseApiError,
+  SupabaseApiInputErrorSource,
+  SupabaseApiRetryOptions,
+} from "./internal/client.ts";
+export {
+  markSupabaseApiInputErrorAsUserInput,
+  SupabaseApiConfigError,
+  SupabaseApiInputError,
+} from "./internal/client.ts";
 export type { SupabaseApiClientOptions, SupabaseApiConfig } from "./internal/client.ts";
 export { apiConfigLayer, DEFAULT_SUPABASE_API_URL } from "./config/api-config.layer.ts";
 export { ApiConfig } from "./config/api-config.service.ts";

--- a/packages/api/src/internal/client.ts
+++ b/packages/api/src/internal/client.ts
@@ -47,7 +47,8 @@ export interface SupabaseApiClientOptions {
 export type SupabaseApiError =
   | HttpBody.HttpBodyError
   | HttpClientError.HttpClientError
-  | SchemaError;
+  | SchemaError
+  | SupabaseApiInputError;
 
 export interface SupabaseApiClientShape {
   readonly execute: <Id extends OperationId>(
@@ -80,6 +81,40 @@ export class SupabaseApiConfigError extends Error {
     super(message);
     this.name = "SupabaseApiConfigError";
   }
+}
+
+export type SupabaseApiInputErrorSource = "generated_client" | "user_input";
+
+/**
+ * The generated client's input schema rejected the request input before any
+ * request was sent. This defaults to `generated_client` because a schema
+ * rejection can be caused by a request assembled incorrectly by its caller;
+ * command boundaries may opt a confirmed user-derived request into
+ * `user_input` without inspecting the schema error message. The original
+ * schema failure is preserved as `cause`.
+ */
+export class SupabaseApiInputError extends Error {
+  readonly _tag = "SupabaseApiInputError";
+  #source: SupabaseApiInputErrorSource = "generated_client";
+
+  get source(): SupabaseApiInputErrorSource {
+    return this.#source;
+  }
+
+  constructor(message: string, options?: { readonly cause?: unknown }) {
+    super(message, options);
+    this.name = "SupabaseApiInputError";
+  }
+
+  static markAsUserInput<T extends SupabaseApiInputError>(error: T): T {
+    error.#source = "user_input";
+    return error;
+  }
+}
+
+/** Mark a confirmed user-derived request while preserving error identity. */
+export function markSupabaseApiInputErrorAsUserInput<T extends SupabaseApiInputError>(error: T): T {
+  return SupabaseApiInputError.markAsUserInput(error);
 }
 
 function resolveSupabaseApiConfig(
@@ -516,7 +551,9 @@ export function makeSupabaseApiClient(
     return {
       execute: (definition, input) =>
         Effect.gen(function* () {
-          const validated = yield* Schema.decodeUnknownEffect(definition.inputSchema)(input);
+          const validated = yield* Schema.decodeUnknownEffect(definition.inputSchema)(input).pipe(
+            Effect.mapError((error) => new SupabaseApiInputError(error.message, { cause: error })),
+          );
           const response = yield* executeRequest(prepared, definition, validated);
           if (isJsonOperation(definition)) {
             return yield* decodeJsonResponse(definition, response);
@@ -531,7 +568,9 @@ export function makeSupabaseApiClient(
         }),
       executeRaw: (definition, input, headers) =>
         Effect.gen(function* () {
-          const validated = yield* Schema.decodeUnknownEffect(definition.inputSchema)(input);
+          const validated = yield* Schema.decodeUnknownEffect(definition.inputSchema)(input).pipe(
+            Effect.mapError((error) => new SupabaseApiInputError(error.message, { cause: error })),
+          );
           const request = yield* buildRequest(definition, validated).pipe(
             Effect.map((request) =>
               headers === undefined ? request : HttpClientRequest.setHeaders(request, headers),

--- a/packages/api/src/internal/client.unit.test.ts
+++ b/packages/api/src/internal/client.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { Effect, Exit, Layer, Option, Redacted } from "effect";
+import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
@@ -8,7 +9,11 @@ import * as UrlParams from "effect/unstable/http/UrlParams";
 import * as Schema from "effect/Schema";
 
 import { operationDefinitions } from "../generated/contracts.ts";
-import { makeSupabaseApiClient } from "./client.ts";
+import {
+  makeSupabaseApiClient,
+  markSupabaseApiInputErrorAsUserInput,
+  SupabaseApiInputError,
+} from "./client.ts";
 
 const textDecoder = new TextDecoder();
 
@@ -155,6 +160,83 @@ const config = {
 } as const;
 
 describe("makeSupabaseApiClient", () => {
+  test("defaults request-schema failures to generated-client provenance", async () => {
+    let requests = 0;
+    const client = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.provide(
+          httpClientLayer((request) => {
+            requests += 1;
+            return Effect.succeed(jsonResponse(request, 200, {}));
+          }),
+        ),
+      ),
+    );
+
+    const executeError = await Effect.runPromise(
+      client
+        .execute(operationDefinitions.v1DeleteAFunction, {
+          ref: "invalid-ref",
+          function_slug: "hello-world",
+        })
+        .pipe(Effect.flip),
+    );
+    const executeRawError = await Effect.runPromise(
+      client
+        .executeRaw(operationDefinitions.v1DeleteAFunction, {
+          ref: "invalid-ref",
+          function_slug: "hello-world",
+        })
+        .pipe(Effect.flip),
+    );
+
+    for (const error of [executeError, executeRawError]) {
+      expect(error).toBeInstanceOf(SupabaseApiInputError);
+      if (!(error instanceof SupabaseApiInputError)) {
+        throw new Error("expected SupabaseApiInputError");
+      }
+      expect(error.source).toBe("generated_client");
+    }
+
+    if (!(executeRawError instanceof SupabaseApiInputError)) {
+      throw new Error("expected SupabaseApiInputError");
+    }
+    expect(markSupabaseApiInputErrorAsUserInput(executeRawError)).toBe(executeRawError);
+    expect(executeRawError.source).toBe("user_input");
+    expect(requests).toBe(0);
+  });
+
+  test("fails request-body construction before sending a request", async () => {
+    class BrokenBlob extends Blob {
+      override arrayBuffer(): Promise<ArrayBuffer> {
+        return Promise.reject(new Error("body read failed"));
+      }
+    }
+
+    let requests = 0;
+    const error = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.flatMap((client) =>
+          client.executeRaw(operationDefinitions.v1CreateAFunction, {
+            ref: "abcdefghijklmnopqrst",
+            slug: "demo",
+            body: new BrokenBlob([]),
+          }),
+        ),
+        Effect.provide(
+          httpClientLayer((request) => {
+            requests += 1;
+            return Effect.succeed(functionResponse(request, 201));
+          }),
+        ),
+        Effect.flip,
+      ),
+    );
+
+    expect(error).toBeInstanceOf(HttpBody.HttpBodyError);
+    expect(requests).toBe(0);
+  });
+
   test("retries transport errors for POST requests", async () => {
     let attempts = 0;
 

--- a/packages/stack/src/DaemonProtocol.ts
+++ b/packages/stack/src/DaemonProtocol.ts
@@ -8,12 +8,19 @@ const DaemonErrorCodeSchema = Schema.Literals([
   "STACK_BUILD_ERROR",
 ]);
 
+const StackBuildReasonSchema = Schema.Literals([
+  "invalid_config",
+  "docker_not_running",
+  "asset_preparation",
+]);
+
 export const DaemonErrorResponseSchema = Schema.Struct({
   code: DaemonErrorCodeSchema,
   error: Schema.String,
   service: Schema.optionalKey(Schema.String),
   exitCode: Schema.optionalKey(Schema.Number),
   timeoutMs: Schema.optionalKey(Schema.Number),
+  reason: Schema.optionalKey(StackBuildReasonSchema),
 });
 
 export type DaemonErrorResponse = typeof DaemonErrorResponseSchema.Type;

--- a/packages/stack/src/DaemonServer.ts
+++ b/packages/stack/src/DaemonServer.ts
@@ -51,8 +51,15 @@ export class DaemonServer extends Context.Service<
             },
             500,
           );
-        const buildErrorResponse = (detail: string) =>
-          errorResponse({ code: "STACK_BUILD_ERROR", error: detail }, 500);
+        const buildErrorResponse = (detail: string, reason?: DaemonErrorResponse["reason"]) =>
+          errorResponse(
+            {
+              code: "STACK_BUILD_ERROR",
+              error: detail,
+              ...(reason === undefined ? {} : { reason }),
+            },
+            500,
+          );
         const invalidReloadPayloadResponse = () =>
           errorResponse(
             { code: "STACK_BUILD_ERROR", error: "Invalid Edge Functions reload payload" },
@@ -144,7 +151,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -168,7 +175,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -252,7 +259,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -280,7 +287,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -300,7 +307,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notFoundResponse(e.name)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
             ),
           ),
@@ -320,7 +327,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -347,7 +354,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),
@@ -374,7 +381,7 @@ export class DaemonServer extends Context.Service<
                 Effect.succeed(notReadyResponse(e.name, e.reason, e.exitCode)),
               ),
               Effect.catchTag("StackBuildError", (e) =>
-                Effect.succeed(buildErrorResponse(e.detail)),
+                Effect.succeed(buildErrorResponse(e.detail, e.reason)),
               ),
               Effect.catchTag("StackReadinessError", (e) =>
                 terminalReadinessResponse(e.target, e.timeoutMs, e.detail),

--- a/packages/stack/src/LocalStack.ts
+++ b/packages/stack/src/LocalStack.ts
@@ -19,7 +19,12 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type { CleanupTargets } from "./CleanupTargets.ts";
 import { cleanupLocalStackResources } from "./cleanup.ts";
-import { StackBuildError, StackNotRunningError, StackReadinessError } from "./errors.ts";
+import {
+  DockerPullError,
+  StackBuildError,
+  StackNotRunningError,
+  StackReadinessError,
+} from "./errors.ts";
 import {
   clearFunctionsRuntimeConfig,
   configureFunctionsRuntime,
@@ -273,6 +278,10 @@ export const localStackLayer = (
                   new StackBuildError({
                     detail: "Failed to prepare stack assets",
                     cause,
+                    reason:
+                      cause instanceof DockerPullError && cause.daemonDown
+                        ? "docker_not_running"
+                        : "asset_preparation",
                   }),
               ),
             )
@@ -435,6 +444,7 @@ export const localStackLayer = (
               new StackBuildError({
                 detail: "Invalid Edge Functions bundle",
                 cause,
+                reason: "invalid_config",
               }),
           ),
         );

--- a/packages/stack/src/RemoteStack.integration.test.ts
+++ b/packages/stack/src/RemoteStack.integration.test.ts
@@ -1,6 +1,6 @@
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabase/process-compose";
-import { Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect";
+import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Result, Stream } from "effect";
 import * as http from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { DaemonServer } from "./DaemonServer.ts";
@@ -75,8 +75,13 @@ const MOCK_LOGS: ReadonlyArray<LogEntry> = [
 function mockStack(
   options: {
     readonly startServiceBuildError?: string;
+    readonly startServiceBuildReason?:
+      | "invalid_config"
+      | "docker_not_running"
+      | "asset_preparation";
     readonly startServiceReadyError?: string;
     readonly waitReadyBuildError?: string;
+    readonly waitReadyBuildReason?: "invalid_config" | "docker_not_running" | "asset_preparation";
     readonly waitReadyTimeoutMs?: number;
     readonly restartServiceReadyError?: string;
   } = {},
@@ -102,7 +107,14 @@ function mockStack(
       name === "unknown"
         ? Effect.fail(new ServiceNotFoundError({ name }))
         : options.startServiceBuildError !== undefined
-          ? Effect.fail(new StackBuildError({ detail: options.startServiceBuildError }))
+          ? Effect.fail(
+              new StackBuildError({
+                detail: options.startServiceBuildError,
+                ...(options.startServiceBuildReason === undefined
+                  ? {}
+                  : { reason: options.startServiceBuildReason }),
+              }),
+            )
           : options.startServiceReadyError !== undefined
             ? Effect.fail(
                 new ServiceReadyError({
@@ -158,7 +170,14 @@ function mockStack(
       const match = MOCK_STATES.find((s) => s.name === name);
       if (match === undefined) return Effect.fail(new ServiceNotFoundError({ name }));
       if (options.waitReadyBuildError !== undefined) {
-        return Effect.fail(new StackBuildError({ detail: options.waitReadyBuildError }));
+        return Effect.fail(
+          new StackBuildError({
+            detail: options.waitReadyBuildError,
+            ...(options.waitReadyBuildReason === undefined
+              ? {}
+              : { reason: options.waitReadyBuildReason }),
+          }),
+        );
       }
       if (options.waitReadyTimeoutMs !== undefined) {
         return Effect.fail(
@@ -242,7 +261,7 @@ function buildClientLayer(url: string): Layer.Layer<Stack, never, never> {
     request: (socketPath, path, init) =>
       Effect.tryPromise({
         try: () => fetch(`${url}${path}`, init),
-        catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+        catch: (cause) => new UnixHttpClientError({ socketPath, path, cause, reason: "transport" }),
       }),
   });
   return RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer));
@@ -398,7 +417,8 @@ describe("RemoteStack integration", () => {
                 { once: true },
               );
             }),
-          catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+          catch: (cause) =>
+            new UnixHttpClientError({ socketPath, path, cause, reason: "transport" }),
         }),
     });
     const runtime = ManagedRuntime.make(
@@ -414,11 +434,92 @@ describe("RemoteStack integration", () => {
     }
   });
 
+  test("distinguishes daemon status failures from protocol failures", async () => {
+    const scenarios = [
+      { response: new Response("failed", { status: 500 }), reason: "status" },
+      {
+        response: new Response("not-json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        reason: "protocol",
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const clientLayer = Layer.succeed(UnixHttpClient, {
+        request: () => Effect.succeed(scenario.response),
+      });
+      const runtime = ManagedRuntime.make(
+        RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer)),
+      );
+      try {
+        const exit = await runtime.runPromise(
+          Effect.flatMap(Stack, (stack) => stack.getInfo()).pipe(Effect.exit),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const defect = Cause.findDefect(exit.cause);
+          expect(Result.isSuccess(defect)).toBe(true);
+          if (Result.isSuccess(defect)) {
+            expect(defect.success).toBeInstanceOf(UnixHttpClientError);
+            expect(defect.success).toMatchObject({ reason: scenario.reason, path: "/status" });
+          }
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    }
+  });
+
+  test("preserves daemon identity for invalid SSE responses", async () => {
+    const scenarios = [
+      { response: () => new Response("failed", { status: 500 }), reason: "status" },
+      {
+        response: () =>
+          new Response("data: not-json\n\n", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        reason: "protocol",
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const clientLayer = Layer.succeed(UnixHttpClient, {
+        request: () => Effect.succeed(scenario.response()),
+      });
+      const runtime = ManagedRuntime.make(
+        RemoteStack.layer("test.sock").pipe(Layer.provide(clientLayer)),
+      );
+      try {
+        const exit = await runtime.runPromise(
+          Effect.flatMap(Stack, (stack) => Stream.runCollect(stack.subscribeAllLogs())).pipe(
+            Effect.exit,
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const defect = Cause.findDefect(exit.cause);
+          expect(Result.isSuccess(defect)).toBe(true);
+          if (Result.isSuccess(defect)) {
+            expect(defect.success).toBeInstanceOf(UnixHttpClientError);
+            expect(defect.success).toMatchObject({ reason: scenario.reason, path: "/logs" });
+          }
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    }
+  });
+
   test("preserves StackBuildError across remote service operations", async () => {
     const failingMock = mockStack({
       restartServiceReadyError: "restart failed readiness",
       startServiceBuildError: "stack is stopped",
+      startServiceBuildReason: "docker_not_running",
       waitReadyBuildError: "service has not been activated",
+      waitReadyBuildReason: "invalid_config",
     });
     const failingServer = ManagedRuntime.make(buildServerLayer(failingMock));
     let failingClient: ManagedRuntime.ManagedRuntime<Stack, never> | undefined;
@@ -433,11 +534,17 @@ describe("RemoteStack integration", () => {
         Effect.flatMap(Stack, (stack) => stack.startService("auth")).pipe(Effect.flip),
       );
       expect(startError._tag).toBe("StackBuildError");
+      if (startError._tag === "StackBuildError") {
+        expect(startError.reason).toBe("docker_not_running");
+      }
 
       const readyError = await failingClient.runPromise(
         Effect.flatMap(Stack, (stack) => stack.waitReady("auth")).pipe(Effect.flip),
       );
       expect(readyError._tag).toBe("StackBuildError");
+      if (readyError._tag === "StackBuildError") {
+        expect(readyError.reason).toBe("invalid_config");
+      }
 
       const restartError = await failingClient.runPromise(
         Effect.flatMap(Stack, (stack) => stack.restartService("auth")).pipe(Effect.flip),

--- a/packages/stack/src/RemoteStack.ts
+++ b/packages/stack/src/RemoteStack.ts
@@ -1,7 +1,7 @@
 import { ServiceNotFoundError, ServiceReadyError, type LogEntry } from "@supabase/process-compose";
 import { Effect, Layer, Schema, Stream } from "effect";
 import * as Sse from "effect/unstable/encoding/Sse";
-import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 import { DaemonErrorResponseSchema } from "./DaemonProtocol.ts";
 import { StackBuildError, StackReadinessError } from "./errors.ts";
 import { Stack, StackInfoSchema } from "./Stack.ts";
@@ -93,6 +93,33 @@ function unixResponse(socketPath: string, path: string, init?: RequestInit) {
   );
 }
 
+/** Preserve daemon RPC identity when an HTTP status or body cannot be decoded. */
+function dieOnNonOkStatus<A>(
+  socketPath: string,
+  path: string,
+  effect: Effect.Effect<A, HttpClientError.HttpClientError>,
+) {
+  return effect.pipe(
+    Effect.mapError(
+      (cause) => new UnixHttpClientError({ socketPath, path, cause, reason: "status" }),
+    ),
+    Effect.orDie,
+  );
+}
+
+function dieOnBodyDecodeError<A, E, R>(
+  socketPath: string,
+  path: string,
+  effect: Effect.Effect<A, E, R>,
+) {
+  return effect.pipe(
+    Effect.mapError(
+      (cause) => new UnixHttpClientError({ socketPath, path, cause, reason: "protocol" }),
+    ),
+    Effect.orDie,
+  );
+}
+
 function withAbortSignal<A, E, R>(
   effect: (signal: AbortSignal) => Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> {
@@ -104,6 +131,8 @@ function withAbortSignal<A, E, R>(
 }
 
 const failDaemonResponse = (
+  socketPath: string,
+  path: string,
   response: HttpClientResponse.HttpClientResponse,
   fallbackName: string,
 ): Effect.Effect<
@@ -111,8 +140,10 @@ const failDaemonResponse = (
   ServiceNotFoundError | ServiceReadyError | StackBuildError | StackReadinessError
 > =>
   Effect.gen(function* () {
-    const body = yield* HttpClientResponse.schemaBodyJson(DaemonErrorResponseSchema)(response).pipe(
-      Effect.orDie,
+    const body = yield* dieOnBodyDecodeError(
+      socketPath,
+      path,
+      HttpClientResponse.schemaBodyJson(DaemonErrorResponseSchema)(response),
     );
     switch (body.code) {
       case "SERVICE_NOT_FOUND":
@@ -124,7 +155,10 @@ const failDaemonResponse = (
           ...(body.exitCode === undefined ? {} : { exitCode: body.exitCode }),
         });
       case "STACK_BUILD_ERROR":
-        return yield* new StackBuildError({ detail: body.error });
+        return yield* new StackBuildError({
+          detail: body.error,
+          ...(body.reason === undefined ? {} : { reason: body.reason }),
+        });
       case "STACK_READINESS_TIMEOUT":
         return yield* new StackReadinessError({
           target: body.service ?? fallbackName,
@@ -135,6 +169,8 @@ const failDaemonResponse = (
   });
 
 const expectDaemonOk = (
+  socketPath: string,
+  path: string,
   response: HttpClientResponse.HttpClientResponse,
   fallbackName: string,
 ): Effect.Effect<
@@ -143,15 +179,21 @@ const expectDaemonOk = (
 > =>
   response.status >= 200 && response.status < 300
     ? Effect.void
-    : failDaemonResponse(response, fallbackName);
+    : failDaemonResponse(socketPath, path, response, fallbackName);
 
 /** Fetch JSON from the daemon, dying on HTTP errors. */
 function fetchStatus(socketPath: string, path: string, method = "GET") {
   return Effect.gen(function* () {
     const response = yield* unixResponse(socketPath, path, { method });
-    const okResponse = yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
-    return yield* HttpClientResponse.schemaBodyJson(StatusResponseSchema)(okResponse).pipe(
-      Effect.orDie,
+    const okResponse = yield* dieOnNonOkStatus(
+      socketPath,
+      path,
+      HttpClientResponse.filterStatusOk(response),
+    );
+    return yield* dieOnBodyDecodeError(
+      socketPath,
+      path,
+      HttpClientResponse.schemaBodyJson(StatusResponseSchema)(okResponse),
     );
   });
 }
@@ -159,9 +201,15 @@ function fetchStatus(socketPath: string, path: string, method = "GET") {
 function fetchLogEntries(socketPath: string, path: string) {
   return Effect.gen(function* () {
     const response = yield* unixResponse(socketPath, path);
-    const okResponse = yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
-    return yield* HttpClientResponse.schemaBodyJson(Schema.Array(LogEntrySchema))(okResponse).pipe(
-      Effect.orDie,
+    const okResponse = yield* dieOnNonOkStatus(
+      socketPath,
+      path,
+      HttpClientResponse.filterStatusOk(response),
+    );
+    return yield* dieOnBodyDecodeError(
+      socketPath,
+      path,
+      HttpClientResponse.schemaBodyJson(Schema.Array(LogEntrySchema))(okResponse),
     );
   });
 }
@@ -190,8 +238,22 @@ function sseStream<A>(socketPath: string, path: string, parse: (data: string) =>
     Effect.gen(function* () {
       const controller = new AbortController();
       const response = yield* unixFetch(socketPath, path, { signal: controller.signal });
-      if (!response.ok || !response.body) {
-        return yield* Effect.die(new Error(`SSE request failed: ${response.status}`));
+      if (!response.ok) {
+        return yield* new UnixHttpClientError({
+          socketPath,
+          path,
+          cause: new Error(`SSE request failed: ${response.status}`),
+          reason: "status",
+        });
+      }
+      const body = response.body;
+      if (body === null) {
+        return yield* new UnixHttpClientError({
+          socketPath,
+          path,
+          cause: new Error("SSE response body is missing"),
+          reason: "protocol",
+        });
       }
 
       // State shared across chunks — parser is stateful, accumulates partial events
@@ -203,15 +265,22 @@ function sseStream<A>(socketPath: string, path: string, parse: (data: string) =>
       });
 
       return Stream.fromReadableStream({
-        evaluate: () => response.body!,
-        onError: (error) => (error instanceof Error ? error : new Error(String(error))),
+        evaluate: () => body,
+        onError: (cause) =>
+          new UnixHttpClientError({ socketPath, path, cause, reason: "transport" }),
       }).pipe(
-        Stream.flatMap((chunk: Uint8Array) => {
-          collected.length = 0;
-          parser.feed(new TextDecoder().decode(chunk, { stream: true }));
-          return Stream.fromIterable(Array.from(collected));
-        }),
-        Stream.orDie,
+        Stream.mapEffect((chunk: Uint8Array) =>
+          Effect.try({
+            try: () => {
+              collected.length = 0;
+              parser.feed(new TextDecoder().decode(chunk, { stream: true }));
+              return Array.from(collected);
+            },
+            catch: (cause) =>
+              new UnixHttpClientError({ socketPath, path, cause, reason: "protocol" }),
+          }),
+        ),
+        Stream.flatMap(Stream.fromIterable),
         Stream.ensuring(Effect.sync(() => controller.abort())),
       );
     }),
@@ -271,8 +340,9 @@ export const RemoteStack = {
           start: () =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, "/start", { method: "POST" });
-                yield* expectDaemonOk(response, "stack").pipe(
+                const path = "/start";
+                const response = yield* unixResponse(socketPath, path, { method: "POST" });
+                yield* expectDaemonOk(socketPath, path, response, "stack").pipe(
                   Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
                 );
               }),
@@ -281,16 +351,26 @@ export const RemoteStack = {
           stop: () =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, "/stop", { method: "POST" });
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const path = "/stop";
+                const response = yield* unixResponse(socketPath, path, { method: "POST" });
+                yield* dieOnNonOkStatus(
+                  socketPath,
+                  path,
+                  HttpClientResponse.filterStatusOk(response),
+                );
               }),
             ),
 
           dispose: () =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, "/stop", { method: "POST" });
-                yield* HttpClientResponse.filterStatusOk(response).pipe(Effect.orDie);
+                const path = "/stop";
+                const response = yield* unixResponse(socketPath, path, { method: "POST" });
+                yield* dieOnNonOkStatus(
+                  socketPath,
+                  path,
+                  HttpClientResponse.filterStatusOk(response),
+                );
               }),
             ),
 
@@ -298,10 +378,11 @@ export const RemoteStack = {
             withUnixHttpClient(
               Effect.gen(function* () {
                 const servicePath = yield* publicServicePath(name);
-                const response = yield* unixResponse(socketPath, `/services/${servicePath}/start`, {
+                const path = `/services/${servicePath}/start`;
+                const response = yield* unixResponse(socketPath, path, {
                   method: "POST",
                 });
-                yield* expectDaemonOk(response, name);
+                yield* expectDaemonOk(socketPath, path, response, name);
               }),
             ),
 
@@ -309,10 +390,11 @@ export const RemoteStack = {
             withUnixHttpClient(
               Effect.gen(function* () {
                 const servicePath = yield* publicServicePath(name);
-                const response = yield* unixResponse(socketPath, `/services/${servicePath}/stop`, {
+                const path = `/services/${servicePath}/stop`;
+                const response = yield* unixResponse(socketPath, path, {
                   method: "POST",
                 });
-                yield* expectDaemonOk(response, name).pipe(
+                yield* expectDaemonOk(socketPath, path, response, name).pipe(
                   Effect.catchTag("ServiceReadyError", (error) => Effect.die(error)),
                   Effect.catchTag("StackReadinessError", (error) => Effect.die(error)),
                 );
@@ -323,38 +405,37 @@ export const RemoteStack = {
             withUnixHttpClient(
               Effect.gen(function* () {
                 const servicePath = yield* publicServicePath(name);
-                const response = yield* unixResponse(
-                  socketPath,
-                  `/services/${servicePath}/restart`,
-                  {
-                    method: "POST",
-                  },
-                );
-                yield* expectDaemonOk(response, name);
+                const path = `/services/${servicePath}/restart`;
+                const response = yield* unixResponse(socketPath, path, {
+                  method: "POST",
+                });
+                yield* expectDaemonOk(socketPath, path, response, name);
               }),
             ),
 
           reloadFunctions: (opts) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, "/functions/reload", {
+                const path = "/functions/reload";
+                const response = yield* unixResponse(socketPath, path, {
                   method: "POST",
                   headers: { "content-type": "application/json" },
                   body: JSON.stringify(opts ?? {}),
                 });
-                yield* expectDaemonOk(response, "edge-runtime");
+                yield* expectDaemonOk(socketPath, path, response, "edge-runtime");
               }),
             ),
 
           reloadEdgeRuntime: (opts) =>
             withUnixHttpClient(
               Effect.gen(function* () {
-                const response = yield* unixResponse(socketPath, "/edge-runtime/reload", {
+                const path = "/edge-runtime/reload";
+                const response = yield* unixResponse(socketPath, path, {
                   method: "POST",
                   headers: { "content-type": "application/json" },
                   body: JSON.stringify(opts),
                 });
-                yield* expectDaemonOk(response, "edge-runtime");
+                yield* expectDaemonOk(socketPath, path, response, "edge-runtime");
               }),
             ),
 
@@ -407,17 +488,14 @@ export const RemoteStack = {
               withAbortSignal((signal) =>
                 Effect.gen(function* () {
                   const servicePath = yield* publicServicePath(name);
-                  const response = yield* unixResponse(
-                    socketPath,
-                    `/services/${servicePath}/ready`,
-                    {
-                      method: "POST",
-                      signal,
-                      headers: { "content-type": "application/json" },
-                      body: JSON.stringify(opts ?? inheritReadyOptions),
-                    },
-                  );
-                  yield* expectDaemonOk(response, name);
+                  const path = `/services/${servicePath}/ready`;
+                  const response = yield* unixResponse(socketPath, path, {
+                    method: "POST",
+                    signal,
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(opts ?? inheritReadyOptions),
+                  });
+                  yield* expectDaemonOk(socketPath, path, response, name);
                 }),
               ),
             ),
@@ -426,13 +504,14 @@ export const RemoteStack = {
             withUnixHttpClient(
               withAbortSignal((signal) =>
                 Effect.gen(function* () {
-                  const response = yield* unixResponse(socketPath, "/ready", {
+                  const path = "/ready";
+                  const response = yield* unixResponse(socketPath, path, {
                     method: "POST",
                     signal,
                     headers: { "content-type": "application/json" },
                     body: JSON.stringify(opts ?? inheritReadyOptions),
                   });
-                  yield* expectDaemonOk(response, "stack").pipe(
+                  yield* expectDaemonOk(socketPath, path, response, "stack").pipe(
                     Effect.catchTag("ServiceNotFoundError", (error) => Effect.die(error)),
                   );
                 }),

--- a/packages/stack/src/StackBuilder.ts
+++ b/packages/stack/src/StackBuilder.ts
@@ -108,6 +108,7 @@ export const validateResolvedConfig = (
         return yield* Effect.fail(
           new StackBuildError({
             detail: `mode "native" only supports postgres, auth, and postgrest. Disable ${enabledDockerOnly.join(", ")} or switch to "auto" or "docker".`,
+            reason: "invalid_config",
           }),
         );
       }
@@ -117,6 +118,7 @@ export const validateResolvedConfig = (
       return yield* Effect.fail(
         new StackBuildError({
           detail: "imgproxy requires storage to be enabled",
+          reason: "invalid_config",
         }),
       );
     }
@@ -125,6 +127,7 @@ export const validateResolvedConfig = (
       return yield* Effect.fail(
         new StackBuildError({
           detail: "vector requires analytics to be enabled",
+          reason: "invalid_config",
         }),
       );
     }
@@ -133,6 +136,7 @@ export const validateResolvedConfig = (
       return yield* Effect.fail(
         new StackBuildError({
           detail: "studio requires pgmeta to be enabled",
+          reason: "invalid_config",
         }),
       );
     }

--- a/packages/stack/src/StackConfigResolver.ts
+++ b/packages/stack/src/StackConfigResolver.ts
@@ -307,7 +307,11 @@ async function resolveFunctionsConfig(config: StackConfig, projectDir: string) {
       config.functions,
     );
   } catch (cause) {
-    throw new StackBuildError({ detail: "Invalid Edge Functions bundle", cause });
+    throw new StackBuildError({
+      detail: "Invalid Edge Functions bundle",
+      cause,
+      reason: "invalid_config",
+    });
   }
 }
 

--- a/packages/stack/src/StackPreparation.ts
+++ b/packages/stack/src/StackPreparation.ts
@@ -2,7 +2,7 @@ import { Cause, Data, Effect, Exit, Layer, Queue, Context, Stream } from "effect
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { BinaryResolver } from "./BinaryResolver.ts";
 import type { ChecksumMismatchError } from "./errors.ts";
-import { DockerPullError } from "./errors.ts";
+import { DockerPullError, isDockerDaemonDownMessage } from "./errors.ts";
 import { isDockerOnlyService } from "./ServiceCatalog.ts";
 import {
   DEFAULT_VERSIONS,
@@ -202,6 +202,7 @@ const pullImage = (
     yield* callbacks?.onDownloadStart ?? Effect.void;
 
     const failures: PullAttemptFailure[] = [];
+    let spawnFailed = false;
 
     for (const image of images) {
       for (
@@ -212,6 +213,9 @@ const pullImage = (
         const attempt = attemptIndex + 1;
         const result = yield* Effect.exit(runPullCommand(spawner, image));
         if (Exit.isSuccess(result)) {
+          // A successful spawn proves the runtime is usable; an earlier
+          // transient spawn failure must not taint the final classification.
+          spawnFailed = false;
           if (result.value.exitCode === 0) {
             return image;
           }
@@ -226,6 +230,10 @@ const pullImage = (
             break;
           }
         } else {
+          // A failed effect (rather than a non-zero exit) means the container
+          // runtime could not be spawned at all — a local Docker setup
+          // problem, not a registry failure.
+          spawnFailed = true;
           const cause = Cause.squash(result.cause);
           const message = cause instanceof Error ? cause.message : String(cause);
           failures.push({ image, attempt, message });
@@ -251,6 +259,8 @@ const pullImage = (
         image: images[0] ?? "unknown",
         detail: `Failed to pull Docker image from all registries. ${detail}`,
         cause: new Error(detail),
+        daemonDown:
+          spawnFailed || failures.some((failure) => isDockerDaemonDownMessage(failure.message)),
       }),
     );
   });

--- a/packages/stack/src/UnixHttpClient.ts
+++ b/packages/stack/src/UnixHttpClient.ts
@@ -4,6 +4,7 @@ export class UnixHttpClientError extends Data.TaggedError("UnixHttpClientError")
   readonly socketPath: string;
   readonly path: string;
   readonly cause: unknown;
+  readonly reason: "transport" | "status" | "protocol";
 }> {}
 
 export class UnixHttpClient extends Context.Service<

--- a/packages/stack/src/effect.ts
+++ b/packages/stack/src/effect.ts
@@ -9,6 +9,7 @@ export {
   ChecksumMismatchError,
   DockerPullError,
   DownloadError,
+  isDockerDaemonDownMessage,
   PortConflictError,
   StackBuildError,
   StackError,

--- a/packages/stack/src/errors.ts
+++ b/packages/stack/src/errors.ts
@@ -20,11 +20,47 @@ export class DockerPullError extends Data.TaggedError("DockerPullError")<{
   readonly image: string;
   readonly detail: string;
   readonly cause: unknown;
+  /**
+   * Whether the pull failed because the container runtime itself is unusable
+   * locally — the daemon is unreachable (detected from the runtime's output
+   * at the boundary where it is produced) or the docker binary could not be
+   * spawned at all. Consumers must branch on this instead of sniffing
+   * `detail` text.
+   */
+  readonly daemonDown: boolean;
 }> {}
+
+/**
+ * Whether a container runtime's output indicates the daemon itself is not
+ * running. This is the boundary vocabulary for `DockerPullError.daemonDown`
+ * and shared with the CLI's legacy docker-run layer so both paths agree on
+ * what "daemon down" looks like.
+ */
+export const isDockerDaemonDownMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("cannot connect to the docker daemon") ||
+    normalized.includes("docker daemon is not running") ||
+    normalized.includes("docker desktop is not running") ||
+    normalized.includes("is the docker daemon running") ||
+    // Spawn succeeds but the socket is not accessible (e.g. a Linux user
+    // missing docker group membership) — a local setup problem, not a
+    // registry failure.
+    normalized.includes("permission denied while trying to connect to the docker daemon")
+  );
+};
 
 export class StackBuildError extends Data.TaggedError("StackBuildError")<{
   readonly detail: string;
   readonly cause?: unknown;
+  /**
+   * Structured discriminant for consumers that need to distinguish failure
+   * classes without parsing `detail`: `invalid_config` for user-fixable
+   * configuration problems, `docker_not_running` for an unavailable local
+   * runtime, and `asset_preparation` for other download/registry failures.
+   * Absent for internal invariant violations.
+   */
+  readonly reason?: "invalid_config" | "docker_not_running" | "asset_preparation";
 }> {}
 
 export class StackNotRunningError extends Data.TaggedError("StackNotRunningError")<{
@@ -64,6 +100,7 @@ export function toStackError(err: unknown): StackError {
         return new StackError({
           code: "SERVICE_NOT_FOUND",
           message: taggedMessage,
+          cause: err,
         });
       case "StackBuildError":
         return new StackError({

--- a/packages/stack/src/platform-bun.ts
+++ b/packages/stack/src/platform-bun.ts
@@ -16,7 +16,7 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
         const requestInit: BunUnixRequestInit = { ...init, unix: socketPath };
         return fetch(`http://localhost${path}`, requestInit);
       },
-      catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+      catch: (cause) => new UnixHttpClientError({ socketPath, path, cause, reason: "transport" }),
     }),
 });
 

--- a/packages/stack/src/platform-node.ts
+++ b/packages/stack/src/platform-node.ts
@@ -91,7 +91,7 @@ export const unixHttpClientLayer = Layer.succeed(UnixHttpClient, {
           request.end(body);
         });
       },
-      catch: (cause) => new UnixHttpClientError({ socketPath, path, cause }),
+      catch: (cause) => new UnixHttpClientError({ socketPath, path, cause, reason: "transport" }),
     }),
 });
 


### PR DESCRIPTION
## TL;DR

Defines a shared, CLI error taxonomy for KPI reporting..

## What's introduced?

- A shared taxonomy for describing why a CLI command failed, whether the failure is actionable, and how the user can recover. 
- Consistent classifications across known CLI errors, backed by automated coverage that prevents new errors from going unclassified.
- Stable error fingerprints and precise definitions for measuring recovery, repeat failures, and internal or unknown CLI bugs.

## Why is it needed?

`cli_command_executed` tells us that a command failed, but not whether it was user-actionable, caused by an external service, or a CLI bug. 
This establishes that distinction without capturing raw error text or user-specific data & 
 lays the foundation for CLI-1561 (completed locally, will push once this lands in)  to add these fields to telemetry...

## ref

- Closes CLI-1560
- supersedes/extends: https://github.com/supabase/cli/pull/5829