### PR TITLE
fix(cli): retry local db connection

### DIFF
--- a/apps/cli/src/legacy/commands/db/start/start.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/start/start.integration.test.ts
@@ -25,6 +25,7 @@ import {
   LegacyNetworkIdFlag,
 } from "../../../../shared/legacy/global-flags.ts";
 import type { OutputFormat } from "../../../../shared/output/types.ts";
+import { LegacyDbConnectError } from "../../../shared/legacy-db-connection.errors.ts";
 import {
   LegacyDbConnection,
   type LegacyDbSession,
@@ -276,6 +277,10 @@ interface SetupOpts {
   readonly catalogStdout?: string;
   /** Fails the mocked catalog-export call with this message instead of succeeding. */
   readonly catalogExportFailWith?: string;
+  /** Number of initial `LegacyDbConnection.connect` attempts that fail before succeeding. */
+  readonly connectFailures?: number;
+  /** Whether the mocked connect failures are dial-level (`retryable`). Defaults to `true`. */
+  readonly connectFailuresRetryable?: boolean;
 }
 
 function setup(opts: SetupOpts = {}) {
@@ -312,6 +317,25 @@ function setup(opts: SetupOpts = {}) {
     requireSslForHost: () => Effect.succeed(false),
   });
 
+  let connectAttempts = 0;
+  const connectFailures = opts.connectFailures ?? 0;
+  const dbConnection = Layer.succeed(LegacyDbConnection, {
+    connect: () =>
+      Effect.suspend(() => {
+        connectAttempts += 1;
+        if (connectAttempts <= connectFailures) {
+          return Effect.fail(
+            new LegacyDbConnectError({
+              message:
+                "failed to connect to postgres: failed to connect to `host=127.0.0.1 user=postgres database=postgres`: connect ECONNREFUSED 127.0.0.1:54322",
+              ...(opts.connectFailuresRetryable === false ? {} : { retryable: true }),
+            }),
+          );
+        }
+        return Effect.succeed(dbSession.session);
+      }),
+  });
+
   const layer = Layer.mergeAll(
     BunServices.layer,
     out.layer,
@@ -319,7 +343,7 @@ function setup(opts: SetupOpts = {}) {
     telemetry.layer,
     child.layer,
     alwaysReadyHttpClientLayer,
-    Layer.succeed(LegacyDbConnection, { connect: () => Effect.succeed(dbSession.session) }),
+    dbConnection,
     legacyDockerRunLayer.pipe(
       Layer.provide(child.layer),
       Layer.provide(mockProcessControl().layer),
@@ -336,7 +360,17 @@ function setup(opts: SetupOpts = {}) {
     edgeRuntime,
     sslProbe,
   );
-  return { layer, out, telemetry, child, dbSession, edgeRunCalls };
+  return {
+    layer,
+    out,
+    telemetry,
+    child,
+    dbSession,
+    edgeRunCalls,
+    get connectAttempts() {
+      return connectAttempts;
+    },
+  };
 }
 
 const currentBranchPath = (workdir: string) =>
@@ -378,6 +412,32 @@ describe("legacy db start", () => {
       });
     },
   );
+
+  it.live(
+    "fresh volume: retries the host connect while the published port is not yet reachable (#6136)",
+    () => {
+      const s = setup({ route: freshVolumeRoute(defaultRoute()), connectFailures: 2 });
+      return Effect.gen(function* () {
+        yield* legacyDbStart(DEFAULT_FLAGS).pipe(Effect.provide(s.layer));
+        expect(s.connectAttempts).toBe(3);
+        expect(readFileSync(currentBranchPath(tempRoot.current), "utf8")).toBe("main");
+      });
+    },
+    15_000,
+  );
+
+  it.live("fresh volume: a non-dial connect failure is not retried", () => {
+    const s = setup({
+      route: freshVolumeRoute(defaultRoute()),
+      connectFailures: 1,
+      connectFailuresRetryable: false,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbStart(DEFAULT_FLAGS).pipe(Effect.provide(s.layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(s.connectAttempts).toBe(1);
+    });
+  });
 
   it.live(
     "PG <= 14 on a fresh volume: execs schema/globals SQL directly instead of the PG15+ one-shot migrate jobs",

--- a/apps/cli/src/legacy/shared/db-bootstrap/db-setup.ts
+++ b/apps/cli/src/legacy/shared/db-bootstrap/db-setup.ts
@@ -108,7 +108,7 @@
  */
 
 import type { ProjectConfig } from "@supabase/config";
-import { Clock, Data, Effect, type FileSystem, Option, type Path } from "effect";
+import { Clock, Data, Effect, type FileSystem, Option, type Path, Schedule } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
 import type { LocalServiceVersionOverrides } from "../../../shared/services/services.shared.ts";
@@ -1125,16 +1125,28 @@ export const legacyRunFreshDbSetup = <E>(
       const dbConnection = yield* LegacyDbConnection;
       const { setup } = input;
       const dbPassword = legacyStartInternalDbPassword(setup.dbUrl);
-      const session = yield* dbConnection.connect(
-        {
-          host: input.hostname,
-          port: input.dbPort,
-          user: "postgres",
-          password: dbPassword,
-          database: "postgres",
-        },
-        { isLocal: true, dnsResolver: "native" },
-      );
+      // Go's `SetupLocalDatabase` dials this first host-facing connect exactly
+      // once (`start.go:360-363`); we deliberately diverge and retry dial-level
+      // failures: the container's internal health check says nothing about the
+      // HOST side, where Docker Desktop (Windows/WSL2) can publish the port a
+      // few seconds late (#6136).
+      const session = yield* dbConnection
+        .connect(
+          {
+            host: input.hostname,
+            port: input.dbPort,
+            user: "postgres",
+            password: dbPassword,
+            database: "postgres",
+          },
+          { isLocal: true, dnsResolver: "native" },
+        )
+        .pipe(
+          Effect.retry({
+            schedule: Schedule.max([Schedule.spaced("1 seconds"), Schedule.recurs(10)]),
+            while: (error) => error.retryable === true,
+          }),
+        );
 
       // Go's `initSchema` (`start.go:243-254`) branches to `initSchema15` — the ONLY place
       // `ResolveJWKS` is ever called — solely on `majorVersion >= 15`; the PG13/14 branch

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.ts
@@ -175,6 +175,29 @@ const LEGACY_DIAL_ERROR_CODES = new Set([
   "EHOSTUNREACH",
   "EADDRNOTAVAIL",
 ]);
+// Connect-timeout failures that carry no errno `code`, matched by their exact
+// driver text: node-postgres' client connect timeout (`pg/lib/client.js`), its
+// pool acquire timeout (`pg/lib/pool.js`), and this layer's own probe timeout
+// (`legacyAcquireProbedPool`). All three are the port of Go's `connect_timeout`
+// firing — a `context.DeadlineExceeded`, which satisfies `net.Error`.
+const LEGACY_CONNECT_TIMEOUT_MESSAGES = new Set([
+  "Connection timed out",
+  "timeout expired",
+  "timeout exceeded when trying to connect",
+]);
+
+/**
+ * Whether a connect failure is a dial-level error — refused, timed out, or
+ * unreachable — rather than a server, auth, TLS, or config error. Sets
+ * `LegacyDbConnectError.retryable`, which the fresh-db bootstrap's connect
+ * retry keys off (`db-setup.ts`, #6136).
+ */
+export function legacyIsDialFailure(error: unknown): boolean {
+  const cause = legacyDeepestConnectCause(error);
+  if (hasStringCode(cause) && LEGACY_DIAL_ERROR_CODES.has(cause.code)) return true;
+  const message = typeof cause === "object" && cause !== null ? Reflect.get(cause, "message") : "";
+  return typeof message === "string" && LEGACY_CONNECT_TIMEOUT_MESSAGES.has(message);
+}
 // The complete documented Node/OpenSSL X509 certificate-verification code
 // family (Node tls docs "X509 certificate error codes", OpenSSL's
 // `X509_verify_cert_error` set), complemented by node's ERR_TLS_*/ERR_SSL_*

--- a/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-connect-errors.unit.test.ts
@@ -8,6 +8,7 @@ import {
   legacyConnectFailureMessage,
   legacyConnectSuggestion,
   legacyIpv6Suggestion,
+  legacyIsDialFailure,
   legacyIsIPv6ConnectivityError,
   legacyIsIPv6ConnectivityErrorCause,
 } from "./legacy-connect-errors.ts";
@@ -479,6 +480,48 @@ describe("legacyConnectSuggestion", () => {
 
   it("returns undefined for an unrecognized connect error", () => {
     expect(legacyConnectSuggestion(sqlError(new Error("some other failure")), ctx)).toBeUndefined();
+  });
+});
+
+describe("legacyIsDialFailure", () => {
+  it("classifies dial errno failures", () => {
+    expect(
+      legacyIsDialFailure(realSqlConnectError(dialError("ECONNREFUSED", "127.0.0.1", 54322))),
+    ).toBe(true);
+    expect(
+      legacyIsDialFailure(realSqlConnectError(dialError("ETIMEDOUT", "127.0.0.1", 54322))),
+    ).toBe(true);
+  });
+
+  it("classifies the last attempt of a multi-address dial", () => {
+    expect(
+      legacyIsDialFailure(
+        realSqlConnectError(
+          new AggregateError([
+            dialError("ENETUNREACH", "::1", 54322),
+            dialError("ECONNREFUSED", "127.0.0.1", 54322),
+          ]),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("classifies the code-less connect timeouts", () => {
+    expect(legacyIsDialFailure(realSqlConnectError(new Error("Connection timed out")))).toBe(true);
+    expect(legacyIsDialFailure(realSqlConnectError(new Error("timeout expired")))).toBe(true);
+    expect(
+      legacyIsDialFailure(
+        realSqlConnectError(new Error("timeout exceeded when trying to connect")),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify server, auth, or unknown errors", () => {
+    expect(legacyIsDialFailure(realSqlConnectError(authFailedError()))).toBe(false);
+    expect(
+      legacyIsDialFailure(realSqlConnectError(new Error("Connection terminated unexpectedly"))),
+    ).toBe(false);
+    expect(legacyIsDialFailure(undefined)).toBe(false);
   });
 });
 

--- a/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.errors.ts
@@ -14,6 +14,12 @@ import {
 export class LegacyDbConnectError extends Data.TaggedError("LegacyDbConnectError")<{
   readonly message: string;
   readonly suggestion?: string;
+  /**
+   * True when the failure was dial-level (`legacyIsDialFailure`) rather than
+   * a server, auth, or config error — the fresh-db bootstrap's connect retry
+   * keys off this field (`db-setup.ts`, #6136).
+   */
+  readonly retryable?: boolean;
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     return actionability.dbConnection;

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -203,6 +203,7 @@ describe("legacyDbConnectionSqlPgLayer connect failures", () => {
       const port = yield* Effect.promise(acquireClosedPort);
       const error = yield* connectFailure({ port });
       expect(error.suggestion).toBe(LEGACY_SUGGEST_LOCAL_STACK);
+      expect(error.retryable).toBe(true);
     }),
   );
 
@@ -235,6 +236,7 @@ describe("legacyDbConnectionSqlPgLayer connect failures", () => {
         );
         expect(error.suggestion).toBe(LEGACY_SUGGEST_ENV_VAR);
         expect(error.message).not.toContain(SENTINEL_PASSWORD);
+        expect(error.retryable).toBeUndefined();
       }),
   );
 
@@ -259,6 +261,8 @@ describe("legacyDbConnectionSqlPgLayer connect failures", () => {
             "Connection terminated unexpectedly",
         );
         expect(error.suggestion).toBeUndefined();
+        // An unexpected EOF is not a dial-level failure — never marked retryable.
+        expect(error.retryable).toBeUndefined();
       }),
   );
 });

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -14,6 +14,7 @@ import { to as pgCopyTo } from "pg-copy-streams";
 import {
   legacyConnectFailureMessage,
   legacyConnectSuggestion,
+  legacyIsDialFailure,
   legacyIsSqlState,
 } from "./legacy-connect-errors.ts";
 import {
@@ -665,6 +666,7 @@ const connect = (
       return new LegacyDbConnectError({
         message: `failed to connect to postgres: ${legacyConnectFailureMessage(cfg, error)}`,
         ...(suggestion === undefined ? {} : { suggestion }),
+        ...(legacyIsDialFailure(error) ? { retryable: true } : {}),
       });
     };
 


### PR DESCRIPTION
## TL;DR
fixes `supabase db start` on `Windows/WSL2` 
killing a healthy Postgres container right after it becomes healthy, which was caused by a single 2 second host connection attempt while Docker Desktop publishes the container port with a short delay, 

and is now fixed by retrying the first fresh volume connection on dial level errors with 1 second backoff for up to 10 attempts. 
Auth and config errors still fail on the first attempt, and the error text on exhausted retries is unchanged...

## ref:
- closes: https://github.com/supabase/cli/issues/6136
- closes CLI-2152