### PR TITLE
chore(cli): attach failure metadata

### DIFF
--- a/apps/cli/docs/analytics.md
+++ b/apps/cli/docs/analytics.md
@@ -63,8 +63,8 @@ It is emitted once per handled command invocation and includes:
 - `exit_code`
 - `duration_ms`
 
-Failed invocations (`exit_code != 0`) also carry a sanitized error
-classification:
+Failed invocations (`exit_code != 0`) handled by the TS shells also carry a
+sanitized error classification:
 
 - `error_kind`
 - `error_category`
@@ -78,6 +78,13 @@ These values come exclusively from the closed taxonomy in
 and the KPI query semantics (strict recovery, repeat errors, internal/unknown
 bug rate) are documented there in `CliErrorActionabilityMetricDefinitions`.
 A `workflow` property is reserved in the catalog but not emitted yet.
+
+Not every failure is classified: pure Go-proxy commands report through the Go
+binary, which does not emit these fields, and events from CLI versions before
+they existed never carry them. KPI queries therefore scope to
+`error_kind IS NOT NULL`, and the `classificationCoverage` metric definition
+reports the classified share of failures so the covered fraction is explicit
+rather than assumed.
 
 Flag capture is intentionally conservative:
 

--- a/apps/cli/docs/analytics.md
+++ b/apps/cli/docs/analytics.md
@@ -63,6 +63,22 @@ It is emitted once per handled command invocation and includes:
 - `exit_code`
 - `duration_ms`
 
+Failed invocations (`exit_code != 0`) also carry a sanitized error
+classification:
+
+- `error_kind`
+- `error_category`
+- `error_fingerprint`
+- `has_suggestion`
+- `suggestion_type`
+- `suggested_command` (only when the remediation is an allowlisted command)
+
+These values come exclusively from the closed taxonomy in
+`src/shared/telemetry/error-actionability.ts` — never from raw error text —
+and the KPI query semantics (strict recovery, repeat errors, internal/unknown
+bug rate) are documented there in `CliErrorActionabilityMetricDefinitions`.
+A `workflow` property is reserved in the catalog but not emitted yet.
+
 Flag capture is intentionally conservative:
 
 - `flags_used` is always captured

--- a/apps/cli/src/legacy/commands/db/diff/diff.handler.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.handler.ts
@@ -331,7 +331,10 @@ export const legacyDbDiff = Effect.fn("legacy.db.diff")(function* (flags: Legacy
       Effect.gen(function* () {
         const env = { SUPABASE_TELEMETRY_DISABLED: "1" };
         if (output.format !== "text") {
-          const captured = yield* proxy.execCapture(rebuildDelegateArgs(flags), { env });
+          const captured = yield* proxy.execCapture(rebuildDelegateArgs(flags), {
+            env,
+            suppressChildTelemetry: true,
+          });
           yield* output.success("Diff complete.", {
             diff: captured,
             file: null,
@@ -340,7 +343,7 @@ export const legacyDbDiff = Effect.fn("legacy.db.diff")(function* (flags: Legacy
           });
           return;
         }
-        yield* proxy.exec(rebuildDelegateArgs(flags), { env });
+        yield* proxy.exec(rebuildDelegateArgs(flags), { env, suppressChildTelemetry: true });
       });
     if (usePgAdmin) {
       yield* delegateDiff("pgadmin");

--- a/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
@@ -368,7 +368,11 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
       Effect.gen(function* () {
         const env = { SUPABASE_TELEMETRY_DISABLED: "1" };
         if (output.format !== "text") {
-          yield* proxy.execCapture(rebuildDelegateArgs(flags), { env, stdin: "ignore" });
+          yield* proxy.execCapture(rebuildDelegateArgs(flags), {
+            env,
+            stdin: "ignore",
+            suppressChildTelemetry: true,
+          });
           yield* output.success("Schema pulled.", {
             declarative: false,
             schemaWritten: null,
@@ -377,7 +381,7 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
           });
           return;
         }
-        yield* proxy.exec(rebuildDelegateArgs(flags), { env });
+        yield* proxy.exec(rebuildDelegateArgs(flags), { env, suppressChildTelemetry: true });
       });
 
     // Connectivity check (Go's `ConnectByConfig` at the top of `pull.Run`).

--- a/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
+++ b/apps/cli/src/legacy/commands/db/reset/reset.handler.ts
@@ -256,13 +256,20 @@ export const legacyDbReset = Effect.fn("legacy.db.reset")(function* (flags: Lega
       Effect.gen(function* () {
         const env = { SUPABASE_TELEMETRY_DISABLED: "1" };
         if (output.format === "text") {
-          yield* proxy.exec(buildResetArgs(flags, connType, yes), { env });
+          yield* proxy.exec(buildResetArgs(flags, connType, yes), {
+            env,
+            suppressChildTelemetry: true,
+          });
         } else {
           // Machine-output mode is non-interactive: give the Go child a non-TTY stdin
           // (`stdin: "ignore"`) so it can't block on (or be answered at) Go's
           // destructive reset prompt — it takes the default `false`, matching the
           // native reset path which suppresses prompts under json/stream-json.
-          yield* proxy.execCapture(buildResetArgs(flags, connType, yes), { env, stdin: "ignore" });
+          yield* proxy.execCapture(buildResetArgs(flags, connType, yes), {
+            env,
+            stdin: "ignore",
+            suppressChildTelemetry: true,
+          });
           yield* output.success("Reset remote database.", {
             target: "remote",
             version: resolvedVersion,

--- a/apps/cli/src/legacy/commands/functions/download/download.handler.ts
+++ b/apps/cli/src/legacy/commands/functions/download/download.handler.ts
@@ -50,8 +50,10 @@ export const legacyFunctionsDownload = Effect.fn("legacy.functions.download")(fu
       const args = makeGoProxyDownloadArgs(proxyFlags, projectRef);
       const env = { SUPABASE_TELEMETRY_DISABLED: "1" };
       return captureOutput
-        ? Effect.asVoid(proxy.execCapture(args, { env, stdin: "ignore" }))
-        : proxy.exec(args, { env });
+        ? Effect.asVoid(
+            proxy.execCapture(args, { env, stdin: "ignore", suppressChildTelemetry: true }),
+          )
+        : proxy.exec(args, { env, suppressChildTelemetry: true });
     },
   }).pipe(
     Effect.ensuring(

--- a/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
+++ b/apps/cli/src/legacy/commands/inspect/report/report.csvq.ts
@@ -2,6 +2,7 @@ import { Option } from "effect";
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../../../shared/telemetry/error-actionability.ts";
 
@@ -52,6 +53,7 @@ import {
 
 /** Thrown for grammar or evaluation outside the supported csvq subset. */
 export class LegacyInspectCsvqError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyInspectCsvqError";
   override readonly name = "LegacyInspectCsvqError";
 
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {

--- a/apps/cli/src/legacy/shared/legacy-config-validate.ts
+++ b/apps/cli/src/legacy/shared/legacy-config-validate.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join } from "node:path";
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
 import { legacyGoUrlParse } from "./legacy-storage-url.ts";
@@ -167,6 +168,7 @@ export function legacyParseGoBool(value: string): boolean | undefined {
  * is a byte-identical, purely internal refactor.
  */
 export class LegacyConfigValidateError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyConfigValidateError";
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     return actionability.invalidConfig;
   }

--- a/apps/cli/src/legacy/shared/legacy-go-struct-output.encoders.ts
+++ b/apps/cli/src/legacy/shared/legacy-go-struct-output.encoders.ts
@@ -1,6 +1,7 @@
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
 
@@ -1068,6 +1069,7 @@ function yamlBlockLiteral(s: string, indent: number): string {
  * on `snippets list -o toml`) or a `nil` element inside an inline array.
  */
 export class LegacyGoTomlEncodeError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyGoTomlEncodeError";
   constructor(message = "toml: cannot encode a map with non-string key type") {
     super(message);
     this.name = "LegacyGoTomlEncodeError";

--- a/apps/cli/src/legacy/shared/legacy-local-config-values.ts
+++ b/apps/cli/src/legacy/shared/legacy-local-config-values.ts
@@ -15,6 +15,7 @@ import {
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
 import { legacyResolveApiExternalUrl } from "./legacy-api-url.ts";
@@ -171,6 +172,7 @@ function apiUrlWithPath(apiExternalUrl: string, path: string): string {
  * short secret.
  */
 export class LegacyInvalidJwtSecretError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyInvalidJwtSecretError";
   constructor() {
     super("Invalid config for auth.jwt_secret. Must be at least 16 characters");
     this.name = "LegacyInvalidJwtSecretError";
@@ -196,6 +198,7 @@ const MIN_JWT_SECRET_LENGTH = 16;
  * string), but the parity-relevant part — hard-fail, same field name — is.
  */
 export class LegacyInvalidPortEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyInvalidPortEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(`Invalid config for ${dottedFieldPath}: cannot parse "${value}" as a port`);
     this.name = "LegacyInvalidPortEnvOverrideError";
@@ -296,6 +299,7 @@ export function legacyEnvOverride(
  * `stop` with a malformed bool override.
  */
 export class LegacyInvalidBoolEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyInvalidBoolEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(`Invalid config for ${dottedFieldPath}: cannot parse "${value}" as a bool`);
     this.name = "LegacyInvalidBoolEnvOverrideError";
@@ -352,6 +356,8 @@ export function legacyEnvOverrideBool(
  * {@link LegacyInvalidBoolEnvOverrideError}.
  */
 export class LegacyInvalidAnalyticsBackendEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] =
+    "LegacyInvalidAnalyticsBackendEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "postgres", "bigquery"`,
@@ -398,6 +404,8 @@ function envOverrideAnalyticsBackend(
  * {@link LegacyInvalidAnalyticsBackendEnvOverrideError}.
  */
 export class LegacyInvalidRealtimeIpVersionEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] =
+    "LegacyInvalidRealtimeIpVersionEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "IPv4", "IPv6"`,
@@ -461,6 +469,7 @@ export function legacyEnvOverrideApiMaxRows(
  * {@link LegacyInvalidRealtimeIpVersionEnvOverrideError}.
  */
 export class LegacyInvalidPoolModeEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyInvalidPoolModeEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "transaction", "session"`,
@@ -499,6 +508,8 @@ export function legacyEnvOverridePoolMode(
  * {@link LegacyInvalidPoolModeEnvOverrideError}.
  */
 export class LegacyInvalidEdgeRuntimePolicyEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] =
+    "LegacyInvalidEdgeRuntimePolicyEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "per_worker", "oneshot"`,
@@ -1300,6 +1311,8 @@ function legacyEnvOverrideOptionalBool(
  * {@link LegacyInvalidRealtimeIpVersionEnvOverrideError}.
  */
 export class LegacyInvalidSessionReplicationRoleEnvOverrideError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] =
+    "LegacyInvalidSessionReplicationRoleEnvOverrideError";
   constructor(dottedFieldPath: string, value: string) {
     super(
       `Invalid config for ${dottedFieldPath}: cannot parse "${value}" as one of "origin", "replica", "local"`,

--- a/apps/cli/src/legacy/shared/legacy-storage-url.ts
+++ b/apps/cli/src/legacy/shared/legacy-storage-url.ts
@@ -1,6 +1,7 @@
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
 
@@ -34,6 +35,7 @@ const LEGACY_STORAGE_INVALID_URL_MESSAGE = "URL must match pattern ss:///bucket/
  * `errors.Errorf("failed to parse … url: %w", err)`.
  */
 export class LegacyGoUrlParseError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyGoUrlParseError";
   constructor(rawURL: string, inner: string) {
     super(`parse "${rawURL}": ${inner}`);
     this.name = "LegacyGoUrlParseError";
@@ -51,6 +53,7 @@ export class LegacyGoUrlParseError extends Error {
  * parse-error tagged error.
  */
 export class LegacyStorageUrlPatternError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyStorageUrlPatternError";
   constructor() {
     super(LEGACY_STORAGE_INVALID_URL_MESSAGE);
     this.name = "LegacyStorageUrlPatternError";

--- a/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
+++ b/apps/cli/src/legacy/shared/legacy-string-slice-flag.ts
@@ -1,6 +1,7 @@
 import {
   actionability,
   type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
 
@@ -38,6 +39,7 @@ const lengthNL = (b: Uint8Array): number => (b.length > 0 && b[b.length - 1] ===
  *    `readAsCSV` propagates `csv.Reader.Read`'s `io.EOF` unchanged).
  */
 export class LegacyStringSliceFlagParseError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "LegacyStringSliceFlagParseError";
   readonly value: string;
   private constructor(value: string, message: string) {
     super(message);

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Exit, Option, Stdio } from "effect";
+import { Cause, Clock, Effect, Exit, Option, Stdio } from "effect";
 import { Param } from "effect/unstable/cli";
 import {
   CommandRuntime,
@@ -15,11 +15,22 @@ import { ProcessControl } from "../../shared/runtime/process-control.service.ts"
 import { withAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
 import {
+  type CliErrorActionability,
+  classifyCliErrorActionability,
+  unknownProcessControlledFailureActionability,
+} from "../../shared/telemetry/error-actionability.ts";
+import { LegacyDbAdvisorsFailOnError } from "../commands/db/advisors/advisors.errors.ts";
+import { LegacyDbLintFailOnError } from "../commands/db/lint/lint.errors.ts";
+import {
   EventCommandExecuted,
   PropDurationMs,
   PropExitCode,
   PropOutputFormat,
 } from "../../shared/telemetry/event-catalog.ts";
+import {
+  failureTelemetryPropertiesForCause,
+  toFailureTelemetryProperties,
+} from "../../shared/telemetry/failure-metadata.ts";
 import {
   LEGACY_RESOURCE_OUTPUT_FORMATS,
   LegacyInvalidOutputFormatError,
@@ -32,6 +43,23 @@ import {
   VALUE_CONSUMING_SHORT_FLAGS,
 } from "../shared/legacy-db-target-flags.ts";
 import { legacyUnwrapToSingleParam } from "../shared/legacy-param-introspection.ts";
+
+/**
+ * Classifies a command that succeeded its Effect but recorded a nonzero exit
+ * code through ProcessControl. `db lint`/`db advisors` do this deliberately in
+ * machine mode after a `--fail-on` trigger (to keep the JSON payload on stdout
+ * intact), so their telemetry derives from the same typed error their text
+ * mode raises — the classification stays declared on the error class itself.
+ */
+function processControlledFailureActionability(command: string): CliErrorActionability {
+  if (command === "db lint") {
+    return classifyCliErrorActionability(new LegacyDbLintFailOnError({ message: "" }));
+  }
+  if (command === "db advisors") {
+    return classifyCliErrorActionability(new LegacyDbAdvisorsFailOnError({ message: "" }));
+  }
+  return unknownProcessControlledFailureActionability;
+}
 
 interface LegacyCommandInstrumentationOptions<Flags extends Record<string, unknown> = never> {
   readonly analytics?: boolean;
@@ -441,6 +469,11 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
           onNone: () => analyticsContext,
           onSome: (distinct_id) => ({ ...analyticsContext, distinct_id }),
         });
+        const failureMetadata = Exit.isFailure(exit)
+          ? failureTelemetryPropertiesForCause(exit.cause)
+          : recordedExitCode === 1
+            ? toFailureTelemetryProperties(processControlledFailureActionability(command))
+            : {};
 
         yield* analytics
           .capture(EventCommandExecuted, {
@@ -449,8 +482,17 @@ function withLegacyCommandAnalyticsImplementation<Flags extends Record<string, u
             [PropOutputFormat]: Option.isSome(resolvedOutputFormat)
               ? resolvedOutputFormat.value
               : resolveOutputFormatForTelemetry(args, output.format),
+            ...failureMetadata,
           })
-          .pipe(withAnalyticsContext(captureContext));
+          .pipe(
+            withAnalyticsContext(captureContext),
+            // Best-effort: a capture failure or defect must never replace the
+            // command's own result, but fiber interruption (Ctrl+C landing
+            // during this trailing capture) must still propagate.
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause) ? Effect.failCause(cause) : Effect.void,
+            ),
+          );
 
         if (Exit.isFailure(exit)) {
           return yield* Effect.failCause(exit.cause);

--- a/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
+++ b/apps/cli/src/legacy/telemetry/legacy-command-instrumentation.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Stdio } from "effect";
+import { Cause, Effect, Exit, Layer, Option, Stdio } from "effect";
 import { Flag } from "effect/unstable/cli";
 import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.ts";
 import {
@@ -11,7 +11,17 @@ import {
 } from "../../shared/legacy/global-flags.ts";
 import { CurrentAnalyticsContext } from "../../shared/telemetry/analytics-context.ts";
 import { Analytics } from "../../shared/telemetry/analytics.service.ts";
+import {
+  PropErrorCategory,
+  PropErrorFingerprint,
+  PropErrorKind,
+  PropHasSuggestion,
+  PropSuggestedCommand,
+  PropSuggestionType,
+  PropWorkflow,
+} from "../../shared/telemetry/event-catalog.ts";
 import { ProcessControl } from "../../shared/runtime/process-control.service.ts";
+import { LegacyDbDumpRunError } from "../commands/db/dump/dump.errors.ts";
 import { LegacyIdentityStitch } from "../shared/legacy-identity-stitch.ts";
 import { withLegacyCommandInstrumentation } from "./legacy-command-instrumentation.ts";
 import {
@@ -19,6 +29,16 @@ import {
   LegacyInvalidOutputFormatError,
 } from "../shared/legacy-go-output-flag.ts";
 import { mockOutput, mockProcessControl } from "../../../tests/helpers/mocks.ts";
+
+const FAILURE_PROPERTY_NAMES = [
+  PropErrorKind,
+  PropErrorCategory,
+  PropErrorFingerprint,
+  PropHasSuggestion,
+  PropSuggestionType,
+  PropSuggestedCommand,
+  PropWorkflow,
+] as const;
 
 function mockLegacyIdentityStitch(opts: { stitchedDistinctId?: string }) {
   return {
@@ -61,6 +81,30 @@ function mockContextualAnalytics() {
   return { layer, captured };
 }
 
+function failingAnalytics(defect: unknown) {
+  return Layer.succeed(
+    Analytics,
+    Analytics.of({
+      capture: () => Effect.die(defect),
+      identify: () => Effect.void,
+      alias: () => Effect.void,
+      groupIdentify: () => Effect.void,
+    }),
+  );
+}
+
+function interruptingAnalytics() {
+  return Layer.succeed(
+    Analytics,
+    Analytics.of({
+      capture: () => Effect.interrupt,
+      identify: () => Effect.void,
+      alias: () => Effect.void,
+      groupIdentify: () => Effect.void,
+    }),
+  );
+}
+
 describe("withLegacyCommandInstrumentation", () => {
   it.live("annotates the command span and emits cli_command_executed", () => {
     const analytics = mockContextualAnalytics();
@@ -90,6 +134,9 @@ describe("withLegacyCommandInstrumentation", () => {
           expect(event?.properties.exit_code).toBe(0);
           expect(typeof event?.properties.duration_ms).toBe("number");
           expect(event?.properties.output_format).toBe("text");
+          for (const property of FAILURE_PROPERTY_NAMES) {
+            expect(event?.properties).not.toHaveProperty(property);
+          }
         }),
       ),
     );
@@ -615,10 +662,13 @@ describe("withLegacyCommandInstrumentation", () => {
     );
   });
 
-  it.live("captures failed commands with exit_code=1", () => {
+  it.live("adds sanitized metadata from the original typed failure", () => {
     const analytics = mockContextualAnalytics();
+    const secret = "dump failed for postgres://customer.internal/private";
 
-    return withLegacyCommandInstrumentation()(Effect.fail(new Error("boom"))).pipe(
+    return withLegacyCommandInstrumentation()(
+      Effect.fail(new LegacyDbDumpRunError({ message: secret })),
+    ).pipe(
       Effect.provide(analytics.layer),
       Effect.provide(mockProcessControl().layer),
       Effect.provide(mockOutput({ format: "text" }).layer),
@@ -628,14 +678,72 @@ describe("withLegacyCommandInstrumentation", () => {
       Effect.tap(() =>
         Effect.sync(() => {
           expect(analytics.captured).toHaveLength(1);
-          expect(analytics.captured[0]?.properties.exit_code).toBe(1);
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "user_actionable",
+            error_category: "db_connection",
+            error_fingerprint: "tag:LegacyDbDumpRunError",
+            has_suggestion: true,
+            suggestion_type: "update_config",
+          });
+          expect(analytics.captured[0]?.properties).not.toHaveProperty(PropSuggestedCommand);
+          expect(analytics.captured[0]?.properties).not.toHaveProperty(PropWorkflow);
+          expect(JSON.stringify(analytics.captured[0])).not.toContain(secret);
         }),
       ),
       Effect.asVoid,
     );
   });
 
-  it.live("records exit_code=1 when a handler set a non-zero exit code without failing", () => {
+  it.live("preserves the command failure when telemetry capture defects", () => {
+    const failure = new LegacyDbDumpRunError({ message: "command failure" });
+
+    return Effect.fail(failure).pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(failingAnalytics(new Error("telemetry defect"))),
+      Effect.provide(mockProcessControl().layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["db", "dump"]) })),
+      Effect.provide(commandRuntimeLayer(["db", "dump"])),
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Option.getOrUndefined(Cause.findErrorOption(exit.cause))).toBe(failure);
+            expect(Cause.hasDies(exit.cause)).toBe(false);
+          }
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("propagates fiber interruption from telemetry capture", () => {
+    // A capture failure or defect is swallowed (best-effort telemetry), but an
+    // interruption landing during the trailing capture must not be — the fiber
+    // is being cancelled and swallowing would fight the cancellation.
+    return Effect.void.pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(interruptingAnalytics()),
+      Effect.provide(mockProcessControl().layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["db", "dump"]) })),
+      Effect.provide(commandRuntimeLayer(["db", "dump"])),
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+          }
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("classifies db lint machine-mode fail-on like its typed text-mode error", () => {
     // Go records the telemetry exit code from the real process exit code
     // (`cmd/root.go:177` -> `exitCode(err)` = 1). `db lint`/`db advisors` set
     // ProcessControl's exit code in json/stream-json mode after a --fail-on
@@ -657,7 +765,110 @@ describe("withLegacyCommandInstrumentation", () => {
       Effect.tap(() =>
         Effect.sync(() => {
           expect(analytics.captured).toHaveLength(1);
-          expect(analytics.captured[0]?.properties.exit_code).toBe(1);
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "user_actionable",
+            error_category: "invalid_config",
+            error_fingerprint: "tag:LegacyDbLintFailOnError",
+            has_suggestion: false,
+            suggestion_type: "none",
+          });
+        }),
+      ),
+    );
+  });
+
+  it.live("classifies db advisors machine-mode fail-on like its typed text-mode error", () => {
+    const analytics = mockContextualAnalytics();
+    const processControl = mockProcessControl();
+
+    return Effect.gen(function* () {
+      const pc = yield* ProcessControl;
+      yield* pc.setExitCode(1);
+    }).pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(processControl.layer),
+      Effect.provide(mockOutput({ format: "json" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["db", "advisors"]) })),
+      Effect.provide(commandRuntimeLayer(["db", "advisors"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "user_actionable",
+            error_category: "invalid_config",
+            error_fingerprint: "tag:LegacyDbAdvisorsFailOnError",
+            has_suggestion: false,
+            suggestion_type: "none",
+          });
+        }),
+      ),
+    );
+  });
+
+  it.live("classifies a command that sets its exit code outside the instrumentation", () => {
+    // `db dump` converts its run failure into an exit code in the command pipe
+    // (`Effect.catchTag(...)` applied AFTER this wrapper), not inside the
+    // handler like `db lint`/`db advisors`. Instrumentation is the innermost
+    // wrapper, so it still sees the typed failure and must classify it rather
+    // than fall back to the process-controlled `unknown` bucket. Reordering
+    // that pipe would silently degrade this command's telemetry.
+    const analytics = mockContextualAnalytics();
+    const processControl = mockProcessControl();
+    const failure = new LegacyDbDumpRunError({ message: "container exited 1" });
+
+    return Effect.fail(failure).pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.catchTag("LegacyDbDumpRunError", () =>
+        Effect.gen(function* () {
+          const pc = yield* ProcessControl;
+          yield* pc.setExitCode(1);
+        }),
+      ),
+      Effect.provide(analytics.layer),
+      Effect.provide(processControl.layer),
+      Effect.provide(mockOutput({ format: "json" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["db", "dump"]) })),
+      Effect.provide(commandRuntimeLayer(["db", "dump"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "user_actionable",
+            error_category: "db_connection",
+            error_fingerprint: "tag:LegacyDbDumpRunError",
+          });
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("uses a static unknown fallback for other process-controlled failures", () => {
+    const analytics = mockContextualAnalytics();
+    const processControl = mockProcessControl();
+
+    return Effect.gen(function* () {
+      const pc = yield* ProcessControl;
+      yield* pc.setExitCode(2);
+    }).pipe(
+      withLegacyCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(processControl.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["unknown", "command"]) })),
+      Effect.provide(commandRuntimeLayer(["unknown", "command"])),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "unknown",
+            error_category: "unknown",
+            error_fingerprint: "error:ProcessControlledFailure",
+            has_suggestion: false,
+            suggestion_type: "none",
+          });
         }),
       ),
     );

--- a/apps/cli/src/next/commands/functions/download/download.handler.ts
+++ b/apps/cli/src/next/commands/functions/download/download.handler.ts
@@ -28,8 +28,10 @@ export const functionsDownload = Effect.fnUntraced(function* (flags: FunctionsDo
       const args = makeGoProxyDownloadArgs(proxyFlags, projectRef);
       const cwd = projectHome.projectRoot;
       return captureOutput
-        ? Effect.asVoid(proxy.execCapture(args, { cwd, stdin: "ignore" }))
-        : proxy.exec(args, { cwd });
+        ? Effect.asVoid(
+            proxy.execCapture(args, { cwd, stdin: "ignore", suppressChildTelemetry: true }),
+          )
+        : proxy.exec(args, { cwd, suppressChildTelemetry: true });
     },
   });
 });

--- a/apps/cli/src/shared/legacy/go-proxy.layer.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.layer.ts
@@ -202,10 +202,13 @@ export function makeGoProxyLayer(opts?: {
               // Scoped via `Effect.scoped` so listeners are always removed on
               // normal completion, failure, or fiber interruption.
               yield* processControl.holdSignals(["SIGINT", "SIGTERM", "SIGHUP"]);
-              // Per-call env (execOpts.env) overlays the construction-time env;
-              // `extendEnv: true` keeps both on top of the inherited process env.
-              const env =
-                opts?.env || execOpts?.env ? { ...opts?.env, ...execOpts?.env } : undefined;
+              // Parent instrumentation owns command telemetry. Disable it in
+              // the child so one invocation can never emit duplicate events.
+              const env = {
+                ...opts?.env,
+                ...execOpts?.env,
+                SUPABASE_TELEMETRY_DISABLED: "1",
+              };
               const command = ChildProcess.make(binary, [...globalArgs, ...args], {
                 cwd: execOpts?.cwd ?? opts?.cwd,
                 env,
@@ -242,8 +245,11 @@ export function makeGoProxyLayer(opts?: {
               }
               const binary = resolved.found;
               yield* processControl.holdSignals(["SIGINT", "SIGTERM", "SIGHUP"]);
-              const env =
-                opts?.env || execOpts?.env ? { ...opts?.env, ...execOpts?.env } : undefined;
+              const env = {
+                ...opts?.env,
+                ...execOpts?.env,
+                SUPABASE_TELEMETRY_DISABLED: "1",
+              };
               // Capture stdout (pipe) while keeping stderr inherited, so the child's
               // progress still reaches the user but its stdout is collected for
               // wrapping rather than written to our stdout. stdin defaults to

--- a/apps/cli/src/shared/legacy/go-proxy.layer.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.layer.ts
@@ -202,12 +202,16 @@ export function makeGoProxyLayer(opts?: {
               // Scoped via `Effect.scoped` so listeners are always removed on
               // normal completion, failure, or fiber interruption.
               yield* processControl.holdSignals(["SIGINT", "SIGTERM", "SIGHUP"]);
-              // Parent instrumentation owns command telemetry. Disable it in
-              // the child so one invocation can never emit duplicate events.
+              // Only an instrumented caller that delegates the whole command
+              // suppresses child telemetry, because there the parent already
+              // emits `cli_command_executed`. Pure proxy commands have no
+              // parent event, so the child must stay free to report.
               const env = {
                 ...opts?.env,
                 ...execOpts?.env,
-                SUPABASE_TELEMETRY_DISABLED: "1",
+                ...(execOpts?.suppressChildTelemetry === true
+                  ? { SUPABASE_TELEMETRY_DISABLED: "1" }
+                  : {}),
               };
               const command = ChildProcess.make(binary, [...globalArgs, ...args], {
                 cwd: execOpts?.cwd ?? opts?.cwd,
@@ -245,10 +249,14 @@ export function makeGoProxyLayer(opts?: {
               }
               const binary = resolved.found;
               yield* processControl.holdSignals(["SIGINT", "SIGTERM", "SIGHUP"]);
+              // Same rule as `exec`: only an instrumented caller that owns the
+              // parent `cli_command_executed` event suppresses child telemetry.
               const env = {
                 ...opts?.env,
                 ...execOpts?.env,
-                SUPABASE_TELEMETRY_DISABLED: "1",
+                ...(execOpts?.suppressChildTelemetry === true
+                  ? { SUPABASE_TELEMETRY_DISABLED: "1" }
+                  : {}),
               };
               // Capture stdout (pipe) while keeping stderr inherited, so the child's
               // progress still reaches the user but its stdout is collected for

--- a/apps/cli/src/shared/legacy/go-proxy.layer.unit.test.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.layer.unit.test.ts
@@ -283,6 +283,51 @@ describe("makeGoProxyLayer", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("leaves child telemetry enabled for pure proxy commands", () => {
+    // Pure proxy commands (`migration squash`, `db branch *`, `db remote *`,
+    // `gen keys`) have no TS instrumentation, so the Go child is the only
+    // emitter of `cli_command_executed`. Disabling it here would drop those
+    // commands from telemetry entirely.
+    const spawner = mockSpawner({ kind: "success", code: 0 });
+    const pc = mockProcessControl();
+    const layer = makeGoProxyLayer({ binary: TEST_BINARY }).pipe(
+      Layer.provide(Layer.mergeAll(spawner.layer, pc.layer)),
+    );
+    return Effect.gen(function* () {
+      const proxy = yield* LegacyGoProxy;
+      yield* proxy.exec(["migration", "squash"]);
+      yield* proxy.execCapture(["gen", "keys"]);
+
+      for (const captured of spawner.spawned) {
+        expect(captured.options.env ?? {}).not.toHaveProperty("SUPABASE_TELEMETRY_DISABLED");
+      }
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("suppresses child telemetry when the caller owns the parent event", () => {
+    // Instrumented handlers that delegate the whole command (db pull/diff/reset,
+    // functions download) already emit `cli_command_executed` themselves, so the
+    // child's copy would double-count.
+    const spawner = mockSpawner({ kind: "success", code: 0 });
+    const pc = mockProcessControl();
+    const layer = makeGoProxyLayer({ binary: TEST_BINARY }).pipe(
+      Layer.provide(Layer.mergeAll(spawner.layer, pc.layer)),
+    );
+    return Effect.gen(function* () {
+      const proxy = yield* LegacyGoProxy;
+      yield* proxy.exec(["db", "pull"], { suppressChildTelemetry: true });
+      yield* proxy.execCapture(["db", "diff"], {
+        env: { CUSTOM: "kept" },
+        suppressChildTelemetry: true,
+      });
+
+      for (const captured of spawner.spawned) {
+        expect(captured.options.env).toMatchObject({ SUPABASE_TELEMETRY_DISABLED: "1" });
+      }
+      expect(spawner.spawned[1]?.options.env).toMatchObject({ CUSTOM: "kept" });
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("propagates non-zero exit codes via LegacyGoChildExitError", () => {
     const spawner = mockSpawner({ kind: "success", code: 7 });
     const pc = mockProcessControl();

--- a/apps/cli/src/shared/legacy/go-proxy.service.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.service.ts
@@ -16,15 +16,23 @@ interface LegacyGoProxyShape {
    * variables onto the subprocess (merged on top of the inherited process env);
    * use it to pass values the user supplied as environment variables back to the
    * proxy as environment variables, rather than cross-mapping them onto CLI
-   * flags (CLI-1617). Child telemetry is always disabled because the parent
-   * command owns the single `cli_command_executed` event. Disabling it
-   * wholesale is safe: the only Go-side events besides the root command event
-   * belong to `link` and `login`, and both commands are native TS — no proxied
-   * invocation can lose a distinct Go-only event.
+   * flags (CLI-1617).
+   *
+   * `opts.suppressChildTelemetry` disables telemetry in the child. Set it ONLY
+   * from a handler that is itself wrapped in command instrumentation and
+   * delegates the whole command to Go, where the parent already emits
+   * `cli_command_executed` and the child's copy would double-count. Pure proxy
+   * handlers (no TS instrumentation) must leave it unset: for those the Go
+   * child is the only emitter, and disabling it would drop the command from
+   * telemetry entirely.
    */
   readonly exec: (
     args: ReadonlyArray<string>,
-    opts?: { readonly cwd?: string; readonly env?: Record<string, string> },
+    opts?: {
+      readonly cwd?: string;
+      readonly env?: Record<string, string>;
+      readonly suppressChildTelemetry?: boolean;
+    },
   ) => Effect.Effect<void, LegacyGoChildExitError>;
 
   /**
@@ -53,6 +61,7 @@ interface LegacyGoProxyShape {
       readonly cwd?: string;
       readonly env?: Record<string, string>;
       readonly stdin?: "inherit" | "ignore";
+      readonly suppressChildTelemetry?: boolean;
     },
   ) => Effect.Effect<string, LegacyGoChildExitError>;
 }

--- a/apps/cli/src/shared/legacy/go-proxy.service.ts
+++ b/apps/cli/src/shared/legacy/go-proxy.service.ts
@@ -16,7 +16,11 @@ interface LegacyGoProxyShape {
    * variables onto the subprocess (merged on top of the inherited process env);
    * use it to pass values the user supplied as environment variables back to the
    * proxy as environment variables, rather than cross-mapping them onto CLI
-   * flags (CLI-1617).
+   * flags (CLI-1617). Child telemetry is always disabled because the parent
+   * command owns the single `cli_command_executed` event. Disabling it
+   * wholesale is safe: the only Go-side events besides the root command event
+   * belong to `link` and `login`, and both commands are native TS — no proxied
+   * invocation can lose a distinct Go-only event.
    */
   readonly exec: (
     args: ReadonlyArray<string>,

--- a/apps/cli/src/shared/telemetry/command-instrumentation.ts
+++ b/apps/cli/src/shared/telemetry/command-instrumentation.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Exit, Option, Stdio } from "effect";
+import { Cause, Clock, Effect, Exit, Option, Stdio } from "effect";
 import {
   CommandRuntime,
   getCommandRuntimeCommand,
@@ -7,6 +7,13 @@ import {
 import { Output } from "../output/output.service.ts";
 import { withAnalyticsContext } from "./analytics-context.ts";
 import { Analytics } from "./analytics.service.ts";
+import {
+  EventCommandExecuted,
+  PropDurationMs,
+  PropExitCode,
+  PropOutputFormat,
+} from "./event-catalog.ts";
+import { failureTelemetryPropertiesForCause } from "./failure-metadata.ts";
 
 interface CommandInstrumentationOptions<Flags extends Record<string, unknown> = never> {
   readonly analytics?: boolean;
@@ -119,12 +126,21 @@ function withCommandAnalyticsImplementation<Flags extends Record<string, unknown
         const finishedAt = yield* Clock.currentTimeMillis;
 
         yield* analytics
-          .capture("cli_command_executed", {
-            exit_code: Exit.isSuccess(exit) ? 0 : 1,
-            duration_ms: finishedAt - startedAt,
-            output_format: output.format,
+          .capture(EventCommandExecuted, {
+            [PropExitCode]: Exit.isSuccess(exit) ? 0 : 1,
+            [PropDurationMs]: finishedAt - startedAt,
+            [PropOutputFormat]: output.format,
+            ...(Exit.isFailure(exit) ? failureTelemetryPropertiesForCause(exit.cause) : {}),
           })
-          .pipe(withAnalyticsContext(analyticsContext));
+          .pipe(
+            withAnalyticsContext(analyticsContext),
+            // Best-effort: a capture failure or defect must never replace the
+            // command's own result, but fiber interruption (Ctrl+C landing
+            // during this trailing capture) must still propagate.
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause) ? Effect.failCause(cause) : Effect.void,
+            ),
+          );
 
         if (Exit.isFailure(exit)) {
           return yield* Effect.failCause(exit.cause);

--- a/apps/cli/src/shared/telemetry/command-instrumentation.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/command-instrumentation.unit.test.ts
@@ -1,10 +1,47 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Stdio } from "effect";
+import { Cause, Data, Effect, Exit, Layer, Option, Stdio } from "effect";
 import { commandRuntimeLayer } from "../runtime/command-runtime.layer.ts";
 import { CurrentAnalyticsContext } from "./analytics-context.ts";
 import { Analytics } from "./analytics.service.ts";
 import { withCommandInstrumentation } from "./command-instrumentation.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "./error-actionability.ts";
+import {
+  PropErrorCategory,
+  PropErrorFingerprint,
+  PropErrorKind,
+  PropHasSuggestion,
+  PropSuggestedCommand,
+  PropSuggestionType,
+  PropWorkflow,
+} from "./event-catalog.ts";
 import { mockOutput } from "../../../tests/helpers/mocks.ts";
+
+const FAILURE_PROPERTY_NAMES = [
+  PropErrorKind,
+  PropErrorCategory,
+  PropErrorFingerprint,
+  PropHasSuggestion,
+  PropSuggestionType,
+  PropSuggestedCommand,
+  PropWorkflow,
+] as const;
+
+class InstrumentationAuthError extends Data.TaggedError("InstrumentationAuthError")<{
+  readonly message: string;
+  readonly path: string;
+  readonly sql: string;
+  readonly projectRef: string;
+  readonly hostname: string;
+  readonly token: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.authLogin;
+  }
+}
 
 function mockContextualAnalytics() {
   const captured: Array<{
@@ -33,6 +70,30 @@ function mockContextualAnalytics() {
   );
 
   return { layer, captured };
+}
+
+function failingAnalytics(defect: unknown) {
+  return Layer.succeed(
+    Analytics,
+    Analytics.of({
+      capture: () => Effect.die(defect),
+      identify: () => Effect.void,
+      alias: () => Effect.void,
+      groupIdentify: () => Effect.void,
+    }),
+  );
+}
+
+function interruptingAnalytics() {
+  return Layer.succeed(
+    Analytics,
+    Analytics.of({
+      capture: () => Effect.interrupt,
+      identify: () => Effect.void,
+      alias: () => Effect.void,
+      groupIdentify: () => Effect.void,
+    }),
+  );
 }
 
 describe("withCommandInstrumentation", () => {
@@ -92,15 +153,27 @@ describe("withCommandInstrumentation", () => {
           expect(command?.properties.flags_used).toEqual(["detach", "exclude"]);
           expect(command?.properties.flag_values).toEqual({});
           expect(command?.properties.exit_code).toBe(0);
+          for (const property of FAILURE_PROPERTY_NAMES) {
+            expect(command?.properties).not.toHaveProperty(property);
+          }
         }),
       ),
     );
   });
 
-  it.live("captures failed commands with a non-zero exit code", () => {
+  it.live("adds sanitized actionability metadata and preserves the original failure", () => {
     const analytics = mockContextualAnalytics();
+    const secrets = {
+      message: "failed at /Users/alice/private/config.toml",
+      path: "/Users/alice/private/config.toml",
+      sql: "select * from customer_private_table",
+      projectRef: "abcdefghijklmnopqrst",
+      hostname: "db.customer.internal",
+      token: "customer-secret-token",
+    };
+    const failure = new InstrumentationAuthError(secrets);
 
-    const program = withCommandInstrumentation()(Effect.fail(new Error("boom"))).pipe(
+    const program = withCommandInstrumentation()(Effect.fail(failure)).pipe(
       Effect.provide(analytics.layer),
       Effect.provide(mockOutput({ format: "text" }).layer),
       Effect.provide(
@@ -110,16 +183,114 @@ describe("withCommandInstrumentation", () => {
       ),
       Effect.provide(commandRuntimeLayer(["login"])),
       Effect.exit,
-      Effect.tap(() =>
+      Effect.tap((exit) =>
         Effect.sync(() => {
           expect(analytics.captured).toHaveLength(1);
-          expect(analytics.captured[0]?.event).toBe("cli_command_executed");
-          expect(analytics.captured[0]?.properties.exit_code).toBe(1);
+          const event = analytics.captured[0];
+          expect(event?.event).toBe("cli_command_executed");
+          expect(event?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "user_actionable",
+            error_category: "auth",
+            error_fingerprint: "tag:InstrumentationAuthError",
+            has_suggestion: true,
+            suggestion_type: "login",
+            suggested_command: "supabase login",
+          });
+          expect(event?.properties).not.toHaveProperty(PropWorkflow);
+          const encoded = JSON.stringify(event);
+          for (const secret of Object.values(secrets)) expect(encoded).not.toContain(secret);
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Option.getOrUndefined(Cause.findErrorOption(exit.cause))).toBe(failure);
+          }
         }),
       ),
     );
 
     return program.pipe(Effect.asVoid);
+  });
+
+  it.live("classifies defects as internal panics without capturing their message", () => {
+    const analytics = mockContextualAnalytics();
+    const secret = "panic at /Users/alice/customer-project";
+
+    return Effect.die(new TypeError(secret)).pipe(
+      withCommandInstrumentation(),
+      Effect.provide(analytics.layer),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["branches", "list"]) })),
+      Effect.provide(commandRuntimeLayer(["branches", "list"])),
+      Effect.exit,
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(analytics.captured[0]?.properties).toMatchObject({
+            exit_code: 1,
+            error_kind: "internal_bug",
+            error_category: "panic",
+            error_fingerprint: "error:TypeError",
+            has_suggestion: true,
+            suggestion_type: "rerun_debug",
+          });
+          expect(JSON.stringify(analytics.captured[0])).not.toContain(secret);
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("preserves the command failure when telemetry capture defects", () => {
+    const failure = new InstrumentationAuthError({
+      message: "command failure",
+      path: "path",
+      sql: "sql",
+      projectRef: "project",
+      hostname: "host",
+      token: "token",
+    });
+
+    return Effect.fail(failure).pipe(
+      withCommandInstrumentation(),
+      Effect.provide(failingAnalytics(new Error("telemetry defect"))),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["login"]) })),
+      Effect.provide(commandRuntimeLayer(["login"])),
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Option.getOrUndefined(Cause.findErrorOption(exit.cause))).toBe(failure);
+            expect(Cause.hasDies(exit.cause)).toBe(false);
+          }
+        }),
+      ),
+      Effect.asVoid,
+    );
+  });
+
+  it.live("propagates fiber interruption from telemetry capture", () => {
+    // A capture failure or defect is swallowed (best-effort telemetry), but an
+    // interruption landing during the trailing capture must not be — the fiber
+    // is being cancelled and swallowing would fight the cancellation.
+    return Effect.void.pipe(
+      withCommandInstrumentation(),
+      Effect.provide(interruptingAnalytics()),
+      Effect.provide(mockOutput({ format: "text" }).layer),
+      Effect.provide(Stdio.layerTest({ args: Effect.succeed(["login"]) })),
+      Effect.provide(commandRuntimeLayer(["login"])),
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+          }
+        }),
+      ),
+      Effect.asVoid,
+    );
   });
 
   it.live("captures flag values only when explicitly allowlisted", () => {

--- a/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { CliError } from "effect/unstable/cli";
 
 // Vitest (via Vite) provides `import.meta.glob` at runtime; the workspace
 // tsconfig does not load `vite/client`, so declare the one member we use.
@@ -13,6 +14,7 @@ import {
   CliErrorCategory,
   CliErrorKind,
   CliSuggestionType,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
   isClassifiedExternalErrorTag,
 } from "./error-actionability.ts";
@@ -61,7 +63,9 @@ const categoryValues = new Set<string>(Object.values(CliErrorCategory));
 const suggestionValues = new Set<string>(Object.values(CliSuggestionType));
 
 interface DeclaredErrorClass {
+  readonly constructor: object;
   readonly exportName: string;
+  readonly isTagged: boolean;
   readonly tag: string;
   readonly prototype: object;
 }
@@ -81,7 +85,13 @@ function collectErrorClasses(module: Record<string, unknown>): Array<DeclaredErr
     } catch {
       tag = undefined;
     }
-    classes.push({ exportName, tag: typeof tag === "string" ? tag : exportName, prototype });
+    classes.push({
+      constructor: value,
+      exportName,
+      isTagged: typeof tag === "string",
+      tag: typeof tag === "string" ? tag : exportName,
+      prototype,
+    });
   }
   return classes;
 }
@@ -122,7 +132,7 @@ describe("apps/cli error classes declare their actionability", () => {
         ).toBe(true);
       }
 
-      for (const { exportName, tag, prototype } of classes) {
+      for (const { constructor, exportName, isTagged, tag, prototype } of classes) {
         const descriptor = Object.getOwnPropertyDescriptor(prototype, ErrorActionabilityId);
         expect(
           typeof descriptor?.get,
@@ -143,6 +153,19 @@ describe("apps/cli error classes declare their actionability", () => {
         expect(categoryValues.has(String(record["error_category"]))).toBe(true);
         expect(typeof record["has_suggestion"]).toBe("boolean");
         expect(suggestionValues.has(String(record["suggestion_type"]))).toBe(true);
+
+        if (!isTagged) {
+          const fingerprintDescriptor = Object.getOwnPropertyDescriptor(
+            constructor,
+            ErrorActionabilityFingerprintId,
+          );
+          expect(
+            fingerprintDescriptor !== undefined &&
+              "value" in fingerprintDescriptor &&
+              fingerprintDescriptor.value === exportName,
+            `${exportName} is an untagged Error and must declare its stable source identifier as an own static [ErrorActionabilityFingerprintId] value`,
+          ).toBe(true);
+        }
       }
     });
   }
@@ -170,4 +193,50 @@ describe("workspace package error tags have external adapters", () => {
       }
     });
   }
+});
+
+describe("Effect CLI parser errors have exhaustive handling", () => {
+  it("covers every exported parser error class", () => {
+    const tags = new Set<string>();
+    const probe = {
+      option: "--probe",
+      command: [],
+      suggestions: [],
+      parentCommand: "parent",
+      childCommand: "child",
+      argument: "argument",
+      arguments: [],
+      value: "value",
+      expected: "expected",
+      kind: "flag",
+      subcommand: "subcommand",
+      parent: [],
+      cause: new Error("probe"),
+      commandPath: [],
+      errors: [],
+    };
+
+    for (const value of Object.values(CliError)) {
+      if (typeof value !== "function") continue;
+      const prototype: unknown = value.prototype;
+      if (typeof prototype !== "object" || prototype === null) continue;
+      if (!(prototype instanceof Error)) continue;
+
+      try {
+        const tag = Reflect.get(Reflect.construct(value, [probe]), "_tag");
+        if (typeof tag === "string") tags.add(tag);
+      } catch {
+        // Non-error exports and constructors that require runtime setup are
+        // outside the parser error union checked at compile time by the map.
+      }
+    }
+
+    expect(tags.size).toBeGreaterThan(5);
+    for (const tag of tags) {
+      expect(
+        tag === "ShowHelp" || tag === "UserError" || isClassifiedExternalErrorTag(tag),
+        `Effect CLI parser error "${tag}" has no actionability handling`,
+      ).toBe(true);
+    }
+  });
 });

--- a/apps/cli/src/shared/telemetry/error-actionability-minified.integration.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability-minified.integration.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, test } from "vitest";
+
+describe("release-minified error fingerprints", () => {
+  test("keeps a declared tagged error's source identifier", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "supabase-error-actionability-"));
+    const bundlePath = join(tempDir, "fixture.mjs");
+    const errorModule = resolve(import.meta.dirname, "../functions/delete.errors.ts");
+    const plainErrorModule = resolve(
+      import.meta.dirname,
+      "../../legacy/shared/legacy-config-validate.ts",
+    );
+    const classifierModule = resolve(import.meta.dirname, "error-actionability.ts");
+
+    try {
+      const build = await Bun.build({
+        entrypoints: ["actionability-fixture"],
+        target: "bun",
+        minify: true,
+        plugins: [
+          {
+            name: "actionability-fixture",
+            setup(builder) {
+              builder.onResolve({ filter: /^actionability-fixture$/ }, () => ({
+                path: "actionability-fixture",
+                namespace: "actionability-fixture",
+              }));
+              builder.onLoad({ filter: /.*/, namespace: "actionability-fixture" }, () => ({
+                contents: `
+                    import { InvalidFunctionSlugError } from ${JSON.stringify(errorModule)};
+                    import { LegacyConfigValidateError } from ${JSON.stringify(plainErrorModule)};
+                    import { classifyCliErrorActionability } from ${JSON.stringify(classifierModule)};
+                    export const taggedConstructorName = InvalidFunctionSlugError.name;
+                    export const taggedClassification = classifyCliErrorActionability(
+                      new InvalidFunctionSlugError({ message: "private user input" }),
+                    );
+                    export const plainConstructorName = LegacyConfigValidateError.name;
+                    export const plainClassification = classifyCliErrorActionability(
+                      new LegacyConfigValidateError("private user input"),
+                    );
+                  `,
+                loader: "ts",
+              }));
+            },
+          },
+        ],
+      });
+
+      expect(build.success, build.logs.map(String).join("\n")).toBe(true);
+      expect(build.outputs).toHaveLength(1);
+      const output = build.outputs[0];
+      expect(output).toBeDefined();
+      if (output === undefined) return;
+
+      await Bun.write(bundlePath, output);
+      const fixture = await import(`${pathToFileURL(bundlePath).href}?run=${crypto.randomUUID()}`);
+      expect(Reflect.get(fixture, "taggedConstructorName")).not.toBe("InvalidFunctionSlugError");
+      expect(Reflect.get(fixture, "taggedClassification")).toEqual({
+        error_kind: "user_actionable",
+        error_category: "invalid_input",
+        error_fingerprint: "tag:InvalidFunctionSlugError",
+        has_suggestion: true,
+        suggestion_type: "provide_flags",
+      });
+      expect(Reflect.get(fixture, "plainConstructorName")).not.toBe("LegacyConfigValidateError");
+      expect(Reflect.get(fixture, "plainClassification")).toEqual({
+        error_kind: "user_actionable",
+        error_category: "invalid_config",
+        error_fingerprint: "error:LegacyConfigValidateError",
+        has_suggestion: true,
+        suggestion_type: "update_config",
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/shared/telemetry/error-actionability.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.ts
@@ -1,4 +1,5 @@
 import { Cause, Option } from "effect";
+import type { CliError as EffectCliError } from "effect/unstable/cli";
 
 /**
  * CLI error actionability taxonomy for KPI reporting (CLI-1560).
@@ -13,7 +14,7 @@ import { Cause, Option } from "effect";
  * exhaustiveness-checked against those packages' sources.
  *
  * Everything emitted from here is sanitized by construction: kinds, categories,
- * suggestion types, and fingerprints are closed enums or `tag:`-prefixed safe
+ * suggestion types, and fingerprints use closed enums and source-owned
  * identifiers — never raw error text or user-specific data.
  */
 
@@ -212,13 +213,14 @@ export const CliErrorActionabilityMetricDefinitions = {
     command_identity:
       "Exact equality of the command property, which is the normalized command path emitted by CLI instrumentation without argument values.",
     order_by: "event timestamp ascending",
-    eligible_failure: "exit_code != 0 AND error_fingerprint IS NOT NULL",
+    eligible_failure:
+      "exit_code != 0 AND error_kind = 'user_actionable' AND error_fingerprint IS NOT NULL",
     repeated_when:
       "Failed event F is a repeat when an earlier failed event P in the same partition has P.error_fingerprint = F.error_fingerprint and no event S in that partition has P.timestamp < S.timestamp < F.timestamp and S.exit_code = 0.",
     reset_when:
       "Any exit_code = 0 event in the partition clears every prior fingerprint for that command. A different $session_id starts a new partition; successes for other commands do not reset it.",
     description:
-      "The second and each later occurrence of the same error_fingerprint is a repeat until that normalized command succeeds or the session changes.",
+      "The second and each later occurrence of the same user-actionable error_fingerprint is a repeat until that normalized command succeeds or the session changes.",
   },
   internalUnknownBugRate: {
     id: "failed_commands_internal_bug_or_unknown",
@@ -248,6 +250,11 @@ export const CliErrorActionabilityMetricDefinitions = {
  */
 export const ErrorActionabilityId: unique symbol = Symbol(
   "@supabase/cli/telemetry/ErrorActionability",
+);
+
+/** Stable source identifier for CLI-owned plain `Error` subclasses. */
+export const ErrorActionabilityFingerprintId: unique symbol = Symbol(
+  "@supabase/cli/telemetry/ErrorActionabilityFingerprint",
 );
 
 /**
@@ -637,7 +644,9 @@ function readDeclaration(error: unknown): CliErrorActionabilityDeclaration | und
 
 function safeIdentifier(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
-  return /^[A-Za-z][A-Za-z0-9_]*$/.test(value) ? value : undefined;
+  // The length cap is defense-in-depth: every legitimate identifier is a
+  // class/tag name, so an oversized value is never a real CLI error source.
+  return /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(value) ? value : undefined;
 }
 
 function readErrorTag(error: unknown): string | undefined {
@@ -651,14 +660,44 @@ function readErrorName(error: unknown): string | undefined {
   return safeIdentifier(readString(error, "name"));
 }
 
-function readDeclaredErrorConstructorName(error: unknown): string | undefined {
+function readDeclaredErrorFingerprintId(error: unknown): string | undefined {
   if (!(error instanceof Error)) return undefined;
   const prototype = Object.getPrototypeOf(error);
   if (!isErrorRecord(prototype)) return undefined;
-  const constructor = prototype["constructor"];
+  const constructorDescriptor = Object.getOwnPropertyDescriptor(prototype, "constructor");
+  if (constructorDescriptor === undefined || !("value" in constructorDescriptor)) return undefined;
+  const constructor = constructorDescriptor.value;
   if (typeof constructor !== "function") return undefined;
-  const name = safeIdentifier(constructor.name);
-  return name === "Error" ? undefined : name;
+  const identifierDescriptor = Object.getOwnPropertyDescriptor(
+    constructor,
+    ErrorActionabilityFingerprintId,
+  );
+  if (identifierDescriptor === undefined || !("value" in identifierDescriptor)) return undefined;
+  return typeof identifierDescriptor.value === "string"
+    ? safeIdentifier(identifierDescriptor.value)
+    : undefined;
+}
+
+/**
+ * `Data.TaggedError` stores its literal tag as an own data property named
+ * `name` on a base prototype. Unlike `constructor.name`, that value survives
+ * identifier minification. Never invoke prototype getters here: only the
+ * static data property created by Effect is a safe fingerprint authority.
+ */
+function readStableTaggedPrototypeName(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  let prototype: unknown = Object.getPrototypeOf(error);
+  while (prototype !== Error.prototype) {
+    if (!isErrorRecord(prototype)) return undefined;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, "name");
+    if (descriptor !== undefined && "value" in descriptor) {
+      const name =
+        typeof descriptor.value === "string" ? safeIdentifier(descriptor.value) : undefined;
+      if (name !== undefined && name !== "Error") return name;
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return undefined;
 }
 
 function fingerprint(
@@ -689,18 +728,27 @@ function toActionability(
  * `apps/cli` must declare {@link ErrorActionabilityId} instead of being
  * added here.
  */
-const externalActionabilityByTag: Record<
-  string,
-  (error: ErrorRecord) => CliErrorActionabilityDeclaration
-> = {
-  // effect/unstable/cli parser failures (ShowHelp and UserError recurse in
-  // classifyCliErrorActionability instead of mapping here)
+type ErrorActionabilityAdapter = (error: ErrorRecord) => CliErrorActionabilityDeclaration;
+
+type EffectCliAdapterTag = Exclude<EffectCliError.CliError["_tag"], "ShowHelp" | "UserError">;
+
+// ShowHelp and UserError recurse in classifyCliErrorActionability. This map is
+// typed against Effect's complete parser-error union so dependency upgrades
+// cannot silently add an unclassified parser failure.
+const effectCliActionabilityByTag = {
   MissingOption: () => actionability.invalidInput,
   MissingArgument: () => actionability.invalidInput,
   DuplicateOption: () => actionability.invalidInput,
+  UnexpectedArgument: () => actionability.invalidInput,
   InvalidValue: () => actionability.invalidInput,
-  UnknownSubcommand: () => actionability.invalidInput,
+  // Effect 4.0.0-beta.103 has this typo in the runtime tag. Keep the adapter
+  // keyed to reality; the emitted fingerprint is normalized below.
+  UnknownSubcomand: () => actionability.invalidInput,
   UnrecognizedOption: () => actionability.invalidInput,
+} satisfies Record<EffectCliAdapterTag, ErrorActionabilityAdapter>;
+
+const externalActionabilityByTag: Record<string, ErrorActionabilityAdapter> = {
+  ...effectCliActionabilityByTag,
 
   // effect PlatformError — OS/filesystem operations. `reason` is
   // `BadArgument | SystemError`; BadArgument means the CLI itself passed a
@@ -918,12 +966,19 @@ function classifyAtDepth(error: unknown, depth: number): CliErrorActionability {
   }
   const declared = readDeclaration(error);
   if (declared !== undefined) {
-    const constructorName = readDeclaredErrorConstructorName(error);
+    const stableTaggedName = readStableTaggedPrototypeName(error);
     const tag = readErrorTag(error);
-    if (tag !== undefined && tag === constructorName) {
+    if (stableTaggedName !== undefined && tag === stableTaggedName) {
       return toActionability(declared, "tag", tag);
     }
-    return toActionability(declared, "error", constructorName);
+    // The declared static identifier outranks the prototype walk: a class
+    // extending a native Error subtype (e.g. `extends TypeError`) would
+    // otherwise pick up the native prototype's own `name` and collide on it.
+    return toActionability(
+      declared,
+      "error",
+      readDeclaredErrorFingerprintId(error) ?? stableTaggedName ?? "DeclaredError",
+    );
   }
 
   const tag = readErrorTag(error);
@@ -973,7 +1028,8 @@ function classifyAtDepth(error: unknown, depth: number): CliErrorActionability {
     if (Object.hasOwn(externalActionabilityByTag, tag)) {
       const external = externalActionabilityByTag[tag];
       if (external !== undefined) {
-        return toActionability(external(error), "tag", tag);
+        const fingerprintTag = tag === "UnknownSubcomand" ? "UnknownSubcommand" : tag;
+        return toActionability(external(error), "tag", fingerprintTag);
       }
     }
     return toActionability(actionability.unknown, "tag", undefined);
@@ -1029,3 +1085,15 @@ export function classifyCliCauseActionability(cause: Cause.Cause<unknown>): CliE
   const error = Option.getOrElse(Cause.findErrorOption(cause), () => Cause.squash(cause));
   return classifyCliErrorActionability(error);
 }
+
+/**
+ * Fallback for a command that deliberately signalled failure through
+ * ProcessControl without failing its Effect, when no typed error is available
+ * to derive a classification from (see `withLegacyCommandInstrumentation`,
+ * which classifies the command's own fail-on error class where one exists).
+ */
+export const unknownProcessControlledFailureActionability: CliErrorActionability = toActionability(
+  actionability.unknown,
+  "error",
+  "ProcessControlledFailure",
+);

--- a/apps/cli/src/shared/telemetry/error-actionability.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.ts
@@ -225,10 +225,18 @@ export const CliErrorActionabilityMetricDefinitions = {
   internalUnknownBugRate: {
     id: "failed_commands_internal_bug_or_unknown",
     event: "cli_command_executed",
-    denominator: "count where exit_code != 0",
+    denominator: "count where exit_code != 0 AND error_kind IS NOT NULL",
     numerator: "count where exit_code != 0 AND error_kind IN ('internal_bug', 'unknown')",
     description:
-      "Internal/unknown bug failure rate is the share of failed commands classified as internal_bug or unknown.",
+      "Internal/unknown bug failure rate is the share of classified failed commands reported as internal_bug or unknown. Failures without error_kind (pure Go-proxy commands, CLI versions predating the classification) are excluded from both sides; classificationCoverage reports their share.",
+  },
+  classificationCoverage: {
+    id: "failed_commands_with_classification",
+    event: "cli_command_executed",
+    denominator: "count where exit_code != 0",
+    numerator: "count where exit_code != 0 AND error_kind IS NOT NULL",
+    description:
+      "Share of failed commands carrying the error classification. Pure Go-proxy commands report through the Go binary without these fields, and older CLI versions never send them, so the recovery, repeat, and bug-rate metrics cover exactly this fraction of the failure volume.",
   },
 } as const;
 

--- a/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
@@ -1,4 +1,5 @@
 import { Cause, Data } from "effect";
+import { CliError } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 import { markSupabaseApiInputErrorAsUserInput, SupabaseApiInputError } from "@supabase/api/effect";
 import { LegacyBootstrapHealthError } from "../../legacy/commands/bootstrap/bootstrap.errors.ts";
@@ -8,6 +9,7 @@ import {
   classifyCliCauseActionability,
   classifyCliErrorActionability,
   CliErrorActionabilityMetricDefinitions,
+  ErrorActionabilityFingerprintId,
   ErrorActionabilityId,
   statusCodeActionability,
 } from "./error-actionability.ts";
@@ -47,6 +49,8 @@ class DeclaredNoSuggestionError extends Data.TaggedError("DeclaredNoSuggestionEr
 }
 
 class PlainDeclaredError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "PlainDeclaredError";
+
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     return actionability.invalidConfig;
   }
@@ -89,6 +93,57 @@ describe("classifyCliErrorActionability", () => {
     const result = classifyCliErrorActionability(new PlainDeclaredError("private path"));
     expect(result.error_category).toBe("invalid_config");
     expect(result.error_fingerprint).toBe("error:PlainDeclaredError");
+  });
+
+  it("prefers the declared static identifier over a native ancestor's prototype name", () => {
+    // TypeError.prototype carries an own `name` data property ("TypeError");
+    // without the static-identifier precedence, every declared class extending
+    // a native Error subtype would collide on the native name.
+    class NativeSubtypeDeclaredError extends TypeError {
+      static readonly [ErrorActionabilityFingerprintId] = "NativeSubtypeDeclaredError";
+
+      get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+        return actionability.invalidConfig;
+      }
+    }
+    const result = classifyCliErrorActionability(new NativeSubtypeDeclaredError("boom"));
+    expect(result.error_category).toBe("invalid_config");
+    expect(result.error_fingerprint).toBe("error:NativeSubtypeDeclaredError");
+  });
+
+  it("classifies Effect's runtime unknown-subcommand tag without fingerprinting user input", () => {
+    const secret = "customerProjectRef123";
+    const result = classifyCliErrorActionability(
+      new CliError.UnknownSubcommand({
+        subcommand: secret,
+        suggestions: [],
+      }),
+    );
+
+    expect(result).toEqual({
+      error_kind: "user_actionable",
+      error_category: "invalid_input",
+      error_fingerprint: "tag:UnknownSubcommand",
+      has_suggestion: false,
+      suggestion_type: "none",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("classifies Effect's unexpected positional arguments without fingerprinting their values", () => {
+    const secret = "/Users/alice/private.sql";
+    const result = classifyCliErrorActionability(
+      new CliError.UnexpectedArgument({ arguments: [secret] }),
+    );
+
+    expect(result).toEqual({
+      error_kind: "user_actionable",
+      error_category: "invalid_input",
+      error_fingerprint: "tag:UnexpectedArgument",
+      has_suggestion: false,
+      suggestion_type: "none",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
   });
 
   it("does not claim a generic remediation for local permission failures", () => {
@@ -359,8 +414,19 @@ describe("classifyCliErrorActionability", () => {
     const errorResult = classifyCliErrorActionability(
       declarationCarrier(secret, actionability.invalidInput),
     );
-    expect(errorResult.error_fingerprint).toBe("error:DeclarationCarrierError");
+    expect(errorResult.error_fingerprint).toBe("error:DeclaredError");
     expect(JSON.stringify([plainResult, errorResult])).not.toContain(secret);
+  });
+
+  it("does not trust mutable instance tags or names over the tagged prototype", () => {
+    const secret = "CustomerProjectRef123";
+    const error = new DeclaredError({ message: "failed" });
+    Reflect.set(error, "_tag", secret);
+    Reflect.set(error, "name", secret);
+
+    const result = classifyCliErrorActionability(error);
+    expect(result.error_fingerprint).toBe("error:DeclaredError");
+    expect(JSON.stringify(result)).not.toContain(secret);
   });
 
   it("does not accept declarations through the global symbol registry", () => {
@@ -821,7 +887,7 @@ describe("metric definitions", () => {
       "command",
     ]);
     expect(CliErrorActionabilityMetricDefinitions.repeatError.eligible_failure).toBe(
-      "exit_code != 0 AND error_fingerprint IS NOT NULL",
+      "exit_code != 0 AND error_kind = 'user_actionable' AND error_fingerprint IS NOT NULL",
     );
     expect(CliErrorActionabilityMetricDefinitions.repeatError.repeated_when).toContain(
       "P.error_fingerprint = F.error_fingerprint",

--- a/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.unit.test.ts
@@ -870,6 +870,18 @@ describe("metric definitions", () => {
     expect(CliErrorActionabilityMetricDefinitions.internalUnknownBugRate.id).toBe(
       "failed_commands_internal_bug_or_unknown",
     );
+    expect(CliErrorActionabilityMetricDefinitions.internalUnknownBugRate.denominator).toBe(
+      "count where exit_code != 0 AND error_kind IS NOT NULL",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.classificationCoverage.id).toBe(
+      "failed_commands_with_classification",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.classificationCoverage.numerator).toBe(
+      "count where exit_code != 0 AND error_kind IS NOT NULL",
+    );
+    expect(CliErrorActionabilityMetricDefinitions.classificationCoverage.denominator).toBe(
+      "count where exit_code != 0",
+    );
     expect(CliErrorActionabilityMetricDefinitions.strictRecovery.partition_by).toEqual([
       "device_id",
       "$session_id",

--- a/apps/cli/src/shared/telemetry/event-catalog.ts
+++ b/apps/cli/src/shared/telemetry/event-catalog.ts
@@ -1,6 +1,9 @@
 // CLI telemetry catalog. Mirrors apps/cli-go/internal/telemetry/events.go
 // 1:1 so legacy/ ports send byte-identical PostHog payloads. When the Go
-// catalog changes, update this file in the same PR.
+// catalog changes, update this file in the same PR. The failure-classification
+// properties below (error_kind … workflow) are TS-only: the native shells
+// classify failures (CLI-1561) and the Go binary never emits these fields, so
+// they are deliberately absent from the Go catalog.
 
 export const EventCommandExecuted = "cli_command_executed";
 export const EventProjectLinked = "cli_project_linked";
@@ -29,6 +32,15 @@ export const PropFlags = "flags";
 export const PropExitCode = "exit_code";
 export const PropDurationMs = "duration_ms";
 export const PropOutputFormat = "output_format";
+export const PropErrorKind = "error_kind";
+export const PropErrorCategory = "error_category";
+export const PropErrorFingerprint = "error_fingerprint";
+export const PropHasSuggestion = "has_suggestion";
+export const PropSuggestionType = "suggestion_type";
+export const PropSuggestedCommand = "suggested_command";
+// Reserved for a closed workflow label; nothing emits it until a closed
+// vocabulary is agreed (tests assert its absence on failure events).
+export const PropWorkflow = "workflow";
 
 export const GroupOrganization = "organization";
 export const GroupProject = "project";

--- a/apps/cli/src/shared/telemetry/failure-metadata.e2e.test.ts
+++ b/apps/cli/src/shared/telemetry/failure-metadata.e2e.test.ts
@@ -1,0 +1,111 @@
+import { createServer, type Server } from "node:http";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { runSupabase } from "../../../tests/helpers/cli.ts";
+
+type CapturedEvent = {
+  readonly event: unknown;
+  readonly properties: unknown;
+};
+
+describe("failed command telemetry", () => {
+  let server: Server;
+  let host: string;
+  const capturedEvents: CapturedEvent[] = [];
+
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        const body = Buffer.concat(chunks);
+        const decoded = request.headers["content-encoding"] === "gzip" ? gunzipSync(body) : body;
+        const payload: unknown = JSON.parse(decoded.toString());
+        if (typeof payload === "object" && payload !== null) {
+          const batch = Reflect.get(payload, "batch");
+          if (Array.isArray(batch)) capturedEvents.push(...batch);
+        }
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("Failed to allocate a telemetry receiver port");
+    }
+    host = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error === undefined ? resolve() : reject(error)));
+    });
+  });
+
+  beforeEach(() => {
+    capturedEvents.length = 0;
+  });
+
+  // Legacy auth-gate failures abort during runtime-layer construction, before
+  // the instrumented handler runs, and deliberately keep their existing
+  // no-event behavior — so the legacy case exercises an in-handler failure.
+  test.each([
+    {
+      entrypoint: "next" as const,
+      args: ["branches", "list"],
+      command: "branches list",
+      expected: {
+        error_kind: "user_actionable",
+        error_category: "project_not_linked",
+        error_fingerprint: "tag:ProjectNotLinkedError",
+        has_suggestion: true,
+        suggestion_type: "link_project",
+        suggested_command: "supabase link",
+      },
+      rawErrors: ["No project is linked in this directory."],
+    },
+    {
+      entrypoint: "legacy" as const,
+      args: [
+        "db",
+        "query",
+        "--db-url",
+        "postgres://postgres:postgres@127.0.0.1:1/postgres",
+        "select 1",
+      ],
+      command: "db query",
+      expected: {
+        error_kind: "user_actionable",
+        error_category: "db_connection",
+        error_fingerprint: "tag:LegacyDbConnectError",
+        has_suggestion: true,
+        suggestion_type: "update_config",
+      },
+      rawErrors: ["failed to connect", "127.0.0.1", "select 1"],
+    },
+  ])("emits sanitized metadata from the compiled $entrypoint shell", async (testCase) => {
+    const result = await runSupabase(testCase.args, {
+      entrypoint: testCase.entrypoint,
+      env: {
+        SUPABASE_ACCESS_TOKEN: "",
+        SUPABASE_TELEMETRY_DISABLED: "0",
+        DO_NOT_TRACK: "0",
+        SUPABASE_TELEMETRY_POSTHOG_KEY: "phc_failure_metadata_e2e",
+        SUPABASE_TELEMETRY_POSTHOG_HOST: host,
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    const event = capturedEvents.find((candidate) => candidate.event === "cli_command_executed");
+    expect(event).toBeDefined();
+    expect(event?.properties).toMatchObject({
+      command: testCase.command,
+      exit_code: 1,
+      ...testCase.expected,
+    });
+    expect(event?.properties).not.toHaveProperty("workflow");
+    const encoded = JSON.stringify(event);
+    for (const rawError of testCase.rawErrors) expect(encoded).not.toContain(rawError);
+  });
+});

--- a/apps/cli/src/shared/telemetry/failure-metadata.ts
+++ b/apps/cli/src/shared/telemetry/failure-metadata.ts
@@ -1,0 +1,36 @@
+import type { Cause } from "effect";
+import {
+  classifyCliCauseActionability,
+  type CliErrorActionability,
+} from "./error-actionability.ts";
+import {
+  PropErrorCategory,
+  PropErrorFingerprint,
+  PropErrorKind,
+  PropHasSuggestion,
+  PropSuggestedCommand,
+  PropSuggestionType,
+} from "./event-catalog.ts";
+
+/** Projects the closed taxonomy contract onto the public telemetry schema. */
+export function toFailureTelemetryProperties(
+  classification: CliErrorActionability,
+): Record<string, unknown> {
+  const properties = {
+    [PropErrorKind]: classification.error_kind,
+    [PropErrorCategory]: classification.error_category,
+    [PropErrorFingerprint]: classification.error_fingerprint,
+    [PropHasSuggestion]: classification.has_suggestion,
+    [PropSuggestionType]: classification.suggestion_type,
+  };
+
+  return classification.suggested_command === undefined
+    ? properties
+    : { ...properties, [PropSuggestedCommand]: classification.suggested_command };
+}
+
+export function failureTelemetryPropertiesForCause(
+  cause: Cause.Cause<unknown>,
+): Record<string, unknown> {
+  return toFailureTelemetryProperties(classifyCliCauseActionability(cause));
+}


### PR DESCRIPTION
## TL;DR

`cli_command_executed` already records that a command failed, but not why, 
so failures cannot be separated into user mistakes, external service problems, and CLI bugs. 
Failed events now carry sanitized classification metadata derived from the error the command raised, never from its message text...

## What's introduced?

- Failed events carry `error_kind`, `error_category`, `error_fingerprint`, `has_suggestion`, `suggestion_type`, and `suggested_command` when the remediation is one of a small allowlist of commands. Successful events are unchanged.
- Every value comes from a closed vocabulary, so no raw error text reaches PostHog, and paths, SQL, project refs, hostnames, tokens, and other user specific values cannot be captured.
- `workflow` is reserved in the event catalog and left unset until there is an agreed closed vocabulary for it.

## Why is it needed?

Recovery rate, repeat failures, and the internal or unknown bug rate are all computed from these fields, 
so until they exist those reports have nothing to filter or group on. 
Classifying each failure where the error is raised makes that measurable without sending the error text itself....

## Ref

- closes: CLI-1561
