### PR TITLE
feat(api): support v2 namespace endpoints in @supabase/api

### DIFF
--- a/.github/workflows/api-package-sync.yml
+++ b/.github/workflows/api-package-sync.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Regenerate API package
         run: pnpm generate
         working-directory: packages/api
+        env:
+          SUPABASE_API_URL: https://api.supabase.com
 
       - name: Format API package
         run: pnpm exec nx run @supabase/api:fmt:fix
@@ -32,7 +34,7 @@ jobs:
       - name: Check for generated changes
         id: check
         run: |
-          if git diff --ignore-space-at-eol --exit-code --quiet packages/api/src/generated; then
+          if git diff --ignore-space-at-eol --exit-code --quiet packages/api/src/generated packages/api/scripts/openapi-source.json; then
             echo "No generated changes detected."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
@@ -61,7 +63,7 @@ jobs:
           body: |
             This PR was automatically created to sync the generated `@supabase/api` package with the latest Management API OpenAPI document.
 
-            Changes were detected in the upstream OpenAPI document exposed by `https://api.supabase.com/api/v1-json`.
+            Changes were detected in the upstream OpenAPI documents exposed by `https://api.supabase.com/api/v1-json` and `https://api.supabase.com/api/v2-json`.
           branch: sync/api-package
           base: develop
 

--- a/apps/cli/tests/helpers/legacy-mocks.ts
+++ b/apps/cli/tests/helpers/legacy-mocks.ts
@@ -642,8 +642,17 @@ export function mockLegacyPlatformApiService(
     },
   });
 
+  // The legacy shell is a Go-parity port and only calls v1 operations, so v2
+  // has no stub support — any v2 call from legacy code is a wiring bug.
+  const v2Proxy = new Proxy({} as ApiClient["v2"], {
+    get(_target, prop: string) {
+      return () => Effect.die(`Unmocked LegacyPlatformApi.v2.${prop}`);
+    },
+  });
+
   const layer = Layer.succeed(LegacyPlatformApi, {
     v1: v1Proxy,
+    v2: v2Proxy,
     // Direct-service consumers don't exercise the raw-execute escape hatch.
     executeRaw: () => Effect.die("Unmocked LegacyPlatformApi.executeRaw"),
   } as ApiClient);

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -98,7 +98,15 @@ The spec is built from two upstream OpenAPI documents, `{baseUrl}/api/v1-json` a
 `components.schemas` are unioned, and `info.title` is normalized to `Supabase API`), then
 overrides from `scripts/openapi-overrides.json` are applied to the merged document. The result is
 validated — operation ids must be unique, and version-prefixed operation ids must match the
-path's leading segment — before being written to `src/generated/openapi.json`.
+path's leading segment — before being written to `src/generated/openapi.json`. The merged
+document keeps only the keys the generator consumes (`openapi`, `info`, `paths`,
+`components.schemas`); upstream extras such as `servers`, `tags`, and `components.securitySchemes`
+are dropped so the snapshot never contains keys a regeneration would remove.
+
+The committed snapshot and the generated modules are also checked against each other offline in
+ordinary test runs: `scripts/generated-output-sync.unit.test.ts` re-renders every generated file
+from the committed snapshot and requires byte equality, and `src/generated-contract-sync.unit.test.ts`
+asserts the operation-level bijection. Hand edits to `src/generated` fail both.
 
 The base URL is resolved in this order:
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,13 +2,6 @@
 
 Generated Supabase Management API SDK built directly from the Supabase OpenAPI spec.
 
-> **Temporary (CLI-2157):** the committed snapshot on this branch is generated from staging
-> (`api.supabase.green`) because `GET /v2/projects/{ref}/config` (`api.v2.getProjectConfig`,
-> schema `V2ProjectConfigResponse`) has not shipped to production yet. Develop's hourly prod sync
-> (`api-package-sync.yml`) would remove exactly that endpoint once this merges. Before merging,
-> either the endpoint must ship to production or the snapshot must be regenerated from production
-> by re-pointing `scripts/openapi-source.json`.
-
 The package exposes:
 
 - `@supabase/api` for the runtime-specific Promise client helpers plus generated contracts

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,6 +2,13 @@
 
 Generated Supabase Management API SDK built directly from the Supabase OpenAPI spec.
 
+> **Temporary (CLI-2157):** the committed snapshot on this branch is generated from staging
+> (`api.supabase.green`) because `GET /v2/projects/{ref}/config` (`api.v2.getProjectConfig`,
+> schema `V2ProjectConfigResponse`) has not shipped to production yet. Develop's hourly prod sync
+> (`api-package-sync.yml`) would remove exactly that endpoint once this merges. Before merging,
+> either the endpoint must ship to production or the snapshot must be regenerated from production
+> by re-pointing `scripts/openapi-source.json`.
+
 The package exposes:
 
 - `@supabase/api` for the runtime-specific Promise client helpers plus generated contracts
@@ -17,7 +24,13 @@ import { createApiClient } from "@supabase/api";
 const client = await createApiClient({ accessToken: "<token>" });
 
 const projects = await client.v1.listAllProjects();
+const projectConfig = await client.v2.getProjectConfig({ ref: "<project-ref>" });
 ```
+
+Operations are namespaced by version, derived from the leading path segment (`/v1/...` or
+`/v2/...`). Same-named operations can coexist under separate namespaces: `client.v1.listOrganizationMembers`
+and `client.v2.listOrganizationMembers` are distinct operations hitting `/v1/...` and `/v2/...`
+respectively.
 
 `baseUrl` defaults to `https://api.supabase.com` and `accessToken` can also come from
 `SUPABASE_ACCESS_TOKEN`.
@@ -31,7 +44,10 @@ import { makeApiClient } from "@supabase/api/effect";
 const program = Effect.gen(function* () {
   const client = yield* makeApiClient({ accessToken: "<token>" });
 
-  return yield* client.v1.listAllProjects();
+  const projects = yield* client.v1.listAllProjects();
+  const projectConfig = yield* client.v2.getProjectConfig({ ref: "<project-ref>" });
+
+  return { projects, projectConfig };
 });
 ```
 
@@ -51,6 +67,7 @@ The only callable client surface is the versioned namespace:
 
 ```ts
 const projects = await client.v1.listAllProjects();
+const projectConfig = await client.v2.getProjectConfig({ ref: "<project-ref>" });
 ```
 
 For tools that need the raw generated spec:
@@ -74,14 +91,67 @@ The public binary input contract is:
 ## Development
 
 ```sh
-pnpm check:all   # Run all quality checks in parallel
-pnpm fix:all     # Auto-fix lint, format, and unused exports in parallel
-pnpm test        # Run tests
-pnpm generate    # Refresh the OpenAPI spec and regenerate the SDK
+pnpm check:all       # Run all quality checks in parallel
+pnpm fix:all         # Auto-fix lint, format, and unused exports in parallel
+pnpm test            # Run tests
+pnpm generate        # Refresh the OpenAPI spec and regenerate the SDK
+pnpm generate:check  # Regenerate in place and fail on any resulting diff
 ```
+
+## Spec pipeline
+
+The spec is built from two upstream OpenAPI documents, `{baseUrl}/api/v1-json` and
+`{baseUrl}/api/v2-json`. They are fetched and merged into a single document (paths and
+`components.schemas` are unioned, and `info.title` is normalized to `Supabase API`), then
+overrides from `scripts/openapi-overrides.json` are applied to the merged document. The result is
+validated — operation ids must be unique, and version-prefixed operation ids must match the
+path's leading segment — before being written to `src/generated/openapi.json`.
+
+The base URL is resolved in this order:
+
+1. `SUPABASE_API_URL` environment variable
+2. `scripts/openapi-source.json`, a committed sidecar file (`{ "baseUrl": ... }`) that is
+   rewritten after every successful `pnpm generate` run
+3. `https://api.supabase.com`
 
 To refresh from staging instead of production:
 
 ```sh
 SUPABASE_API_URL=https://api.supabase.green pnpm generate
 ```
+
+`pnpm generate` is the single command to regenerate the spec and SDK. `pnpm generate:check`
+regenerates in place, formats, and fails if that produces any diff in `src/generated` or
+`scripts/openapi-source.json` — useful for verifying the committed snapshot is still current. If a
+failed check leaves an unwanted diff, discard it with:
+
+```sh
+git restore -- src/generated scripts/openapi-source.json
+```
+
+The hourly [`api-package-sync.yml`](../../.github/workflows/api-package-sync.yml) workflow runs
+`generate` against production and opens a PR against `develop` whenever it detects drift, acting
+as the automated drift detector for the committed snapshot.
+
+### Overrides
+
+`scripts/openapi-overrides.json` is a JSON-Patch-_like_ array applied to the merged document. It
+supports:
+
+- `test` — assert a value at `path` before proceeding (as in RFC 6902)
+- `add` — add a value at `path`; throws if the key already exists
+- `replace` — replace the value at `path`
+- `remove` — remove the value at `path` **if present**
+
+`remove` is deliberately remove-if-present rather than RFC 6902's strict "must exist" semantics,
+because the upstream documents differ between environments — staging's `v2-json` is currently
+served by two backend variants that disagree about some paths. Entries may carry a `$comment`
+field to document why an override exists.
+
+### Known limitation: `deepObject` query parameters
+
+Three v2 operations declare object-valued query parameters with `style: deepObject`:
+`v2-list-organization-members`, `v2-list-organization-projects`, and
+`v2-list-organization-github-connections`. The client currently serializes these as JSON strings
+rather than the expected `page[size]=...` form. Do not rely on those parameters until this is
+fixed.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "generate:spec": "bun run scripts/download-openapi.ts",
     "generate": "bun run generate:spec && bun run scripts/generate.ts",
+    "generate:check": "bun run generate && pnpm exec nx run @supabase/api:fmt:fix && git diff --exit-code -- src/generated scripts/openapi-source.json",
     "test": "nx run-many -t test:core test:e2e --projects=$npm_package_name",
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name",
     "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "generate:spec": "bun run scripts/download-openapi.ts",
     "generate": "bun run generate:spec && bun run scripts/generate.ts",
-    "generate:check": "bun run generate && pnpm exec nx run @supabase/api:fmt:fix && git diff --exit-code -- src/generated scripts/openapi-source.json",
+    "generate:check": "pnpm generate && pnpm exec nx run @supabase/api:fmt:fix && git diff --exit-code -- src/generated scripts/openapi-source.json",
     "test": "nx run-many -t test:core test:e2e --projects=$npm_package_name",
     "test:core": "nx run-many -t test:unit test:integration --projects=$npm_package_name",
     "check:all": "nx run-many -t types:check lint:check fmt:check knip:check --projects=$npm_package_name",
@@ -46,7 +46,8 @@
       "scripts/download-openapi.ts",
       "scripts/download-openapi.unit.test.ts",
       "scripts/generate.ts",
-      "scripts/generate.unit.test.ts"
+      "scripts/generate.unit.test.ts",
+      "scripts/generated-output-sync.unit.test.ts"
     ],
     "ignoreDependencies": [
       "undici",

--- a/packages/api/scripts/download-openapi.ts
+++ b/packages/api/scripts/download-openapi.ts
@@ -7,17 +7,35 @@ const DEFAULT_SUPABASE_API_URL = "https://api.supabase.com";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const OPENAPI_SPEC_PATH = path.join(scriptDir, "../src/generated/openapi.json");
 const OPENAPI_OVERRIDES_PATH = path.join(scriptDir, "openapi-overrides.json");
+const OPENAPI_SOURCE_PATH = path.join(scriptDir, "openapi-source.json");
+
+const OPENAPI_DOCUMENT_VERSIONS = ["v1", "v2"] as const;
+type OpenApiDocumentVersion = (typeof OPENAPI_DOCUMENT_VERSIONS)[number];
+
+const HTTP_METHOD_KEYS = ["get", "post", "put", "patch", "delete", "head"] as const;
 
 type OpenApiDocument = {
   readonly [key: string]: unknown;
   readonly paths: Record<string, unknown>;
+  readonly components?: {
+    readonly schemas?: Record<string, unknown>;
+  };
 };
 
-type JsonPatchOperation = {
-  readonly op: "add" | "test" | "replace";
-  readonly path: string;
-  readonly value: unknown;
+type OpenApiSource = {
+  readonly baseUrl: string;
 };
+
+type JsonPatchOperation =
+  | {
+      readonly op: "add" | "test" | "replace";
+      readonly path: string;
+      readonly value: unknown;
+    }
+  | {
+      readonly op: "remove";
+      readonly path: string;
+    };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -109,15 +127,66 @@ function addJsonPointerValue(document: unknown, pointer: string, value: unknown)
   parent[key] = value;
 }
 
+function removeJsonPointerValue(document: unknown, pointer: string): boolean {
+  const segments = jsonPointerSegments(pointer);
+  if (segments.length === 0) {
+    return false;
+  }
+
+  let parent: unknown = document;
+  for (const segment of segments.slice(0, -1)) {
+    if (Array.isArray(parent)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+        return false;
+      }
+      parent = parent[index];
+      continue;
+    }
+    if (isRecord(parent) && segment in parent) {
+      parent = parent[segment];
+      continue;
+    }
+    return false;
+  }
+
+  const key = segments[segments.length - 1]!;
+  if (Array.isArray(parent)) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+      return false;
+    }
+    parent.splice(index, 1);
+    return true;
+  }
+
+  if (!isRecord(parent) || !(key in parent)) {
+    return false;
+  }
+  delete parent[key];
+  return true;
+}
+
 function assertJsonPatchOperation(value: unknown): asserts value is JsonPatchOperation {
   if (!isRecord(value)) {
     throw new Error("OpenAPI override entry must be an object.");
   }
-  if (value.op !== "add" && value.op !== "test" && value.op !== "replace") {
-    throw new Error("OpenAPI overrides only support add, test and replace operations.");
+  if (
+    value.op !== "add" &&
+    value.op !== "test" &&
+    value.op !== "replace" &&
+    value.op !== "remove"
+  ) {
+    throw new Error("OpenAPI overrides only support add, test, replace and remove operations.");
   }
   if (typeof value.path !== "string") {
     throw new Error("OpenAPI override path must be a string.");
+  }
+  if (value.op === "remove") {
+    if ("value" in value) {
+      throw new Error("OpenAPI remove overrides must not include a value.");
+    }
+    return;
   }
   if (!("value" in value)) {
     throw new Error("OpenAPI override value is required.");
@@ -147,6 +216,17 @@ export function applyOpenApiOverrides(
       addJsonPointerValue(document, override.path, override.value);
       continue;
     }
+    if (override.op === "remove") {
+      // Deliberate deviation from RFC 6902 (mirroring the existing "add"
+      // deviation below, which throws when the target key already exists):
+      // silently ignore removal of a pointer that doesn't exist. This file
+      // applies to documents that differ between environments — staging's
+      // /api/v2-json is currently served by two backend variants that
+      // disagree about whether the webhook paths exist — so a strict
+      // remove would fail on most staging runs.
+      removeJsonPointerValue(document, override.path);
+      continue;
+    }
     replaceJsonPointerValue(document, override.path, override.value);
   }
   return document;
@@ -160,9 +240,49 @@ async function loadOpenApiOverrides(): Promise<ReadonlyArray<unknown>> {
   return parsed;
 }
 
-export function resolveOpenApiSpecUrl(baseUrl = process.env.SUPABASE_API_URL): string {
-  const normalizedBaseUrl = (baseUrl ?? DEFAULT_SUPABASE_API_URL).replace(/\/+$/, "");
-  return `${normalizedBaseUrl}/api/v1-json`;
+function assertOpenApiSource(value: unknown): asserts value is OpenApiSource {
+  if (!isRecord(value) || typeof value.baseUrl !== "string") {
+    throw new Error('OpenAPI source file must be an object with a string "baseUrl" property.');
+  }
+}
+
+async function loadPinnedBaseUrl(): Promise<string> {
+  const parsed = JSON.parse(await readFile(OPENAPI_SOURCE_PATH, "utf8"));
+  assertOpenApiSource(parsed);
+  return parsed.baseUrl;
+}
+
+async function writeOpenApiSource(baseUrl: string): Promise<void> {
+  const source: OpenApiSource = { baseUrl };
+  await writeFile(OPENAPI_SOURCE_PATH, `${JSON.stringify(source, null, 2)}\n`);
+}
+
+export function resolveOpenApiBaseUrl({
+  envBaseUrl,
+  pinnedBaseUrl,
+}: {
+  readonly envBaseUrl?: string;
+  readonly pinnedBaseUrl?: string;
+}): string {
+  const baseUrl = envBaseUrl ?? pinnedBaseUrl ?? DEFAULT_SUPABASE_API_URL;
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export function resolveOpenApiSpecUrl(
+  baseUrl = process.env.SUPABASE_API_URL,
+  version: OpenApiDocumentVersion = "v1",
+): string {
+  const normalizedBaseUrl = resolveOpenApiBaseUrl({ envBaseUrl: baseUrl });
+  return `${normalizedBaseUrl}/api/${version}-json`;
+}
+
+export function resolveOpenApiSpecUrls(
+  baseUrl?: string,
+): ReadonlyArray<{ readonly version: OpenApiDocumentVersion; readonly url: string }> {
+  return OPENAPI_DOCUMENT_VERSIONS.map((version) => ({
+    version,
+    url: resolveOpenApiSpecUrl(baseUrl, version),
+  }));
 }
 
 export function assertOpenApiDocument(document: unknown): asserts document is OpenApiDocument {
@@ -171,19 +291,193 @@ export function assertOpenApiDocument(document: unknown): asserts document is Op
   }
 }
 
-export async function downloadOpenApiSpec(specUrl = resolveOpenApiSpecUrl()): Promise<void> {
-  const response = await fetch(specUrl);
+function getOpenApiVersion(document: OpenApiDocument): string {
+  if (typeof document.openapi !== "string") {
+    throw new Error('OpenAPI document is missing an "openapi" version string.');
+  }
+  return document.openapi;
+}
 
-  if (!response.ok) {
-    throw new Error(`Failed to download OpenAPI spec from ${specUrl}: ${response.status}`);
+function getInfoVersion(document: OpenApiDocument): string {
+  if (!isRecord(document.info) || typeof document.info.version !== "string") {
+    throw new Error('OpenAPI document is missing an "info.version" string.');
+  }
+  return document.info.version;
+}
+
+export function mergeOpenApiDocuments(
+  documents: ReadonlyArray<{
+    readonly version: OpenApiDocumentVersion;
+    readonly document: OpenApiDocument;
+  }>,
+): OpenApiDocument {
+  const [firstEntry, ...restEntries] = documents;
+  if (firstEntry === undefined) {
+    throw new Error("mergeOpenApiDocuments requires at least one document.");
   }
 
-  const document = await response.json();
-  assertOpenApiDocument(document);
+  const openapiVersion = getOpenApiVersion(firstEntry.document);
+  for (const entry of restEntries) {
+    const entryOpenapiVersion = getOpenApiVersion(entry.document);
+    if (entryOpenapiVersion !== openapiVersion) {
+      throw new Error(
+        `OpenAPI "openapi" version mismatch between ${firstEntry.version} (${openapiVersion}) and ${entry.version} (${entryOpenapiVersion}).`,
+      );
+    }
+  }
 
-  applyOpenApiOverrides(document, await loadOpenApiOverrides());
+  const infoVersion = getInfoVersion(firstEntry.document);
+  for (const entry of restEntries) {
+    const entryInfoVersion = getInfoVersion(entry.document);
+    if (entryInfoVersion !== infoVersion) {
+      throw new Error(
+        `OpenAPI "info.version" mismatch between ${firstEntry.version} (${infoVersion}) and ${entry.version} (${entryInfoVersion}).`,
+      );
+    }
+  }
 
-  await writeFile(OPENAPI_SPEC_PATH, `${JSON.stringify(document, null, 2)}\n`);
+  for (const { version, document } of documents) {
+    for (const pathKey of Object.keys(document.paths)) {
+      if (!pathKey.startsWith(`/${version}/`)) {
+        throw new Error(
+          `OpenAPI path ${JSON.stringify(pathKey)} in the ${version} document does not start with "/${version}/".`,
+        );
+      }
+    }
+  }
+
+  const paths: Record<string, unknown> = {};
+  const pathVersions = new Map<string, OpenApiDocumentVersion>();
+  for (const { version, document } of documents) {
+    for (const [pathKey, pathValue] of Object.entries(document.paths)) {
+      const existingVersion = pathVersions.get(pathKey);
+      if (existingVersion !== undefined) {
+        throw new Error(
+          `Duplicate OpenAPI path ${JSON.stringify(pathKey)} found in both the ${existingVersion} and ${version} documents.`,
+        );
+      }
+      pathVersions.set(pathKey, version);
+      paths[pathKey] = pathValue;
+    }
+  }
+
+  const schemas: Record<string, unknown> = {};
+  const schemaVersions = new Map<string, OpenApiDocumentVersion>();
+  for (const { version, document } of documents) {
+    for (const [name, schema] of Object.entries(document.components?.schemas ?? {})) {
+      const existingVersion = schemaVersions.get(name);
+      if (existingVersion === undefined) {
+        schemaVersions.set(name, version);
+        schemas[name] = schema;
+        continue;
+      }
+      if (!valuesEqual(schemas[name], schema)) {
+        throw new Error(
+          `Conflicting OpenAPI schema ${JSON.stringify(name)} found in both the ${existingVersion} and ${version} documents.`,
+        );
+      }
+    }
+  }
+
+  return {
+    ...firstEntry.document,
+    openapi: openapiVersion,
+    info: { title: "Supabase API", version: infoVersion },
+    paths,
+    components: { ...firstEntry.document.components, schemas },
+  };
+}
+
+// Runs AFTER overrides are applied — this ordering is load-bearing. Prod's
+// v2 document currently has 20 webhook operations sharing just 2 duplicated
+// operationIds, and the overrides remove those paths. Validating before
+// overrides were applied would abort every production regeneration.
+export function assertMergedOpenApiDocument(document: OpenApiDocument): void {
+  const operationClaims = new Map<string, Array<string>>();
+
+  for (const [pathKey, pathValue] of Object.entries(document.paths)) {
+    if (!isRecord(pathValue)) {
+      continue;
+    }
+    for (const method of HTTP_METHOD_KEYS) {
+      const operation = pathValue[method];
+      if (!isRecord(operation)) {
+        continue;
+      }
+
+      const label = `${method.toUpperCase()} ${pathKey}`;
+      const operationId = operation.operationId;
+      if (typeof operationId !== "string" || operationId.length === 0) {
+        // generate.ts silently skips operations without an operationId; the
+        // documented escape hatch is adding a "remove" override for the path.
+        console.warn(`OpenAPI operation ${label} has no operationId; generate.ts will skip it.`);
+        continue;
+      }
+
+      const claims = operationClaims.get(operationId);
+      if (claims === undefined) {
+        operationClaims.set(operationId, [label]);
+      } else {
+        claims.push(label);
+      }
+
+      const versionPrefixMatch = /^(v\d+)-/i.exec(operationId);
+      if (versionPrefixMatch) {
+        const prefix = versionPrefixMatch[1]!.toLowerCase();
+        const leadingSegment = pathKey.split("/")[1]?.toLowerCase();
+        if (leadingSegment !== prefix) {
+          throw new Error(
+            `OpenAPI operationId ${JSON.stringify(operationId)} for ${label} has version prefix ${JSON.stringify(prefix)} that does not match the path's leading segment ${JSON.stringify(leadingSegment ?? "")}.`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const [operationId, claims] of operationClaims) {
+    if (claims.length > 1) {
+      throw new Error(
+        `Duplicate OpenAPI operationId ${JSON.stringify(operationId)} claimed by: ${claims.join(", ")}.`,
+      );
+    }
+  }
+}
+
+export async function downloadOpenApiSpec(): Promise<void> {
+  const pinnedBaseUrl = await loadPinnedBaseUrl();
+  const baseUrl = resolveOpenApiBaseUrl({
+    envBaseUrl: process.env.SUPABASE_API_URL,
+    pinnedBaseUrl,
+  });
+  console.log(`Resolved OpenAPI base URL: ${baseUrl}`);
+
+  const documents: Array<{
+    readonly version: OpenApiDocumentVersion;
+    readonly document: OpenApiDocument;
+  }> = [];
+  for (const { version, url } of resolveOpenApiSpecUrls(baseUrl)) {
+    console.log(`Fetching ${version} OpenAPI document from ${url}`);
+    const response = await fetch(url);
+
+    // Hard-fail on a missing document instead of tolerating it: a 404 on
+    // /api/v2-json would silently delete the whole v2 namespace from the
+    // generated client, and the hourly regeneration sync would auto-merge
+    // that deletion without anyone noticing.
+    if (!response.ok) {
+      throw new Error(`Failed to download OpenAPI spec from ${url}: ${response.status}`);
+    }
+
+    const document = await response.json();
+    assertOpenApiDocument(document);
+    documents.push({ version, document });
+  }
+
+  const mergedDocument = mergeOpenApiDocuments(documents);
+  applyOpenApiOverrides(mergedDocument, await loadOpenApiOverrides());
+  assertMergedOpenApiDocument(mergedDocument);
+
+  await writeFile(OPENAPI_SPEC_PATH, `${JSON.stringify(mergedDocument, null, 2)}\n`);
+  await writeOpenApiSource(baseUrl);
 }
 
 if (import.meta.main) {

--- a/packages/api/scripts/download-openapi.ts
+++ b/packages/api/scripts/download-openapi.ts
@@ -246,8 +246,19 @@ function assertOpenApiSource(value: unknown): asserts value is OpenApiSource {
   }
 }
 
-async function loadPinnedBaseUrl(): Promise<string> {
-  const parsed = JSON.parse(await readFile(OPENAPI_SOURCE_PATH, "utf8"));
+async function loadPinnedBaseUrl(): Promise<string | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(OPENAPI_SOURCE_PATH, "utf8");
+  } catch (error) {
+    // A missing pin falls through to the default base URL; only a present
+    // but malformed pin is an error worth stopping for.
+    if (isRecord(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(raw);
   assertOpenApiSource(parsed);
   return parsed.baseUrl;
 }
@@ -379,12 +390,17 @@ export function mergeOpenApiDocuments(
     }
   }
 
+  // The merged document carries only the keys the generator consumes.
+  // Upstream extras (`servers`, `tags`, `components.securitySchemes`, …)
+  // must not reach the snapshot even transiently: generate.ts rewrites the
+  // file without them, so if they were written here a crash between the two
+  // steps would leave a plausible-looking openapi.json that disagrees with
+  // every healthy regeneration.
   return {
-    ...firstEntry.document,
     openapi: openapiVersion,
     info: { title: "Supabase API", version: infoVersion },
     paths,
-    components: { ...firstEntry.document.components, schemas },
+    components: { schemas },
   };
 }
 
@@ -444,11 +460,12 @@ export function assertMergedOpenApiDocument(document: OpenApiDocument): void {
 }
 
 export async function downloadOpenApiSpec(): Promise<void> {
-  const pinnedBaseUrl = await loadPinnedBaseUrl();
-  const baseUrl = resolveOpenApiBaseUrl({
-    envBaseUrl: process.env.SUPABASE_API_URL,
-    pinnedBaseUrl,
-  });
+  const envBaseUrl = process.env.SUPABASE_API_URL;
+  // The sidecar is consulted only when the environment does not override it,
+  // so an explicit SUPABASE_API_URL works even when the pin is absent or
+  // malformed.
+  const pinnedBaseUrl = envBaseUrl === undefined ? await loadPinnedBaseUrl() : undefined;
+  const baseUrl = resolveOpenApiBaseUrl({ envBaseUrl, pinnedBaseUrl });
   console.log(`Resolved OpenAPI base URL: ${baseUrl}`);
 
   const documents: Array<{

--- a/packages/api/scripts/download-openapi.unit.test.ts
+++ b/packages/api/scripts/download-openapi.unit.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   applyOpenApiOverrides,
+  assertMergedOpenApiDocument,
   assertOpenApiDocument,
+  mergeOpenApiDocuments,
+  resolveOpenApiBaseUrl,
   resolveOpenApiSpecUrl,
+  resolveOpenApiSpecUrls,
 } from "./download-openapi.ts";
 
 describe("download-openapi", () => {
@@ -106,5 +110,270 @@ describe("download-openapi", () => {
         ],
       ),
     ).toThrow("cannot be added");
+  });
+
+  test("derives the v2 spec URL and still normalizes a trailing slash", () => {
+    expect(resolveOpenApiSpecUrl("https://api.supabase.com", "v2")).toBe(
+      "https://api.supabase.com/api/v2-json",
+    );
+    expect(resolveOpenApiSpecUrl("https://api.supabase.com/", "v2")).toBe(
+      "https://api.supabase.com/api/v2-json",
+    );
+  });
+
+  test("resolves both the v1 and v2 spec URLs for a single base URL", () => {
+    expect(resolveOpenApiSpecUrls("https://api.supabase.com")).toEqual([
+      { version: "v1", url: "https://api.supabase.com/api/v1-json" },
+      { version: "v2", url: "https://api.supabase.com/api/v2-json" },
+    ]);
+  });
+
+  test("resolves the base URL with env > pinned > default precedence", () => {
+    expect(
+      resolveOpenApiBaseUrl({
+        envBaseUrl: "https://env.supabase.com",
+        pinnedBaseUrl: "https://pinned.supabase.com",
+      }),
+    ).toBe("https://env.supabase.com");
+    expect(resolveOpenApiBaseUrl({ pinnedBaseUrl: "https://pinned.supabase.com" })).toBe(
+      "https://pinned.supabase.com",
+    );
+    expect(resolveOpenApiBaseUrl({})).toBe("https://api.supabase.com");
+  });
+
+  test("merging a single document is an identity for its paths and schemas", () => {
+    const document = {
+      openapi: "3.0.0",
+      info: { title: "Some Title", version: "1.0.0" },
+      paths: { "/v1/a": { get: {} } },
+      components: { schemas: { Foo: { type: "string" } } },
+    };
+
+    const merged = mergeOpenApiDocuments([{ version: "v1", document }]);
+
+    expect(merged.paths).toEqual(document.paths);
+    expect(merged.components?.schemas).toEqual(document.components.schemas);
+  });
+
+  test("merges v1 and v2 documents, ordering v1 paths before v2 and unioning their schemas", () => {
+    const v1Document = {
+      openapi: "3.0.0",
+      info: { title: "V1 Title", version: "1.0.0" },
+      paths: { "/v1/a": { get: {} }, "/v1/b": { get: {} } },
+      components: { schemas: { Foo: { type: "string" } } },
+    };
+    const v2Document = {
+      openapi: "3.0.0",
+      info: { title: "V2 Title", version: "1.0.0" },
+      paths: { "/v2/c": { get: {} } },
+      components: { schemas: { Bar: { type: "number" } } },
+    };
+
+    const merged = mergeOpenApiDocuments([
+      { version: "v1", document: v1Document },
+      { version: "v2", document: v2Document },
+    ]);
+
+    expect(Object.keys(merged.paths)).toEqual(["/v1/a", "/v1/b", "/v2/c"]);
+    expect(merged.components?.schemas).toEqual({
+      Foo: { type: "string" },
+      Bar: { type: "number" },
+    });
+    expect(merged.info).toEqual({ title: "Supabase API", version: "1.0.0" });
+  });
+
+  test('throws when the documents\' "openapi" versions disagree', () => {
+    const v1Document = { openapi: "3.0.0", info: { version: "1.0.0" }, paths: { "/v1/a": {} } };
+    const v2Document = { openapi: "3.1.0", info: { version: "1.0.0" }, paths: { "/v2/a": {} } };
+
+    expect(() =>
+      mergeOpenApiDocuments([
+        { version: "v1", document: v1Document },
+        { version: "v2", document: v2Document },
+      ]),
+    ).toThrow('OpenAPI "openapi" version mismatch between v1 (3.0.0) and v2 (3.1.0).');
+  });
+
+  test('throws when the documents\' "info.version" disagree', () => {
+    const v1Document = { openapi: "3.0.0", info: { version: "1.0.0" }, paths: { "/v1/a": {} } };
+    const v2Document = { openapi: "3.0.0", info: { version: "2.0.0" }, paths: { "/v2/a": {} } };
+
+    expect(() =>
+      mergeOpenApiDocuments([
+        { version: "v1", document: v1Document },
+        { version: "v2", document: v2Document },
+      ]),
+    ).toThrow('OpenAPI "info.version" mismatch between v1 (1.0.0) and v2 (2.0.0).');
+  });
+
+  test("throws when a v2 document contains a path outside the /v2/ namespace", () => {
+    const v1Document = { openapi: "3.0.0", info: { version: "1.0.0" }, paths: { "/v1/a": {} } };
+    const v2Document = { openapi: "3.0.0", info: { version: "1.0.0" }, paths: { "/v1/foo": {} } };
+
+    expect(() =>
+      mergeOpenApiDocuments([
+        { version: "v1", document: v1Document },
+        { version: "v2", document: v2Document },
+      ]),
+    ).toThrow('OpenAPI path "/v1/foo" in the v2 document does not start with "/v2/".');
+  });
+
+  test("throws when the same path key appears twice across documents", () => {
+    // Can only happen when the same declared version is fetched/merged twice,
+    // since a document's own version-prefix check would otherwise reject a
+    // literal path belonging to a different version before this check runs.
+    const firstDocument = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v1/a": { get: {} } },
+    };
+    const secondDocument = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v1/a": { post: {} } },
+    };
+
+    expect(() =>
+      mergeOpenApiDocuments([
+        { version: "v1", document: firstDocument },
+        { version: "v1", document: secondDocument },
+      ]),
+    ).toThrow('Duplicate OpenAPI path "/v1/a" found in both the v1 and v1 documents.');
+  });
+
+  test("dedupes an identical duplicate schema found in both documents", () => {
+    const v1Document = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v1/a": {} },
+      components: { schemas: { Shared: { type: "string" } } },
+    };
+    const v2Document = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v2/a": {} },
+      components: { schemas: { Shared: { type: "string" } } },
+    };
+
+    const merged = mergeOpenApiDocuments([
+      { version: "v1", document: v1Document },
+      { version: "v2", document: v2Document },
+    ]);
+
+    expect(merged.components?.schemas).toEqual({ Shared: { type: "string" } });
+  });
+
+  test("throws when two documents disagree on the same schema name", () => {
+    const v1Document = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v1/a": {} },
+      components: { schemas: { Shared: { type: "string" } } },
+    };
+    const v2Document = {
+      openapi: "3.0.0",
+      info: { version: "1.0.0" },
+      paths: { "/v2/a": {} },
+      components: { schemas: { Shared: { type: "number" } } },
+    };
+
+    expect(() =>
+      mergeOpenApiDocuments([
+        { version: "v1", document: v1Document },
+        { version: "v2", document: v2Document },
+      ]),
+    ).toThrow('Conflicting OpenAPI schema "Shared" found in both the v1 and v2 documents.');
+  });
+
+  test("throws on duplicate operationId across the v2 webhook paths (CLI-2157 platform bug)", () => {
+    const document = {
+      paths: {
+        "/v2/projects/{ref}/webhooks/endpoints": {
+          get: { operationId: "allV2ProjectsByRefWebhooks" },
+        },
+        "/v2/projects/{ref}/webhooks/endpoints/{id}": {
+          get: { operationId: "allV2ProjectsByRefWebhooks" },
+        },
+      },
+    };
+
+    expect(() => assertMergedOpenApiDocument(document)).toThrow(
+      'Duplicate OpenAPI operationId "allV2ProjectsByRefWebhooks" claimed by: GET /v2/projects/{ref}/webhooks/endpoints, GET /v2/projects/{ref}/webhooks/endpoints/{id}.',
+    );
+  });
+
+  test("throws when an operationId's version prefix disagrees with its path", () => {
+    const document = { paths: { "/v2/x": { get: { operationId: "v1-x" } } } };
+
+    expect(() => assertMergedOpenApiDocument(document)).toThrow(
+      'OpenAPI operationId "v1-x" for GET /v2/x has version prefix "v1" that does not match the path\'s leading segment "v2".',
+    );
+  });
+
+  test("warns instead of throwing when an operation has no operationId", () => {
+    const document = { paths: { "/v1/a": { get: {} } } };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => assertMergedOpenApiDocument(document)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "OpenAPI operation GET /v1/a has no operationId; generate.ts will skip it.",
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("applyOpenApiOverrides tolerantly removes JSON pointers that no longer exist", () => {
+    const withExistingPath = { paths: { "/v1/foo": { get: {} } } };
+    applyOpenApiOverrides(withExistingPath, [{ op: "remove", path: "/paths/~1v1~1foo" }]);
+    expect(withExistingPath.paths).toEqual({});
+
+    const withMissingPath = { paths: {} };
+    applyOpenApiOverrides(withMissingPath, [{ op: "remove", path: "/paths/~1v1~1missing" }]);
+    expect(withMissingPath.paths).toEqual({});
+
+    const withMissingIntermediateSegment = { paths: {} };
+    applyOpenApiOverrides(withMissingIntermediateSegment, [
+      { op: "remove", path: "/paths/~1nope/get" },
+    ]);
+    expect(withMissingIntermediateSegment.paths).toEqual({});
+
+    const withArray = { paths: {}, components: { schemas: { Foo: { enum: ["a", "b", "c"] } } } };
+    applyOpenApiOverrides(withArray, [{ op: "remove", path: "/components/schemas/Foo/enum/1" }]);
+    expect(withArray.components.schemas.Foo.enum).toEqual(["a", "c"]);
+  });
+
+  test("rejects a remove override that carries a value", () => {
+    expect(() =>
+      applyOpenApiOverrides({ paths: {} }, [{ op: "remove", path: "/paths", value: {} }]),
+    ).toThrow("OpenAPI remove overrides must not include a value.");
+  });
+
+  test("assertMergedOpenApiDocument passes after the webhook-collision remove overrides are applied but fails without them", () => {
+    const buildDocument = () => ({
+      paths: {
+        "/v2/projects/{ref}/webhooks/endpoints": {
+          get: { operationId: "allV2ProjectsByRefWebhooks" },
+        },
+        "/v2/projects/{ref}/webhooks/endpoints/{id}": {
+          get: { operationId: "allV2ProjectsByRefWebhooks" },
+        },
+        "/v2/projects/{ref}": {
+          get: { operationId: "v2-get-a-project" },
+        },
+      },
+    });
+
+    const overrides = [
+      { op: "remove", path: "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints" },
+      { op: "remove", path: "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints~1{id}" },
+    ];
+
+    expect(() => assertMergedOpenApiDocument(buildDocument())).toThrow(
+      'Duplicate OpenAPI operationId "allV2ProjectsByRefWebhooks"',
+    );
+
+    const patchedDocument = applyOpenApiOverrides(buildDocument(), overrides);
+    expect(Object.keys(patchedDocument.paths)).toEqual(["/v2/projects/{ref}"]);
+    expect(() => assertMergedOpenApiDocument(patchedDocument)).not.toThrow();
   });
 });

--- a/packages/api/scripts/generate.ts
+++ b/packages/api/scripts/generate.ts
@@ -111,6 +111,8 @@ type OperationDefinition = {
   readonly schemaBase: string;
   readonly method: HttpMethod;
   readonly path: string;
+  readonly version: string;
+  readonly methodName: string;
   readonly description: string;
   readonly pathParams: ReadonlyArray<string>;
   readonly queryParams: ReadonlyArray<string>;
@@ -142,7 +144,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function loadSpec(): OpenApiDocument {
+export function loadSpec(): OpenApiDocument {
   const parsed = JSON.parse(readFileSync(sourceSpecPath, "utf8"));
   if (!isRecord(parsed) || !isRecord(parsed.paths)) {
     throw new Error(`Invalid OpenAPI document at ${sourceSpecPath}`);
@@ -588,7 +590,94 @@ function buildCombinedInputSchema(
   };
 }
 
-function extractOperations(document: OpenApiDocument): ReadonlyArray<OperationDefinition> {
+// The version namespace is derived from the path (not the operationId) so
+// that `/v2/...` routes land in `api.v2` regardless of how their operationId
+// happens to be spelled in the upstream spec.
+export function operationVersionFromPath(path: string): string {
+  const version = path.split("/")[1];
+  if (version === undefined || !/^v\d+$/u.test(version)) {
+    throw new Error(`Expected a version-prefixed path, got ${path}`);
+  }
+  return version;
+}
+
+// Strips a leading version prefix (e.g. `v1`/`V2`) from a camelized operation
+// name, lowercasing the character that follows it, so `v2GetProjectConfig`
+// becomes `getProjectConfig`. Operation names without a version prefix are
+// returned unchanged — the path, not the operationId, is the authority on
+// version.
+export function operationMethodName(operationName: string): string {
+  const match = /^([vV]\d+)(.*)$/u.exec(operationName);
+  if (!match) {
+    return operationName;
+  }
+
+  const methodBase = match[2];
+  if (methodBase === undefined || methodBase.length === 0) {
+    return operationName;
+  }
+
+  const first = methodBase.slice(0, 1).toLowerCase();
+  return `${first}${methodBase.slice(1)}`;
+}
+
+// A version prefix on the operationId is optional, but when present it must
+// agree with the path-derived version — otherwise the generated namespace
+// (from the path) and the SDK method name (from the operationId) would imply
+// different API versions for the same operation.
+function assertOperationVersionAgreement(operation: {
+  readonly operationId: string;
+  readonly operationName: string;
+  readonly path: string;
+  readonly version: string;
+}): void {
+  const match = /^[vV]\d+/u.exec(operation.operationName);
+  if (!match) {
+    return;
+  }
+
+  const operationNameVersion = match[0].toLowerCase();
+  if (operationNameVersion !== operation.version) {
+    throw new Error(
+      `Operation "${operation.operationId}" at path "${operation.path}" has operationId version "${operationNameVersion}" that disagrees with the path-derived version "${operation.version}"`,
+    );
+  }
+}
+
+function assertUniqueOperations(operations: ReadonlyArray<OperationDefinition>): void {
+  const byNamespaceMethod = new Map<string, OperationDefinition>();
+  const byOperationName = new Map<string, OperationDefinition>();
+  const bySchemaBase = new Map<string, OperationDefinition>();
+
+  for (const operation of operations) {
+    const namespaceMethod = `${operation.version}.${operation.methodName}`;
+    const existingNamespaceMethod = byNamespaceMethod.get(namespaceMethod);
+    if (existingNamespaceMethod) {
+      throw new Error(
+        `Duplicate namespace method "${namespaceMethod}": "${existingNamespaceMethod.operationId}" (${existingNamespaceMethod.method} ${existingNamespaceMethod.path}) collides with "${operation.operationId}" (${operation.method} ${operation.path})`,
+      );
+    }
+    byNamespaceMethod.set(namespaceMethod, operation);
+
+    const existingOperationName = byOperationName.get(operation.operationName);
+    if (existingOperationName) {
+      throw new Error(
+        `Duplicate operation name "${operation.operationName}": "${existingOperationName.operationId}" (${existingOperationName.method} ${existingOperationName.path}) collides with "${operation.operationId}" (${operation.method} ${operation.path})`,
+      );
+    }
+    byOperationName.set(operation.operationName, operation);
+
+    const existingSchemaBase = bySchemaBase.get(operation.schemaBase);
+    if (existingSchemaBase) {
+      throw new Error(
+        `Duplicate schema base "${operation.schemaBase}": "${existingSchemaBase.operationId}" (${existingSchemaBase.method} ${existingSchemaBase.path}) collides with "${operation.operationId}" (${operation.method} ${operation.path})`,
+      );
+    }
+    bySchemaBase.set(operation.schemaBase, operation);
+  }
+}
+
+export function extractOperations(document: OpenApiDocument): ReadonlyArray<OperationDefinition> {
   const operations: Array<OperationDefinition> = [];
 
   for (const [pathName, pathItem] of Object.entries(document.paths)) {
@@ -602,13 +691,25 @@ function extractOperations(document: OpenApiDocument): ReadonlyArray<OperationDe
       const { response, schema: outputSchema } = getResponseDefinition(document, operation);
       const schemaBase = identifier(operation.operationId);
       const description = operation.description?.trim() || operation.summary?.trim() || schemaBase;
+      const operationName = camelize(operation.operationId);
+      const version = operationVersionFromPath(pathName);
+      const methodName = operationMethodName(operationName);
+
+      assertOperationVersionAgreement({
+        operationId: operation.operationId,
+        operationName,
+        path: pathName,
+        version,
+      });
 
       operations.push({
         operationId: operation.operationId,
-        operationName: camelize(operation.operationId),
+        operationName,
         schemaBase,
         method: httpMethods[method],
         path: pathName,
+        version,
+        methodName,
         description,
         pathParams: (operation.parameters ?? [])
           .filter((parameter) => parameter.in === "path")
@@ -629,7 +730,11 @@ function extractOperations(document: OpenApiDocument): ReadonlyArray<OperationDe
     }
   }
 
-  return operations.sort((left, right) => left.operationId.localeCompare(right.operationId));
+  const sortedOperations = operations.sort((left, right) =>
+    left.operationId.localeCompare(right.operationId),
+  );
+  assertUniqueOperations(sortedOperations);
+  return sortedOperations;
 }
 
 function renderSchemaSource(
@@ -758,7 +863,7 @@ function renderResponse(definition: ResponseDefinition): string {
   return `{ kind: ${JSON.stringify(definition.kind)} }`;
 }
 
-function renderContracts(
+export function renderContracts(
   document: OpenApiDocument,
   operations: ReadonlyArray<OperationDefinition>,
 ): string {
@@ -818,34 +923,12 @@ export type VoidOperationDefinition<Id extends OperationId = OperationId> = Extr
 `;
 }
 
-function splitOperationVersion(operationName: string): {
-  readonly version: string;
-  readonly methodName: string;
-} {
-  const match = /^((?:v|V)\d+)(.+)$/u.exec(operationName);
-  if (!match) {
-    throw new Error(`Expected a version-prefixed operation id, got ${operationName}`);
-  }
-
-  const [, version, methodBase] = match;
-  if (version === undefined || methodBase === undefined || methodBase.length === 0) {
-    throw new Error(`Expected an operation method segment after the version in ${operationName}`);
-  }
-  const first = methodBase.slice(0, 1).toLowerCase();
-
-  return {
-    version,
-    methodName: `${first}${methodBase.slice(1)}`,
-  };
-}
-
-function renderEffectClient(operations: ReadonlyArray<OperationDefinition>): string {
+export function renderEffectClient(operations: ReadonlyArray<OperationDefinition>): string {
   const versionedOperations = new Map<string, Array<OperationDefinition>>();
   for (const operation of operations) {
-    const { version } = splitOperationVersion(operation.operationName);
-    const group = versionedOperations.get(version);
+    const group = versionedOperations.get(operation.version);
     if (group === undefined) {
-      versionedOperations.set(version, [operation]);
+      versionedOperations.set(operation.version, [operation]);
     } else {
       group.push(operation);
     }
@@ -856,7 +939,7 @@ function renderEffectClient(operations: ReadonlyArray<OperationDefinition>): str
     .map(([version, groupedOperations]) => {
       const methods = groupedOperations
         .map((operation) => {
-          const { methodName } = splitOperationVersion(operation.operationName);
+          const { methodName } = operation;
           const isEmptyInput =
             operation.inputSchema.type === "object" &&
             Object.keys(operation.inputSchema.properties ?? {}).length === 0;
@@ -886,7 +969,7 @@ ${methods}
 
   const executorCases = operations
     .map((operation) => {
-      const { version, methodName } = splitOperationVersion(operation.operationName);
+      const { version, methodName } = operation;
       const isEmptyInput =
         operation.inputSchema.type === "object" &&
         Object.keys(operation.inputSchema.properties ?? {}).length === 0;

--- a/packages/api/scripts/generate.ts
+++ b/packages/api/scripts/generate.ts
@@ -10,7 +10,7 @@ import * as SchemaRepresentation from "effect/SchemaRepresentation";
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
 type OpenApiHttpMethod = Lowercase<HttpMethod>;
 
-type OpenApiDocument = {
+export type OpenApiDocument = {
   readonly openapi: string;
   readonly info?: {
     readonly title?: string;
@@ -22,7 +22,7 @@ type OpenApiDocument = {
   };
 };
 
-type OpenApiOperation = {
+export type OpenApiOperation = {
   readonly operationId?: string;
   readonly summary?: string;
   readonly description?: string;

--- a/packages/api/scripts/generate.unit.test.ts
+++ b/packages/api/scripts/generate.unit.test.ts
@@ -3,6 +3,7 @@ import * as JsonSchema from "effect/JsonSchema";
 import * as SchemaRepresentation from "effect/SchemaRepresentation";
 import { describe, expect, test } from "vitest";
 
+import type { OpenApiDocument, OpenApiOperation } from "./generate.ts";
 import {
   extractOperations,
   normalizeNullableJsonSchema,
@@ -18,7 +19,7 @@ function jsonResponseOperation(
   operationId: string,
   pathParamName: string,
   responseSchema: Record<string, unknown>,
-) {
+): OpenApiOperation {
   return {
     operationId,
     parameters: [{ name: pathParamName, in: "path", required: true, schema: { type: "string" } }],
@@ -34,7 +35,7 @@ function jsonResponseOperation(
   };
 }
 
-function twoVersionFixture() {
+function twoVersionFixture(): OpenApiDocument {
   return {
     openapi: "3.0.0",
     info: { title: "Test API", version: "1.0.0" },

--- a/packages/api/scripts/generate.unit.test.ts
+++ b/packages/api/scripts/generate.unit.test.ts
@@ -4,10 +4,70 @@ import * as SchemaRepresentation from "effect/SchemaRepresentation";
 import { describe, expect, test } from "vitest";
 
 import {
+  extractOperations,
   normalizeNullableJsonSchema,
   normalizeQueryParameterSchema,
+  operationMethodName,
+  operationVersionFromPath,
+  renderContracts,
+  renderEffectClient,
   sanitizeOpenApiSchema,
 } from "./generate.ts";
+
+function jsonResponseOperation(
+  operationId: string,
+  pathParamName: string,
+  responseSchema: Record<string, unknown>,
+) {
+  return {
+    operationId,
+    parameters: [{ name: pathParamName, in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      "200": {
+        content: {
+          "application/json": {
+            schema: responseSchema,
+          },
+        },
+      },
+    },
+  };
+}
+
+function twoVersionFixture() {
+  return {
+    openapi: "3.0.0",
+    info: { title: "Test API", version: "1.0.0" },
+    paths: {
+      "/v1/organizations/{slug}/members": {
+        get: jsonResponseOperation("v1-list-organization-members", "slug", {
+          type: "array",
+          items: { type: "object", properties: {}, required: [] },
+        }),
+      },
+      "/v1/projects/{ref}": {
+        get: jsonResponseOperation("v1-get-a-project", "ref", {
+          type: "object",
+          properties: {},
+          required: [],
+        }),
+      },
+      "/v2/organizations/{slug}/members": {
+        get: jsonResponseOperation("v2-list-organization-members", "slug", {
+          type: "array",
+          items: { type: "object", properties: {}, required: [] },
+        }),
+      },
+      "/v2/projects/{ref}/config": {
+        get: jsonResponseOperation("v2-get-a-project-config", "ref", {
+          type: "object",
+          properties: {},
+          required: [],
+        }),
+      },
+    },
+  };
+}
 
 function renderOpenApiSchema(schema: Parameters<typeof JsonSchema.fromSchemaOpenApi3_0>[0]) {
   const normalized = normalizeNullableJsonSchema(
@@ -118,5 +178,103 @@ describe("generate", () => {
         },
       }),
     ).toContain('"default": Schema.optionalKey(Schema.Json');
+  });
+
+  test("extractOperations derives version from the path and methodName from the operationId", () => {
+    const operations = extractOperations(twoVersionFixture());
+
+    expect(operations.map((operation) => operation.operationId)).toEqual([
+      "v1-get-a-project",
+      "v1-list-organization-members",
+      "v2-get-a-project-config",
+      "v2-list-organization-members",
+    ]);
+    expect(
+      operations.map((operation) => ({
+        version: operation.version,
+        methodName: operation.methodName,
+      })),
+    ).toEqual([
+      { version: "v1", methodName: "getAProject" },
+      { version: "v1", methodName: "listOrganizationMembers" },
+      { version: "v2", methodName: "getAProjectConfig" },
+      { version: "v2", methodName: "listOrganizationMembers" },
+    ]);
+
+    const membersOperations = operations.filter(
+      (operation) => operation.methodName === "listOrganizationMembers",
+    );
+    expect(membersOperations).toHaveLength(2);
+    expect(membersOperations.map((operation) => operation.version)).toEqual(["v1", "v2"]);
+  });
+
+  test("operationMethodName strips a real v1 version prefix and passes unprefixed names through unchanged", () => {
+    expect(operationMethodName("v1GetABranchConfig")).toBe("getABranchConfig");
+    expect(operationMethodName("v1ListAllProjects")).toBe("listAllProjects");
+    expect(operationMethodName("healthCheck")).toBe("healthCheck");
+  });
+
+  test("operationVersionFromPath reads the version segment from a versioned path", () => {
+    expect(operationVersionFromPath("/v2/projects/{ref}/config")).toBe("v2");
+  });
+
+  test("operationVersionFromPath throws for a path with no version prefix", () => {
+    expect(() => operationVersionFromPath("/health")).toThrow(
+      "Expected a version-prefixed path, got /health",
+    );
+  });
+
+  test("extractOperations throws when a path's version disagrees with the operationId's version prefix", () => {
+    const document = {
+      openapi: "3.0.0",
+      paths: {
+        "/v2/x": { get: jsonResponseOperation("v1-x", "x", { type: "object" }) },
+      },
+    };
+
+    expect(() => extractOperations(document)).toThrow(
+      'Operation "v1-x" at path "/v2/x" has operationId version "v1" that disagrees with the path-derived version "v2"',
+    );
+  });
+
+  test("extractOperations throws when two operationIds camelize to the same (version, methodName) pair", () => {
+    const document = {
+      openapi: "3.0.0",
+      paths: {
+        "/v2/a": { get: jsonResponseOperation("v2-get-config", "x", { type: "object" }) },
+        "/v2/b": { get: jsonResponseOperation("v2-get--config", "x", { type: "object" }) },
+      },
+    };
+
+    expect(() => extractOperations(document)).toThrow(
+      'Duplicate namespace method "v2.getConfig": "v2-get--config" (GET /v2/b) collides with "v2-get-config" (GET /v2/a)',
+    );
+  });
+
+  test("renderEffectClient emits both version namespaces with the shared method name and a versioned executor case", () => {
+    const document = twoVersionFixture();
+    const operations = extractOperations(document);
+    const source = renderEffectClient(operations);
+
+    expect(source).toContain("  v1: {");
+    expect(source).toContain("  v2: {");
+
+    const v1Block = source.slice(source.indexOf("  v1: {"), source.indexOf("  v2: {"));
+    const v2Block = source.slice(source.indexOf("  v2: {"));
+    expect(v1Block).toContain("listOrganizationMembers: (");
+    expect(v2Block).toContain("listOrganizationMembers: (");
+
+    expect(source).toContain("api.v2.listOrganizationMembers(decoded)");
+  });
+
+  test("renderContracts includes both versioned operation names and the raw kebab operationIds", () => {
+    const document = twoVersionFixture();
+    const operations = extractOperations(document);
+    const source = renderContracts(document, operations);
+
+    expect(source).toContain('"v1ListOrganizationMembers": {');
+    expect(source).toContain('"v2ListOrganizationMembers": {');
+    expect(source).toContain('  "v1-list-organization-members": "v1ListOrganizationMembers",');
+    expect(source).toContain('  "v2-list-organization-members": "v2ListOrganizationMembers",');
   });
 });

--- a/packages/api/scripts/generated-output-sync.unit.test.ts
+++ b/packages/api/scripts/generated-output-sync.unit.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+import { extractOperations, loadSpec, renderContracts, renderEffectClient } from "./generate.ts";
+
+// Full-fidelity drift guard: re-renders every generated file from the
+// committed openapi.json snapshot, formats the result through the same oxfmt
+// the pipeline uses, and requires byte equality with the committed files.
+// Unlike the operation-level bijection test in src/generated-contract-sync,
+// this catches hand edits to schema definitions, parameter lists, request
+// bodies, response types, and the executor switch — anything short of
+// editing the snapshot and the generated output consistently, which the
+// hourly upstream sync then catches.
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.join(scriptDir, "..");
+const generatedDir = path.join(packageDir, "src", "generated");
+const oxfmtBin = path.join(packageDir, "node_modules", ".bin", "oxfmt");
+
+function formatWithOxfmt(source: string, fileName: string): string {
+  const formatted = execFileSync(oxfmtBin, [`--stdin-filepath=${fileName}`], {
+    input: source,
+    cwd: packageDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  // oxfmt's file mode (what the pipeline runs) trims trailing blank lines to
+  // a single newline; its stdin mode preserves them. Normalize so the two
+  // modes agree.
+  return formatted.replace(/\n+$/, "\n");
+}
+
+function committedFile(fileName: string): string {
+  return readFileSync(path.join(generatedDir, fileName), "utf8");
+}
+
+function expectSameSource(rendered: string, fileName: string): void {
+  const committed = committedFile(fileName);
+  if (rendered === committed) {
+    return;
+  }
+  const renderedLines = rendered.split("\n");
+  const committedLines = committed.split("\n");
+  const limit = Math.min(renderedLines.length, committedLines.length);
+  let line = 0;
+  while (line < limit && renderedLines[line] === committedLines[line]) {
+    line += 1;
+  }
+  expect.fail(
+    `src/generated/${fileName} is not what the generator renders from the committed snapshot ` +
+      `(first difference at line ${line + 1}):\n` +
+      `  committed: ${JSON.stringify(committedLines[line] ?? "<end of file>")}\n` +
+      `  rendered:  ${JSON.stringify(renderedLines[line] ?? "<end of file>")}\n` +
+      `Hand edits to src/generated are not allowed — run \`pnpm generate\` instead.`,
+  );
+}
+
+// Rendering contracts.ts runs the real schema codegen for every operation,
+// which takes well over vitest's default 5s budget.
+const RENDER_TIMEOUT_MS = 120_000;
+
+describe("generated output sync", () => {
+  const document = loadSpec();
+  const operations = extractOperations(document);
+
+  test(
+    "contracts.ts is byte-identical to the generator's render of the committed snapshot",
+    { timeout: RENDER_TIMEOUT_MS },
+    () => {
+      expectSameSource(
+        formatWithOxfmt(renderContracts(document, operations), "contracts.ts"),
+        "contracts.ts",
+      );
+    },
+  );
+
+  test(
+    "effect-client.ts is byte-identical to the generator's render of the committed snapshot",
+    { timeout: RENDER_TIMEOUT_MS },
+    () => {
+      expectSameSource(
+        formatWithOxfmt(renderEffectClient(operations), "effect-client.ts"),
+        "effect-client.ts",
+      );
+    },
+  );
+
+  test(
+    "openapi.json is byte-identical to the generator's normalized rewrite of itself",
+    { timeout: RENDER_TIMEOUT_MS },
+    () => {
+      expectSameSource(
+        formatWithOxfmt(`${JSON.stringify(document, null, 2)}\n`, "openapi.json"),
+        "openapi.json",
+      );
+    },
+  );
+});

--- a/packages/api/scripts/generated-output-sync.unit.test.ts
+++ b/packages/api/scripts/generated-output-sync.unit.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
@@ -21,16 +21,20 @@ const generatedDir = path.join(packageDir, "src", "generated");
 const oxfmtBin = path.join(packageDir, "node_modules", ".bin", "oxfmt");
 
 function formatWithOxfmt(source: string, fileName: string): string {
-  const formatted = execFileSync(oxfmtBin, [`--stdin-filepath=${fileName}`], {
-    input: source,
-    cwd: packageDir,
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  // oxfmt's file mode (what the pipeline runs) trims trailing blank lines to
-  // a single newline; its stdin mode preserves them. Normalize so the two
-  // modes agree.
-  return formatted.replace(/\n+$/, "\n");
+  // oxfmt runs in file mode (also what the pipeline's fmt:fix runs) rather
+  // than through stdin/stdout: Bun on Linux truncates a child's piped stdout
+  // at ~219 KB, and these renders are 600+ KB. The temp directory lives
+  // inside the package so oxfmt resolves the same configuration, but not
+  // under node_modules, which oxfmt skips by default.
+  const tempDir = mkdtempSync(path.join(packageDir, ".generated-output-sync-"));
+  try {
+    const tempFile = path.join(tempDir, fileName);
+    writeFileSync(tempFile, source);
+    execFileSync(oxfmtBin, [tempFile], { cwd: packageDir });
+    return readFileSync(tempFile, "utf8");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 function committedFile(fileName: string): string {

--- a/packages/api/scripts/openapi-overrides.json
+++ b/packages/api/scripts/openapi-overrides.json
@@ -622,5 +622,70 @@
     "op": "replace",
     "path": "/components/schemas/UpdateAuthConfigBody/properties/sms_test_otp/pattern",
     "value": "^(?:[0-9]{1,15}=(?:[0-9]+,[0-9]{1,15}=|[0-9]{2,}=)*[0-9]+,?)?$"
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints",
+    "$comment": "CLI-2157: the platform's v2 spec gives all 10 project-webhook operations the shared operationId \"allV2ProjectsByRefWebhooks\" (and all 10 org-webhook operations share \"allV2OrganizationsBySlugWebhooks\") — duplicated and not version-prefixed, which breaks codegen. Remove-if-present because staging's v2-json is currently served by two backend variants that disagree on whether these paths exist."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints~1{id}",
+    "$comment": "CLI-2157: part of the project-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints~1{id}~1deliveries",
+    "$comment": "CLI-2157: part of the project-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1endpoints~1{id}~1test",
+    "$comment": "CLI-2157: part of the project-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1deliveries~1{id}",
+    "$comment": "CLI-2157: part of the project-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1projects~1{ref}~1webhooks~1deliveries~1{id}~1retry",
+    "$comment": "CLI-2157: part of the project-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1endpoints",
+    "$comment": "CLI-2157: the platform's v2 spec gives all 10 org-webhook operations the shared operationId \"allV2OrganizationsBySlugWebhooks\" (and all 10 project-webhook operations share \"allV2ProjectsByRefWebhooks\") — duplicated and not version-prefixed, which breaks codegen. Remove-if-present because staging's v2-json is currently served by two backend variants that disagree on whether these paths exist."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1endpoints~1{id}",
+    "$comment": "CLI-2157: part of the org-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1endpoints~1{id}~1deliveries",
+    "$comment": "CLI-2157: part of the org-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1endpoints~1{id}~1test",
+    "$comment": "CLI-2157: part of the org-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1deliveries~1{id}",
+    "$comment": "CLI-2157: part of the org-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/paths/~1v2~1organizations~1{slug}~1webhooks~1deliveries~1{id}~1retry",
+    "$comment": "CLI-2157: part of the org-webhook operationId collision; see the endpoints path comment above."
+  },
+  {
+    "op": "remove",
+    "path": "/components/schemas/APIErrorObject",
+    "$comment": "CLI-2157: referenced only by the removed webhook paths (verified in prod and staging); removing it also makes the staging document deterministic."
   }
 ]

--- a/packages/api/scripts/openapi-source.json
+++ b/packages/api/scripts/openapi-source.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "https://api.supabase.green"
+}

--- a/packages/api/scripts/openapi-source.json
+++ b/packages/api/scripts/openapi-source.json
@@ -1,3 +1,3 @@
 {
-  "baseUrl": "https://api.supabase.green"
+  "baseUrl": "https://api.supabase.com"
 }

--- a/packages/api/src/effect.unit.test.ts
+++ b/packages/api/src/effect.unit.test.ts
@@ -442,6 +442,75 @@ describe("makeApiClient", () => {
     ]);
   });
 
+  test("addresses same-named v1 and v2 operations independently by namespace", async () => {
+    const seenRequests: Array<{ method: string; url: string }> = [];
+
+    const client = await Effect.runPromise(
+      makeApiClient(config).pipe(
+        Effect.provide(
+          httpClientLayer((request) => {
+            seenRequests.push({
+              method: request.method,
+              url: request.url,
+            });
+
+            if (request.url === "https://api.supabase.com/v1/organizations/my-org/members") {
+              return Effect.succeed(
+                jsonResponse(request, 200, [
+                  {
+                    user_id: "user-id",
+                    user_name: "user-name",
+                    role_name: "Owner",
+                    mfa_enabled: false,
+                    avatar_url: null,
+                  },
+                ]),
+              );
+            }
+
+            return Effect.succeed(
+              jsonResponse(request, 200, {
+                data: [],
+                links: { prev: null, next: null },
+              }),
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(typeof client.v1.listOrganizationMembers).toBe("function");
+    expect(typeof client.v2.listOrganizationMembers).toBe("function");
+
+    const v1Members = await Effect.runPromise(
+      client.v1.listOrganizationMembers({ slug: "my-org" }),
+    );
+    const v2Members = await Effect.runPromise(
+      client.v2.listOrganizationMembers({ slug: "my-org" }),
+    );
+
+    expect(v1Members).toEqual([
+      {
+        user_id: "user-id",
+        user_name: "user-name",
+        role_name: "Owner",
+        mfa_enabled: false,
+        avatar_url: null,
+      },
+    ]);
+    expect(v2Members.data).toEqual([]);
+    expect(seenRequests).toEqual([
+      {
+        method: "GET",
+        url: "https://api.supabase.com/v1/organizations/my-org/members",
+      },
+      {
+        method: "GET",
+        url: "https://api.supabase.com/v2/organizations/my-org/members",
+      },
+    ]);
+  });
+
   test("serializes generated binary methods through the effect facade", async () => {
     let seenRequest: HttpClientRequest.HttpClientRequest | undefined;
 

--- a/packages/api/src/generated-contract-sync.unit.test.ts
+++ b/packages/api/src/generated-contract-sync.unit.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import { openApiOperationIdMap, operationDefinitions } from "./generated/contracts.ts";
+import { versionedEffectOperations } from "./generated/effect-client.ts";
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "patch", "head", "options", "trace"] as const;
+
+interface OpenApiOperationObject {
+  readonly operationId?: string;
+}
+
+type OpenApiPathItem = Readonly<Record<string, OpenApiOperationObject | undefined>>;
+
+interface OpenApiDocumentShape {
+  readonly paths: Readonly<Record<string, OpenApiPathItem>>;
+}
+
+interface SnapshotOperation {
+  readonly path: string;
+  readonly method: string;
+  readonly operationId: string;
+}
+
+const openApiJsonPath = join(dirname(fileURLToPath(import.meta.url)), "generated/openapi.json");
+const rawOpenApiJson = readFileSync(openApiJsonPath, "utf8");
+const openApiDocument = JSON.parse(rawOpenApiJson) as OpenApiDocumentShape;
+
+function extractSnapshotOperations(
+  document: OpenApiDocumentShape,
+): ReadonlyArray<SnapshotOperation> {
+  const operations: Array<SnapshotOperation> = [];
+  for (const [path, pathItem] of Object.entries(document.paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation?.operationId) {
+        continue;
+      }
+      operations.push({ path, method: method.toUpperCase(), operationId: operation.operationId });
+    }
+  }
+  return operations;
+}
+
+function leadingPathSegment(path: string): string {
+  const segment = path.split("/")[1];
+  if (segment === undefined) {
+    throw new Error(`Expected a version-prefixed path, got "${path}"`);
+  }
+  return segment;
+}
+
+// Mirrors scripts/generate.ts's operationMethodName: strips the leading
+// version prefix from the SDK operation id and lowercases the character that
+// follows it, e.g. "v2GetProjectConfig" -> "getProjectConfig".
+function methodNameFromSdkOperationId(sdkOperationId: string): string {
+  const match = /^v\d+(.+)$/.exec(sdkOperationId);
+  const rest = match?.[1];
+  if (!rest) {
+    return sdkOperationId;
+  }
+  return `${rest[0]!.toLowerCase()}${rest.slice(1)}`;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringProperty(value: unknown, key: string): string {
+  if (!isRecord(value)) {
+    throw new Error(`Expected an object while reading property "${key}"`);
+  }
+  const propertyValue = value[key];
+  if (typeof propertyValue !== "string") {
+    throw new Error(`Expected a string property "${key}", got ${typeof propertyValue}`);
+  }
+  return propertyValue;
+}
+
+const operationIdMap = new Map<string, string>(Object.entries(openApiOperationIdMap));
+const definitionsByOperationName = new Map<string, unknown>(Object.entries(operationDefinitions));
+const versionedOperationsByVersion = new Map<string, unknown>(
+  Object.entries(versionedEffectOperations),
+);
+
+function versionedOperationFunction(version: string, methodName: string): unknown {
+  const operations = versionedOperationsByVersion.get(version);
+  if (!isRecord(operations)) {
+    return undefined;
+  }
+  return operations[methodName];
+}
+
+const snapshotOperations = extractSnapshotOperations(openApiDocument);
+
+describe("generated client drift against the committed openapi.json snapshot", () => {
+  test("maps every snapshot operation to a matching generated contract and versioned client method", () => {
+    for (const { path, method, operationId } of snapshotOperations) {
+      const sdkOperationId = operationIdMap.get(operationId);
+      expect(sdkOperationId, `no openApiOperationIdMap entry for "${operationId}"`).toBeDefined();
+      if (sdkOperationId === undefined) {
+        continue;
+      }
+
+      const definition = definitionsByOperationName.get(sdkOperationId);
+      expect(
+        definition,
+        `no operationDefinitions entry for "${sdkOperationId}" (${method} ${path})`,
+      ).toBeDefined();
+
+      expect(stringProperty(definition, "method")).toBe(method);
+      expect(stringProperty(definition, "path")).toBe(path);
+
+      const namespace = leadingPathSegment(path);
+      const methodName = methodNameFromSdkOperationId(sdkOperationId);
+      expect(
+        typeof versionedOperationFunction(namespace, methodName),
+        `versionedEffectOperations.${namespace}.${methodName} is not a function for "${sdkOperationId}" (${method} ${path})`,
+      ).toBe("function");
+    }
+  });
+
+  test("does not carry a hand-added or stale operation in the generated contracts", () => {
+    const sdkOperationIdsFromSnapshot = snapshotOperations.map(({ operationId }) =>
+      operationIdMap.get(operationId),
+    );
+
+    expect(new Set(sdkOperationIdsFromSnapshot).size).toBe(sdkOperationIdsFromSnapshot.length);
+    expect(sdkOperationIdsFromSnapshot.length).toBe(Object.keys(operationDefinitions).length);
+    expect(new Set(sdkOperationIdsFromSnapshot)).toEqual(
+      new Set(Object.keys(operationDefinitions)),
+    );
+  });
+
+  test("does not carry a hand-added or stale method on the versioned effect client", () => {
+    const totalVersionedOperationFunctions = Array.from(
+      versionedOperationsByVersion.values(),
+    ).reduce<number>(
+      (total, operations) =>
+        isRecord(operations) ? total + Object.keys(operations).length : total,
+      0,
+    );
+
+    const versionMethodPairsFromSnapshot = new Set(
+      snapshotOperations.map(({ path, operationId }) => {
+        const sdkOperationId = operationIdMap.get(operationId);
+        return `${leadingPathSegment(path)}.${
+          sdkOperationId ? methodNameFromSdkOperationId(sdkOperationId) : operationId
+        }`;
+      }),
+    );
+
+    expect(versionMethodPairsFromSnapshot.size).toBe(snapshotOperations.length);
+    expect(totalVersionedOperationFunctions).toBe(snapshotOperations.length);
+  });
+
+  test("exposes exactly the API versions present in the snapshot as top-level namespaces", () => {
+    const versionsFromSnapshot = new Set(
+      snapshotOperations.map(({ path }) => leadingPathSegment(path)),
+    );
+
+    expect(Object.keys(versionedEffectOperations).sort()).toEqual(
+      Array.from(versionsFromSnapshot).sort(),
+    );
+    expect(versionsFromSnapshot).toContain("v1");
+    expect(versionsFromSnapshot).toContain("v2");
+  });
+
+  // A byte-for-byte `JSON.stringify(parsed, null, 2) + "\n"` reproduction of
+  // the committed file does not hold: oxfmt collapses short arrays (e.g.
+  // `"tags": ["Environments"]`) onto a single line after generation, so a
+  // naive re-stringify diverges purely on formatting, not content. This
+  // instead checks that the committed bytes parse deterministically and keep
+  // the single trailing newline `scripts/generate.ts` writes.
+  test("parses the committed snapshot deterministically and keeps a single trailing newline", () => {
+    const reparsed = JSON.parse(readFileSync(openApiJsonPath, "utf8")) as OpenApiDocumentShape;
+    expect(reparsed).toEqual(openApiDocument);
+    expect(rawOpenApiJson.endsWith("\n")).toBe(true);
+    expect(rawOpenApiJson.endsWith("\n\n")).toBe(false);
+  });
+});

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -9989,6 +9989,2005 @@ export const V1VerifyDnsConfigOutput = Schema.Struct({
     }),
   }),
 });
+export const V2AssignOrganizationMemberRoleInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  user_id: Schema.String.annotate({ format: "uuid" }).check(
+    Schema.isPattern(
+      new RegExp(
+        "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+      ),
+    ).annotate({
+      expected:
+        "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+    }),
+  ),
+  data: Schema.Struct({
+    type: Schema.Literal("organization_member_role").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      role: Schema.Literals(["owner", "administrator", "developer", "read-only"]).annotate({
+        description:
+          "Role name to assign. Must be one of: owner, administrator, developer, read-only. Must be on a Team or Enterprise plan to use the read-only role.",
+      }),
+      projects: Schema.optionalKey(
+        Schema.Array(Schema.Struct({ ref: Schema.String.annotate({ description: "Project ref" }) }))
+          .annotate({
+            description:
+              "The projects to assign a project-scoped role for. If omitted, assigns an org-wide role.",
+          })
+          .check(
+            Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }),
+          ),
+      ),
+    }),
+  }),
+});
+export const V2AssignOrganizationMemberRoleOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("organization_member_role").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      name: Schema.String.annotate({
+        description: "Role name. For project-scoped assignments this is the base role name.",
+      }),
+      scope: Schema.Literals(["organization", "project"]).annotate({
+        description:
+          "Whether this role applies org-wide or is scoped to specific projects for the user.",
+      }),
+      projects: Schema.Array(Schema.Struct({ ref: Schema.String, name: Schema.String })).annotate({
+        description: "Project refs this role is scoped to. Empty array for org-level roles.",
+      }),
+    }),
+  }),
+});
+export const V2CreateLogDrainInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  data: Schema.Struct({
+    type: Schema.Literal("log_drain").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      name: Schema.String,
+      description: Schema.optionalKey(Schema.String),
+      config: Schema.Union([
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          schema: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          port: Schema.optionalKey(
+            Schema.Union([
+              Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+              Schema.Null,
+            ]),
+          ),
+          hostname: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "postgres" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          http: Schema.optionalKey(Schema.Literals(["http1", "http2"])),
+          gzip: Schema.optionalKey(Schema.Boolean),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "webhook" }),
+        Schema.Struct({
+          project_id: Schema.optionalKey(Schema.String),
+          dataset_id: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "bigquery" }),
+        Schema.Struct({
+          api_key: Schema.optionalKey(Schema.String),
+          region: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "datadog" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "loki" }),
+        Schema.Struct({ dsn: Schema.optionalKey(Schema.String) }).annotate({ title: "sentry" }),
+        Schema.Struct({
+          domain: Schema.optionalKey(Schema.String),
+          api_token: Schema.optionalKey(Schema.String),
+          dataset_name: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "axiom" }),
+        Schema.Struct({
+          host: Schema.optionalKey(Schema.String),
+          port: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(65535).annotate({
+                  expected: "a value less than or equal to 65535",
+                }),
+              ),
+          ),
+          tls: Schema.optionalKey(Schema.Boolean),
+          structured_data: Schema.optionalKey(Schema.String),
+          cipher_key: Schema.optionalKey(Schema.String),
+          ca_cert: Schema.optionalKey(Schema.String),
+          client_cert: Schema.optionalKey(Schema.String),
+          client_key: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "syslog" }),
+      ]),
+      backend_type: Schema.Literals([
+        "postgres",
+        "bigquery",
+        "clickhouse",
+        "webhook",
+        "datadog",
+        "loki",
+        "sentry",
+        "s3",
+        "axiom",
+        "last9",
+        "otlp",
+        "syslog",
+      ]),
+    }),
+  }),
+});
+export const V2CreateLogDrainOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("log_drain").annotate({ description: "Resource type." }),
+    id: Schema.String,
+    attributes: Schema.Struct({
+      name: Schema.String,
+      description: Schema.optionalKey(Schema.String),
+      config: Schema.Union([
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          schema: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          port: Schema.optionalKey(
+            Schema.Union([
+              Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+              Schema.Null,
+            ]),
+          ),
+          hostname: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "postgres" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          http: Schema.optionalKey(Schema.Literals(["http1", "http2"])),
+          gzip: Schema.optionalKey(Schema.Boolean),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "webhook" }),
+        Schema.Struct({
+          project_id: Schema.optionalKey(Schema.String),
+          dataset_id: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "bigquery" }),
+        Schema.Struct({
+          api_key: Schema.optionalKey(Schema.String),
+          region: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "datadog" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "loki" }),
+        Schema.Struct({ dsn: Schema.optionalKey(Schema.String) }).annotate({ title: "sentry" }),
+        Schema.Struct({
+          domain: Schema.optionalKey(Schema.String),
+          api_token: Schema.optionalKey(Schema.String),
+          dataset_name: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "axiom" }),
+        Schema.Struct({
+          host: Schema.optionalKey(Schema.String),
+          port: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(65535).annotate({
+                  expected: "a value less than or equal to 65535",
+                }),
+              ),
+          ),
+          tls: Schema.optionalKey(Schema.Boolean),
+          structured_data: Schema.optionalKey(Schema.String),
+          cipher_key: Schema.optionalKey(Schema.String),
+          ca_cert: Schema.optionalKey(Schema.String),
+          client_cert: Schema.optionalKey(Schema.String),
+          client_key: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "syslog" }),
+      ]),
+      backend_type: Schema.Literals([
+        "postgres",
+        "bigquery",
+        "clickhouse",
+        "webhook",
+        "datadog",
+        "loki",
+        "sentry",
+        "s3",
+        "axiom",
+        "last9",
+        "otlp",
+        "syslog",
+      ]),
+    }),
+  }),
+});
+export const V2CreateOrganizationInvitationsInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_invitation").annotate({ description: "Resource type." }),
+      attributes: Schema.Struct({
+        email: Schema.String.annotate({ format: "email" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          }),
+        ),
+        role: Schema.Literals(["owner", "administrator", "developer", "read-only"]).annotate({
+          description:
+            "Role name to assign. Must be on a Team or Enterprise plan to use the read-only role.",
+        }),
+        projects: Schema.optionalKey(
+          Schema.Array(
+            Schema.Struct({ ref: Schema.String.annotate({ description: "Project ref" }) }),
+          )
+            .annotate({
+              description:
+                "The projects to limit a user to. If omitted, user will have org-wide access with the provided role.",
+            })
+            .check(
+              Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }),
+            ),
+        ),
+        require_sso: Schema.optionalKey(Schema.Boolean),
+      }),
+    }),
+  )
+    .check(Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }))
+    .check(Schema.isMaxLength(50).annotate({ expected: "a value with a length of at most 50" })),
+});
+export const V2CreateOrganizationInvitationsOutput = Schema.Struct({
+  error: Schema.optionalKey(
+    Schema.Struct({
+      id: Schema.optionalKey(Schema.String),
+      code: Schema.String,
+      message: Schema.String,
+      description: Schema.optionalKey(Schema.String),
+      links: Schema.optionalKey(
+        Schema.Record(
+          Schema.String,
+          Schema.Struct({
+            href: Schema.String,
+            rel: Schema.optionalKey(Schema.String),
+            title: Schema.optionalKey(Schema.String),
+            type: Schema.optionalKey(Schema.String),
+            describedby: Schema.optionalKey(Schema.String),
+            meta: Schema.optionalKey(
+              Schema.Record(Schema.String, Schema.Json.annotate({ expected: "JSON value" })),
+            ),
+          }),
+        ),
+      ),
+      meta: Schema.optionalKey(
+        Schema.Record(Schema.String, Schema.Json.annotate({ expected: "JSON value" })),
+      ),
+      issues: Schema.optionalKey(
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.optionalKey(Schema.String),
+            code: Schema.String,
+            message: Schema.String,
+            description: Schema.optionalKey(Schema.String),
+            links: Schema.optionalKey(
+              Schema.Record(
+                Schema.String,
+                Schema.Struct({
+                  href: Schema.String,
+                  rel: Schema.optionalKey(Schema.String),
+                  title: Schema.optionalKey(Schema.String),
+                  type: Schema.optionalKey(Schema.String),
+                  describedby: Schema.optionalKey(Schema.String),
+                  meta: Schema.optionalKey(
+                    Schema.Record(Schema.String, Schema.Json.annotate({ expected: "JSON value" })),
+                  ),
+                }),
+              ),
+            ),
+            meta: Schema.Struct({
+              email: Schema.String.annotate({ format: "email" }).check(
+                Schema.isPattern(
+                  new RegExp(
+                    "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                  ),
+                ).annotate({
+                  expected:
+                    "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                }),
+              ),
+            }),
+          }),
+        ),
+      ),
+    }),
+  ),
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_invitation").annotate({ description: "Resource type." }),
+      attributes: Schema.Struct({
+        email: Schema.String.annotate({ format: "email" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          }),
+        ),
+      }),
+    }),
+  ),
+});
+export const V2CreatePrivateLinkAssociationInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  data: Schema.Struct({
+    type: Schema.Literal("private_link_association").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      aws_account_id: Schema.String.annotate({
+        description: "The AWS account ID to add to the project PrivateLink share.",
+      })
+        .check(
+          Schema.isMinLength(12).annotate({ expected: "a value with a length of at least 12" }),
+        )
+        .check(Schema.isMaxLength(12).annotate({ expected: "a value with a length of at most 12" }))
+        .check(
+          Schema.isPattern(new RegExp("^\\d{12}$")).annotate({
+            expected: "a string matching the RegExp ^\\d{12}$",
+          }),
+        ),
+      account_name: Schema.optionalKey(
+        Schema.String.annotate({
+          description: "Optional human-readable name for the AWS account.",
+        }).check(
+          Schema.isMaxLength(128).annotate({ expected: "a value with a length of at most 128" }),
+        ),
+      ),
+      database_identifier: Schema.optionalKey(
+        Schema.String.annotate({
+          description:
+            "Identifier of the read replica this PrivateLink share should target. Omit to target the primary database.",
+        }),
+      ),
+    }),
+  }),
+});
+export const V2CreatePrivateLinkAssociationOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("private_link_association").annotate({ description: "Resource type." }),
+    id: Schema.String,
+    attributes: Schema.Struct({
+      aws_account_id: Schema.String.annotate({
+        description: "The AWS account ID this PrivateLink share is associated with.",
+      })
+        .check(
+          Schema.isMinLength(12).annotate({ expected: "a value with a length of at least 12" }),
+        )
+        .check(Schema.isMaxLength(12).annotate({ expected: "a value with a length of at most 12" }))
+        .check(
+          Schema.isPattern(new RegExp("^\\d{12}$")).annotate({
+            expected: "a string matching the RegExp ^\\d{12}$",
+          }),
+        ),
+      account_name: Schema.optionalKey(
+        Schema.String.annotate({ description: "Human-readable name for the AWS account." }),
+      ),
+      status: Schema.Literals([
+        "CREATING",
+        "READY",
+        "ASSOCIATION_REQUEST_EXPIRED",
+        "ASSOCIATION_ACCEPTED",
+        "CREATION_FAILED",
+        "DELETING",
+      ]).annotate({
+        description:
+          "\n  - `CREATING`: The PrivateLink resources and the Association are in the process of being created. The PrivateLink Share cannot be accepted yet.\n  - `READY`: The PrivateLink resources have been created and the PrivateLink Share can be accepted for the duration of 12h after sharing. See `shared_at`.\n  - `ASSOCIATION_REQUEST_EXPIRED`: The PrivateLink Share has not been accepted within the 12h time limit. This association can now be deleted.\n  - `ASSOCIATION_ACCEPTED`: The PrivateLink Share was successfully accepted.\n  - `CREATION_FAILED`: The PrivateLink resources failed to create. This likely means something went wrong on Supabase's and and support should be contacted.\n  - `DELETING`: The PrivateLink resources and the Association are in the process of being deleted. The PrivateLink Share cannot be accepted yet.\n",
+      }),
+      shared_at: Schema.Union([
+        Schema.String.annotate({
+          description:
+            "The time and date at which the AWS Resource Share Association was requested from Supabase. `null` means that the association was not yet requested while the PrivateLink Association is pending.",
+          format: "date-time",
+        }),
+        Schema.Null,
+      ]),
+      database_type: Schema.Literals(["PRIMARY", "READ_REPLICA"]).annotate({
+        description:
+          "Whether this PrivateLink share targets the primary database or a read replica.",
+      }),
+      database_identifier: Schema.String.annotate({
+        description:
+          "Identifier of the database this PrivateLink share targets - the project ref for the primary, or the read replica identifier.",
+      }),
+    }),
+  }),
+});
+export const V2DeleteLogDrainInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  id: Schema.String.annotate({ format: "uuid" }).check(
+    Schema.isPattern(
+      new RegExp(
+        "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+      ),
+    ).annotate({
+      expected:
+        "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+    }),
+  ),
+});
+export const V2DeleteOrganizationInvitationsInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_invitation").annotate({ description: "Resource type." }),
+      attributes: Schema.Struct({
+        email: Schema.String.annotate({ format: "email" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          }),
+        ),
+      }),
+    }),
+  )
+    .check(Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }))
+    .check(Schema.isMaxLength(100).annotate({ expected: "a value with a length of at most 100" })),
+});
+export const V2DeleteOrganizationInvitationsOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_invitation").annotate({ description: "Resource type." }),
+      attributes: Schema.Struct({
+        email: Schema.String.annotate({ format: "email" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          }),
+        ),
+      }),
+    }),
+  ),
+});
+export const V2DeletePrivateLinkAssociationInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  aws_account_id: Schema.String,
+});
+export const V2DeletePrivateLinkAssociationForDatabaseInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  aws_account_id: Schema.String,
+  database_identifier: Schema.String,
+});
+export const V2GetProjectConfigInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+});
+export const V2GetProjectConfigOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("project_config").annotate({ description: "Resource type." }),
+    id: Schema.String.annotate({ description: "Project ref." }),
+    attributes: Schema.Struct({
+      database: Schema.Struct({
+        ssl_enforced: Schema.Boolean.annotate({
+          description: "Whether the database rejects plaintext connections",
+        }),
+        network_restrictions: Schema.Struct({
+          entitlement: Schema.Literals(["disallowed", "allowed"]),
+          status: Schema.Literals(["stored", "applied"]).annotate({
+            description: "Whether the allowlist below is applied to the project or only stored.",
+          }),
+          allowed_cidrs: Schema.Array(
+            Schema.Struct({ address: Schema.String, type: Schema.Literals(["v4", "v6"]) }),
+          ),
+          updated_at: Schema.optionalKey(Schema.String),
+          applied_at: Schema.optionalKey(Schema.String),
+        }),
+        postgres_settings: Schema.Struct({
+          effective_cache_size: Schema.optionalKey(Schema.String),
+          logical_decoding_work_mem: Schema.optionalKey(Schema.String),
+          log_autovacuum_min_duration: Schema.optionalKey(
+            Schema.String.annotate({ description: "Default unit: ms" }).check(
+              Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")).annotate(
+                {
+                  expected:
+                    "a string matching the RegExp ^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$",
+                },
+              ),
+            ),
+          ),
+          log_checkpoints: Schema.optionalKey(Schema.Boolean),
+          log_connections: Schema.optionalKey(Schema.Boolean),
+          log_disconnections: Schema.optionalKey(Schema.Boolean),
+          log_duration: Schema.optionalKey(Schema.Boolean),
+          log_lock_waits: Schema.optionalKey(Schema.Boolean),
+          log_recovery_conflict_waits: Schema.optionalKey(Schema.Boolean),
+          log_replication_commands: Schema.optionalKey(Schema.Boolean),
+          log_startup_progress_interval: Schema.optionalKey(
+            Schema.String.annotate({ description: "Default unit: ms" }).check(
+              Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")).annotate(
+                {
+                  expected:
+                    "a string matching the RegExp ^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$",
+                },
+              ),
+            ),
+          ),
+          log_temp_files: Schema.optionalKey(Schema.String),
+          maintenance_work_mem: Schema.optionalKey(Schema.String),
+          track_activity_query_size: Schema.optionalKey(Schema.String),
+          max_connections: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(1).annotate({
+                  expected: "a value greater than or equal to 1",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(262143).annotate({
+                  expected: "a value less than or equal to 262143",
+                }),
+              ),
+          ),
+          max_locks_per_transaction: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(10).annotate({
+                  expected: "a value greater than or equal to 10",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(2147483640).annotate({
+                  expected: "a value less than or equal to 2147483640",
+                }),
+              ),
+          ),
+          max_logical_replication_workers: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(262143).annotate({
+                  expected: "a value less than or equal to 262143",
+                }),
+              ),
+          ),
+          max_parallel_maintenance_workers: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(1024).annotate({
+                  expected: "a value less than or equal to 1024",
+                }),
+              ),
+          ),
+          max_parallel_workers: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(1024).annotate({
+                  expected: "a value less than or equal to 1024",
+                }),
+              ),
+          ),
+          max_parallel_workers_per_gather: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(1024).annotate({
+                  expected: "a value less than or equal to 1024",
+                }),
+              ),
+          ),
+          max_replication_slots: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+          ),
+          max_slot_wal_keep_size: Schema.optionalKey(Schema.String),
+          max_standby_archive_delay: Schema.optionalKey(Schema.String),
+          max_standby_streaming_delay: Schema.optionalKey(Schema.String),
+          max_sync_workers_per_subscription: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(262143).annotate({
+                  expected: "a value less than or equal to 262143",
+                }),
+              ),
+          ),
+          max_wal_size: Schema.optionalKey(Schema.String),
+          max_wal_senders: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+          ),
+          max_worker_processes: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(262143).annotate({
+                  expected: "a value less than or equal to 262143",
+                }),
+              ),
+          ),
+          session_replication_role: Schema.optionalKey(
+            Schema.Literals(["origin", "replica", "local"]),
+          ),
+          shared_buffers: Schema.optionalKey(Schema.String),
+          statement_timeout: Schema.optionalKey(
+            Schema.String.annotate({ description: "Default unit: ms" }).check(
+              Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")).annotate(
+                {
+                  expected:
+                    "a string matching the RegExp ^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$",
+                },
+              ),
+            ),
+          ),
+          track_commit_timestamp: Schema.optionalKey(Schema.Boolean),
+          wal_keep_size: Schema.optionalKey(Schema.String),
+          wal_sender_timeout: Schema.optionalKey(
+            Schema.String.annotate({ description: "Default unit: ms" }).check(
+              Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")).annotate(
+                {
+                  expected:
+                    "a string matching the RegExp ^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$",
+                },
+              ),
+            ),
+          ),
+          work_mem: Schema.optionalKey(Schema.String),
+          checkpoint_timeout: Schema.optionalKey(
+            Schema.String.annotate({ description: "Default unit: s" }).check(
+              Schema.isPattern(new RegExp("^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$")).annotate(
+                {
+                  expected:
+                    "a string matching the RegExp ^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$",
+                },
+              ),
+            ),
+          ),
+          hot_standby_feedback: Schema.optionalKey(Schema.Boolean),
+          cron_log_statement: Schema.optionalKey(Schema.Boolean),
+        }).annotate({
+          description:
+            "Postgres parameter overrides. Empty when the project runs entirely on defaults.",
+        }),
+      }),
+      pooler: Schema.Struct({
+        pool_mode: Schema.Literals(["transaction", "session", "statement"]),
+        ignore_startup_parameters: Schema.String,
+        server_idle_timeout: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        server_lifetime: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        query_wait_timeout: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        reserve_pool_size: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        default_pool_size: Schema.Number.annotate({
+          description:
+            "Defaults to the pooler's size for the project's compute when not overridden.",
+        })
+          .check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_client_conn: Schema.Number.annotate({
+          description:
+            "Defaults to the pooler's size for the project's compute when not overridden.",
+        })
+          .check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+      }),
+      auth: Schema.Record(Schema.String, Schema.Json.annotate({ expected: "JSON value" })).annotate(
+        {
+          description:
+            "Effective Auth config, keyed by lowercased GoTrue setting name and resolved through the `gotrue_config` view, so a setting the project has never overridden is reported at its platform default. Secrets are returned as an HMAC of their value, never in plaintext.",
+        },
+      ),
+      api: Schema.Struct({
+        db_schema: Schema.String.annotate({ description: "Schemas exposed through the Data API" }),
+        db_extra_search_path: Schema.String,
+        max_rows: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        db_pool_acquisition_timeout: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        db_pool: Schema.Union([
+          Schema.Number.annotate({
+            description:
+              "If `null`, no pool size is written to the project's PostgREST config and PostgREST's own default applies. The platform does not pick a value here.",
+          })
+            .check(Schema.isInt().annotate({ expected: "an integer" }))
+            .check(
+              Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                expected: "a value greater than or equal to -9007199254740991",
+              }),
+            )
+            .check(
+              Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                expected: "a value less than or equal to 9007199254740991",
+              }),
+            ),
+          Schema.Null,
+        ]),
+      }),
+      realtime: Schema.Struct({
+        private_only: Schema.Boolean,
+        max_concurrent_users: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_events_per_second: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_bytes_per_second: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_channels_per_client: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_joins_per_second: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_presence_events_per_second: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        max_payload_size_in_kb: Schema.Number.check(
+          Schema.isInt().annotate({ expected: "an integer" }),
+        )
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        presence_enabled: Schema.Boolean,
+        suspend: Schema.Boolean,
+        connection_pool: Schema.Number.annotate({
+          description:
+            "Defaults to Realtime's pool size for the project's compute when not overridden.",
+        })
+          .check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        postgres_changes_pool: Schema.Union([
+          Schema.Number.annotate({
+            description: "If `null`, no override is stored and Realtime applies its own default.",
+          })
+            .check(Schema.isInt().annotate({ expected: "an integer" }))
+            .check(
+              Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                expected: "a value greater than or equal to -9007199254740991",
+              }),
+            )
+            .check(
+              Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                expected: "a value less than or equal to 9007199254740991",
+              }),
+            ),
+          Schema.Null,
+        ]),
+      }),
+      storage: Schema.Struct({
+        file_size_limit: Schema.Number.annotate({ format: "int64" })
+          .check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+              expected: "a value greater than or equal to -9007199254740991",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+              expected: "a value less than or equal to 9007199254740991",
+            }),
+          ),
+        features: Schema.Struct({
+          image_transformation: Schema.Struct({ enabled: Schema.Boolean }),
+          s3_protocol: Schema.Struct({ enabled: Schema.Boolean }),
+          purge_cache: Schema.Struct({ enabled: Schema.Boolean }),
+          iceberg_catalog: Schema.Struct({
+            enabled: Schema.Boolean,
+            max_namespaces: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+            max_tables: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+            max_catalogs: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+          }),
+          vector_buckets: Schema.Struct({
+            enabled: Schema.Boolean,
+            max_buckets: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+            max_indexes: Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(-9007199254740991).annotate({
+                  expected: "a value greater than or equal to -9007199254740991",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(9007199254740991).annotate({
+                  expected: "a value less than or equal to 9007199254740991",
+                }),
+              ),
+          }),
+        }),
+        capabilities: Schema.Struct({ list_v2: Schema.Boolean, iceberg_catalog: Schema.Boolean }),
+        upstream_target: Schema.Literals(["main", "canary"]),
+        migration_version: Schema.String,
+        database_pool_mode: Schema.String,
+      }).annotate({
+        description:
+          "Read from the storage service's admin API rather than the middleware DB, so unlike the rest of this resource it reflects the tenant's live config.",
+      }),
+    }),
+  }),
+});
+export const V2ListLogDrainsInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+});
+export const V2ListLogDrainsOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("log_drain").annotate({ description: "Resource type." }),
+      id: Schema.String,
+      attributes: Schema.Struct({
+        name: Schema.String,
+        description: Schema.optionalKey(Schema.String),
+        config: Schema.Union([
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            schema: Schema.optionalKey(Schema.String),
+            username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            port: Schema.optionalKey(
+              Schema.Union([
+                Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+                Schema.Null,
+              ]),
+            ),
+            hostname: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "postgres" }),
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.String),
+            http: Schema.optionalKey(Schema.Literals(["http1", "http2"])),
+            gzip: Schema.optionalKey(Schema.Boolean),
+            headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+          }).annotate({ title: "webhook" }),
+          Schema.Struct({
+            project_id: Schema.optionalKey(Schema.String),
+            dataset_id: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "bigquery" }),
+          Schema.Struct({
+            api_key: Schema.optionalKey(Schema.String),
+            region: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "datadog" }),
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.String),
+            username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+          }).annotate({ title: "loki" }),
+          Schema.Struct({ dsn: Schema.optionalKey(Schema.String) }).annotate({ title: "sentry" }),
+          Schema.Struct({
+            domain: Schema.optionalKey(Schema.String),
+            api_token: Schema.optionalKey(Schema.String),
+            dataset_name: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "axiom" }),
+          Schema.Struct({
+            host: Schema.optionalKey(Schema.String),
+            port: Schema.optionalKey(
+              Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+                .check(
+                  Schema.isGreaterThanOrEqualTo(0).annotate({
+                    expected: "a value greater than or equal to 0",
+                  }),
+                )
+                .check(
+                  Schema.isLessThanOrEqualTo(65535).annotate({
+                    expected: "a value less than or equal to 65535",
+                  }),
+                ),
+            ),
+            tls: Schema.optionalKey(Schema.Boolean),
+            structured_data: Schema.optionalKey(Schema.String),
+            cipher_key: Schema.optionalKey(Schema.String),
+            ca_cert: Schema.optionalKey(Schema.String),
+            client_cert: Schema.optionalKey(Schema.String),
+            client_key: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "syslog" }),
+        ]),
+        backend_type: Schema.Literals([
+          "postgres",
+          "bigquery",
+          "clickhouse",
+          "webhook",
+          "datadog",
+          "loki",
+          "sentry",
+          "s3",
+          "axiom",
+          "last9",
+          "otlp",
+          "syslog",
+        ]),
+      }),
+    }),
+  ),
+});
+export const V2ListOrganizationGithubConnectionsInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  page: Schema.optionalKey(
+    Schema.Struct({
+      size: Schema.optionalKey(
+        Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(1).annotate({
+              expected: "a value greater than or equal to 1",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(100).annotate({
+              expected: "a value less than or equal to 100",
+            }),
+          ),
+      ),
+      after: Schema.optionalKey(
+        Schema.String.annotate({ description: "Project ref" })
+          .check(
+            Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+          )
+          .check(
+            Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }),
+          )
+          .check(
+            Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+              expected: "a string matching the RegExp ^[a-z]+$",
+            }),
+          ),
+      ),
+      before: Schema.optionalKey(
+        Schema.String.annotate({ description: "Project ref" })
+          .check(
+            Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+          )
+          .check(
+            Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }),
+          )
+          .check(
+            Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+              expected: "a string matching the RegExp ^[a-z]+$",
+            }),
+          ),
+      ),
+    }),
+  ),
+  filter: Schema.optionalKey(
+    Schema.Struct({
+      project_ref: Schema.optionalKey(
+        Schema.String.annotate({ description: "Project ref" })
+          .check(
+            Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+          )
+          .check(
+            Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }),
+          )
+          .check(
+            Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+              expected: "a string matching the RegExp ^[a-z]+$",
+            }),
+          ),
+      ),
+    }),
+  ),
+});
+export const V2ListOrganizationGithubConnectionsOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("github_connection").annotate({ description: "Resource type." }),
+      id: Schema.String.annotate({ description: "Connection id." }),
+      attributes: Schema.Struct({
+        inserted_at: Schema.String.annotate({ description: "When the connection was created" }),
+        updated_at: Schema.String.annotate({ description: "When the connection was last updated" }),
+        installation_id: Schema.Number.annotate({
+          description: "GitHub App installation id",
+        }).check(Schema.isFinite().annotate({ expected: "a finite number" })),
+        workdir: Schema.String.annotate({
+          description: "Directory within the repository the project lives in",
+        }),
+        supabase_changes_only: Schema.Boolean.annotate({
+          description: "Whether branches are only created for changes under `supabase/`",
+        }),
+        branch_limit: Schema.Number.annotate({
+          description: "Maximum number of preview branches",
+        }).check(Schema.isFinite().annotate({ expected: "a finite number" })),
+        new_branch_per_pr: Schema.Boolean.annotate({
+          description: "Whether a preview branch is created for every pull request",
+        }),
+        project: Schema.Struct({
+          id: Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+          ref: Schema.String.annotate({ description: "Project ref" })
+            .check(
+              Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+            )
+            .check(
+              Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }),
+            )
+            .check(
+              Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+                expected: "a string matching the RegExp ^[a-z]+$",
+              }),
+            ),
+          name: Schema.String,
+        }).annotate({ description: "The connected Supabase project" }),
+        repository: Schema.Struct({
+          id: Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+          name: Schema.String,
+        }).annotate({ description: "The connected GitHub repository" }),
+        user: Schema.Union([
+          Schema.Struct({
+            id: Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+            username: Schema.String,
+            primary_email: Schema.Union([Schema.String, Schema.Null]),
+          }).annotate({ description: "The user who created the connection, if still known" }),
+          Schema.Null,
+        ]),
+      }),
+    }),
+  ),
+  links: Schema.Struct({
+    first: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the first page if available." }),
+        Schema.Null,
+      ]),
+    ),
+    prev: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the previous page." }),
+      Schema.Null,
+    ]),
+    next: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the next page." }),
+      Schema.Null,
+    ]),
+    last: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the last page if available." }),
+        Schema.Null,
+      ]),
+    ),
+  }),
+});
+export const V2ListOrganizationMembersInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  page: Schema.optionalKey(
+    Schema.Struct({
+      size: Schema.optionalKey(
+        Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(1).annotate({
+              expected: "a value greater than or equal to 1",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(100).annotate({
+              expected: "a value less than or equal to 100",
+            }),
+          ),
+      ),
+      after: Schema.optionalKey(
+        Schema.String.annotate({ format: "uuid" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+          }),
+        ),
+      ),
+      before: Schema.optionalKey(
+        Schema.String.annotate({ format: "uuid" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+          }),
+        ),
+      ),
+    }),
+  ),
+  filter: Schema.optionalKey(
+    Schema.Struct({
+      username: Schema.optionalKey(Schema.String),
+      primary_email: Schema.optionalKey(
+        Schema.String.annotate({ format: "email" }).check(
+          Schema.isPattern(
+            new RegExp(
+              "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            ),
+          ).annotate({
+            expected:
+              "a string matching the RegExp ^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          }),
+        ),
+      ),
+    }),
+  ),
+});
+export const V2ListOrganizationMembersOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_member").annotate({ description: "Resource type." }),
+      id: Schema.String.annotate({ format: "uuid" }).check(
+        Schema.isPattern(
+          new RegExp(
+            "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+          ),
+        ).annotate({
+          expected:
+            "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+        }),
+      ),
+      attributes: Schema.Struct({
+        username: Schema.Union([
+          Schema.String.annotate({ description: "Member's username" }),
+          Schema.Null,
+        ]),
+        primary_email: Schema.Union([
+          Schema.String.annotate({ description: "Member's primary email" }),
+          Schema.Null,
+        ]),
+        mfa_enabled: Schema.Boolean.annotate({
+          description: "Whether Multi-Factor Authentication is enabled for this member",
+        }),
+        is_sso_user: Schema.Boolean.annotate({
+          description: "Whether this member is a Single Sign-On user",
+        }),
+        avatar_url: Schema.Union([
+          Schema.String.annotate({ description: "Member's avatar URL" }),
+          Schema.Null,
+        ]),
+        roles: Schema.Array(
+          Schema.Struct({
+            name: Schema.String.annotate({
+              description: "Role name. For project-scoped roles this is the base role name.",
+            }),
+            scope: Schema.Literals(["organization", "project"]).annotate({
+              description:
+                "Whether this role applies org-wide or is scoped to specific projects for the user.",
+            }),
+            projects: Schema.Array(
+              Schema.Struct({ ref: Schema.String, name: Schema.String }),
+            ).annotate({
+              description: "Project refs this role is scoped to. Empty array for org-level roles.",
+            }),
+          }),
+        ).annotate({
+          description:
+            "Roles assigned to this member. Includes both org-level and project-scoped roles.",
+        }),
+      }),
+    }),
+  ),
+  links: Schema.Struct({
+    first: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the first page if available." }),
+        Schema.Null,
+      ]),
+    ),
+    prev: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the previous page." }),
+      Schema.Null,
+    ]),
+    next: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the next page." }),
+      Schema.Null,
+    ]),
+    last: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the last page if available." }),
+        Schema.Null,
+      ]),
+    ),
+  }),
+});
+export const V2ListOrganizationProjectsInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+  page: Schema.optionalKey(
+    Schema.Struct({
+      size: Schema.optionalKey(
+        Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+          .check(
+            Schema.isGreaterThanOrEqualTo(1).annotate({
+              expected: "a value greater than or equal to 1",
+            }),
+          )
+          .check(
+            Schema.isLessThanOrEqualTo(100).annotate({
+              expected: "a value less than or equal to 100",
+            }),
+          ),
+      ),
+      after: Schema.optionalKey(
+        Schema.String.check(
+          Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }),
+        ),
+      ),
+      before: Schema.optionalKey(
+        Schema.String.check(
+          Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }),
+        ),
+      ),
+    }),
+  ),
+  sort: Schema.optionalKey(Schema.Literals(["inserted_at", "-inserted_at"])),
+  search: Schema.optionalKey(
+    Schema.String.check(
+      Schema.isMinLength(1).annotate({ expected: "a value with a length of at least 1" }),
+    ),
+  ),
+});
+export const V2ListOrganizationProjectsOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("project").annotate({ description: "Resource type." }),
+      id: Schema.String.annotate({ description: "Project ref" })
+        .check(
+          Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+        )
+        .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+        .check(
+          Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+            expected: "a string matching the RegExp ^[a-z]+$",
+          }),
+        ),
+      attributes: Schema.Struct({
+        name: Schema.String.annotate({ description: "Project name" }),
+        status: Schema.Literals([
+          "INACTIVE",
+          "ACTIVE_HEALTHY",
+          "ACTIVE_UNHEALTHY",
+          "COMING_UP",
+          "UNKNOWN",
+          "GOING_DOWN",
+          "INIT_FAILED",
+          "REMOVED",
+          "RESTORING",
+          "UPGRADING",
+          "PAUSING",
+          "RESTORE_FAILED",
+          "RESTARTING",
+          "PAUSE_FAILED",
+          "RESIZING",
+        ]).annotate({ description: "Project status" }),
+        cloud_provider: Schema.String.annotate({
+          description: "Cloud provider hosting the project",
+        }),
+        region: Schema.String.annotate({ description: "Region the project is hosted in" }),
+        inserted_at: Schema.String.annotate({ description: "When the project was created" }),
+        databases: Schema.Array(
+          Schema.Struct({
+            cloud_provider: Schema.String,
+            identifier: Schema.String,
+            region: Schema.Union([Schema.String, Schema.Null]),
+            status: Schema.Literals([
+              "ACTIVE_HEALTHY",
+              "ACTIVE_UNHEALTHY",
+              "COMING_UP",
+              "GOING_DOWN",
+              "INIT_FAILED",
+              "REMOVED",
+              "RESTORING",
+              "UNKNOWN",
+              "INIT_READ_REPLICA",
+              "INIT_READ_REPLICA_FAILED",
+              "RESTARTING",
+              "RESIZING",
+            ]),
+            type: Schema.Literals(["PRIMARY", "READ_REPLICA"]),
+            infra_compute_size: Schema.optionalKey(
+              Schema.Literals([
+                "pico",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge",
+                "4xlarge",
+                "8xlarge",
+                "12xlarge",
+                "16xlarge",
+                "24xlarge",
+                "24xlarge_optimized_memory",
+                "24xlarge_optimized_cpu",
+                "24xlarge_high_memory",
+                "48xlarge",
+                "48xlarge_optimized_memory",
+                "48xlarge_optimized_cpu",
+                "48xlarge_high_memory",
+              ]),
+            ),
+            disk_volume_size_gb: Schema.optionalKey(
+              Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+            ),
+            disk_type: Schema.optionalKey(Schema.Literals(["gp3", "io2"])),
+            disk_throughput_mbps: Schema.optionalKey(
+              Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+            ),
+            disk_last_modified_at: Schema.optionalKey(Schema.String),
+          }),
+        ).annotate({
+          description: "The project's databases including compute and disk attributes.",
+        }),
+      }),
+    }),
+  ),
+  links: Schema.Struct({
+    first: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the first page if available." }),
+        Schema.Null,
+      ]),
+    ),
+    prev: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the previous page." }),
+      Schema.Null,
+    ]),
+    next: Schema.Union([
+      Schema.String.annotate({ description: "URL path to the next page." }),
+      Schema.Null,
+    ]),
+    last: Schema.optionalKey(
+      Schema.Union([
+        Schema.String.annotate({ description: "URL path to the last page if available." }),
+        Schema.Null,
+      ]),
+    ),
+  }),
+});
+export const V2ListOrganizationRolesInput = Schema.Struct({
+  slug: Schema.String.check(
+    Schema.isPattern(new RegExp("^[\\w-]+$")).annotate({
+      expected: "a string matching the RegExp ^[\\w-]+$",
+    }),
+  ),
+});
+export const V2ListOrganizationRolesOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("organization_role").annotate({ description: "Resource type." }),
+      attributes: Schema.Struct({ name: Schema.String.annotate({ description: "Role name." }) }),
+    }),
+  ),
+});
+export const V2ListPrivateLinkAssociationsInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+});
+export const V2ListPrivateLinkAssociationsOutput = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("private_link_association").annotate({ description: "Resource type." }),
+      id: Schema.String,
+      attributes: Schema.Struct({
+        aws_account_id: Schema.String.annotate({
+          description: "The AWS account ID this PrivateLink share is associated with.",
+        })
+          .check(
+            Schema.isMinLength(12).annotate({ expected: "a value with a length of at least 12" }),
+          )
+          .check(
+            Schema.isMaxLength(12).annotate({ expected: "a value with a length of at most 12" }),
+          )
+          .check(
+            Schema.isPattern(new RegExp("^\\d{12}$")).annotate({
+              expected: "a string matching the RegExp ^\\d{12}$",
+            }),
+          ),
+        account_name: Schema.optionalKey(
+          Schema.String.annotate({ description: "Human-readable name for the AWS account." }),
+        ),
+        status: Schema.Literals([
+          "CREATING",
+          "READY",
+          "ASSOCIATION_REQUEST_EXPIRED",
+          "ASSOCIATION_ACCEPTED",
+          "CREATION_FAILED",
+          "DELETING",
+        ]).annotate({
+          description:
+            "\n  - `CREATING`: The PrivateLink resources and the Association are in the process of being created. The PrivateLink Share cannot be accepted yet.\n  - `READY`: The PrivateLink resources have been created and the PrivateLink Share can be accepted for the duration of 12h after sharing. See `shared_at`.\n  - `ASSOCIATION_REQUEST_EXPIRED`: The PrivateLink Share has not been accepted within the 12h time limit. This association can now be deleted.\n  - `ASSOCIATION_ACCEPTED`: The PrivateLink Share was successfully accepted.\n  - `CREATION_FAILED`: The PrivateLink resources failed to create. This likely means something went wrong on Supabase's and and support should be contacted.\n  - `DELETING`: The PrivateLink resources and the Association are in the process of being deleted. The PrivateLink Share cannot be accepted yet.\n",
+        }),
+        shared_at: Schema.Union([
+          Schema.String.annotate({
+            description:
+              "The time and date at which the AWS Resource Share Association was requested from Supabase. `null` means that the association was not yet requested while the PrivateLink Association is pending.",
+            format: "date-time",
+          }),
+          Schema.Null,
+        ]),
+        database_type: Schema.Literals(["PRIMARY", "READ_REPLICA"]).annotate({
+          description:
+            "Whether this PrivateLink share targets the primary database or a read replica.",
+        }),
+        database_identifier: Schema.String.annotate({
+          description:
+            "Identifier of the database this PrivateLink share targets - the project ref for the primary, or the read replica identifier.",
+        }),
+      }),
+    }),
+  ),
+});
+export const V2PreviewAProjectTransferInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  data: Schema.Struct({
+    type: Schema.Literal("project_transfer_input").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({ target_organization_slug: Schema.String }),
+  }),
+});
+export const V2PreviewAProjectTransferOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("project_transfer_result").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      valid: Schema.Boolean,
+      warnings: Schema.Array(Schema.Struct({ key: Schema.String, message: Schema.String })),
+      errors: Schema.Array(Schema.Struct({ key: Schema.String, message: Schema.String })),
+      info: Schema.Array(Schema.Struct({ key: Schema.String, message: Schema.String })),
+    }),
+  }),
+});
+export const V2TransferAProjectInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  data: Schema.Struct({
+    type: Schema.Literal("project_transfer_input").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({ target_organization_slug: Schema.String }),
+  }),
+});
+export const V2UpdateLogDrainInput = Schema.Struct({
+  ref: Schema.String.check(
+    Schema.isMinLength(20).annotate({ expected: "a value with a length of at least 20" }),
+  )
+    .check(Schema.isMaxLength(20).annotate({ expected: "a value with a length of at most 20" }))
+    .check(
+      Schema.isPattern(new RegExp("^[a-z]+$")).annotate({
+        expected: "a string matching the RegExp ^[a-z]+$",
+      }),
+    ),
+  id: Schema.String.annotate({ format: "uuid" }).check(
+    Schema.isPattern(
+      new RegExp(
+        "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+      ),
+    ).annotate({
+      expected:
+        "a string matching the RegExp ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+    }),
+  ),
+  data: Schema.Struct({
+    type: Schema.Literal("log_drain").annotate({ description: "Resource type." }),
+    attributes: Schema.Struct({
+      name: Schema.optionalKey(Schema.String),
+      description: Schema.optionalKey(Schema.String),
+      config: Schema.optionalKey(
+        Schema.Union([
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            schema: Schema.optionalKey(Schema.String),
+            username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            port: Schema.optionalKey(
+              Schema.Union([
+                Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+                Schema.Null,
+              ]),
+            ),
+            hostname: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "postgres" }),
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.String),
+            http: Schema.optionalKey(Schema.Literals(["http1", "http2"])),
+            gzip: Schema.optionalKey(Schema.Boolean),
+            headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+          }).annotate({ title: "webhook" }),
+          Schema.Struct({
+            project_id: Schema.optionalKey(Schema.String),
+            dataset_id: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "bigquery" }),
+          Schema.Struct({
+            api_key: Schema.optionalKey(Schema.String),
+            region: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "datadog" }),
+          Schema.Struct({
+            url: Schema.optionalKey(Schema.String),
+            username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+            headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+          }).annotate({ title: "loki" }),
+          Schema.Struct({ dsn: Schema.optionalKey(Schema.String) }).annotate({ title: "sentry" }),
+          Schema.Struct({
+            domain: Schema.optionalKey(Schema.String),
+            api_token: Schema.optionalKey(Schema.String),
+            dataset_name: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "axiom" }),
+          Schema.Struct({
+            host: Schema.optionalKey(Schema.String),
+            port: Schema.optionalKey(
+              Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+                .check(
+                  Schema.isGreaterThanOrEqualTo(0).annotate({
+                    expected: "a value greater than or equal to 0",
+                  }),
+                )
+                .check(
+                  Schema.isLessThanOrEqualTo(65535).annotate({
+                    expected: "a value less than or equal to 65535",
+                  }),
+                ),
+            ),
+            tls: Schema.optionalKey(Schema.Boolean),
+            structured_data: Schema.optionalKey(Schema.String),
+            cipher_key: Schema.optionalKey(Schema.String),
+            ca_cert: Schema.optionalKey(Schema.String),
+            client_cert: Schema.optionalKey(Schema.String),
+            client_key: Schema.optionalKey(Schema.String),
+          }).annotate({ title: "syslog" }),
+        ]),
+      ),
+      backend_type: Schema.Literals([
+        "postgres",
+        "bigquery",
+        "clickhouse",
+        "webhook",
+        "datadog",
+        "loki",
+        "sentry",
+        "s3",
+        "axiom",
+        "last9",
+        "otlp",
+        "syslog",
+      ]),
+    }),
+  }),
+});
+export const V2UpdateLogDrainOutput = Schema.Struct({
+  data: Schema.Struct({
+    type: Schema.Literal("log_drain").annotate({ description: "Resource type." }),
+    id: Schema.String,
+    attributes: Schema.Struct({
+      name: Schema.String,
+      description: Schema.optionalKey(Schema.String),
+      config: Schema.Union([
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          schema: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          port: Schema.optionalKey(
+            Schema.Union([
+              Schema.Number.check(Schema.isFinite().annotate({ expected: "a finite number" })),
+              Schema.Null,
+            ]),
+          ),
+          hostname: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "postgres" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          http: Schema.optionalKey(Schema.Literals(["http1", "http2"])),
+          gzip: Schema.optionalKey(Schema.Boolean),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "webhook" }),
+        Schema.Struct({
+          project_id: Schema.optionalKey(Schema.String),
+          dataset_id: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "bigquery" }),
+        Schema.Struct({
+          api_key: Schema.optionalKey(Schema.String),
+          region: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "datadog" }),
+        Schema.Struct({
+          url: Schema.optionalKey(Schema.String),
+          username: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          password: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+          headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+        }).annotate({ title: "loki" }),
+        Schema.Struct({ dsn: Schema.optionalKey(Schema.String) }).annotate({ title: "sentry" }),
+        Schema.Struct({
+          domain: Schema.optionalKey(Schema.String),
+          api_token: Schema.optionalKey(Schema.String),
+          dataset_name: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "axiom" }),
+        Schema.Struct({
+          host: Schema.optionalKey(Schema.String),
+          port: Schema.optionalKey(
+            Schema.Number.check(Schema.isInt().annotate({ expected: "an integer" }))
+              .check(
+                Schema.isGreaterThanOrEqualTo(0).annotate({
+                  expected: "a value greater than or equal to 0",
+                }),
+              )
+              .check(
+                Schema.isLessThanOrEqualTo(65535).annotate({
+                  expected: "a value less than or equal to 65535",
+                }),
+              ),
+          ),
+          tls: Schema.optionalKey(Schema.Boolean),
+          structured_data: Schema.optionalKey(Schema.String),
+          cipher_key: Schema.optionalKey(Schema.String),
+          ca_cert: Schema.optionalKey(Schema.String),
+          client_cert: Schema.optionalKey(Schema.String),
+          client_key: Schema.optionalKey(Schema.String),
+        }).annotate({ title: "syslog" }),
+      ]),
+      backend_type: Schema.Literals([
+        "postgres",
+        "bigquery",
+        "clickhouse",
+        "webhook",
+        "datadog",
+        "loki",
+        "sentry",
+        "s3",
+        "axiom",
+        "last9",
+        "otlp",
+        "syslog",
+      ]),
+    }),
+  }),
+});
 export const V1ApplyAMigrationOutput = Schema.Void;
 export const V1ApplyProjectAddonOutput = Schema.Void;
 export const V1AuthorizeUserOutput = Schema.Void;
@@ -10027,6 +12026,10 @@ export const V1UndoOutput = Schema.Void;
 export const V1UpdateRealtimeConfigOutput = Schema.Void;
 export const V1UpdateStorageConfigOutput = Schema.Void;
 export const V1UpsertAMigrationOutput = Schema.Void;
+export const V2DeleteLogDrainOutput = Schema.Void;
+export const V2DeletePrivateLinkAssociationOutput = Schema.Void;
+export const V2DeletePrivateLinkAssociationForDatabaseOutput = Schema.Void;
+export const V2TransferAProjectOutput = Schema.Void;
 
 export const openApiOperationIdMap = {
   "v1-accept-invite-external-jit-access": "v1AcceptInviteExternalJitAccess",
@@ -10199,6 +12202,24 @@ export const openApiOperationIdMap = {
   "v1-upgrade-postgres-version": "v1UpgradePostgresVersion",
   "v1-upsert-a-migration": "v1UpsertAMigration",
   "v1-verify-dns-config": "v1VerifyDnsConfig",
+  "v2-assign-organization-member-role": "v2AssignOrganizationMemberRole",
+  "v2-create-log-drain": "v2CreateLogDrain",
+  "v2-create-organization-invitations": "v2CreateOrganizationInvitations",
+  "v2-create-private-link-association": "v2CreatePrivateLinkAssociation",
+  "v2-delete-log-drain": "v2DeleteLogDrain",
+  "v2-delete-organization-invitations": "v2DeleteOrganizationInvitations",
+  "v2-delete-private-link-association": "v2DeletePrivateLinkAssociation",
+  "v2-delete-private-link-association-for-database": "v2DeletePrivateLinkAssociationForDatabase",
+  "v2-get-project-config": "v2GetProjectConfig",
+  "v2-list-log-drains": "v2ListLogDrains",
+  "v2-list-organization-github-connections": "v2ListOrganizationGithubConnections",
+  "v2-list-organization-members": "v2ListOrganizationMembers",
+  "v2-list-organization-projects": "v2ListOrganizationProjects",
+  "v2-list-organization-roles": "v2ListOrganizationRoles",
+  "v2-list-private-link-associations": "v2ListPrivateLinkAssociations",
+  "v2-preview-a-project-transfer": "v2PreviewAProjectTransfer",
+  "v2-transfer-a-project": "v2TransferAProject",
+  "v2-update-log-drain": "v2UpdateLogDrain",
 } as const;
 
 export const operationDefinitions = {
@@ -12909,6 +14930,250 @@ export const operationDefinitions = {
     response: { kind: "json" },
     inputSchema: V1VerifyDnsConfigInput,
     outputSchema: V1VerifyDnsConfigOutput,
+  },
+  v2AssignOrganizationMemberRole: {
+    id: "v2AssignOrganizationMemberRole",
+    description:
+      "Assigns an org-wide role when projects is omitted, or creates a project-scoped assignment when projects is provided. Uses an org-level role template id from GET /v2/organizations/{slug}/roles. Stale role assignments are automatically cleaned up: if a role no longer has any projects, it is deleted; overlapping project assignments in other roles are automatically removed to avoid duplication.",
+    method: "PATCH",
+    path: "/v2/organizations/{slug}/members/{user_id}/roles",
+    pathParams: ["slug", "user_id"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2AssignOrganizationMemberRoleInput,
+    outputSchema: V2AssignOrganizationMemberRoleOutput,
+  },
+  v2CreateLogDrain: {
+    id: "v2CreateLogDrain",
+    description: "Create a log drain for a project",
+    method: "POST",
+    path: "/v2/projects/{ref}/analytics/log-drains",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2CreateLogDrainInput,
+    outputSchema: V2CreateLogDrainOutput,
+  },
+  v2CreateOrganizationInvitations: {
+    id: "v2CreateOrganizationInvitations",
+    description:
+      "Creates member invitations for an organization. Each invitation can have different role and project scope settings.",
+    method: "POST",
+    path: "/v2/organizations/{slug}/members/invitations",
+    pathParams: ["slug"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2CreateOrganizationInvitationsInput,
+    outputSchema: V2CreateOrganizationInvitationsOutput,
+  },
+  v2CreatePrivateLinkAssociation: {
+    id: "v2CreatePrivateLinkAssociation",
+    description:
+      "Adds an AWS account to the project's PrivateLink configuration and schedules the AWS resources to be created.",
+    method: "POST",
+    path: "/v2/projects/{ref}/private-link/associations",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2CreatePrivateLinkAssociationInput,
+    outputSchema: V2CreatePrivateLinkAssociationOutput,
+  },
+  v2DeleteLogDrain: {
+    id: "v2DeleteLogDrain",
+    description: "Delete a project log drain",
+    method: "DELETE",
+    path: "/v2/projects/{ref}/analytics/log-drains/{id}",
+    pathParams: ["ref", "id"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "void" },
+    inputSchema: V2DeleteLogDrainInput,
+    outputSchema: V2DeleteLogDrainOutput,
+  },
+  v2DeleteOrganizationInvitations: {
+    id: "v2DeleteOrganizationInvitations",
+    description: "Bulk delete member invitations for an organization by email address.",
+    method: "DELETE",
+    path: "/v2/organizations/{slug}/members/invitations",
+    pathParams: ["slug"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2DeleteOrganizationInvitationsInput,
+    outputSchema: V2DeleteOrganizationInvitationsOutput,
+  },
+  v2DeletePrivateLinkAssociation: {
+    id: "v2DeletePrivateLinkAssociation",
+    description:
+      "Removes an AWS account from the project's PrivateLink configuration (targeting the primary database). Cleans up the associated AWS resources.",
+    method: "DELETE",
+    path: "/v2/projects/{ref}/private-link/associations/aws-account/{aws_account_id}",
+    pathParams: ["ref", "aws_account_id"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "void" },
+    inputSchema: V2DeletePrivateLinkAssociationInput,
+    outputSchema: V2DeletePrivateLinkAssociationOutput,
+  },
+  v2DeletePrivateLinkAssociationForDatabase: {
+    id: "v2DeletePrivateLinkAssociationForDatabase",
+    description:
+      "Removes an AWS account from the project's PrivateLink configuration for the given read replica. Cleans up the associated AWS resources.",
+    method: "DELETE",
+    path: "/v2/projects/{ref}/private-link/associations/aws-account/{aws_account_id}/database/{database_identifier}",
+    pathParams: ["ref", "aws_account_id", "database_identifier"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "void" },
+    inputSchema: V2DeletePrivateLinkAssociationForDatabaseInput,
+    outputSchema: V2DeletePrivateLinkAssociationForDatabaseOutput,
+  },
+  v2GetProjectConfig: {
+    id: "v2GetProjectConfig",
+    description:
+      "Returns the project's database, pooler, Auth, Data API, Realtime and Storage configuration — the same configuration a branch inherits from its base project. Each is the effective config, so a setting the project has never overridden is reported at its platform default rather than as null. Auth secrets are returned as an HMAC of their value. `storage` is read live from the storage service; the rest come from this platform's own records.",
+    method: "GET",
+    path: "/v2/projects/{ref}/config",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2GetProjectConfigInput,
+    outputSchema: V2GetProjectConfigOutput,
+  },
+  v2ListLogDrains: {
+    id: "v2ListLogDrains",
+    description: "List project log drains",
+    method: "GET",
+    path: "/v2/projects/{ref}/analytics/log-drains",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListLogDrainsInput,
+    outputSchema: V2ListLogDrainsOutput,
+  },
+  v2ListOrganizationGithubConnections: {
+    id: "v2ListOrganizationGithubConnections",
+    description:
+      "Returns a cursor-paginated list of the GitHub connections of the organization's projects.\n\nUse `page[after]` and `page[before]` to navigate pages and `page[size]` to control the page size.\nPaging walks the organization projects, so a page holds at most `page[size]` connections and can hold fewer (or none) when some of its projects are not connected.\nFollow `links.next` until it is `null` rather than stopping on a short page.\n\nUse `filter[project_ref]` to narrow the list down to a single project.",
+    method: "GET",
+    path: "/v2/organizations/{slug}/integrations/github/connections",
+    pathParams: ["slug"],
+    queryParams: ["page", "filter"],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListOrganizationGithubConnectionsInput,
+    outputSchema: V2ListOrganizationGithubConnectionsOutput,
+  },
+  v2ListOrganizationMembers: {
+    id: "v2ListOrganizationMembers",
+    description:
+      "Returns a cursor-paginated list of organization members including their roles and project-scoped permissions.",
+    method: "GET",
+    path: "/v2/organizations/{slug}/members",
+    pathParams: ["slug"],
+    queryParams: ["page", "filter"],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListOrganizationMembersInput,
+    outputSchema: V2ListOrganizationMembersOutput,
+  },
+  v2ListOrganizationProjects: {
+    id: "v2ListOrganizationProjects",
+    description:
+      "Returns a cursor-paginated list of projects for the specified organization, including their databases.\n\nUse `page[after]` and `page[before]` to navigate pages and `page[size]` to control the number of projects returned per page.",
+    method: "GET",
+    path: "/v2/organizations/{slug}/projects",
+    pathParams: ["slug"],
+    queryParams: ["page", "sort", "search"],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListOrganizationProjectsInput,
+    outputSchema: V2ListOrganizationProjectsOutput,
+  },
+  v2ListOrganizationRoles: {
+    id: "v2ListOrganizationRoles",
+    description: "Returns a list of org-level roles for the organization.",
+    method: "GET",
+    path: "/v2/organizations/{slug}/roles",
+    pathParams: ["slug"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListOrganizationRolesInput,
+    outputSchema: V2ListOrganizationRolesOutput,
+  },
+  v2ListPrivateLinkAssociations: {
+    id: "v2ListPrivateLinkAssociations",
+    description: "List AWS accounts attached to the project PrivateLink share",
+    method: "GET",
+    path: "/v2/projects/{ref}/private-link/associations",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "none" },
+    response: { kind: "json" },
+    inputSchema: V2ListPrivateLinkAssociationsInput,
+    outputSchema: V2ListPrivateLinkAssociationsOutput,
+  },
+  v2PreviewAProjectTransfer: {
+    id: "v2PreviewAProjectTransfer",
+    description:
+      "Previews transferring a project to a different organizations, shows eligibility and impact",
+    method: "POST",
+    path: "/v2/projects/{ref}/transfers/previews",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2PreviewAProjectTransferInput,
+    outputSchema: V2PreviewAProjectTransferOutput,
+  },
+  v2TransferAProject: {
+    id: "v2TransferAProject",
+    description: "Transfers a project to a different organization",
+    method: "POST",
+    path: "/v2/projects/{ref}/transfers",
+    pathParams: ["ref"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "void" },
+    inputSchema: V2TransferAProjectInput,
+    outputSchema: V2TransferAProjectOutput,
+  },
+  v2UpdateLogDrain: {
+    id: "v2UpdateLogDrain",
+    description: "Update a project log drain",
+    method: "PUT",
+    path: "/v2/projects/{ref}/analytics/log-drains/{id}",
+    pathParams: ["ref", "id"],
+    queryParams: [],
+    headerParams: [],
+    requestBody: { kind: "json", contentType: "application/json", fields: ["data"] },
+    response: { kind: "json" },
+    inputSchema: V2UpdateLogDrainInput,
+    outputSchema: V2UpdateLogDrainOutput,
   },
 } as const;
 

--- a/packages/api/src/generated/effect-client.ts
+++ b/packages/api/src/generated/effect-client.ts
@@ -2340,6 +2340,260 @@ export const versionedEffectOperations = {
         );
       }),
   },
+  v2: {
+    assignOrganizationMemberRole: (
+      input: typeof operationDefinitions.v2AssignOrganizationMemberRole.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2AssignOrganizationMemberRole.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2AssignOrganizationMemberRole">(
+          operationDefinitions.v2AssignOrganizationMemberRole,
+          input,
+        );
+      }),
+    createLogDrain: (
+      input: typeof operationDefinitions.v2CreateLogDrain.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2CreateLogDrain.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2CreateLogDrain">(
+          operationDefinitions.v2CreateLogDrain,
+          input,
+        );
+      }),
+    createOrganizationInvitations: (
+      input: typeof operationDefinitions.v2CreateOrganizationInvitations.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2CreateOrganizationInvitations.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2CreateOrganizationInvitations">(
+          operationDefinitions.v2CreateOrganizationInvitations,
+          input,
+        );
+      }),
+    createPrivateLinkAssociation: (
+      input: typeof operationDefinitions.v2CreatePrivateLinkAssociation.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2CreatePrivateLinkAssociation.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2CreatePrivateLinkAssociation">(
+          operationDefinitions.v2CreatePrivateLinkAssociation,
+          input,
+        );
+      }),
+    deleteLogDrain: (
+      input: typeof operationDefinitions.v2DeleteLogDrain.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2DeleteLogDrain.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2DeleteLogDrain">(
+          operationDefinitions.v2DeleteLogDrain,
+          input,
+        );
+      }),
+    deleteOrganizationInvitations: (
+      input: typeof operationDefinitions.v2DeleteOrganizationInvitations.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2DeleteOrganizationInvitations.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2DeleteOrganizationInvitations">(
+          operationDefinitions.v2DeleteOrganizationInvitations,
+          input,
+        );
+      }),
+    deletePrivateLinkAssociation: (
+      input: typeof operationDefinitions.v2DeletePrivateLinkAssociation.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2DeletePrivateLinkAssociation.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2DeletePrivateLinkAssociation">(
+          operationDefinitions.v2DeletePrivateLinkAssociation,
+          input,
+        );
+      }),
+    deletePrivateLinkAssociationForDatabase: (
+      input: typeof operationDefinitions.v2DeletePrivateLinkAssociationForDatabase.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2DeletePrivateLinkAssociationForDatabase.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2DeletePrivateLinkAssociationForDatabase">(
+          operationDefinitions.v2DeletePrivateLinkAssociationForDatabase,
+          input,
+        );
+      }),
+    getProjectConfig: (
+      input: typeof operationDefinitions.v2GetProjectConfig.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2GetProjectConfig.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2GetProjectConfig">(
+          operationDefinitions.v2GetProjectConfig,
+          input,
+        );
+      }),
+    listLogDrains: (
+      input: typeof operationDefinitions.v2ListLogDrains.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListLogDrains.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListLogDrains">(
+          operationDefinitions.v2ListLogDrains,
+          input,
+        );
+      }),
+    listOrganizationGithubConnections: (
+      input: typeof operationDefinitions.v2ListOrganizationGithubConnections.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListOrganizationGithubConnections.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListOrganizationGithubConnections">(
+          operationDefinitions.v2ListOrganizationGithubConnections,
+          input,
+        );
+      }),
+    listOrganizationMembers: (
+      input: typeof operationDefinitions.v2ListOrganizationMembers.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListOrganizationMembers.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListOrganizationMembers">(
+          operationDefinitions.v2ListOrganizationMembers,
+          input,
+        );
+      }),
+    listOrganizationProjects: (
+      input: typeof operationDefinitions.v2ListOrganizationProjects.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListOrganizationProjects.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListOrganizationProjects">(
+          operationDefinitions.v2ListOrganizationProjects,
+          input,
+        );
+      }),
+    listOrganizationRoles: (
+      input: typeof operationDefinitions.v2ListOrganizationRoles.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListOrganizationRoles.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListOrganizationRoles">(
+          operationDefinitions.v2ListOrganizationRoles,
+          input,
+        );
+      }),
+    listPrivateLinkAssociations: (
+      input: typeof operationDefinitions.v2ListPrivateLinkAssociations.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2ListPrivateLinkAssociations.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2ListPrivateLinkAssociations">(
+          operationDefinitions.v2ListPrivateLinkAssociations,
+          input,
+        );
+      }),
+    previewAProjectTransfer: (
+      input: typeof operationDefinitions.v2PreviewAProjectTransfer.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2PreviewAProjectTransfer.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2PreviewAProjectTransfer">(
+          operationDefinitions.v2PreviewAProjectTransfer,
+          input,
+        );
+      }),
+    transferAProject: (
+      input: typeof operationDefinitions.v2TransferAProject.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2TransferAProject.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2TransferAProject">(
+          operationDefinitions.v2TransferAProject,
+          input,
+        );
+      }),
+    updateLogDrain: (
+      input: typeof operationDefinitions.v2UpdateLogDrain.inputSchema.Type,
+    ): Effect.Effect<
+      typeof operationDefinitions.v2UpdateLogDrain.outputSchema.Type,
+      SupabaseApiError,
+      SupabaseApiClient
+    > =>
+      Effect.gen(function* () {
+        const client = yield* SupabaseApiClient;
+        return yield* client.execute<"v2UpdateLogDrain">(
+          operationDefinitions.v2UpdateLogDrain,
+          input,
+        );
+      }),
+  },
 } as const;
 
 export type GeneratedEffectOperations = typeof versionedEffectOperations;
@@ -3031,5 +3285,79 @@ export function executeApiClientOperation(
       return Schema.decodeUnknownEffect(operationDefinitions.v1VerifyDnsConfig.inputSchema)(
         input,
       ).pipe(Effect.flatMap((decoded) => api.v1.verifyDnsConfig(decoded)));
+    case "v2AssignOrganizationMemberRole":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2AssignOrganizationMemberRole.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.assignOrganizationMemberRole(decoded)));
+    case "v2CreateLogDrain":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2CreateLogDrain.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.createLogDrain(decoded)));
+    case "v2CreateOrganizationInvitations":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2CreateOrganizationInvitations.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.createOrganizationInvitations(decoded)));
+    case "v2CreatePrivateLinkAssociation":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2CreatePrivateLinkAssociation.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.createPrivateLinkAssociation(decoded)));
+    case "v2DeleteLogDrain":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2DeleteLogDrain.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.deleteLogDrain(decoded)));
+    case "v2DeleteOrganizationInvitations":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2DeleteOrganizationInvitations.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.deleteOrganizationInvitations(decoded)));
+    case "v2DeletePrivateLinkAssociation":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2DeletePrivateLinkAssociation.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.deletePrivateLinkAssociation(decoded)));
+    case "v2DeletePrivateLinkAssociationForDatabase":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2DeletePrivateLinkAssociationForDatabase.inputSchema,
+      )(input).pipe(
+        Effect.flatMap((decoded) => api.v2.deletePrivateLinkAssociationForDatabase(decoded)),
+      );
+    case "v2GetProjectConfig":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2GetProjectConfig.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.getProjectConfig(decoded)));
+    case "v2ListLogDrains":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2ListLogDrains.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.listLogDrains(decoded)));
+    case "v2ListOrganizationGithubConnections":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2ListOrganizationGithubConnections.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.listOrganizationGithubConnections(decoded)));
+    case "v2ListOrganizationMembers":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2ListOrganizationMembers.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.listOrganizationMembers(decoded)));
+    case "v2ListOrganizationProjects":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2ListOrganizationProjects.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.listOrganizationProjects(decoded)));
+    case "v2ListOrganizationRoles":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2ListOrganizationRoles.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.listOrganizationRoles(decoded)));
+    case "v2ListPrivateLinkAssociations":
+      return Schema.decodeUnknownEffect(
+        operationDefinitions.v2ListPrivateLinkAssociations.inputSchema,
+      )(input).pipe(Effect.flatMap((decoded) => api.v2.listPrivateLinkAssociations(decoded)));
+    case "v2PreviewAProjectTransfer":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2PreviewAProjectTransfer.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.previewAProjectTransfer(decoded)));
+    case "v2TransferAProject":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2TransferAProject.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.transferAProject(decoded)));
+    case "v2UpdateLogDrain":
+      return Schema.decodeUnknownEffect(operationDefinitions.v2UpdateLogDrain.inputSchema)(
+        input,
+      ).pipe(Effect.flatMap((decoded) => api.v2.updateLogDrain(decoded)));
   }
 }

--- a/packages/api/src/generated/openapi.json
+++ b/packages/api/src/generated/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Supabase API (v1)",
+    "title": "Supabase API",
     "version": "1.0.0"
   },
   "paths": {
@@ -11241,6 +11241,1334 @@
         "x-fga-permissions": [["organization_projects_read"]],
         "x-oauth-scope": "projects:read"
       }
+    },
+    "/v2/projects/{ref}/analytics/log-drains": {
+      "get": {
+        "operationId": "v2-list-log-drains",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLogDrainsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to fetch log drains"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List project log drains",
+        "tags": ["Analytics"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: analytics_config:read",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["analytics"],
+        "x-fga-permissions": [["analytics_config_read"]],
+        "x-oauth-scope": "analytics_config:read"
+      },
+      "post": {
+        "operationId": "v2-create-log-drain",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLogDrainRequestOpenApi"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogDrainResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "402": {
+            "description": "This feature requires the Pro, Team, or Enterprise organization plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanGateErrorBodyV2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to create a log drain"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Create a log drain for a project",
+        "tags": ["Analytics"],
+        "x-allowed-plans": ["Pro", "Team", "Enterprise"],
+        "x-badges": [
+          {
+            "name": "Only available on Pro, Team, Enterprise",
+            "position": "before"
+          },
+          {
+            "name": "OAuth scope: analytics_config:write",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["analytics"],
+        "x-fga-permissions": [["analytics_config_write"]],
+        "x-oauth-scope": "analytics_config:write"
+      }
+    },
+    "/v2/projects/{ref}/analytics/log-drains/{id}": {
+      "put": {
+        "operationId": "v2-update-log-drain",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Log drains identifier",
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLogDrainRequestOpenApi"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogDrainResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to update log drain"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Update a project log drain",
+        "tags": ["Analytics"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: analytics_config:write",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["analytics"],
+        "x-fga-permissions": [["analytics_config_write"]],
+        "x-oauth-scope": "analytics_config:write"
+      },
+      "delete": {
+        "operationId": "v2-delete-log-drain",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Log drains identifier",
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to delete a log drain"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Delete a project log drain",
+        "tags": ["Analytics"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: analytics_config:write",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["analytics"],
+        "x-fga-permissions": [["analytics_config_write"]],
+        "x-oauth-scope": "analytics_config:write"
+      }
+    },
+    "/v2/projects/{ref}/config": {
+      "get": {
+        "description": "Returns the project's database, pooler, Auth, Data API, Realtime and Storage configuration — the same configuration a branch inherits from its base project. Each is the effective config, so a setting the project has never overridden is reported at its platform default rather than as null. Auth secrets are returned as an HMAC of their value. `storage` is read live from the storage service; the rest come from this platform's own records.",
+        "operationId": "v2-get-project-config",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ProjectConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "[Alpha] Get a project's service configuration",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["management-api", "infra"],
+        "x-fga-permissions": [
+          [
+            "database_config_read",
+            "database_read",
+            "database_ssl_config_read",
+            "database_network_restrictions_read",
+            "auth_config_read",
+            "data_api_config_read",
+            "realtime_config_read",
+            "storage_config_read"
+          ]
+        ]
+      }
+    },
+    "/v2/projects/{ref}/transfers/previews": {
+      "post": {
+        "operationId": "v2-preview-a-project-transfer",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2TransferProjectBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2PreviewProjectTransferResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Previews transferring a project to a different organizations, shows eligibility and impact",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["project_admin_read"]]
+      }
+    },
+    "/v2/projects/{ref}/transfers": {
+      "post": {
+        "operationId": "v2-transfer-a-project",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2TransferProjectBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Transfers a project to a different organization",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["organization_admin_write"]]
+      }
+    },
+    "/v2/projects/{ref}/private-link/associations": {
+      "get": {
+        "operationId": "v2-list-private-link-associations",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListPrivateLinkAssociationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to retrieve AWS accounts for project"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List AWS accounts attached to the project PrivateLink share",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["platform-networking", "management-api"],
+        "x-fga-permissions": [["project_admin_read"]]
+      },
+      "post": {
+        "description": "Adds an AWS account to the project's PrivateLink configuration and schedules the AWS resources to be created.",
+        "operationId": "v2-create-private-link-association",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2CreatePrivateLinkAssociationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2PrivateLinkAssociationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "402": {
+            "description": "This feature requires the Team, or Enterprise organization plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanGateErrorBodyV2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to add AWS account to PrivateLink share"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Add an AWS account to the project PrivateLink share",
+        "tags": ["Projects"],
+        "x-allowed-plans": ["Team", "Enterprise"],
+        "x-badges": [
+          {
+            "name": "Only available on Team, Enterprise",
+            "position": "before"
+          }
+        ],
+        "x-endpoint-owners": ["platform-networking", "management-api"],
+        "x-fga-permissions": [["project_admin_write"]]
+      }
+    },
+    "/v2/projects/{ref}/private-link/associations/aws-account/{aws_account_id}": {
+      "delete": {
+        "description": "Removes an AWS account from the project's PrivateLink configuration (targeting the primary database). Cleans up the associated AWS resources.",
+        "operationId": "v2-delete-private-link-association",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          },
+          {
+            "name": "aws_account_id",
+            "required": true,
+            "in": "path",
+            "description": "AWS account ID used in PrivateLink association",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to remove AWS account from PrivateLink share"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Remove an AWS account from the project PrivateLink share",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["platform-networking", "management-api"],
+        "x-fga-permissions": [["project_admin_write"]]
+      }
+    },
+    "/v2/projects/{ref}/private-link/associations/aws-account/{aws_account_id}/database/{database_identifier}": {
+      "delete": {
+        "description": "Removes an AWS account from the project's PrivateLink configuration for the given read replica. Cleans up the associated AWS resources.",
+        "operationId": "v2-delete-private-link-association-for-database",
+        "parameters": [
+          {
+            "name": "ref",
+            "required": true,
+            "in": "path",
+            "description": "Project ref",
+            "schema": {
+              "minLength": 20,
+              "maxLength": 20,
+              "pattern": "^[a-z]+$",
+              "example": "abcdefghijklmnopqrst",
+              "type": "string"
+            }
+          },
+          {
+            "name": "aws_account_id",
+            "required": true,
+            "in": "path",
+            "description": "AWS account ID used in PrivateLink association",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "database_identifier",
+            "required": true,
+            "in": "path",
+            "description": "Identifier of the read replica this PrivateLink association targets",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to remove AWS account from PrivateLink share"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Remove an AWS account from a specific database PrivateLink share",
+        "tags": ["Projects"],
+        "x-endpoint-owners": ["platform-networking", "management-api"],
+        "x-fga-permissions": [["project_admin_write"]]
+      }
+    },
+    "/v2/organizations/{slug}/members": {
+      "get": {
+        "description": "Returns a cursor-paginated list of organization members including their roles and project-scoped permissions.",
+        "operationId": "v2-list-organization-members",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "properties": {
+                "size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 100
+                },
+                "after": {
+                  "type": "string",
+                  "format": "uuid",
+                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                },
+                "before": {
+                  "type": "string",
+                  "format": "uuid",
+                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                }
+              },
+              "type": "object"
+            },
+            "style": "deepObject"
+          },
+          {
+            "name": "filter",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "properties": {
+                "username": {
+                  "type": "string"
+                },
+                "primary_email": {
+                  "type": "string",
+                  "format": "email",
+                  "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                }
+              },
+              "type": "object"
+            },
+            "style": "deepObject"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListMembersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List members of an organization",
+        "tags": ["Organizations"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: organizations:read",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["members_read"]],
+        "x-oauth-scope": "organizations:read"
+      }
+    },
+    "/v2/organizations/{slug}/members/{user_id}/roles": {
+      "patch": {
+        "description": "Assigns an org-wide role when projects is omitted, or creates a project-scoped assignment when projects is provided. Uses an org-level role template id from GET /v2/organizations/{slug}/roles. Stale role assignments are automatically cleaned up: if a role no longer has any projects, it is deleted; overlapping project assignments in other roles are automatically removed to avoid duplication.",
+        "operationId": "v2-assign-organization-member-role",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2AssignOrganizationMemberRoleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberRoleResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "402": {
+            "description": "This feature requires the Enterprise organization plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanGateErrorBodyV2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Failed to assign organization member role"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Assign or change an organization member role",
+        "tags": ["Organizations"],
+        "x-allowed-plans": ["Enterprise"],
+        "x-badges": [
+          {
+            "name": "Only available on Enterprise",
+            "position": "before"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["organization_admin_write"]]
+      }
+    },
+    "/v2/organizations/{slug}/roles": {
+      "get": {
+        "description": "Returns a list of org-level roles for the organization.",
+        "operationId": "v2-list-organization-roles",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListRolesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List roles of an organization",
+        "tags": ["Organizations"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: organizations:read",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["members_read"]],
+        "x-oauth-scope": "organizations:read"
+      }
+    },
+    "/v2/organizations/{slug}/members/invitations": {
+      "post": {
+        "description": "Creates member invitations for an organization. Each invitation can have different role and project scope settings.",
+        "operationId": "v2-create-organization-invitations",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2CreateInvitationsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2CreateInvitationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "402": {
+            "description": "This feature requires the Enterprise organization plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanGateErrorBodyV2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Creates organization invitations",
+        "tags": ["Organizations Members Invitations"],
+        "x-allowed-plans": ["Enterprise"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: organizations:write",
+            "position": "after"
+          },
+          {
+            "name": "Only available on Enterprise",
+            "position": "before"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["members_write"]],
+        "x-oauth-scope": "organizations:write"
+      },
+      "delete": {
+        "description": "Bulk delete member invitations for an organization by email address.",
+        "operationId": "v2-delete-organization-invitations",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/V2DeleteInvitationsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2DeleteInvitationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "402": {
+            "description": "This feature requires the Enterprise organization plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanGateErrorBodyV2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Deletes organization invitations by email",
+        "tags": ["Organizations Members Invitations"],
+        "x-allowed-plans": ["Enterprise"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: organizations:write",
+            "position": "after"
+          },
+          {
+            "name": "Only available on Enterprise",
+            "position": "before"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["members_write"]],
+        "x-oauth-scope": "organizations:write"
+      }
+    },
+    "/v2/organizations/{slug}/projects": {
+      "get": {
+        "description": "Returns a cursor-paginated list of projects for the specified organization, including their databases.\n\nUse `page[after]` and `page[before]` to navigate pages and `page[size]` to control the number of projects returned per page.",
+        "operationId": "v2-list-organization-projects",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "properties": {
+                "size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 100
+                },
+                "after": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "before": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "type": "object"
+            },
+            "style": "deepObject"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Sort order by creation time: `inserted_at` (oldest first) or `-inserted_at` (newest first). Defaults to `inserted_at`.",
+            "schema": {
+              "example": "-inserted_at",
+              "type": "string",
+              "enum": ["inserted_at", "-inserted_at"]
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Case-insensitive substring match on the project name.",
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListProjectsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List projects of an organization",
+        "tags": ["Organizations"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: projects:read",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["management-api"],
+        "x-fga-permissions": [["organization_projects_read"]],
+        "x-oauth-scope": "projects:read"
+      }
+    },
+    "/v2/organizations/{slug}/integrations/github/connections": {
+      "get": {
+        "description": "Returns a cursor-paginated list of the GitHub connections of the organization's projects.\n\nUse `page[after]` and `page[before]` to navigate pages and `page[size]` to control the page size.\nPaging walks the organization projects, so a page holds at most `page[size]` connections and can hold fewer (or none) when some of its projects are not connected.\nFollow `links.next` until it is `null` rather than stopping on a short page.\n\nUse `filter[project_ref]` to narrow the list down to a single project.",
+        "operationId": "v2-list-organization-github-connections",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "description": "Organization slug",
+            "schema": {
+              "pattern": "^[\\w-]+$",
+              "example": "tsrqponmlkjihgfedcba",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "properties": {
+                "size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 100
+                },
+                "after": {
+                  "type": "string",
+                  "minLength": 20,
+                  "maxLength": 20,
+                  "pattern": "^[a-z]+$",
+                  "description": "Project ref",
+                  "example": "abcdefghijklmnopqrst"
+                },
+                "before": {
+                  "type": "string",
+                  "minLength": 20,
+                  "maxLength": 20,
+                  "pattern": "^[a-z]+$",
+                  "description": "Project ref",
+                  "example": "abcdefghijklmnopqrst"
+                }
+              },
+              "type": "object"
+            },
+            "style": "deepObject"
+          },
+          {
+            "name": "filter",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "properties": {
+                "project_ref": {
+                  "type": "string",
+                  "minLength": 20,
+                  "maxLength": 20,
+                  "pattern": "^[a-z]+$",
+                  "description": "Project ref",
+                  "example": "abcdefghijklmnopqrst"
+                }
+              },
+              "type": "object"
+            },
+            "style": "deepObject"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/V2ListGitHubConnectionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden action"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List GitHub connections of an organization",
+        "tags": ["Organizations"],
+        "x-badges": [
+          {
+            "name": "OAuth scope: projects:read",
+            "position": "after"
+          }
+        ],
+        "x-endpoint-owners": ["management-api", "dev-workflows"],
+        "x-fga-permissions": [["organization_projects_read"]],
+        "x-oauth-scope": "projects:read"
+      }
     }
   },
   "components": {
@@ -20859,6 +22187,2539 @@
           }
         },
         "required": ["projects", "pagination"]
+      },
+      "ListLogDrainsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["log_drain"]
+                },
+                "id": {
+                  "type": "string"
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "config": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "schema": {
+                              "type": "string"
+                            },
+                            "username": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "password": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "port": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "hostname": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "postgres"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "url": {
+                              "type": "string"
+                            },
+                            "http": {
+                              "type": "string",
+                              "enum": ["http1", "http2"]
+                            },
+                            "gzip": {
+                              "type": "boolean"
+                            },
+                            "headers": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "webhook"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "project_id": {
+                              "type": "string"
+                            },
+                            "dataset_id": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "bigquery"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "api_key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "datadog"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "url": {
+                              "type": "string"
+                            },
+                            "username": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "password": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "headers": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "loki"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "dsn": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "sentry"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "domain": {
+                              "type": "string"
+                            },
+                            "api_token": {
+                              "type": "string"
+                            },
+                            "dataset_name": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "axiom"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 65535
+                            },
+                            "tls": {
+                              "default": false,
+                              "type": "boolean"
+                            },
+                            "structured_data": {
+                              "type": "string"
+                            },
+                            "cipher_key": {
+                              "type": "string"
+                            },
+                            "ca_cert": {
+                              "type": "string"
+                            },
+                            "client_cert": {
+                              "type": "string"
+                            },
+                            "client_key": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "syslog"
+                        }
+                      ]
+                    },
+                    "backend_type": {
+                      "type": "string",
+                      "enum": [
+                        "postgres",
+                        "bigquery",
+                        "clickhouse",
+                        "webhook",
+                        "datadog",
+                        "loki",
+                        "sentry",
+                        "s3",
+                        "axiom",
+                        "last9",
+                        "otlp",
+                        "syslog"
+                      ]
+                    }
+                  },
+                  "required": ["name", "config", "backend_type"]
+                }
+              },
+              "required": ["type", "id", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "CreateLogDrainRequestOpenApi": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["log_drain"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "schema": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "port": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "hostname": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "postgres"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "http": {
+                            "type": "string",
+                            "enum": ["http1", "http2"]
+                          },
+                          "gzip": {
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "webhook"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "project_id": {
+                            "type": "string"
+                          },
+                          "dataset_id": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "bigquery"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "api_key": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "datadog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "loki"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "dsn": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "sentry"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "domain": {
+                            "type": "string"
+                          },
+                          "api_token": {
+                            "type": "string"
+                          },
+                          "dataset_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "axiom"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535
+                          },
+                          "tls": {
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "structured_data": {
+                            "type": "string"
+                          },
+                          "cipher_key": {
+                            "type": "string"
+                          },
+                          "ca_cert": {
+                            "type": "string"
+                          },
+                          "client_cert": {
+                            "type": "string"
+                          },
+                          "client_key": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "syslog"
+                      }
+                    ]
+                  },
+                  "backend_type": {
+                    "type": "string",
+                    "enum": [
+                      "postgres",
+                      "bigquery",
+                      "clickhouse",
+                      "webhook",
+                      "datadog",
+                      "loki",
+                      "sentry",
+                      "s3",
+                      "axiom",
+                      "last9",
+                      "otlp",
+                      "syslog"
+                    ]
+                  }
+                },
+                "required": ["name", "config", "backend_type"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "LogDrainResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["log_drain"]
+              },
+              "id": {
+                "type": "string"
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "schema": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "port": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "hostname": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "postgres"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "http": {
+                            "type": "string",
+                            "enum": ["http1", "http2"]
+                          },
+                          "gzip": {
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "webhook"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "project_id": {
+                            "type": "string"
+                          },
+                          "dataset_id": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "bigquery"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "api_key": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "datadog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "loki"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "dsn": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "sentry"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "domain": {
+                            "type": "string"
+                          },
+                          "api_token": {
+                            "type": "string"
+                          },
+                          "dataset_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "axiom"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535
+                          },
+                          "tls": {
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "structured_data": {
+                            "type": "string"
+                          },
+                          "cipher_key": {
+                            "type": "string"
+                          },
+                          "ca_cert": {
+                            "type": "string"
+                          },
+                          "client_cert": {
+                            "type": "string"
+                          },
+                          "client_key": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "syslog"
+                      }
+                    ]
+                  },
+                  "backend_type": {
+                    "type": "string",
+                    "enum": [
+                      "postgres",
+                      "bigquery",
+                      "clickhouse",
+                      "webhook",
+                      "datadog",
+                      "loki",
+                      "sentry",
+                      "s3",
+                      "axiom",
+                      "last9",
+                      "otlp",
+                      "syslog"
+                    ]
+                  }
+                },
+                "required": ["name", "config", "backend_type"]
+              }
+            },
+            "required": ["type", "id", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "PlanGateErrorBodyV2": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "HTTP status-derived error code, e.g. \"payment_required\""
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable explanation of the plan gate"
+              }
+            },
+            "required": ["code", "message"],
+            "description": "Plan-gate error object"
+          }
+        },
+        "required": ["error"]
+      },
+      "UpdateLogDrainRequestOpenApi": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["log_drain"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "schema": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "port": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "hostname": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "postgres"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "http": {
+                            "type": "string",
+                            "enum": ["http1", "http2"]
+                          },
+                          "gzip": {
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "webhook"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "project_id": {
+                            "type": "string"
+                          },
+                          "dataset_id": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "bigquery"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "api_key": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "datadog"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "password": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "loki"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "dsn": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "sentry"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "domain": {
+                            "type": "string"
+                          },
+                          "api_token": {
+                            "type": "string"
+                          },
+                          "dataset_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "axiom"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535
+                          },
+                          "tls": {
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "structured_data": {
+                            "type": "string"
+                          },
+                          "cipher_key": {
+                            "type": "string"
+                          },
+                          "ca_cert": {
+                            "type": "string"
+                          },
+                          "client_cert": {
+                            "type": "string"
+                          },
+                          "client_key": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "title": "syslog"
+                      }
+                    ]
+                  },
+                  "backend_type": {
+                    "type": "string",
+                    "enum": [
+                      "postgres",
+                      "bigquery",
+                      "clickhouse",
+                      "webhook",
+                      "datadog",
+                      "loki",
+                      "sentry",
+                      "s3",
+                      "axiom",
+                      "last9",
+                      "otlp",
+                      "syslog"
+                    ]
+                  }
+                },
+                "required": ["backend_type"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ProjectConfigResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_config"]
+              },
+              "id": {
+                "type": "string",
+                "description": "Project ref."
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "object",
+                    "properties": {
+                      "ssl_enforced": {
+                        "type": "boolean",
+                        "description": "Whether the database rejects plaintext connections"
+                      },
+                      "network_restrictions": {
+                        "type": "object",
+                        "properties": {
+                          "entitlement": {
+                            "type": "string",
+                            "enum": ["disallowed", "allowed"]
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["stored", "applied"],
+                            "description": "Whether the allowlist below is applied to the project or only stored."
+                          },
+                          "allowed_cidrs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["v4", "v6"]
+                                }
+                              },
+                              "required": ["address", "type"]
+                            }
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "applied_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["entitlement", "status", "allowed_cidrs"]
+                      },
+                      "postgres_settings": {
+                        "type": "object",
+                        "properties": {
+                          "effective_cache_size": {
+                            "type": "string"
+                          },
+                          "logical_decoding_work_mem": {
+                            "type": "string"
+                          },
+                          "log_autovacuum_min_duration": {
+                            "type": "string",
+                            "description": "Default unit: ms",
+                            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+                          },
+                          "log_checkpoints": {
+                            "type": "boolean"
+                          },
+                          "log_connections": {
+                            "type": "boolean"
+                          },
+                          "log_disconnections": {
+                            "type": "boolean"
+                          },
+                          "log_duration": {
+                            "type": "boolean"
+                          },
+                          "log_lock_waits": {
+                            "type": "boolean"
+                          },
+                          "log_recovery_conflict_waits": {
+                            "type": "boolean"
+                          },
+                          "log_replication_commands": {
+                            "type": "boolean"
+                          },
+                          "log_startup_progress_interval": {
+                            "type": "string",
+                            "description": "Default unit: ms",
+                            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+                          },
+                          "log_temp_files": {
+                            "type": "string"
+                          },
+                          "maintenance_work_mem": {
+                            "type": "string"
+                          },
+                          "track_activity_query_size": {
+                            "type": "string"
+                          },
+                          "max_connections": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 262143
+                          },
+                          "max_locks_per_transaction": {
+                            "type": "integer",
+                            "minimum": 10,
+                            "maximum": 2147483640
+                          },
+                          "max_logical_replication_workers": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 262143
+                          },
+                          "max_parallel_maintenance_workers": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1024
+                          },
+                          "max_parallel_workers": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1024
+                          },
+                          "max_parallel_workers_per_gather": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1024
+                          },
+                          "max_replication_slots": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "max_slot_wal_keep_size": {
+                            "type": "string"
+                          },
+                          "max_standby_archive_delay": {
+                            "type": "string"
+                          },
+                          "max_standby_streaming_delay": {
+                            "type": "string"
+                          },
+                          "max_sync_workers_per_subscription": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 262143
+                          },
+                          "max_wal_size": {
+                            "type": "string"
+                          },
+                          "max_wal_senders": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "max_worker_processes": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 262143
+                          },
+                          "session_replication_role": {
+                            "type": "string",
+                            "enum": ["origin", "replica", "local"]
+                          },
+                          "shared_buffers": {
+                            "type": "string"
+                          },
+                          "statement_timeout": {
+                            "type": "string",
+                            "description": "Default unit: ms",
+                            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+                          },
+                          "track_commit_timestamp": {
+                            "type": "boolean"
+                          },
+                          "wal_keep_size": {
+                            "type": "string"
+                          },
+                          "wal_sender_timeout": {
+                            "type": "string",
+                            "description": "Default unit: ms",
+                            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+                          },
+                          "work_mem": {
+                            "type": "string"
+                          },
+                          "checkpoint_timeout": {
+                            "type": "string",
+                            "description": "Default unit: s",
+                            "pattern": "^(-?[0-9]+(?:\\.[0-9]+)?)(us|ms|s|min|h|d)?$"
+                          },
+                          "hot_standby_feedback": {
+                            "type": "boolean"
+                          },
+                          "cron_log_statement": {
+                            "type": "boolean"
+                          }
+                        },
+                        "description": "Postgres parameter overrides. Empty when the project runs entirely on defaults."
+                      }
+                    },
+                    "required": ["ssl_enforced", "network_restrictions", "postgres_settings"]
+                  },
+                  "pooler": {
+                    "type": "object",
+                    "properties": {
+                      "pool_mode": {
+                        "type": "string",
+                        "enum": ["transaction", "session", "statement"]
+                      },
+                      "ignore_startup_parameters": {
+                        "type": "string"
+                      },
+                      "server_idle_timeout": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "server_lifetime": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "query_wait_timeout": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "reserve_pool_size": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "default_pool_size": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "Defaults to the pooler's size for the project's compute when not overridden."
+                      },
+                      "max_client_conn": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "Defaults to the pooler's size for the project's compute when not overridden."
+                      }
+                    },
+                    "required": [
+                      "pool_mode",
+                      "ignore_startup_parameters",
+                      "server_idle_timeout",
+                      "server_lifetime",
+                      "query_wait_timeout",
+                      "reserve_pool_size",
+                      "default_pool_size",
+                      "max_client_conn"
+                    ]
+                  },
+                  "auth": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Effective Auth config, keyed by lowercased GoTrue setting name and resolved through the `gotrue_config` view, so a setting the project has never overridden is reported at its platform default. Secrets are returned as an HMAC of their value, never in plaintext."
+                  },
+                  "api": {
+                    "type": "object",
+                    "properties": {
+                      "db_schema": {
+                        "type": "string",
+                        "description": "Schemas exposed through the Data API"
+                      },
+                      "db_extra_search_path": {
+                        "type": "string"
+                      },
+                      "max_rows": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "db_pool_acquisition_timeout": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "db_pool": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "If `null`, no pool size is written to the project's PostgREST config and PostgREST's own default applies. The platform does not pick a value here.",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "db_schema",
+                      "db_extra_search_path",
+                      "max_rows",
+                      "db_pool_acquisition_timeout",
+                      "db_pool"
+                    ]
+                  },
+                  "realtime": {
+                    "type": "object",
+                    "properties": {
+                      "private_only": {
+                        "type": "boolean"
+                      },
+                      "max_concurrent_users": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_events_per_second": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_bytes_per_second": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_channels_per_client": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_joins_per_second": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_presence_events_per_second": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "max_payload_size_in_kb": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "presence_enabled": {
+                        "type": "boolean"
+                      },
+                      "suspend": {
+                        "type": "boolean"
+                      },
+                      "connection_pool": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "Defaults to Realtime's pool size for the project's compute when not overridden."
+                      },
+                      "postgres_changes_pool": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "If `null`, no override is stored and Realtime applies its own default.",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "private_only",
+                      "max_concurrent_users",
+                      "max_events_per_second",
+                      "max_bytes_per_second",
+                      "max_channels_per_client",
+                      "max_joins_per_second",
+                      "max_presence_events_per_second",
+                      "max_payload_size_in_kb",
+                      "presence_enabled",
+                      "suspend",
+                      "connection_pool",
+                      "postgres_changes_pool"
+                    ]
+                  },
+                  "storage": {
+                    "type": "object",
+                    "properties": {
+                      "file_size_limit": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "format": "int64"
+                      },
+                      "features": {
+                        "type": "object",
+                        "properties": {
+                          "image_transformation": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": ["enabled"]
+                          },
+                          "s3_protocol": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": ["enabled"]
+                          },
+                          "purge_cache": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": ["enabled"]
+                          },
+                          "iceberg_catalog": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "max_namespaces": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "max_tables": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "max_catalogs": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": ["enabled", "max_namespaces", "max_tables", "max_catalogs"]
+                          },
+                          "vector_buckets": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "max_buckets": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "max_indexes": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": ["enabled", "max_buckets", "max_indexes"]
+                          }
+                        },
+                        "required": [
+                          "image_transformation",
+                          "s3_protocol",
+                          "purge_cache",
+                          "iceberg_catalog",
+                          "vector_buckets"
+                        ]
+                      },
+                      "capabilities": {
+                        "type": "object",
+                        "properties": {
+                          "list_v2": {
+                            "type": "boolean"
+                          },
+                          "iceberg_catalog": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": ["list_v2", "iceberg_catalog"]
+                      },
+                      "upstream_target": {
+                        "type": "string",
+                        "enum": ["main", "canary"]
+                      },
+                      "migration_version": {
+                        "type": "string"
+                      },
+                      "database_pool_mode": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "file_size_limit",
+                      "features",
+                      "capabilities",
+                      "upstream_target",
+                      "migration_version",
+                      "database_pool_mode"
+                    ],
+                    "description": "Read from the storage service's admin API rather than the middleware DB, so unlike the rest of this resource it reflects the tenant's live config."
+                  }
+                },
+                "required": ["database", "pooler", "auth", "api", "realtime", "storage"]
+              }
+            },
+            "required": ["type", "id", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2TransferProjectBody": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_transfer_input"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "target_organization_slug": {
+                    "type": "string"
+                  }
+                },
+                "required": ["target_organization_slug"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2PreviewProjectTransferResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["project_transfer_result"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "valid": {
+                    "type": "boolean"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "message"]
+                    }
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "message"]
+                    }
+                  },
+                  "info": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["key", "message"]
+                    }
+                  }
+                },
+                "required": ["valid", "warnings", "errors", "info"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ListPrivateLinkAssociationsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["private_link_association"]
+                },
+                "id": {
+                  "type": "string"
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "aws_account_id": {
+                      "type": "string",
+                      "minLength": 12,
+                      "maxLength": 12,
+                      "pattern": "^\\d{12}$",
+                      "description": "The AWS account ID this PrivateLink share is associated with."
+                    },
+                    "account_name": {
+                      "description": "Human-readable name for the AWS account.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "CREATING",
+                        "READY",
+                        "ASSOCIATION_REQUEST_EXPIRED",
+                        "ASSOCIATION_ACCEPTED",
+                        "CREATION_FAILED",
+                        "DELETING"
+                      ],
+                      "description": "\n  - `CREATING`: The PrivateLink resources and the Association are in the process of being created. The PrivateLink Share cannot be accepted yet.\n  - `READY`: The PrivateLink resources have been created and the PrivateLink Share can be accepted for the duration of 12h after sharing. See `shared_at`.\n  - `ASSOCIATION_REQUEST_EXPIRED`: The PrivateLink Share has not been accepted within the 12h time limit. This association can now be deleted.\n  - `ASSOCIATION_ACCEPTED`: The PrivateLink Share was successfully accepted.\n  - `CREATION_FAILED`: The PrivateLink resources failed to create. This likely means something went wrong on Supabase's and and support should be contacted.\n  - `DELETING`: The PrivateLink resources and the Association are in the process of being deleted. The PrivateLink Share cannot be accepted yet.\n"
+                    },
+                    "shared_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "description": "The time and date at which the AWS Resource Share Association was requested from Supabase. `null` means that the association was not yet requested while the PrivateLink Association is pending.",
+                      "nullable": true
+                    },
+                    "database_type": {
+                      "type": "string",
+                      "enum": ["PRIMARY", "READ_REPLICA"],
+                      "description": "Whether this PrivateLink share targets the primary database or a read replica."
+                    },
+                    "database_identifier": {
+                      "type": "string",
+                      "description": "Identifier of the database this PrivateLink share targets - the project ref for the primary, or the read replica identifier."
+                    }
+                  },
+                  "required": [
+                    "aws_account_id",
+                    "status",
+                    "shared_at",
+                    "database_type",
+                    "database_identifier"
+                  ]
+                }
+              },
+              "required": ["type", "id", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2CreatePrivateLinkAssociationRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["private_link_association"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "aws_account_id": {
+                    "type": "string",
+                    "minLength": 12,
+                    "maxLength": 12,
+                    "pattern": "^\\d{12}$",
+                    "description": "The AWS account ID to add to the project PrivateLink share."
+                  },
+                  "account_name": {
+                    "description": "Optional human-readable name for the AWS account.",
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "database_identifier": {
+                    "description": "Identifier of the read replica this PrivateLink share should target. Omit to target the primary database.",
+                    "type": "string"
+                  }
+                },
+                "required": ["aws_account_id"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2PrivateLinkAssociationResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["private_link_association"]
+              },
+              "id": {
+                "type": "string"
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "aws_account_id": {
+                    "type": "string",
+                    "minLength": 12,
+                    "maxLength": 12,
+                    "pattern": "^\\d{12}$",
+                    "description": "The AWS account ID this PrivateLink share is associated with."
+                  },
+                  "account_name": {
+                    "description": "Human-readable name for the AWS account.",
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "CREATING",
+                      "READY",
+                      "ASSOCIATION_REQUEST_EXPIRED",
+                      "ASSOCIATION_ACCEPTED",
+                      "CREATION_FAILED",
+                      "DELETING"
+                    ],
+                    "description": "\n  - `CREATING`: The PrivateLink resources and the Association are in the process of being created. The PrivateLink Share cannot be accepted yet.\n  - `READY`: The PrivateLink resources have been created and the PrivateLink Share can be accepted for the duration of 12h after sharing. See `shared_at`.\n  - `ASSOCIATION_REQUEST_EXPIRED`: The PrivateLink Share has not been accepted within the 12h time limit. This association can now be deleted.\n  - `ASSOCIATION_ACCEPTED`: The PrivateLink Share was successfully accepted.\n  - `CREATION_FAILED`: The PrivateLink resources failed to create. This likely means something went wrong on Supabase's and and support should be contacted.\n  - `DELETING`: The PrivateLink resources and the Association are in the process of being deleted. The PrivateLink Share cannot be accepted yet.\n"
+                  },
+                  "shared_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "description": "The time and date at which the AWS Resource Share Association was requested from Supabase. `null` means that the association was not yet requested while the PrivateLink Association is pending.",
+                    "nullable": true
+                  },
+                  "database_type": {
+                    "type": "string",
+                    "enum": ["PRIMARY", "READ_REPLICA"],
+                    "description": "Whether this PrivateLink share targets the primary database or a read replica."
+                  },
+                  "database_identifier": {
+                    "type": "string",
+                    "description": "Identifier of the database this PrivateLink share targets - the project ref for the primary, or the read replica identifier."
+                  }
+                },
+                "required": [
+                  "aws_account_id",
+                  "status",
+                  "shared_at",
+                  "database_type",
+                  "database_identifier"
+                ]
+              }
+            },
+            "required": ["type", "id", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ListMembersResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_member"]
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "string",
+                      "description": "Member's username",
+                      "nullable": true
+                    },
+                    "primary_email": {
+                      "type": "string",
+                      "description": "Member's primary email",
+                      "nullable": true
+                    },
+                    "mfa_enabled": {
+                      "type": "boolean",
+                      "description": "Whether Multi-Factor Authentication is enabled for this member"
+                    },
+                    "is_sso_user": {
+                      "type": "boolean",
+                      "description": "Whether this member is a Single Sign-On user"
+                    },
+                    "avatar_url": {
+                      "type": "string",
+                      "description": "Member's avatar URL",
+                      "nullable": true
+                    },
+                    "roles": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Role name. For project-scoped roles this is the base role name.",
+                            "example": "developer"
+                          },
+                          "scope": {
+                            "type": "string",
+                            "enum": ["organization", "project"],
+                            "description": "Whether this role applies org-wide or is scoped to specific projects for the user."
+                          },
+                          "projects": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["ref", "name"]
+                            },
+                            "description": "Project refs this role is scoped to. Empty array for org-level roles."
+                          }
+                        },
+                        "required": ["name", "scope", "projects"]
+                      },
+                      "description": "Roles assigned to this member. Includes both org-level and project-scoped roles."
+                    }
+                  },
+                  "required": [
+                    "username",
+                    "primary_email",
+                    "mfa_enabled",
+                    "is_sso_user",
+                    "avatar_url",
+                    "roles"
+                  ]
+                }
+              },
+              "required": ["type", "id", "attributes"]
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "first": {
+                "type": "string",
+                "description": "URL path to the first page if available.",
+                "example": "/v2/organizations/my-org/members?page[size]=10",
+                "nullable": true
+              },
+              "prev": {
+                "type": "string",
+                "description": "URL path to the previous page.",
+                "example": "/v2/organizations/my-org/members?page[size]=10&page[before]=019adf7d-4513-74c5-bb9a-f1bc0f7a95d7",
+                "nullable": true
+              },
+              "next": {
+                "type": "string",
+                "description": "URL path to the next page.",
+                "example": "/v2/organizations/my-org/members?page[size]=10&page[after]=019adf7d-4513-7062-b292-78b86cc470a4",
+                "nullable": true
+              },
+              "last": {
+                "type": "string",
+                "description": "URL path to the last page if available.",
+                "example": "/v2/organizations/my-org/members?page[size]=10&page[after]=019adf7d-4513-71ba-b264-21900edb4295",
+                "nullable": true
+              }
+            },
+            "required": ["prev", "next"]
+          }
+        },
+        "required": ["data", "links"]
+      },
+      "V2AssignOrganizationMemberRoleRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["organization_member_role"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": ["owner", "administrator", "developer", "read-only"],
+                    "description": "Role name to assign. Must be one of: owner, administrator, developer, read-only. Must be on a Team or Enterprise plan to use the read-only role.",
+                    "example": "developer"
+                  },
+                  "projects": {
+                    "description": "The projects to assign a project-scoped role for. If omitted, assigns an org-wide role.",
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ref": {
+                          "type": "string",
+                          "description": "Project ref",
+                          "example": "abcjuqabhgwjjutfvtpa"
+                        }
+                      },
+                      "required": ["ref"]
+                    }
+                  }
+                },
+                "required": ["role"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "OrganizationMemberRoleResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Resource type.",
+                "enum": ["organization_member_role"]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Role name. For project-scoped assignments this is the base role name.",
+                    "example": "developer"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": ["organization", "project"],
+                    "description": "Whether this role applies org-wide or is scoped to specific projects for the user."
+                  },
+                  "projects": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ref": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["ref", "name"]
+                    },
+                    "description": "Project refs this role is scoped to. Empty array for org-level roles."
+                  }
+                },
+                "required": ["name", "scope", "projects"]
+              }
+            },
+            "required": ["type", "attributes"]
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ListRolesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_role"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Role name.",
+                      "example": "developer"
+                    }
+                  },
+                  "required": ["name"]
+                }
+              },
+              "required": ["type", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2CreateInvitationsRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "minItems": 1,
+            "maxItems": 50,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_invitation"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                    },
+                    "role": {
+                      "type": "string",
+                      "enum": ["owner", "administrator", "developer", "read-only"],
+                      "description": "Role name to assign. Must be on a Team or Enterprise plan to use the read-only role.",
+                      "example": "developer"
+                    },
+                    "projects": {
+                      "description": "The projects to limit a user to. If omitted, user will have org-wide access with the provided role.",
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "ref": {
+                            "type": "string",
+                            "description": "Project ref",
+                            "example": "abcjuqabhgwjjutfvtpa"
+                          }
+                        },
+                        "required": ["ref"]
+                      }
+                    },
+                    "require_sso": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["email", "role"]
+                }
+              },
+              "required": ["type", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2CreateInvitationsResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "links": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "href": {
+                      "type": "string"
+                    },
+                    "rel": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "describedby": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": ["href"]
+                }
+              },
+              "meta": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "issues": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "links": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "href": {
+                            "type": "string"
+                          },
+                          "rel": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "describedby": {
+                            "type": "string"
+                          },
+                          "meta": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "required": ["href"]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                        }
+                      },
+                      "required": ["email"]
+                    }
+                  },
+                  "required": ["code", "message", "meta"]
+                }
+              }
+            },
+            "required": ["code", "message"]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_invitation"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                    }
+                  },
+                  "required": ["email"]
+                }
+              },
+              "required": ["type", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2DeleteInvitationsRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "minItems": 1,
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_invitation"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                    }
+                  },
+                  "required": ["email"]
+                }
+              },
+              "required": ["type", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2DeleteInvitationsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["organization_invitation"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                    }
+                  },
+                  "required": ["email"]
+                }
+              },
+              "required": ["type", "attributes"]
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "V2ListProjectsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["project"]
+                },
+                "id": {
+                  "type": "string",
+                  "minLength": 20,
+                  "maxLength": 20,
+                  "pattern": "^[a-z]+$",
+                  "description": "Project ref",
+                  "example": "abcdefghijklmnopqrst"
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Project name"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "INACTIVE",
+                        "ACTIVE_HEALTHY",
+                        "ACTIVE_UNHEALTHY",
+                        "COMING_UP",
+                        "UNKNOWN",
+                        "GOING_DOWN",
+                        "INIT_FAILED",
+                        "REMOVED",
+                        "RESTORING",
+                        "UPGRADING",
+                        "PAUSING",
+                        "RESTORE_FAILED",
+                        "RESTARTING",
+                        "PAUSE_FAILED",
+                        "RESIZING"
+                      ],
+                      "description": "Project status"
+                    },
+                    "cloud_provider": {
+                      "type": "string",
+                      "description": "Cloud provider hosting the project"
+                    },
+                    "region": {
+                      "type": "string",
+                      "description": "Region the project is hosted in"
+                    },
+                    "inserted_at": {
+                      "type": "string",
+                      "description": "When the project was created"
+                    },
+                    "databases": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "cloud_provider": {
+                            "type": "string"
+                          },
+                          "identifier": {
+                            "type": "string"
+                          },
+                          "region": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "ACTIVE_HEALTHY",
+                              "ACTIVE_UNHEALTHY",
+                              "COMING_UP",
+                              "GOING_DOWN",
+                              "INIT_FAILED",
+                              "REMOVED",
+                              "RESTORING",
+                              "UNKNOWN",
+                              "INIT_READ_REPLICA",
+                              "INIT_READ_REPLICA_FAILED",
+                              "RESTARTING",
+                              "RESIZING"
+                            ]
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": ["PRIMARY", "READ_REPLICA"]
+                          },
+                          "infra_compute_size": {
+                            "type": "string",
+                            "enum": [
+                              "pico",
+                              "nano",
+                              "micro",
+                              "small",
+                              "medium",
+                              "large",
+                              "xlarge",
+                              "2xlarge",
+                              "4xlarge",
+                              "8xlarge",
+                              "12xlarge",
+                              "16xlarge",
+                              "24xlarge",
+                              "24xlarge_optimized_memory",
+                              "24xlarge_optimized_cpu",
+                              "24xlarge_high_memory",
+                              "48xlarge",
+                              "48xlarge_optimized_memory",
+                              "48xlarge_optimized_cpu",
+                              "48xlarge_high_memory"
+                            ]
+                          },
+                          "disk_volume_size_gb": {
+                            "type": "number"
+                          },
+                          "disk_type": {
+                            "type": "string",
+                            "enum": ["gp3", "io2"]
+                          },
+                          "disk_throughput_mbps": {
+                            "type": "number"
+                          },
+                          "disk_last_modified_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["cloud_provider", "identifier", "region", "status", "type"]
+                      },
+                      "description": "The project's databases including compute and disk attributes."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "status",
+                    "cloud_provider",
+                    "region",
+                    "inserted_at",
+                    "databases"
+                  ]
+                }
+              },
+              "required": ["type", "id", "attributes"]
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "first": {
+                "type": "string",
+                "description": "URL path to the first page if available.",
+                "example": "/v2/organizations/my-org/projects?page[size]=10",
+                "nullable": true
+              },
+              "prev": {
+                "type": "string",
+                "description": "URL path to the previous page.",
+                "example": "/v2/organizations/my-org/projects?page[size]=10&page[before]=019adf7d-4513-74c5-bb9a-f1bc0f7a95d7",
+                "nullable": true
+              },
+              "next": {
+                "type": "string",
+                "description": "URL path to the next page.",
+                "example": "/v2/organizations/my-org/projects?page[size]=10&page[after]=019adf7d-4513-7062-b292-78b86cc470a4",
+                "nullable": true
+              },
+              "last": {
+                "type": "string",
+                "description": "URL path to the last page if available.",
+                "example": "/v2/organizations/my-org/projects?page[size]=10&page[after]=019adf7d-4513-71ba-b264-21900edb4295",
+                "nullable": true
+              }
+            },
+            "required": ["prev", "next"]
+          }
+        },
+        "required": ["data", "links"]
+      },
+      "V2ListGitHubConnectionsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Resource type.",
+                  "enum": ["github_connection"]
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Connection id.",
+                  "example": "7"
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "inserted_at": {
+                      "type": "string",
+                      "description": "When the connection was created"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "When the connection was last updated"
+                    },
+                    "installation_id": {
+                      "type": "number",
+                      "description": "GitHub App installation id"
+                    },
+                    "workdir": {
+                      "type": "string",
+                      "description": "Directory within the repository the project lives in"
+                    },
+                    "supabase_changes_only": {
+                      "type": "boolean",
+                      "description": "Whether branches are only created for changes under `supabase/`"
+                    },
+                    "branch_limit": {
+                      "type": "number",
+                      "description": "Maximum number of preview branches"
+                    },
+                    "new_branch_per_pr": {
+                      "type": "boolean",
+                      "description": "Whether a preview branch is created for every pull request"
+                    },
+                    "project": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "minLength": 20,
+                          "maxLength": 20,
+                          "pattern": "^[a-z]+$",
+                          "description": "Project ref",
+                          "example": "abcdefghijklmnopqrst"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["id", "ref", "name"],
+                      "description": "The connected Supabase project"
+                    },
+                    "repository": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["id", "name"],
+                      "description": "The connected GitHub repository"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "primary_email": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": ["id", "username", "primary_email"],
+                      "description": "The user who created the connection, if still known",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "inserted_at",
+                    "updated_at",
+                    "installation_id",
+                    "workdir",
+                    "supabase_changes_only",
+                    "branch_limit",
+                    "new_branch_per_pr",
+                    "project",
+                    "repository",
+                    "user"
+                  ]
+                }
+              },
+              "required": ["type", "id", "attributes"]
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "first": {
+                "type": "string",
+                "description": "URL path to the first page if available.",
+                "example": "/v2/organizations/my-org/integrations/github/connections?page[size]=10",
+                "nullable": true
+              },
+              "prev": {
+                "type": "string",
+                "description": "URL path to the previous page.",
+                "example": "/v2/organizations/my-org/integrations/github/connections?page[size]=10&page[before]=019adf7d-4513-74c5-bb9a-f1bc0f7a95d7",
+                "nullable": true
+              },
+              "next": {
+                "type": "string",
+                "description": "URL path to the next page.",
+                "example": "/v2/organizations/my-org/integrations/github/connections?page[size]=10&page[after]=019adf7d-4513-7062-b292-78b86cc470a4",
+                "nullable": true
+              },
+              "last": {
+                "type": "string",
+                "description": "URL path to the last page if available.",
+                "example": "/v2/organizations/my-org/integrations/github/connections?page[size]=10&page[after]=019adf7d-4513-71ba-b264-21900edb4295",
+                "nullable": true
+              }
+            },
+            "required": ["prev", "next"]
+          }
+        },
+        "required": ["data", "links"]
       }
     }
   }

--- a/packages/api/src/internal/client.unit.test.ts
+++ b/packages/api/src/internal/client.unit.test.ts
@@ -1054,7 +1054,6 @@ describe("makeSupabaseApiClient", () => {
     expect(seenRequest?.headers.authorization).toBe("Bearer test-token");
   });
 
-  // NOTE(CLI-2157): v2GetProjectConfig is staging-only until the endpoint ships to prod; delete or re-point this test if the snapshot is regenerated from prod before then.
   test("decodes a nested v2GetProjectConfig payload through the unified execute path", async () => {
     const result = await Effect.runPromise(
       makeSupabaseApiClient(config).pipe(

--- a/packages/api/src/internal/client.unit.test.ts
+++ b/packages/api/src/internal/client.unit.test.ts
@@ -1016,4 +1016,132 @@ describe("makeSupabaseApiClient", () => {
       }),
     ).toThrow();
   });
+
+  test("surfaces a 404 on a v2 operation as a distinguishable status error and wires the request identically to v1", async () => {
+    let seenRequest: HttpClientRequest.HttpClientRequest | undefined;
+
+    const client = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.provide(
+          httpClientLayer((request) => {
+            seenRequest = request;
+            return Effect.succeed(
+              jsonResponse(request, 404, { message: "Organization not found" }),
+            );
+          }),
+        ),
+      ),
+    );
+
+    const error = await Effect.runPromise(
+      client
+        .execute(operationDefinitions.v2ListOrganizationMembers, { slug: "my-org" })
+        .pipe(Effect.flip),
+    );
+
+    expect(HttpClientError.isHttpClientError(error)).toBe(true);
+    if (!HttpClientError.isHttpClientError(error)) {
+      throw new Error("expected HttpClientError");
+    }
+    expect(error.reason._tag).toBe("StatusCodeError");
+    if (error.reason._tag !== "StatusCodeError") {
+      throw new Error("expected StatusCodeError");
+    }
+    expect(error.reason.response.status).toBe(404);
+
+    expect(seenRequest).toBeDefined();
+    expect(seenRequest?.url).toBe("https://api.supabase.com/v2/organizations/my-org/members");
+    expect(seenRequest?.headers.authorization).toBe("Bearer test-token");
+  });
+
+  // NOTE(CLI-2157): v2GetProjectConfig is staging-only until the endpoint ships to prod; delete or re-point this test if the snapshot is regenerated from prod before then.
+  test("decodes a nested v2GetProjectConfig payload through the unified execute path", async () => {
+    const result = await Effect.runPromise(
+      makeSupabaseApiClient(config).pipe(
+        Effect.flatMap((client) =>
+          client.execute<"v2GetProjectConfig">(operationDefinitions.v2GetProjectConfig, {
+            ref: "abcdefghijklmnopqrst",
+          }),
+        ),
+        Effect.provide(
+          httpClientLayer((request) =>
+            Effect.succeed(
+              jsonResponse(request, 200, {
+                data: {
+                  type: "project_config",
+                  id: "abcdefghijklmnopqrst",
+                  attributes: {
+                    database: {
+                      ssl_enforced: true,
+                      network_restrictions: {
+                        entitlement: "disallowed",
+                        status: "stored",
+                        allowed_cidrs: [],
+                      },
+                      postgres_settings: {},
+                    },
+                    pooler: {
+                      pool_mode: "transaction",
+                      ignore_startup_parameters: "",
+                      server_idle_timeout: 0,
+                      server_lifetime: 0,
+                      query_wait_timeout: 0,
+                      reserve_pool_size: 0,
+                      default_pool_size: 0,
+                      max_client_conn: 0,
+                    },
+                    auth: {},
+                    api: {
+                      db_schema: "public",
+                      db_extra_search_path: "",
+                      max_rows: 1000,
+                      db_pool_acquisition_timeout: 0,
+                      db_pool: null,
+                    },
+                    realtime: {
+                      private_only: false,
+                      max_concurrent_users: 0,
+                      max_events_per_second: 0,
+                      max_bytes_per_second: 0,
+                      max_channels_per_client: 0,
+                      max_joins_per_second: 0,
+                      max_presence_events_per_second: 0,
+                      max_payload_size_in_kb: 0,
+                      presence_enabled: true,
+                      suspend: false,
+                      connection_pool: 0,
+                      postgres_changes_pool: null,
+                    },
+                    storage: {
+                      file_size_limit: 0,
+                      features: {
+                        image_transformation: { enabled: true },
+                        s3_protocol: { enabled: true },
+                        purge_cache: { enabled: true },
+                        iceberg_catalog: {
+                          enabled: false,
+                          max_namespaces: 0,
+                          max_tables: 0,
+                          max_catalogs: 0,
+                        },
+                        vector_buckets: { enabled: false, max_buckets: 0, max_indexes: 0 },
+                      },
+                      capabilities: { list_v2: true, iceberg_catalog: true },
+                      upstream_target: "main",
+                      migration_version: "1",
+                      database_pool_mode: "transaction",
+                    },
+                  },
+                },
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.data.attributes.database.network_restrictions.entitlement).toBe("disallowed");
+    expect(result.data.attributes.storage.upstream_target).toBe("main");
+    expect(result.data.attributes.api.db_pool).toBeNull();
+  });
 });


### PR DESCRIPTION
## What changed

\`@supabase/api\` previously modeled only the Management API v1 namespace. The upstream API publishes two OpenAPI documents (\`/api/v1-json\` and \`/api/v2-json\`), and the config endpoint needed by CLI-2156/CLI-2064 lives on v2. This PR makes v2 a first-class namespace:

- **\`scripts/download-openapi.ts\`** fetches both documents from the same base URL, merges them (paths + \`components.schemas\` unioned with collision asserts; \`info.title\` normalized), applies overrides to the merged document, and validates operationId uniqueness and version/path agreement. A missing v2 document is a hard failure — tolerating it would silently delete the namespace and the hourly sync would auto-merge the deletion.
- **\`scripts/generate.ts\`** derives the client namespace from the path's leading segment (\`/v2/...\` → \`api.v2.*\`) instead of the operationId prefix, with a hard error on duplicate \`(version, method)\` pairs. Adding a v3 later requires no generator changes. All 170 existing v1 operations produce byte-identical output — the regenerated \`contracts.ts\`/\`effect-client.ts\` diff is additions-only (verified: zero removed lines).
- **\`scripts/openapi-overrides.json\`** gains a tolerant \`remove\` op (remove-if-present, a documented RFC 6902 deviation) and 13 entries removing the v2 webhook paths + \`APIErrorObject\`. Upstream spec bug (still present in prod): all 10 project-webhook operations share one operationId (\`allV2ProjectsByRefWebhooks\`), the 10 org-webhook ones share another — duplicated and not version-prefixed, which breaks codegen.
- **\`scripts/openapi-source.json\`** (new, committed) pins the spec source base URL — \`https://api.supabase.com\` — so \`pnpm generate\` reproduces the snapshot with no env var and provenance is visible in diffs. \`SUPABASE_API_URL\` still overrides it (e.g. for staging).
- **Drift detection**: \`src/generated-contract-sync.unit.test.ts\` asserts a full bijection between the committed snapshot and the generated modules in ordinary PR CI (this is what catches a hand-edited snapshot or client — the failure mode from the #6111 POC). \`pnpm generate:check\` mirrors the hourly sync's regenerate→format→diff sequence for live verification.
- **\`api-package-sync.yml\`** is pinned to \`https://api.supabase.com\` so develop's hourly sync always regenerates from prod regardless of the sidecar.

The proving case, \`GET /v2/projects/{ref}/config\` → \`api.v2.getProjectConfig\` (typed \`V2ProjectConfigResponse\`), was staging-only when this branch started; it shipped to production on 2026-08-11 with a byte-identical definition, the snapshot regenerates from prod exactly, and the source pin now points at prod. No merge gate remains.

## Known limitation

Three v2 operations (\`v2-list-organization-members\`, \`v2-list-organization-projects\`, \`v2-list-organization-github-connections\`) declare \`style: deepObject\` object query params, which the client currently serializes as JSON strings rather than \`page[size]=...\`. Documented in the README; the typed surface is correct, the wire format for those params is not.

Part of CLI-2157 (unblocks CLI-2156 and CLI-2064).