### PR TITLE
docs(cli): scope Go CLI authority to parity-relevant legacy work

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -34,6 +34,28 @@ Both call `runCli(root)` from `shared/cli/run.ts`.
 
 ---
 
+## Legacy Port Status and Go CLI Authority
+
+`src/legacy/` started as a from-scratch 1:1 port of the Go CLI (`apps/cli-go/`) and is now largely
+there: see [`docs/go-cli-porting-status.md`](./docs/go-cli-porting-status.md#legacy-shell-command-status)
+for the live per-command tracker. As of writing, 95 of 103 legacy leaf commands are natively ported;
+only a small residual set is still a Phase 0 proxy to the Go binary.
+
+This changes what "Go CLI is authoritative" means day to day. `apps/cli-go/` is required reading
+only when:
+
+- Replacing one of the remaining Phase 0 wrapped commands with a native implementation, or
+- Changing something on an already-ported command's established parity surface — command/flag
+  names, stdout/stderr text, exit codes, filesystem/API side effects, telemetry payload shape.
+
+For everything else in `src/legacy/` — bug fixes that don't touch that surface, internal refactors,
+hoisting shared helpers, adding a documented TS-only flag/feature, tests, tooling — treat it like any
+other TypeScript workspace. Go behavior is not the deciding standard, and there's no need to consult
+`apps/cli-go/`. See [ADR 0016](../../docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md)
+for the full rationale.
+
+---
+
 ## Learning more about the "effect" library
 
 This project uses **Effect V4**. The full source code for the `effect` library is in `.repos/effect/`.
@@ -103,7 +125,11 @@ Also check the following `legacy/` infrastructure before writing equivalent help
 
 ## Phase 0: Go Binary Wrapper
 
-Before any command is natively implemented in TypeScript, the first step for each command is to **wrap** it: define the command in the TS command tree and proxy all invocations to the bundled Go binary via subprocess.
+This phase is now the exception, not the default: only the commands listed as `wrapped` in the
+[Legacy Shell Command Status table](./docs/go-cli-porting-status.md#legacy-shell-command-status)
+still need it. A genuinely new command with no existing TS or Go surface is rare at this point in
+the port; when one does show up, the first step is to **wrap** it: define the command in the TS
+command tree and proxy all invocations to the bundled Go binary via subprocess.
 
 ### Proxy handler pattern
 
@@ -255,6 +281,12 @@ The legacy shell is a **strict 1:1 port** — not a redesign. The compatibility 
 - Same exit codes
 
 When in doubt about expected output or behavior, run the equivalent command against the Go CLI reference at `apps/cli-go/` and match it exactly.
+
+This contract governs behavior a command has already established — it does not mean every change in
+`src/legacy/` requires consulting Go. It applies when finishing one of the remaining Phase 0 ports,
+or changing an already-ported command in a way that could affect the surface above. It does not
+apply to internal refactors, TS-only additions, or bug fixes that leave that surface unchanged — see
+[Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority).
 
 ---
 
@@ -512,4 +544,12 @@ bun run --parallel "*:check"
 
 ### `apps/cli-go/`
 
-The [old Supabase CLI](https://github.com/supabase/cli) written in Go. When porting a command to the legacy shell, use this as the authoritative source for expected output, flags, and behavior. Match it exactly. Exception: `internal/start` (Go's `supabase start`) was deleted outright as unreachable once ported (CLI-1966) — for that command, the last commit with the source intact (`a253ccba25c21356ccd33044c4474aecb77d1ae4`) is the authoritative reference instead.
+The [old Supabase CLI](https://github.com/supabase/cli) written in Go. Use this as the authoritative
+source, matched exactly, when porting one of the remaining wrapped commands to native TS, or when
+changing an already-ported legacy command's established output/flags/behavior. It is not required
+reading for other legacy-shell work — see
+[Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority) and
+[ADR 0016](../../docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md). Exception:
+`internal/start` (Go's `supabase start`) was deleted outright as unreachable once ported (CLI-1966)
+— for that command, the last commit with the source intact
+(`a253ccba25c21356ccd33044c4474aecb77d1ae4`) is the authoritative reference instead.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -44,9 +44,13 @@ only a small residual set is still a Phase 0 proxy to the Go binary.
 This changes what "Go CLI is authoritative" means day to day. `apps/cli-go/` is required reading
 only when:
 
-- Replacing one of the remaining Phase 0 wrapped commands with a native implementation, or
-- Changing something on an already-ported command's established parity surface — command/flag
-  names, stdout/stderr text, exit codes, filesystem/API side effects, telemetry payload shape.
+- Working on one of the remaining Phase 0 wrapped commands — maintaining its command/flag
+  definition and proxy handler (these gate which invocations reach the Go binary and must still
+  match it exactly) or replacing the wrapper with a native implementation, or
+- Changing something on an already-ported command's established parity surface: command/flag
+  names, stdout/stderr text, exit codes, all documented side effects (filesystem, database,
+  Docker/subprocess, API requests), or telemetry semantics (which events fire, when, and their
+  payload shape).
 
 For everything else in `src/legacy/` — bug fixes that don't touch that surface, internal refactors,
 hoisting shared helpers, adding a documented TS-only flag/feature, tests, tooling — treat it like any
@@ -127,9 +131,14 @@ Also check the following `legacy/` infrastructure before writing equivalent help
 
 This phase is now the exception, not the default: only the commands listed as `wrapped` in the
 [Legacy Shell Command Status table](./docs/go-cli-porting-status.md#legacy-shell-command-status)
-still need it. A genuinely new command with no existing TS or Go surface is rare at this point in
-the port; when one does show up, the first step is to **wrap** it: define the command in the TS
-command tree and proxy all invocations to the bundled Go binary via subprocess.
+still need it. A Go CLI command that exists in `apps/cli-go/` but has no TS surface yet is rare at
+this point in the port; when one does show up, the first step is to **wrap** it: define the command
+in the TS command tree and proxy all invocations to the bundled Go binary via subprocess. Wrapping
+only works for a command the Go CLI already implements — there is nothing to proxy to otherwise. A
+genuinely TS-only addition with no Go equivalent (for example a TS-only flag on an already-ported
+command, per the "Flag divergences from the Go reference" list in
+[`docs/go-cli-porting-status.md`](./docs/go-cli-porting-status.md)) is implemented natively and does
+not go through Phase 0 at all.
 
 ### Proxy handler pattern
 
@@ -283,10 +292,13 @@ The legacy shell is a **strict 1:1 port** — not a redesign. The compatibility 
 When in doubt about expected output or behavior, run the equivalent command against the Go CLI reference at `apps/cli-go/` and match it exactly.
 
 This contract governs behavior a command has already established — it does not mean every change in
-`src/legacy/` requires consulting Go. It applies when finishing one of the remaining Phase 0 ports,
-or changing an already-ported command in a way that could affect the surface above. It does not
-apply to internal refactors, TS-only additions, or bug fixes that leave that surface unchanged — see
-[Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority).
+`src/legacy/` requires consulting Go. It applies when working on one of the remaining Phase 0
+wrapped commands (its command/flag definition or its native replacement), or changing an
+already-ported command in a way that could affect the surface above — which, per each command's
+`SIDE_EFFECTS.md`, also includes database mutations and Docker/subprocess behavior, and per the
+Telemetry Parity section below also includes which events fire and when, not just payload shape. It
+does not apply to internal refactors, TS-only additions, or bug fixes that leave that surface
+unchanged — see [Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority).
 
 ---
 
@@ -545,8 +557,9 @@ bun run --parallel "*:check"
 ### `apps/cli-go/`
 
 The [old Supabase CLI](https://github.com/supabase/cli) written in Go. Use this as the authoritative
-source, matched exactly, when porting one of the remaining wrapped commands to native TS, or when
-changing an already-ported legacy command's established output/flags/behavior. It is not required
+source, matched exactly, when working on one of the remaining wrapped commands (maintaining its
+command/flag definition, or replacing the wrapper with native TS), or when changing an
+already-ported legacy command's established output/flags/behavior/side-effects. It is not required
 reading for other legacy-shell work — see
 [Legacy Port Status and Go CLI Authority](#legacy-port-status-and-go-cli-authority) and
 [ADR 0016](../../docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md). Exception:

--- a/apps/cli/docs/go-cli-porting-status.md
+++ b/apps/cli/docs/go-cli-porting-status.md
@@ -7,6 +7,8 @@ Reference:
 - Old Go CLI help dump: [`go-cli-reference.md`](./go-cli-reference.md)
 - Current TS root command: [`../src/next/cli/root.ts`](../src/next/cli/root.ts)
 
+The legacy shell's port is largely complete (see [Legacy Shell Command Status](#legacy-shell-command-status) below). This tracker records what's still `wrapped`; it does not mean every legacy-shell change requires consulting the Go CLI — see [ADR 0016](../../../docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md) and [`AGENTS.md`](../AGENTS.md#legacy-port-status-and-go-cli-authority) for the scope of when Go is actually authoritative.
+
 ## Legend
 
 - `ported`: TS command exists and the flag/parameter surface is materially aligned with the old Go CLI

--- a/docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md
+++ b/docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md
@@ -28,19 +28,21 @@ standard.
 
 `apps/cli-go/` remains authoritative, and must be consulted, for exactly two situations:
 
-1. **Finishing a Phase 0 → Phase 1 port** — replacing one of the remaining wrapped commands (the
-   `wrapped` rows in the Legacy Shell Command Status table) with a native implementation.
+1. **Working on one of the remaining wrapped commands** — either maintaining its command/flag
+   definition and proxy handler (these gate which invocations reach the Go binary and must still
+   match it exactly) or replacing the wrapper with a native implementation (Phase 0 → Phase 1).
 2. **A change that touches an already-ported command's established parity surface** — command or
-   flag names, stdout/stderr text, exit codes, filesystem/API side effects, or telemetry payload
-   shape. Here, Go source is a regression check ("does this still match what we already shipped"),
-   not a design source.
+   flag names, stdout/stderr text, exit codes, all documented side effects (filesystem, database,
+   Docker/subprocess, API requests — see each command's `SIDE_EFFECTS.md`), or telemetry semantics
+   (which events fire, when, and their payload shape). Here, Go source is a regression check ("does
+   this still match what we already shipped"), not a design source.
 
 For everything else in `src/legacy/` — internal refactors, bug fixes that don't change the surface
-above, hoisting shared helpers, adding a documented TS-only flag/feature (the pattern already
-established by `--skip-vault`, `--reveal`, `--high-availability`), tests, tooling, telemetry
-internals — `apps/cli-go/` is not required reading and Go behavior is not the deciding standard.
-Normal engineering judgment (correctness, tests, maintainability, DX) applies, the same as it does
-in `src/next/` or `src/shared/`.
+above, hoisting shared helpers, adding a documented TS-only flag/feature on an already-ported
+command (the pattern already established by `--skip-vault`, `--reveal`, `--high-availability`),
+tests, tooling — `apps/cli-go/` is not required reading and Go behavior is not the deciding
+standard. Normal engineering judgment (correctness, tests, maintainability, DX) applies, the same as
+it does in `src/next/` or `src/shared/`.
 
 `apps/cli/AGENTS.md` is updated to lead with this scope instead of assuming every reader is mid-port.
 
@@ -62,17 +64,21 @@ surface from a parity check it never needed.
   auditing `apps/cli-go/` or justifying themselves against Go behavior that isn't in scope.
 - Review feedback on such changes is judged on normal engineering merit instead of being forced
   through a parity lens that doesn't apply.
-- The two cases where Go really is authoritative (finishing the last 8 ports; not regressing the 95
-  already-ported commands) are named explicitly instead of being implied by a blanket rule.
+- The two cases where Go really is authoritative (the 8 still-wrapped commands, including finishing
+  their ports; not regressing the 95 already-ported commands) are named explicitly instead of being
+  implied by a blanket rule.
 
 ### Negative
 
 - Contributors now have to briefly classify a change (does it touch the parity surface?) rather than
-  defaulting to "always check Go." Misclassification risk is mitigated by
-  [`apps/cli/docs/go-cli-porting-status.md`](../../apps/cli/docs/go-cli-porting-status.md) staying
-  the source of truth for which commands are still `wrapped`, and by CI's `testParity` /
-  `*.e2e.test.ts` suites catching accidental output/behavior drift on already-ported commands
-  regardless of whether a human or agent consulted Go first.
+  defaulting to "always check Go." Misclassification risk is partly, not fully, mitigated:
+  [`apps/cli/docs/go-cli-porting-status.md`](../../apps/cli/docs/go-cli-porting-status.md) stays the
+  source of truth for which commands are still `wrapped`, and CI's `testParity` /
+  `*.e2e.test.ts` suites catch output/behavior drift on the already-ported commands and code paths
+  they cover — but that coverage is deliberately partial (e.g. `db pull --local` and `db lint
+  --local` skip `testParity` today, see `apps/cli-e2e/src/tests/database-core.e2e.test.ts`), so a
+  misclassified change on an uncovered path can still land without a human or agent ever consulting
+  Go.
 
 ## Alternatives Considered
 

--- a/docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md
+++ b/docs/adr/0016-legacy-port-completion-and-go-cli-authority-scope.md
@@ -1,0 +1,93 @@
+# 0016. Legacy Port Completion and Go CLI Authority Scope
+
+**Status**: proposed
+**Date**: 2026-08-11
+
+## Problem Statement
+
+`src/legacy/` started as a from-scratch, strict 1:1 port of the Go CLI (`apps/cli-go/`): every
+command began as a Phase 0 proxy to the Go binary, then moved to a native TypeScript implementation
+(Phase 1+). While that was true, treating `apps/cli-go/` as the unconditional authority for anything
+touching `src/legacy/` was correct — nearly every change was either wrapping a new command or
+replacing its proxy, and the Go source was the only available spec for what the command should do.
+
+That phase is essentially over. Per [`apps/cli/docs/go-cli-porting-status.md`](../../apps/cli/docs/go-cli-porting-status.md#legacy-shell-command-status),
+95 of 103 legacy leaf commands (~92%) are natively ported; only 8 remain Phase 0 proxies. Most
+changes landing in `src/legacy/` today are ordinary engineering on already-ported commands — bug
+fixes, internal refactors, hoisting shared helpers, adding documented TS-only flags, telemetry and
+observability work, tests — not porting.
+
+`apps/cli/AGENTS.md` still reads, top to bottom, as porting-era guidance: it opens with the Phase
+0/1 wrapping workflow and states unconditionally that `apps/cli-go/` is "the authoritative source"
+for the legacy shell. Agents (and humans) doing net-new work keep following that instruction
+literally — auditing Go source, or judging review feedback against Go parity, for changes that have
+nothing to do with Go parity. This slows down unrelated work and anchors reviews to the wrong
+standard.
+
+## Decision
+
+`apps/cli-go/` remains authoritative, and must be consulted, for exactly two situations:
+
+1. **Finishing a Phase 0 → Phase 1 port** — replacing one of the remaining wrapped commands (the
+   `wrapped` rows in the Legacy Shell Command Status table) with a native implementation.
+2. **A change that touches an already-ported command's established parity surface** — command or
+   flag names, stdout/stderr text, exit codes, filesystem/API side effects, or telemetry payload
+   shape. Here, Go source is a regression check ("does this still match what we already shipped"),
+   not a design source.
+
+For everything else in `src/legacy/` — internal refactors, bug fixes that don't change the surface
+above, hoisting shared helpers, adding a documented TS-only flag/feature (the pattern already
+established by `--skip-vault`, `--reveal`, `--high-availability`), tests, tooling, telemetry
+internals — `apps/cli-go/` is not required reading and Go behavior is not the deciding standard.
+Normal engineering judgment (correctness, tests, maintainability, DX) applies, the same as it does
+in `src/next/` or `src/shared/`.
+
+`apps/cli/AGENTS.md` is updated to lead with this scope instead of assuming every reader is mid-port.
+
+## Rationale
+
+The cost of the blanket framing was asymmetric: it made net-new work slower and reviews harder to
+reason about, without making the remaining real parity work (8 commands, plus regression risk on the
+95 already ported) any safer — that work is already called out explicitly in the porting-status
+tracker and doesn't need a blanket rule to be found. Scoping the authority claim to the two cases
+where it actually matters keeps the real guarantee (the legacy shell does not silently regress
+against Go, and the last wrapped commands still get ported) while freeing the other ~92% of the
+surface from a parity check it never needed.
+
+## Consequences
+
+### Positive
+
+- Net-new changes in `src/legacy/` — bug fixes, refactors, TS-only additions — no longer require
+  auditing `apps/cli-go/` or justifying themselves against Go behavior that isn't in scope.
+- Review feedback on such changes is judged on normal engineering merit instead of being forced
+  through a parity lens that doesn't apply.
+- The two cases where Go really is authoritative (finishing the last 8 ports; not regressing the 95
+  already-ported commands) are named explicitly instead of being implied by a blanket rule.
+
+### Negative
+
+- Contributors now have to briefly classify a change (does it touch the parity surface?) rather than
+  defaulting to "always check Go." Misclassification risk is mitigated by
+  [`apps/cli/docs/go-cli-porting-status.md`](../../apps/cli/docs/go-cli-porting-status.md) staying
+  the source of truth for which commands are still `wrapped`, and by CI's `testParity` /
+  `*.e2e.test.ts` suites catching accidental output/behavior drift on already-ported commands
+  regardless of whether a human or agent consulted Go first.
+
+## Alternatives Considered
+
+1. **Keep the blanket authority framing and rely on agents/reviewers to infer scope.** Rejected —
+   this is what's failing today; the framing is read literally.
+2. **Drop Go-CLI parity as a concern entirely now that the port is mostly done.** Rejected — the
+   remaining 8 wrapped commands still need porting, and the whole point of `src/legacy/` is to be a
+   stable-channel drop-in replacement for the Go CLI, so already-ported commands must not regress.
+
+## Related Decisions
+
+- None yet — this is the first ADR to describe the `legacy`/`next` split and the scope of Go CLI
+  authority explicitly; prior guidance lived only in `apps/cli/AGENTS.md`.
+
+## See Also
+
+- [`apps/cli/AGENTS.md`](../../apps/cli/AGENTS.md)
+- [`apps/cli/docs/go-cli-porting-status.md`](../../apps/cli/docs/go-cli-porting-status.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,6 +56,7 @@ When an ADR becomes outdated, mark it as `deprecated` or reference the supersedi
 | 0011 | [CLI Release & Distribution Strategy](0011-cli-release-and-distribution-strategy.md)       | proposed |
 | 0013 | [Live E2E Tests Bypass the Replay Server](0013-live-e2e-bypasses-replay-server.md)         | proposed |
 | 0015 | [Managed Stack Contract Fixtures](0015-managed-stack-contract-fixtures.md)                 | proposed |
+| 0016 | [Legacy Port Completion and Go CLI Authority Scope](0016-legacy-port-completion-and-go-cli-authority-scope.md) | proposed |
 
 ## Template
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update (ADR + agent guide).

## What is the current behavior?

`apps/cli/AGENTS.md` reads, top to bottom, as porting-era guidance: it opens with the Phase 0/1 wrapping workflow and states unconditionally that `apps/cli-go/` is "the authoritative source" for anything touching `src/legacy/`. That was correct while the legacy shell was being built from scratch, but the port is now largely done — 95 of 103 legacy leaf commands (~92%, per `apps/cli/docs/go-cli-porting-status.md`) are natively ported, with only 8 remaining Phase 0 proxies. Agents (and humans) doing net-new work in `src/legacy/` — bug fixes, refactors, TS-only additions, tests — keep following the unconditional framing literally and audit Go source, or judge review feedback against Go parity, for changes that have nothing to do with it.

## What is the new behavior?

- Adds **ADR 0016** recording the decision and its rationale, and indexes it in `docs/adr/README.md`.
- Adds a "Legacy Port Status and Go CLI Authority" section near the top of `apps/cli/AGENTS.md` stating current completion and exactly when `apps/cli-go/` is required reading: finishing one of the remaining wrapped ports, or changing an already-ported command's established parity surface (command/flag names, stdout/stderr text, exit codes, filesystem/API side effects, telemetry payload shape). Everything else in `src/legacy/` is treated like any other TypeScript workspace.
- Reframes the "Phase 0: Go Binary Wrapper" section as the exception path for the residual wrapped commands, not the default onboarding workflow.
- Adds the same scoping caveat to the "Legacy Port: Go CLI Output Parity" section and the `apps/cli-go/` reference blurb.
- Adds a pointer from `go-cli-porting-status.md`'s header to the ADR/AGENTS.md scoping.

Companion change (not in this diff, personal Claude Code config): updated the `go-parity-auditor` and `review-adjudicator` subagent definitions to apply the same scoping — parity is the deciding standard only for the two cases above, not for every legacy-shell change.