### PR TITLE
chore(cli): generate docs spec from TS (CLI-2171)

### DIFF
--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -22,3 +22,13 @@ npx prettier -w apps/docs/spec/cli_v1_commands.yaml
 ```
 
 3. If there are new commands added, update [common-cli-sections.json](https://github.com/supabase/supabase/blob/master/apps/docs/spec/common-cli-sections.json) manually
+
+## Maintenance
+
+When adding or changing a command or flag, update the matching entries in
+`src/legacy/docs/legacy-docs-spec.tables.ts` — each table's doc comment says
+when it applies: `TAGS`, `DEFAULT_OVERRIDES`, `REQUIRED`, `EXPERIMENTAL` (and
+`_OPTIONAL`), `EXCLUDED` (whole commands), `EXCLUDED_FLAGS`, `ARG_OVERRIDES`,
+`CHOICE_OVERRIDES`, `EXTRA_FLAGS`. The spec build fails on entries that no
+longer resolve against the command tree, but new commands and flags must be
+added by hand — nothing detects a missing entry for a new surface.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,6 +30,7 @@
     "build:legacy": "bun scripts/build-binary.ts legacy",
     "build:shim": "bun build src/shared/cli/bin.ts --outfile dist/supabase.js --target node",
     "generate:go-serve-template": "bun scripts/generate-go-serve-template.ts",
+    "docs:spec": "bun scripts/generate-docs-spec.ts",
     "dev:next": "pnpm exec bun src/next/main.ts",
     "dev:legacy": "pnpm exec bun src/legacy/main.ts",
     "test": "nx run-many -t test:core test:e2e --projects=$npm_package_name",

--- a/apps/cli/scripts/generate-docs-spec.ts
+++ b/apps/cli/scripts/generate-docs-spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Emits the `clispec 001` CLI reference document for the supabase.com docs
+ * site (`supabase/supabase` `apps/docs/spec/cli_v1_commands.yaml`) from the
+ * legacy Effect command tree plus the content under `apps/cli/docs/`
+ * (`supabase/` description overlays, `templates/examples.yaml`).
+ *
+ * Contract (documented in `docs/README.md`): the spec YAML is the ONLY thing
+ * written to stdout, so `bun scripts/generate-docs-spec.ts > cli_v1_commands.yaml`
+ * yields a clean parseable file; diagnostics go to stderr. The spec version
+ * defaults to `latest` and can be overridden with an argument (a leading
+ * `v` is stripped) — the workspace package.json version is a semantic-release
+ * placeholder, so it is never used.
+ */
+import path from "node:path";
+import process from "node:process";
+import { legacyReadDocsContent } from "../src/legacy/docs/legacy-docs-spec.content.ts";
+import {
+  legacyBuildDocsSpec,
+  legacyStringifyDocsSpec,
+} from "../src/legacy/docs/legacy-docs-spec.ts";
+import { legacyRoot } from "../src/legacy/cli/root.ts";
+
+function resolveVersion(): string {
+  const argument = process.argv[2];
+  if (argument === undefined || argument === "") return "latest";
+  return argument.startsWith("v") ? argument.slice(1) : argument;
+}
+
+const content = legacyReadDocsContent(path.resolve(import.meta.dir, "../docs"));
+
+const spec = legacyBuildDocsSpec({
+  root: legacyRoot,
+  version: resolveVersion(),
+  overlays: content.overlays,
+  examples: content.examples,
+});
+
+process.stdout.write(legacyStringifyDocsSpec(spec));

--- a/apps/cli/src/legacy/docs/generate-docs-spec.script.unit.test.ts
+++ b/apps/cli/src/legacy/docs/generate-docs-spec.script.unit.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const cliRoot = path.resolve(import.meta.dirname, "../../..");
+
+/**
+ * Subprocess-level coverage of the `scripts/generate-docs-spec.ts` entrypoint
+ * — the contract `docs/README.md` documents: the spec YAML is the ONLY thing
+ * on stdout (`> cli_v1_commands.yaml` must yield a clean parseable file), the
+ * version defaults to `latest`, and a `v`-prefixed argument is stripped. The
+ * builder itself is covered in-process by `legacy-docs-spec.unit.test.ts`;
+ * these two spawns pin the argv handling, path resolution, and stdout purity
+ * that direct helper calls cannot.
+ */
+describe("generate-docs-spec.ts entrypoint", () => {
+  function runScript(args: ReadonlyArray<string>): { stdout: string; stderr: string } {
+    const result = Bun.spawnSync(["bun", "scripts/generate-docs-spec.ts", ...args], {
+      cwd: cliRoot,
+    });
+    expect(result.exitCode).toBe(0);
+    return { stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+  }
+
+  it("emits only parseable spec YAML on stdout, defaulting the version to latest", () => {
+    const { stdout, stderr } = runScript([]);
+    expect(stderr).toBe("");
+    const spec = parse(stdout);
+    expect(spec.clispec).toBe("001");
+    expect(spec.info.version).toBe("latest");
+    expect(spec.commands.length).toBeGreaterThanOrEqual(144);
+  }, 30_000);
+
+  it("strips a leading v from the version argument", () => {
+    const { stdout } = runScript(["v2.113.0"]);
+    expect(parse(stdout).info.version).toBe("2.113.0");
+  }, 30_000);
+});

--- a/apps/cli/src/legacy/docs/legacy-docs-introspection.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-introspection.ts
@@ -1,0 +1,119 @@
+import { GlobalFlag } from "effect/unstable/cli";
+import type { Command, Param, Primitive } from "effect/unstable/cli";
+
+/**
+ * `.config.flags`/`.config.arguments` (a command's own declared params),
+ * `.contextConfig.flags` (flags inherited via `Command.withSharedFlags`), and
+ * `.globalFlags` (a command's own declared global flags) are genuinely absent
+ * from the public `Command`/`Command.Any` TypeScript interface — only `name`,
+ * `description`, `shortDescription`, `alias`, `examples`, `subcommands`,
+ * `annotations`, and `hidden` are public — but they exist at runtime
+ * (`internal/command.ts`'s `makeCommand`, via `Object.assign`; that internal
+ * module is not importable — its package.json export map entry is `null` — so
+ * there is no type-safe import to reach for instead).
+ *
+ * A bare `as unknown as` would silently paper over that gap (forbidden by
+ * this repo's typing rules — see `CLAUDE.md`), so this narrows through a
+ * runtime type guard instead, the same `"<field>" in value` shape
+ * `legacy-param-introspection.ts`'s `legacyIsWrappedParam` establishes for
+ * the identical problem. The guard checks the nested arrays consumers
+ * actually dereference, so if a future `effect` version drops or reshapes
+ * one of these fields, `legacyCommandInternals` throws a descriptive error
+ * instead of silently completing against `undefined`.
+ *
+ * `legacy/cli/legacy-complete.ts` keeps its own private equivalents of these
+ * guards — deliberately not hoisted, so the docs generator stays purely
+ * additive over the existing tree.
+ */
+export interface LegacyCommandInternals {
+  readonly config: {
+    readonly flags: ReadonlyArray<Param.AnyFlag>;
+    readonly arguments: ReadonlyArray<Param.AnyArgument>;
+  };
+  readonly contextConfig: { readonly flags: ReadonlyArray<Param.AnyFlag> };
+  readonly globalFlags: ReadonlyArray<GlobalFlag.GlobalFlag<any>>;
+}
+
+function legacyHasCommandInternals(
+  command: Command.Command.Any,
+): command is Command.Command.Any & LegacyCommandInternals {
+  if (!("config" in command && "contextConfig" in command && "globalFlags" in command)) {
+    return false;
+  }
+  const config: unknown = command.config;
+  const contextConfig: unknown = command.contextConfig;
+  const globalFlags: unknown = command.globalFlags;
+  return (
+    typeof config === "object" &&
+    config !== null &&
+    "flags" in config &&
+    Array.isArray(config.flags) &&
+    "arguments" in config &&
+    Array.isArray(config.arguments) &&
+    typeof contextConfig === "object" &&
+    contextConfig !== null &&
+    "flags" in contextConfig &&
+    Array.isArray(contextConfig.flags) &&
+    Array.isArray(globalFlags)
+  );
+}
+
+export function legacyCommandInternals(command: Command.Command.Any): LegacyCommandInternals {
+  if (!legacyHasCommandInternals(command)) {
+    throw new Error(
+      `legacy-docs-introspection.ts: command "${command.name}" is missing the internal config/contextConfig/globalFlags fields tree introspection relies on — effect's Command implementation shape may have changed.`,
+    );
+  }
+  return command;
+}
+
+/** A command's children, flattened across subcommand groups. */
+export function legacyFlattenSubcommands(
+  command: Command.Command.Any,
+): ReadonlyArray<Command.Command.Any> {
+  return command.subcommands.flatMap((group) => group.commands);
+}
+
+/**
+ * A command's user-facing scoped global flag params. `GlobalFlag.Completions`
+ * and `GlobalFlag.LogLevel` are TS-only framework additions with no Go/cobra
+ * equivalent; they are normally only injected via `GlobalFlag.BuiltIns` at
+ * parse time (never stored on a command's own `.globalFlags`), so the filter
+ * is a defensive guard rather than something that changes today's output —
+ * kept explicit so it stays true if that ever changes.
+ */
+export function legacyUserGlobalFlagParams(
+  command: Command.Command.Any,
+): ReadonlyArray<Param.AnyFlag> {
+  return legacyCommandInternals(command)
+    .globalFlags.filter(
+      (entry) => entry !== GlobalFlag.Completions && entry !== GlobalFlag.LogLevel,
+    )
+    .map((entry) => entry.flag);
+}
+
+/**
+ * `Flag.choice`/`Flag.choiceWithValue`'s `choiceKeys` (the valid value set) is
+ * attached to the `Choice`-tagged `Primitive<A>` via `Object.assign` at
+ * runtime (`Primitive.choice`,
+ * `.repos/effect/packages/effect/src/unstable/cli/Primitive.ts`) but carries
+ * an `@internal` JSDoc tag and is absent from the public `Primitive<A>`
+ * interface — the identical gap `LegacyCommandInternals` above works around
+ * for `Command`, so this reuses the same runtime type-guard idiom instead of
+ * an `as` cast.
+ */
+interface LegacyChoicePrimitive {
+  readonly choiceKeys: ReadonlyArray<string>;
+}
+
+function legacyHasChoiceKeys(
+  primitive: Primitive.Primitive<unknown>,
+): primitive is Primitive.Primitive<unknown> & LegacyChoicePrimitive {
+  return "choiceKeys" in primitive;
+}
+
+export function legacyChoiceKeysOf(
+  primitive: Primitive.Primitive<unknown>,
+): ReadonlyArray<string> | undefined {
+  return legacyHasChoiceKeys(primitive) ? primitive.choiceKeys : undefined;
+}

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.content.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.content.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { parse } from "yaml";
+import type { LegacyDocsExample } from "./legacy-docs-spec.ts";
+
+/**
+ * Loads the docs-spec content inputs from `apps/cli/docs/`: the description
+ * overlay markdown under `supabase/` (keyed by docs-relative POSIX path, the
+ * same keys `legacyDocsOverlayPath` produces on every platform) and the
+ * per-command examples from `templates/examples.yaml` (keyed by doc id).
+ * Shared by the generator (`scripts/generate-docs-spec.ts`) and the unit
+ * tests.
+ */
+export interface LegacyDocsContent {
+  readonly overlays: ReadonlyMap<string, string>;
+  readonly examples: Readonly<Record<string, ReadonlyArray<LegacyDocsExample>>>;
+}
+
+export function legacyReadDocsContent(docsDir: string): LegacyDocsContent {
+  const overlays = new Map<string, string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(entryPath);
+      else if (entry.name.endsWith(".md")) {
+        const key = path.relative(docsDir, entryPath).split(path.sep).join("/");
+        overlays.set(key, readFileSync(entryPath, "utf8"));
+      }
+    }
+  };
+  walk(path.join(docsDir, "supabase"));
+
+  const examplesPath = path.join(docsDir, "templates/examples.yaml");
+  return { overlays, examples: legacyParseExamples(parse(readFileSync(examplesPath, "utf8"))) };
+}
+
+/**
+ * Narrows the parsed `examples.yaml` document to its expected shape — a
+ * mapping of doc id to example entries with optional string fields — failing
+ * with the offending doc id instead of letting a malformed file flow into
+ * the published spec.
+ */
+function legacyParseExamples(
+  parsed: unknown,
+): Readonly<Record<string, ReadonlyArray<LegacyDocsExample>>> {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("legacy-docs-spec.content.ts: examples.yaml must be a mapping of doc ids.");
+  }
+  const examples: Record<string, ReadonlyArray<LegacyDocsExample>> = {};
+  for (const [docId, entries] of Object.entries(parsed)) {
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `legacy-docs-spec.content.ts: examples.yaml entry "${docId}" must be a list of examples.`,
+      );
+    }
+    examples[docId] = entries.map((entry, index) => {
+      if (typeof entry !== "object" || entry === null) {
+        throw new Error(
+          `legacy-docs-spec.content.ts: examples.yaml entry "${docId}"[${index}] must be a mapping.`,
+        );
+      }
+      const fields = new Map<string, unknown>(Object.entries(entry));
+      return {
+        ...legacyOptionalString(docId, index, fields, "id"),
+        ...legacyOptionalString(docId, index, fields, "name"),
+        ...legacyOptionalString(docId, index, fields, "code"),
+        ...legacyOptionalString(docId, index, fields, "response"),
+      };
+    });
+  }
+  return examples;
+}
+
+function legacyOptionalString(
+  docId: string,
+  index: number,
+  fields: ReadonlyMap<string, unknown>,
+  field: "id" | "name" | "code" | "response",
+): Partial<Record<"id" | "name" | "code" | "response", string>> {
+  if (!fields.has(field)) return {};
+  const value = fields.get(field);
+  if (typeof value !== "string") {
+    throw new Error(
+      `legacy-docs-spec.content.ts: examples.yaml "${docId}"[${index}].${field} must be a string.`,
+    );
+  }
+  return { [field]: value };
+}

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.content.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.content.ts
@@ -54,12 +54,19 @@ function legacyParseExamples(
       );
     }
     examples[docId] = entries.map((entry, index) => {
-      if (typeof entry !== "object" || entry === null) {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         throw new Error(
           `legacy-docs-spec.content.ts: examples.yaml entry "${docId}"[${index}] must be a mapping.`,
         );
       }
       const fields = new Map<string, unknown>(Object.entries(entry));
+      for (const key of fields.keys()) {
+        if (key !== "id" && key !== "name" && key !== "code" && key !== "response") {
+          throw new Error(
+            `legacy-docs-spec.content.ts: examples.yaml "${docId}"[${index}] has unknown field "${key}" — allowed fields are id, name, code, response.`,
+          );
+        }
+      }
       return {
         ...legacyOptionalString(docId, index, fields, "id"),
         ...legacyOptionalString(docId, index, fields, "name"),

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
@@ -232,6 +232,33 @@ export const LEGACY_DOCS_CHOICE_OVERRIDES: Readonly<Record<string, ReadonlyArray
 };
 
 /**
+ * Flags excluded from the published reference, keyed `"<doc id> <flag id>"`.
+ * Cobra hid deprecated flags from help and docs; the Effect port keeps
+ * `--include-raw-output` parse-visible for compatibility (see
+ * `commands/domains/SIDE_EFFECTS.md`), so the docs exclusion is restored
+ * here. Validated at build time like the other tables.
+ */
+export const LEGACY_DOCS_EXCLUDED_FLAGS: ReadonlySet<string> = new Set([
+  "supabase-domains-activate include-raw-output",
+  "supabase-domains-create include-raw-output",
+  "supabase-domains-delete include-raw-output",
+  "supabase-domains-get include-raw-output",
+  "supabase-domains-reverify include-raw-output",
+]);
+
+/**
+ * Usage argument overrides, keyed by doc id — for commands whose published
+ * argument rendering cannot be derived from the Effect tree. Both were
+ * hand-written cobra `Use` strings: the parser accepts zero occurrences
+ * (`secrets set --env-file` passes no positionals; `storage rm` validates in
+ * the handler), but the documented shape is required.
+ */
+export const LEGACY_DOCS_ARG_OVERRIDES: Readonly<Record<string, string>> = {
+  "supabase-secrets-set": "<NAME=VALUE> ...",
+  "supabase-storage-rm": "<file> ...",
+};
+
+/**
  * Flags rendered with a Required badge on the docs site, keyed
  * `"<doc id> <flag id>"`. Effect optionality cannot express this — several
  * of these TS flags are intentionally `Flag.optional` at parse time for

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
@@ -1,0 +1,250 @@
+import type { LegacyDocsFlag } from "./legacy-docs-spec.ts";
+
+/**
+ * Static data for the docs spec generator — information the Effect command
+ * tree cannot express structurally:
+ *
+ * - Docs-site section tags: envelope compatibility only (the site's
+ *   navigation comes from `common-cli-sections.json`, not from tags).
+ * - Experimental leaves: each appends the root `--experimental` flag with
+ *   `required: true` to its flag list.
+ * - Deprecated commands: visible in `--help` (with a "(deprecated)" suffix)
+ *   but excluded from the published reference.
+ * - Flag defaults: `Flag.withDefault` captures the value in a closure
+ *   (`Param.ts`: `map(optional(self), Option.getOrElse(...))`), so defaults
+ *   that differ from the type's zero value are recorded here, keyed
+ *   `"<doc id> <flag id>"`.
+ *
+ * The values were frozen from the retired Go generator's output when the
+ * pipeline was re-pointed at the TS tree, and every entry was verified
+ * against it while both generators coexisted.
+ * Flag display types derive purely from the Effect tree — Go-only scalar
+ * typing (uint/duration/time) was deliberately not ported, so the reference
+ * shows the TS types `--help` shows.
+ * `legacyBuildDocsSpec` validates every key here against the walked tree and
+ * fails the build on stale entries.
+ */
+
+export interface LegacyDocsInfoTag {
+  readonly id: string;
+  readonly title: string;
+}
+
+export const LEGACY_DOCS_INFO_TAGS: ReadonlyArray<LegacyDocsInfoTag> = [
+  { id: "quick-start", title: "Quick Start" },
+  { id: "local-dev", title: "Local Development" },
+  { id: "management-api", title: "Management APIs" },
+  { id: "other-commands", title: "Additional Commands" },
+];
+
+/** Docs-site section tag per top-level command. */
+export const LEGACY_DOCS_TAGS: Readonly<Record<string, ReadonlyArray<string>>> = {
+  "supabase-bootstrap": ["quick-start"],
+  "supabase-backups": ["management-api"],
+  "supabase-branches": ["management-api"],
+  "supabase-completion": ["other-commands"],
+  "supabase-config": ["management-api"],
+  "supabase-db": ["local-dev"],
+  "supabase-domains": ["management-api"],
+  "supabase-encryption": ["management-api"],
+  "supabase-functions": ["management-api"],
+  "supabase-gen": ["local-dev"],
+  "supabase-init": ["local-dev"],
+  "supabase-inspect": ["local-dev"],
+  "supabase-issue": ["other-commands"],
+  "supabase-link": ["local-dev"],
+  "supabase-login": ["local-dev"],
+  "supabase-logout": ["local-dev"],
+  "supabase-migration": ["local-dev"],
+  "supabase-network-bans": ["management-api"],
+  "supabase-network-restrictions": ["management-api"],
+  "supabase-orgs": ["management-api"],
+  "supabase-postgres-config": ["management-api"],
+  "supabase-projects": ["management-api"],
+  "supabase-secrets": ["management-api"],
+  "supabase-seed": ["local-dev"],
+  "supabase-services": ["local-dev"],
+  "supabase-snippets": ["management-api"],
+  "supabase-ssl-enforcement": ["management-api"],
+  "supabase-sso": ["management-api"],
+  "supabase-start": ["local-dev"],
+  "supabase-status": ["local-dev"],
+  "supabase-stop": ["local-dev"],
+  "supabase-storage": ["management-api"],
+  "supabase-telemetry": ["local-dev"],
+  "supabase-test": ["local-dev"],
+  "supabase-unlink": ["local-dev"],
+  "supabase-vanity-subdomains": ["management-api"],
+};
+
+/** Leaves that require `--experimental`. */
+export const LEGACY_DOCS_EXPERIMENTAL: ReadonlySet<string> = new Set([
+  "supabase-network-bans-get",
+  "supabase-network-bans-remove",
+  "supabase-network-restrictions-get",
+  "supabase-network-restrictions-update",
+  "supabase-postgres-config-delete",
+  "supabase-postgres-config-get",
+  "supabase-postgres-config-update",
+  "supabase-ssl-enforcement-get",
+  "supabase-ssl-enforcement-update",
+  "supabase-storage-cp",
+  "supabase-storage-ls",
+  "supabase-storage-mv",
+  "supabase-storage-rm",
+  "supabase-vanity-subdomains-activate",
+  "supabase-vanity-subdomains-check-availability",
+  "supabase-vanity-subdomains-delete",
+  "supabase-vanity-subdomains-get",
+]);
+
+/**
+ * Leaves gated on `--experimental` OR `[experimental.pgdelta] enabled = true`
+ * in config.toml — the flag is documented but not marked required, since the
+ * config path also passes the gate.
+ */
+export const LEGACY_DOCS_EXPERIMENTAL_OPTIONAL: ReadonlySet<string> = new Set([
+  "supabase-db-schema-declarative-generate",
+  "supabase-db-schema-declarative-sync",
+]);
+
+/**
+ * Deprecated commands: kept visible in `--help` (with a "(deprecated)"
+ * suffix) but excluded from the published reference.
+ */
+export const LEGACY_DOCS_EXCLUDED: ReadonlySet<string> = new Set([
+  "supabase-gen-keys",
+  "supabase-inspect-db-cache-hit",
+  "supabase-inspect-db-index-sizes",
+  "supabase-inspect-db-index-usage",
+  "supabase-inspect-db-role-configs",
+  "supabase-inspect-db-role-connections",
+  "supabase-inspect-db-seq-scans",
+  "supabase-inspect-db-table-index-sizes",
+  "supabase-inspect-db-table-record-counts",
+  "supabase-inspect-db-table-sizes",
+  "supabase-inspect-db-total-index-size",
+  "supabase-inspect-db-total-table-sizes",
+  "supabase-inspect-db-unused-indexes",
+]);
+
+/**
+ * Flag defaults that differ from the primitive type's zero value, keyed
+ * `"<doc id> <flag id>"` (root global flags use doc id `supabase`). TS-only
+ * flags add entries by hand.
+ */
+export const LEGACY_DOCS_DEFAULT_OVERRIDES: Readonly<Record<string, string>> = {
+  "supabase agent": "auto",
+  "supabase dns-resolver": "native",
+  "supabase output": "pretty",
+  "supabase output-format": "text",
+  "supabase profile": "supabase",
+  "supabase-db-advisors fail-on": "none",
+  "supabase-db-advisors level": "warn",
+  "supabase-db-advisors local": "true",
+  "supabase-db-advisors type": "all",
+  "supabase-db-diff local": "true",
+  "supabase-db-diff use-migra": "true",
+  "supabase-db-dump linked": "true",
+  "supabase-db-lint fail-on": "none",
+  "supabase-db-lint level": "warning",
+  "supabase-db-lint local": "true",
+  "supabase-db-pull diff-engine": "migra",
+  "supabase-db-pull linked": "true",
+  "supabase-db-push linked": "true",
+  "supabase-db-query local": "true",
+  "supabase-db-reset local": "true",
+  "supabase-db-schema-declarative-sync file": "declarative_sync",
+  "supabase-functions-deploy jobs": "1",
+  "supabase-functions-new auth": "apikey",
+  "supabase-gen-bearer-jwt payload": "{}",
+  "supabase-gen-bearer-jwt sub": "anonymous",
+  "supabase-gen-bearer-jwt valid-for": "30m0s",
+  "supabase-gen-signing-key algorithm": "ES256",
+  "supabase-gen-types lang": "typescript",
+  "supabase-gen-types query-timeout": "15s",
+  "supabase-gen-types swift-access-control": "internal",
+  "supabase-inspect-db-bloat linked": "true",
+  "supabase-inspect-db-blocking linked": "true",
+  "supabase-inspect-db-calls linked": "true",
+  "supabase-inspect-db-db-stats linked": "true",
+  "supabase-inspect-db-index-stats linked": "true",
+  "supabase-inspect-db-locks linked": "true",
+  "supabase-inspect-db-long-running-queries linked": "true",
+  "supabase-inspect-db-outliers linked": "true",
+  "supabase-inspect-db-replication-slots linked": "true",
+  "supabase-inspect-db-role-stats linked": "true",
+  "supabase-inspect-db-table-stats linked": "true",
+  "supabase-inspect-db-traffic-profile linked": "true",
+  "supabase-inspect-db-vacuum-stats linked": "true",
+  "supabase-inspect-report linked": "true",
+  "supabase-inspect-report output-dir": ".",
+  "supabase-login name": "built-in token name generator",
+  "supabase-migration-down last": "1",
+  "supabase-migration-down local": "true",
+  "supabase-migration-fetch linked": "true",
+  "supabase-migration-list linked": "true",
+  "supabase-migration-repair linked": "true",
+  "supabase-migration-squash local": "true",
+  "supabase-migration-up local": "true",
+  "supabase-seed-buckets local": "true",
+  "supabase-storage-cp cache-control": "max-age=3600",
+  "supabase-storage-cp content-type": "auto-detect",
+  "supabase-storage-cp jobs": "1",
+  "supabase-storage-cp linked": "true",
+  "supabase-storage-ls linked": "true",
+  "supabase-storage-mv linked": "true",
+  "supabase-storage-rm linked": "true",
+  "supabase-test-db local": "true",
+  "supabase-test-new template": "pgtap",
+};
+
+/**
+ * Flag docs injected into specific commands beyond what their Effect config
+ * declares, keyed by doc id. `db query` reuses the global `-o, --output`
+ * choice at parse time (which documents only the globally valid formats), so
+ * its own page documents the query-specific formats here.
+ */
+export const LEGACY_DOCS_EXTRA_FLAGS: Readonly<Record<string, ReadonlyArray<LegacyDocsFlag>>> = {
+  "supabase-db-query": [
+    {
+      id: "output",
+      name: "-o, --output <[ json | table | csv ]>",
+      description: "Output format: table, json, or csv.",
+      default_value: "json",
+      accepted_values: [
+        { id: "json", name: "json", type: "[ json | table | csv ]" },
+        { id: "table", name: "table", type: "[ json | table | csv ]" },
+        { id: "csv", name: "csv", type: "[ json | table | csv ]" },
+      ],
+    },
+  ],
+};
+
+/**
+ * Documented accepted values where the Effect choice union is wider than the
+ * globally valid set, keyed `"<doc id> <flag id>"`. The root `-o, --output`
+ * union includes `table`/`csv` only because `db query` reuses the global
+ * flag; everywhere else the valid formats are the five below.
+ */
+export const LEGACY_DOCS_CHOICE_OVERRIDES: Readonly<Record<string, ReadonlyArray<string>>> = {
+  "supabase output": ["env", "pretty", "json", "toml", "yaml"],
+};
+
+/**
+ * Flags rendered with a Required badge on the docs site, keyed
+ * `"<doc id> <flag id>"`. Effect optionality cannot express this — several
+ * of these TS flags are intentionally `Flag.optional` at parse time for
+ * validation-ordering reasons unrelated to required-ness.
+ */
+export const LEGACY_DOCS_REQUIRED: ReadonlySet<string> = new Set([
+  "supabase-domains-create custom-hostname",
+  "supabase-gen-bearer-jwt role",
+  "supabase-migration-repair status",
+  "supabase-sso-add type",
+  "supabase-vanity-subdomains-activate desired-subdomain",
+  "supabase-vanity-subdomains-check-availability desired-subdomain",
+]);
+
+export const LEGACY_DOCS_INFO_DESCRIPTION =
+  "Supabase CLI provides you with tools to develop your application locally, and deploy your application to the Supabase platform.";

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.ts
@@ -1,0 +1,479 @@
+import { Option } from "effect";
+import { stringify } from "yaml";
+import { GlobalFlag } from "effect/unstable/cli";
+import type { Command, Param } from "effect/unstable/cli";
+import {
+  legacyChoiceKeysOf,
+  legacyCommandInternals,
+  legacyFlattenSubcommands,
+  legacyUserGlobalFlagParams,
+} from "./legacy-docs-introspection.ts";
+import { legacyUnwrapParam } from "../shared/legacy-param-introspection.ts";
+import {
+  LEGACY_DOCS_DEFAULT_OVERRIDES,
+  LEGACY_DOCS_CHOICE_OVERRIDES,
+  LEGACY_DOCS_EXCLUDED,
+  LEGACY_DOCS_EXPERIMENTAL,
+  LEGACY_DOCS_EXTRA_FLAGS,
+  LEGACY_DOCS_EXPERIMENTAL_OPTIONAL,
+  LEGACY_DOCS_INFO_DESCRIPTION,
+  LEGACY_DOCS_INFO_TAGS,
+  LEGACY_DOCS_REQUIRED,
+  LEGACY_DOCS_TAGS,
+} from "./legacy-docs-spec.tables.ts";
+import type { LegacyDocsInfoTag } from "./legacy-docs-spec.tables.ts";
+
+/**
+ * Builds the `clispec 001` document consumed by the supabase.com CLI
+ * reference (`supabase/supabase` `apps/docs/spec/cli_v1_commands.yaml`) from
+ * the legacy Effect command tree — replacing the retired Go generator's
+ * cobra walk.
+ *
+ * The semantic contract this preserves (verified against the retired Go
+ * generator's output when the pipeline was re-pointed — all 135 command ids,
+ * titles, subcommand sets, flag sets, defaults and accepted values matched):
+ * command `id` is `CommandPath` with spaces replaced by dashes and is the
+ * public URL slug plus the join key into `common-cli-sections.json`;
+ * `subcommands`, `flags`, `tags`, `links` are always arrays; `default_value`
+ * is always present; flag `name` is a preformatted display string
+ * (`-p, --password <string>`); enum flags carry `accepted_values`;
+ * experimental leaves append the root `--experimental` flag with
+ * `required: true`. Go-yaml serialization quirks (trailing-newline padding of
+ * long strings, reversed command order) are deliberately not reproduced —
+ * every downstream consumer parses the YAML and joins on `id`.
+ *
+ * Every static-table key (`legacy-docs-spec.tables.ts`) is validated
+ * against the walked tree at build
+ * time — a stale entry (after a command or flag rename) fails the build with
+ * the offending keys listed instead of silently degrading the published
+ * reference.
+ */
+
+export interface LegacyDocsExample {
+  readonly id?: string;
+  readonly name?: string;
+  readonly code?: string;
+  readonly response?: string;
+}
+
+export interface LegacyDocsAcceptedValue {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+}
+
+export interface LegacyDocsFlag {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly required?: boolean;
+  readonly default_value: string;
+  readonly accepted_values?: ReadonlyArray<LegacyDocsAcceptedValue>;
+}
+
+export interface LegacyDocsCommand {
+  readonly id: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly description: string;
+  readonly examples?: ReadonlyArray<LegacyDocsExample>;
+  readonly tags: ReadonlyArray<string>;
+  readonly links: ReadonlyArray<never>;
+  readonly usage?: string;
+  readonly subcommands: ReadonlyArray<string>;
+  readonly flags: ReadonlyArray<LegacyDocsFlag>;
+}
+
+export interface LegacyDocsInfo {
+  readonly id: string;
+  readonly version: string;
+  readonly title: string;
+  readonly language: string;
+  readonly source: string;
+  readonly bugs: string;
+  readonly spec: string;
+  readonly description: string;
+  readonly tags: ReadonlyArray<LegacyDocsInfoTag>;
+}
+
+export interface LegacyDocsSpec {
+  readonly clispec: string;
+  readonly info: LegacyDocsInfo;
+  readonly flags: ReadonlyArray<LegacyDocsFlag>;
+  readonly commands: ReadonlyArray<LegacyDocsCommand>;
+}
+
+export interface LegacyDocsSpecInput {
+  readonly root: Command.Command.Any;
+  readonly version: string;
+  /** Overlay markdown keyed by docs-relative POSIX path, e.g. `supabase/db/push.md`. */
+  readonly overlays: ReadonlyMap<string, string>;
+  /** Examples keyed by doc id, from `docs/templates/examples.yaml`. */
+  readonly examples: Readonly<Record<string, ReadonlyArray<LegacyDocsExample>>>;
+}
+
+/**
+ * Overlay file path for a command path — the layout contract of
+ * `docs/supabase/`: one directory per word, except paths deeper than three
+ * words flatten the tail into one dash-joined filename
+ * (`supabase inspect db bloat` → `supabase/inspect/db-bloat.md`).
+ */
+export function legacyDocsOverlayPath(commandPath: ReadonlyArray<string>): string {
+  const names =
+    commandPath.length > 3
+      ? [...commandPath.slice(0, 2), commandPath.slice(2).join("-")]
+      : [...commandPath];
+  return `${names.join("/")}.md`;
+}
+
+/**
+ * Every current overlay file's first line is a human heading
+ * (`## supabase-...`) that must not reach the published description; it is
+ * dropped (keeping its trailing newline). A file without a leading heading
+ * keeps its full content rather than silently losing its first line.
+ */
+export function legacyDocsStripOverlayHeading(contents: string): string {
+  if (!contents.startsWith("#")) return contents;
+  const newline = contents.indexOf("\n");
+  return newline === -1 ? "" : contents.slice(newline);
+}
+
+/** Locale-independent byte-wise ordering, so the emitted YAML is machine-independent. */
+function legacyDocsCompare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+const LEGACY_DOCS_ENUM_TYPE_MAX_JOINED_LENGTH = 40;
+
+/**
+ * Enum display type: `[ a | b ]` while the joined value list stays under 40
+ * characters, otherwise plain `string` — rendered inside `<...>` in the flag
+ * name and repeated on each accepted value.
+ */
+function legacyDocsEnumTypeString(choices: ReadonlyArray<string>): string {
+  const joined = choices.join(" | ");
+  return joined.length < LEGACY_DOCS_ENUM_TYPE_MAX_JOINED_LENGTH ? `[ ${joined} ]` : "string";
+}
+
+function legacyDocsPrimitiveVarname(
+  single: Param.Single<Param.ParamKind, unknown>,
+  isVariadic: boolean,
+): string | undefined {
+  if (single.typeName !== undefined) return single.typeName;
+  switch (single.primitiveType._tag) {
+    case "Boolean":
+      return undefined;
+    case "Integer":
+      return "int";
+    case "Float":
+      return "float";
+    case "Date":
+      return "time";
+    default:
+      return isVariadic ? "strings" : "string";
+  }
+}
+
+function legacyDocsTypeDefault(
+  single: Param.Single<Param.ParamKind, unknown>,
+  isVariadic: boolean,
+): string {
+  if (single.primitiveType._tag === "Boolean") return "false";
+  if (isVariadic) return "[]";
+  if (single.primitiveType._tag === "Integer" || single.primitiveType._tag === "Float") return "0";
+  return "";
+}
+
+function legacyDocsFlagDoc(
+  commandPath: ReadonlyArray<string>,
+  param: Param.AnyFlag,
+): LegacyDocsFlag | undefined {
+  const unwrapped = legacyUnwrapParam(param);
+  if (unwrapped === undefined) return undefined;
+  const { single, isVariadic } = unwrapped;
+  if (single.hidden) return undefined;
+
+  const docId = commandPath.join("-");
+  const overrideKey = `${docId} ${single.name}`;
+
+  let acceptedValues: ReadonlyArray<LegacyDocsAcceptedValue> | undefined;
+  let enumType: string | undefined;
+  const choices =
+    LEGACY_DOCS_CHOICE_OVERRIDES[overrideKey] ?? legacyChoiceKeysOf(single.primitiveType);
+  if (choices !== undefined) {
+    enumType = legacyDocsEnumTypeString(choices);
+    const type = enumType;
+    acceptedValues = choices.map((value) => ({ id: value, name: value, type }));
+  }
+
+  const varname = enumType ?? legacyDocsPrimitiveVarname(single, isVariadic);
+
+  const shorthand = single.aliases.find((alias) => alias.length === 1);
+  const name = `${shorthand === undefined ? "" : `-${shorthand}, `}--${single.name}${
+    varname === undefined ? "" : ` <${varname}>`
+  }`;
+
+  const required = LEGACY_DOCS_REQUIRED.has(overrideKey);
+
+  return {
+    id: single.name,
+    name,
+    description: Option.getOrElse(single.description, () => ""),
+    ...(required ? { required: true } : {}),
+    default_value:
+      LEGACY_DOCS_DEFAULT_OVERRIDES[overrideKey] ?? legacyDocsTypeDefault(single, isVariadic),
+    ...(acceptedValues === undefined ? {} : { accepted_values: acceptedValues }),
+  };
+}
+
+function legacyDocsArgumentUsage(param: Param.AnyArgument): string | undefined {
+  const unwrapped = legacyUnwrapParam(param);
+  if (unwrapped === undefined) return undefined;
+  const { single, isOptional, isVariadic, variadicMin } = unwrapped;
+  if (single.hidden) return undefined;
+  const optional = isOptional || (isVariadic && variadicMin === 0);
+  const rendered = optional ? `[${single.name}]` : `<${single.name}>`;
+  return isVariadic ? `${rendered} ...` : rendered;
+}
+
+function legacyDocsVisibleChildren(
+  command: Command.Command.Any,
+): ReadonlyArray<Command.Command.Any> {
+  return legacyFlattenSubcommands(command)
+    .filter((child) => !child.hidden)
+    .toSorted((a, b) => legacyDocsCompare(a.name, b.name));
+}
+
+function legacyDocsExamplesFor(
+  docId: string,
+  command: Command.Command.Any,
+  examples: Readonly<Record<string, ReadonlyArray<LegacyDocsExample>>>,
+): ReadonlyArray<LegacyDocsExample> | undefined {
+  const fromYaml = examples[docId];
+  if (fromYaml !== undefined && fromYaml.length > 0) return fromYaml;
+  if (command.examples.length === 0) return undefined;
+  return command.examples.map((example, index) => ({
+    id: `example-${index + 1}`,
+    name: example.description ?? example.command,
+    code: example.command,
+  }));
+}
+
+/** First line of a command's long description, for the listing summary fallback. */
+function legacyDocsSummary(command: Command.Command.Any): string {
+  if (command.shortDescription !== undefined) return command.shortDescription;
+  const description = command.description ?? "";
+  const newline = description.indexOf("\n");
+  return newline === -1 ? description : description.slice(0, newline);
+}
+
+/** The root `--experimental` flag doc injected into experimental leaves. */
+function legacyDocsExperimentalFlag(rootFlags: ReadonlyArray<LegacyDocsFlag>): LegacyDocsFlag {
+  const experimental = rootFlags.find((flag) => flag.id === "experimental");
+  if (experimental === undefined) {
+    throw new Error(
+      "legacy-docs-spec.ts: the root command tree declares no --experimental global flag; the experimental-leaf injection cannot be built.",
+    );
+  }
+  return { ...experimental, required: true };
+}
+
+export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec {
+  const rootPath = ["supabase"];
+  const rootFlagParams: ReadonlyArray<Param.AnyFlag> = [
+    ...legacyUserGlobalFlagParams(input.root),
+    GlobalFlag.Help.flag,
+  ];
+  const rootFlags = rootFlagParams
+    .map((param) => legacyDocsFlagDoc(rootPath, param))
+    .filter((flag) => flag !== undefined)
+    .toSorted((a, b) => legacyDocsCompare(a.id, b.id));
+  const experimentalFlag = legacyDocsExperimentalFlag(rootFlags);
+  const { required: _experimentalRequired, ...experimentalOptionalFlag } = experimentalFlag;
+  const rootFlagIds = new Set(rootFlags.map((flag) => flag.id));
+
+  const commands: Array<LegacyDocsCommand> = [];
+  const emittedIds = new Set<string>();
+  const skippedExcludedIds = new Set<string>();
+  const seenFlagKeys = new Set<string>(rootFlags.map((flag) => `supabase ${flag.id}`));
+
+  const flagDocsFor = (
+    commandPath: ReadonlyArray<string>,
+    params: ReadonlyArray<Param.AnyFlag>,
+  ): ReadonlyArray<LegacyDocsFlag> => {
+    const docId = commandPath.join("-");
+    return params
+      .map((param) => legacyDocsFlagDoc(commandPath, param))
+      .filter((flag) => flag !== undefined)
+      .map((flag) => {
+        seenFlagKeys.add(`${docId} ${flag.id}`);
+        return flag;
+      })
+      .toSorted((a, b) => legacyDocsCompare(a.id, b.id));
+  };
+
+  const visit = (
+    command: Command.Command.Any,
+    commandPath: ReadonlyArray<string>,
+    inheritedParams: ReadonlyArray<Param.AnyFlag>,
+  ): void => {
+    const docId = commandPath.join("-");
+    const children = legacyDocsVisibleChildren(command);
+    const internals = legacyCommandInternals(command);
+    const isLeaf = children.length === 0;
+    emittedIds.add(docId);
+
+    const overlay = input.overlays.get(legacyDocsOverlayPath(commandPath));
+    const description =
+      overlay === undefined ? (command.description ?? "") : legacyDocsStripOverlayHeading(overlay);
+
+    const flags: Array<LegacyDocsFlag> = [];
+    if (isLeaf) {
+      const own = [
+        ...flagDocsFor(commandPath, internals.config.flags),
+        ...(LEGACY_DOCS_EXTRA_FLAGS[docId] ?? []),
+      ].toSorted((a, b) => legacyDocsCompare(a.id, b.id));
+      own.forEach((flag) => seenFlagKeys.add(`${docId} ${flag.id}`));
+      flags.push(...own);
+      if (LEGACY_DOCS_EXPERIMENTAL.has(docId)) flags.push(experimentalFlag);
+      if (LEGACY_DOCS_EXPERIMENTAL_OPTIONAL.has(docId)) flags.push(experimentalOptionalFlag);
+      const ownIds = new Set(own.map((flag) => flag.id));
+      const inherited = flagDocsFor(commandPath, inheritedParams).filter(
+        (flag) => !ownIds.has(flag.id) && !rootFlagIds.has(flag.id),
+      );
+      flags.push(...inherited);
+    }
+
+    let usage: string | undefined;
+    if (isLeaf) {
+      const argUsages = internals.config.arguments
+        .map(legacyDocsArgumentUsage)
+        .filter((part) => part !== undefined);
+      usage = [...commandPath, ...argUsages, "[flags]"].join(" ");
+    }
+
+    const tags = LEGACY_DOCS_TAGS[docId];
+    if (tags === undefined && commandPath.length === 2) {
+      throw new Error(
+        `legacy-docs-spec.ts: top-level command "${docId}" has no LEGACY_DOCS_TAGS entry — add its docs-site section tag (or "other-commands") to legacy-docs-spec.tables.ts.`,
+      );
+    }
+
+    const commandExamples = legacyDocsExamplesFor(docId, command, input.examples);
+
+    commands.push({
+      id: docId,
+      title: commandPath.join(" "),
+      summary: legacyDocsSummary(command),
+      description,
+      ...(commandExamples === undefined ? {} : { examples: commandExamples }),
+      tags: tags ?? [],
+      links: [],
+      ...(usage === undefined ? {} : { usage }),
+      subcommands: children
+        .map((child) => [...commandPath, child.name].join("-"))
+        .filter((childId) => !LEGACY_DOCS_EXCLUDED.has(childId)),
+      flags,
+    });
+
+    // A non-root command's scoped global flags (`Command.withGlobalFlags`
+    // below root, e.g. `seed`'s `--linked`/`--local`) behave like persistent
+    // flags: the reference surfaces them on every leaf beneath the command,
+    // alongside shared (`contextConfig`) flags.
+    const childInherited = [
+      ...inheritedParams,
+      ...internals.contextConfig.flags,
+      ...legacyUserGlobalFlagParams(command),
+    ];
+    for (const child of children) {
+      const childPath = [...commandPath, child.name];
+      const childId = childPath.join("-");
+      if (LEGACY_DOCS_EXCLUDED.has(childId)) {
+        skippedExcludedIds.add(childId);
+        continue;
+      }
+      visit(child, childPath, childInherited);
+    }
+  };
+
+  for (const child of legacyDocsVisibleChildren(input.root)) {
+    const childPath = ["supabase", child.name];
+    const childId = childPath.join("-");
+    if (LEGACY_DOCS_EXCLUDED.has(childId)) {
+      skippedExcludedIds.add(childId);
+      continue;
+    }
+    visit(child, childPath, []);
+  }
+
+  legacyValidateDocsTables({ emittedIds, skippedExcludedIds, seenFlagKeys });
+
+  return {
+    clispec: "001",
+    info: {
+      id: "cli",
+      version: input.version,
+      title: "Supabase CLI",
+      language: "sh",
+      source: "https://github.com/supabase/cli",
+      bugs: "https://github.com/supabase/cli/issues",
+      spec: "https://github.com/supabase/spec/cli_v1_commands.yaml",
+      description: LEGACY_DOCS_INFO_DESCRIPTION,
+      tags: LEGACY_DOCS_INFO_TAGS,
+    },
+    flags: rootFlags,
+    commands,
+  };
+}
+
+/**
+ * Serializes the spec for publication. Emitted under YAML 1.1 quoting rules
+ * so scalars like `yes`/`no` stay strings for downstream YAML 1.1 parsers
+ * (PyYAML, Psych, go-yaml v2); the output remains equally valid YAML 1.2.
+ */
+export function legacyStringifyDocsSpec(spec: LegacyDocsSpec): string {
+  return stringify(spec, { indent: 2, lineWidth: 0, version: "1.1" });
+}
+
+/**
+ * Fails the build when any static-table key no longer resolves against the
+ * walked tree — the guard that keeps the frozen tables honest after a
+ * command or flag rename, since nothing else cross-checks them once the Go
+ * generator is gone.
+ */
+function legacyValidateDocsTables(seen: {
+  readonly emittedIds: ReadonlySet<string>;
+  readonly skippedExcludedIds: ReadonlySet<string>;
+  readonly seenFlagKeys: ReadonlySet<string>;
+}): void {
+  const stale: Array<string> = [];
+  for (const key of Object.keys(LEGACY_DOCS_DEFAULT_OVERRIDES)) {
+    if (!seen.seenFlagKeys.has(key)) stale.push(`LEGACY_DOCS_DEFAULT_OVERRIDES: "${key}"`);
+  }
+  for (const id of Object.keys(LEGACY_DOCS_TAGS)) {
+    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_TAGS: "${id}"`);
+  }
+  for (const id of LEGACY_DOCS_EXPERIMENTAL) {
+    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXPERIMENTAL: "${id}"`);
+  }
+  for (const id of LEGACY_DOCS_EXPERIMENTAL_OPTIONAL) {
+    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXPERIMENTAL_OPTIONAL: "${id}"`);
+  }
+  for (const key of Object.keys(LEGACY_DOCS_CHOICE_OVERRIDES)) {
+    if (!seen.seenFlagKeys.has(key)) stale.push(`LEGACY_DOCS_CHOICE_OVERRIDES: "${key}"`);
+  }
+  for (const id of Object.keys(LEGACY_DOCS_EXTRA_FLAGS)) {
+    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXTRA_FLAGS: "${id}"`);
+  }
+  for (const id of LEGACY_DOCS_EXCLUDED) {
+    if (!seen.skippedExcludedIds.has(id)) stale.push(`LEGACY_DOCS_EXCLUDED: "${id}"`);
+  }
+  for (const key of LEGACY_DOCS_REQUIRED) {
+    if (!seen.seenFlagKeys.has(key)) stale.push(`LEGACY_DOCS_REQUIRED: "${key}"`);
+  }
+  if (stale.length > 0) {
+    throw new Error(
+      `legacy-docs-spec.ts: stale static-table entries no longer resolve against the command tree — fix or remove them:\n  ${stale.join("\n  ")}`,
+    );
+  }
+}

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.ts
@@ -299,7 +299,17 @@ function legacyDocsExperimentalFlag(rootFlags: ReadonlyArray<LegacyDocsFlag>): L
       "legacy-docs-spec.ts: the root command tree declares no --experimental global flag; the experimental-leaf injection cannot be built.",
     );
   }
-  return { ...experimental, required: true };
+  // `required` before `default_value`, matching every other required flag.
+  return {
+    id: experimental.id,
+    name: experimental.name,
+    description: experimental.description,
+    required: true,
+    default_value: experimental.default_value,
+    ...(experimental.accepted_values === undefined
+      ? {}
+      : { accepted_values: experimental.accepted_values }),
+  };
 }
 
 export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec {
@@ -322,6 +332,8 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
   const seenFlagKeys = new Set<string>(rootFlags.map((flag) => `supabase ${flag.id}`));
   const consumedExcludedFlagKeys = new Set<string>();
   const consumedArgOverrideIds = new Set<string>();
+  const consumedExtraFlagIds = new Set<string>();
+  const consumedExperimentalIds = new Set<string>();
   const consumedOverlayPaths = new Set<string>();
   const allowedOrphanOverlayPaths = new Set<string>();
 
@@ -373,14 +385,29 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
     if (isLeaf) {
       const declared = flagDocsFor(commandPath, internals.config.flags);
       const declaredIds = new Set(declared.map((flag) => flag.id));
-      const own = [
-        ...declared,
-        ...(LEGACY_DOCS_EXTRA_FLAGS[docId] ?? []).filter((flag) => !declaredIds.has(flag.id)),
-      ].toSorted((a, b) => legacyDocsCompare(a.id, b.id));
+      const extraFlags = LEGACY_DOCS_EXTRA_FLAGS[docId];
+      if (extraFlags !== undefined) {
+        consumedExtraFlagIds.add(docId);
+        const shadowed = extraFlags.filter((flag) => declaredIds.has(flag.id));
+        if (shadowed.length > 0) {
+          throw new Error(
+            `legacy-docs-spec.ts: LEGACY_DOCS_EXTRA_FLAGS entry "${docId}" is shadowed by declared flag(s) ${shadowed.map((flag) => `--${flag.id}`).join(", ")} — the command now declares the flag itself; remove the stale table entry.`,
+          );
+        }
+      }
+      const own = [...declared, ...(extraFlags ?? [])].toSorted((a, b) =>
+        legacyDocsCompare(a.id, b.id),
+      );
       own.forEach((flag) => seenFlagKeys.add(`${docId} ${flag.id}`));
       flags.push(...own);
-      if (LEGACY_DOCS_EXPERIMENTAL.has(docId)) flags.push(experimentalFlag);
-      if (LEGACY_DOCS_EXPERIMENTAL_OPTIONAL.has(docId)) flags.push(experimentalOptionalFlag);
+      if (LEGACY_DOCS_EXPERIMENTAL.has(docId)) {
+        consumedExperimentalIds.add(docId);
+        flags.push(experimentalFlag);
+      }
+      if (LEGACY_DOCS_EXPERIMENTAL_OPTIONAL.has(docId)) {
+        consumedExperimentalIds.add(docId);
+        flags.push(experimentalOptionalFlag);
+      }
       const ownIds = new Set(own.map((flag) => flag.id));
       const inherited = flagDocsFor(commandPath, inheritedParams).filter(
         (flag) => !ownIds.has(flag.id) && !rootFlagIds.has(flag.id),
@@ -474,6 +501,8 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
     seenFlagKeys,
     consumedExcludedFlagKeys,
     consumedArgOverrideIds,
+    consumedExtraFlagIds,
+    consumedExperimentalIds,
   });
   legacyValidateDocsContent(input, {
     emittedIds,
@@ -529,6 +558,8 @@ function legacyValidateDocsTables(seen: {
   readonly seenFlagKeys: ReadonlySet<string>;
   readonly consumedExcludedFlagKeys: ReadonlySet<string>;
   readonly consumedArgOverrideIds: ReadonlySet<string>;
+  readonly consumedExtraFlagIds: ReadonlySet<string>;
+  readonly consumedExperimentalIds: ReadonlySet<string>;
 }): void {
   const stale: Array<string> = [];
   for (const key of Object.keys(LEGACY_DOCS_DEFAULT_OVERRIDES)) {
@@ -538,16 +569,18 @@ function legacyValidateDocsTables(seen: {
     if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_TAGS: "${id}"`);
   }
   for (const id of LEGACY_DOCS_EXPERIMENTAL) {
-    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXPERIMENTAL: "${id}"`);
+    if (!seen.consumedExperimentalIds.has(id)) stale.push(`LEGACY_DOCS_EXPERIMENTAL: "${id}"`);
   }
   for (const id of LEGACY_DOCS_EXPERIMENTAL_OPTIONAL) {
-    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXPERIMENTAL_OPTIONAL: "${id}"`);
+    if (!seen.consumedExperimentalIds.has(id)) {
+      stale.push(`LEGACY_DOCS_EXPERIMENTAL_OPTIONAL: "${id}"`);
+    }
   }
   for (const key of Object.keys(LEGACY_DOCS_CHOICE_OVERRIDES)) {
     if (!seen.seenFlagKeys.has(key)) stale.push(`LEGACY_DOCS_CHOICE_OVERRIDES: "${key}"`);
   }
   for (const id of Object.keys(LEGACY_DOCS_EXTRA_FLAGS)) {
-    if (!seen.emittedIds.has(id)) stale.push(`LEGACY_DOCS_EXTRA_FLAGS: "${id}"`);
+    if (!seen.consumedExtraFlagIds.has(id)) stale.push(`LEGACY_DOCS_EXTRA_FLAGS: "${id}"`);
   }
   for (const id of LEGACY_DOCS_EXCLUDED) {
     if (!seen.skippedExcludedIds.has(id)) stale.push(`LEGACY_DOCS_EXCLUDED: "${id}"`);

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.ts
@@ -10,12 +10,14 @@ import {
 } from "./legacy-docs-introspection.ts";
 import { legacyUnwrapParam } from "../shared/legacy-param-introspection.ts";
 import {
-  LEGACY_DOCS_DEFAULT_OVERRIDES,
+  LEGACY_DOCS_ARG_OVERRIDES,
   LEGACY_DOCS_CHOICE_OVERRIDES,
+  LEGACY_DOCS_DEFAULT_OVERRIDES,
   LEGACY_DOCS_EXCLUDED,
+  LEGACY_DOCS_EXCLUDED_FLAGS,
   LEGACY_DOCS_EXPERIMENTAL,
-  LEGACY_DOCS_EXTRA_FLAGS,
   LEGACY_DOCS_EXPERIMENTAL_OPTIONAL,
+  LEGACY_DOCS_EXTRA_FLAGS,
   LEGACY_DOCS_INFO_DESCRIPTION,
   LEGACY_DOCS_INFO_TAGS,
   LEGACY_DOCS_REQUIRED,
@@ -29,24 +31,40 @@ import type { LegacyDocsInfoTag } from "./legacy-docs-spec.tables.ts";
  * the legacy Effect command tree — replacing the retired Go generator's
  * cobra walk.
  *
- * The semantic contract this preserves (verified against the retired Go
- * generator's output when the pipeline was re-pointed — all 135 command ids,
- * titles, subcommand sets, flag sets, defaults and accepted values matched):
- * command `id` is `CommandPath` with spaces replaced by dashes and is the
- * public URL slug plus the join key into `common-cli-sections.json`;
- * `subcommands`, `flags`, `tags`, `links` are always arrays; `default_value`
- * is always present; flag `name` is a preformatted display string
- * (`-p, --password <string>`); enum flags carry `accepted_values`;
- * experimental leaves append the root `--experimental` flag with
- * `required: true`. Go-yaml serialization quirks (trailing-newline padding of
- * long strings, reversed command order) are deliberately not reproduced —
- * every downstream consumer parses the YAML and joins on `id`.
+ * The load-bearing contract, verified against the retired Go generator's
+ * output while both coexisted: command `id` is `CommandPath` with spaces
+ * replaced by dashes and is the public URL slug plus the join key into
+ * `common-cli-sections.json`; `subcommands`, `flags`, `tags`, `links` are
+ * always arrays; `default_value` is always present; flag `name` is a
+ * preformatted display string (`-p, --password <string>`); enum flags carry
+ * `accepted_values`; experimental leaves append the root `--experimental`
+ * flag. All 135 Go command ids, titles, subcommand sets, defaults and
+ * accepted values matched; flag sets matched once deprecated flags were
+ * excluded (`LEGACY_DOCS_EXCLUDED_FLAGS`).
  *
- * Every static-table key (`legacy-docs-spec.tables.ts`) is validated
- * against the walked tree at build
- * time — a stale entry (after a command or flag rename) fails the build with
- * the offending keys listed instead of silently degrading the published
- * reference.
+ * Deliberately NOT reproduced from the Go output:
+ * - go-yaml serialization quirks: trailing-newline padding of long strings
+ *   and the reversed command order (consumers parse the YAML and join on
+ *   `id`);
+ * - cobra's `UseLine` rule of appending ` [flags]` only when a command
+ *   declares its own local flags — every leaf here accepts flags, so the
+ *   suffix is emitted on all leaf usage strings;
+ * - cobra's flag ordering where persistent group flags trailed local ones —
+ *   flags that were persistent in cobra are own config flags in the Effect
+ *   tree and sort alphabetically with the rest;
+ * - Go-only scalar display typing (`uint`/`duration`/`time`/`stringArray`) —
+ *   flag types render as the Effect tree (and `--help`) declares them;
+ * - argument labels in usage strings render the Effect tree's names, which
+ *   can differ from Go's hand-written `Use` wording (`[name]` vs
+ *   `[project name]`) and are sometimes more precise (`orgs create <name>`,
+ *   `functions deploy [Function name] ...`);
+ * - TS-only surfaces (commands, flags, examples) are additions by design.
+ *
+ * Every static-table key (`legacy-docs-spec.tables.ts`) and every content
+ * input (description overlays, `examples.yaml` entries) is validated against
+ * the walked tree at build time — a stale entry after a command or flag
+ * rename fails the build with the offending keys listed instead of silently
+ * degrading the published reference.
  */
 
 export interface LegacyDocsExample {
@@ -184,12 +202,26 @@ function legacyDocsTypeDefault(
   return "";
 }
 
+/**
+ * Descriptions may embed tab-indented shell snippets (the completion
+ * family); the published spec has always carried them as four spaces, and
+ * tab indentation can stop rendering as a code block downstream.
+ */
+function legacyDocsNormalizeText(text: string): string {
+  return text.replaceAll("\t", "    ");
+}
+
+/** Doc for a visible flag; `undefined` for hidden flags; throws on an unrecognizable param. */
 function legacyDocsFlagDoc(
   commandPath: ReadonlyArray<string>,
   param: Param.AnyFlag,
 ): LegacyDocsFlag | undefined {
   const unwrapped = legacyUnwrapParam(param);
-  if (unwrapped === undefined) return undefined;
+  if (unwrapped === undefined) {
+    throw new Error(
+      `legacy-docs-spec.ts: a flag on "${commandPath.join(" ")}" wraps an unrecognized Param variant — effect's Param union may have changed; the spec cannot be built without dropping it silently.`,
+    );
+  }
   const { single, isVariadic } = unwrapped;
   if (single.hidden) return undefined;
 
@@ -218,7 +250,7 @@ function legacyDocsFlagDoc(
   return {
     id: single.name,
     name,
-    description: Option.getOrElse(single.description, () => ""),
+    description: legacyDocsNormalizeText(Option.getOrElse(single.description, () => "")),
     ...(required ? { required: true } : {}),
     default_value:
       LEGACY_DOCS_DEFAULT_OVERRIDES[overrideKey] ?? legacyDocsTypeDefault(single, isVariadic),
@@ -226,9 +258,16 @@ function legacyDocsFlagDoc(
   };
 }
 
-function legacyDocsArgumentUsage(param: Param.AnyArgument): string | undefined {
+function legacyDocsArgumentUsage(
+  commandPath: ReadonlyArray<string>,
+  param: Param.AnyArgument,
+): string | undefined {
   const unwrapped = legacyUnwrapParam(param);
-  if (unwrapped === undefined) return undefined;
+  if (unwrapped === undefined) {
+    throw new Error(
+      `legacy-docs-spec.ts: an argument on "${commandPath.join(" ")}" wraps an unrecognized Param variant — effect's Param union may have changed; the spec cannot be built without dropping it silently.`,
+    );
+  }
   const { single, isOptional, isVariadic, variadicMin } = unwrapped;
   if (single.hidden) return undefined;
   const optional = isOptional || (isVariadic && variadicMin === 0);
@@ -242,21 +281,6 @@ function legacyDocsVisibleChildren(
   return legacyFlattenSubcommands(command)
     .filter((child) => !child.hidden)
     .toSorted((a, b) => legacyDocsCompare(a.name, b.name));
-}
-
-function legacyDocsExamplesFor(
-  docId: string,
-  command: Command.Command.Any,
-  examples: Readonly<Record<string, ReadonlyArray<LegacyDocsExample>>>,
-): ReadonlyArray<LegacyDocsExample> | undefined {
-  const fromYaml = examples[docId];
-  if (fromYaml !== undefined && fromYaml.length > 0) return fromYaml;
-  if (command.examples.length === 0) return undefined;
-  return command.examples.map((example, index) => ({
-    id: `example-${index + 1}`,
-    name: example.description ?? example.command,
-    code: example.command,
-  }));
 }
 
 /** First line of a command's long description, for the listing summary fallback. */
@@ -296,7 +320,18 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
   const emittedIds = new Set<string>();
   const skippedExcludedIds = new Set<string>();
   const seenFlagKeys = new Set<string>(rootFlags.map((flag) => `supabase ${flag.id}`));
+  const consumedExcludedFlagKeys = new Set<string>();
+  const consumedArgOverrideIds = new Set<string>();
+  const consumedOverlayPaths = new Set<string>();
+  const allowedOrphanOverlayPaths = new Set<string>();
 
+  /**
+   * Builds the visible flag docs for a command's params, dropping hidden
+   * flags and `LEGACY_DOCS_EXCLUDED_FLAGS` entries (deprecated flags cobra
+   * hid from the reference). Does NOT record `seenFlagKeys` — callers record
+   * only the flags that actually reach the output, so table validation
+   * reflects the published spec, not intermediate candidates.
+   */
   const flagDocsFor = (
     commandPath: ReadonlyArray<string>,
     params: ReadonlyArray<Param.AnyFlag>,
@@ -305,9 +340,13 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
     return params
       .map((param) => legacyDocsFlagDoc(commandPath, param))
       .filter((flag) => flag !== undefined)
-      .map((flag) => {
-        seenFlagKeys.add(`${docId} ${flag.id}`);
-        return flag;
+      .filter((flag) => {
+        const key = `${docId} ${flag.id}`;
+        if (LEGACY_DOCS_EXCLUDED_FLAGS.has(key)) {
+          consumedExcludedFlagKeys.add(key);
+          return false;
+        }
+        return true;
       })
       .toSorted((a, b) => legacyDocsCompare(a.id, b.id));
   };
@@ -323,15 +362,20 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
     const isLeaf = children.length === 0;
     emittedIds.add(docId);
 
-    const overlay = input.overlays.get(legacyDocsOverlayPath(commandPath));
-    const description =
-      overlay === undefined ? (command.description ?? "") : legacyDocsStripOverlayHeading(overlay);
+    const overlayPath = legacyDocsOverlayPath(commandPath);
+    const overlay = input.overlays.get(overlayPath);
+    if (overlay !== undefined) consumedOverlayPaths.add(overlayPath);
+    const description = legacyDocsNormalizeText(
+      overlay === undefined ? (command.description ?? "") : legacyDocsStripOverlayHeading(overlay),
+    );
 
     const flags: Array<LegacyDocsFlag> = [];
     if (isLeaf) {
+      const declared = flagDocsFor(commandPath, internals.config.flags);
+      const declaredIds = new Set(declared.map((flag) => flag.id));
       const own = [
-        ...flagDocsFor(commandPath, internals.config.flags),
-        ...(LEGACY_DOCS_EXTRA_FLAGS[docId] ?? []),
+        ...declared,
+        ...(LEGACY_DOCS_EXTRA_FLAGS[docId] ?? []).filter((flag) => !declaredIds.has(flag.id)),
       ].toSorted((a, b) => legacyDocsCompare(a.id, b.id));
       own.forEach((flag) => seenFlagKeys.add(`${docId} ${flag.id}`));
       flags.push(...own);
@@ -341,14 +385,20 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
       const inherited = flagDocsFor(commandPath, inheritedParams).filter(
         (flag) => !ownIds.has(flag.id) && !rootFlagIds.has(flag.id),
       );
+      inherited.forEach((flag) => seenFlagKeys.add(`${docId} ${flag.id}`));
       flags.push(...inherited);
     }
 
     let usage: string | undefined;
     if (isLeaf) {
-      const argUsages = internals.config.arguments
-        .map(legacyDocsArgumentUsage)
-        .filter((part) => part !== undefined);
+      const argOverride = LEGACY_DOCS_ARG_OVERRIDES[docId];
+      if (argOverride !== undefined) consumedArgOverrideIds.add(docId);
+      const argUsages =
+        argOverride !== undefined
+          ? [argOverride]
+          : internals.config.arguments
+              .map((param) => legacyDocsArgumentUsage(commandPath, param))
+              .filter((part) => part !== undefined);
       usage = [...commandPath, ...argUsages, "[flags]"].join(" ");
     }
 
@@ -359,7 +409,17 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
       );
     }
 
-    const commandExamples = legacyDocsExamplesFor(docId, command, input.examples);
+    const fromYaml = input.examples[docId];
+    const commandExamples =
+      fromYaml !== undefined && fromYaml.length > 0
+        ? fromYaml
+        : command.examples.length > 0
+          ? command.examples.map((example, index) => ({
+              id: `example-${index + 1}`,
+              name: example.description ?? example.command,
+              code: example.command,
+            }))
+          : undefined;
 
     commands.push({
       id: docId,
@@ -390,6 +450,7 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
       const childId = childPath.join("-");
       if (LEGACY_DOCS_EXCLUDED.has(childId)) {
         skippedExcludedIds.add(childId);
+        allowedOrphanOverlayPaths.add(legacyDocsOverlayPath(childPath));
         continue;
       }
       visit(child, childPath, childInherited);
@@ -401,12 +462,25 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
     const childId = childPath.join("-");
     if (LEGACY_DOCS_EXCLUDED.has(childId)) {
       skippedExcludedIds.add(childId);
+      allowedOrphanOverlayPaths.add(legacyDocsOverlayPath(childPath));
       continue;
     }
     visit(child, childPath, []);
   }
 
-  legacyValidateDocsTables({ emittedIds, skippedExcludedIds, seenFlagKeys });
+  legacyValidateDocsTables({
+    emittedIds,
+    skippedExcludedIds,
+    seenFlagKeys,
+    consumedExcludedFlagKeys,
+    consumedArgOverrideIds,
+  });
+  legacyValidateDocsContent(input, {
+    emittedIds,
+    skippedExcludedIds,
+    consumedOverlayPaths,
+    allowedOrphanOverlayPaths,
+  });
 
   return {
     clispec: "001",
@@ -430,9 +504,17 @@ export function legacyBuildDocsSpec(input: LegacyDocsSpecInput): LegacyDocsSpec 
  * Serializes the spec for publication. Emitted under YAML 1.1 quoting rules
  * so scalars like `yes`/`no` stay strings for downstream YAML 1.1 parsers
  * (PyYAML, Psych, go-yaml v2); the output remains equally valid YAML 1.2.
+ * Anchors/aliases are disabled — the injected `--experimental` doc is the
+ * same object on every experimental leaf, and the serializer would otherwise
+ * emit `&a1`/`*a1` references the published file never carried.
  */
 export function legacyStringifyDocsSpec(spec: LegacyDocsSpec): string {
-  return stringify(spec, { indent: 2, lineWidth: 0, version: "1.1" });
+  return stringify(spec, {
+    indent: 2,
+    lineWidth: 0,
+    version: "1.1",
+    aliasDuplicateObjects: false,
+  });
 }
 
 /**
@@ -445,6 +527,8 @@ function legacyValidateDocsTables(seen: {
   readonly emittedIds: ReadonlySet<string>;
   readonly skippedExcludedIds: ReadonlySet<string>;
   readonly seenFlagKeys: ReadonlySet<string>;
+  readonly consumedExcludedFlagKeys: ReadonlySet<string>;
+  readonly consumedArgOverrideIds: ReadonlySet<string>;
 }): void {
   const stale: Array<string> = [];
   for (const key of Object.keys(LEGACY_DOCS_DEFAULT_OVERRIDES)) {
@@ -471,9 +555,51 @@ function legacyValidateDocsTables(seen: {
   for (const key of LEGACY_DOCS_REQUIRED) {
     if (!seen.seenFlagKeys.has(key)) stale.push(`LEGACY_DOCS_REQUIRED: "${key}"`);
   }
+  for (const key of LEGACY_DOCS_EXCLUDED_FLAGS) {
+    if (!seen.consumedExcludedFlagKeys.has(key)) stale.push(`LEGACY_DOCS_EXCLUDED_FLAGS: "${key}"`);
+  }
+  for (const id of Object.keys(LEGACY_DOCS_ARG_OVERRIDES)) {
+    if (!seen.consumedArgOverrideIds.has(id)) stale.push(`LEGACY_DOCS_ARG_OVERRIDES: "${id}"`);
+  }
   if (stale.length > 0) {
     throw new Error(
       `legacy-docs-spec.ts: stale static-table entries no longer resolve against the command tree — fix or remove them:\n  ${stale.join("\n  ")}`,
+    );
+  }
+}
+
+/**
+ * Extends the build-fails-on-drift guarantee to the content inputs: an
+ * overlay whose path maps to no walked command, or an `examples.yaml` doc id
+ * matching no emitted command, would otherwise vanish from the published
+ * reference silently (the page falls back to the terse tree description).
+ * Overlays belonging to `LEGACY_DOCS_EXCLUDED` commands are deliberate
+ * orphans (deprecated pages keep their content until the follow-up cleanup)
+ * and stay allowed.
+ */
+function legacyValidateDocsContent(
+  input: LegacyDocsSpecInput,
+  seen: {
+    readonly emittedIds: ReadonlySet<string>;
+    readonly skippedExcludedIds: ReadonlySet<string>;
+    readonly consumedOverlayPaths: ReadonlySet<string>;
+    readonly allowedOrphanOverlayPaths: ReadonlySet<string>;
+  },
+): void {
+  const orphaned: Array<string> = [];
+  for (const path of input.overlays.keys()) {
+    if (!seen.consumedOverlayPaths.has(path) && !seen.allowedOrphanOverlayPaths.has(path)) {
+      orphaned.push(`overlay: "${path}"`);
+    }
+  }
+  for (const docId of Object.keys(input.examples)) {
+    if (!seen.emittedIds.has(docId) && !seen.skippedExcludedIds.has(docId)) {
+      orphaned.push(`examples.yaml: "${docId}"`);
+    }
+  }
+  if (orphaned.length > 0) {
+    throw new Error(
+      `legacy-docs-spec.ts: content inputs match no command in the walked tree — a rename would silently drop them from the published reference:\n  ${orphaned.join("\n  ")}`,
     );
   }
 }

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
@@ -1,0 +1,230 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { legacyRoot } from "../cli/root.ts";
+import { legacyReadDocsContent } from "./legacy-docs-spec.content.ts";
+import {
+  legacyBuildDocsSpec,
+  legacyDocsOverlayPath,
+  legacyDocsStripOverlayHeading,
+  legacyStringifyDocsSpec,
+} from "./legacy-docs-spec.ts";
+import type { LegacyDocsCommand } from "./legacy-docs-spec.ts";
+import { LEGACY_DOCS_EXCLUDED } from "./legacy-docs-spec.tables.ts";
+
+interface LegacyBuiltSpecFixture {
+  readonly content: ReturnType<typeof legacyReadDocsContent>;
+  readonly spec: ReturnType<typeof legacyBuildDocsSpec>;
+  readonly byId: ReadonlyMap<string, LegacyDocsCommand>;
+}
+
+let legacyBuiltSpecCache: LegacyBuiltSpecFixture | undefined;
+
+/** Lazily built once, so runs filtered to the pure helpers skip the tree walk and disk reads. */
+function legacyBuiltSpec(): LegacyBuiltSpecFixture {
+  if (legacyBuiltSpecCache === undefined) {
+    const content = legacyReadDocsContent(path.resolve(import.meta.dirname, "../../../docs"));
+    const spec = legacyBuildDocsSpec({
+      root: legacyRoot,
+      version: "1.2.3",
+      overlays: content.overlays,
+      examples: content.examples,
+    });
+    legacyBuiltSpecCache = {
+      content,
+      spec,
+      byId: new Map(spec.commands.map((command) => [command.id, command])),
+    };
+  }
+  return legacyBuiltSpecCache;
+}
+
+describe("legacyDocsOverlayPath", () => {
+  it("maps shallow command paths one directory per word", () => {
+    expect(legacyDocsOverlayPath(["supabase", "link"])).toBe("supabase/link.md");
+    expect(legacyDocsOverlayPath(["supabase", "db", "push"])).toBe("supabase/db/push.md");
+  });
+
+  it("flattens paths deeper than three words into a dash-joined tail", () => {
+    expect(legacyDocsOverlayPath(["supabase", "inspect", "db", "bloat"])).toBe(
+      "supabase/inspect/db-bloat.md",
+    );
+    expect(legacyDocsOverlayPath(["supabase", "db", "schema", "declarative", "sync"])).toBe(
+      "supabase/db/schema-declarative-sync.md",
+    );
+  });
+});
+
+describe("legacyDocsStripOverlayHeading", () => {
+  it("drops a leading heading line but keeps its newline", () => {
+    expect(legacyDocsStripOverlayHeading("## supabase-link\n\nBody text.\n")).toBe(
+      "\n\nBody text.\n",
+    );
+  });
+
+  it("returns empty for a heading-only file", () => {
+    expect(legacyDocsStripOverlayHeading("## supabase-link")).toBe("");
+  });
+
+  it("keeps content that does not start with a heading", () => {
+    expect(legacyDocsStripOverlayHeading("Creates a resource.\nMore.\n")).toBe(
+      "Creates a resource.\nMore.\n",
+    );
+  });
+});
+
+describe("legacyBuildDocsSpec", () => {
+  it("emits the clispec envelope with the requested version", () => {
+    const { spec } = legacyBuiltSpec();
+    expect(spec.clispec).toBe("001");
+    expect(spec.info.id).toBe("cli");
+    expect(spec.info.version).toBe("1.2.3");
+    expect(spec.info.tags.map((tag) => tag.id)).toEqual([
+      "quick-start",
+      "local-dev",
+      "management-api",
+      "other-commands",
+    ]);
+  });
+
+  it("keeps every load-bearing per-command field shape", () => {
+    const { spec } = legacyBuiltSpec();
+    for (const command of spec.commands) {
+      expect(command.id).toBe(command.title.replaceAll(" ", "-"));
+      expect(Array.isArray(command.tags)).toBe(true);
+      expect(Array.isArray(command.links)).toBe(true);
+      expect(Array.isArray(command.subcommands)).toBe(true);
+      expect(Array.isArray(command.flags)).toBe(true);
+      for (const flag of command.flags) {
+        expect(typeof flag.default_value).toBe("string");
+        expect(flag.name.includes(`--${flag.id}`)).toBe(true);
+      }
+    }
+  });
+
+  it("excludes Go-deprecated commands from the spec and from subcommand lists", () => {
+    const { byId } = legacyBuiltSpec();
+    for (const excluded of LEGACY_DOCS_EXCLUDED) {
+      expect(byId.has(excluded)).toBe(false);
+    }
+    expect(byId.get("supabase-gen")?.subcommands).not.toContain("supabase-gen-keys");
+    expect(byId.get("supabase-inspect-db")?.subcommands).not.toContain(
+      "supabase-inspect-db-cache-hit",
+    );
+  });
+
+  it("includes the TS-only completion and issue families", () => {
+    const { byId } = legacyBuiltSpec();
+    expect(byId.get("supabase-completion")?.subcommands).toContain("supabase-completion-zsh");
+    expect(byId.get("supabase-issue")?.tags).toEqual(["other-commands"]);
+  });
+
+  it("renders link with its overlay description and flag display names", () => {
+    const { byId, content } = legacyBuiltSpec();
+    const link = byId.get("supabase-link");
+    expect(link).toBeDefined();
+    expect(link?.tags).toEqual(["local-dev"]);
+    expect(link?.usage).toBe("supabase link [flags]");
+    expect(link?.flags.map((flag) => flag.id)).toEqual(["password", "project-ref", "skip-pooler"]);
+    expect(link?.flags.find((flag) => flag.id === "password")?.name).toBe(
+      "-p, --password <string>",
+    );
+    expect(link?.description).toBe(
+      legacyDocsStripOverlayHeading(content.overlays.get("supabase/link.md") ?? ""),
+    );
+  });
+
+  it("injects the required --experimental flag into experimental leaves only", () => {
+    const { byId } = legacyBuiltSpec();
+    const storageLs = byId.get("supabase-storage-ls");
+    const experimental = storageLs?.flags.find((flag) => flag.id === "experimental");
+    expect(experimental).toMatchObject({ required: true, default_value: "false" });
+    expect(byId.get("supabase-db-push")?.flags.some((flag) => flag.id === "experimental")).toBe(
+      false,
+    );
+    const declarativeSync = byId
+      .get("supabase-db-schema-declarative-sync")
+      ?.flags.find((flag) => flag.id === "experimental");
+    expect(declarativeSync).toBeDefined();
+    expect(declarativeSync?.required).toBeUndefined();
+  });
+
+  it("emits enum flags with accepted_values and defaults", () => {
+    const { byId } = legacyBuiltSpec();
+    const algorithm = byId
+      .get("supabase-gen-signing-key")
+      ?.flags.find((flag) => flag.id === "algorithm");
+    expect(algorithm?.name).toBe("--algorithm <[ ES256 | RS256 ]>");
+    expect(algorithm?.default_value).toBe("ES256");
+    expect(algorithm?.accepted_values?.map((value) => value.id)).toEqual(["ES256", "RS256"]);
+  });
+
+  it("marks required flags with a required badge", () => {
+    const { byId } = legacyBuiltSpec();
+    const status = byId
+      .get("supabase-migration-repair")
+      ?.flags.find((flag) => flag.id === "status");
+    expect(status?.required).toBe(true);
+  });
+
+  it("renders flag display types from the Effect tree, matching --help", () => {
+    const { byId } = legacyBuiltSpec();
+    const jobs = byId.get("supabase-functions-deploy")?.flags.find((flag) => flag.id === "jobs");
+    expect(jobs?.name).toBe("-j, --jobs <int>");
+    const validFor = byId
+      .get("supabase-gen-bearer-jwt")
+      ?.flags.find((flag) => flag.id === "valid-for");
+    expect(validFor?.name).toBe("--valid-for <string>");
+  });
+
+  it("keeps flags off group commands but always as an array", () => {
+    const { byId } = legacyBuiltSpec();
+    const db = byId.get("supabase-db");
+    expect(db?.flags).toEqual([]);
+    expect(db?.usage).toBeUndefined();
+    expect(db?.subcommands).toContain("supabase-db-push");
+  });
+
+  it("sources examples from examples.yaml, falling back to Command.withExamples", () => {
+    const { byId } = legacyBuiltSpec();
+    const initExamples = byId.get("supabase-init")?.examples;
+    expect(initExamples?.[0]).toMatchObject({ id: "basic-usage", code: "supabase init" });
+    const snippetsExamples = byId.get("supabase-snippets-list")?.examples;
+    expect(snippetsExamples?.length).toBeGreaterThan(0);
+    expect(snippetsExamples?.[0]?.id).toBe("example-1");
+    expect(snippetsExamples?.[0]?.response).toBeUndefined();
+  });
+
+  it("documents db query's output formats via the injected flag", () => {
+    const { byId } = legacyBuiltSpec();
+    const output = byId.get("supabase-db-query")?.flags.find((flag) => flag.id === "output");
+    expect(output?.name).toBe("-o, --output <[ json | table | csv ]>");
+    expect(output?.default_value).toBe("json");
+    expect(output?.accepted_values?.map((value) => value.id)).toEqual(["json", "table", "csv"]);
+  });
+
+  it("quotes YAML 1.1 boolean-like scalars in the serialized spec", () => {
+    const { spec } = legacyBuiltSpec();
+    const yaml = legacyStringifyDocsSpec(spec);
+    expect(yaml).toContain('id: "yes"');
+    expect(yaml).not.toMatch(/^\s+- id: yes$/m);
+  });
+
+  it("exposes the root global flags including the TS-only --output-format", () => {
+    const { spec } = legacyBuiltSpec();
+    const rootFlagIds = spec.flags.map((flag) => flag.id);
+    expect(rootFlagIds).toContain("help");
+    expect(rootFlagIds).toContain("experimental");
+    expect(rootFlagIds).toContain("output-format");
+    const output = spec.flags.find((flag) => flag.id === "output");
+    expect(output?.default_value).toBe("pretty");
+    expect(output?.accepted_values?.map((value) => value.id)).toEqual([
+      "env",
+      "pretty",
+      "json",
+      "toml",
+      "yaml",
+    ]);
+    expect(spec.flags.find((flag) => flag.id === "output-format")?.default_value).toBe("text");
+  });
+});

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Command } from "effect/unstable/cli";
+import { Command, Flag } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 
 import { LegacyExperimentalFlag } from "../../shared/legacy/global-flags.ts";
@@ -129,7 +129,7 @@ describe("legacyBuildDocsSpec", () => {
     const link = byId.get("supabase-link");
     expect(link).toBeDefined();
     expect(link?.tags).toEqual(["local-dev"]);
-    expect(link?.usage).toBe("supabase link [flags]");
+    expect(link?.usage).toBe("supabase link [ref-or-branch] [flags]");
     expect(link?.flags.map((flag) => flag.id)).toEqual(["password", "project-ref", "skip-pooler"]);
     expect(link?.flags.find((flag) => flag.id === "password")?.name).toBe(
       "-p, --password <string>",
@@ -144,6 +144,13 @@ describe("legacyBuildDocsSpec", () => {
     const storageLs = byId.get("supabase-storage-ls");
     const experimental = storageLs?.flags.find((flag) => flag.id === "experimental");
     expect(experimental).toMatchObject({ required: true, default_value: "false" });
+    expect(Object.keys(experimental ?? {})).toEqual([
+      "id",
+      "name",
+      "description",
+      "required",
+      "default_value",
+    ]);
     expect(byId.get("supabase-db-push")?.flags.some((flag) => flag.id === "experimental")).toBe(
       false,
     );
@@ -303,7 +310,21 @@ describe("build guards fail loudly", () => {
       Command.withGlobalFlags([LegacyExperimentalFlag]),
     );
     expect(() => legacyBuildDocsSpec({ root, ...emptyInput })).toThrow(
-      /stale static-table entries[^]*LEGACY_DOCS_EXPERIMENTAL/,
+      /stale static-table entries[^]*LEGACY_DOCS_EXPERIMENTAL[^]*LEGACY_DOCS_EXTRA_FLAGS/,
+    );
+  });
+
+  it("throws when a declared flag shadows an extra-flags table entry", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withSubcommands([
+        Command.make("db").pipe(
+          Command.withSubcommands([Command.make("query", { output: Flag.string("output") })]),
+        ),
+      ]),
+      Command.withGlobalFlags([LegacyExperimentalFlag]),
+    );
+    expect(() => legacyBuildDocsSpec({ root, ...emptyInput })).toThrow(
+      /LEGACY_DOCS_EXTRA_FLAGS entry "supabase-db-query" is shadowed by declared flag\(s\) --output/,
     );
   });
 

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.unit.test.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { Command } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
+
+import { LegacyExperimentalFlag } from "../../shared/legacy/global-flags.ts";
 
 import { legacyRoot } from "../cli/root.ts";
 import { legacyReadDocsContent } from "./legacy-docs-spec.content.ts";
@@ -10,7 +15,7 @@ import {
   legacyStringifyDocsSpec,
 } from "./legacy-docs-spec.ts";
 import type { LegacyDocsCommand } from "./legacy-docs-spec.ts";
-import { LEGACY_DOCS_EXCLUDED } from "./legacy-docs-spec.tables.ts";
+import { LEGACY_DOCS_EXCLUDED, LEGACY_DOCS_EXPERIMENTAL } from "./legacy-docs-spec.tables.ts";
 
 interface LegacyBuiltSpecFixture {
   readonly content: ReturnType<typeof legacyReadDocsContent>;
@@ -226,5 +231,174 @@ describe("legacyBuildDocsSpec", () => {
       "yaml",
     ]);
     expect(spec.flags.find((flag) => flag.id === "output-format")?.default_value).toBe("text");
+  });
+});
+
+describe("review fixes stay fixed", () => {
+  it("excludes the deprecated --include-raw-output from every domains page", () => {
+    const { spec, byId } = legacyBuiltSpec();
+    for (const command of spec.commands) {
+      expect(
+        command.flags.some((flag) => flag.id === "include-raw-output"),
+        `${command.id} publishes include-raw-output`,
+      ).toBe(false);
+    }
+    expect(byId.get("supabase-domains-get")?.flags.map((flag) => flag.id)).toContain("project-ref");
+  });
+
+  it("renders required variadic usage from the override table", () => {
+    const { byId } = legacyBuiltSpec();
+    expect(byId.get("supabase-storage-rm")?.usage).toBe("supabase storage rm <file> ... [flags]");
+    expect(byId.get("supabase-secrets-set")?.usage).toBe(
+      "supabase secrets set <NAME=VALUE> ... [flags]",
+    );
+  });
+
+  it("normalizes tabs to four spaces in descriptions", () => {
+    const { spec } = legacyBuiltSpec();
+    for (const command of spec.commands) {
+      expect(command.description.includes("\t"), `${command.id} description has a tab`).toBe(false);
+      for (const flag of command.flags) {
+        expect(flag.description.includes("\t"), `${command.id} --${flag.id} has a tab`).toBe(false);
+      }
+    }
+    expect(byIdDescription("supabase-completion-bash")).toContain("    source <(");
+  });
+
+  it("serializes without YAML anchors or aliases", () => {
+    const { spec } = legacyBuiltSpec();
+    const yaml = legacyStringifyDocsSpec(spec);
+    expect(yaml).not.toMatch(/&a\d+/);
+    expect(yaml).not.toMatch(/\*a\d+/);
+  });
+});
+
+function byIdDescription(id: string): string {
+  const command = legacyBuiltSpec().byId.get(id);
+  if (command === undefined) throw new Error(`no command ${id}`);
+  return command.description;
+}
+
+describe("build guards fail loudly", () => {
+  const emptyInput = { version: "0", overlays: new Map<string, string>(), examples: {} };
+
+  it("throws when the root declares no --experimental global flag", () => {
+    const root = Command.make("supabase").pipe(Command.withSubcommands([Command.make("link")]));
+    expect(() => legacyBuildDocsSpec({ root, ...emptyInput })).toThrow(
+      /no --experimental global flag/,
+    );
+  });
+
+  it("throws for a top-level command without a docs section tag", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withSubcommands([Command.make("not-a-real-command")]),
+      Command.withGlobalFlags([LegacyExperimentalFlag]),
+    );
+    expect(() => legacyBuildDocsSpec({ root, ...emptyInput })).toThrow(/no LEGACY_DOCS_TAGS entry/);
+  });
+
+  it("throws listing stale static-table entries for a shrunken tree", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withSubcommands([Command.make("link")]),
+      Command.withGlobalFlags([LegacyExperimentalFlag]),
+    );
+    expect(() => legacyBuildDocsSpec({ root, ...emptyInput })).toThrow(
+      /stale static-table entries[^]*LEGACY_DOCS_EXPERIMENTAL/,
+    );
+  });
+
+  it("throws for orphaned overlays and examples keys", () => {
+    const root = Command.make("supabase").pipe(
+      Command.withSubcommands([Command.make("link")]),
+      Command.withGlobalFlags([LegacyExperimentalFlag]),
+    );
+    const overlays = new Map([["supabase/lonk.md", "## x\n\nBody.\n"]]);
+    const build = () =>
+      legacyBuildDocsSpec({
+        root,
+        version: "0",
+        overlays,
+        examples: { "supabase-lonk": [{ id: "a", code: "x" }] },
+      });
+    // the stale-table throw fires first on this synthetic tree; assert the
+    // content guard directly by checking its message is reachable when the
+    // table validation is satisfied — covered via the real-tree fixture below.
+    expect(build).toThrow(/stale static-table entries/);
+    const { content } = legacyBuiltSpec();
+    const badExamples = { ...content.examples, "supabase-not-a-command": [{ id: "a" }] };
+    expect(() =>
+      legacyBuildDocsSpec({
+        root: legacyRoot,
+        version: "0",
+        overlays: content.overlays,
+        examples: badExamples,
+      }),
+    ).toThrow(/content inputs match no command[^]*supabase-not-a-command/);
+    const badOverlays = new Map(content.overlays);
+    badOverlays.set("supabase/not-a-real-command.md", "## x\n\nBody.\n");
+    expect(() =>
+      legacyBuildDocsSpec({
+        root: legacyRoot,
+        version: "0",
+        overlays: badOverlays,
+        examples: content.examples,
+      }),
+    ).toThrow(/content inputs match no command[^]*overlay: "supabase\/not-a-real-command\.md"/);
+  });
+});
+
+describe("legacyReadDocsContent rejects malformed examples.yaml", () => {
+  function withTempDocs(examplesYaml: string): () => void {
+    const dir = mkdtempSync(path.join(tmpdir(), "docs-spec-test-"));
+    mkdirSync(path.join(dir, "supabase"), { recursive: true });
+    mkdirSync(path.join(dir, "templates"), { recursive: true });
+    writeFileSync(path.join(dir, "supabase", "link.md"), "## supabase-link\n\nBody.\n");
+    writeFileSync(path.join(dir, "templates", "examples.yaml"), examplesYaml);
+    return () => {
+      try {
+        legacyReadDocsContent(dir);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+  }
+
+  it("rejects a non-mapping document", () => {
+    expect(withTempDocs("- just\n- a list\n")).toThrow(/must be a mapping of doc ids/);
+  });
+
+  it("rejects a nested-array entry (mis-indented list)", () => {
+    expect(withTempDocs("supabase-link:\n  - - id: oops\n")).toThrow(/must be a mapping/);
+  });
+
+  it("rejects unknown fields (typo'd keys)", () => {
+    expect(withTempDocs("supabase-link:\n  - titel: typo\n    code: x\n")).toThrow(
+      /unknown field "titel"/,
+    );
+  });
+
+  it("rejects non-string field values", () => {
+    expect(withTempDocs("supabase-link:\n  - id: 5\n")).toThrow(/id must be a string/);
+  });
+});
+
+describe("LEGACY_DOCS_EXPERIMENTAL mirrors the runtime gate", () => {
+  it("matches the legacyRequireExperimental call sites exactly", () => {
+    const commandsDir = path.resolve(import.meta.dirname, "../commands");
+    const gated = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const entryPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(entryPath);
+        else if (entry.name.endsWith(".command.ts")) {
+          if (readFileSync(entryPath, "utf8").includes("yield* legacyRequireExperimental")) {
+            const relative = path.relative(commandsDir, path.dirname(entryPath));
+            gated.add(`supabase-${relative.split(path.sep).join("-")}`);
+          }
+        }
+      }
+    };
+    walk(commandsDir);
+    expect([...gated].sort()).toEqual([...LEGACY_DOCS_EXPERIMENTAL].sort());
   });
 });


### PR DESCRIPTION
## TL;DR

re-points CLI reference docs generation at the TypeScript command tree, replacing the retired Go generator with `scripts/generate-docs-spec.ts`.

## What's introduced?

- `scripts/generate-docs-spec.ts`, walking the legacy Effect command tree and merging the overlays and examples under `apps/cli/docs` into the reference spec
- docs-local introspection helpers and unit tests
- build time validation of the static tables, so command or flag renames fail loudly

Purely additive, no existing source files modified.

## Why was it needed?

- the reference was generated from the Go command tree, which the Go CLI deprecation deletes
- TS only additions never appeared on the docs site

The output was parity checked against the Go generator before its removal: all 135 command ids, anchors, flags and defaults match, and TS only surfaces like `completion` and `issue` now appear.

## ref:
- stacks on top of: https://github.com/supabase/cli/pull/6155 
- closes: CLI-2171