### PR TITLE
chore(stack): resolve deferred managed-layer hygiene (CLI-2174)

### DIFF
--- a/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability-coverage.unit.test.ts
@@ -40,6 +40,69 @@ import {
 const ERROR_DEFINITION_PATTERN =
   /TaggedError\(\s*"([A-Za-z0-9_]+)"|class\s+[A-Za-z0-9_]+\s+extends\s+[A-Za-z0-9_.]*Error\(\s*"([A-Za-z0-9_]+)"|class\s+([A-Za-z0-9_]+)\s+extends\s+Error\b/gs;
 
+// Removes `//` line comments and `/* */` block comments from a source string
+// so the regex-based scan below never mistakes a comment merely mentioning
+// `class X extends Error` (or a TaggedError example) for a real definition.
+// String and template literals are treated as opaque runs — a `//` or `/*`
+// inside `"https://..."` (or a backtick template) must survive untouched.
+// Stripped comment bytes are replaced with spaces (newlines are preserved)
+// so line numbers and any line-based logic elsewhere stay unaffected. This
+// is a compact scanner, not a full tokenizer: it does not special-case regex
+// literals or `${...}` interpolation inside template literals.
+function stripComments(source: string): string {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      out += c;
+      i += 1;
+      while (i < n) {
+        const ch = source[i];
+        out += ch;
+        i += 1;
+        if (ch === "\\" && i < n) {
+          out += source[i];
+          i += 1;
+          continue;
+        }
+        if (ch === quote) break;
+      }
+      continue;
+    }
+
+    if (c === "/" && next === "/") {
+      out += "  ";
+      i += 2;
+      while (i < n && source[i] !== "\n") {
+        out += " ";
+        i += 1;
+      }
+      continue;
+    }
+
+    if (c === "/" && next === "*") {
+      out += "  ";
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) {
+        out += source[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      out += "  ";
+      i += 2;
+      continue;
+    }
+
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
 function scanErrorTags(root: string): Map<string, Array<string>> {
   const tagsByFile = new Map<string, Array<string>>();
   const walk = (dir: string) => {
@@ -50,15 +113,71 @@ function scanErrorTags(root: string): Map<string, Array<string>> {
         continue;
       }
       if (!path.endsWith(".ts") || path.endsWith(".test.ts")) continue;
-      const tags = [...readFileSync(path, "utf8").matchAll(ERROR_DEFINITION_PATTERN)].map(
-        (match) => match[1] ?? match[2] ?? match[3] ?? "",
-      );
+      const tags = [
+        ...stripComments(readFileSync(path, "utf8")).matchAll(ERROR_DEFINITION_PATTERN),
+      ].map((match) => match[1] ?? match[2] ?? match[3] ?? "");
       if (tags.length > 0) tagsByFile.set(path, tags);
     }
   };
   walk(root);
   return tagsByFile;
 }
+
+// Extracts the error tags a snippet of source would contribute to the scan,
+// mirroring the comment-stripping + matching pipeline `scanErrorTags` runs
+// against real files, without touching the filesystem.
+function extractErrorTags(source: string): Array<string> {
+  return [...stripComments(source).matchAll(ERROR_DEFINITION_PATTERN)].map(
+    (match) => match[1] ?? match[2] ?? match[3] ?? "",
+  );
+}
+
+describe("stripComments", () => {
+  it("removes a line comment mentioning a fake error class", () => {
+    const source = "// class Fake extends Error\nconst x = 1;";
+    expect(extractErrorTags(source)).toEqual([]);
+  });
+
+  it("removes a block comment mentioning a fake TaggedError example", () => {
+    const source = '/* e.g. Data.TaggedError("FakeTag") */\nconst x = 1;';
+    expect(extractErrorTags(source)).toEqual([]);
+  });
+
+  it("removes a block comment spanning multiple lines", () => {
+    const source = [
+      "/*",
+      " * class AlsoFake extends Error",
+      ' * Data.TaggedError("AlsoFakeTag")',
+      " */",
+      "const x = 1;",
+    ].join("\n");
+    expect(extractErrorTags(source)).toEqual([]);
+  });
+
+  it("keeps a string literal containing `//` intact and still finds a real definition after it", () => {
+    const source = [
+      'const url = "https://example.com/foo";',
+      "export class RealError extends Error {}",
+    ].join("\n");
+    expect(extractErrorTags(source)).toEqual(["RealError"]);
+  });
+
+  it("keeps a template literal containing `//` intact and still finds a real definition after it", () => {
+    const source = [
+      "const url = `https://example.com/${path}`;",
+      'export class TemplateError extends Data.TaggedError("TemplateError") {}',
+    ].join("\n");
+    expect(extractErrorTags(source)).toEqual(["TemplateError"]);
+  });
+
+  it("still finds a real definition that follows a comment about a fake one", () => {
+    const source = [
+      "// This looks like a class Fake extends Error but is not",
+      'export class RealTaggedError extends Data.TaggedError("RealTaggedError") {}',
+    ].join("\n");
+    expect(extractErrorTags(source)).toEqual(["RealTaggedError"]);
+  });
+});
 
 const kindValues = new Set<string>(Object.values(CliErrorKind));
 const categoryValues = new Set<string>(Object.values(CliErrorCategory));

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -314,7 +314,11 @@ That marker protocol is the one place in the managed surface that uses raw `node
 of the `FileSystem` service the policy layer reclaims stack state through: writing a temporary file,
 hardlinking it into place, re-reading the winning marker on `EEXIST`, and removing the temporary path
 is a single indivisible claim, and the hardlink with that `EEXIST` contract is not part of the platform
-service's surface.
+service's surface. The claim itself is `claimFileAtomically` in `managed/atomic-claim.ts`, shared with
+`StateManager`'s single-stack state claim so both settle a race the same way; a filesystem without
+hardlinks (`EPERM` or `ENOTSUP`) falls back to an exclusive create, which still decides the race but
+publishes without the hardlink's all-or-nothing guarantee. The marker protocol owns what a lost race
+means: the identity claim adopts the winning marker, while a claimed stack state is a failure.
 
 No mutable runtime state or credential value is stored in that marker. Read-only discovery does
 not create it. The registry stores only an opaque credential reference, never resolved plaintext
@@ -456,7 +460,11 @@ effects: the fiber scheduler preempts at its operation budget, and a fiber parke
 `COMMIT` would let another fiber `BEGIN IMMEDIATE` on the same connection — SQLite refuses the nested
 transaction, and either fiber's `COMMIT` could publish the other's writes. Keeping the whole
 transaction in one JavaScript turn is therefore what makes a partially applied decision
-unobservable and keeps interruption from ever landing inside a transaction.
+unobservable and keeps interruption from ever landing inside a transaction. Synchrony cannot rule out
+the other way two transactions could meet, a decision that re-enters the repository, so the handles
+currently inside a transaction are tracked and a re-entering `BEGIN` is refused before it runs:
+SQLite has no nested transactions, and unwinding the inner attempt would roll back the outer
+decision's writes.
 
 The database handle's lifetime is a scope. `sqliteManagedStackRepositoryLayer` acquires the handle
 with `Effect.acquireRelease`, so opening the file and registering its close are one step nothing can

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -480,7 +480,10 @@ the caller's bound on the entire wait and is applied as a timeout around the rep
 the poll instead of being checked between polls. Both shipped adapters answer synchronously, so a look
 at the pending row always completes; with an embedder-supplied asynchronous repository that timeout can
 preempt a look that is still in flight. That is safe — a look has no side effects — but it means the
-option bounds the wait, not the number of looks that finish.
+option bounds the wait, not the number of looks that finish. The answer the repeat stops on is checked
+rather than asserted through a type refinement: a recurrence bound added to that schedule later would
+hand back the final still-pending answer, and the check turns that into a defect instead of an
+unpublished stack presented as a published one.
 
 Interruption is part of the contract, not an afterthought. Provisioning owns a pending row, an
 operation claim, and the directories it created, so its create path runs under
@@ -490,7 +493,16 @@ releases its claim the same way. An interrupted call stays interrupted rather th
 failure of the work — a caller's own timeout is not a `ManagedStackInitializationError` — and recovery
 re-raises interruption instead of recording a retained claim or a reconciliation failure that never
 happened, so the operation the next pass should still recover does not look like one recovery already
-gave up on.
+gave up on. That rule covers the steps whose exits recovery absorbs one at a time — the liveness probe,
+the runtime inspection, the state reclamation — not just the pass as a whole.
+
+The single deliberate exception is the claim release on a failed operation's way out: it discards
+whatever it raises, its own interruption included, because the caller's outcome is the failure the
+operation actually suffered and a release reporting interruption would replace it. The mask itself
+begins after the pending row and its claim exist, which is sound only because both shipped adapters
+decide synchronously and offer no suspension point during that write. An asynchronous embedder
+repository interrupted mid-prepare would leave a pending row and a claim nothing compensates, so the
+mask has to be extended over row creation before asynchronous repositories become real.
 
 An Effect consumer provides the composed layer, which is the primary API:
 
@@ -545,7 +557,9 @@ alongside those interruptions rather than after them, a statement already on its
 race the close and fail against a closed handle: a caller that closes while work is outstanding must
 read those rejections as "did not complete", not as evidence about the registry. A call made after
 `close()` rejects with an `Error` saying the handle is closed, rather than with the runtime's own bare
-internal string. The handle is also an `AsyncDisposable`, so
+internal string. That diagnosis comes from the handle's own closed state, never from what a rejection
+says, so a caller's callback that refuses with a string mentioning disposal still reaches the caller
+as itself. The handle is also an `AsyncDisposable`, so
 `await using service = await createManagedStackService()` closes it on every path out of the block. The
 facade hands back the very repository the service uses, so an embedder can read the registry without
 opening a second handle on it.

--- a/packages/stack/src/StateManager.ts
+++ b/packages/stack/src/StateManager.ts
@@ -1,9 +1,8 @@
 import { Data, Effect, Layer, Schema, Context } from "effect";
 import { FileSystem, Path } from "effect";
 import { execFileSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
-import { link, unlink, writeFile } from "node:fs/promises";
+import { claimFileAtomically } from "./managed/atomic-claim.ts";
 import { AllocatedPortsSchema, type AllocatedPorts } from "./PortAllocator.ts";
 import {
   PartialVersionManifestSchema,
@@ -345,27 +344,24 @@ function makeClaim(deps: StateManagerDeps) {
       const dir = deps.stackDir(state.name);
       yield* deps.fs.makeDirectory(dir, { recursive: true });
       const statePath = deps.stateFile(state.name);
-      const temporaryPath = `${statePath}.claim-${process.pid}-${randomUUID()}`;
-      yield* Effect.tryPromise({
-        try: async () => {
-          await writeFile(temporaryPath, encodePrettyJson(encodeStackState(state)), { flag: "wx" });
-          try {
-            await link(temporaryPath, statePath);
-          } finally {
-            await unlink(temporaryPath).catch(() => undefined);
-          }
-        },
+      const outcome = yield* Effect.tryPromise({
+        try: () => claimFileAtomically(statePath, encodePrettyJson(encodeStackState(state))),
         catch: (cause) =>
           new StateClaimError({
             name: state.name,
             path: statePath,
-            reason:
-              cause instanceof Error && "code" in cause && cause.code === "EEXIST"
-                ? "already-claimed"
-                : "io-error",
+            reason: "io-error",
             cause,
           }),
       });
+      if (outcome === "already-exists") {
+        return yield* new StateClaimError({
+          name: state.name,
+          path: statePath,
+          reason: "already-claimed",
+          cause: undefined,
+        });
+      }
     }).pipe(
       Effect.catchTag("PlatformError", (cause) =>
         Effect.fail(

--- a/packages/stack/src/managed-atomic-claim.unit.test.ts
+++ b/packages/stack/src/managed-atomic-claim.unit.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { claimFileAtomically } from "./managed/atomic-claim.ts";
+
+const temporaryRoots: Array<string> = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), "atomic-claim-test-"));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const codedError = (code: string): Error => Object.assign(new Error(code), { code });
+
+const refusingLink = (code: string) => (): Promise<never> => Promise.reject(codedError(code));
+
+const strayTemporaryFiles = (root: string): ReadonlyArray<string> =>
+  readdirSync(root).filter((entry) => entry.includes(".tmp."));
+
+describe("atomic file claim", () => {
+  it("publishes the content when nothing holds the path yet", async () => {
+    const root = makeRoot();
+    const target = join(root, "claim.json");
+
+    await expect(claimFileAtomically(target, "mine\n", { mode: 0o600 })).resolves.toBe("claimed");
+
+    expect(readFileSync(target, "utf8")).toBe("mine\n");
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expect(strayTemporaryFiles(root)).toEqual([]);
+  });
+
+  it("reports a claim someone else already published and leaves it untouched", async () => {
+    const root = makeRoot();
+    const target = join(root, "claim.json");
+    writeFileSync(target, "theirs\n");
+
+    await expect(claimFileAtomically(target, "mine\n")).resolves.toBe("already-exists");
+
+    expect(readFileSync(target, "utf8")).toBe("theirs\n");
+    expect(strayTemporaryFiles(root)).toEqual([]);
+  });
+
+  it.each(["EPERM", "ENOTSUP"])(
+    "claims through an exclusive create where hardlinks refuse with %s",
+    async (code) => {
+      const root = makeRoot();
+      const target = join(root, "claim.json");
+
+      await expect(
+        claimFileAtomically(target, "mine\n", { mode: 0o600, linkFile: refusingLink(code) }),
+      ).resolves.toBe("claimed");
+
+      expect(readFileSync(target, "utf8")).toBe("mine\n");
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+      expect(strayTemporaryFiles(root)).toEqual([]);
+    },
+  );
+
+  it("still settles the race for a loser on a filesystem without hardlinks", async () => {
+    const root = makeRoot();
+    const target = join(root, "claim.json");
+    writeFileSync(target, "theirs\n");
+
+    await expect(
+      claimFileAtomically(target, "mine\n", { linkFile: refusingLink("EPERM") }),
+    ).resolves.toBe("already-exists");
+
+    expect(readFileSync(target, "utf8")).toBe("theirs\n");
+    expect(strayTemporaryFiles(root)).toEqual([]);
+  });
+
+  it("propagates a publication failure that is neither a lost race nor a missing hardlink", async () => {
+    const root = makeRoot();
+    const target = join(root, "claim.json");
+
+    await expect(
+      claimFileAtomically(target, "mine\n", { linkFile: refusingLink("EACCES") }),
+    ).rejects.toThrow("EACCES");
+
+    expect(readdirSync(root)).toEqual([]);
+  });
+
+  it("names the temporary file from an injected identifier so a run stays reproducible", async () => {
+    const root = makeRoot();
+    const target = join(root, "claim.json");
+    const observed: Array<string> = [];
+
+    await claimFileAtomically(target, "mine\n", {
+      temporaryId: "fixed-id",
+      linkFile: (existingPath) => {
+        observed.push(existingPath);
+        return Promise.reject(codedError("EPERM"));
+      },
+    });
+
+    expect(observed).toEqual([`${target}.tmp.fixed-id`]);
+    expect(strayTemporaryFiles(root)).toEqual([]);
+  });
+});

--- a/packages/stack/src/managed-effect.integration.test.ts
+++ b/packages/stack/src/managed-effect.integration.test.ts
@@ -310,6 +310,78 @@ describe("managed stack Effect surface", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.live("keeps a delete's own failure when releasing its claim reports interruption", () => {
+    // Releasing the claim on the way out is best effort in the strongest sense.
+    // An embedder repository whose `finishOperation` is cancelled must not turn
+    // the failure the caller actually suffered into an interruption the caller
+    // never asked for — the release has no outcome of its own to report.
+    const root = makeRoot();
+    const stateRoot = join(root, "managed");
+    const workspace = makeWorkspace(root);
+    const repository = createInMemoryManagedStackRepository();
+    let releaseIsCancelled = false;
+    const cancelling: ManagedStackRepositoryShape = {
+      ...repository,
+      finishOperation: (stackId, operationToken, outcome, at, error) =>
+        releaseIsCancelled
+          ? Effect.interrupt
+          : repository.finishOperation(stackId, operationToken, outcome, at, error),
+    };
+    const layer = managedLayer(stateRoot, { repository: cancelling });
+    class StopRefused {
+      readonly _tag = "StopRefused";
+    }
+    return Effect.gen(function* () {
+      const managed = yield* ManagedStackService;
+      const { stack } = yield* managed.provisionOrdinaryStack({ workspacePath: workspace });
+      yield* managed.updateStack(stack.id, { lifecycle: "running" });
+      releaseIsCancelled = true;
+
+      const exit = yield* managed
+        .deleteStack(stack.id, { stop: () => Effect.fail(new StopRefused()) })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(false);
+      expect(Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined).toBeInstanceOf(
+        StopRefused,
+      );
+      expect((yield* managed.inspectStack(stack.id))?.status).toBe("active");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("propagates an interrupted runtime inspection instead of retaining the operation", () => {
+    // The absorbed steps inside a recovery pass follow the same rule as the pass
+    // itself: an interrupted inspection has no answer about the runtime, so
+    // retaining the operation on its behalf would report a decision recovery
+    // never made.
+    const { workspace, layer } = setupInMemory();
+    return Effect.gen(function* () {
+      const managed = yield* ManagedStackService;
+      const repository = yield* ManagedStackRepository;
+      const { stack } = yield* managed.provisionOrdinaryStack({ workspacePath: workspace });
+      const claimed = yield* repository.claimOperation({
+        token: crypto.randomUUID(),
+        stackId: stack.id,
+        kind: "start",
+        now: "2026-08-11T00:00:00.000Z",
+      });
+      if (!claimed.acquired) {
+        return yield* Effect.die(new Error("Expected to stage an abandoned operation"));
+      }
+
+      const exit = yield* managed
+        .reconcileAbandonedOperations({ inspectRuntime: () => Effect.interrupt })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+      // The claim survives for the next pass, exactly as it would had the pass
+      // never looked at it.
+      expect(
+        (yield* repository.listActiveOperations()).map((operation) => operation.token),
+      ).toEqual([claimed.operation.token]);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.live("propagates an interrupted recovery pass instead of recording it as a failure", () => {
     // Recovery reports rather than fails, but an interrupted step has no outcome
     // to report: recording one would mark a stack failed and release a claim on

--- a/packages/stack/src/managed-service.integration.test.ts
+++ b/packages/stack/src/managed-service.integration.test.ts
@@ -47,6 +47,7 @@ import {
 } from "./managed/model.ts";
 import { createInMemoryManagedStackRepository } from "./managed/repository-memory.ts";
 import { ManagedStackRepository, type ManagedStackRepositoryShape } from "./managed/repository.ts";
+import { sqliteManagedStackRepositoryLayer, type ManagedSqliteDatabase } from "./managed/sqlite.ts";
 import type { MakeManagedStackServiceOptions, ManagedStackServiceHandle } from "./managed-bun.ts";
 import {
   bunSqliteManagedStackRepositoryLayer,
@@ -77,6 +78,53 @@ const openRegistry = async (
   return {
     repository: Context.get(await runtime.context(), ManagedStackRepository),
     close: () => runtime.dispose(),
+  };
+};
+
+/**
+ * An in-memory registry handle that runs `reenterOnce`'s callback the first time
+ * a decision reads a row, so a test can re-enter the repository from inside a
+ * transaction the way a mistaken caller would.
+ */
+const reentrantRegistry = (): {
+  readonly handle: ManagedSqliteDatabase;
+  readonly reenterOnce: (reentry: () => void) => void;
+} => {
+  const database = new Database(":memory:");
+  let pending: (() => void) | undefined;
+  const trigger = (): void => {
+    const reentry = pending;
+    pending = undefined;
+    reentry?.();
+  };
+  return {
+    reenterOnce: (reentry) => {
+      pending = reentry;
+    },
+    handle: {
+      exec(sql) {
+        database.exec(sql);
+      },
+      prepare(sql) {
+        const statement = database.query(sql);
+        return {
+          run(parameters = []) {
+            statement.run(...parameters);
+          },
+          get(parameters = []) {
+            trigger();
+            return statement.get(...parameters) ?? undefined;
+          },
+          all(parameters = []) {
+            trigger();
+            return statement.all(...parameters);
+          },
+        };
+      },
+      close() {
+        database.close();
+      },
+    },
   };
 };
 
@@ -2613,6 +2661,49 @@ describe("managed repository and lifecycle", () => {
 
     expect(Exit.isSuccess(exit) ? "committed" : Cause.pretty(exit.cause)).toBe("committed");
     await registry.close();
+  });
+
+  it("refuses a registry decision that re-enters the repository, keeping its own writes", async () => {
+    // SQLite has no nested transactions, so a decision that calls back into the
+    // repository can only lose: the inner `BEGIN` is refused, and unwinding the
+    // inner attempt would roll back the writes the outer decision has already
+    // made. The guard therefore refuses before any statement runs.
+    const root = makeRoot();
+    const workspace = makeWorkspace(root);
+    const identity = (await Effect.runPromise(ensureOrdinaryWorkspaceIdentity(workspace))).identity;
+    const sqlite = reentrantRegistry();
+    const runtime = ManagedRuntime.make(sqliteManagedStackRepositoryLayer(() => sqlite.handle));
+    const repository = Context.get(await runtime.context(), ManagedStackRepository);
+
+    let nested: Exit.Exit<ReadonlyArray<ManagedStackRecord>> | undefined;
+    sqlite.reenterOnce(() => {
+      nested = Effect.runSyncExit(repository.listStacks());
+    });
+
+    const stackId = crypto.randomUUID();
+    const prepared = runRepo(
+      repository.prepareOrdinaryStack({
+        identity,
+        canonicalPath: realpathSync(workspace),
+        locationId: crypto.randomUUID(),
+        stackId,
+        stackName: "default",
+        paths: managedStackPaths(join(root, "managed"), stackId),
+        operationToken: crypto.randomUUID(),
+        now: "2026-08-11T00:00:00.000Z",
+        configuration: {},
+      }),
+    );
+
+    if (nested === undefined || !Exit.isFailure(nested)) {
+      throw new Error("Expected the nested decision to be refused");
+    }
+    expect(Cause.pretty(nested.cause)).toContain("A registry transaction is already open");
+    expect(prepared.outcome).toBe("create");
+    // The refusal never touched the transaction in flight, so the outer
+    // decision committed and the handle is free for the next one.
+    expect(runRepo(repository.listStacks()).map((stack) => stack.id)).toEqual([stackId]);
+    await runtime.dispose();
   });
 
   it("writes the current schema version into a fresh registry", async () => {

--- a/packages/stack/src/managed-service.integration.test.ts
+++ b/packages/stack/src/managed-service.integration.test.ts
@@ -835,6 +835,30 @@ describe("managed service options", () => {
     await expect(service.listStacks()).rejects.toThrow(/closed/i);
   });
 
+  it("reports a callback's own rejection as itself even when it mentions disposal", async () => {
+    // Whether the handle is closed is the handle's own state, never something
+    // read back out of what a rejection happens to say: a caller's callback that
+    // refuses with a string mentioning disposal must reach that caller unchanged.
+    const root = makeRoot();
+    const service = await makePersistentService(root);
+    const { stack } = await service.provisionOrdinaryStack({ workspacePath: makeWorkspace(root) });
+    await service.updateStack(stack.id, { lifecycle: "running" });
+
+    let rejection: unknown;
+    try {
+      await service.deleteStack(stack.id, {
+        stop: () => Promise.reject("the container was disposed"),
+      });
+    } catch (error: unknown) {
+      rejection = error;
+    }
+
+    expect(String(rejection)).toContain("the container was disposed");
+    expect(String(rejection)).not.toContain("handle is closed");
+    expect(await service.inspectStack(stack.id)).toMatchObject({ status: "active" });
+    await service.close();
+  });
+
   it("closes a service acquired with await using when its block ends", async () => {
     const root = makeRoot();
     let acquired: ManagedStackServiceHandle | undefined;

--- a/packages/stack/src/managed/atomic-claim.ts
+++ b/packages/stack/src/managed/atomic-claim.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+import { link, unlink, writeFile } from "node:fs/promises";
+import { errorCode } from "./error-code.ts";
+
+export type FileClaimOutcome = "claimed" | "already-exists";
+
+export interface FileClaimOptions {
+  /** Mode for the published file; defaults to the process umask. */
+  readonly mode?: number;
+  /**
+   * Distinguishes one claimant's temporary file from another's; defaults to a
+   * random UUID. Callers that already draw identifiers from an injected factory
+   * pass one from there, so a deterministic run stays deterministic.
+   */
+  readonly temporaryId?: string;
+  /**
+   * The hardlink step, overridable so a test can drive the hardlink-less
+   * fallback on a filesystem that does support hardlinks.
+   */
+  readonly linkFile?: (existingPath: string, newPath: string) => Promise<void>;
+}
+
+const createExclusively = async (
+  targetPath: string,
+  content: string,
+  mode: number | undefined,
+): Promise<FileClaimOutcome> => {
+  try {
+    await writeFile(targetPath, content, { flag: "wx", mode });
+    return "claimed";
+  } catch (error: unknown) {
+    if (errorCode(error) === "EEXIST") {
+      return "already-exists";
+    }
+    throw error;
+  }
+};
+
+/**
+ * Publishes `content` at `targetPath` unless a claimant got there first.
+ *
+ * The content is written to a sibling temporary file and hardlinked into place,
+ * because `link` publishes the whole file in one step and refuses an existing
+ * target: writing `targetPath` directly could crash halfway and publish a
+ * partial claim, and testing for the file before writing it would lose the very
+ * race the claim exists to settle. Filesystems without hardlinks — exFAT,
+ * FAT32, some network mounts — refuse `link` with `EPERM` or `ENOTSUP`; those
+ * fall back to an exclusive create, which still settles the race but gives up
+ * the all-or-nothing publish. Any other failure is a real one and propagates.
+ *
+ * A `SIGKILL` between the temporary write and its removal strands a
+ * `.tmp.<id>` sibling. Nothing ever reads those, so a stranded one is junk
+ * rather than a claim anybody can observe.
+ */
+export const claimFileAtomically = async (
+  targetPath: string,
+  content: string,
+  options: FileClaimOptions = {},
+): Promise<FileClaimOutcome> => {
+  const linkFile = options.linkFile ?? link;
+  const temporaryPath = `${targetPath}.tmp.${options.temporaryId ?? randomUUID()}`;
+  await writeFile(temporaryPath, content, { flag: "wx", mode: options.mode });
+  try {
+    await linkFile(temporaryPath, targetPath);
+    return "claimed";
+  } catch (error: unknown) {
+    const code = errorCode(error);
+    if (code === "EEXIST") {
+      return "already-exists";
+    }
+    if (code !== "EPERM" && code !== "ENOTSUP") {
+      throw error;
+    }
+    return await createExclusively(targetPath, content, options.mode);
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined);
+  }
+};

--- a/packages/stack/src/managed/create-service.ts
+++ b/packages/stack/src/managed/create-service.ts
@@ -122,16 +122,28 @@ const managedStackServiceHandle = async <ER>(
   const repository = Context.get(context, ManagedStackRepository);
 
   /**
-   * Every method's run, so a call that arrives after `close` is reported as one.
-   *
-   * A disposed `ManagedRuntime` answers by dying with a bare string, which would
-   * reach the caller as a rejection with no name, message, or stack. Anything
-   * else is the failure itself and passes through untouched.
+   * Whether this handle has been closed, tracked here rather than read back out
+   * of the rejection a closed run produces: a disposed `ManagedRuntime` answers
+   * by dying with a bare string, and deciding from that string's contents would
+   * misreport a caller's own callback rejecting with a string that happens to
+   * mention disposal.
+   */
+  let closed = false;
+  const dispose = (): Promise<void> => {
+    closed = true;
+    return runtime.dispose();
+  };
+
+  /**
+   * Every method's run, so a call that arrives after `close` is reported as one:
+   * the runtime's bare string reaches the caller as a rejection with no name,
+   * message, or stack. While the handle is open, every failure is the failure
+   * itself and passes through untouched.
    */
   const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
     runtime.runPromise(effect).catch((error: unknown) => {
-      throw typeof error === "string" && error.includes("disposed")
-        ? new Error(`The managed stack service handle is closed (${error})`)
+      throw closed
+        ? new Error(`The managed stack service handle is closed (${String(error)})`)
         : error;
     });
 
@@ -188,8 +200,8 @@ const managedStackServiceHandle = async <ER>(
           fromCallback(() => shouldPrune(location), isBooleanAnswer),
         ),
       ),
-    close: () => runtime.dispose(),
-    [Symbol.asyncDispose]: () => runtime.dispose(),
+    close: dispose,
+    [Symbol.asyncDispose]: dispose,
   };
 };
 

--- a/packages/stack/src/managed/identity.ts
+++ b/packages/stack/src/managed/identity.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { link, mkdir, readFile, realpath, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import { Effect } from "effect";
+import { claimFileAtomically } from "./atomic-claim.ts";
 import {
   InvalidManagedIdentityError,
   ORDINARY_WORKSPACE_IDENTITY_VERSION,
@@ -117,11 +118,10 @@ export interface EnsureOrdinaryWorkspaceIdentityResult {
 
 /**
  * Claiming a workspace stays one `await` chain rather than an `Effect.gen`
- * pipeline: the temporary file, the hardlink that makes the claim atomic, its
- * `EEXIST` re-read of the winning marker, and the `finally` that removes the
- * temporary path are a single indivisible protocol. Interleaving it with other
- * work — or interrupting it between the link and the cleanup — could leave a
- * workspace holding a stray temporary marker.
+ * pipeline: reading the marker, publishing the claim, and re-reading the marker
+ * a losing claimant must adopt are a single indivisible protocol, and an
+ * interruption between those steps would leave the caller with an identity no
+ * workspace agreed to.
  */
 const ensureIdentity = async (
   workspacePath: string,
@@ -141,25 +141,21 @@ const ensureIdentity = async (
   };
 
   await mkdir(dirname(markerPath), { recursive: true });
-  const temporaryPath = `${markerPath}.tmp.${createManagedUuid(idFactory, "identity temporary id")}`;
-  await writeFile(temporaryPath, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
-  try {
-    await link(temporaryPath, markerPath);
+  const outcome = await claimFileAtomically(markerPath, `${JSON.stringify(identity, null, 2)}\n`, {
+    mode: 0o600,
+    temporaryId: createManagedUuid(idFactory, "identity temporary id"),
+  });
+  if (outcome === "claimed") {
     return { identity, created: true, markerPath };
-  } catch (error: unknown) {
-    if (errorCode(error) !== "EEXIST") {
-      throw error;
-    }
-    const winner = await readIdentity(workspacePath);
-    if (winner === undefined) {
-      throw new InvalidManagedIdentityError({
-        message: "Identity publication raced without a winning marker",
-      });
-    }
-    return { identity: winner, created: false, markerPath };
-  } finally {
-    await unlink(temporaryPath).catch(() => undefined);
   }
+
+  const winner = await readIdentity(workspacePath);
+  if (winner === undefined) {
+    throw new InvalidManagedIdentityError({
+      message: "Identity publication raced without a winning marker",
+    });
+  }
+  return { identity: winner, created: false, markerPath };
 };
 
 export const ensureOrdinaryWorkspaceIdentity = (

--- a/packages/stack/src/managed/service.ts
+++ b/packages/stack/src/managed/service.ts
@@ -279,6 +279,16 @@ const recordUnlessInterrupted =
       Cause.hasInterruptsOnly(cause) ? Effect.interrupt : record(cause),
     );
 
+/**
+ * The error an absorbed step refused with, for a report entry to carry — or an
+ * interruption, re-raised before any entry is built. It is the rule
+ * {@link recordUnlessInterrupted} applies to a whole step, applied where the
+ * step's exit is inspected instead: an interrupted step has no outcome, so it
+ * must not become a report entry either way.
+ */
+const absorbedError = <E>(cause: Cause.Cause<E>): Effect.Effect<unknown> =>
+  Cause.hasInterruptsOnly(cause) ? Effect.interrupt : Effect.succeed(Cause.squash(cause));
+
 /** What one look at a stack awaiting publication can refuse to wait for. */
 type PublicationPollFailure = ManagedAbandonedOperationError | ManagedStackNotFoundError;
 
@@ -396,6 +406,13 @@ export class ManagedStackService extends Context.Service<
             recordUnlessInterrupted((cause) => Effect.succeed(dataRetained(Cause.squash(cause)))),
           );
 
+        /**
+         * Marks an operation failed as part of a recovery report, answering
+         * whether the claim was actually released — a claim that could not be
+         * released is reported, not hidden. Interruption is re-raised, because
+         * this is a recording site: there is no report to put an interrupted
+         * step in.
+         */
         const finishOperationBestEffort = (
           stackId: string,
           operationToken: string,
@@ -406,6 +423,36 @@ export class ManagedStackService extends Context.Service<
             // Preserve the operation's original failure when ownership changed concurrently.
             recordUnlessInterrupted(() => Effect.succeed(false)),
           );
+
+        /**
+         * Releases this call's claim on the way out of a failed operation, then
+         * re-raises the cause that got here.
+         *
+         * The release absorbs everything it can raise, its own interruption
+         * included: the caller's outcome is the failure the operation suffered,
+         * and an embedder repository that reports interruption from
+         * `finishOperation` would otherwise replace that failure with an
+         * interruption the caller never asked for. That is the opposite of the
+         * recording sites above, where an interrupted step has no outcome and
+         * interruption is the only honest answer.
+         */
+        const releasingClaimOnFailure =
+          (stackId: string, operationToken: string) =>
+          <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+            Effect.catchCause(self, (cause) =>
+              repository
+                .finishOperation(
+                  stackId,
+                  operationToken,
+                  "failed",
+                  now(),
+                  String(Cause.squash(cause)),
+                )
+                .pipe(
+                  Effect.catchCause(() => Effect.void),
+                  Effect.flatMap(() => Effect.failCause(cause)),
+                ),
+            );
 
         /**
          * A concurrent forced recovery can resolve this same operation before
@@ -516,12 +563,9 @@ export class ManagedStackService extends Context.Service<
           | ManagedStackPublicationTimeoutError
         > =>
           pollPublication(pending).pipe(
-            // A refinement, so the answer the repeat stops on is narrowed to the
-            // published stack. The type argument is explicit because the
-            // narrowing is lost when the generic guard is inferred here.
             Effect.repeat({
               schedule: publicationPollSchedule,
-              while: Option.isNone<ManagedStackRecord>,
+              while: (answer: Option.Option<ManagedStackRecord>) => Option.isNone(answer),
             }),
             // The timeout is the caller's bound on the whole wait, so it
             // interrupts the poll rather than being checked between polls.
@@ -530,7 +574,21 @@ export class ManagedStackService extends Context.Service<
               orElse: () =>
                 Effect.fail(new ManagedStackPublicationTimeoutError({ stackId: pending.id })),
             }),
-            Effect.map((published) => published.value),
+            // Only an unbounded schedule guarantees the repeat stops on a
+            // published stack, and this one is unbounded. A recurrence bound
+            // added later would hand back the final `None` instead, so the
+            // answer is checked rather than asserted through a refinement: a
+            // schedule that gave up is a bug in this module, not an outcome a
+            // caller could act on.
+            Effect.flatMap((published) =>
+              Option.isNone(published)
+                ? Effect.die(
+                    new Error(
+                      `The publication poll for ${pending.id} stopped before the stack was published`,
+                    ),
+                  )
+                : Effect.succeed(published.value),
+            ),
           );
 
         const updateStackRecord = (
@@ -550,11 +608,7 @@ export class ManagedStackService extends Context.Service<
                 Effect.tap(() =>
                   repository.finishOperation(stackId, operation.token, "completed", now()),
                 ),
-                Effect.catchCause((cause) =>
-                  finishOperationBestEffort(stackId, operation.token, Cause.squash(cause)).pipe(
-                    Effect.flatMap(() => Effect.failCause(cause)),
-                  ),
-                ),
+                releasingClaimOnFailure(stackId, operation.token),
               );
           });
 
@@ -654,6 +708,17 @@ export class ManagedStackService extends Context.Service<
             // interrupted: a caller that times out or closes the service must
             // not leave a pending stack and a leaked directory behind. Only the
             // provisioning steps are interruptible; the rollback is not.
+            //
+            // The mask starts after `prepareOrdinaryStack`, so it covers the row
+            // this call owns but not the act of creating it. That is sound only
+            // because every repository this package ships decides synchronously:
+            // both adapters run the pending row and its claim as one SQLite
+            // transaction or one in-memory mutation, with no suspension point an
+            // interruption could land on. An asynchronous embedder repository
+            // breaks that assumption — interrupted mid-prepare it would leave a
+            // pending row and a claim nothing compensates — so the mask must be
+            // extended to cover row creation before async repositories become
+            // real. `deleteStack`'s claim has the same shape.
             return yield* Effect.uninterruptibleMask((restore) =>
               restore(
                 Effect.gen(function* () {
@@ -780,13 +845,7 @@ export class ManagedStackService extends Context.Service<
                   yield* finishDeleteOperationTolerantly(stackId, operation.token);
                   return deletionResult("delete", tombstoned, dataReclamation);
                 }),
-              ).pipe(
-                Effect.catchCause((cause) =>
-                  finishOperationBestEffort(stackId, operation.token, Cause.squash(cause)).pipe(
-                    Effect.flatMap(() => Effect.failCause(cause)),
-                  ),
-                ),
-              ),
+              ).pipe(releasingClaimOnFailure(stackId, operation.token)),
             );
           });
 
@@ -826,11 +885,8 @@ export class ManagedStackService extends Context.Service<
                 if (forcedOperation === undefined && isUsableManagedOwnerPid(operation.ownerPid)) {
                   const alive = yield* Effect.exit(probeProcessAlive(operation.ownerPid));
                   if (Exit.isFailure(alive)) {
-                    retained.push({
-                      operation,
-                      reason: "owner-liveness-unknown",
-                      error: Cause.squash(alive.cause),
-                    });
+                    const error = yield* absorbedError(alive.cause);
+                    retained.push({ operation, reason: "owner-liveness-unknown", error });
                     return;
                   }
                   if (alive.value) {
@@ -858,11 +914,8 @@ export class ManagedStackService extends Context.Service<
                       reconcileOptions.inspectRuntime(stack, operation),
                     );
                     if (Exit.isFailure(inspected)) {
-                      retained.push({
-                        operation,
-                        reason: "runtime-inspection-failed",
-                        error: Cause.squash(inspected.cause),
-                      });
+                      const error = yield* absorbedError(inspected.cause);
+                      retained.push({ operation, reason: "runtime-inspection-failed", error });
                       return;
                     }
                     if (inspected.value === "unknown") {
@@ -889,11 +942,12 @@ export class ManagedStackService extends Context.Service<
                   // failure is the whole report.
                   const removal = yield* Effect.exit(removeStackState(stack));
                   if (Exit.isFailure(removal)) {
+                    const error = yield* absorbedError(removal.cause);
                     failures.push({
                       operation,
                       phase: "state-reclamation",
                       operationReleased: true,
-                      error: Cause.squash(removal.cause),
+                      error,
                     });
                     return;
                   }

--- a/packages/stack/src/managed/sqlite.ts
+++ b/packages/stack/src/managed/sqlite.ts
@@ -368,32 +368,49 @@ const commitPreservingCause = (database: ManagedSqliteDatabase): void => {
   }
 };
 
+/** The handles currently between `BEGIN` and `COMMIT` — see {@link runTransaction}. */
+const openTransactions = new WeakSet<ManagedSqliteDatabase>();
+
 /**
  * `BEGIN`, the decision's statements, and `COMMIT` as one synchronous block.
  *
  * Atomicity here rests on the drivers being synchronous and the handle being
  * single-threaded: nothing else can run between the statements, so a partially
- * applied decision is never observable and two transactions can never nest on
- * the same connection. That only holds while the whole block is one JavaScript
- * turn — splitting the boundary across effects would reintroduce a suspension
- * point where the fiber scheduler could preempt at its operation budget and let
- * another fiber `BEGIN` on this very handle.
+ * applied decision is never observable. That only holds while the whole block is
+ * one JavaScript turn — splitting the boundary across effects would reintroduce
+ * a suspension point where the fiber scheduler could preempt at its operation
+ * budget and let another fiber `BEGIN` on this very handle.
+ *
+ * What synchrony cannot rule out is a decision that re-enters the repository:
+ * SQLite has no nested transactions, so the inner `BEGIN` would refuse with a
+ * driver message about the outer one, and unwinding the inner attempt would
+ * `ROLLBACK` the outer transaction's writes. Reentrancy is a bug in the calling
+ * code rather than a condition to recover from, so it is refused here — before
+ * any statement runs, and without touching the transaction already in flight.
  */
 const runTransaction = <A>(
   database: ManagedSqliteDatabase,
   begin: "BEGIN" | "BEGIN IMMEDIATE",
   run: () => A,
 ): A => {
-  database.exec(begin);
-  let decided: A;
-  try {
-    decided = run();
-  } catch (error: unknown) {
-    rollbackPreservingCause(database);
-    throw error;
+  if (openTransactions.has(database)) {
+    throw new Error("A registry transaction is already open on this database handle");
   }
-  commitPreservingCause(database);
-  return decided;
+  database.exec(begin);
+  openTransactions.add(database);
+  try {
+    let decided: A;
+    try {
+      decided = run();
+    } catch (error: unknown) {
+      rollbackPreservingCause(database);
+      throw error;
+    }
+    commitPreservingCause(database);
+    return decided;
+  } finally {
+    openTransactions.delete(database);
+  }
 };
 
 /**

--- a/packages/stack/src/managed/sqlite.ts
+++ b/packages/stack/src/managed/sqlite.ts
@@ -231,9 +231,69 @@ const rollbackPreservingCause = (database: ManagedSqliteDatabase): void => {
   }
 };
 
-const migrateSchema = (database: ManagedSqliteDatabase): void => {
-  database.exec("BEGIN IMMEDIATE");
+const commitPreservingCause = (database: ManagedSqliteDatabase): void => {
   try {
+    database.exec("COMMIT");
+  } catch (error: unknown) {
+    rollbackPreservingCause(database);
+    throw error;
+  }
+};
+
+/** The handles currently between `BEGIN` and `COMMIT` — see {@link runTransaction}. */
+const openTransactions = new WeakSet<ManagedSqliteDatabase>();
+
+/**
+ * `BEGIN`, the decision's statements, and `COMMIT` as one synchronous block.
+ *
+ * Atomicity here rests on the drivers being synchronous and the handle being
+ * single-threaded: nothing else can run between the statements, so a partially
+ * applied decision is never observable. That only holds while the whole block is
+ * one JavaScript turn — splitting the boundary across effects would reintroduce
+ * a suspension point where the fiber scheduler could preempt at its operation
+ * budget and let another fiber `BEGIN` on this very handle.
+ *
+ * What synchrony cannot rule out is a decision that re-enters the repository:
+ * SQLite has no nested transactions, so the inner `BEGIN` would refuse with a
+ * driver message about the outer one, and unwinding the inner attempt would
+ * `ROLLBACK` the outer transaction's writes. Reentrancy is a bug in the calling
+ * code rather than a condition to recover from, so it is refused here — before
+ * any statement runs, and without touching the transaction already in flight.
+ */
+const runTransaction = <A>(
+  database: ManagedSqliteDatabase,
+  begin: "BEGIN" | "BEGIN IMMEDIATE",
+  run: () => A,
+): A => {
+  if (openTransactions.has(database)) {
+    throw new Error("A registry transaction is already open on this database handle");
+  }
+  database.exec(begin);
+  openTransactions.add(database);
+  try {
+    let decided: A;
+    try {
+      decided = run();
+    } catch (error: unknown) {
+      rollbackPreservingCause(database);
+      throw error;
+    }
+    commitPreservingCause(database);
+    return decided;
+  } finally {
+    openTransactions.delete(database);
+  }
+};
+
+/**
+ * The schema migration is a registry decision like any other, so it runs through
+ * {@link runTransaction}: it is the first thing an opened handle does, before the
+ * repository it initializes exists, so no transaction can be open on the handle
+ * yet. An already-current registry returns without writing and the transaction
+ * commits nothing.
+ */
+const migrateSchema = (database: ManagedSqliteDatabase): void =>
+  runTransaction(database, "BEGIN IMMEDIATE", () => {
     const versionRow = database.prepare("PRAGMA user_version").get();
     const version = getNumber(versionRow, "user_version");
     if (version !== 0 && version !== MANAGED_REGISTRY_SCHEMA_VERSION) {
@@ -243,7 +303,6 @@ const migrateSchema = (database: ManagedSqliteDatabase): void => {
       });
     }
     if (version === MANAGED_REGISTRY_SCHEMA_VERSION) {
-      database.exec("COMMIT");
       return;
     }
     database.exec(`
@@ -324,12 +383,7 @@ const migrateSchema = (database: ManagedSqliteDatabase): void => {
 
       PRAGMA user_version = ${MANAGED_REGISTRY_SCHEMA_VERSION};
     `);
-    database.exec("COMMIT");
-  } catch (error: unknown) {
-    rollbackPreservingCause(database);
-    throw error;
-  }
-};
+  });
 
 /**
  * Prepares a freshly opened handle for use as the registry.
@@ -358,60 +412,6 @@ const initializeRegistry = (
       ),
     });
   });
-
-const commitPreservingCause = (database: ManagedSqliteDatabase): void => {
-  try {
-    database.exec("COMMIT");
-  } catch (error: unknown) {
-    rollbackPreservingCause(database);
-    throw error;
-  }
-};
-
-/** The handles currently between `BEGIN` and `COMMIT` — see {@link runTransaction}. */
-const openTransactions = new WeakSet<ManagedSqliteDatabase>();
-
-/**
- * `BEGIN`, the decision's statements, and `COMMIT` as one synchronous block.
- *
- * Atomicity here rests on the drivers being synchronous and the handle being
- * single-threaded: nothing else can run between the statements, so a partially
- * applied decision is never observable. That only holds while the whole block is
- * one JavaScript turn — splitting the boundary across effects would reintroduce
- * a suspension point where the fiber scheduler could preempt at its operation
- * budget and let another fiber `BEGIN` on this very handle.
- *
- * What synchrony cannot rule out is a decision that re-enters the repository:
- * SQLite has no nested transactions, so the inner `BEGIN` would refuse with a
- * driver message about the outer one, and unwinding the inner attempt would
- * `ROLLBACK` the outer transaction's writes. Reentrancy is a bug in the calling
- * code rather than a condition to recover from, so it is refused here — before
- * any statement runs, and without touching the transaction already in flight.
- */
-const runTransaction = <A>(
-  database: ManagedSqliteDatabase,
-  begin: "BEGIN" | "BEGIN IMMEDIATE",
-  run: () => A,
-): A => {
-  if (openTransactions.has(database)) {
-    throw new Error("A registry transaction is already open on this database handle");
-  }
-  database.exec(begin);
-  openTransactions.add(database);
-  try {
-    let decided: A;
-    try {
-      decided = run();
-    } catch (error: unknown) {
-      rollbackPreservingCause(database);
-      throw error;
-    }
-    commitPreservingCause(database);
-    return decided;
-  } finally {
-    openTransactions.delete(database);
-  }
-};
 
 /**
  * Runs one registry decision inside a transaction. `catchFailure` names the


### PR DESCRIPTION
Resolves the deferred hygiene items from the CLI-2106 review cycle (CLI-2174). Stacked on #6152.

## Items 2–5 (original hygiene set)

- **Shared atomic claim primitive** (items 2+3): the duplicated temp-write → `link()` → `EEXIST` protocol in `managed/identity.ts` and `StateManager.ts` is extracted into `managed/atomic-claim.ts` as a plain-async primitive; Effect callers wrap it. Each call site keeps its own race semantics (identity re-reads the winning marker, StateManager fails with `StateClaimError`).
- **Hardlink-less filesystem fallback** (item 3): when `link()` refuses with `EPERM`/`ENOTSUP` (exFAT, FAT32, some network mounts), the claim falls back to an exclusive `writeFile(..., { flag: "wx" })`, which still settles the race. The link-first rationale and the harmlessness of a SIGKILL-stranded `.tmp.<id>` sibling are documented on the primitive.
- **Transaction reentrancy guard** (item 4): `runTransaction` in `managed/sqlite.ts` now refuses a nested call before issuing `BEGIN` — and without issuing `ROLLBACK` — so an inner attempt can never discard the outer transaction's writes. Tracked per handle via a `WeakSet`.
- **Coverage-guard comment parsing** (item 5): `error-actionability-coverage.unit.test.ts` strips comments (string-literal-aware) before scanning for error-class definitions, so a comment containing `class X extends Error` no longer trips the guard.

## Items 7–12 (Effect-refactor verification follow-ups)

- **Explicit closed flag** (item 7): the facade's post-close guard branches on a `closed` flag set by `close()`/`asyncDispose` instead of sniffing "disposed" out of rejection text, so a callback's own rejection is reported as itself.
- **Original failure preserved through claim release** (item 8): a new `releasingClaimOnFailure` combinator on the catch paths of `updateStackRecord`/`deleteStack` discards anything the release raises (interruption included) and re-raises the original cause; the interrupt re-raise stays scoped to the recording site.
- **Publication-poll runtime guard** (item 9): the poll's final answer is checked at runtime; a bounded schedule ending on `None` dies with a clear message instead of silently yielding `undefined`.
- **No fabricated report entries from interrupts** (item 10): the liveness-probe, runtime-inspection, and state-reclamation absorption points re-raise interrupt-only causes instead of recording them.
- **Claim-before-mask contract gap documented** (item 11): the provision mask now carries a comment pinning the constraint (sync adapters have no suspension point; the mask must extend over row creation before async repositories become real), cross-referencing the same shape in `deleteStack`.
- **`migrateSchema` reuses `runTransaction`** (item 12): migration no longer hand-rolls `BEGIN`/`COMMIT`; it runs on a freshly opened handle before any repository transaction exists, so the new reentrancy guard is not tripped.

## Items resolved without code

- **Item 1 (synchronous cold-start WAL retry)**: already fixed on the CLI-2106 branch — WAL conversion now retries via an Effect `Schedule.exponential` instead of a blocking `Atomics.wait`.
- **Item 6 (`credentials.*` fixture ownership)**: no existing issue owns credential-reference resolution; proposed CLI-2114 (first CLI slice wiring the managed layer) as the owner on Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)