### PR TITLE
test(stack): stabilize postgres persistence e2e

### DIFF
--- a/packages/stack/tests/postgresDataPersistence.e2e.test.ts
+++ b/packages/stack/tests/postgresDataPersistence.e2e.test.ts
@@ -32,10 +32,12 @@ const onlyPostgresConfig = {
 
 const dockerContainerNameFor = (apiPort: string) => `supabase-postgres-${apiPort}`;
 
-const runningContainerIds = (apiPort: string): string =>
+const runningContainerIds = (apiPort: string): ReadonlyArray<string> =>
   execSync(`docker ps -q --filter name=${dockerContainerNameFor(apiPort)}`)
     .toString()
-    .trim();
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
 
 async function queryMarkerRows(dbPort: number): Promise<ReadonlyArray<{ note: string }>> {
   const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
@@ -71,6 +73,7 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
   describe("phase 1: native postgres writes a marker row", () => {
     let stack: StackHandle;
     let apiPort: string;
+    let containerIdsBeforeStart: ReadonlySet<string>;
 
     beforeAll(async () => {
       stack = await createStack({
@@ -79,14 +82,16 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
         postgres: { dataDir },
       });
 
+      apiPort = new URL(stack.url).port;
+      // Only containers introduced by this stack say anything about its runtime mode.
+      containerIdsBeforeStart = new Set(runningContainerIds(apiPort));
+
       try {
         await stack.start();
       } catch (startError) {
         await stack.dispose().catch(() => {});
         throw startError;
       }
-
-      apiPort = new URL(stack.url).port;
 
       const dbPort = parseInt(new URL(stack.dbUrl).port);
       const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
@@ -110,7 +115,9 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
       "runs postgres as a native process, not a Docker container",
       { timeout: TEST_TIMEOUT_MS },
       () => {
-        expect(runningContainerIds(apiPort)).toBe("");
+        expect(
+          runningContainerIds(apiPort).filter((id) => !containerIdsBeforeStart.has(id)),
+        ).toEqual([]);
       },
     );
   });
@@ -179,7 +186,7 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
     }, TEARDOWN_TIMEOUT_MS);
 
     test("runs postgres as a Docker container this time", { timeout: TEST_TIMEOUT_MS }, () => {
-      expect(runningContainerIds(apiPort)).not.toBe("");
+      expect(runningContainerIds(apiPort)).not.toEqual([]);
     });
 
     // This is the assertion this whole file exists to make: the row written while

--- a/packages/stack/tests/postgresDataPersistence.e2e.test.ts
+++ b/packages/stack/tests/postgresDataPersistence.e2e.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { createStack, type StackHandle } from "../src/node.ts";
+import { createStack, prefetch, type StackHandle } from "../src/node.ts";
 import { hasDockerDaemon } from "./helpers/warmup.ts";
 
 const DEV_JWT_SECRET = "super-secret-jwt-token-with-at-least-32-characters-long";
@@ -30,15 +30,12 @@ const onlyPostgresConfig = {
   edgeRuntime: false,
 } as const;
 
-const POSTGRES_CONTAINER_NAME_PREFIX = "supabase-postgres-";
-const dockerContainerNameFor = (apiPort: string) => `${POSTGRES_CONTAINER_NAME_PREFIX}${apiPort}`;
+const dockerContainerNameFor = (apiPort: string) => `supabase-postgres-${apiPort}`;
 
-const runningContainerIds = (nameFilter: string): ReadonlyArray<string> =>
-  execSync(`docker ps -q --filter name=${nameFilter}`)
+const runningContainerIds = (apiPort: string): string =>
+  execSync(`docker ps -q --filter name=${dockerContainerNameFor(apiPort)}`)
     .toString()
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
+    .trim();
 
 async function queryMarkerRows(dbPort: number): Promise<ReadonlyArray<{ note: string }>> {
   const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
@@ -54,9 +51,13 @@ async function queryMarkerRows(dbPort: number): Promise<ReadonlyArray<{ note: st
   }
 }
 
-const dockerDescribe = hasDockerDaemon() ? describe : describe.skip;
+// Native mode can fall back to Docker when its binary is unavailable.
+const canRunPersistenceE2e =
+  hasDockerDaemon() &&
+  (await prefetch({ mode: "native", services: ["postgres"] })).postgres?.type === "binary";
+const persistenceDescribe = canRunPersistenceE2e ? describe : describe.skip;
 
-dockerDescribe("postgres native/docker data persistence e2e", () => {
+persistenceDescribe("postgres native/docker data persistence e2e", () => {
   let dataDir: string;
 
   beforeAll(() => {
@@ -73,19 +74,14 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
 
   describe("phase 1: native postgres writes a marker row", () => {
     let stack: StackHandle;
-    let apiPort: string;
-    let containerIdsBeforeCreate: ReadonlySet<string>;
+    let dbPort: number;
 
     beforeAll(async () => {
-      containerIdsBeforeCreate = new Set(runningContainerIds(POSTGRES_CONTAINER_NAME_PREFIX));
-
       stack = await createStack({
         mode: "native",
         ...onlyPostgresConfig,
         postgres: { dataDir },
       });
-
-      apiPort = new URL(stack.url).port;
 
       try {
         await stack.start();
@@ -94,7 +90,7 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
         throw startError;
       }
 
-      const dbPort = parseInt(new URL(stack.dbUrl).port);
+      dbPort = parseInt(new URL(stack.dbUrl).port);
       const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
       await sql.unsafe(`
         CREATE TABLE IF NOT EXISTS public.persistence_marker (
@@ -112,17 +108,9 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
       expect(existsSync(dataDir)).toBe(true);
     }, TEARDOWN_TIMEOUT_MS);
 
-    test(
-      "runs postgres as a native process, not a Docker container",
-      { timeout: TEST_TIMEOUT_MS },
-      () => {
-        expect(
-          runningContainerIds(dockerContainerNameFor(apiPort)).filter(
-            (id) => !containerIdsBeforeCreate.has(id),
-          ),
-        ).toEqual([]);
-      },
-    );
+    test("writes the marker row with native postgres", { timeout: TEST_TIMEOUT_MS }, async () => {
+      expect(await queryMarkerRows(dbPort)).toEqual([{ note: "native-e2e-marker" }]);
+    });
   });
 
   describe("phase 2: docker postgres reusing the native dataDir", () => {
@@ -189,7 +177,7 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
     }, TEARDOWN_TIMEOUT_MS);
 
     test("runs postgres as a Docker container this time", { timeout: TEST_TIMEOUT_MS }, () => {
-      expect(runningContainerIds(dockerContainerNameFor(apiPort))).not.toEqual([]);
+      expect(runningContainerIds(apiPort)).not.toBe("");
     });
 
     // This is the assertion this whole file exists to make: the row written while

--- a/packages/stack/tests/postgresDataPersistence.e2e.test.ts
+++ b/packages/stack/tests/postgresDataPersistence.e2e.test.ts
@@ -30,10 +30,11 @@ const onlyPostgresConfig = {
   edgeRuntime: false,
 } as const;
 
-const dockerContainerNameFor = (apiPort: string) => `supabase-postgres-${apiPort}`;
+const POSTGRES_CONTAINER_NAME_PREFIX = "supabase-postgres-";
+const dockerContainerNameFor = (apiPort: string) => `${POSTGRES_CONTAINER_NAME_PREFIX}${apiPort}`;
 
-const runningContainerIds = (apiPort: string): ReadonlyArray<string> =>
-  execSync(`docker ps -q --filter name=${dockerContainerNameFor(apiPort)}`)
+const runningContainerIds = (nameFilter: string): ReadonlyArray<string> =>
+  execSync(`docker ps -q --filter name=${nameFilter}`)
     .toString()
     .trim()
     .split(/\s+/)
@@ -73,9 +74,11 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
   describe("phase 1: native postgres writes a marker row", () => {
     let stack: StackHandle;
     let apiPort: string;
-    let containerIdsBeforeStart: ReadonlySet<string>;
+    let containerIdsBeforeCreate: ReadonlySet<string>;
 
     beforeAll(async () => {
+      containerIdsBeforeCreate = new Set(runningContainerIds(POSTGRES_CONTAINER_NAME_PREFIX));
+
       stack = await createStack({
         mode: "native",
         ...onlyPostgresConfig,
@@ -83,8 +86,6 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
       });
 
       apiPort = new URL(stack.url).port;
-      // Only containers introduced by this stack say anything about its runtime mode.
-      containerIdsBeforeStart = new Set(runningContainerIds(apiPort));
 
       try {
         await stack.start();
@@ -116,7 +117,9 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
       { timeout: TEST_TIMEOUT_MS },
       () => {
         expect(
-          runningContainerIds(apiPort).filter((id) => !containerIdsBeforeStart.has(id)),
+          runningContainerIds(dockerContainerNameFor(apiPort)).filter(
+            (id) => !containerIdsBeforeCreate.has(id),
+          ),
         ).toEqual([]);
       },
     );
@@ -186,7 +189,7 @@ dockerDescribe("postgres native/docker data persistence e2e", () => {
     }, TEARDOWN_TIMEOUT_MS);
 
     test("runs postgres as a Docker container this time", { timeout: TEST_TIMEOUT_MS }, () => {
-      expect(runningContainerIds(apiPort)).not.toEqual([]);
+      expect(runningContainerIds(dockerContainerNameFor(apiPort))).not.toEqual([]);
     });
 
     // This is the assertion this whole file exists to make: the row written while

--- a/packages/stack/tests/postgresDataPersistence.e2e.test.ts
+++ b/packages/stack/tests/postgresDataPersistence.e2e.test.ts
@@ -30,12 +30,15 @@ const onlyPostgresConfig = {
   edgeRuntime: false,
 } as const;
 
-const dockerContainerNameFor = (apiPort: string) => `supabase-postgres-${apiPort}`;
+const POSTGRES_CONTAINER_NAME_PREFIX = "supabase-postgres-";
+const dockerContainerNameFor = (apiPort: string) => `${POSTGRES_CONTAINER_NAME_PREFIX}${apiPort}`;
 
-const runningContainerIds = (apiPort: string): string =>
-  execSync(`docker ps -q --filter name=${dockerContainerNameFor(apiPort)}`)
+const runningContainerIds = (nameFilter: string): ReadonlyArray<string> =>
+  execSync(`docker ps -q --filter name=${nameFilter}`)
     .toString()
-    .trim();
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
 
 async function queryMarkerRows(dbPort: number): Promise<ReadonlyArray<{ note: string }>> {
   const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
@@ -74,14 +77,19 @@ persistenceDescribe("postgres native/docker data persistence e2e", () => {
 
   describe("phase 1: native postgres writes a marker row", () => {
     let stack: StackHandle;
-    let dbPort: number;
+    let apiPort: string;
+    let containerIdsBeforeCreate: ReadonlySet<string>;
 
     beforeAll(async () => {
+      containerIdsBeforeCreate = new Set(runningContainerIds(POSTGRES_CONTAINER_NAME_PREFIX));
+
       stack = await createStack({
         mode: "native",
         ...onlyPostgresConfig,
         postgres: { dataDir },
       });
+
+      apiPort = new URL(stack.url).port;
 
       try {
         await stack.start();
@@ -90,7 +98,7 @@ persistenceDescribe("postgres native/docker data persistence e2e", () => {
         throw startError;
       }
 
-      dbPort = parseInt(new URL(stack.dbUrl).port);
+      const dbPort = parseInt(new URL(stack.dbUrl).port);
       const sql = new Bun.SQL(`postgresql://supabase_admin:postgres@127.0.0.1:${dbPort}/postgres`);
       await sql.unsafe(`
         CREATE TABLE IF NOT EXISTS public.persistence_marker (
@@ -108,9 +116,17 @@ persistenceDescribe("postgres native/docker data persistence e2e", () => {
       expect(existsSync(dataDir)).toBe(true);
     }, TEARDOWN_TIMEOUT_MS);
 
-    test("writes the marker row with native postgres", { timeout: TEST_TIMEOUT_MS }, async () => {
-      expect(await queryMarkerRows(dbPort)).toEqual([{ note: "native-e2e-marker" }]);
-    });
+    test(
+      "runs postgres as a native process, not a Docker container",
+      { timeout: TEST_TIMEOUT_MS },
+      () => {
+        expect(
+          runningContainerIds(dockerContainerNameFor(apiPort)).filter(
+            (id) => !containerIdsBeforeCreate.has(id),
+          ),
+        ).toEqual([]);
+      },
+    );
   });
 
   describe("phase 2: docker postgres reusing the native dataDir", () => {
@@ -177,7 +193,7 @@ persistenceDescribe("postgres native/docker data persistence e2e", () => {
     }, TEARDOWN_TIMEOUT_MS);
 
     test("runs postgres as a Docker container this time", { timeout: TEST_TIMEOUT_MS }, () => {
-      expect(runningContainerIds(apiPort)).not.toBe("");
+      expect(runningContainerIds(dockerContainerNameFor(apiPort))).not.toEqual([]);
     });
 
     // This is the assertion this whole file exists to make: the row written while


### PR DESCRIPTION
## TL;DR

Stabilize the Postgres persistence e2e by checking only the Docker containers created during native stack startup.

The test previously checked every matching container on the runner. A container left by another test could therefore cause a failure even when native startup used no Docker containers. 
Capture matching container IDs before startup and assert that no new IDs appear afterward. 
This follows the stack test suite's existing snapshot and diff pattern while preserving Docker startup and data persistence coverage...

## ref: 
spotted on: https://github.com/supabase/cli/actions/runs/31634963213/job/94242831412