### PR TITLE
chore(stack): scope managed registry context reads

### DIFF
--- a/packages/stack/src/managed-resolve-stack.integration.test.ts
+++ b/packages/stack/src/managed-resolve-stack.integration.test.ts
@@ -425,6 +425,20 @@ describe.each(adapters)("resolveStack over git workspaces with the %s adapter", 
     expect(renamed.identity.contextId).toBe(feature.identity.contextId);
     expect(renamed.context).toEqual({ kind: "branch", branch: "feat/renamed" });
     expect(renamed.stack.contextLocator).toBe("feat/renamed");
+
+    // The repository query itself must retain the branch context predicate: the
+    // main branch shares this project and checkout, but its stack is not part of
+    // the renamed branch's projection.
+    const branchStacks = runRepo(
+      service.repository.listStackProjections({
+        identity: {
+          projectId: feature.identity.projectId,
+          checkoutId: feature.identity.checkoutId,
+          contextId: feature.identity.contextId,
+        },
+      }),
+    );
+    expect(branchStacks.map((stack) => stack.id)).toEqual([feature.stack.id]);
   });
 
   it("resolves an ordinary folder through the same path as a checkout", async () => {

--- a/packages/stack/src/managed-service.integration.test.ts
+++ b/packages/stack/src/managed-service.integration.test.ts
@@ -1005,6 +1005,57 @@ describe("managed repository and lifecycle", () => {
     });
   }
 
+  for (const adapter of ["in-memory", "bun-sqlite"] as const) {
+    it(`scopes stack projections and preserves ordering and tombstones with the ${adapter} adapter`, async () => {
+      const root = makeRoot();
+      const service =
+        adapter === "in-memory"
+          ? await makeInMemoryService(root, {
+              clock: () => new Date("2026-08-11T00:00:00.000Z"),
+              idFactory: descendingIdFactory(),
+            })
+          : await makePersistentService(root, {
+              clock: () => new Date("2026-08-11T00:00:00.000Z"),
+              idFactory: descendingIdFactory(),
+            });
+      const workspace = makeWorkspace(root, "scoped");
+      const first = await service.resolveStack({
+        operation: "start",
+        workspacePath: workspace,
+        stackName: "first",
+      });
+      const second = await service.resolveStack({
+        operation: "start",
+        workspacePath: workspace,
+        stackName: "second",
+      });
+      await service.resolveStack({
+        operation: "start",
+        workspacePath: makeWorkspace(root, "foreign"),
+      });
+      await service.deleteStack(first.stack.id);
+
+      const identity = {
+        projectId: first.identity.projectId,
+        checkoutId: first.identity.checkoutId,
+        contextId: first.identity.contextId,
+      };
+      const live = runRepo(service.repository.listStackProjections({ identity }));
+      expect(live.map((stack) => stack.id)).toEqual([second.stack.id]);
+
+      const withTombstones = runRepo(
+        service.repository.listStackProjections({
+          identity,
+          includeTombstoned: true,
+        }),
+      );
+      expect(withTombstones.map((stack) => stack.id)).toEqual(
+        [first.stack.id, second.stack.id].sort(),
+      );
+      await service.close();
+    });
+  }
+
   it("anchors an injected relative state root so a later chdir cannot split stack state", async () => {
     const service = await makeManagedStackService({
       repository: createInMemoryManagedStackRepository(),

--- a/packages/stack/src/managed/repository-memory.ts
+++ b/packages/stack/src/managed/repository-memory.ts
@@ -523,7 +523,7 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
           compareManagedText(left.id, right.id),
       );
 
-  const listStackProjectionRecordsByIdentity = (
+  const listStackProjectionsByIdentity = (
     identity: ManagedIdentityTriple,
     options?: { readonly includeTombstoned?: boolean },
   ): ReadonlyArray<ManagedStackProjection> =>
@@ -581,7 +581,7 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
       Effect.sync(() =>
         options?.identity === undefined
           ? listStackRecords(options).map((stack) => copy(projectStack(stack)))
-          : listStackProjectionRecordsByIdentity(options.identity, options).map(copy),
+          : listStackProjectionsByIdentity(options.identity, options).map(copy),
       ),
     findCheckoutContext: (checkoutId, kind) =>
       Effect.sync(() => {

--- a/packages/stack/src/managed/repository-memory.ts
+++ b/packages/stack/src/managed/repository-memory.ts
@@ -231,6 +231,40 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
     return { acquired: true, operation: copy(operation) };
   };
 
+  /** Applies the shared context-registration policy to this atomic map store. */
+  const registerContext = (input: PrepareStackInput): string => {
+    const contextRegistration = decideManagedContextRegistration({
+      requestedId: input.identity.contextId,
+      projectId: input.identity.projectId,
+      checkoutId: input.identity.checkoutId,
+      context: input.context,
+      now: input.now,
+      checkoutScopedExisting:
+        input.context.kind === "branch"
+          ? undefined
+          : [...contexts.values()].find(
+              (candidate) =>
+                candidate.checkoutId === input.identity.checkoutId &&
+                candidate.kind === input.context.kind,
+            ),
+      requestedExisting: contexts.get(input.identity.contextId),
+    });
+    const contextId =
+      contextRegistration.outcome === "create"
+        ? contextRegistration.context.id
+        : contextRegistration.contextId;
+    if (contextRegistration.outcome === "create") {
+      contexts.set(contextId, contextRegistration.context);
+    } else if (contextRegistration.refreshLocator !== undefined) {
+      const existing = contexts.get(contextId);
+      if (existing === undefined) {
+        throw new Error(`Managed context ${contextId} vanished during registration`);
+      }
+      contexts.set(contextId, { ...existing, locator: contextRegistration.refreshLocator });
+    }
+    return contextId;
+  };
+
   const prepareStack = (input: PrepareStackInput): PrepareStackResult => {
     assertManagedOwnerPid(input.ownerPid);
     return atomic(() => {
@@ -249,35 +283,7 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
         kind: input.checkoutKind,
       });
 
-      const contextRegistration = decideManagedContextRegistration({
-        requestedId: input.identity.contextId,
-        projectId: input.identity.projectId,
-        checkoutId: input.identity.checkoutId,
-        context: input.context,
-        now: input.now,
-        checkoutScopedExisting:
-          input.context.kind === "branch"
-            ? undefined
-            : [...contexts.values()].find(
-                (candidate) =>
-                  candidate.checkoutId === input.identity.checkoutId &&
-                  candidate.kind === input.context.kind,
-              ),
-        requestedExisting: contexts.get(input.identity.contextId),
-      });
-      const contextId =
-        contextRegistration.outcome === "create"
-          ? contextRegistration.context.id
-          : contextRegistration.contextId;
-      if (contextRegistration.outcome === "create") {
-        contexts.set(contextId, contextRegistration.context);
-      } else if (contextRegistration.refreshLocator !== undefined) {
-        const existing = contexts.get(contextId);
-        if (existing === undefined) {
-          throw new Error(`Managed context ${contextId} vanished during registration`);
-        }
-        contexts.set(contextId, { ...existing, locator: contextRegistration.refreshLocator });
-      }
+      const contextId = registerContext(input);
 
       const existingLocation = [...locations.values()].find(
         (location) => location.checkoutId === input.identity.checkoutId,

--- a/packages/stack/src/managed/repository-memory.ts
+++ b/packages/stack/src/managed/repository-memory.ts
@@ -12,6 +12,7 @@ import {
   type ManagedCheckoutKind,
   type ManagedCheckoutLocation,
   type ManagedContextRecord,
+  type ManagedIdentityTriple,
   type ManagedOperationRecord,
   type ManagedRuntimeMetadata,
   type ManagedStackConfiguration,
@@ -23,6 +24,7 @@ import {
   assertManagedOwnerPid,
   assertManagedStackUpdatable,
   compareManagedText,
+  decideManagedContextRegistration,
   managedStackOccupiesPorts,
   reconcileManagedPortAssignments,
   validateManagedPortAssignments,
@@ -229,47 +231,6 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
     return { acquired: true, operation: copy(operation) };
   };
 
-  /** The in-memory counterpart of the SQLite adapter's `registerContext`. */
-  const registerContext = (input: PrepareStackInput): string => {
-    const requested = input.identity.contextId;
-    if (input.context.kind !== "branch") {
-      const owned = [...contexts.values()].find(
-        (candidate) =>
-          candidate.checkoutId === input.identity.checkoutId &&
-          candidate.kind === input.context.kind,
-      );
-      if (owned !== undefined) {
-        return owned.id;
-      }
-    }
-    const existing = contexts.get(requested);
-    if (existing !== undefined) {
-      const existingClaim = existing.checkoutId ?? existing.projectId;
-      const requestedClaim =
-        input.context.kind === "branch" ? input.identity.projectId : input.identity.checkoutId;
-      if (existing.kind !== input.context.kind || existingClaim !== requestedClaim) {
-        throw new DuplicateManagedIdentityError({
-          identityId: requested,
-          existingClaim,
-          requestedClaim,
-        });
-      }
-      if (input.context.kind === "branch" && existing.locator !== input.context.locator) {
-        contexts.set(requested, { ...existing, locator: input.context.locator });
-      }
-      return requested;
-    }
-    contexts.set(requested, {
-      id: requested,
-      projectId: input.identity.projectId,
-      checkoutId: input.context.kind === "branch" ? undefined : input.identity.checkoutId,
-      kind: input.context.kind,
-      locator: input.context.kind === "branch" ? input.context.locator : undefined,
-      createdAt: input.now,
-    });
-    return requested;
-  };
-
   const prepareStack = (input: PrepareStackInput): PrepareStackResult => {
     assertManagedOwnerPid(input.ownerPid);
     return atomic(() => {
@@ -288,7 +249,35 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
         kind: input.checkoutKind,
       });
 
-      const contextId = registerContext(input);
+      const contextRegistration = decideManagedContextRegistration({
+        requestedId: input.identity.contextId,
+        projectId: input.identity.projectId,
+        checkoutId: input.identity.checkoutId,
+        context: input.context,
+        now: input.now,
+        checkoutScopedExisting:
+          input.context.kind === "branch"
+            ? undefined
+            : [...contexts.values()].find(
+                (candidate) =>
+                  candidate.checkoutId === input.identity.checkoutId &&
+                  candidate.kind === input.context.kind,
+              ),
+        requestedExisting: contexts.get(input.identity.contextId),
+      });
+      const contextId =
+        contextRegistration.outcome === "create"
+          ? contextRegistration.context.id
+          : contextRegistration.contextId;
+      if (contextRegistration.outcome === "create") {
+        contexts.set(contextId, contextRegistration.context);
+      } else if (contextRegistration.refreshLocator !== undefined) {
+        const existing = contexts.get(contextId);
+        if (existing === undefined) {
+          throw new Error(`Managed context ${contextId} vanished during registration`);
+        }
+        contexts.set(contextId, { ...existing, locator: contextRegistration.refreshLocator });
+      }
 
       const existingLocation = [...locations.values()].find(
         (location) => location.checkoutId === input.identity.checkoutId,
@@ -528,6 +517,19 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
           compareManagedText(left.id, right.id),
       );
 
+  const listStackProjectionRecordsByIdentity = (
+    identity: ManagedIdentityTriple,
+    options?: { readonly includeTombstoned?: boolean },
+  ): ReadonlyArray<ManagedStackProjection> =>
+    listStackRecords(options)
+      .filter(
+        (stack) =>
+          stack.projectId === identity.projectId &&
+          stack.checkoutId === identity.checkoutId &&
+          stack.contextId === identity.contextId,
+      )
+      .map(projectStack);
+
   return {
     prepareStack: (input) =>
       Effect.try({
@@ -570,7 +572,11 @@ export const createInMemoryManagedStackRepository = (): ManagedStackRepositorySh
         return stack === undefined ? undefined : copy(projectStack(stack));
       }),
     listStackProjections: (options) =>
-      Effect.sync(() => listStackRecords(options).map((stack) => copy(projectStack(stack)))),
+      Effect.sync(() =>
+        options?.identity === undefined
+          ? listStackRecords(options).map((stack) => copy(projectStack(stack)))
+          : listStackProjectionRecordsByIdentity(options.identity, options).map(copy),
+      ),
     findCheckoutContext: (checkoutId, kind) =>
       Effect.sync(() => {
         const context = [...contexts.values()].find(

--- a/packages/stack/src/managed/repository.ts
+++ b/packages/stack/src/managed/repository.ts
@@ -7,6 +7,7 @@ import {
   ManagedPortReservationError,
   ManagedRunningStackPortChangeError,
   ManagedStackNotFoundError,
+  DuplicateManagedIdentityError,
   type ManagedCheckoutKind,
   type ManagedCheckoutLocation,
   type ManagedCheckoutScopedContextKind,
@@ -22,7 +23,71 @@ import {
   type ManagedStackProjection,
   type ManagedStackRecord,
 } from "./model.ts";
-import type { DuplicateManagedIdentityError, ManagedOperationOwnershipError } from "./model.ts";
+import type { ManagedOperationOwnershipError } from "./model.ts";
+
+export interface ManagedContextRegistrationInput {
+  readonly requestedId: string;
+  readonly projectId: string;
+  readonly checkoutId: string;
+  readonly context: ManagedContextDescriptor;
+  readonly now: string;
+  readonly checkoutScopedExisting?: ManagedContextRecord;
+  readonly requestedExisting?: ManagedContextRecord;
+}
+
+export type ManagedContextRegistrationDecision =
+  | {
+      readonly outcome: "existing";
+      readonly contextId: string;
+      readonly refreshLocator?: string;
+    }
+  | { readonly outcome: "create"; readonly context: ManagedContextRecord };
+
+/**
+ * Pure policy for resolving the context a registration should use. Storage
+ * adapters supply the rows they observed and apply the returned decision inside
+ * their own atomic boundary.
+ */
+export const decideManagedContextRegistration = (
+  input: ManagedContextRegistrationInput,
+): ManagedContextRegistrationDecision => {
+  if (input.context.kind !== "branch" && input.checkoutScopedExisting !== undefined) {
+    return { outcome: "existing", contextId: input.checkoutScopedExisting.id };
+  }
+
+  const existing = input.requestedExisting;
+  if (existing !== undefined) {
+    const existingClaim = existing.checkoutId ?? existing.projectId;
+    const requestedClaim = input.context.kind === "branch" ? input.projectId : input.checkoutId;
+    if (existing.kind !== input.context.kind || existingClaim !== requestedClaim) {
+      throw new DuplicateManagedIdentityError({
+        identityId: input.requestedId,
+        existingClaim,
+        requestedClaim,
+      });
+    }
+    return {
+      outcome: "existing",
+      contextId: input.requestedId,
+      refreshLocator:
+        input.context.kind === "branch" && existing.locator !== input.context.locator
+          ? input.context.locator
+          : undefined,
+    };
+  }
+
+  return {
+    outcome: "create",
+    context: {
+      id: input.requestedId,
+      projectId: input.projectId,
+      checkoutId: input.context.kind === "branch" ? undefined : input.checkoutId,
+      kind: input.context.kind,
+      locator: input.context.kind === "branch" ? input.context.locator : undefined,
+      createdAt: input.now,
+    },
+  };
+};
 
 /**
  * Everything one stack registration needs, with every identity already minted by
@@ -181,6 +246,8 @@ export interface ManagedStackRepositoryShape {
   ) => Effect.Effect<ManagedStackProjection | undefined>;
   readonly listStackProjections: (options?: {
     readonly includeTombstoned?: boolean;
+    /** When present, filter before hydrating ports for a resolve. */
+    readonly identity?: ManagedIdentityTriple;
   }) => Effect.Effect<ReadonlyArray<ManagedStackProjection>>;
   /**
    * The one context a checkout has of a checkout-scoped kind, if it has one.

--- a/packages/stack/src/managed/service.ts
+++ b/packages/stack/src/managed/service.ts
@@ -908,7 +908,7 @@ export class ManagedStackService extends Context.Service<
         const contextStacks = (
           identity: ManagedIdentityTriple,
         ): Effect.Effect<ReadonlyArray<ManagedStackProjection>> =>
-          Effect.map(repository.listStackProjections(), (stacks) =>
+          Effect.map(repository.listStackProjections({ identity }), (stacks) =>
             stacks.filter(
               (stack) =>
                 stack.projectId === identity.projectId &&

--- a/packages/stack/src/managed/service.ts
+++ b/packages/stack/src/managed/service.ts
@@ -904,7 +904,12 @@ export class ManagedStackService extends Context.Service<
             : Effect.succeed({ projectId, checkoutId, contextId });
         };
 
-        /** Every live stack of one resolved project, checkout, and context, as a reader sees them. */
+        /**
+         * Every live stack of one resolved project, checkout, and context, as a
+         * reader sees them. The repository identity filter avoids enumerating and
+         * hydrating unrelated stacks; the retained filter protects this service
+         * contract for injected repositories that may not implement that scope.
+         */
         const contextStacks = (
           identity: ManagedIdentityTriple,
         ): Effect.Effect<ReadonlyArray<ManagedStackProjection>> =>

--- a/packages/stack/src/managed/sqlite.ts
+++ b/packages/stack/src/managed/sqlite.ts
@@ -18,6 +18,7 @@ import {
   type ManagedCheckoutScopedContextKind,
   type ManagedContextKind,
   type ManagedContextRecord,
+  type ManagedIdentityTriple,
   type ManagedOperationKind,
   type ManagedOperationRecord,
   type ManagedOperationStatus,
@@ -49,6 +50,7 @@ import type {
 import {
   assertManagedOwnerPid,
   assertManagedStackUpdatable,
+  decideManagedContextRegistration,
   managedStackOccupiesPorts,
   ManagedStackRepository,
   reconcileManagedPortAssignments,
@@ -610,6 +612,29 @@ const selectStackProjections = (
   );
 };
 
+const selectStackProjectionsByIdentity = (
+  database: ManagedSqliteDatabase,
+  identity: ManagedIdentityTriple,
+  options?: { readonly includeTombstoned?: boolean },
+): ReadonlyArray<ManagedStackProjection> => {
+  const statusClause =
+    options?.includeTombstoned === true ? "" : " AND stacks.status != 'tombstoned'";
+  const rows = database
+    .prepare(
+      `${STACK_PROJECTION_SELECT}
+       WHERE stacks.project_id = ? AND stacks.checkout_id = ? AND stacks.context_id = ?${statusClause}
+       ORDER BY stacks.created_at, stacks.id`,
+    )
+    .all([identity.projectId, identity.checkoutId, identity.contextId]);
+  const portsByStack = queryPortsByStack(
+    database,
+    rows.map((row) => getString(row, "id")),
+  );
+  return rows.map((row) =>
+    decodeStackProjectionWithPorts(row, portsByStack.get(getString(row, "id")) ?? []),
+  );
+};
+
 const decodeContext = (row: unknown): ManagedContextRecord => ({
   id: getString(row, "id"),
   projectId: getString(row, "project_id"),
@@ -796,32 +821,31 @@ const insertConfiguration = (
  * detached `HEAD` converge on a single context instead of splitting.
  */
 const registerContext = (database: ManagedSqliteDatabase, input: PrepareStackInput): string => {
-  const requested = input.identity.contextId;
-  if (input.context.kind !== "branch") {
-    const owned = findCheckoutContext(database, input.identity.checkoutId, input.context.kind);
-    if (owned !== undefined) {
-      return owned.id;
-    }
-  }
-  const existing = database.prepare("SELECT * FROM contexts WHERE id = ?").get([requested]);
-  if (existing !== undefined) {
-    const context = decodeContext(existing);
-    const existingClaim = context.checkoutId ?? context.projectId;
-    const requestedClaim =
-      input.context.kind === "branch" ? input.identity.projectId : input.identity.checkoutId;
-    if (context.kind !== input.context.kind || existingClaim !== requestedClaim) {
-      throw new DuplicateManagedIdentityError({
-        identityId: requested,
-        existingClaim,
-        requestedClaim,
-      });
-    }
-    if (input.context.kind === "branch" && context.locator !== input.context.locator) {
+  const requestedExistingRow = database
+    .prepare("SELECT * FROM contexts WHERE id = ?")
+    .get([input.identity.contextId]);
+  const requestedExisting =
+    requestedExistingRow === undefined ? undefined : decodeContext(requestedExistingRow);
+  const checkoutScopedExisting =
+    input.context.kind === "branch"
+      ? undefined
+      : findCheckoutContext(database, input.identity.checkoutId, input.context.kind);
+  const decision = decideManagedContextRegistration({
+    requestedId: input.identity.contextId,
+    projectId: input.identity.projectId,
+    checkoutId: input.identity.checkoutId,
+    context: input.context,
+    now: input.now,
+    checkoutScopedExisting,
+    requestedExisting,
+  });
+  if (decision.outcome === "existing") {
+    if (decision.refreshLocator !== undefined) {
       database
         .prepare("UPDATE contexts SET locator = ? WHERE id = ?")
-        .run([input.context.locator, requested]);
+        .run([decision.refreshLocator, decision.contextId]);
     }
-    return requested;
+    return decision.contextId;
   }
   database
     .prepare(
@@ -829,14 +853,14 @@ const registerContext = (database: ManagedSqliteDatabase, input: PrepareStackInp
              VALUES (?, ?, ?, ?, ?, ?)`,
     )
     .run([
-      requested,
-      input.identity.projectId,
-      input.context.kind === "branch" ? null : input.identity.checkoutId,
-      input.context.kind,
-      input.context.kind === "branch" ? input.context.locator : null,
-      input.now,
+      decision.context.id,
+      decision.context.projectId,
+      decision.context.checkoutId ?? null,
+      decision.context.kind,
+      decision.context.locator ?? null,
+      decision.context.createdAt,
     ]);
-  return requested;
+  return decision.context.id;
 };
 
 const prepareStack = (
@@ -1229,7 +1253,11 @@ const createSqliteManagedStackRepository = (
       getStackProjection: (stackId) =>
         readTransaction(database, () => getStackProjection(database, stackId)),
       listStackProjections: (options) =>
-        readTransaction(database, () => selectStackProjections(database, options)),
+        readTransaction(database, () =>
+          options?.identity === undefined
+            ? selectStackProjections(database, options)
+            : selectStackProjectionsByIdentity(database, options.identity, options),
+        ),
       findCheckoutContext: (checkoutId, kind) =>
         readTransaction(database, () => findCheckoutContext(database, checkoutId, kind)),
       claimOperation: (input) =>


### PR DESCRIPTION
## Summary

- Scope managed stack projection reads to the resolved project, checkout, and context before hydrating port assignments.
- Share one pure context-registration decision across the SQLite and in-memory adapters while keeping each adapter transactionally authoritative.
- Preserve global listing behavior, deterministic ordering, tombstone handling, and existing context identity semantics.

## Linked issue

[CLI-2185](https://linear.app/supabase/issue/CLI-2185/stack-scope-managed-registry-reads-and-centralize-context-policy)

## Reviewer context

This builds on the managed-state APIs introduced by #6171, which is now merged. The branch has been rebased onto develop, so the PR diff is limited to the focused CLI-2185 change.