### PR TITLE
test(codeql): fixture syntax

### DIFF
--- a/apps/cli-go/pkg/function/testdata/modules/imports.ts
+++ b/apps/cli-go/pkg/function/testdata/modules/imports.ts
@@ -57,8 +57,9 @@ import MultiContentAddView from "./views/AddView"
 import MultiContentEditView from "./views/EditView"
 
 
-<MenuItem value="^$" primaryText="Não exibir importados" />
-<MenuItem value="\\w+" primaryText="Exibir importados" />
+// JSX-like snippets are comments so this .ts fixture remains valid syntax.
+// <MenuItem value="^$" primaryText="Não exibir importados" />
+// <MenuItem value="\\w+" primaryText="Exibir importados" />
 
 // *Add all needed dependency to this module
 // *app requires those import modules to function


### PR DESCRIPTION
clears these warnings: 
<img width="1279" height="879" alt="image" src="https://github.com/user-attachments/assets/b377a39b-932e-4c8d-961d-8249515e5576" />