### PR TITLE
fix(cli): surface setup errors (CLI-2187)

### DIFF
--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -1,9 +1,21 @@
-import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync, writeFileSync } from "node:fs";
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { describe, expect, it } from "@effect/vitest";
-import { Duration, Effect, Exit, Fiber, Layer, Option, PubSub, Queue, Sink, Stream } from "effect";
+import {
+  Cause,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Option,
+  PubSub,
+  Queue,
+  Sink,
+  Stream,
+} from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { beforeEach, vi } from "vitest";
 
@@ -2765,6 +2777,117 @@ describe("legacy functions serve integration", () => {
           (call) => call.command === "docker" && call.args[0] === "run",
         ),
       ).toHaveLength(0);
+    });
+  });
+
+  it.live("surfaces the real filesystem error when the functions path is not a directory", () => {
+    deployMockState.runHandler = (command, args) => {
+      if (command !== "docker") {
+        throw new Error(`unexpected process: ${command}`);
+      }
+      if (args[0] === "container" && args[1] === "inspect") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "container" && args[1] === "rm") {
+        writeFileSync(join(tempRoot.current, "supabase", "functions"), "not a directory\n");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`unexpected docker args: ${args.join(" ")}`);
+    };
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        writeProjectConfig(
+          [
+            'project_id = "test-project"',
+            "[functions.hello]",
+            'entrypoint = "./functions/hello/index.ts"',
+            "",
+          ].join("\n"),
+        ),
+      );
+
+      const { layer, out } = setupServe();
+      const error = yield* legacyFunctionsServe(baseFlags()).pipe(
+        Effect.provide(layer),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toContain("ENOTDIR");
+        expect(error.message).toContain(join("supabase", "functions"));
+        expect(error.message).not.toContain("An error occurred in Effect.tryPromise");
+      }
+      expect(out.stderrText).toContain("Setting up Edge Functions runtime...\n");
+      expect(deployMockState.runCalls.map((call) => call.args.slice(0, 2))).toEqual([
+        ["container", "inspect"],
+        ["container", "rm"],
+      ]);
+      expect(
+        deployMockState.runCalls.filter(
+          (call) => call.command === "docker" && call.args[0] === "run",
+        ),
+      ).toHaveLength(0);
+      expect(deployMockState.networkCalls).toHaveLength(0);
+      expect(deployMockState.volumeCalls).toHaveLength(0);
+    });
+  });
+
+  it.live("preserves the primary error when artifact cleanup also fails", () => {
+    deployMockState.runHandler = (command, args) => {
+      if (command !== "docker") {
+        throw new Error(`unexpected process: ${command}`);
+      }
+      if (args[0] === "container" && args[1] === "inspect") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "container" && args[1] === "rm") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`unexpected docker args: ${args.join(" ")}`);
+    };
+
+    return Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        writeProjectConfig(['project_id = "test-project"', ""].join("\n")),
+      );
+      yield* Effect.promise(() =>
+        writeFunctionFile("hello", "index.ts", 'Deno.serve(() => new Response("hello"))\n'),
+      );
+      yield* Effect.promise(() =>
+        writeProjectFile(
+          join("supabase", "functions", ".env"),
+          ['FOO.BAR="line-1\nline-2"', ""].join("\n"),
+        ),
+      );
+      yield* Effect.promise(() =>
+        writeProjectFile(join("supabase", ".temp", "start-secrets"), "not a directory\n"),
+      );
+
+      const { layer, out } = setupServe();
+      const exit = yield* legacyFunctionsServe(baseFlags()).pipe(
+        Effect.provide(layer),
+        Effect.exit,
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) {
+        throw new Error("expected functions serve to fail");
+      }
+      const error = Cause.squash(exit.cause);
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toContain("invalid multiline environment variable name");
+        expect(error.message).toContain("FOO.BAR");
+        expect(error.message).not.toContain("ENOTDIR");
+        expect(error.message).not.toContain("An error occurred in Effect.tryPromise");
+      }
+      expect(out.stderrText).toContain("Warning: failed to clean up Edge Runtime artifacts:");
+      expect(out.stderrText).toContain("ENOTDIR");
+      expect(out.stderrText).toContain(join("supabase", ".temp", "start-secrets"));
+      expect(out.stderrText).not.toContain("An error occurred in Effect.tryPromise");
+      expect(deployMockState.runCalls.filter((call) => call.args[0] === "run")).toHaveLength(0);
     });
   });
 

--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -2883,10 +2883,18 @@ describe("legacy functions serve integration", () => {
         expect(error.message).not.toContain("ENOTDIR");
         expect(error.message).not.toContain("An error occurred in Effect.tryPromise");
       }
-      expect(out.stderrText).toContain("Warning: failed to clean up Edge Runtime artifacts:");
-      expect(out.stderrText).toContain("ENOTDIR");
-      expect(out.stderrText).toContain(join("supabase", ".temp", "start-secrets"));
-      expect(out.stderrText).not.toContain("An error occurred in Effect.tryPromise");
+      expect(out.messages).toContainEqual({
+        type: "warn",
+        message: expect.stringContaining("Failed to clean up Edge Runtime artifacts: ENOTDIR"),
+      });
+      expect(out.messages).toContainEqual({
+        type: "warn",
+        message: expect.stringContaining(join("supabase", ".temp", "start-secrets")),
+      });
+      expect(out.messages).not.toContainEqual({
+        type: "warn",
+        message: expect.stringContaining("An error occurred in Effect.tryPromise"),
+      });
       expect(deployMockState.runCalls.filter((call) => call.args[0] === "run")).toHaveLength(0);
     });
   });

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -1851,14 +1851,12 @@ export const discoverFunctionSlugs = Effect.fnUntraced(function* (
   const functionsDir = join(projectRoot, SUPABASE_FUNCTIONS_DIR);
   const slugs: string[] = [];
 
-  const entries = yield* Effect.tryPromise(() =>
-    readdir(functionsDir, { withFileTypes: true }),
-  ).pipe(
+  const entries = yield* Effect.tryPromise({
+    try: () => readdir(functionsDir, { withFileTypes: true }),
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  }).pipe(
     Effect.catch((error) => {
-      // `Effect.tryPromise`'s default failure is a `Cause.UnknownError`, which stores the
-      // original rejection on `.cause` (inherited from `Error`) — NOT `.error`.
-      const cause = error.cause;
-      return cause instanceof Error && "code" in cause && cause.code === "ENOENT"
+      return "code" in error && error.code === "ENOENT"
         ? Effect.succeed(undefined)
         : Effect.fail(error);
     }),

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -1593,17 +1593,15 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
     // `stagingDir`): this is what lets the cleanup cover the whole staging-write window below,
     // including a mid-write failure between the first and second `writeDocker*` call, not just
     // the final `docker run` step.
-    const cleanupRuntimeArtifacts = Effect.tryPromise({
+    const removeRuntimeArtifacts = Effect.tryPromise({
       try: () => rm(stagingDir, { recursive: true, force: true }),
       catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
     });
-    const cleanupRuntimeArtifactsAfterFailure = cleanupRuntimeArtifacts.pipe(
-      Effect.catch((error) =>
-        output.raw(
-          `Warning: failed to clean up Edge Runtime artifacts: ${error.message}\n`,
-          "stderr",
-        ),
+    const bestEffortCleanupRuntimeArtifacts = removeRuntimeArtifacts.pipe(
+      Effect.tapError((error) =>
+        output.warn(`Failed to clean up Edge Runtime artifacts: ${error.message}`),
       ),
+      Effect.ignoreCause,
     );
 
     const functionConfigs = yield* resolveServeFunctionConfigs(
@@ -1763,10 +1761,10 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
 
       return {
         containerId,
-        cleanup: cleanupRuntimeArtifacts.pipe(Effect.orDie),
+        cleanup: removeRuntimeArtifacts.pipe(Effect.orDie),
         watchSpecs: yield* Effect.promise(() => buildWatchSpecs([...functionBinds])),
       } satisfies StartedRuntime;
-    }).pipe(Effect.onError(() => cleanupRuntimeArtifactsAfterFailure));
+    }).pipe(Effect.onError(() => bestEffortCleanupRuntimeArtifacts));
   },
 );
 

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -1593,9 +1593,18 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
     // `stagingDir`): this is what lets the cleanup cover the whole staging-write window below,
     // including a mid-write failure between the first and second `writeDocker*` call, not just
     // the final `docker run` step.
-    const cleanupRuntimeArtifacts = Effect.tryPromise(() =>
-      rm(stagingDir, { recursive: true, force: true }),
-    ).pipe(Effect.orDie);
+    const cleanupRuntimeArtifacts = Effect.tryPromise({
+      try: () => rm(stagingDir, { recursive: true, force: true }),
+      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    });
+    const cleanupRuntimeArtifactsAfterFailure = cleanupRuntimeArtifacts.pipe(
+      Effect.catch((error) =>
+        output.raw(
+          `Warning: failed to clean up Edge Runtime artifacts: ${error.message}\n`,
+          "stderr",
+        ),
+      ),
+    );
 
     const functionConfigs = yield* resolveServeFunctionConfigs(
       input.projectRoot,
@@ -1754,10 +1763,10 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
 
       return {
         containerId,
-        cleanup: cleanupRuntimeArtifacts,
+        cleanup: cleanupRuntimeArtifacts.pipe(Effect.orDie),
         watchSpecs: yield* Effect.promise(() => buildWatchSpecs([...functionBinds])),
       } satisfies StartedRuntime;
-    }).pipe(Effect.onError(() => cleanupRuntimeArtifacts));
+    }).pipe(Effect.onError(() => cleanupRuntimeArtifactsAfterFailure));
   },
 );
 


### PR DESCRIPTION
## TL;DR

Fixes filesystem errors during `functions serve` setup which were being surfaced as the generic `An error occurred in Effect.tryPromise` message.

We already applied a similar fix in [#5904](https://github.com/supabase/cli/pull/5904) for the same generic error, so it is worth preserving the underlying cause here as well. This also prevents a secondary cleanup failure from masking the original setup error.

## Ref

- Closes https://github.com/supabase/cli/issues/6185