### PR TITLE
fix(cli): persist new migrations on Windows (CLI-2183)

### DIFF
--- a/apps/cli/src/legacy/commands/migration/new/new.handler.ts
+++ b/apps/cli/src/legacy/commands/migration/new/new.handler.ts
@@ -73,30 +73,30 @@ export const legacyMigrationNew = Effect.fn("legacy.migration.new")(function* (
         ? output.raw(`Created new migration at ${legacyBold(relativePath, process.stdout)}\n`)
         : Effect.void;
 
-    // The migration file opens first, then stdin streams into it
-    // via a fixed-size buffer, so a
-    // large `pg_dump | supabase migration new` runs in constant memory. Create
-    // the file (mode 0644, O_CREATE|O_TRUNC), then stream piped stdin into the open
-    // handle rather than buffering the whole pipe. A TTY (char device) writes nothing → empty
-    // file; an empty pipe streams nothing → empty file.
-    yield* Effect.scoped(
-      Effect.gen(function* () {
-        // Fails with "failed to open migration file" if the open fails —
-        // BEFORE the Created-line print, so no line on open failure...
-        const handle = yield* fs.open(migrationPath, { flag: "w", mode: 0o644 }).pipe(
-          Effect.mapError(
-            (cause) =>
-              new LegacyMigrationNewWriteError({
-                message: `failed to open migration file: ${cause.message}`,
-              }),
-          ),
-        );
-        // ...and with "failed to copy from stdin" if the copy fails. A piped
-        // stdin read error must abort here, not silently leave a truncated/empty file — but
-        // the Created-line print is already
-        // scheduled by then, so the Created line still prints (stdout) BEFORE the copy
-        // error surfaces (stderr, exit 1).
-        if (!stdin.isTTY) {
+    // Materialize the empty migration before reporting success instead of relying on an
+    // otherwise-unused open handle. This is the same create-then-append pattern used by
+    // db dump and db pull.
+    yield* fs.writeFile(migrationPath, new Uint8Array(0), { mode: 0o644 }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new LegacyMigrationNewWriteError({
+            message: `failed to open migration file: ${cause.message}`,
+          }),
+      ),
+    );
+
+    // Keep the piped-stdin copy scoped and chunked so large dumps use constant memory.
+    if (!stdin.isTTY) {
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* fs.open(migrationPath, { flag: "a" }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new LegacyMigrationNewWriteError({
+                  message: `failed to open migration file: ${cause.message}`,
+                }),
+            ),
+          );
           yield* stdin.pipedBytesStream.pipe(
             Stream.runForEach((chunk) => handle.writeAll(chunk)),
             Effect.mapError(
@@ -107,8 +107,19 @@ export const legacyMigrationNew = Effect.fn("legacy.migration.new")(function* (
             ),
             Effect.tapError(() => printCreated),
           );
-        }
-      }),
+        }),
+      );
+    }
+
+    // Do not emit success solely because a runtime write reported success. This command's
+    // contract is that the returned path exists when it exits zero.
+    yield* fs.stat(migrationPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new LegacyMigrationNewWriteError({
+            message: `failed to verify migration file: ${cause.message}`,
+          }),
+      ),
     );
 
     if (output.format === "text") {

--- a/apps/cli/src/legacy/commands/migration/new/new.integration.test.ts
+++ b/apps/cli/src/legacy/commands/migration/new/new.integration.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, Layer, Option, Stream } from "effect";
+import { Cause, Effect, Exit, FileSystem, Layer, Option, Stream } from "effect";
 import { badArgument } from "effect/PlatformError";
 
 import { stripAnsi } from "../../../../../tests/helpers/ansi.ts";
@@ -21,6 +21,28 @@ interface SetupOpts {
   readonly format?: OutputFormat;
   readonly isTTY?: boolean;
   readonly piped?: string;
+  readonly openDoesNotMaterialize?: boolean;
+  readonly writeDoesNotMaterialize?: boolean;
+}
+
+function nonMaterializingFsLayer(
+  workdir: string,
+  opts: Pick<SetupOpts, "openDoesNotMaterialize" | "writeDoesNotMaterialize">,
+): Layer.Layer<FileSystem.FileSystem> {
+  return Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(FileSystem.FileSystem, (real) =>
+      FileSystem.FileSystem.of({
+        ...real,
+        open: (path, options) =>
+          opts.openDoesNotMaterialize === true
+            ? real.open(join(workdir, ".deferred-open"), options)
+            : real.open(path, options),
+        writeFile: (path, data, options) =>
+          opts.writeDoesNotMaterialize === true ? Effect.void : real.writeFile(path, data, options),
+      }),
+    ),
+  ).pipe(Layer.provide(BunServices.layer));
 }
 
 function setup(workdir: string, opts: SetupOpts = {}) {
@@ -32,6 +54,9 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     mockStdin(opts.isTTY ?? true, opts.piped),
     mockLegacyCliConfig({ workdir }),
     BunServices.layer,
+    ...(opts.openDoesNotMaterialize === true || opts.writeDoesNotMaterialize === true
+      ? [nonMaterializingFsLayer(workdir, opts)]
+      : []),
   );
   return { layer, out, telemetry };
 }
@@ -82,6 +107,39 @@ describe("legacy migration new", () => {
       yield* legacyMigrationNew({ migrationName: "empty_pipe" });
       const file = onlyMigration(tmp.current);
       expect(readFileSync(join(migrationsDir(tmp.current), file), "utf8")).toBe("");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("materializes the migration without relying on an open handle", () => {
+    const { layer } = setup(tmp.current, { openDoesNotMaterialize: true });
+    return Effect.gen(function* () {
+      yield* legacyMigrationNew({ migrationName: "windows_open" });
+      const file = onlyMigration(tmp.current);
+      expect(readFileSync(join(migrationsDir(tmp.current), file), "utf8")).toBe("");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("does not report success when the migration is not materialized", () => {
+    const { layer, out, telemetry } = setup(tmp.current, {
+      openDoesNotMaterialize: true,
+      writeDoesNotMaterialize: true,
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyMigrationNew({ migrationName: "missing" }).pipe(Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const failure = Cause.findErrorOption(exit.cause);
+        expect(Option.isSome(failure)).toBe(true);
+        if (Option.isSome(failure)) {
+          expect(failure.value).toBeInstanceOf(LegacyMigrationNewWriteError);
+          if (failure.value instanceof LegacyMigrationNewWriteError) {
+            expect(failure.value.message).toContain("failed to verify migration file");
+          }
+        }
+      }
+      expect(readdirSync(migrationsDir(tmp.current))).toEqual([]);
+      expect(out.stdoutText).toBe("");
+      expect(telemetry.flushed).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 


### PR DESCRIPTION
## TL;DR

Ensure `supabase migration new` creates the migration file before reporting success, including on affected Windows environments...

The command now explicitly creates or truncates the migration before streaming piped input,<br> following the existing `db dump` and `db pull` pattern.<br>it also kinda verifies that the file exists before emitting success..

## Ref

* Closes supabase/cli#6174