### PR TITLE
fix: stop overwriting verify_jwt setting on function deploy

### DIFF
--- a/apps/cli-go/internal/functions/deploy/deploy.go
+++ b/apps/cli-go/internal/functions/deploy/deploy.go
@@ -111,7 +111,7 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 		function, ok := utils.Config.Functions[name]
 		if !ok {
 			function.Enabled = true
-			function.VerifyJWT = true
+			// Don't set VerifyJWT when not in config, so the API preserves the existing server-side setting
 		}
 		// Precedence order: flag > config > fallback
 		functionDir := filepath.Join(utils.FunctionsDir, name)
@@ -137,7 +137,8 @@ func GetFunctionConfig(slugs []string, importMapPath string, noVerifyJWT *bool, 
 			}
 		}
 		if noVerifyJWT != nil {
-			function.VerifyJWT = !*noVerifyJWT
+			val := !*noVerifyJWT
+			function.VerifyJWT = &val
 		}
 		functionConfig[name] = function
 	}

--- a/apps/cli-go/internal/functions/serve/serve.go
+++ b/apps/cli-go/internal/functions/serve/serve.go
@@ -290,8 +290,12 @@ func PopulatePerFunctionConfigs(cwd, importMapPath string, noVerifyJWT *bool, fs
 			return nil, "", err
 		}
 		binds = append(binds, modules...)
+		verifyJWT := true
+		if fc.VerifyJWT != nil {
+			verifyJWT = *fc.VerifyJWT
+		}
 		enabled := dockerFunction{
-			VerifyJWT:      fc.VerifyJWT,
+			VerifyJWT:      verifyJWT,
 			EntrypointPath: utils.ToDockerPath(fc.Entrypoint),
 			ImportMapPath:  utils.ToDockerPath(fc.ImportMap),
 			StaticFiles:    make([]string, len(fc.StaticFiles)),

--- a/apps/cli-go/pkg/config/config.go
+++ b/apps/cli-go/pkg/config/config.go
@@ -201,7 +201,7 @@ type (
 
 	function struct {
 		Enabled     bool   `toml:"enabled" json:"enabled"`
-		VerifyJWT   bool   `toml:"verify_jwt" json:"verify_jwt"`
+		VerifyJWT   *bool  `toml:"verify_jwt" json:"verify_jwt"`
 		ImportMap   string `toml:"import_map" json:"import_map"`
 		Entrypoint  string `toml:"entrypoint" json:"entrypoint"`
 		StaticFiles Glob   `toml:"static_files" json:"static_files"`

--- a/apps/cli-go/pkg/function/batch.go
+++ b/apps/cli-go/pkg/function/batch.go
@@ -67,13 +67,13 @@ OUTER:
 		} else if err != nil {
 			return err
 		}
-		meta.VerifyJwt = &function.VerifyJWT
+		meta.VerifyJwt = function.VerifyJWT
 		bodyHash := sha256.Sum256(body.Bytes())
 		meta.SHA256 = hex.EncodeToString(bodyHash[:])
 		// Skip if function has not changed
 		if i, exists := slugToIndex[slug]; exists && i >= 0 &&
 			result[i].EzbrSha256 != nil && *result[i].EzbrSha256 == meta.SHA256 &&
-			result[i].VerifyJwt != nil && *result[i].VerifyJwt == function.VerifyJWT {
+			result[i].VerifyJwt != nil && function.VerifyJWT != nil && *result[i].VerifyJwt == *function.VerifyJWT {
 			fmt.Fprintln(os.Stderr, "No change found in Function:", slug)
 			continue
 		}

--- a/apps/cli-go/pkg/function/batch_test.go
+++ b/apps/cli-go/pkg/function/batch_test.go
@@ -96,7 +96,7 @@ func TestUpsertFunctions(t *testing.T) {
 			}})
 		// Run test
 		err := client.UpsertFunctions(context.Background(), config.FunctionConfig{
-			"test-a": {Enabled: true, VerifyJWT: true},
+			"test-a": {Enabled: true, VerifyJWT: cast.Ptr(true)},
 			"test-b": {Enabled: false},
 		})
 		// Check error

--- a/apps/cli-go/pkg/function/deploy.go
+++ b/apps/cli-go/pkg/function/deploy.go
@@ -34,7 +34,7 @@ func (s *EdgeRuntimeAPI) Deploy(ctx context.Context, functionConfig config.Funct
 			Name:           &slug,
 			EntrypointPath: toRelPath(fc.Entrypoint),
 			ImportMapPath:  cast.Ptr(toRelPath(fc.ImportMap)),
-			VerifyJwt:      &fc.VerifyJWT,
+			VerifyJwt:      fc.VerifyJWT,
 		}
 		files := make([]string, len(fc.StaticFiles))
 		for i, sf := range fc.StaticFiles {


### PR DESCRIPTION
The erify_jwt setting is silently overwritten when deploying functions. This fix preserves the existing verify_jwt value.