### PR TITLE
fix: support require_current_password email setting in auth config

### DIFF
--- a/apps/cli-go/pkg/config/auth.go
+++ b/apps/cli-go/pkg/config/auth.go
@@ -240,16 +240,17 @@ type (
 	}
 
 	email struct {
-		EnableSignup         bool                     `toml:"enable_signup" json:"enable_signup"`
-		DoubleConfirmChanges bool                     `toml:"double_confirm_changes" json:"double_confirm_changes"`
-		EnableConfirmations  bool                     `toml:"enable_confirmations" json:"enable_confirmations"`
-		SecurePasswordChange bool                     `toml:"secure_password_change" json:"secure_password_change"`
-		Template             map[string]emailTemplate `toml:"template" json:"template"`
-		Notification         map[string]notification  `toml:"notification" json:"notification"`
-		Smtp                 *smtp                    `toml:"smtp" json:"smtp"`
-		MaxFrequency         time.Duration            `toml:"max_frequency" json:"max_frequency"`
-		OtpLength            uint                     `toml:"otp_length" json:"otp_length"`
-		OtpExpiry            uint                     `toml:"otp_expiry" json:"otp_expiry"`
+		EnableSignup           bool                     `toml:"enable_signup" json:"enable_signup"`
+		DoubleConfirmChanges   bool                     `toml:"double_confirm_changes" json:"double_confirm_changes"`
+		EnableConfirmations    bool                     `toml:"enable_confirmations" json:"enable_confirmations"`
+		SecurePasswordChange   bool                     `toml:"secure_password_change" json:"secure_password_change"`
+		RequireCurrentPassword bool                     `toml:"require_current_password" json:"require_current_password"`
+		Template               map[string]emailTemplate `toml:"template" json:"template"`
+		Notification           map[string]notification  `toml:"notification" json:"notification"`
+		Smtp                   *smtp                    `toml:"smtp" json:"smtp"`
+		MaxFrequency           time.Duration            `toml:"max_frequency" json:"max_frequency"`
+		OtpLength              uint                     `toml:"otp_length" json:"otp_length"`
+		OtpExpiry              uint                     `toml:"otp_expiry" json:"otp_expiry"`
 	}
 
 	smtp struct {

--- a/apps/cli-go/pkg/config/templates/config.toml
+++ b/apps/cli-go/pkg/config/templates/config.toml
@@ -226,6 +226,8 @@ double_confirm_changes = true
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
+# If enabled, users must provide their current password to change their password.
+require_current_password = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.

--- a/apps/cli-go/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
+++ b/apps/cli-go/pkg/config/testdata/TestEmailDiff/local_disabled_remote_enabled.diff
@@ -1,7 +1,7 @@
 diff remote[auth] local[auth]
 --- remote[auth]
 +++ local[auth]
-@@ -47,13 +47,13 @@
+@@ -49,14 +49,14 @@
  inactivity_timeout = "0s"
  
  [email]
@@ -9,20 +9,21 @@ diff remote[auth] local[auth]
 -double_confirm_changes = true
 -enable_confirmations = true
 -secure_password_change = true
--max_frequency = "1s"
--otp_length = 6
--otp_expiry = 3600
 +enable_signup = false
 +double_confirm_changes = false
 +enable_confirmations = false
 +secure_password_change = false
+ require_current_password = false
+-max_frequency = "1s"
+-otp_length = 6
+-otp_expiry = 3600
 +max_frequency = "1m0s"
 +otp_length = 8
 +otp_expiry = 86400
  [email.template]
  [email.template.confirmation]
  content_path = ""
-@@ -69,25 +69,25 @@
+@@ -72,25 +72,25 @@
  content_path = ""
  [email.notification]
  [email.notification.email_changed]

--- a/apps/cli-go/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
+++ b/apps/cli-go/pkg/config/testdata/TestEmailDiff/local_enabled_remote_disabled.diff
@@ -1,7 +1,7 @@
 diff remote[auth] local[auth]
 --- remote[auth]
 +++ local[auth]
-@@ -47,62 +47,74 @@
+@@ -49,63 +49,75 @@
  inactivity_timeout = "0s"
  
  [email]
@@ -9,13 +9,14 @@ diff remote[auth] local[auth]
 -double_confirm_changes = false
 -enable_confirmations = false
 -secure_password_change = false
--max_frequency = "1m0s"
--otp_length = 6
--otp_expiry = 3600
 +enable_signup = true
 +double_confirm_changes = true
 +enable_confirmations = true
 +secure_password_change = true
+ require_current_password = false
+-max_frequency = "1m0s"
+-otp_length = 6
+-otp_expiry = 3600
 +max_frequency = "1s"
 +otp_length = 8
 +otp_expiry = 86400

--- a/apps/cli-go/pkg/config/testdata/config.toml
+++ b/apps/cli-go/pkg/config/testdata/config.toml
@@ -214,6 +214,8 @@ double_confirm_changes = true
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = true
+# If enabled, users must provide their current password to change their password.
+require_current_password = true
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.

--- a/apps/cli/src/legacy/commands/start/services/gotrue.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/gotrue.service.ts
@@ -488,6 +488,9 @@ export function legacyBuildGotrueEnv(input: LegacyBuildGotrueEnvInput): Record<s
     GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION: String(
       input.email.secure_password_change,
     ),
+    GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD: String(
+      input.email.require_current_password,
+    ),
     GOTRUE_MFA_PHONE_ENROLL_ENABLED: String(input.mfa.phone.enroll_enabled),
     GOTRUE_MFA_PHONE_VERIFY_ENABLED: String(input.mfa.phone.verify_enabled),
     GOTRUE_MFA_TOTP_ENROLL_ENABLED: String(input.mfa.totp.enroll_enabled),

--- a/apps/cli/src/legacy/commands/start/services/gotrue.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/gotrue.service.unit.test.ts
@@ -38,6 +38,7 @@ const baseEnvInput: LegacyBuildGotrueEnvInput = {
     double_confirm_changes: true,
     enable_confirmations: false,
     secure_password_change: false,
+    require_current_password: false,
     max_frequency: "1s",
     otp_length: 6,
     otp_expiry: 3600,
@@ -452,6 +453,27 @@ describe("legacyBuildGotrueEnv", () => {
     test("omits CAPTCHA env when unset", () => {
       const env = legacyBuildGotrueEnv(baseEnvInput);
       expect(env["GOTRUE_SECURITY_CAPTCHA_ENABLED"]).toBeUndefined();
+    });
+  });
+
+  describe("update password", () => {
+    test("emits REQUIRE_REAUTHENTICATION and REQUIRE_CURRENT_PASSWORD from email config", () => {
+      const env = legacyBuildGotrueEnv({
+        ...baseEnvInput,
+        email: {
+          ...baseEnvInput.email,
+          secure_password_change: true,
+          require_current_password: true,
+        },
+      });
+      expect(env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION"]).toBe("true");
+      expect(env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD"]).toBe("true");
+    });
+
+    test("emits false defaults when email config is unset", () => {
+      const env = legacyBuildGotrueEnv(baseEnvInput);
+      expect(env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION"]).toBe("false");
+      expect(env["GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD"]).toBe("false");
     });
   });
 

--- a/apps/cli/src/legacy/shared/legacy-local-config-values.ts
+++ b/apps/cli/src/legacy/shared/legacy-local-config-values.ts
@@ -1023,6 +1023,12 @@ export function legacyResolveAuthEmail(
       "auth.email.secure_password_change",
       projectEnvValues,
     ),
+    require_current_password: legacyEnvOverrideBool(
+      "SUPABASE_AUTH_EMAIL_REQUIRE_CURRENT_PASSWORD",
+      email.require_current_password,
+      "auth.email.require_current_password",
+      projectEnvValues,
+    ),
     max_frequency:
       legacyEnvOverride(
         "SUPABASE_AUTH_EMAIL_MAX_FREQUENCY",

--- a/apps/cli/src/shared/init/project-init.templates.ts
+++ b/apps/cli/src/shared/init/project-init.templates.ts
@@ -226,6 +226,8 @@ double_confirm_changes = true
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
+# If enabled, users must provide their current password to change their password.
+require_current_password = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.

--- a/packages/config/src/auth/email.ts
+++ b/packages/config/src/auth/email.ts
@@ -15,6 +15,7 @@ const defaultEnableSignup = true;
 const defaultDoubleConfirmChanges = true;
 const defaultEnableConfirmations = false;
 const defaultSecurePasswordChange = false;
+const defaultRequireCurrentPassword = false;
 const defaultMaxFrequency = "1s";
 const defaultOtpLength = 6;
 const defaultOtpExpiry = 3600;
@@ -107,6 +108,12 @@ export const email = Schema.Struct({
     tags,
     links: [links.auth],
   }).pipe(Schema.withDecodingDefaultKey(Effect.succeed(defaultSecurePasswordChange))),
+  require_current_password: Schema.Boolean.annotate({
+    default: defaultRequireCurrentPassword,
+    description: "If enabled, users must provide their current password to change their password.",
+    tags,
+    links: [links.auth],
+  }).pipe(Schema.withDecodingDefaultKey(Effect.succeed(defaultRequireCurrentPassword))),
   max_frequency: Schema.String.annotate({
     default: defaultMaxFrequency,
     description:


### PR DESCRIPTION
Fixes #5846

Adds the missing \equire_current_password\ email setting so local auth (gotrue) can require users to confirm their current password on password change:

- Go config schema: \uth.email.require_current_password\ field + init template
- \@supabase/config\: schema field with default \alse\
- Legacy resolver: \SUPABASE_AUTH_EMAIL_REQUIRE_CURRENT_PASSWORD\ env override
- gotrue env: \GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD\ mapping + unit tests
- Go diff snapshots regenerated