### PR TITLE
feat: support SUPABASE_HIDE_VERSION_MESSAGE to suppress upgrade hint

### DIFF
--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -195,7 +195,7 @@ func Execute() {
 	if hint := utils.SuggestClaudePlugin(); hint != "" {
 		fmt.Fprintln(os.Stderr, hint)
 	}
-	if semver.Compare(version, "v"+utils.Version) > 0 {
+	if semver.Compare(version, "v"+utils.Version) > 0 && !utils.HideVersionMessage() {
 		fmt.Fprintln(os.Stderr, suggestUpgrade(version))
 	}
 	if len(utils.CmdSuggestion) > 0 {

--- a/apps/cli-go/cmd/root_test.go
+++ b/apps/cli-go/cmd/root_test.go
@@ -119,3 +119,15 @@ func TestEnvSignals(t *testing.T) {
 	assert.Equal(t, strings.Repeat("x", 80), signals["TERM"])
 	assert.NotContains(t, signals, "AI_AGENT")
 }
+
+func TestHideVersionMessage(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		t.Setenv("SUPABASE_HIDE_VERSION_MESSAGE", "")
+		assert.False(t, utils.HideVersionMessage())
+	})
+
+	t.Run("is true when env var is set", func(t *testing.T) {
+		t.Setenv("SUPABASE_HIDE_VERSION_MESSAGE", "true")
+		assert.True(t, utils.HideVersionMessage())
+	})
+}

--- a/apps/cli-go/internal/utils/misc.go
+++ b/apps/cli-go/internal/utils/misc.go
@@ -30,6 +30,12 @@ var (
 	PostHogEndpoint string
 )
 
+// HideVersionMessage returns true when SUPABASE_HIDE_VERSION_MESSAGE is set,
+// suppressing the "A new version of Supabase CLI is available" upgrade hint.
+func HideVersionMessage() bool {
+	return os.Getenv("SUPABASE_HIDE_VERSION_MESSAGE") != ""
+}
+
 func ShortContainerImageName(imageName string) string {
 	matches := ImageNamePattern.FindStringSubmatch(imageName)
 	if len(matches) < 2 {


### PR DESCRIPTION
Closes #5853

Adds SUPABASE_HIDE_VERSION_MESSAGE env var to suppress the version-upgrade hint, for users (e.g. Nix) who intentionally pin a CLI version.