### PR TITLE
fix(cli): fail test db when no tests ran (CLI-2194)

### DIFF
--- a/apps/cli/docs/go-cli-divergences.md
+++ b/apps/cli/docs/go-cli-divergences.md
@@ -71,6 +71,12 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
 
 ## Behavioral divergences from the Go reference
 
+- `test db` (and its `db test` alias) exits `1` when `pg_prove` ran no tests (CLI-2194, #6206).
+  `pg_prove` prints `Result: NOTESTS` and still exits `0` for an empty run, and Go returns that
+  code verbatim (`internal/db/test/test.go` → `DockerRunOnceWithConfig`), so a typo'd path, an
+  empty tests directory, or a bind the daemon resolved against a different filesystem than the
+  CLI's (a sibling-container Docker socket) all reported a green build that ran zero tests. The
+  TAP stream on stdout is unchanged; the diagnostic goes to stderr like every other failure.
 - `functions serve` per-function env discovery (CLI-2184, #6179): without `--env-file`, each
   `supabase/functions/<function-name>/.env` overrides matching values from the shared
   `supabase/functions/.env` for that Function only; an explicit `--env-file` remains the

--- a/apps/cli/src/legacy/commands/db/test/test.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/test/test.integration.test.ts
@@ -133,7 +133,7 @@ function mockDbConnection() {
   return { layer, execCalls };
 }
 
-function mockDockerRun(opts: { exitCode?: number } = {}) {
+function mockDockerRun(opts: { exitCode?: number; stdout?: ReadonlyArray<string> } = {}) {
   let lastOpts: LegacyDockerRunOpts | undefined;
   const layer = Layer.succeed(LegacyDockerRun, {
     run: (runOpts) => {
@@ -148,9 +148,15 @@ function mockDockerRun(opts: { exitCode?: number } = {}) {
         stderr: "",
       });
     },
-    runStream: (runOpts) => {
+    runStream: (runOpts, streamOpts) => {
       lastOpts = runOpts;
-      return Effect.succeed({ exitCode: opts.exitCode ?? 0, stderr: "" });
+      return Effect.gen(function* () {
+        const encoder = new TextEncoder();
+        for (const chunk of opts.stdout ?? []) {
+          yield* streamOpts.onStdout(encoder.encode(chunk));
+        }
+        return { exitCode: opts.exitCode ?? 0, stderr: "" };
+      });
     },
   });
   return {
@@ -173,6 +179,7 @@ const runtimeInfoLayer = Layer.succeed(RuntimeInfo, {
 interface SetupOpts {
   format?: "text" | "json" | "stream-json";
   exitCode?: number;
+  stdout?: ReadonlyArray<string>;
 }
 
 function setup(opts: SetupOpts = {}) {
@@ -181,7 +188,7 @@ function setup(opts: SetupOpts = {}) {
   const analytics = mockContextualAnalytics();
   const telemetry = mockLegacyTelemetryStateTracked();
   const connection = mockDbConnection();
-  const docker = mockDockerRun({ exitCode: opts.exitCode });
+  const docker = mockDockerRun({ exitCode: opts.exitCode, stdout: opts.stdout });
   const args = ["db", "test"];
   const layer = Layer.mergeAll(
     out.layer,
@@ -307,4 +314,32 @@ describe("legacy db test (alias) integration", () => {
       }).pipe(Effect.provide(layer));
     },
   );
+
+  it.live("fails in text mode when the run found no tests", () => {
+    const { layer, processControl } = setup({
+      exitCode: 0,
+      stdout: ["Files=0, Tests=0,  0 wallclock secs\nResult: NOTESTS\n"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyRunTestDbCommand(flags()));
+      expect(exit._tag).toBe("Failure");
+      // Text mode lets the failed Effect drive the exit code, as for a run failure.
+      expect(processControl.exitCode).toBeUndefined();
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("in json mode, a run that found no tests takes the same stderr + exit 1 path", () => {
+    const { layer, out, processControl } = setup({
+      format: "json",
+      exitCode: 0,
+      stdout: ["Files=0, Tests=0,  0 wallclock secs\nResult: NOTESTS\n"],
+    });
+    return Effect.gen(function* () {
+      yield* legacyRunTestDbCommand(flags());
+      expect(out.stderrText).toContain("no pgTAP tests found in /work/project/supabase/tests");
+      expect(processControl.exitCode).toBe(1);
+      // The TAP stream reached stdout intact, with no JSON envelope appended.
+      expect(out.stdoutText).toBe("Files=0, Tests=0,  0 wallclock secs\nResult: NOTESTS\n");
+    }).pipe(Effect.provide(layer));
+  });
 });

--- a/apps/cli/src/legacy/commands/test/db/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/test/db/SIDE_EFFECTS.md
@@ -61,6 +61,7 @@ One-shot `docker run --rm <pg_prove image>`, where the image is `supabase/pg_pro
 | ---- | ---------------------------------------------------------------------------------------------------- |
 | `0`  | all pgTAP tests pass                                                                                 |
 | `1`  | `pg_prove` exits non-zero (test failures) — `error running container: exit N`                        |
+| `1`  | `pg_prove` ran no tests (`Result: NOTESTS`) — `no pgTAP tests found in <paths>`; Go exits `0` here   |
 | `1`  | `--db-url` / `--linked` / `--local` set together (mutually exclusive)                                |
 | `1`  | database connection failure / pgTAP enable failure / docker failure / `--linked` auth or IPv6 errors |
 | `1`  | `--project-ref` set with a resolved target other than linked (see Notes)                             |
@@ -82,8 +83,8 @@ invocation path.
 ## Output
 
 `pg_prove`'s TAP output streams to **stdout in every output format** (the docker
-subprocess inherits stdout) — `test db` is a live test
-stream with no structured equivalent.
+subprocess's stdout is forwarded chunk-by-chunk, byte-exact and unframed) —
+`test db` is a live test stream with no structured equivalent.
 
 ### `--output-format text`
 

--- a/apps/cli/src/legacy/shared/legacy-docker-run.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-run.layer.ts
@@ -113,6 +113,7 @@ export const legacyDockerRunLayer: Layer.Layer<
         Effect.scoped(
           Effect.gen(function* () {
             const teeStderr = streamOpts.teeStderr ?? false;
+            const captureStderr = streamOpts.captureStderr ?? true;
             yield* processControl.holdSignals(["SIGINT", "SIGTERM", "SIGHUP"]);
             const resolvedOpts = yield* withResolvedImage(opts);
             const args = buildLegacyDockerArgs(
@@ -142,7 +143,9 @@ export const legacyDockerRunLayer: Layer.Layer<
                 ),
                 Stream.runForEach(handle.stderr, (chunk) =>
                   Effect.sync(() => {
-                    stderrChunks.push(chunk);
+                    // Retained only for the returned string — skipped when the caller
+                    // opts out, so a tee-only consumer stays at constant memory.
+                    if (captureStderr) stderrChunks.push(chunk);
                     if (teeStderr) globalThis.process.stderr.write(chunk);
                   }),
                 ).pipe(Effect.mapError(spawnError)),

--- a/apps/cli/src/legacy/shared/legacy-docker-run.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-run.service.ts
@@ -99,12 +99,18 @@ interface LegacyDockerRunShape {
    * propagates as `E`. `teeStderr` mirrors `runCapture` (Go's
    * `io.MultiWriter(os.Stderr, errBuf)`). Returns the exit code + captured stderr; the
    * stdout bytes are not retained.
+   *
+   * `captureStderr` (default `true`) buffers stderr for that returned string. Callers
+   * that only tee it and never read the result should pass `false` — retaining it
+   * grows with the container's total stderr, which the inherited-stdio `run` never did
+   * (`test db`, whose pgTAP suites can emit unbounded psql notices).
    */
   readonly runStream: <E>(
     opts: LegacyDockerRunOpts,
     streamOpts: {
       readonly onStdout: (chunk: Uint8Array) => Effect.Effect<void, E>;
       readonly teeStderr?: boolean;
+      readonly captureStderr?: boolean;
     },
   ) => Effect.Effect<
     { readonly exitCode: number; readonly stderr: string },

--- a/apps/cli/src/legacy/shared/legacy-test-db.command-handler.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.command-handler.ts
@@ -6,7 +6,7 @@ import { withJsonErrorHandling } from "../../shared/output/json-error-handling.t
 import { Output } from "../../shared/output/output.service.ts";
 import { ProcessControl } from "../../shared/runtime/process-control.service.ts";
 import { withLegacyCommandInstrumentation } from "../telemetry/legacy-command-instrumentation.ts";
-import { LegacyTestDbRunError } from "./legacy-test-db.errors.ts";
+import type { LegacyTestDbNoTestsError, LegacyTestDbRunError } from "./legacy-test-db.errors.ts";
 import { legacyTestDb } from "./legacy-test-db.handler.ts";
 
 /**
@@ -21,13 +21,14 @@ export const LEGACY_TEST_DB_SHORT = "Tests local database with pgTAP";
 /**
  * `test db` has no machine-format envelope: its entire output is the streamed
  * pg_prove TAP on stdout (Go has no `--output-format` for it). On a *run* failure
- * (failing tests), the default `withJsonErrorHandling` would append a JSON error
- * object to stdout — after the TAP already streamed — corrupting machine consumers.
+ * (failing tests, or a run that executed none), the default `withJsonErrorHandling`
+ * would append a JSON error object to stdout — after the TAP already streamed —
+ * corrupting machine consumers.
  * So in json/stream-json mode, send the diagnostic to stderr and exit 1 instead,
  * matching Go's `recoverAndExit` (stderr, exit 1). Text mode keeps the normal error
  * rendering; pre-stream errors still flow through `withJsonErrorHandling`.
  */
-const onRunFailure = (error: LegacyTestDbRunError) =>
+const onRunFailure = (error: LegacyTestDbRunError | LegacyTestDbNoTestsError) =>
   Effect.gen(function* () {
     const output = yield* Output;
     if (output.format === "text") return yield* Effect.fail(error);
@@ -114,9 +115,10 @@ export function legacyRunTestDbCommand(
       // --project-ref registrations (cmd/pgdelta_catalog.go:44 and most
       // others) are unmarked, so it stays redacted.
     }),
-    // Run failures (failing tests) must not corrupt the TAP stream on stdout in
-    // machine modes; other errors (pre-stream) still get the JSON envelope.
-    Effect.catchTag("LegacyTestDbRunError", onRunFailure),
+    // Run failures (failing tests, or a run that executed none) must not corrupt the
+    // TAP stream on stdout in machine modes; other errors (pre-stream) still get the
+    // JSON envelope.
+    Effect.catchTag(["LegacyTestDbRunError", "LegacyTestDbNoTestsError"], onRunFailure),
     withJsonErrorHandling,
   );
 }

--- a/apps/cli/src/legacy/shared/legacy-test-db.errors.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.errors.ts
@@ -33,6 +33,19 @@ export class LegacyTestDbRunError extends Data.TaggedError("LegacyTestDbRunError
 }
 
 /**
+ * `pg_prove` ran but found nothing to execute. It reports that as `Result: NOTESTS`
+ * and still exits 0, so without this the command reports success for a run that
+ * executed zero tests (CLI-2194).
+ */
+export class LegacyTestDbNoTestsError extends Data.TaggedError("LegacyTestDbNoTestsError")<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+/**
  * More than one of `--db-url` / `--linked` / `--local` was set. Reproduces
  * cobra's `MarkFlagsMutuallyExclusive("db-url", "linked", "local")` error from
  * `apps/cli-go/cmd/db.go:485`, byte-for-byte.

--- a/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
@@ -39,17 +39,20 @@ const DISABLE_PGTAP = "drop extension if exists pgtap";
 const LEGACY_PG_PROVE_IMAGE = "supabase/pg_prove:3.36";
 const MAX_PROJECT_ID_LENGTH = 40;
 /**
- * `TAP::Harness`'s verdict line when the run aggregated no test files. `pg_prove`
- * still exits 0 for it, so "found nothing to run" is otherwise indistinguishable
- * from "everything passed" — a typo'd path, an empty directory, or a bind the
- * daemon resolved against a different filesystem than the CLI's (a sibling-container
- * Docker socket) all report a green build that ran zero tests (CLI-2194).
+ * `TAP::Harness` closes every run with exactly one `Result: <verdict>` line.
+ * `pg_prove` still exits 0 for the empty-run verdict, so "found nothing to run" is
+ * otherwise indistinguishable from "everything passed" — a typo'd path, an empty
+ * directory, or a bind the daemon resolved against a different filesystem than the
+ * CLI's (a sibling-container Docker socket) all report a green build that ran zero
+ * tests (CLI-2194).
  *
- * Anchored to the start of a line so a `--verbose` run replaying a test's own
- * output cannot trip it mid-line. Matching the harness's human summary is a
- * heuristic, not a guarantee — it is pinned to the image tag above.
+ * Only the harness's FINAL verdict decides: under `--debug` (`--verbose`) the
+ * harness replays each test's raw TAP, and a passing test may legally print its own
+ * `Result: …` line, which must not be mistaken for the run's outcome. Matching the
+ * harness's human summary is a heuristic pinned to the image tag above.
  */
-const NO_TESTS_VERDICT = "\nResult: NOTESTS";
+const VERDICT_PREFIX = "Result: ";
+const NO_TESTS_VERDICT = "Result: NOTESTS";
 
 /** Port of Go's `sanitizeProjectId` (`pkg/config/config.go:1037`). */
 function sanitizeProjectId(src: string): string {
@@ -153,9 +156,9 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
           : { _tag: "host" as const };
 
     const decoder = new TextDecoder();
-    // Seeded with the anchor newline so a stream that opens on the verdict matches.
-    let verdictTail = "\n";
-    let ranNoTests = false;
+    // The trailing partial line, plus the last complete verdict line seen so far.
+    let pendingLine = "";
+    let lastVerdict = "";
 
     const { exitCode } = yield* Effect.scoped(
       Effect.gen(function* () {
@@ -224,11 +227,13 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
           {
             onStdout: (chunk) =>
               Effect.suspend(() => {
-                // Carry one verdict's worth of the previous chunk so a match split
-                // across a chunk boundary is still seen, at constant memory.
-                verdictTail += decoder.decode(chunk, { stream: true });
-                if (verdictTail.includes(NO_TESTS_VERDICT)) ranNoTests = true;
-                verdictTail = verdictTail.slice(-NO_TESTS_VERDICT.length);
+                // Split on newlines, carrying the incomplete trailing line into the
+                // next chunk so a verdict straddling a chunk boundary is still seen.
+                const lines = (pendingLine + decoder.decode(chunk, { stream: true })).split("\n");
+                pendingLine = lines.pop() ?? "";
+                for (const line of lines) {
+                  if (line.startsWith(VERDICT_PREFIX)) lastVerdict = line;
+                }
                 return output.rawBytes(chunk, "stdout");
               }),
             teeStderr: true,
@@ -250,7 +255,9 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
       );
     }
 
-    if (ranNoTests) {
+    // A stream that ends without a trailing newline leaves the verdict unterminated.
+    const finalVerdict = pendingLine.startsWith(VERDICT_PREFIX) ? pendingLine : lastVerdict;
+    if (finalVerdict.trimEnd() === NO_TESTS_VERDICT) {
       return yield* Effect.fail(
         new LegacyTestDbNoTestsError({
           message: `no pgTAP tests found in ${args.hostPaths.join(", ")}`,

--- a/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
@@ -21,6 +21,7 @@ import type { LegacyTestDbFlags } from "./legacy-test-db.command-handler.ts";
 import {
   LegacyTestDbEnablePgtapError,
   LegacyTestDbMutuallyExclusiveFlagsError,
+  LegacyTestDbNoTestsError,
   LegacyTestDbRunError,
 } from "./legacy-test-db.errors.ts";
 import { buildLegacyPgProveArgs } from "./legacy-test-db.pg-prove-args.ts";
@@ -33,9 +34,22 @@ const DISABLE_PGTAP = "drop extension if exists pgtap";
 // The TS config schema does not model an `[images]` override, so it is fixed here.
 // Go resolves it through `GetRegistryImageUrl` (`DockerStart`), honoring
 // `SUPABASE_INTERNAL_IMAGE_REGISTRY` / the default ECR mirror, so do the same
-// before passing it to `docker run`.
+// before passing it to `docker run`. Re-verify `NO_TESTS_VERDICT` still matches
+// when bumping this tag.
 const LEGACY_PG_PROVE_IMAGE = "supabase/pg_prove:3.36";
 const MAX_PROJECT_ID_LENGTH = 40;
+/**
+ * `TAP::Harness`'s verdict line when the run aggregated no test files. `pg_prove`
+ * still exits 0 for it, so "found nothing to run" is otherwise indistinguishable
+ * from "everything passed" — a typo'd path, an empty directory, or a bind the
+ * daemon resolved against a different filesystem than the CLI's (a sibling-container
+ * Docker socket) all report a green build that ran zero tests (CLI-2194).
+ *
+ * Anchored to the start of a line so a `--verbose` run replaying a test's own
+ * output cannot trip it mid-line. Matching the harness's human summary is a
+ * heuristic, not a guarantee — it is pinned to the image tag above.
+ */
+const NO_TESTS_VERDICT = "\nResult: NOTESTS";
 
 /** Port of Go's `sanitizeProjectId` (`pkg/config/config.go:1037`). */
 function sanitizeProjectId(src: string): string {
@@ -138,10 +152,15 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
             })
           : { _tag: "host" as const };
 
-    const exitCode = yield* Effect.scoped(
+    const decoder = new TextDecoder();
+    // Seeded with the anchor newline so a stream that opens on the verdict matches.
+    let verdictTail = "\n";
+    let ranNoTests = false;
+
+    const { exitCode } = yield* Effect.scoped(
       Effect.gen(function* () {
-        // stdout is reserved for the pg_prove TAP stream (the docker subprocess
-        // writes it there directly), so connection diagnostics must go to stderr —
+        // stdout is reserved for the pg_prove TAP stream (forwarded byte-exact
+        // below), so connection diagnostics must go to stderr —
         // exactly as Go does (`ConnectByConfigStream` writes "Connecting to …
         // database…" to `os.Stderr`, `connect.go:205-228`). A `Output.task`
         // spinner would corrupt the TAP stream: clack writes spinner ANSI to
@@ -187,16 +206,34 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
         // Windows Docker Desktop provide the mapping natively (empty there).
         const extraHosts =
           runtimeInfo.platform === "linux" ? ["host.docker.internal:host-gateway"] : [];
-        return yield* docker.run({
-          image: legacyGetRegistryImageUrl(LEGACY_PG_PROVE_IMAGE),
-          cmd: args.cmd,
-          env: runEnv,
-          binds: args.binds,
-          workingDir: args.workingDir,
-          securityOpt: inBitbucket ? [] : ["label:disable"],
-          extraHosts,
-          network,
-        });
+        // Stream (rather than inherit) stdout so the verdict can be read on the way
+        // past; every chunk is forwarded byte-exact and unframed, leaving the TAP
+        // stream identical to what the container wrote. stderr is teed live, as
+        // inheriting it did.
+        return yield* docker.runStream(
+          {
+            image: legacyGetRegistryImageUrl(LEGACY_PG_PROVE_IMAGE),
+            cmd: args.cmd,
+            env: runEnv,
+            binds: args.binds,
+            workingDir: args.workingDir,
+            securityOpt: inBitbucket ? [] : ["label:disable"],
+            extraHosts,
+            network,
+          },
+          {
+            onStdout: (chunk) =>
+              Effect.suspend(() => {
+                // Carry one verdict's worth of the previous chunk so a match split
+                // across a chunk boundary is still seen, at constant memory.
+                verdictTail += decoder.decode(chunk, { stream: true });
+                if (verdictTail.includes(NO_TESTS_VERDICT)) ranNoTests = true;
+                verdictTail = verdictTail.slice(-NO_TESTS_VERDICT.length);
+                return output.rawBytes(chunk, "stdout");
+              }),
+            teeStderr: true,
+          },
+        );
       }),
     );
 
@@ -210,6 +247,14 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
     if (exitCode !== 0) {
       return yield* Effect.fail(
         new LegacyTestDbRunError({ message: `error running container: exit ${exitCode}` }),
+      );
+    }
+
+    if (ranNoTests) {
+      return yield* Effect.fail(
+        new LegacyTestDbNoTestsError({
+          message: `no pgTAP tests found in ${args.hostPaths.join(", ")}`,
+        }),
       );
     }
   }).pipe(Effect.ensuring(telemetryState.flush));

--- a/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
@@ -50,9 +50,14 @@ const MAX_PROJECT_ID_LENGTH = 40;
  * harness replays each test's raw TAP, and a passing test may legally print its own
  * `Result: …` line, which must not be mistaken for the run's outcome. Matching the
  * harness's human summary is a heuristic pinned to the image tag above.
+ *
+ * The verdict alone is not enough: a suite that deliberately skips itself
+ * (`1..0 # SKIP …`) also ends `NOTESTS`, but reports `Files=1`. Only a run that
+ * aggregated ZERO files found nothing to run, so both signals must agree.
  */
 const VERDICT_PREFIX = "Result: ";
 const NO_TESTS_VERDICT = "Result: NOTESTS";
+const FILES_SUMMARY = /^Files=(\d+),/;
 
 /** Port of Go's `sanitizeProjectId` (`pkg/config/config.go:1037`). */
 function sanitizeProjectId(src: string): string {
@@ -156,9 +161,10 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
           : { _tag: "host" as const };
 
     const decoder = new TextDecoder();
-    // The trailing partial line, plus the last complete verdict line seen so far.
+    // The trailing partial line, plus the last complete summary/verdict lines so far.
     let pendingLine = "";
     let lastVerdict = "";
+    let lastSummary = "";
 
     const { exitCode } = yield* Effect.scoped(
       Effect.gen(function* () {
@@ -233,6 +239,7 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
                 pendingLine = lines.pop() ?? "";
                 for (const line of lines) {
                   if (line.startsWith(VERDICT_PREFIX)) lastVerdict = line;
+                  else if (FILES_SUMMARY.test(line)) lastSummary = line;
                 }
                 return output.rawBytes(chunk, "stdout");
               }),
@@ -260,7 +267,8 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
 
     // A stream that ends without a trailing newline leaves the verdict unterminated.
     const finalVerdict = pendingLine.startsWith(VERDICT_PREFIX) ? pendingLine : lastVerdict;
-    if (finalVerdict.trimEnd() === NO_TESTS_VERDICT) {
+    const aggregatedFiles = FILES_SUMMARY.exec(lastSummary)?.[1];
+    if (finalVerdict.trimEnd() === NO_TESTS_VERDICT && aggregatedFiles === "0") {
       return yield* Effect.fail(
         new LegacyTestDbNoTestsError({
           message: `no pgTAP tests found in ${args.hostPaths.join(", ")}`,

--- a/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.handler.ts
@@ -236,7 +236,10 @@ export const legacyTestDb = Effect.fn("legacy.test.db")(function* (flags: Legacy
                 }
                 return output.rawBytes(chunk, "stdout");
               }),
+            // Teed straight to the terminal as inheriting it did; nothing here reads
+            // the buffered copy, and a pgTAP suite's psql notices are unbounded.
             teeStderr: true,
+            captureStderr: false,
           },
         );
       }),

--- a/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
@@ -115,7 +115,12 @@ function mockDbConnection(opts: {
   };
 }
 
-function mockDockerRun(opts: { exitCode?: number; runFails?: boolean }) {
+function mockDockerRun(opts: {
+  exitCode?: number;
+  runFails?: boolean;
+  /** pg_prove's stdout, delivered to `onStdout` one array entry per chunk. */
+  stdout?: ReadonlyArray<string>;
+}) {
   let lastOpts: LegacyDockerRunOpts | undefined;
   const layer = Layer.succeed(LegacyDockerRun, {
     run: (runOpts) => {
@@ -142,7 +147,7 @@ function mockDockerRun(opts: { exitCode?: number; runFails?: boolean }) {
           )
         : Effect.succeed({ exitCode: opts.exitCode ?? 0, stdout: new Uint8Array(0), stderr: "" });
     },
-    runStream: (runOpts) => {
+    runStream: (runOpts, streamOpts) => {
       lastOpts = runOpts;
       return opts.runFails === true
         ? Effect.fail(
@@ -152,7 +157,13 @@ function mockDockerRun(opts: { exitCode?: number; runFails?: boolean }) {
               daemonDown: false,
             }),
           )
-        : Effect.succeed({ exitCode: opts.exitCode ?? 0, stderr: "" });
+        : Effect.gen(function* () {
+            const encoder = new TextEncoder();
+            for (const chunk of opts.stdout ?? []) {
+              yield* streamOpts.onStdout(encoder.encode(chunk));
+            }
+            return { exitCode: opts.exitCode ?? 0, stderr: "" };
+          });
     },
   });
   return {
@@ -184,6 +195,7 @@ interface SetupOpts {
   dropFails?: boolean;
   exitCode?: number;
   runFails?: boolean;
+  stdout?: ReadonlyArray<string>;
   debug?: boolean;
   networkId?: string;
   workdir?: string;
@@ -405,6 +417,71 @@ describe("legacy test db integration", () => {
       if (Exit.isFailure(exit)) {
         expect(JSON.stringify(exit.cause)).toContain("error running container: exit 3");
       }
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("fails when pg_prove ran no tests, even though it exited 0 (CLI-2194)", () => {
+    const { layer } = setup({
+      exitCode: 0,
+      stdout: ["Files=0, Tests=0,  0 wallclock secs\nResult: NOTESTS\n"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags({ paths: ["tests/db"] })));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain(
+          "no pgTAP tests found in /work/project/tests/db",
+        );
+      }
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("detects the NOTESTS verdict when it straddles a stdout chunk boundary", () => {
+    const { layer } = setup({ exitCode: 0, stdout: ["Files=0\nResult: NOTE", "STS\n"] });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isFailure(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("detects the NOTESTS verdict arriving one byte per chunk", () => {
+    const { layer } = setup({
+      exitCode: 0,
+      stdout: [..."Files=0\nResult: NOTESTS\n"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isFailure(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("detects the NOTESTS verdict opening the stream, with no line before it", () => {
+    // The seeded newline exists for exactly this case: stream start counts as a
+    // line start, so the anchored match still fires.
+    const { layer } = setup({ exitCode: 0, stdout: ["Result: NOTESTS\n"] });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isFailure(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("does not trip on the verdict text mid-line, as a --verbose replay can emit", () => {
+    const { layer } = setup({
+      exitCode: 0,
+      stdout: ["# diag: Result: NOTESTS is what an empty run prints\n", "Result: PASS\n"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isSuccess(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("forwards the TAP stream to stdout byte-exact and succeeds on a passing run", () => {
+    const chunks = ["a.test.sql .. ok\n", "All tests successful.\n", "Result: PASS\n"];
+    const { layer, out } = setup({ exitCode: 0, stdout: chunks });
+    return Effect.gen(function* () {
+      yield* legacyTestDb(flags());
+      expect(out.stdoutText).toBe(chunks.join(""));
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
@@ -122,6 +122,9 @@ function mockDockerRun(opts: {
   stdout?: ReadonlyArray<string>;
 }) {
   let lastOpts: LegacyDockerRunOpts | undefined;
+  let lastStreamOpts:
+    | { readonly teeStderr?: boolean; readonly captureStderr?: boolean }
+    | undefined;
   const layer = Layer.succeed(LegacyDockerRun, {
     run: (runOpts) => {
       lastOpts = runOpts;
@@ -149,6 +152,7 @@ function mockDockerRun(opts: {
     },
     runStream: (runOpts, streamOpts) => {
       lastOpts = runOpts;
+      lastStreamOpts = streamOpts;
       return opts.runFails === true
         ? Effect.fail(
             new LegacyDockerRunError({
@@ -170,6 +174,9 @@ function mockDockerRun(opts: {
     layer,
     get lastOpts() {
       return lastOpts;
+    },
+    get lastStreamOpts() {
+      return lastStreamOpts;
     },
   };
 }
@@ -498,6 +505,17 @@ describe("legacy test db integration", () => {
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
       expect(Exit.isSuccess(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("tees container stderr without retaining it, as inheriting stdio did", () => {
+    // A pgTAP suite's psql notices are unbounded; buffering them for a string nothing
+    // reads would grow with the whole run (PR #6210 review).
+    const { layer, docker } = setup();
+    return Effect.gen(function* () {
+      yield* legacyTestDb(flags());
+      expect(docker.lastStreamOpts?.teeStderr).toBe(true);
+      expect(docker.lastStreamOpts?.captureStderr).toBe(false);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
@@ -444,7 +444,7 @@ describe("legacy test db integration", () => {
   });
 
   it.live("detects the NOTESTS verdict when it straddles a stdout chunk boundary", () => {
-    const { layer } = setup({ exitCode: 0, stdout: ["Files=0\nResult: NOTE", "STS\n"] });
+    const { layer } = setup({ exitCode: 0, stdout: ["Files=0, Tests=0\nResult: NOTE", "STS\n"] });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
       expect(Exit.isFailure(exit)).toBe(true);
@@ -454,7 +454,7 @@ describe("legacy test db integration", () => {
   it.live("detects the NOTESTS verdict arriving one byte per chunk", () => {
     const { layer } = setup({
       exitCode: 0,
-      stdout: [..."Files=0\nResult: NOTESTS\n"],
+      stdout: [..."Files=0, Tests=0\nResult: NOTESTS\n"],
     });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
@@ -462,19 +462,27 @@ describe("legacy test db integration", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("detects the NOTESTS verdict opening the stream, with no line before it", () => {
-    const { layer } = setup({ exitCode: 0, stdout: ["Result: NOTESTS\n"] });
+  it.live("detects the NOTESTS verdict when the stream ends without a trailing newline", () => {
+    const { layer } = setup({ exitCode: 0, stdout: ["Files=0, Tests=0\nResult: NOTESTS"] });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
       expect(Exit.isFailure(exit)).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("detects the NOTESTS verdict when the stream ends without a trailing newline", () => {
-    const { layer } = setup({ exitCode: 0, stdout: ["Files=0\nResult: NOTESTS"] });
+  it.live("passes a suite that deliberately skips itself, which also ends NOTESTS", () => {
+    // `1..0 # SKIP …` reports `Files=1, Tests=0` + `Result: NOTESTS` and exits 0. A
+    // file WAS found, so this is a successful run, not an empty one (PR #6210 review).
+    const { layer } = setup({
+      exitCode: 0,
+      stdout: [
+        "skip.test.sql .. skipped: not applicable on this platform\n",
+        "Files=1, Tests=0,  0 wallclock secs\nResult: NOTESTS\n",
+      ],
+    });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
-      expect(Exit.isFailure(exit)).toBe(true);
+      expect(Exit.isSuccess(exit)).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 
@@ -499,7 +507,7 @@ describe("legacy test db integration", () => {
         "ok 1 - passes\n",
         "Result: NOTESTS is diagnostic text\n",
         "ok 2 - passes\n",
-        "Files=1, Tests=2\nResult: PASS\n",
+        "Files=1, Tests=2,  0 wallclock secs\nResult: PASS\n",
       ],
     });
     return Effect.gen(function* () {

--- a/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.integration.test.ts
@@ -456,9 +456,15 @@ describe("legacy test db integration", () => {
   });
 
   it.live("detects the NOTESTS verdict opening the stream, with no line before it", () => {
-    // The seeded newline exists for exactly this case: stream start counts as a
-    // line start, so the anchored match still fires.
     const { layer } = setup({ exitCode: 0, stdout: ["Result: NOTESTS\n"] });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isFailure(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("detects the NOTESTS verdict when the stream ends without a trailing newline", () => {
+    const { layer } = setup({ exitCode: 0, stdout: ["Files=0\nResult: NOTESTS"] });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));
       expect(Exit.isFailure(exit)).toBe(true);
@@ -469,6 +475,25 @@ describe("legacy test db integration", () => {
     const { layer } = setup({
       exitCode: 0,
       stdout: ["# diag: Result: NOTESTS is what an empty run prints\n", "Result: PASS\n"],
+    });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyTestDb(flags()));
+      expect(Exit.isSuccess(exit)).toBe(true);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("takes the harness's final verdict, not a passing test's own Result: line", () => {
+    // `--debug` replays each test's raw TAP, and a passing test may legally print a
+    // line of its own starting `Result: NOTESTS…`. Only the harness's last verdict
+    // decides the run (PR #6210 review).
+    const { layer } = setup({
+      exitCode: 0,
+      stdout: [
+        "ok 1 - passes\n",
+        "Result: NOTESTS is diagnostic text\n",
+        "ok 2 - passes\n",
+        "Files=1, Tests=2\nResult: PASS\n",
+      ],
     });
     return Effect.gen(function* () {
       const exit = yield* Effect.exit(legacyTestDb(flags()));

--- a/apps/cli/src/legacy/shared/legacy-test-db.pg-prove-args.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.pg-prove-args.ts
@@ -8,6 +8,12 @@ export interface LegacyPgProveArgs {
   readonly cmd: ReadonlyArray<string>;
   /** Docker volume binds, each `hostpath:dockerpath:ro`. */
   readonly binds: ReadonlyArray<string>;
+  /**
+   * The searched paths as they exist on the *host*, for diagnostics. Deliberately
+   * not the `legacyToDockerPath` form used in `cmd`: on Windows that has the volume
+   * name stripped, so an error naming it would point at a path the user does not have.
+   */
+  readonly hostPaths: ReadonlyArray<string>;
   /** Container working directory (dir of the first test path). */
   readonly workingDir: Option.Option<string>;
 }
@@ -39,6 +45,7 @@ export function buildLegacyPgProveArgs(opts: {
 
   const cmd: string[] = ["pg_prove", "--ext", ".pg", "--ext", ".sql", "-r"];
   const binds: string[] = [];
+  const hostPaths: string[] = [];
   const seenTargets = new Set<string>();
   // `testFiles` is never empty (it defaults to supabase/tests), so the first
   // iteration always sets this; Go derives workingDir from the first path only.
@@ -48,6 +55,7 @@ export function buildLegacyPgProveArgs(opts: {
     const fp = nodePath.isAbsolute(candidate) ? candidate : nodePath.join(opts.cwd, candidate);
     const dockerPath = legacyToDockerPath(fp);
     cmd.push(dockerPath);
+    hostPaths.push(fp);
 
     // Mount the *directory* containing a test file (not the lone file) so psql
     // `\ir ./sibling.sql` includes resolve: they look relative to the test file's
@@ -70,5 +78,5 @@ export function buildLegacyPgProveArgs(opts: {
 
   if (opts.debug) cmd.push("--verbose");
 
-  return { cmd, binds, workingDir: Option.some(workingDir) };
+  return { cmd, binds, hostPaths, workingDir: Option.some(workingDir) };
 }

--- a/apps/cli/src/legacy/shared/legacy-test-db.pg-prove-args.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-test-db.pg-prove-args.unit.test.ts
@@ -90,6 +90,8 @@ describe("buildLegacyPgProveArgs", () => {
     ]);
     // workingDir is derived from the first path only (a file → its parent).
     expect(Option.getOrNull(result.workingDir)).toBe("/abs");
+    // `hostPaths` reports what pg_prove searches — the files/dirs, not their mounts.
+    expect(result.hostPaths).toEqual(["/abs/first_test.sql", "/abs/second/dir"]);
   });
 
   test("appends --verbose when debug is enabled", () => {


### PR DESCRIPTION
## TL;DR

fixes `supabase test db` reporting success on a run that executed zero tests, 
which was caused by passing `pg_prove`'s exit code straight through when it prints `Result: NOTESTS` and still exits 0
and is now fixed by watching the TAP summary for that verdict and failing with a msg naming the paths that were searched. 
A typo'd path, an empty tests directory, and a bind mount the Docker daemon resolved against a different filesystem than the CLI all hit this, so CI could stay green while testing nothing. 
The TAP stream on stdout is unchanged, the diagnostic goes to stderr, and the new exit 1 is recorded in the Go divergence because Go exits 0 here...

## ref:
- closes: https://github.com/supabase/cli/issues/6206
