### PR TITLE
fix(stack): settle managed identity recovery safely

### DIFF
--- a/packages/stack/src/managed-discovery.integration.test.ts
+++ b/packages/stack/src/managed-discovery.integration.test.ts
@@ -785,6 +785,48 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
     expect((await inspect(service.repository, repository)).activeTransition).toBeUndefined();
   });
 
+  it("does not expose a reserved branch transition on an unrelated branch", async () => {
+    const root = makeRoot();
+    const repository = makeRepository(root);
+    const service = await open(root);
+    openHandles.push(service);
+    const started = await service.resolveStack({ workspacePath: repository, operation: "start" });
+    git(repository, "branch", "-m", "renamed");
+    const inspection = await inspect(service.repository, repository);
+    await Effect.runPromise(
+      service.repository.reserveIdentityTransition({
+        id: "00000000-0000-7000-8000-000000000302",
+        kind: "adopt-context",
+        projectId: started.identity.projectId,
+        checkoutId: started.identity.checkoutId,
+        contextId: started.identity.contextId,
+        branch: "renamed",
+        path: repository,
+        projectIdentityLocation: inspection.workspace.projectIdentityLocation,
+        expectedGitValue: started.identity.contextId,
+        targetGitValue: started.identity.contextId,
+        expectedOwnerBranch: "main",
+        now: new Date().toISOString(),
+      }),
+    );
+
+    git(repository, "checkout", "-q", "-b", "other");
+    expect((await inspect(service.repository, repository)).activeTransition).toBeUndefined();
+
+    git(repository, "checkout", "-q", "renamed");
+    expect((await inspect(service.repository, repository)).activeTransition).toMatchObject({
+      kind: "adopt-context",
+      branch: "renamed",
+      phase: "reserved",
+    });
+    await expect(
+      service.abandonIdentityTransition({
+        transitionId: "00000000-0000-7000-8000-000000000302",
+        workspacePath: repository,
+      }),
+    ).resolves.toEqual({ outcome: "abandoned" });
+  });
+
   it("releases an untouched reservation when a project winner appears before publication", async () => {
     const root = makeRoot();
     const repository = makeRepository(root);
@@ -1459,50 +1501,75 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
   });
 
   it.each([
-    ["branch-copy", "00000000-0000-7000-8000-000000000126"],
-    ["adopt-context", "00000000-0000-7000-8000-000000000127"],
-  ] as const)("refuses %s abandonment when Git path is replaced", async (kind, transitionId) => {
-    const root = makeRoot();
-    const original = makeRepository(root, `${kind}-original`);
-    const path = join(root, `${kind}-transition-path`);
-    renameSync(original, path);
-    const service = await open(root);
-    openHandles.push(service);
-    const started =
-      kind === "adopt-context"
-        ? await service.resolveStack({ workspacePath: path, operation: "start" })
-        : undefined;
-    if (kind === "adopt-context") git(path, "branch", "-m", "renamed");
-    const replacement = makeRepository(root, `${kind}-replacement`);
-    renameSync(replacement, join(root, `${kind}-replacement-moved`));
-    renameSync(path, join(root, `${kind}-original-moved`));
-    renameSync(join(root, `${kind}-replacement-moved`), path);
-    const reserved = await Effect.runPromise(
-      service.repository.reserveIdentityTransition({
-        id: transitionId,
-        kind,
-        projectId: started?.identity.projectId ?? "00000000-0000-7000-8000-000000000128",
-        checkoutId: started?.identity.checkoutId ?? "00000000-0000-7000-8000-000000000129",
-        contextId: started?.identity.contextId ?? "00000000-0000-7000-8000-000000000130",
-        branch: kind === "adopt-context" ? "renamed" : "main",
-        path,
-        expectedGitValue:
-          kind === "branch-copy"
-            ? "00000000-0000-7000-8000-000000000130"
-            : started?.identity.contextId,
-        targetGitValue: kind === "branch-copy" ? "00000000-0000-7000-8000-000000000131" : undefined,
-        expectedOwnerBranch: kind === "adopt-context" ? "main" : undefined,
-        now: new Date().toISOString(),
-      }),
-    );
-    const replaced = await inspect(service.repository, path);
-    expect(replaced.state).toBe("transitioning");
-    expect(replaced.workspace.checkoutKind).not.toBe("ordinary");
-    await expect(
-      service.abandonIdentityTransition({ transitionId: reserved.id, workspacePath: path }),
-    ).rejects.toMatchObject({ _tag: "ManagedIdentityTransitionOwnershipError" });
-    expect((await inspect(service.repository, path)).activeTransition?.id).toBe(reserved.id);
-  });
+    {
+      kind: "branch-copy" as const,
+      transitionId: "00000000-0000-7000-8000-000000000126",
+      expectedState: "transitioning" as const,
+      transitionVisible: true,
+    },
+    {
+      kind: "adopt-context" as const,
+      transitionId: "00000000-0000-7000-8000-000000000127",
+      expectedState: "duplicate" as const,
+      transitionVisible: false,
+    },
+  ])(
+    "refuses $kind abandonment when Git path is replaced",
+    async ({ kind, transitionId, expectedState, transitionVisible }) => {
+      const root = makeRoot();
+      const original = makeRepository(root, `${kind}-original`);
+      const path = join(root, `${kind}-transition-path`);
+      renameSync(original, path);
+      const service = await open(root);
+      openHandles.push(service);
+      const started =
+        kind === "adopt-context"
+          ? await service.resolveStack({ workspacePath: path, operation: "start" })
+          : undefined;
+      if (kind === "adopt-context") git(path, "branch", "-m", "renamed");
+      const replacement = makeRepository(root, `${kind}-replacement`);
+      renameSync(replacement, join(root, `${kind}-replacement-moved`));
+      renameSync(path, join(root, `${kind}-original-moved`));
+      renameSync(join(root, `${kind}-replacement-moved`), path);
+      const reserved = await Effect.runPromise(
+        service.repository.reserveIdentityTransition({
+          id: transitionId,
+          kind,
+          projectId: started?.identity.projectId ?? "00000000-0000-7000-8000-000000000128",
+          checkoutId: started?.identity.checkoutId ?? "00000000-0000-7000-8000-000000000129",
+          contextId: started?.identity.contextId ?? "00000000-0000-7000-8000-000000000130",
+          branch: kind === "adopt-context" ? "renamed" : "main",
+          path,
+          expectedGitValue:
+            kind === "branch-copy"
+              ? "00000000-0000-7000-8000-000000000130"
+              : started?.identity.contextId,
+          targetGitValue:
+            kind === "branch-copy" ? "00000000-0000-7000-8000-000000000131" : undefined,
+          expectedOwnerBranch: kind === "adopt-context" ? "main" : undefined,
+          now: new Date().toISOString(),
+        }),
+      );
+      const replaced = await inspect(service.repository, path);
+      expect(replaced.state).toBe(expectedState);
+      expect(replaced.workspace.checkoutKind).not.toBe("ordinary");
+      if (transitionVisible) {
+        expect(replaced.activeTransition?.id).toBe(reserved.id);
+      } else {
+        expect(replaced.activeTransition).toBeUndefined();
+      }
+      await expect(
+        service.abandonIdentityTransition({ transitionId: reserved.id, workspacePath: path }),
+      ).rejects.toMatchObject({ _tag: "ManagedIdentityTransitionOwnershipError" });
+      if (transitionVisible) {
+        expect((await inspect(service.repository, path)).activeTransition?.id).toBe(reserved.id);
+      } else {
+        expect(
+          (await Effect.runPromise(service.repository.listIdentityClaims())).transitions,
+        ).toContainEqual(expect.objectContaining({ id: reserved.id, phase: "reserved" }));
+      }
+    },
+  );
 
   it("advances a reserved rebind before publishing its registry location", async () => {
     const root = makeRoot();
@@ -2222,8 +2289,11 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
     const migrated = await service.resolveStack({ workspacePath: nested, operation: "start" });
 
     expect(migrated.identity).toEqual(ordinary.identity);
+    expect(migrated.identityMarkerCreated).toBe(true);
     expect(migrated.stack.id).toBe(ordinary.stack.id);
     expect((await inspect(service.repository, nested)).state).toBe("healthy");
+    const reused = await service.resolveStack({ workspacePath: nested, operation: "start" });
+    expect(reused.identityMarkerCreated).toBe(false);
   });
 
   it("resumes detached folder-to-Git migration with the original context and marker", async () => {

--- a/packages/stack/src/managed-resolve-stack.integration.test.ts
+++ b/packages/stack/src/managed-resolve-stack.integration.test.ts
@@ -536,6 +536,23 @@ describe.each(adapters)("resolveStack over git workspaces with the %s adapter", 
     expect(branchStacks.map((stack) => stack.id)).toEqual([feature.stack.id]);
   });
 
+  it("settles a moved checkout and renamed branch in one subsequent start", async () => {
+    const root = makeRoot();
+    const original = makeRepository(root, "original");
+    const moved = join(root, "moved");
+    const service = await openService(root);
+    const first = await service.resolveStack({ workspacePath: original, operation: "start" });
+
+    git(original, "branch", "-m", "main", "renamed");
+    renameSync(original, moved);
+
+    const recovered = await service.resolveStack({ workspacePath: moved, operation: "start" });
+    expect(recovered.outcome).toBe("reuse");
+    expect(recovered.stack.id).toBe(first.stack.id);
+    expect(recovered.identity).toEqual(first.identity);
+    expect(recovered.context).toEqual({ kind: "branch", branch: "renamed" });
+  });
+
   it("repairs a copied branch on its first mutating start without changing the owner", async () => {
     const root = makeRoot();
     const repository = makeRepository(root);

--- a/packages/stack/src/managed-service.integration.test.ts
+++ b/packages/stack/src/managed-service.integration.test.ts
@@ -646,6 +646,32 @@ describe("ordinary-folder managed stack contract", () => {
     await service.close();
   });
 
+  it("preserves an in-flight typed failure when close races before rejection", async () => {
+    const root = makeRoot();
+    const base = createInMemoryManagedStackRepository();
+    let signalStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    const typedFailure = new InvalidManagedIdentityError({ message: "controlled failure" });
+    const service = await makeManagedStackService({
+      repository: {
+        ...base,
+        listStackProjections: () =>
+          Effect.sync(() => {
+            signalStarted();
+            throw typedFailure;
+          }),
+      },
+      stateRoot: join(root, "close-race-managed"),
+    });
+    const inFlight = service.listStacks();
+    await started;
+    await service.close();
+
+    await expect(inFlight).rejects.toBe(typedFailure);
+  });
+
   it("rejects a copied ordinary-folder identity claim", async () => {
     const root = makeRoot();
     const firstWorkspace = makeWorkspace(root, "first");

--- a/packages/stack/src/managed/create-service.ts
+++ b/packages/stack/src/managed/create-service.ts
@@ -156,12 +156,14 @@ const managedStackServiceHandle = async <ER>(
    * message, or stack. While the handle is open, every failure is the failure
    * itself and passes through untouched.
    */
-  const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
-    runtime.runPromise(effect).catch((error: unknown) => {
-      throw closed
+  const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+    const callWasClosed = closed;
+    return runtime.runPromise(effect).catch((error: unknown) => {
+      throw callWasClosed
         ? new Error(`The managed stack service handle is closed (${String(error)})`)
         : error;
     });
+  };
 
   /**
    * A function declaration rather than a property initializer, so the handle's

--- a/packages/stack/src/managed/discovery.ts
+++ b/packages/stack/src/managed/discovery.ts
@@ -149,19 +149,26 @@ const transitionMatches = (
     return transition.path === workspaceRoot && newCheckoutTopologyMatches(transition, context);
   }
   const branch = context.kind === "branch" ? context.branch : undefined;
+  if (
+    (transition.kind === "folder-to-git" ||
+      transition.kind === "adopt-context" ||
+      transition.kind === "branch-copy") &&
+    transition.branch !== branch
+  ) {
+    return false;
+  }
   return (
-    (transition.kind !== "folder-to-git" || transition.branch === branch) &&
-    ((transition.projectId === identity.projectId &&
+    (transition.projectId === identity.projectId &&
       transition.checkoutId === undefined &&
       transition.contextId === undefined &&
       transition.branch === undefined &&
       transition.path === undefined) ||
-      transition.path === workspaceRoot ||
-      (transition.checkoutId !== undefined && transition.checkoutId === identity.checkoutId) ||
-      (transition.contextId !== undefined && transition.contextId === identity.contextId) ||
-      (transition.branch !== undefined &&
-        transition.branch === branch &&
-        transition.projectId === identity.projectId))
+    transition.path === workspaceRoot ||
+    (transition.checkoutId !== undefined && transition.checkoutId === identity.checkoutId) ||
+    (transition.contextId !== undefined && transition.contextId === identity.contextId) ||
+    (transition.branch !== undefined &&
+      transition.branch === branch &&
+      transition.projectId === identity.projectId)
   );
 };
 
@@ -543,17 +550,14 @@ export const discoverWorkspace = (
       // becoming a repository. It is read as transition evidence only; its
       // values never populate the active Git identity below.
       const markerPath = ordinaryWorkspaceIdentityPath(inspection.workspaceRoot);
-      const fs = yield* FileSystem.FileSystem;
-      const markerExists = yield* fs
-        .exists(markerPath)
-        .pipe(Effect.catchTag("PlatformError", () => Effect.succeed(false)));
       const marker = yield* readOrdinaryWorkspaceIdentityWithFileSystem(inspection.workspaceRoot);
-      const markerTracked = markerExists
-        ? yield* isOrdinaryIdentityMarkerTracked(inspection.workspaceRoot)
-        : false;
+      const markerTracked =
+        marker !== undefined
+          ? yield* isOrdinaryIdentityMarkerTracked(inspection.workspaceRoot)
+          : false;
       ordinaryMarker = {
         path: markerPath,
-        present: markerExists,
+        present: marker !== undefined,
         tracked: markerTracked,
         identity: marker,
       };

--- a/packages/stack/src/managed/git.integration.test.ts
+++ b/packages/stack/src/managed/git.integration.test.ts
@@ -572,6 +572,26 @@ describe("git-stored identity", () => {
     }).pipe(Effect.provide(gitLayer)),
   );
 
+  it.live("collapses duplicated equal branch context values during replacement", () =>
+    Effect.gen(function* () {
+      const root = makeRoot();
+      const repository = makeRepository(root);
+      const inspection = yield* inspectCheckout(repository);
+      const expected = "00000000-0000-7000-8000-000000000304";
+      const target = "00000000-0000-7000-8000-000000000305";
+      const config = gitConfigPath(inspection.commonDirectory);
+      git(repository, "config", gitBranchContextIdKey("main"), expected);
+      git(repository, "config", "--add", gitBranchContextIdKey("main"), expected);
+
+      yield* replaceBranchContextId(inspection, "main", expected, target);
+
+      expect(storedConfigValue(config, gitBranchContextIdKey("main"))).toBe(target);
+      expect(git(repository, "config", "--get-all", gitBranchContextIdKey("main"))).toBe(
+        `${target}\n`,
+      );
+    }).pipe(Effect.provide(gitLayer)),
+  );
+
   it.live("gives sibling linked worktrees one project and separate checkouts", () =>
     Effect.gen(function* () {
       const root = makeRoot();

--- a/packages/stack/src/managed/git.ts
+++ b/packages/stack/src/managed/git.ts
@@ -774,7 +774,13 @@ const gitConfigReplaceExpected = (
       () =>
         Effect.gen(function* () {
           const current = yield* gitConfigOnce(["--file", file, "--get-all", key], true, file);
-          if ((current ?? "").trim() !== expected) {
+          const settled = settledValue(
+            (current ?? "")
+              .split("\n")
+              .map((candidate) => candidate.trim())
+              .filter((candidate) => candidate.length > 0),
+          );
+          if (settled !== expected) {
             return yield* Effect.fail(
               new InvalidManagedIdentityError({
                 message: `${key} changed before conditional replacement`,

--- a/packages/stack/src/managed/service.ts
+++ b/packages/stack/src/managed/service.ts
@@ -522,44 +522,86 @@ export class ManagedStackService extends Context.Service<
               );
             }
             let recoveryReportForStart = settledReport;
-            if (
-              resolveOptions.operation === "start" &&
-              (settledReport.folderToGitClaims.length > 0 ||
-                (settledReport.state === "transitioning" &&
-                  settledReport.activeTransition?.kind === "folder-to-git"))
-            ) {
-              recoveryReportForStart = yield* workspaceIdentity.migrateFolderToGit(settledReport);
-            }
-            if (resolveOptions.operation === "start" && settledReport.state === "moved") {
-              recoveryReportForStart = yield* workspaceIdentity.rebindCheckout({
-                workspacePath: resolveOptions.workspacePath,
-                checkoutId: settledReport.identity.checkoutId,
-                observation: settledReport,
-              });
-            }
-            if (
-              resolveOptions.operation === "start" &&
-              (((settledReport.state === "adoptable" || settledReport.state === "orphaned") &&
-                settledReport.recoveryOperations.some(
-                  (operation) => operation.operation === "adoptContext",
-                )) ||
-                (settledReport.state === "transitioning" &&
-                  settledReport.activeTransition?.kind === "adopt-context"))
-            ) {
-              recoveryReportForStart = yield* workspaceIdentity.adoptContext({
-                workspacePath: resolveOptions.workspacePath,
-                observation: settledReport,
-              });
-            }
-            if (
-              resolveOptions.operation === "start" &&
-              ((recoveryReportForStart.state === "duplicate" &&
-                workspaceIdentity.branchCopyIsUnambiguous(recoveryReportForStart)) ||
-                (recoveryReportForStart.state === "transitioning" &&
-                  recoveryReportForStart.activeTransition?.kind === "branch-copy"))
-            ) {
-              recoveryReportForStart =
-                yield* workspaceIdentity.repairCopiedBranch(recoveryReportForStart);
+            let identityMarkerCreated = false;
+            if (resolveOptions.operation === "start") {
+              const automaticRecoveryKind = (
+                candidate: ManagedWorkspaceDiscovery,
+              ):
+                | "folder-to-git"
+                | "rebind-checkout"
+                | "adopt-context"
+                | "branch-copy"
+                | undefined => {
+                if (
+                  candidate.folderToGitClaims.length > 0 ||
+                  (candidate.state === "transitioning" &&
+                    candidate.activeTransition?.kind === "folder-to-git")
+                ) {
+                  return "folder-to-git";
+                }
+                if (candidate.state === "moved") return "rebind-checkout";
+                if (
+                  ((candidate.state === "adoptable" || candidate.state === "orphaned") &&
+                    candidate.recoveryOperations.some(
+                      (operation) => operation.operation === "adoptContext",
+                    )) ||
+                  (candidate.state === "transitioning" &&
+                    candidate.activeTransition?.kind === "adopt-context")
+                ) {
+                  return "adopt-context";
+                }
+                if (
+                  (candidate.state === "duplicate" &&
+                    workspaceIdentity.branchCopyIsUnambiguous(candidate)) ||
+                  (candidate.state === "transitioning" &&
+                    candidate.activeTransition?.kind === "branch-copy")
+                ) {
+                  return "branch-copy";
+                }
+                return undefined;
+              };
+              const maxRecoveryIterations = 8;
+              let iteration = 0;
+              while (true) {
+                const kind = automaticRecoveryKind(recoveryReportForStart);
+                if (kind === undefined) break;
+                if (iteration >= maxRecoveryIterations) {
+                  return yield* Effect.fail(
+                    new InvalidManagedIdentityError({
+                      message: "Managed workspace recovery did not converge",
+                    }),
+                  );
+                }
+                const before = discoveryObservation(recoveryReportForStart);
+                if (kind === "folder-to-git") {
+                  const migrated =
+                    yield* workspaceIdentity.migrateFolderToGit(recoveryReportForStart);
+                  recoveryReportForStart = migrated.report;
+                  identityMarkerCreated ||= migrated.identityMarkerCreated;
+                } else if (kind === "rebind-checkout") {
+                  recoveryReportForStart = yield* workspaceIdentity.rebindCheckout({
+                    workspacePath: resolveOptions.workspacePath,
+                    checkoutId: recoveryReportForStart.identity.checkoutId,
+                    observation: recoveryReportForStart,
+                  });
+                } else if (kind === "adopt-context") {
+                  recoveryReportForStart = yield* workspaceIdentity.adoptContext({
+                    workspacePath: resolveOptions.workspacePath,
+                    observation: recoveryReportForStart,
+                  });
+                } else {
+                  recoveryReportForStart =
+                    yield* workspaceIdentity.repairCopiedBranch(recoveryReportForStart);
+                }
+                iteration += 1;
+                if (before === discoveryObservation(recoveryReportForStart)) {
+                  return yield* Effect.fail(
+                    new InvalidManagedIdentityError({
+                      message: "Managed workspace recovery made no progress",
+                    }),
+                  );
+                }
+              }
             }
             const plan: ResolvedWorkspacePlan = {
               workspace: recoveryReportForStart.workspace,
@@ -573,7 +615,7 @@ export class ManagedStackService extends Context.Service<
                       contextId: recoveryReportForStart.registryContextId,
                     }
                   : recoveryReportForStart.identity,
-              identityMarkerCreated: false,
+              identityMarkerCreated,
             };
             if (
               resolveOptions.operation === "start" &&

--- a/packages/stack/src/managed/workspace-identity.ts
+++ b/packages/stack/src/managed/workspace-identity.ts
@@ -613,10 +613,15 @@ export const makeWorkspaceIdentity = ({
    * sequence, so an interrupted publication can only resume after every
    * expected value still matches.
    */
+  interface ManagedFolderToGitRecoveryResult {
+    readonly report: ManagedWorkspaceDiscovery;
+    readonly identityMarkerCreated: boolean;
+  }
+
   const migrateFolderToGit = (
     report: ManagedWorkspaceDiscovery,
   ): Effect.Effect<
-    ManagedWorkspaceDiscovery,
+    ManagedFolderToGitRecoveryResult,
     | InvalidManagedIdentityError
     | DuplicateManagedIdentityError
     | UnsupportedGitWorkspaceError
@@ -625,7 +630,9 @@ export const makeWorkspaceIdentity = ({
     Effect.gen(function* () {
       const resuming = report.activeTransition?.kind === "folder-to-git";
       if (!resuming) {
-        if (report.folderToGitClaims.length === 0) return report;
+        if (report.folderToGitClaims.length === 0) {
+          return { report, identityMarkerCreated: false };
+        }
         if (report.folderToGitClaims.length > 1) {
           return yield* Effect.fail(
             new ManagedCheckoutConflictError({
@@ -641,7 +648,7 @@ export const makeWorkspaceIdentity = ({
           report.identity.checkoutId !== undefined ||
           report.identity.contextId !== undefined
         ) {
-          return report;
+          return { report, identityMarkerCreated: false };
         }
       }
       const claim =
@@ -657,7 +664,9 @@ export const makeWorkspaceIdentity = ({
               canonicalPath: report.activeTransition.path,
             }
           : undefined);
-      if (claim === undefined || report.workspace.checkoutKind === "ordinary") return report;
+      if (claim === undefined || report.workspace.checkoutKind === "ordinary") {
+        return { report, identityMarkerCreated: false };
+      }
       const path = report.workspace.workspaceRoot;
       const inspection = yield* withWorkspaceServices(inspectWorkspace(path));
       if (inspection.kind !== "git-checkout") {
@@ -715,6 +724,7 @@ export const makeWorkspaceIdentity = ({
         );
       }
 
+      let identityMarkerCreated = false;
       if (transition.phase === "reserved") {
         const ordinaryMarker = yield* withWorkspaceServices(
           readOrdinaryWorkspaceIdentityWithFileSystem(path),
@@ -811,7 +821,7 @@ export const makeWorkspaceIdentity = ({
             }),
           );
         yield* publishConfig(GIT_PROJECT_ID_KEY, claim.projectId);
-        yield* withWorkspaceServices(
+        identityMarkerCreated = yield* withWorkspaceServices(
           publishGitCheckoutIdentity(inspection.gitDirectory, claim.checkoutId),
         );
         if (inspection.head.kind !== "detached") {
@@ -935,7 +945,7 @@ export const makeWorkspaceIdentity = ({
         });
       }
       const migrated = yield* discover(path);
-      return migrated;
+      return { report: migrated, identityMarkerCreated };
     });
 
   const requestedRecoveryPath = (


### PR DESCRIPTION
## Summary

- settle chained managed identity recovery from the latest discovery state
- keep branch-scoped transitions isolated while preserving conflict evidence
- preserve marker, Git config, and service error semantics across recovery races

## Context

This follows PR #6202 and Linear CLI-2108. It addresses confirmed pre-wiring edge cases around interrupted branch recovery, rename-plus-move settlement, folder-to-Git marker reporting, duplicated Git config values, and service shutdown races.

Automatic recovery remains internal and bounded. Explicit recovery operations and fail-closed ambiguity behavior are unchanged.