### PR TITLE
refactor(stack): simplify managed identity policy

### DIFF
--- a/docs/superpowers/specs/2026-08-15-managed-identity-maintainability-design.md
+++ b/docs/superpowers/specs/2026-08-15-managed-identity-maintainability-design.md
@@ -1,0 +1,92 @@
+# Managed Identity Maintainability Design
+
+## Context
+
+Pull request #6214 fixes confirmed managed-identity recovery defects found after #6202. The same
+review identified duplication and documentation drift in the code that owns workspace discovery,
+identity settlement, Git configuration locking, and recovery tests.
+
+The managed surface has not shipped as a stable compatibility boundary. The repository's
+refactoring policy therefore favors the simplest current model over preserving unused exports.
+
+## Goal
+
+Reduce verified maintenance hazards in the managed-identity implementation without broadening
+#6214 into a package-wide decomposition or changing developer-visible behavior.
+
+## Scope
+
+### Shared workspace facts
+
+Create one small pure module that derives the managed workspace, context, and context descriptor
+from a workspace inspection. Discovery and identity publication will consume this derivation
+instead of rebuilding ordinary-folder and Git-checkout facts independently.
+
+The discovery types remain the public read-only report contract. Resolved-plan types remain the
+mutation-settlement contract; structurally similar types will not be merged merely to remove lines.
+
+### Concurrent registration settlement
+
+Move reusable topology and monotonic-publication predicates out of the large identity
+implementation into a focused pure settlement module. The module will express the benign
+first-start outcomes accepted by the facade, while transition-specific ownership checks remain in
+their existing recovery flows.
+
+The service facade will consume the named settlement policy rather than reassembling it from field
+comparisons. Existing double discovery remains intact because it is the race-settlement guard.
+
+### Git lock retry policy
+
+Define the 10 millisecond exponential retry with a 400 millisecond bound once inside the Git module
+and reuse it for ordinary Git config locking and explicit conditional-replacement lock acquisition.
+The retrying Git config path and the non-retrying self-lock-aware path remain distinct.
+
+### Unused Promise canonicalizer
+
+Delete the Promise-based `canonicalizeManagedWorkspacePath`, its Node filesystem imports, its
+managed entrypoint export, and the export assertion. Repository-wide search found no consumer; the
+Effect filesystem implementation remains the only production path.
+
+### Documentation and test quality
+
+Correct the managed architecture documentation:
+
+- describe four public entrypoint levels rather than three;
+- describe the actual testing entrypoint, including fixtures, validators, repository seams, and
+  transport test tags; and
+- repair the malformed acquisition-failure sentence.
+
+Strengthen the managed discovery integration tests by requiring exactly one concurrent rebind
+winner, tracking every opened SQLite handle for cleanup, and removing assertions that only restate
+discovery's already-filtered projection.
+
+## Module size and ownership
+
+Line count is a diagnostic, not a rule. This change will not mechanically slice large files or
+introduce pass-through modules. New shared policy belongs in focused pure modules measured in
+hundreds of lines, and the large identity implementation must shrink rather than grow.
+
+The broader decomposition of `workspace-identity.ts`, `sqlite.ts`, `git.ts`, and `repository.ts` is
+explicitly deferred until #6214 is complete. That follow-up will choose deep modules around domain
+ownership rather than file size alone.
+
+## Error behavior
+
+No error tag, error code, recovery ordering, transition ownership rule, or fail-closed ambiguity
+behavior changes. Settlement helpers only name behavior already exercised through the managed
+public Interface. Removing the unused Promise canonicalizer is the only exported-surface change.
+
+## Verification
+
+Behavior remains protected through existing public-interface integration suites for managed
+discovery, identity, resolution, and Git configuration. Focused tests will cover the strengthened
+concurrent-rebind assertion and cleanup correction. Completion requires the full `packages/stack`
+unit and integration suite plus type, lint, format, and unused-code checks.
+
+## Explicit exclusions
+
+- No generic identity matcher across exact, compatible, monotonic, and ownership semantics.
+- No wholesale merge of branch-copy and adopt-context takeover implementations.
+- No merge of resolved-plan and discovery contracts.
+- No contract-fixture execution-policy change.
+- No package-wide file decomposition.

--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -7,7 +7,7 @@ delegated to [`@supabase/process-compose`](../../process-compose/docs/architectu
 
 ## Public entrypoints
 
-The package exposes three levels of Interface:
+The package exposes four levels of Interface:
 
 - `@supabase/stack` selects `bun.ts` or `node.ts` through export conditions and exposes the
   Promise-oriented `createStack()` / `StackHandle` Interface plus prefetch helpers.
@@ -15,8 +15,9 @@ The package exposes three levels of Interface:
   Effect Interfaces plus platform-bound layer factories used by the CLI and advanced callers.
 - `@supabase/stack/managed` selects the Node or Bun SQLite Adapter and exposes managed identity,
   discovery, persistence, and lifecycle coordination. Its repository can be replaced by a caller.
-- `@supabase/stack/testing` exposes only the service tags needed to replace daemon transport in
-  consumer tests. Runtime implementation tags do not leak through the root or Effect barrels.
+- `@supabase/stack/testing` exposes test-only tags plus contract fixtures, validators, the
+  in-memory repository seam, and transport helpers. Runtime implementation tags do not leak
+  through the root or Effect barrels.
 
 Internal runtime Adapters provide Effect filesystem, path, child-process, HTTP-server, and Unix
 socket HTTP implementations. `createStack.ts` and the layer factories remain platform-agnostic;
@@ -590,9 +591,9 @@ than incidental:
   build the runtime's context through `runtime.context()`, because opening the registry is I/O: a
   file is created and hardened, and a cold start may have to wait out another
   process' WAL conversion. Everything that can refuse the acquisition arrives as a rejection — a
-  blank state root, an owner PID that could never be probed, and a registry written by an
-  option failures reject with typed error instances, so a caller has one failure channel instead of a
-  throw plus a rejection.
+  blank state root, an owner PID that could never be probed, an incompatible registry, or invalid
+  options reject with typed error instances, so a caller has one failure channel instead of a throw
+  plus a rejection.
 - **Reads are Promises too.** `inspectStack` and `listStacks` return Promises rather than answering
   inline. A handle that read synchronously would only be hiding the registry's I/O from its caller,
   and it is what forced the cold-start retry below to block. The `repository` accessor stays a plain

--- a/packages/stack/src/entrypoints.unit.test.ts
+++ b/packages/stack/src/entrypoints.unit.test.ts
@@ -124,7 +124,6 @@ describe("@supabase/stack entrypoints", () => {
       "assertManagedStackRoot",
       "assertManagedUuid",
       "bunSqliteManagedStackRepositoryLayer",
-      "canonicalizeManagedWorkspacePath",
       "createManagedStackService",
       "createManagedUuid",
       "ensureBranchContextId",

--- a/packages/stack/src/managed-discovery.integration.test.ts
+++ b/packages/stack/src/managed-discovery.integration.test.ts
@@ -225,6 +225,7 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
     } else {
       serviceB = await open(root);
       const base = await open(root);
+      openHandles.push(base);
       const wrapped: ManagedStackRepositoryShape = {
         ...base.repository,
         listIdentityClaims: (projectId) =>
@@ -255,14 +256,6 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
     expect(injectedStart).toBeDefined();
     await injectedStart;
     expect(startedA.identity.checkoutId).toBeDefined();
-
-    const reportA = await serviceA.discoverWorkspace(workspaceA);
-    expect(reportA.locations.map((location) => location.canonicalPath)).not.toContain(workspaceB);
-    const fresh = makeDirectory(root, "workspace-c");
-    const reportFresh = await serviceA.discoverWorkspace(fresh);
-    expect(reportFresh.locations.map((location) => location.canonicalPath)).not.toContain(
-      workspaceB,
-    );
   });
 
   it("resolves healthy branch, detached, and ordinary identities", async () => {
@@ -1737,17 +1730,45 @@ describe.each(adapters)("managed discovery with the %s adapter", (_name, open) =
     openHandles.push(service);
     const first = await service.resolveStack({ workspacePath: previous, operation: "start" });
     renameSync(previous, next);
+
+    let arrivals = 0;
+    let releaseReservations: () => void = () => undefined;
+    const bothReservations = new Promise<void>((resolve) => {
+      releaseReservations = resolve;
+    });
+    const gateReservation = (repository: ManagedStackRepositoryShape) => ({
+      ...repository,
+      reserveIdentityTransition: (
+        input: Parameters<typeof repository.reserveIdentityTransition>[0],
+      ) =>
+        Effect.gen(function* () {
+          arrivals += 1;
+          if (arrivals === 2) releaseReservations();
+          yield* Effect.promise(() => bothReservations);
+          return yield* repository.reserveIdentityTransition(input);
+        }),
+    });
+    const serviceA = await makeManagedStackService({
+      repository: gateReservation(service.repository),
+      stateRoot: join(root, "concurrent-recovery-managed-a"),
+      publicationPollMs: 1,
+    });
+    const serviceB = await makeManagedStackService({
+      repository: gateReservation(service.repository),
+      stateRoot: join(root, "concurrent-recovery-managed-b"),
+      publicationPollMs: 1,
+    });
+    openHandles.push(serviceA, serviceB);
     const outcomes = await Promise.allSettled([
-      service.rebindCheckout({ workspacePath: next, checkoutId: first.identity.checkoutId }),
-      service.rebindCheckout({ workspacePath: next, checkoutId: first.identity.checkoutId }),
+      serviceA.rebindCheckout({ workspacePath: next, checkoutId: first.identity.checkoutId }),
+      serviceB.rebindCheckout({ workspacePath: next, checkoutId: first.identity.checkoutId }),
     ]);
-    expect(outcomes.some((outcome) => outcome.status === "fulfilled")).toBe(true);
+    expect(arrivals).toBe(2);
     const successful = outcomes.flatMap((outcome) =>
       outcome.status === "fulfilled" ? [outcome.value] : [],
     );
-    expect(
-      successful.every((result) => result.identity.checkoutId === first.identity.checkoutId),
-    ).toBe(true);
+    expect(successful).toHaveLength(1);
+    expect(successful[0]?.identity.checkoutId).toBe(first.identity.checkoutId);
     for (const outcome of outcomes) {
       if (outcome.status === "rejected") {
         expect(outcome.reason).toMatchObject({

--- a/packages/stack/src/managed.ts
+++ b/packages/stack/src/managed.ts
@@ -20,7 +20,6 @@ export type {
   EnsureGitCheckoutIdentityResult,
 } from "./managed/git.ts";
 export {
-  canonicalizeManagedWorkspacePath,
   ensureOrdinaryWorkspaceIdentity,
   readOrdinaryWorkspaceIdentity,
 } from "./managed/identity.ts";

--- a/packages/stack/src/managed/discovery.ts
+++ b/packages/stack/src/managed/discovery.ts
@@ -3,9 +3,7 @@ import {
   InvalidManagedIdentityError,
   UnsupportedGitWorkspaceError,
   type ManagedCheckoutLocation,
-  type ManagedCheckoutKind,
   type ManagedContextDescriptor,
-  type ManagedContextKind,
   type ManagedIdentityTransitionRecord,
   type ManagedIdentityClaims,
   type ManagedOperationRecord,
@@ -20,7 +18,6 @@ import {
   readBranchContextId,
   readGitCheckoutIdentityWithFileSystem,
   type GitCheckoutInspection,
-  type WorkspaceInspection,
 } from "./git.ts";
 import {
   canonicalizeManagedWorkspacePathWithFileSystem,
@@ -32,7 +29,17 @@ import {
   protectedManagedCheckoutLocationIds,
   type ManagedStackRepositoryShape,
 } from "./repository.ts";
-import { checkoutKindOf, newCheckoutTopologyMatches } from "./topology.ts";
+import { newCheckoutTopologyMatches } from "./topology.ts";
+import {
+  workspaceMetadata,
+  type ManagedWorkspaceDiscoveryContext,
+  type ManagedWorkspaceDiscoveryWorkspace,
+} from "./workspace-metadata.ts";
+
+export type {
+  ManagedWorkspaceDiscoveryContext,
+  ManagedWorkspaceDiscoveryWorkspace,
+} from "./workspace-metadata.ts";
 
 export type ManagedWorkspaceDiscoveryState =
   | "adoptable"
@@ -49,20 +56,6 @@ export type ManagedRecoveryOperation =
   | { readonly operation: "rebindCheckout"; readonly checkoutId: string; readonly path: string }
   | { readonly operation: "adoptContext"; readonly contextId: string; readonly branch: string }
   | { readonly operation: "prune"; readonly recordIds: ReadonlyArray<string> };
-
-export interface ManagedWorkspaceDiscoveryWorkspace {
-  readonly checkoutKind: ManagedCheckoutKind;
-  readonly canonicalPath: string;
-  readonly workspaceRoot: string;
-  readonly projectIdentityLocation: string;
-  readonly checkoutIdentityLocation: string;
-}
-
-export interface ManagedWorkspaceDiscoveryContext {
-  readonly kind: ManagedContextKind;
-  readonly branch?: string;
-  readonly commit?: string;
-}
 
 export interface ManagedWorkspaceDiscoveryIdentity {
   readonly projectId?: string;
@@ -470,48 +463,6 @@ const inspectBranchOwners = (
     }
     return { contextId, claims: liveClaims };
   });
-
-const workspaceMetadata = (
-  inspection: WorkspaceInspection,
-): {
-  readonly workspace: ManagedWorkspaceDiscoveryWorkspace;
-  readonly context: ManagedWorkspaceDiscoveryContext;
-  readonly contextDescriptor: ManagedContextDescriptor;
-} => {
-  if (inspection.kind === "ordinary-folder") {
-    const markerPath = ordinaryWorkspaceIdentityPath(inspection.canonicalPath);
-    return {
-      workspace: {
-        checkoutKind: "ordinary",
-        canonicalPath: inspection.canonicalPath,
-        workspaceRoot: inspection.canonicalPath,
-        projectIdentityLocation: markerPath,
-        checkoutIdentityLocation: markerPath,
-      },
-      context: { kind: "workspace" },
-      contextDescriptor: { kind: "workspace" },
-    };
-  }
-  const context: ManagedWorkspaceDiscoveryContext =
-    inspection.head.kind === "detached"
-      ? { kind: "detached", commit: inspection.head.commit }
-      : { kind: "branch", branch: inspection.head.branch };
-  const contextDescriptor: ManagedContextDescriptor =
-    inspection.head.kind === "detached"
-      ? { kind: "detached" }
-      : { kind: "branch", locator: inspection.head.branch };
-  return {
-    workspace: {
-      checkoutKind: checkoutKindOf(inspection),
-      canonicalPath: inspection.canonicalPath,
-      workspaceRoot: inspection.workspaceRoot,
-      projectIdentityLocation: inspection.commonDirectory,
-      checkoutIdentityLocation: inspection.gitDirectory,
-    },
-    context,
-    contextDescriptor,
-  };
-};
 
 /** Read-only managed identity discovery. No repository or identity writes occur. */
 export const discoverWorkspace = (

--- a/packages/stack/src/managed/git.ts
+++ b/packages/stack/src/managed/git.ts
@@ -658,6 +658,9 @@ const runGitConfig = (
     });
   });
 
+const gitLockRetrySchedule = () =>
+  Schedule.exponential(Duration.millis(10)).pipe(Schedule.upTo({ duration: Duration.millis(400) }));
+
 /**
  * `git config` does not wait for another process' config lock — it refuses
  * immediately — so waiting is this store's job. Every claim in a repository with
@@ -679,9 +682,7 @@ const gitConfig = (
         ),
         {
           while: (error) => error.kind === "retryable",
-          schedule: Schedule.exponential(Duration.millis(10)).pipe(
-            Schedule.upTo({ duration: Duration.millis(400) }),
-          ),
+          schedule: gitLockRetrySchedule(),
         },
       ),
       (error) =>
@@ -764,9 +765,7 @@ const gitConfigReplaceExpected = (
     const acquireLock = fs.writeFileString(lockPath, "", { flag: "wx" }).pipe(
       Effect.retry({
         while: (error) => error.reason._tag === "AlreadyExists",
-        schedule: Schedule.exponential(Duration.millis(10)).pipe(
-          Schedule.upTo({ duration: Duration.millis(400) }),
-        ),
+        schedule: gitLockRetrySchedule(),
       }),
     );
     yield* Effect.acquireUseRelease(

--- a/packages/stack/src/managed/identity.ts
+++ b/packages/stack/src/managed/identity.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { Effect, FileSystem, type PlatformError } from "effect";
 import { claimFileAtomically } from "./atomic-claim.ts";
@@ -63,30 +63,6 @@ const decodeIdentity = (content: string): OrdinaryWorkspaceIdentity => {
     contextId: identityField(value, "contextId"),
   };
 };
-
-/**
- * The canonical path of a workspace directory, whatever it turns out to be.
- *
- * Every resolve starts here, ordinary folders and git checkouts alike: a path
- * that is not a directory is a caller mistake rather than a workspace to
- * classify, and canonicalizing once keeps a symlinked alias from registering as
- * a second location for the same checkout.
- */
-export const canonicalizeManagedWorkspacePath = (
-  workspacePath: string,
-): Effect.Effect<string, InvalidManagedIdentityError> =>
-  failsWithIdentity(
-    Effect.tryPromise({
-      try: async () => {
-        const info = await stat(workspacePath);
-        if (!info.isDirectory()) {
-          throw new InvalidManagedIdentityError({ message: `${workspacePath} is not a directory` });
-        }
-        return realpath(workspacePath);
-      },
-      catch: asRaised,
-    }),
-  );
 
 /** Effect FileSystem variant used by managed discovery. */
 export const canonicalizeManagedWorkspacePathWithFileSystem = (

--- a/packages/stack/src/managed/service.ts
+++ b/packages/stack/src/managed/service.ts
@@ -37,6 +37,7 @@ import {
 import type { ManagedIdentityRecoveryError } from "./repository.ts";
 import type { ManagedWorkspaceDiscovery } from "./discovery.ts";
 import { discoveryObservation } from "./discovery-observation.ts";
+import { benignConcurrentRegistration } from "./workspace-settlement.ts";
 import {
   makeStackLifecycle,
   type StackLifecycle,
@@ -480,40 +481,10 @@ export class ManagedStackService extends Context.Service<
               resolveOptions.operation === "start"
                 ? yield* workspaceIdentity.discover(resolveOptions.workspacePath)
                 : report;
-            const sameWorkspaceTopology = workspaceIdentity.sameManagedWorkspaceTopology(
-              report,
-              settledReport,
-            );
-            const settledIdentityIsMonotonic = workspaceIdentity.identityPublicationIsMonotonic(
-              report,
-              settledReport,
-            );
-            const settledIdentityPublished =
-              settledReport.identity.projectId !== undefined &&
-              settledReport.identity.checkoutId !== undefined &&
-              settledReport.identity.contextId !== undefined;
-            const settledNewCheckoutReservation =
-              report.state === "unregistered" &&
-              settledReport.state === "transitioning" &&
-              settledReport.activeTransition?.kind === "new-checkout" &&
-              settledReport.activeTransition.path === settledReport.workspace.workspaceRoot &&
-              settledReport.activeTransition.projectIdentityLocation ===
-                settledReport.workspace.projectIdentityLocation &&
-              settledReport.conflicts.length === 0;
-            const benignConcurrentRegistration =
-              report.state === "unregistered" &&
-              sameWorkspaceTopology &&
-              settledIdentityIsMonotonic &&
-              ((settledReport.activeTransition === undefined &&
-                ((settledReport.state === "healthy" &&
-                  settledIdentityPublished &&
-                  settledReport.conflicts.length === 0) ||
-                  workspaceIdentity.concurrentIdentityPublication(report, settledReport))) ||
-                settledNewCheckoutReservation);
             if (
               resolveOptions.operation === "start" &&
               discoveryObservation(report) !== discoveryObservation(settledReport) &&
-              !benignConcurrentRegistration
+              !benignConcurrentRegistration(report, settledReport)
             ) {
               return yield* Effect.fail(
                 new InvalidManagedIdentityError({

--- a/packages/stack/src/managed/workspace-identity.ts
+++ b/packages/stack/src/managed/workspace-identity.ts
@@ -49,6 +49,11 @@ import {
 } from "./topology.ts";
 import { discoveryObservation } from "./discovery-observation.ts";
 import { workspaceMetadata } from "./workspace-metadata.ts";
+import {
+  concurrentIdentityPublication,
+  identityPublicationIsMonotonic,
+  sameManagedWorkspaceTopology,
+} from "./workspace-settlement.ts";
 
 export interface WorkspaceIdentityDependencies {
   readonly repository: ManagedStackRepositoryShape;
@@ -174,50 +179,6 @@ const observationMatches = (
     report.context.commit === commit
   );
 };
-
-const sameManagedWorkspaceTopology = (
-  report: ManagedWorkspaceDiscovery,
-  freshReport: ManagedWorkspaceDiscovery,
-): boolean =>
-  report.workspace.checkoutKind === freshReport.workspace.checkoutKind &&
-  report.workspace.workspaceRoot === freshReport.workspace.workspaceRoot &&
-  report.workspace.projectIdentityLocation === freshReport.workspace.projectIdentityLocation &&
-  report.workspace.checkoutIdentityLocation === freshReport.workspace.checkoutIdentityLocation &&
-  report.context.kind === freshReport.context.kind &&
-  report.context.branch === freshReport.context.branch &&
-  report.context.commit === freshReport.context.commit;
-
-const identityPublicationIsMonotonic = (
-  report: ManagedWorkspaceDiscovery,
-  freshReport: ManagedWorkspaceDiscovery,
-): boolean =>
-  (report.identity.projectId === undefined ||
-    report.identity.projectId === freshReport.identity.projectId) &&
-  (report.identity.checkoutId === undefined ||
-    report.identity.checkoutId === freshReport.identity.checkoutId) &&
-  (report.identity.contextId === undefined ||
-    report.identity.contextId === freshReport.identity.contextId);
-
-const identityPublicationAdvanced = (
-  report: ManagedWorkspaceDiscovery,
-  freshReport: ManagedWorkspaceDiscovery,
-): boolean =>
-  (report.identity.projectId === undefined && freshReport.identity.projectId !== undefined) ||
-  (report.identity.checkoutId === undefined && freshReport.identity.checkoutId !== undefined) ||
-  (report.identity.contextId === undefined && freshReport.identity.contextId !== undefined);
-
-/** A same-topology start may have published part of the Git identity meanwhile. */
-const concurrentIdentityPublication = (
-  report: ManagedWorkspaceDiscovery,
-  freshReport: ManagedWorkspaceDiscovery,
-): boolean =>
-  report.state === "unregistered" &&
-  freshReport.state === "unregistered" &&
-  freshReport.conflicts.length === 0 &&
-  freshReport.activeTransition === undefined &&
-  sameManagedWorkspaceTopology(report, freshReport) &&
-  identityPublicationIsMonotonic(report, freshReport) &&
-  identityPublicationAdvanced(report, freshReport);
 
 const newCheckoutTransitionMatches = (
   transition: ManagedIdentityTransitionRecord | undefined,
@@ -2251,8 +2212,5 @@ export const makeWorkspaceIdentity = ({
     repairCopiedBranch,
     adoptContext,
     abandonIdentityTransition,
-    sameManagedWorkspaceTopology,
-    identityPublicationIsMonotonic,
-    concurrentIdentityPublication,
   };
 };

--- a/packages/stack/src/managed/workspace-identity.ts
+++ b/packages/stack/src/managed/workspace-identity.ts
@@ -33,7 +33,7 @@ import {
   type GitCheckoutInspection,
 } from "./git.ts";
 import { assertManagedUuid } from "./ids.ts";
-import { ordinaryWorkspaceIdentityPath, gitConfigPath } from "./paths.ts";
+import { gitConfigPath } from "./paths.ts";
 import {
   ManagedStackRepository,
   type AbandonManagedIdentityTransitionResult,
@@ -48,6 +48,7 @@ import {
   newCheckoutTopologyMatches,
 } from "./topology.ts";
 import { discoveryObservation } from "./discovery-observation.ts";
+import { workspaceMetadata } from "./workspace-metadata.ts";
 
 export interface WorkspaceIdentityDependencies {
   readonly repository: ManagedStackRepositoryShape;
@@ -363,9 +364,9 @@ export const makeWorkspaceIdentity = ({
           }),
         );
       }
+      const metadata = workspaceMetadata(inspection);
 
       if (inspection.kind === "ordinary-folder") {
-        const markerPath = ordinaryWorkspaceIdentityPath(canonicalPath);
         const marker =
           targetIdentity === undefined
             ? yield* ensureOrdinaryWorkspaceIdentity(canonicalPath, idFactory)
@@ -382,15 +383,7 @@ export const makeWorkspaceIdentity = ({
         return {
           // A folder keeps all three identities in one marker, so that
           // marker is both identity locations.
-          workspace: {
-            checkoutKind: "ordinary",
-            canonicalPath,
-            workspaceRoot: canonicalPath,
-            projectIdentityLocation: markerPath,
-            checkoutIdentityLocation: markerPath,
-          },
-          context: { kind: "workspace" },
-          contextDescriptor: { kind: "workspace" },
+          ...metadata,
           identity: {
             projectId: identity?.projectId,
             checkoutId: identity?.checkoutId,
@@ -433,23 +426,8 @@ export const makeWorkspaceIdentity = ({
             targetIdentity.contextId,
           );
         }
-        const head = inspection.head;
         return {
-          workspace: {
-            checkoutKind: checkoutKindOf(inspection),
-            canonicalPath: inspection.canonicalPath,
-            workspaceRoot: inspection.workspaceRoot,
-            projectIdentityLocation: inspection.commonDirectory,
-            checkoutIdentityLocation: inspection.gitDirectory,
-          },
-          context:
-            head.kind === "detached"
-              ? { kind: "detached", commit: head.commit }
-              : { kind: "branch", branch: head.branch },
-          contextDescriptor:
-            head.kind === "detached"
-              ? { kind: "detached" }
-              : { kind: "branch", locator: head.branch },
+          ...metadata,
           identity: targetIdentity,
           identityMarkerCreated: checkoutIdentityCreated,
         };
@@ -460,24 +438,10 @@ export const makeWorkspaceIdentity = ({
       const checkoutId = claimed.checkoutId;
       const head = inspection.head;
       return {
-        workspace: {
-          checkoutKind: checkoutKindOf(inspection),
-          canonicalPath: inspection.canonicalPath,
-          workspaceRoot: inspection.workspaceRoot,
-          projectIdentityLocation: inspection.commonDirectory,
-          checkoutIdentityLocation: inspection.gitDirectory,
-        },
+        ...metadata,
         // An unborn branch names a context exactly as a born one does: it is
         // the state a fresh repository starts in, and a first start there
         // must not be treated as a detached `HEAD`.
-        context:
-          head.kind === "detached"
-            ? { kind: "detached", commit: head.commit }
-            : { kind: "branch", branch: head.branch },
-        contextDescriptor:
-          head.kind === "detached"
-            ? { kind: "detached" }
-            : { kind: "branch", locator: head.branch },
         identity: {
           projectId: claimed.projectId,
           checkoutId,

--- a/packages/stack/src/managed/workspace-metadata.ts
+++ b/packages/stack/src/managed/workspace-metadata.ts
@@ -1,0 +1,58 @@
+import type { ManagedCheckoutKind, ManagedContextDescriptor, ManagedContextKind } from "./model.ts";
+import type { WorkspaceInspection } from "./git.ts";
+import { ordinaryWorkspaceIdentityPath } from "./paths.ts";
+import { checkoutKindOf } from "./topology.ts";
+
+export interface ManagedWorkspaceDiscoveryWorkspace {
+  readonly checkoutKind: ManagedCheckoutKind;
+  readonly canonicalPath: string;
+  readonly workspaceRoot: string;
+  readonly projectIdentityLocation: string;
+  readonly checkoutIdentityLocation: string;
+}
+
+export interface ManagedWorkspaceDiscoveryContext {
+  readonly kind: ManagedContextKind;
+  readonly branch?: string;
+  readonly commit?: string;
+}
+
+export interface ManagedWorkspaceMetadata {
+  readonly workspace: ManagedWorkspaceDiscoveryWorkspace;
+  readonly context: ManagedWorkspaceDiscoveryContext;
+  readonly contextDescriptor: ManagedContextDescriptor;
+}
+
+export const workspaceMetadata = (inspection: WorkspaceInspection): ManagedWorkspaceMetadata => {
+  if (inspection.kind === "ordinary-folder") {
+    const markerPath = ordinaryWorkspaceIdentityPath(inspection.canonicalPath);
+    return {
+      workspace: {
+        checkoutKind: "ordinary",
+        canonicalPath: inspection.canonicalPath,
+        workspaceRoot: inspection.canonicalPath,
+        projectIdentityLocation: markerPath,
+        checkoutIdentityLocation: markerPath,
+      },
+      context: { kind: "workspace" },
+      contextDescriptor: { kind: "workspace" },
+    };
+  }
+  return {
+    workspace: {
+      checkoutKind: checkoutKindOf(inspection),
+      canonicalPath: inspection.canonicalPath,
+      workspaceRoot: inspection.workspaceRoot,
+      projectIdentityLocation: inspection.commonDirectory,
+      checkoutIdentityLocation: inspection.gitDirectory,
+    },
+    context:
+      inspection.head.kind === "detached"
+        ? { kind: "detached", commit: inspection.head.commit }
+        : { kind: "branch", branch: inspection.head.branch },
+    contextDescriptor:
+      inspection.head.kind === "detached"
+        ? { kind: "detached" }
+        : { kind: "branch", locator: inspection.head.branch },
+  };
+};

--- a/packages/stack/src/managed/workspace-settlement.ts
+++ b/packages/stack/src/managed/workspace-settlement.ts
@@ -1,0 +1,72 @@
+import type { ManagedWorkspaceDiscovery } from "./discovery.ts";
+
+export const sameManagedWorkspaceTopology = (
+  before: ManagedWorkspaceDiscovery,
+  after: ManagedWorkspaceDiscovery,
+): boolean =>
+  before.workspace.checkoutKind === after.workspace.checkoutKind &&
+  before.workspace.workspaceRoot === after.workspace.workspaceRoot &&
+  before.workspace.projectIdentityLocation === after.workspace.projectIdentityLocation &&
+  before.workspace.checkoutIdentityLocation === after.workspace.checkoutIdentityLocation &&
+  before.context.kind === after.context.kind &&
+  before.context.branch === after.context.branch &&
+  before.context.commit === after.context.commit;
+
+export const identityPublicationIsMonotonic = (
+  before: ManagedWorkspaceDiscovery,
+  after: ManagedWorkspaceDiscovery,
+): boolean =>
+  (before.identity.projectId === undefined ||
+    before.identity.projectId === after.identity.projectId) &&
+  (before.identity.checkoutId === undefined ||
+    before.identity.checkoutId === after.identity.checkoutId) &&
+  (before.identity.contextId === undefined ||
+    before.identity.contextId === after.identity.contextId);
+
+const identityPublicationAdvanced = (
+  before: ManagedWorkspaceDiscovery,
+  after: ManagedWorkspaceDiscovery,
+): boolean =>
+  (before.identity.projectId === undefined && after.identity.projectId !== undefined) ||
+  (before.identity.checkoutId === undefined && after.identity.checkoutId !== undefined) ||
+  (before.identity.contextId === undefined && after.identity.contextId !== undefined);
+
+/** A same-topology start may have published part of the Git identity meanwhile. */
+export const concurrentIdentityPublication = (
+  before: ManagedWorkspaceDiscovery,
+  after: ManagedWorkspaceDiscovery,
+): boolean =>
+  before.state === "unregistered" &&
+  after.state === "unregistered" &&
+  after.conflicts.length === 0 &&
+  after.activeTransition === undefined &&
+  sameManagedWorkspaceTopology(before, after) &&
+  identityPublicationIsMonotonic(before, after) &&
+  identityPublicationAdvanced(before, after);
+
+export const benignConcurrentRegistration = (
+  before: ManagedWorkspaceDiscovery,
+  after: ManagedWorkspaceDiscovery,
+): boolean => {
+  const identityComplete =
+    after.identity.projectId !== undefined &&
+    after.identity.checkoutId !== undefined &&
+    after.identity.contextId !== undefined;
+  const newCheckoutReserved =
+    before.state === "unregistered" &&
+    after.state === "transitioning" &&
+    after.activeTransition?.kind === "new-checkout" &&
+    after.activeTransition.path === after.workspace.workspaceRoot &&
+    after.activeTransition.projectIdentityLocation === after.workspace.projectIdentityLocation &&
+    after.conflicts.length === 0;
+
+  return (
+    before.state === "unregistered" &&
+    sameManagedWorkspaceTopology(before, after) &&
+    identityPublicationIsMonotonic(before, after) &&
+    ((after.activeTransition === undefined &&
+      ((after.state === "healthy" && identityComplete && after.conflicts.length === 0) ||
+        concurrentIdentityPublication(before, after))) ||
+      newCheckoutReserved)
+  );
+};

--- a/packages/stack/src/managed/workspace-settlement.unit.test.ts
+++ b/packages/stack/src/managed/workspace-settlement.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { ManagedWorkspaceDiscovery } from "./discovery.ts";
+import { benignConcurrentRegistration } from "./workspace-settlement.ts";
+
+const report = (overrides: Partial<ManagedWorkspaceDiscovery> = {}): ManagedWorkspaceDiscovery => ({
+  state: "unregistered",
+  workspace: {
+    checkoutKind: "git",
+    canonicalPath: "/workspace",
+    workspaceRoot: "/workspace",
+    projectIdentityLocation: "/workspace/.git",
+    checkoutIdentityLocation: "/workspace/.git",
+  },
+  context: { kind: "branch", branch: "main" },
+  contextDescriptor: { kind: "branch", locator: "main" },
+  identity: {},
+  folderToGitClaims: [],
+  stacks: [],
+  locations: [],
+  activeOperations: [],
+  conflicts: [],
+  warnings: [],
+  recoveryOperations: [],
+  ...overrides,
+});
+
+describe("benignConcurrentRegistration", () => {
+  it("accepts a same-topology healthy winner", () => {
+    const before = report();
+    const after = report({
+      state: "healthy",
+      identity: { projectId: "project", checkoutId: "checkout", contextId: "context" },
+    });
+    expect(benignConcurrentRegistration(before, after)).toBe(true);
+  });
+
+  it("accepts monotonic partial identity publication", () => {
+    const before = report();
+    const after = report({ identity: { projectId: "project" } });
+    expect(benignConcurrentRegistration(before, after)).toBe(true);
+  });
+
+  it("accepts a same-workspace new-checkout reservation", () => {
+    const before = report();
+    const after = report({
+      state: "transitioning",
+      activeTransition: {
+        id: "transition",
+        kind: "new-checkout",
+        phase: "reserved",
+        path: "/workspace",
+        projectIdentityLocation: "/workspace/.git",
+        createdAt: "2026-08-15T00:00:00.000Z",
+        updatedAt: "2026-08-15T00:00:00.000Z",
+      },
+    });
+    expect(benignConcurrentRegistration(before, after)).toBe(true);
+  });
+
+  it("rejects topology changes and non-monotonic identities", () => {
+    expect(
+      benignConcurrentRegistration(
+        report(),
+        report({ workspace: { ...report().workspace, workspaceRoot: "/moved" } }),
+      ),
+    ).toBe(false);
+    expect(
+      benignConcurrentRegistration(
+        report({ identity: { projectId: "project" } }),
+        report({ identity: { projectId: "different-project" } }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- centralize workspace metadata derivation and first-start settlement policy in focused pure modules
- remove the obsolete Promise path canonicalizer and share the Git lock retry schedule
- strengthen deterministic recovery-race coverage, close a SQLite test handle leak, and correct architecture documentation

This is a maintainability follow-up to #6214. It deliberately keeps the broader `packages/stack` decomposition out of scope so that work can be designed separately.