### PR TITLE
feat(cli): support named remote Supabase projects via --remote

### DIFF
--- a/apps/cli/docs/go-cli-divergences.md
+++ b/apps/cli/docs/go-cli-divergences.md
@@ -10,13 +10,14 @@ something the old Go CLI didn't — it is not a compatibility promise.
 
 These commands exist in the TS CLI today but have no direct top-level equivalent in the old Go CLI reference.
 
-| TS command        | TS path                                                                                                            | Notes                                                                                                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dev`             | `planned`                                                                                                          | Reserved for a TS-native long-running local development workflow command that watches files and orchestrates subcommands. Track this as TS-only unless a direct Go equivalent emerges.        |
-| `logs`            | [`../src/next/commands/logs/logs.command.ts`](../src/next/commands/logs/logs.command.ts)                           | Streams local stack logs. No top-level `logs` command exists in the old Go CLI reference.                                                                                                     |
-| `api`             | [`../src/next/commands/platform/api.command.ts`](../src/next/commands/platform/api.command.ts)                     | Low-level Management API client. It supersedes the old generated tree with explicit discovery via `supabase api routes` and execution via `supabase api request <route> [--method <METHOD>]`. |
-| `stack`           | [`../src/next/cli/root.ts`](../src/next/cli/root.ts)                                                               | TS-only local runtime namespace exposing `stack start`, `stack stop`, `stack status`, `stack list`, and `stack update`. Top-level `start`, `stop`, and `status` remain aliases.               |
-| `branches switch` | [`../src/next/commands/branches/switch/switch.command.ts`](../src/next/commands/branches/switch/switch.command.ts) | No direct Go equivalent. Updates local active-branch state so subsequent commands target the selected branch.                                                                                 |
+| TS command                  | TS path                                                                                                                                                                                                        | Notes                                                                                                                                                                                                                   |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dev`                       | `planned`                                                                                                                                                                                                      | Reserved for a TS-native long-running local development workflow command that watches files and orchestrates subcommands. Track this as TS-only unless a direct Go equivalent emerges.                                  |
+| `logs`                      | [`../src/next/commands/logs/logs.command.ts`](../src/next/commands/logs/logs.command.ts)                                                                                                                       | Streams local stack logs. No top-level `logs` command exists in the old Go CLI reference.                                                                                                                               |
+| `api`                       | [`../src/next/commands/platform/api.command.ts`](../src/next/commands/platform/api.command.ts)                                                                                                                 | Low-level Management API client. It supersedes the old generated tree with explicit discovery via `supabase api routes` and execution via `supabase api request <route> [--method <METHOD>]`.                           |
+| `stack`                     | [`../src/next/cli/root.ts`](../src/next/cli/root.ts)                                                                                                                                                           | TS-only local runtime namespace exposing `stack start`, `stack stop`, `stack status`, `stack list`, and `stack update`. Top-level `start`, `stop`, and `status` remain aliases.                                         |
+| `branches switch`           | [`../src/next/commands/branches/switch/switch.command.ts`](../src/next/commands/branches/switch/switch.command.ts)                                                                                             | No direct Go equivalent. Updates local active-branch state so subsequent commands target the selected branch.                                                                                                           |
+| `remotes {list,add,remove}` | [`../src/legacy/commands/remotes/remotes.command.ts`](../src/legacy/commands/remotes/remotes.command.ts), [`../src/next/commands/remotes/remotes.command.ts`](../src/next/commands/remotes/remotes.command.ts) | TS-only, no Go equivalent. CRUD over the existing `[remotes.<name>]` config block (`packages/config`'s `RemotesSchema` — previously write-only via hand-editing `config.toml`). Shared handlers, native in both shells. |
 
 ## Flag divergences from the Go reference
 
@@ -55,6 +56,20 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
   `POST /v1/projects` accepts them (restored via `packages/api/scripts/openapi-overrides.json`,
   CLI-2180). Both flags are hidden and gated behind `--experimental` (or `SUPABASE_EXPERIMENTAL`)
   until PROD-548 exposes them officially; omitting them matches Go exactly.
+- Both shells have a TS-only GLOBAL `--remote <name>` flag (`SUPABASE_REMOTE`
+  env fallback), no Go equivalent. Resolves the named `[remotes.<name>]`
+  entry's `project_id` and feeds it into the existing ref-resolution chain at
+  the same point an explicit `--project-ref` would — legacy: all 4
+  `LegacyProjectRefResolver` methods, from one central injection in
+  `legacy-project-ref.layer.ts`, so every command that resolves a linked ref
+  gets it without a per-command flag edit; next: `resolveProjectRef`/`link`'s
+  `chooseProjectRef` via `next/config/resolve-project-ref.ts`. Exits nonzero when
+  combined with an explicit `--project-ref`, with `--local`/`--db-url` on `db push`,
+  or with the two remaining Go-delegate paths (`db pull --experimental`,
+  `db diff --use-pg-schema`) — those delegated children re-resolve their own
+  ref and know nothing of `--remote`. Prints `Target: remote "<name>" (<ref>)`
+  on stderr before any mutation/network write. Never persists a "current
+  remote" — resolved fresh on every invocation.
 - `link` has a TS-only `[ref-or-branch]` positional argument (no Go equivalent), and its
   `--project-ref` flag additionally accepts a branch name. A value matching the 20-lowercase-letter
   project ref shape is always treated as a ref; any other non-empty value is resolved to its

--- a/apps/cli/docs/supabase/remotes/add.md
+++ b/apps/cli/docs/supabase/remotes/add.md
@@ -1,0 +1,11 @@
+## supabase-remotes-add
+
+Registers a named remote Supabase project in `supabase/config.toml` (or `supabase/config.json`), so it can be targeted per-invocation with the global `--remote <name>` flag instead of relinking your project.
+
+```
+supabase remotes add staging --project-ref abcdefghijklmnopqrst
+```
+
+Adding a name that already targets the same project ref is a no-op. Adding a name that already exists with a different ref fails without writing.
+
+The remote's project ref is not a secret and is committed with the rest of `supabase/config.toml`.

--- a/apps/cli/docs/supabase/remotes/list.md
+++ b/apps/cli/docs/supabase/remotes/list.md
@@ -1,0 +1,7 @@
+## supabase-remotes-list
+
+Lists the named remote Supabase projects registered in `supabase/config.toml` (or `supabase/config.json`), one row per `[remotes.<name>]` block.
+
+Each row shows the remote's name and the project ref it targets. Use a name with the global `--remote <name>` flag (or the `SUPABASE_REMOTE` environment variable) to target that project for a single invocation, without changing your linked project.
+
+This command performs no network access — it only reads the project config.

--- a/apps/cli/docs/supabase/remotes/remove.md
+++ b/apps/cli/docs/supabase/remotes/remove.md
@@ -1,0 +1,9 @@
+## supabase-remotes-remove
+
+Removes a named remote from `supabase/config.toml` (or `supabase/config.json`).
+
+```
+supabase remotes remove staging
+```
+
+Refuses to remove a remote whose `[remotes.<name>]` block declares any key besides `project_id` — remove the extra config first. Removing the last configured remote leaves no empty `[remotes]` table behind.

--- a/apps/cli/src/legacy/cli/root.ts
+++ b/apps/cli/src/legacy/cli/root.ts
@@ -22,6 +22,7 @@ import { legacyNetworkRestrictionsCommand } from "../commands/network-restrictio
 import { legacyOrgsCommand } from "../commands/orgs/orgs.command.ts";
 import { legacyPostgresConfigCommand } from "../commands/postgres-config/postgres-config.command.ts";
 import { legacyProjectsCommand } from "../commands/projects/projects.command.ts";
+import { legacyRemotesCommand } from "../commands/remotes/remotes.command.ts";
 import { legacySecretsCommand } from "../commands/secrets/secrets.command.ts";
 import { legacySeedCommand } from "../commands/seed/seed.command.ts";
 import { legacyServicesCommand } from "../commands/services/services.command.ts";
@@ -83,6 +84,7 @@ export const legacyRoot = Command.make("supabase").pipe(
     legacyOrgsCommand,
     legacyPostgresConfigCommand,
     legacyProjectsCommand,
+    legacyRemotesCommand,
     legacySecretsCommand,
     legacySeedCommand,
     legacyServicesCommand,

--- a/apps/cli/src/legacy/commands/db/diff/diff.handler.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.handler.ts
@@ -5,6 +5,7 @@ import {
   LegacyDebugFlag,
   LegacyDnsResolverFlag,
   LegacyNetworkIdFlag,
+  legacyResolveRemoteFlag,
 } from "../../../../shared/legacy/global-flags.ts";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
 import { detectGitBranch } from "../../../../shared/git/git-branch.ts";
@@ -378,6 +379,16 @@ export const legacyDbDiff = Effect.fn("legacy.db.diff")(function* (flags: Legacy
       return yield* Effect.fail(
         new LegacyDbDiffTargetFlagsError({
           message: "--project-ref is not supported with --use-pg-schema",
+        }),
+      );
+    }
+    // Same rationale as the --project-ref guard above: `--remote` is TS-only
+    // and the delegated Go child re-resolves its own linked ref.
+    const remoteFlag = yield* legacyResolveRemoteFlag;
+    if (usePgSchema && Option.isSome(remoteFlag)) {
+      return yield* Effect.fail(
+        new LegacyDbDiffTargetFlagsError({
+          message: "--remote is not supported with --use-pg-schema",
         }),
       );
     }

--- a/apps/cli/src/legacy/commands/db/diff/diff.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/diff/diff.integration.test.ts
@@ -26,6 +26,7 @@ import {
   LegacyDnsResolverFlag,
   LegacyExperimentalFlag,
   LegacyNetworkIdFlag,
+  LegacyRemoteFlag,
 } from "../../../../shared/legacy/global-flags.ts";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
 import type { OutputFormat } from "../../../../shared/output/types.ts";
@@ -91,6 +92,8 @@ interface SetupOpts {
   // `LegacyProjectNotLinkedError` absent an explicit `--project-ref` flag,
   // instead of silently falling back to `opts.linkedRef ?? LEGACY_VALID_REF`.
   readonly linkedFails?: boolean;
+  // `--remote <name>` global flag value (T11: db diff --use-pg-schema reject matrix).
+  readonly remoteFlag?: string;
   // --- CLI-1968 (native --use-pgadmin) ---
   // Per-differ-run `--json-diff` stdout, one entry per `runCapture` call to the differ
   // image (index 0 = the no-`--schema` run, or the 1st `--schema` run; index 1 = the
@@ -359,6 +362,10 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     }),
     Layer.succeed(LegacyExperimentalFlag, false),
     Layer.succeed(LegacyDebugFlag, false),
+    Layer.succeed(
+      LegacyRemoteFlag,
+      opts.remoteFlag === undefined ? Option.none() : Option.some(opts.remoteFlag),
+    ),
     Layer.succeed(CliArgs, { args: [] }),
     mockRuntimeInfo({ platform: opts.platform ?? "linux" }),
   );
@@ -980,6 +987,20 @@ describe("legacy db diff", () => {
       );
       expect(Exit.isFailure(exit)).toBe(true);
       expect(JSON.stringify(exit)).toContain("--project-ref is not supported with --use-pg-schema");
+      expect(s.proxyCalls).toEqual([]);
+      expect(s.proxyCaptureCalls).toEqual([]);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.effect("rejects --remote combined with --use-pg-schema before delegating", () => {
+    // `--remote` is TS-only and the delegated Go child re-resolves its own
+    // linked ref, so it can't be forwarded either — same rationale as the
+    // --project-ref guard above (V19).
+    const s = setup(tmp.current, { remoteFlag: "staging" });
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(legacyDbDiff(flags({ usePgSchema: Option.some(true) })));
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(JSON.stringify(exit)).toContain("--remote is not supported with --use-pg-schema");
       expect(s.proxyCalls).toEqual([]);
       expect(s.proxyCaptureCalls).toEqual([]);
     }).pipe(Effect.provide(s.layer));

--- a/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.handler.ts
@@ -6,6 +6,7 @@ import {
   LegacyDnsResolverFlag,
   LegacyNetworkIdFlag,
   legacyResolveExperimentalWithProjectEnv,
+  legacyResolveRemoteFlag,
   legacyResolveYesWithProjectEnv,
 } from "../../../../shared/legacy/global-flags.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
@@ -293,6 +294,19 @@ export const legacyDbPull = Effect.fn("legacy.db.pull")(function* (flags: Legacy
         new LegacyDbPullTargetFlagsError({
           message:
             "--project-ref is not supported with the --experimental structured-dump pull; use --declarative instead",
+        }),
+      );
+    }
+
+    // Same rationale as the --project-ref guard just above: the delegated Go
+    // child re-resolves its own linked ref and knows nothing of `--remote`
+    // (TS-only, no Go equivalent).
+    const remoteFlag = yield* legacyResolveRemoteFlag;
+    if (Option.isSome(remoteFlag) && delegatesExperimentalPull) {
+      return yield* Effect.fail(
+        new LegacyDbPullTargetFlagsError({
+          message:
+            "--remote is not supported with the --experimental structured-dump pull; use --declarative instead",
         }),
       );
     }

--- a/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/pull/pull.integration.test.ts
@@ -27,6 +27,7 @@ import {
   LegacyDnsResolverFlag,
   LegacyExperimentalFlag,
   LegacyNetworkIdFlag,
+  LegacyRemoteFlag,
   LegacyYesFlag,
 } from "../../../../shared/legacy/global-flags.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
@@ -89,6 +90,8 @@ interface SetupOpts {
   readonly pipedAnswers?: ReadonlyArray<string>;
   readonly yes?: boolean;
   readonly experimental?: boolean;
+  // `--remote <name>` global flag value (T11: db pull --experimental reject matrix).
+  readonly remoteFlag?: string;
   readonly promptConfirmResponses?: ReadonlyArray<boolean>;
   readonly resolvedRef?: string;
   // Fail the first edge-runtime run with this message (the second succeeds with
@@ -327,6 +330,10 @@ function setup(workdir: string, opts: SetupOpts = {}) {
     ),
     Layer.succeed(LegacyYesFlag, opts.yes ?? false),
     Layer.succeed(LegacyExperimentalFlag, opts.experimental ?? false),
+    Layer.succeed(
+      LegacyRemoteFlag,
+      opts.remoteFlag === undefined ? Option.none() : Option.some(opts.remoteFlag),
+    ),
     Layer.succeed(LegacyDebugFlag, false),
     Layer.succeed(LegacyDnsResolverFlag, "native"),
     Layer.succeed(LegacyNetworkIdFlag, Option.none()),
@@ -502,6 +509,21 @@ describe("legacy db pull", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       expect(JSON.stringify(exit)).toContain(
         "--project-ref is not supported with the --experimental structured-dump pull; use --declarative instead",
+      );
+      expect(s.proxyCalls).toEqual([]);
+      expect(s.proxyCaptureCalls).toEqual([]);
+    }).pipe(Effect.provide(s.layer));
+  });
+
+  it.effect("rejects --remote combined with --experimental before delegating", () => {
+    // Same rationale as the --project-ref guard above (V19): `--remote` is
+    // TS-only and the delegated Go child re-resolves its own linked ref.
+    const s = setup(tmp.current, { experimental: true, remoteFlag: "staging" });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPull(flags({})).pipe(Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(JSON.stringify(exit)).toContain(
+        "--remote is not supported with the --experimental structured-dump pull; use --declarative instead",
       );
       expect(s.proxyCalls).toEqual([]);
       expect(s.proxyCaptureCalls).toEqual([]);

--- a/apps/cli/src/legacy/commands/db/push/push.handler.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.handler.ts
@@ -2,7 +2,10 @@ import { Effect, FileSystem, Option, Path } from "effect";
 
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
 import { LegacyDnsResolverFlag } from "../../../../shared/legacy/global-flags.ts";
-import { legacyResolveYesWithProjectEnv } from "../../../../shared/legacy/global-flags.ts";
+import {
+  legacyResolveRemoteFlag,
+  legacyResolveYesWithProjectEnv,
+} from "../../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../../shared/output/output.service.ts";
 import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
@@ -71,6 +74,18 @@ export const legacyDbPush = Effect.fn("legacy.db.push")(function* (flags: Legacy
         new LegacyDbPushTargetFlagsError({
           message:
             "--project-ref only applies when targeting the linked project; use it with --linked (not --local or --db-url)",
+        }),
+      );
+    }
+
+    // Same rationale as the --project-ref guard above: `--remote` only ever
+    // resolves a linked-project ref, so it's meaningless on --local/--db-url.
+    const remoteFlag = yield* legacyResolveRemoteFlag;
+    if (Option.isSome(remoteFlag) && connType !== "linked") {
+      return yield* Effect.fail(
+        new LegacyDbPushTargetFlagsError({
+          message:
+            "--remote only applies when targeting the linked project; use it with --linked (not --local or --db-url)",
         }),
       );
     }

--- a/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
+++ b/apps/cli/src/legacy/commands/db/push/push.integration.test.ts
@@ -15,7 +15,11 @@ import {
   useLegacyTempWorkdir,
 } from "../../../../../tests/helpers/legacy-mocks.ts";
 import { CliArgs } from "../../../../shared/cli/cli-args.service.ts";
-import { LegacyDnsResolverFlag, LegacyYesFlag } from "../../../../shared/legacy/global-flags.ts";
+import {
+  LegacyDnsResolverFlag,
+  LegacyRemoteFlag,
+  LegacyYesFlag,
+} from "../../../../shared/legacy/global-flags.ts";
 import type { OutputFormat } from "../../../../shared/output/types.ts";
 import { LegacyProjectRefResolver } from "../../../config/legacy-project-ref.service.ts";
 import { LegacyProjectNotLinkedError } from "../../../config/legacy-project-ref.errors.ts";
@@ -185,6 +189,7 @@ function setup(
     // `mockResolver` is otherwise silent, so tests pin the established output
     // ordering against this stand-in line.
     simulateInitialisingLoginRole?: boolean;
+    remoteFlag?: string;
   },
 ) {
   if (opts.toml !== undefined) {
@@ -266,6 +271,10 @@ function setup(
     Layer.succeed(CliArgs, { args: opts.args ?? ["db", "push", "--local"] }),
     Layer.succeed(LegacyYesFlag, opts.yes ?? false),
     Layer.succeed(LegacyDnsResolverFlag, "native"),
+    Layer.succeed(
+      LegacyRemoteFlag,
+      opts.remoteFlag === undefined ? Option.none() : Option.some(opts.remoteFlag),
+    ),
     projectRefLayer,
     telemetry.layer,
     linkedCache.layer,
@@ -334,6 +343,41 @@ describe("legacy db push", () => {
     return Effect.gen(function* () {
       const exit = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
       expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  it.live("rejects --remote combined with --local", () => {
+    const { layer } = setup(tmp.current, {
+      toml: 'project_id = "test"\n',
+      args: ["db", "push", "--local"],
+      remoteFlag: "staging",
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPush(DEFAULT_FLAGS).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("only applies when targeting the linked");
+      }
+    });
+  });
+
+  it.live("rejects --remote combined with --db-url", () => {
+    const dbUrl = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+    const { layer } = setup(tmp.current, {
+      toml: 'project_id = "test"\n',
+      args: ["db", "push", "--db-url", dbUrl],
+      remoteFlag: "staging",
+    });
+    return Effect.gen(function* () {
+      const exit = yield* legacyDbPush({
+        ...DEFAULT_FLAGS,
+        dbUrl: Option.some(dbUrl),
+        local: false,
+      }).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(JSON.stringify(exit.cause)).toContain("only applies when targeting the linked");
+      }
     });
   });
 

--- a/apps/cli/src/legacy/commands/remotes/add/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/remotes/add/SIDE_EFFECTS.md
@@ -1,0 +1,60 @@
+# `supabase remotes add <name> --project-ref <ref>`
+
+TS-only command, no Go equivalent — see `docs/go-cli-divergences.md`.
+
+## Files Read
+
+| Path                                              | Format    | When   |
+| ------------------------------------------------- | --------- | ------ |
+| `<workdir>/supabase/config.toml` or `config.json` | TOML/JSON | always |
+
+## Files Written
+
+| Path                                              | Format    | When                                                                                                                                                                            |
+| ------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<workdir>/supabase/config.toml` or `config.json` | TOML/JSON | on success, when the name/ref pair is new — TOML gets an APPEND-ONLY `[remotes.<name>]` block; JSON gets a structural, order-preserving key insert. Atomic (tmp file + rename). |
+
+## API Routes
+
+—
+
+## Environment Variables
+
+| Variable           | Purpose                        | Required? |
+| ------------------ | ------------------------------ | --------- |
+| `SUPABASE_WORKDIR` | resolves the project directory | no        |
+
+## Exit Codes
+
+| Code | Condition                                                                                 |
+| ---- | ----------------------------------------------------------------------------------------- |
+| `0`  | success, including a no-op re-add of an identical name/ref pair                           |
+| `1`  | no config file found; invalid name; invalid ref; name already exists with a DIFFERENT ref |
+
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups         |
+| ---------------------- | ------------------------------------------ | ----------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` |
+
+## Output
+
+### `--output-format text`
+
+```
+Added remote "staging" -> abcdefghijklmnopqrst.
+```
+
+### `--output-format json`
+
+```json
+{ "name": "staging", "project_ref": "abcdefghijklmnopqrst", "wrote": true }
+```
+
+## Notes
+
+- Never goes through `saveProjectConfig`'s full schema re-serialize — that
+  would strip comments/formatting from the rest of the file. TOML edits are
+  append-only; every byte before the append offset is untouched.
+- Idempotent: re-adding the same name with the identical ref is a no-op,
+  exit 0.

--- a/apps/cli/src/legacy/commands/remotes/add/add.command.ts
+++ b/apps/cli/src/legacy/commands/remotes/add/add.command.ts
@@ -1,0 +1,29 @@
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
+import { legacyRemotesAdd } from "./add.handler.ts";
+import { legacyRemotesRuntimeLayer } from "../remotes.layers.ts";
+
+const config = {
+  name: Argument.string("name").pipe(Argument.withDescription("Name for the remote.")),
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref the remote targets."),
+  ),
+} as const;
+
+export type LegacyRemotesAddFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyRemotesAddCommand = Command.make("add", config).pipe(
+  Command.withDescription(
+    "Register a named remote Supabase project in supabase/config.toml. Idempotent when the name already targets the same ref.",
+  ),
+  Command.withShortDescription("Register a remote"),
+  Command.withHandler((flags) =>
+    legacyRemotesAdd(flags).pipe(
+      withLegacyCommandInstrumentation({ flags, safeFlags: ["project-ref"] }),
+      withJsonErrorHandling,
+    ),
+  ),
+  Command.provide(legacyRemotesRuntimeLayer(["remotes", "add"])),
+);

--- a/apps/cli/src/legacy/commands/remotes/add/add.handler.ts
+++ b/apps/cli/src/legacy/commands/remotes/add/add.handler.ts
@@ -1,0 +1,16 @@
+import { Effect } from "effect";
+import { remotesAdd } from "../../../../shared/remotes/remotes-crud.ts";
+import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
+import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
+import type { LegacyRemotesAddFlags } from "./add.command.ts";
+
+export const legacyRemotesAdd = Effect.fn("legacy.remotes.add")(function* (
+  flags: LegacyRemotesAddFlags,
+) {
+  const cliConfig = yield* LegacyCliConfig;
+  const telemetryState = yield* LegacyTelemetryState;
+
+  yield* remotesAdd(cliConfig.workdir, flags.name, flags.projectRef).pipe(
+    Effect.ensuring(telemetryState.flush),
+  );
+});

--- a/apps/cli/src/legacy/commands/remotes/list/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/remotes/list/SIDE_EFFECTS.md
@@ -1,0 +1,65 @@
+# `supabase remotes list`
+
+TS-only command, no Go equivalent — see `docs/go-cli-divergences.md`.
+
+## Files Read
+
+| Path                                              | Format    | When   |
+| ------------------------------------------------- | --------- | ------ |
+| `<workdir>/supabase/config.toml` or `config.json` | TOML/JSON | always |
+
+## Files Written
+
+| Path | Format | When |
+| ---- | ------ | ---- |
+| —    | —      | —    |
+
+## API Routes
+
+—
+
+## Environment Variables
+
+| Variable           | Purpose                        | Required? |
+| ------------------ | ------------------------------ | --------- |
+| `SUPABASE_WORKDIR` | resolves the project directory | no        |
+
+## Exit Codes
+
+| Code | Condition                                     |
+| ---- | --------------------------------------------- |
+| `0`  | success (including an empty registry)         |
+| `1`  | no `supabase/config.toml`/`config.json` found |
+
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups         |
+| ---------------------- | ------------------------------------------ | ----------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` |
+
+## Output
+
+### `--output-format text`
+
+```
+NAME     PROJECT REF
+staging  abcdefghijklmnopqrst
+```
+
+### `--output-format json`
+
+```json
+{ "remotes": [{ "name": "staging", "project_ref": "abcdefghijklmnopqrst" }] }
+```
+
+### `--output-format stream-json`
+
+```ndjson
+{"type":"result","data":{"remotes":[{"name":"staging","project_ref":"abcdefghijklmnopqrst"}]}}
+```
+
+## Notes
+
+- Pure config read — never touches the network (V17).
+- Reads the POST-`env()`-interpolation document, so an `env(REF)`-valued
+  `project_id` shows its resolved ref, not the literal `env(...)` string.

--- a/apps/cli/src/legacy/commands/remotes/list/list.command.ts
+++ b/apps/cli/src/legacy/commands/remotes/list/list.command.ts
@@ -1,0 +1,14 @@
+import { Command } from "effect/unstable/cli";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
+import { legacyRemotesList } from "./list.handler.ts";
+import { legacyRemotesRuntimeLayer } from "../remotes.layers.ts";
+
+export const legacyRemotesListCommand = Command.make("list").pipe(
+  Command.withDescription("List named remote Supabase projects from supabase/config.toml."),
+  Command.withShortDescription("List configured remotes"),
+  Command.withHandler(() =>
+    legacyRemotesList().pipe(withLegacyCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(legacyRemotesRuntimeLayer(["remotes", "list"])),
+);

--- a/apps/cli/src/legacy/commands/remotes/list/list.handler.ts
+++ b/apps/cli/src/legacy/commands/remotes/list/list.handler.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect";
+import { remotesList } from "../../../../shared/remotes/remotes-crud.ts";
+import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
+import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
+
+export const legacyRemotesList = Effect.fn("legacy.remotes.list")(function* () {
+  const cliConfig = yield* LegacyCliConfig;
+  const telemetryState = yield* LegacyTelemetryState;
+
+  yield* remotesList(cliConfig.workdir).pipe(Effect.ensuring(telemetryState.flush));
+});

--- a/apps/cli/src/legacy/commands/remotes/remotes.command.ts
+++ b/apps/cli/src/legacy/commands/remotes/remotes.command.ts
@@ -1,0 +1,16 @@
+import { Command } from "effect/unstable/cli";
+import { legacyRemotesAddCommand } from "./add/add.command.ts";
+import { legacyRemotesListCommand } from "./list/list.command.ts";
+import { legacyRemotesRemoveCommand } from "./remove/remove.command.ts";
+
+export const legacyRemotesCommand = Command.make("remotes").pipe(
+  Command.withDescription(
+    "Manage named remote Supabase projects in supabase/config.toml, selectable per-invocation via --remote.",
+  ),
+  Command.withShortDescription("Manage named remote projects"),
+  Command.withSubcommands([
+    legacyRemotesListCommand,
+    legacyRemotesAddCommand,
+    legacyRemotesRemoveCommand,
+  ]),
+);

--- a/apps/cli/src/legacy/commands/remotes/remotes.e2e.test.ts
+++ b/apps/cli/src/legacy/commands/remotes/remotes.e2e.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { runSupabase } from "../../../../tests/helpers/cli.ts";
+
+const E2E_TIMEOUT_MS = 30_000;
+const REF = "abcdefghijklmnopqrst";
+
+describe("supabase remotes (legacy)", () => {
+  let projectDir: string;
+
+  beforeAll(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "supabase-remotes-e2e-"));
+    mkdirSync(join(projectDir, "supabase"), { recursive: true });
+    writeFileSync(join(projectDir, "supabase", "config.toml"), 'project_id = "local"\n');
+  });
+
+  afterAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test(
+    "remotes add -> remotes list -> db push --remote (golden path)",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      const add = await runSupabase(["remotes", "add", "staging", "--project-ref", REF], {
+        entrypoint: "legacy",
+        cwd: projectDir,
+      });
+      expect(add.exitCode).toBe(0);
+      expect(add.stdout).toContain(`Added remote "staging" -> ${REF}.`);
+
+      const list = await runSupabase(["remotes", "list"], {
+        entrypoint: "legacy",
+        cwd: projectDir,
+      });
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toContain("staging");
+      expect(list.stdout).toContain(REF);
+
+      // An unknown --remote name fails deterministically before any network
+      // access — proving `--remote` threads all the way from argv parsing through
+      // `LegacyProjectRefResolver` without requiring a real backend.
+      const push = await runSupabase(["db", "push", "--remote", "ghost", "--dry-run"], {
+        entrypoint: "legacy",
+        cwd: projectDir,
+      });
+      expect(push.exitCode).toBe(1);
+      expect(push.stderr).toContain('Unknown remote "ghost"');
+      expect(push.stderr).toContain("supabase remotes add ghost");
+    },
+  );
+
+  test("remotes remove deletes a registered remote", { timeout: E2E_TIMEOUT_MS }, async () => {
+    const add = await runSupabase(["remotes", "add", "prod", "--project-ref", REF], {
+      entrypoint: "legacy",
+      cwd: projectDir,
+    });
+    expect(add.exitCode).toBe(0);
+
+    const remove = await runSupabase(["remotes", "remove", "prod"], {
+      entrypoint: "legacy",
+      cwd: projectDir,
+    });
+    expect(remove.exitCode).toBe(0);
+    expect(remove.stdout).toContain('Removed remote "prod".');
+
+    const list = await runSupabase(["remotes", "list"], {
+      entrypoint: "legacy",
+      cwd: projectDir,
+    });
+    expect(list.stdout).not.toContain("prod");
+  });
+});

--- a/apps/cli/src/legacy/commands/remotes/remotes.integration.test.ts
+++ b/apps/cli/src/legacy/commands/remotes/remotes.integration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "@effect/vitest";
+import { BunServices } from "@effect/platform-bun";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Effect, Exit, Layer } from "effect";
+import {
+  mockLegacyCliConfig,
+  mockLegacyTelemetryStateTracked,
+  useLegacyTempWorkdir,
+} from "../../../../tests/helpers/legacy-mocks.ts";
+import { mockOutput } from "../../../../tests/helpers/mocks.ts";
+import { legacyRemotesAdd } from "./add/add.handler.ts";
+import { legacyRemotesList } from "./list/list.handler.ts";
+import { legacyRemotesRemove } from "./remove/remove.handler.ts";
+
+const REF_A = "abcdefghijklmnopqrst";
+const REF_B = "zzzzzzzzzzzzzzzzzzzz";
+
+function writeConfig(dir: string, content: string) {
+  return Effect.promise(async () => {
+    await mkdir(join(dir, "supabase"), { recursive: true });
+    await writeFile(join(dir, "supabase", "config.toml"), content);
+  });
+}
+
+function setup(workdir: string, format: "text" | "json" = "text") {
+  const out = mockOutput({ format });
+  const telemetry = mockLegacyTelemetryStateTracked();
+  const layer = Layer.mergeAll(
+    out.layer,
+    telemetry.layer,
+    mockLegacyCliConfig({ workdir }),
+    BunServices.layer,
+  );
+  return { layer, out, telemetry };
+}
+
+describe("supabase remotes", () => {
+  const workdir = useLegacyTempWorkdir();
+
+  it.live("add then list then remove a remote end to end", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir.current, 'project_id = "local"\n');
+      const { layer, out, telemetry } = setup(workdir.current);
+
+      yield* legacyRemotesAdd({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      expect(telemetry.flushCount).toBe(1);
+      expect(out.stdoutText).toContain(`Added remote "staging" -> ${REF_A}.`);
+
+      yield* legacyRemotesList().pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain("staging");
+      expect(out.stdoutText).toContain(REF_A);
+
+      yield* legacyRemotesRemove({ name: "staging" }).pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain('Removed remote "staging".');
+    }),
+  );
+
+  it.live("re-adding the same name with the same ref is a no-op", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir.current, "");
+      const { layer, out } = setup(workdir.current);
+
+      yield* legacyRemotesAdd({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      yield* legacyRemotesAdd({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain("nothing to do");
+    }),
+  );
+
+  it.live("re-adding the same name with a different ref fails", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir.current, "");
+      const { layer } = setup(workdir.current);
+
+      yield* legacyRemotesAdd({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      const exit = yield* legacyRemotesAdd({ name: "staging", projectRef: REF_B }).pipe(
+        Effect.provide(layer),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("removing an unknown remote fails", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir.current, "");
+      const { layer } = setup(workdir.current);
+
+      const exit = yield* legacyRemotesRemove({ name: "ghost" }).pipe(
+        Effect.provide(layer),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("remotes * fails when no project config exists", () =>
+    Effect.gen(function* () {
+      const { layer } = setup(workdir.current);
+      const exit = yield* legacyRemotesList().pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("json mode emits a structured payload instead of a table", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir.current, `[remotes.staging]\nproject_id = "${REF_A}"\n`);
+      const { layer, out } = setup(workdir.current, "json");
+
+      yield* legacyRemotesList().pipe(Effect.provide(layer));
+      const success = out.messages.find((m) => m.type === "success");
+      expect(success?.data).toEqual({ remotes: [{ name: "staging", project_ref: REF_A }] });
+    }),
+  );
+});

--- a/apps/cli/src/legacy/commands/remotes/remotes.layers.ts
+++ b/apps/cli/src/legacy/commands/remotes/remotes.layers.ts
@@ -1,0 +1,16 @@
+import { Layer } from "effect";
+import { commandRuntimeLayer } from "../../../shared/runtime/command-runtime.layer.ts";
+import { legacyCliConfigLayer } from "../../config/legacy-cli-config.layer.ts";
+import { legacyDebugLoggerLayer } from "../../shared/legacy-debug-logger.layer.ts";
+import { legacyTelemetryStateLayer } from "../../telemetry/legacy-telemetry-state.layer.ts";
+
+/**
+ * Runtime layer for `supabase remotes {list,add,remove}` — pure local config
+ * reads/writes, no Management API, no Docker. Deliberately lighter than
+ * `legacyManagementApiRuntimeLayer`: no credentials/platform-API stack, since
+ * these commands never need a token.
+ */
+export function legacyRemotesRuntimeLayer(subcommand: ReadonlyArray<string>) {
+  const cliConfig = legacyCliConfigLayer.pipe(Layer.provide(legacyDebugLoggerLayer));
+  return Layer.mergeAll(cliConfig, legacyTelemetryStateLayer, commandRuntimeLayer([...subcommand]));
+}

--- a/apps/cli/src/legacy/commands/remotes/remove/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/remotes/remove/SIDE_EFFECTS.md
@@ -1,0 +1,60 @@
+# `supabase remotes remove <name>`
+
+TS-only command, no Go equivalent — see `docs/go-cli-divergences.md`.
+
+## Files Read
+
+| Path                                              | Format    | When   |
+| ------------------------------------------------- | --------- | ------ |
+| `<workdir>/supabase/config.toml` or `config.json` | TOML/JSON | always |
+
+## Files Written
+
+| Path                                              | Format    | When                                                                               |
+| ------------------------------------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `<workdir>/supabase/config.toml` or `config.json` | TOML/JSON | on success — deletes the `[remotes.<name>]` block/key. Atomic (tmp file + rename). |
+
+## API Routes
+
+—
+
+## Environment Variables
+
+| Variable           | Purpose                        | Required? |
+| ------------------ | ------------------------------ | --------- |
+| `SUPABASE_WORKDIR` | resolves the project directory | no        |
+
+## Exit Codes
+
+| Code | Condition                                                                                 |
+| ---- | ----------------------------------------------------------------------------------------- |
+| `0`  | success                                                                                   |
+| `1`  | no config file found; name not found; block declares config beyond `project_id` (refused) |
+
+## Telemetry Events Fired
+
+| Event                  | When                                       | Notable properties / groups         |
+| ---------------------- | ------------------------------------------ | ----------------------------------- |
+| `cli_command_executed` | post-run, success or failure (via wrapper) | `exit_code`, `duration_ms`, `flags` |
+
+## Output
+
+### `--output-format text`
+
+```
+Removed remote "staging".
+```
+
+### `--output-format json`
+
+```json
+{ "name": "staging" }
+```
+
+## Notes
+
+- Refuses to remove a `[remotes.<name>]` block that declares keys beyond
+  `project_id` — deleting it would silently drop hand-authored remote-specific
+  config. Delete those keys first.
+- Removing the last remote never leaves a stray empty `[remotes]` table
+  (TOML) or `"remotes": {}` (JSON).

--- a/apps/cli/src/legacy/commands/remotes/remove/remove.command.ts
+++ b/apps/cli/src/legacy/commands/remotes/remove/remove.command.ts
@@ -1,0 +1,26 @@
+import { Argument, Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
+import { legacyRemotesRemove } from "./remove.handler.ts";
+import { legacyRemotesRuntimeLayer } from "../remotes.layers.ts";
+
+const config = {
+  name: Argument.string("name").pipe(Argument.withDescription("Name of the remote to remove.")),
+} as const;
+
+export type LegacyRemotesRemoveFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const legacyRemotesRemoveCommand = Command.make("remove", config).pipe(
+  Command.withDescription(
+    "Remove a named remote from supabase/config.toml. Refuses when the block declares config beyond project_id.",
+  ),
+  Command.withShortDescription("Remove a remote"),
+  Command.withHandler((flags) =>
+    legacyRemotesRemove(flags).pipe(
+      withLegacyCommandInstrumentation({ flags }),
+      withJsonErrorHandling,
+    ),
+  ),
+  Command.provide(legacyRemotesRuntimeLayer(["remotes", "remove"])),
+);

--- a/apps/cli/src/legacy/commands/remotes/remove/remove.handler.ts
+++ b/apps/cli/src/legacy/commands/remotes/remove/remove.handler.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect";
+import { remotesRemove } from "../../../../shared/remotes/remotes-crud.ts";
+import { LegacyCliConfig } from "../../../config/legacy-cli-config.service.ts";
+import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
+import type { LegacyRemotesRemoveFlags } from "./remove.command.ts";
+
+export const legacyRemotesRemove = Effect.fn("legacy.remotes.remove")(function* (
+  flags: LegacyRemotesRemoveFlags,
+) {
+  const cliConfig = yield* LegacyCliConfig;
+  const telemetryState = yield* LegacyTelemetryState;
+
+  yield* remotesRemove(cliConfig.workdir, flags.name).pipe(Effect.ensuring(telemetryState.flush));
+});

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.ts
@@ -1,8 +1,12 @@
 import { Effect, FileSystem, Layer, Option, Path } from "effect";
 
 import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api-factory.service.ts";
+import { emitRemoteTarget } from "../../shared/remotes/emit-remote-target.ts";
+import { resolveRemoteRef } from "../../shared/remotes/remote-lookup.ts";
+import { resolveRequestedRemoteName } from "../../shared/remotes/resolve-remote-selection.ts";
 import { Output } from "../../shared/output/output.service.ts";
 import { Tty } from "../../shared/runtime/tty.service.ts";
+import { legacyResolveRemoteFlag } from "../../shared/legacy/global-flags.ts";
 import { legacyReadProjectRefFile } from "../shared/legacy-temp-paths.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 import {
@@ -37,6 +41,40 @@ export const legacyProjectRefLayer = Layer.effect(
     const platformApi = yield* LegacyPlatformApiFactory;
 
     const readRefFile = legacyReadProjectRefFile(fs, path, cliConfig.workdir);
+
+    /**
+     * Resolves `--remote`/`SUPABASE_REMOTE` ahead of every other resolution
+     * method's own flag-value precedence, and — when a remote was requested
+     * — substitutes its ref in place of `flagValue`, so the rest of each
+     * method's existing chain (env → ref file → prompt) runs completely
+     * unchanged. This is the ONE place `--remote` plugs into ref resolution
+     * (`shared/legacy/global-flags.ts`'s `LegacyRemoteFlag` doc comment) —
+     * every one of the leaf commands that call `LegacyProjectRefResolver`
+     * gets `--remote` support from this single file, never a per-command edit.
+     * `--remote` + an explicit `flagValue` (the command's own `--project-ref`)
+     * is a conflict; prints the `Target:` echo before returning.
+     */
+    const resolveEffectiveFlagValue = Effect.fnUntraced(function* (
+      flagValue: Option.Option<string>,
+    ) {
+      const remoteFlag = yield* legacyResolveRemoteFlag;
+      const requested = yield* resolveRequestedRemoteName({
+        remoteFlag,
+        remoteEnv: process.env["SUPABASE_REMOTE"],
+        conflictingRefFlagExplicit: Option.isSome(flagValue) && flagValue.value.length > 0,
+      });
+      if (Option.isNone(requested)) {
+        return flagValue;
+      }
+      // `resolveRemoteRef`/`emitRemoteTarget` independently require FileSystem/Path/Output
+      // re-provide the SAME instances this layer already captured above.
+      const ref = yield* resolveRemoteRef(cliConfig.workdir, requested.value).pipe(
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(Path.Path, path),
+      );
+      yield* emitRemoteTarget(requested.value, ref).pipe(Effect.provideService(Output, output));
+      return Option.some(ref);
+    });
 
     const promptForProjectRef = Effect.fnUntraced(function* (title: string) {
       const api = yield* platformApi.make.pipe(
@@ -79,8 +117,9 @@ export const legacyProjectRefLayer = Layer.effect(
     });
 
     return LegacyProjectRefResolver.of({
-      resolve: (flagValue) =>
+      resolve: (rawFlagValue) =>
         Effect.gen(function* () {
+          const flagValue = yield* resolveEffectiveFlagValue(rawFlagValue);
           if (Option.isSome(flagValue) && flagValue.value.length > 0) {
             return yield* assertValid(flagValue.value);
           }
@@ -99,8 +138,9 @@ export const legacyProjectRefLayer = Layer.effect(
             new LegacyProjectNotLinkedError({ message: PROJECT_NOT_LINKED_MESSAGE }),
           );
         }),
-      resolveForLink: (flagValue) =>
+      resolveForLink: (rawFlagValue) =>
         Effect.gen(function* () {
+          const flagValue = yield* resolveEffectiveFlagValue(rawFlagValue);
           if (Option.isSome(flagValue) && flagValue.value.length > 0) {
             return yield* assertValid(flagValue.value);
           }
@@ -118,8 +158,9 @@ export const legacyProjectRefLayer = Layer.effect(
             }),
           );
         }),
-      resolveOptional: (flagValue) =>
+      resolveOptional: (rawFlagValue) =>
         Effect.gen(function* () {
+          const flagValue = yield* resolveEffectiveFlagValue(rawFlagValue);
           if (Option.isSome(flagValue) && flagValue.value.length > 0) {
             return Option.some(flagValue.value);
           }
@@ -132,8 +173,9 @@ export const legacyProjectRefLayer = Layer.effect(
           // hard `resolve`/`loadProjectRef` paths, which surface it).
           return yield* readRefFile.pipe(Effect.orElseSucceed(() => Option.none<string>()));
         }),
-      loadProjectRef: (flagValue) =>
+      loadProjectRef: (rawFlagValue) =>
         Effect.gen(function* () {
+          const flagValue = yield* resolveEffectiveFlagValue(rawFlagValue);
           // Resolution order: flag → env → ref file → hard "not linked"
           // failure, with format validation, and NO interactive prompt.
           if (Option.isSome(flagValue) && flagValue.value.length > 0) {

--- a/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.layer.unit.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach } from "vitest";
 import { LegacyPlatformApiFactory } from "../auth/legacy-platform-api-factory.service.ts";
 import { LegacyPlatformApi } from "../auth/legacy-platform-api.service.ts";
 import { mockOutput, mockTty } from "../../../tests/helpers/mocks.ts";
+import { LegacyRemoteFlag } from "../../shared/legacy/global-flags.ts";
 import { LegacyCliConfig } from "./legacy-cli-config.service.ts";
 import { LegacyProjectRefResolver } from "./legacy-project-ref.service.ts";
 import { legacyProjectRefLayer } from "./legacy-project-ref.layer.ts";
@@ -60,12 +61,19 @@ function makeLayer(opts: {
     region: string;
   }>;
   promptSelectResponses?: ReadonlyArray<string>;
+  remoteFlag?: string;
 }) {
   const out = mockOutput({
     format: opts.format ?? "text",
     promptSelectResponses: opts.promptSelectResponses,
   });
-  const layer = legacyProjectRefLayer.pipe(
+  // `LegacyRemoteFlag` is read via `Effect.serviceOption` INSIDE the resolver's
+  // returned methods, which run in the CALLER's ambient context, not the
+  // layer-build context — `Layer.provide` below hides its dependency's output
+  // from downstream consumers, so nesting the flag inside that chain would make
+  // it invisible to `resolve(...)`. It must be a sibling via `Layer.mergeAll`,
+  // matching how production provides it at the CLI root.
+  const resolverLayer = legacyProjectRefLayer.pipe(
     Layer.provide(mockCliConfig(opts)),
     Layer.provide(mockTty({ stdinIsTty: opts.stdinIsTty ?? false, stdoutIsTty: false })),
     Layer.provide(out.layer),
@@ -76,7 +84,19 @@ function makeLayer(opts: {
     ),
     Layer.provide(BunServices.layer),
   );
+  const layer = Layer.mergeAll(
+    resolverLayer,
+    Layer.succeed(
+      LegacyRemoteFlag,
+      opts.remoteFlag === undefined ? Option.none() : Option.some(opts.remoteFlag),
+    ),
+  );
   return { layer, out };
+}
+
+function writeRemotesConfig(workdir: string, content: string) {
+  mkdirSync(join(workdir, "supabase"), { recursive: true });
+  writeFileSync(join(workdir, "supabase", "config.toml"), content);
 }
 
 let tempRoot: string;
@@ -391,6 +411,81 @@ describe("legacyProjectRefLayer", () => {
         if (Exit.isFailure(exit)) {
           expect(JSON.stringify(exit.cause)).toContain("LegacyInvalidProjectRefError");
         }
+      }).pipe(Effect.provide(layer));
+    });
+  });
+
+  describe("--remote resolution", () => {
+    it.effect("resolves --remote <name> to its project ref and echoes Target: to stderr", () => {
+      writeRemotesConfig(tempRoot, `[remotes.staging]\nproject_id = "${VALID_REF}"\n`);
+      const { layer, out } = makeLayer({ workdir: tempRoot, remoteFlag: "staging" });
+      return Effect.gen(function* () {
+        const { resolve } = yield* LegacyProjectRefResolver;
+        const ref = yield* resolve(Option.none());
+        expect(ref).toBe(VALID_REF);
+        expect(out.stderrText).toContain(`Target: remote "staging" (${VALID_REF})`);
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("--remote wins even when SUPABASE_PROJECT_ID is also set", () => {
+      writeRemotesConfig(tempRoot, `[remotes.staging]\nproject_id = "${VALID_REF}"\n`);
+      const { layer } = makeLayer({
+        workdir: tempRoot,
+        projectId: ANOTHER_REF,
+        remoteFlag: "staging",
+      });
+      return Effect.gen(function* () {
+        const { resolve } = yield* LegacyProjectRefResolver;
+        const ref = yield* resolve(Option.none());
+        expect(ref).toBe(VALID_REF);
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("fails with a conflict when --remote and an explicit ref flag are both given", () => {
+      writeRemotesConfig(tempRoot, `[remotes.staging]\nproject_id = "${VALID_REF}"\n`);
+      const { layer } = makeLayer({ workdir: tempRoot, remoteFlag: "staging" });
+      return Effect.gen(function* () {
+        const { resolve } = yield* LegacyProjectRefResolver;
+        const exit = yield* Effect.exit(resolve(Option.some(ANOTHER_REF)));
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(JSON.stringify(exit.cause)).toContain("RemoteFlagConflictError");
+        }
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("fails with UnknownRemoteError for a name absent from the registry", () => {
+      writeRemotesConfig(tempRoot, `[remotes.staging]\nproject_id = "${VALID_REF}"\n`);
+      const { layer } = makeLayer({ workdir: tempRoot, remoteFlag: "ghost" });
+      return Effect.gen(function* () {
+        const { resolve } = yield* LegacyProjectRefResolver;
+        const exit = yield* Effect.exit(resolve(Option.none()));
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(JSON.stringify(exit.cause)).toContain("UnknownRemoteError");
+        }
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("fails with NoProjectConfigError when no config exists at all", () => {
+      const { layer } = makeLayer({ workdir: tempRoot, remoteFlag: "staging" });
+      return Effect.gen(function* () {
+        const { resolve } = yield* LegacyProjectRefResolver;
+        const exit = yield* Effect.exit(resolve(Option.none()));
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(JSON.stringify(exit.cause)).toContain("NoProjectConfigError");
+        }
+      }).pipe(Effect.provide(layer));
+    });
+
+    it.effect("resolveOptional also honors --remote", () => {
+      writeRemotesConfig(tempRoot, `[remotes.staging]\nproject_id = "${VALID_REF}"\n`);
+      const { layer } = makeLayer({ workdir: tempRoot, remoteFlag: "staging" });
+      return Effect.gen(function* () {
+        const { resolveOptional } = yield* LegacyProjectRefResolver;
+        const ref = yield* resolveOptional(Option.none());
+        expect(ref).toEqual(Option.some(VALID_REF));
       }).pipe(Effect.provide(layer));
     });
   });

--- a/apps/cli/src/legacy/config/legacy-project-ref.service.ts
+++ b/apps/cli/src/legacy/config/legacy-project-ref.service.ts
@@ -1,6 +1,18 @@
 import type { Effect, Option } from "effect";
 import { Context } from "effect";
+import type { PlatformError } from "effect/PlatformError";
 
+import type {
+  DuplicateRemoteProjectIdError,
+  InvalidRemoteProjectIdError,
+  ProjectConfigParseError,
+  ProjectEnvParseError,
+} from "@supabase/config";
+import type {
+  NoProjectConfigError,
+  RemoteFlagConflictError,
+  UnknownRemoteError,
+} from "../../shared/remotes/remotes.errors.ts";
 import type { LegacyProjectRefReadError } from "../shared/legacy-temp-paths.ts";
 import type {
   LegacyInvalidProjectRefError,
@@ -8,12 +20,35 @@ import type {
   LegacyProjectRefRequiredError,
 } from "./legacy-project-ref.errors.ts";
 
+/**
+ * Every resolution method's error channel additionally carries the
+ * `--remote`/`SUPABASE_REMOTE` errors — resolved centrally, ahead of the
+ * method's own flag-value precedence, by `legacy-project-ref.layer.ts`. See
+ * that file's `resolveEffectiveFlagValue` for why this lives in exactly one
+ * place instead of on all leaf commands. The `@supabase/config` pair is
+ * `listRemotes`'s own static error surface — never actually raised on the default,
+ * non-`goViperCompat` load path this seam uses, but part of the function's
+ * declared type regardless of the runtime option value.
+ */
+type LegacyRemoteResolutionError =
+  | RemoteFlagConflictError
+  | UnknownRemoteError
+  | NoProjectConfigError
+  | DuplicateRemoteProjectIdError
+  | InvalidRemoteProjectIdError
+  | ProjectConfigParseError
+  | ProjectEnvParseError
+  | PlatformError;
+
 interface LegacyProjectRefResolverShape {
   readonly resolve: (
     flagValue: Option.Option<string>,
   ) => Effect.Effect<
     string,
-    LegacyProjectNotLinkedError | LegacyInvalidProjectRefError | LegacyProjectRefReadError,
+    | LegacyProjectNotLinkedError
+    | LegacyInvalidProjectRefError
+    | LegacyProjectRefReadError
+    | LegacyRemoteResolutionError,
     never
   >;
   /**
@@ -30,7 +65,10 @@ interface LegacyProjectRefResolverShape {
     flagValue: Option.Option<string>,
   ) => Effect.Effect<
     string,
-    LegacyProjectNotLinkedError | LegacyInvalidProjectRefError | LegacyProjectRefRequiredError,
+    | LegacyProjectNotLinkedError
+    | LegacyInvalidProjectRefError
+    | LegacyProjectRefRequiredError
+    | LegacyRemoteResolutionError,
     never
   >;
   /**
@@ -49,7 +87,7 @@ interface LegacyProjectRefResolverShape {
    */
   readonly resolveOptional: (
     flagValue: Option.Option<string>,
-  ) => Effect.Effect<Option.Option<string>, never, never>;
+  ) => Effect.Effect<Option.Option<string>, LegacyRemoteResolutionError, never>;
   /**
    * Non-prompting resolution chain (flag -> `cliConfig.projectId` -> ref file)
    * that **fails hard** with `LegacyProjectNotLinkedError` when nothing
@@ -66,7 +104,10 @@ interface LegacyProjectRefResolverShape {
     flagValue: Option.Option<string>,
   ) => Effect.Effect<
     string,
-    LegacyProjectNotLinkedError | LegacyInvalidProjectRefError | LegacyProjectRefReadError,
+    | LegacyProjectNotLinkedError
+    | LegacyInvalidProjectRefError
+    | LegacyProjectRefReadError
+    | LegacyRemoteResolutionError,
     never
   >;
   /**

--- a/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
+++ b/apps/cli/src/legacy/docs/legacy-docs-spec.tables.ts
@@ -61,6 +61,7 @@ export const LEGACY_DOCS_TAGS: Readonly<Record<string, ReadonlyArray<string>>> =
   "supabase-orgs": ["management-api"],
   "supabase-postgres-config": ["management-api"],
   "supabase-projects": ["management-api"],
+  "supabase-remotes": ["local-dev"],
   "supabase-secrets": ["management-api"],
   "supabase-seed": ["local-dev"],
   "supabase-services": ["local-dev"],

--- a/apps/cli/src/legacy/shared/legacy-db-config.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-config.service.ts
@@ -24,6 +24,18 @@ import type {
   LegacyDbConfigUnbanStatusError,
 } from "./legacy-db-config.errors.ts";
 import type { LegacyDbConfigFlags, LegacyResolvedDbConfig } from "./legacy-db-config.types.ts";
+import type {
+  DuplicateRemoteProjectIdError,
+  InvalidRemoteProjectIdError,
+  ProjectConfigParseError,
+  ProjectEnvParseError,
+} from "@supabase/config";
+import type { PlatformError } from "effect/PlatformError";
+import type {
+  NoProjectConfigError,
+  RemoteFlagConflictError,
+  UnknownRemoteError,
+} from "../../shared/remotes/remotes.errors.ts";
 
 /** Every error the resolver can raise across the direct / local / linked paths. */
 export type LegacyDbConfigError =
@@ -54,7 +66,17 @@ export type LegacyDbConfigError =
   | LegacyPlatformApiFactoryError
   // The lazy linked runtime rebuilds `legacyCliConfigLayer`, whose strict
   // profile resolution can fail inside the resolver effect the same way.
-  | LegacyProfileLoadError;
+  | LegacyProfileLoadError
+  // `--remote`/`SUPABASE_REMOTE`, resolved centrally ahead of every
+  // `LegacyProjectRefResolver` method (`legacy-project-ref.layer.ts`).
+  | RemoteFlagConflictError
+  | UnknownRemoteError
+  | NoProjectConfigError
+  | DuplicateRemoteProjectIdError
+  | InvalidRemoteProjectIdError
+  | ProjectConfigParseError
+  | ProjectEnvParseError
+  | PlatformError;
 
 // The `--linked` path builds a lazy Management API runtime (so `--local` /
 // `--db-url` never resolve an access token) and provides ALL of its own

--- a/apps/cli/src/legacy/shared/legacy-db-target-flags.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-target-flags.ts
@@ -97,6 +97,7 @@ export const VALUE_CONSUMING_LONG_FLAGS = new Set([
   "network-id",
   "dns-resolver",
   "agent",
+  "remote",
   // Every other value-consuming flag declared directly across legacy/commands/
   // (CLI-1896 review follow-up — see the doc comment above).
   "add-domains",

--- a/apps/cli/src/legacy/shared/legacy-db-target-flags.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-target-flags.unit.test.ts
@@ -8,6 +8,12 @@ import {
   VALUE_CONSUMING_SHORT_FLAGS,
 } from "./legacy-db-target-flags.ts";
 
+describe("VALUE_CONSUMING_LONG_FLAGS", () => {
+  it("includes remote", () => {
+    expect(VALUE_CONSUMING_LONG_FLAGS.has("remote")).toBe(true);
+  });
+});
+
 describe("resolveLegacyDbTargetFlags", () => {
   it("returns empty setFlags and undefined connType when no args", () => {
     const result = resolveLegacyDbTargetFlags([]);

--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect";
 import { CliOutput, Command } from "effect/unstable/cli";
-import { OutputFormatFlag } from "../../shared/cli/global-flags.ts";
+import { OutputFormatFlag, RemoteFlag } from "../../shared/cli/global-flags.ts";
 import { AiTool } from "../../shared/telemetry/ai-tool.service.ts";
 import { aiToolLayer } from "../../shared/telemetry/ai-tool.layer.ts";
 import { isBuiltInTextRequest, resolveAgentOutputFormat } from "../../shared/cli/agent-output.ts";
@@ -15,6 +15,7 @@ import { loginCommand } from "../commands/login/login.command.ts";
 import { logoutCommand } from "../commands/logout/logout.command.ts";
 import { logsCommand } from "../commands/logs/logs.command.ts";
 import { apiCommand } from "../commands/platform/api.command.ts";
+import { remotesCommand } from "../commands/remotes/remotes.command.ts";
 import { servicesCommand } from "../commands/services/services.command.ts";
 import { startCommand } from "../commands/start/start.command.ts";
 import { statusCommand } from "../commands/status/status.command.ts";
@@ -49,6 +50,7 @@ export const nextRoot = Command.make("supabase").pipe(
     statusCommand,
     logsCommand,
     apiCommand,
+    remotesCommand,
   ]),
   Command.provide(
     Layer.unwrap(
@@ -67,5 +69,5 @@ export const nextRoot = Command.make("supabase").pipe(
       }),
     ),
   ),
-  Command.withGlobalFlags([OutputFormatFlag]),
+  Command.withGlobalFlags([OutputFormatFlag, RemoteFlag]),
 );

--- a/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.integration.test.ts
@@ -16,7 +16,6 @@ import * as UrlParams from "effect/unstable/http/UrlParams";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { CliConfig } from "../../../config/cli-config.service.ts";
 import { PlatformApi } from "../../../auth/platform-api.service.ts";
-import { ProjectHome } from "../../../config/project-home.service.ts";
 import type { ProjectLinkStateValue } from "../../../config/project-link-state.service.ts";
 import {
   ConflictingFunctionDeployFlagsError,
@@ -24,6 +23,7 @@ import {
 } from "../../../../shared/functions/deploy.errors.ts";
 import {
   mockOutput,
+  mockProjectHome,
   mockProjectLinkState,
   mockRuntimeInfo,
   mockStdin,
@@ -134,26 +134,6 @@ function cliConfigLayer() {
       telemetryDebug: Option.none(),
       telemetryDisabled: Option.none(),
       doNotTrack: Option.none(),
-    }),
-  );
-}
-
-function mockProjectHome(projectRoot: string) {
-  const projectHomeDir = join(projectRoot, ".supabase");
-  return Layer.succeed(
-    ProjectHome,
-    ProjectHome.of({
-      projectRoot,
-      supabaseDir: join(projectRoot, "supabase"),
-      projectHomeDir,
-      projectLinkPath: join(projectHomeDir, "project.json"),
-      projectLocalVersionsPath: join(projectHomeDir, "local-versions.json"),
-      ensureProjectHomeDir: Effect.void,
-      stackDir: (name) => join(projectHomeDir, "stacks", name),
-      stackStatePath: (name) => join(projectHomeDir, "stacks", name, "state.json"),
-      stackMetadataPath: (name) => join(projectHomeDir, "stacks", name, "stack.json"),
-      stackDataDir: (name) => join(projectHomeDir, "stacks", name, "data"),
-      stackLogsDir: (name) => join(projectHomeDir, "stacks", name, "logs"),
     }),
   );
 }
@@ -457,6 +437,7 @@ function setup(
     readonly stdinInput?: string;
   } = {},
 ) {
+  const projectRoot = opts.projectRoot ?? cwd;
   const out = mockOutput({ format: opts.format ?? "text", interactive: false });
   const api = mockDeployApi(opts.api);
   const layer = Layer.mergeAll(
@@ -465,7 +446,7 @@ function setup(
     api.layer,
     cliConfigLayer(),
     mockRuntimeInfo({ cwd }),
-    mockProjectHome(opts.projectRoot ?? cwd),
+    mockProjectHome({ projectRoot }),
     mockProjectLinkState(opts.linked === false ? undefined : LINK_STATE),
     Stdio.layerTest({
       args: Effect.succeed(opts.rawArgs ?? ["functions", "deploy"]),

--- a/apps/cli/src/next/commands/functions/download/download.integration.test.ts
+++ b/apps/cli/src/next/commands/functions/download/download.integration.test.ts
@@ -15,12 +15,12 @@ import {
   ProjectNotLinkedError,
   type ProjectLinkStateValue,
 } from "../../../config/project-link-state.service.ts";
-import { ProjectHome } from "../../../config/project-home.service.ts";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import {
   emptyEnv,
   mockOutput,
+  mockProjectHome,
   mockProjectLinkState,
   mockRuntimeInfo,
 } from "../../../../../tests/helpers/mocks.ts";
@@ -294,6 +294,7 @@ function setup(
     childLayer?: ReturnType<typeof mockChildProcessSpawner>["layer"];
   } = {},
 ) {
+  const projectRoot = opts.projectRoot ?? cwd;
   const out = mockOutput({ format: opts.format ?? "text", interactive: false });
   const api = mockDownloadApi(opts);
   const proxy = mockLegacyGoProxy();
@@ -304,7 +305,7 @@ function setup(
     proxy.layer,
     mockRuntimeInfo({ cwd }),
     mockProjectLinkState(opts.linked === false ? undefined : LINK_STATE),
-    mockProjectHome(opts.projectRoot ?? cwd),
+    mockProjectHome({ projectRoot }),
     Stdio.layerTest({
       args: Effect.succeed(opts.rawArgs ?? ["functions", "download"]),
     }),
@@ -339,26 +340,6 @@ function mockLegacyGoProxy() {
       return captureCalls;
     },
   };
-}
-
-function mockProjectHome(projectRoot: string) {
-  const projectHomeDir = join(projectRoot, ".supabase");
-  return Layer.succeed(
-    ProjectHome,
-    ProjectHome.of({
-      projectRoot,
-      supabaseDir: join(projectRoot, "supabase"),
-      projectHomeDir,
-      projectLinkPath: join(projectHomeDir, "project.json"),
-      projectLocalVersionsPath: join(projectHomeDir, "local-versions.json"),
-      ensureProjectHomeDir: Effect.void,
-      stackDir: (name) => join(projectHomeDir, "stacks", name),
-      stackStatePath: (name) => join(projectHomeDir, "stacks", name, "state.json"),
-      stackMetadataPath: (name) => join(projectHomeDir, "stacks", name, "stack.json"),
-      stackDataDir: (name) => join(projectHomeDir, "stacks", name, "data"),
-      stackLogsDir: (name) => join(projectHomeDir, "stacks", name, "logs"),
-    }),
-  );
 }
 
 describe("functions download", () => {

--- a/apps/cli/src/next/commands/functions/functions.shared.ts
+++ b/apps/cli/src/next/commands/functions/functions.shared.ts
@@ -1,24 +1,4 @@
-import { Effect, Option } from "effect";
-import {
-  ProjectLinkState,
-  ProjectNotLinkedError,
-} from "../../config/project-link-state.service.ts";
-
-export const resolveProjectRef = Effect.fnUntraced(function* (projectRef: Option.Option<string>) {
-  if (Option.isSome(projectRef)) {
-    return projectRef.value;
-  }
-
-  const projectLinkState = yield* ProjectLinkState;
-  const maybeLinkState = yield* projectLinkState.load;
-  if (Option.isNone(maybeLinkState)) {
-    return yield* Effect.fail(
-      new ProjectNotLinkedError({
-        detail: "No project is linked in this directory.",
-        suggestion: "Run `supabase link` first or pass `--project-ref`.",
-      }),
-    );
-  }
-
-  return maybeLinkState.value.project.ref;
-});
+// Hoisted to `next/config/resolve-project-ref.ts` so `link`'s own ref
+// resolution can share the same `--remote` seam — re-exported here so
+// existing `functions deploy/delete/download` imports are unaffected.
+export { resolveProjectRef } from "../../config/resolve-project-ref.ts";

--- a/apps/cli/src/next/commands/link/link.handler.ts
+++ b/apps/cli/src/next/commands/link/link.handler.ts
@@ -3,6 +3,7 @@ import { StateManager, projectStateManagerPathsFromRoot } from "@supabase/stack/
 import { ensureProjectStateIgnored } from "../../config/project-gitignore.ts";
 import { ProjectHome } from "../../config/project-home.service.ts";
 import { refreshLinkedProjectSnapshot } from "../../config/project-link-refresh.ts";
+import { resolveEffectiveProjectRefFlag } from "../../config/resolve-project-ref.ts";
 import {
   ProjectLinkRemote,
   formatLinkedProjectLabel,
@@ -43,8 +44,9 @@ const promptForAccessibleProject = Effect.fnUntraced(function* () {
   );
 });
 
-const chooseProjectRef = Effect.fnUntraced(function* (flagProjectRef: Option.Option<string>) {
+const chooseProjectRef = Effect.fnUntraced(function* (rawFlagProjectRef: Option.Option<string>) {
   const output = yield* Output;
+  const flagProjectRef = yield* resolveEffectiveProjectRefFlag(rawFlagProjectRef);
 
   if (Option.isSome(flagProjectRef)) {
     return flagProjectRef.value.trim();

--- a/apps/cli/src/next/commands/remotes/add/add.command.ts
+++ b/apps/cli/src/next/commands/remotes/add/add.command.ts
@@ -1,0 +1,28 @@
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { projectCommandBaseLayer } from "../../../config/project-runtime.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { add } from "./add.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(Argument.withDescription("Name for the remote.")),
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref the remote targets."),
+  ),
+} as const;
+
+export type RemotesAddFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const remotesAddCommand = Command.make("add", config).pipe(
+  Command.withDescription(
+    "Register a named remote Supabase project in supabase/config.toml. Idempotent when the name already targets the same ref.",
+  ),
+  Command.withShortDescription("Register a remote"),
+  Command.withHandler((flags) =>
+    add(flags).pipe(withCommandInstrumentation({ flags }), withJsonErrorHandling),
+  ),
+  Command.provide(commandRuntimeLayer(["remotes", "add"])),
+  Command.provide(projectCommandBaseLayer),
+);

--- a/apps/cli/src/next/commands/remotes/add/add.handler.ts
+++ b/apps/cli/src/next/commands/remotes/add/add.handler.ts
@@ -1,0 +1,9 @@
+import { Effect } from "effect";
+import { remotesAdd } from "../../../../shared/remotes/remotes-crud.ts";
+import { ProjectHome } from "../../../config/project-home.service.ts";
+import type { RemotesAddFlags } from "./add.command.ts";
+
+export const add = Effect.fn("remotes.add")(function* (flags: RemotesAddFlags) {
+  const projectHome = yield* ProjectHome;
+  yield* remotesAdd(projectHome.projectRoot, flags.name, flags.projectRef);
+});

--- a/apps/cli/src/next/commands/remotes/list/list.command.ts
+++ b/apps/cli/src/next/commands/remotes/list/list.command.ts
@@ -1,0 +1,14 @@
+import { Command } from "effect/unstable/cli";
+import { projectCommandBaseLayer } from "../../../config/project-runtime.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { list } from "./list.handler.ts";
+
+export const remotesListCommand = Command.make("list").pipe(
+  Command.withDescription("List named remote Supabase projects from supabase/config.toml."),
+  Command.withShortDescription("List configured remotes"),
+  Command.withHandler(() => list().pipe(withCommandInstrumentation(), withJsonErrorHandling)),
+  Command.provide(commandRuntimeLayer(["remotes", "list"])),
+  Command.provide(projectCommandBaseLayer),
+);

--- a/apps/cli/src/next/commands/remotes/list/list.handler.ts
+++ b/apps/cli/src/next/commands/remotes/list/list.handler.ts
@@ -1,0 +1,8 @@
+import { Effect } from "effect";
+import { remotesList } from "../../../../shared/remotes/remotes-crud.ts";
+import { ProjectHome } from "../../../config/project-home.service.ts";
+
+export const list = Effect.fn("remotes.list")(function* () {
+  const projectHome = yield* ProjectHome;
+  yield* remotesList(projectHome.projectRoot);
+});

--- a/apps/cli/src/next/commands/remotes/remotes.command.ts
+++ b/apps/cli/src/next/commands/remotes/remotes.command.ts
@@ -1,0 +1,12 @@
+import { Command } from "effect/unstable/cli";
+import { remotesAddCommand } from "./add/add.command.ts";
+import { remotesListCommand } from "./list/list.command.ts";
+import { remotesRemoveCommand } from "./remove/remove.command.ts";
+
+export const remotesCommand = Command.make("remotes").pipe(
+  Command.withDescription(
+    "Manage named remote Supabase projects in supabase/config.toml, selectable per-invocation via --remote.",
+  ),
+  Command.withShortDescription("Manage named remote projects"),
+  Command.withSubcommands([remotesListCommand, remotesAddCommand, remotesRemoveCommand]),
+);

--- a/apps/cli/src/next/commands/remotes/remotes.integration.test.ts
+++ b/apps/cli/src/next/commands/remotes/remotes.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "@effect/vitest";
+import { BunServices } from "@effect/platform-bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach } from "vitest";
+import { Effect, Exit, Layer } from "effect";
+import { mockOutput, mockProjectHome } from "../../../../tests/helpers/mocks.ts";
+import { add } from "./add/add.handler.ts";
+import { list } from "./list/list.handler.ts";
+import { remove } from "./remove/remove.handler.ts";
+
+const REF_A = "abcdefghijklmnopqrst";
+const REF_B = "zzzzzzzzzzzzzzzzzzzz";
+
+function writeConfig(dir: string, content: string) {
+  return Effect.promise(async () => {
+    await mkdir(join(dir, "supabase"), { recursive: true });
+    await writeFile(join(dir, "supabase", "config.toml"), content);
+  });
+}
+
+function setup(workdir: string, format: "text" | "json" = "text") {
+  const out = mockOutput({ format });
+  const layer = Layer.mergeAll(
+    out.layer,
+    mockProjectHome({ projectRoot: workdir }),
+    BunServices.layer,
+  );
+  return { layer, out };
+}
+
+describe("supabase remotes (next)", () => {
+  let workdir: string;
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), "supabase-next-test-"));
+  });
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it.live("add then list then remove a remote end to end", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir, 'project_id = "local"\n');
+      const { layer, out } = setup(workdir);
+
+      yield* add({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain(`Added remote "staging" -> ${REF_A}.`);
+
+      yield* list().pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain("staging");
+      expect(out.stdoutText).toContain(REF_A);
+
+      yield* remove({ name: "staging" }).pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain('Removed remote "staging".');
+    }),
+  );
+
+  it.live("re-adding the same name with the same ref is a no-op", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir, "");
+      const { layer, out } = setup(workdir);
+
+      yield* add({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      yield* add({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      expect(out.stdoutText).toContain("nothing to do");
+    }),
+  );
+
+  it.live("re-adding the same name with a different ref fails", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir, "");
+      const { layer } = setup(workdir);
+
+      yield* add({ name: "staging", projectRef: REF_A }).pipe(Effect.provide(layer));
+      const exit = yield* add({ name: "staging", projectRef: REF_B }).pipe(
+        Effect.provide(layer),
+        Effect.exit,
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("removing an unknown remote fails", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir, "");
+      const { layer } = setup(workdir);
+
+      const exit = yield* remove({ name: "ghost" }).pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("remotes * fails when no project config exists", () =>
+    Effect.gen(function* () {
+      const { layer } = setup(workdir);
+      const exit = yield* list().pipe(Effect.provide(layer), Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("json mode emits a structured payload instead of a table", () =>
+    Effect.gen(function* () {
+      yield* writeConfig(workdir, `[remotes.staging]\nproject_id = "${REF_A}"\n`);
+      const { layer, out } = setup(workdir, "json");
+
+      yield* list().pipe(Effect.provide(layer));
+      const success = out.messages.find((m) => m.type === "success");
+      expect(success?.data).toEqual({ remotes: [{ name: "staging", project_ref: REF_A }] });
+    }),
+  );
+});

--- a/apps/cli/src/next/commands/remotes/remove/remove.command.ts
+++ b/apps/cli/src/next/commands/remotes/remove/remove.command.ts
@@ -1,0 +1,25 @@
+import { Argument, Command } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { projectCommandBaseLayer } from "../../../config/project-runtime.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { remove } from "./remove.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(Argument.withDescription("Name of the remote to remove.")),
+} as const;
+
+export type RemotesRemoveFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const remotesRemoveCommand = Command.make("remove", config).pipe(
+  Command.withDescription(
+    "Remove a named remote from supabase/config.toml. Refuses when the block declares config beyond project_id.",
+  ),
+  Command.withShortDescription("Remove a remote"),
+  Command.withHandler((flags) =>
+    remove(flags).pipe(withCommandInstrumentation({ flags }), withJsonErrorHandling),
+  ),
+  Command.provide(commandRuntimeLayer(["remotes", "remove"])),
+  Command.provide(projectCommandBaseLayer),
+);

--- a/apps/cli/src/next/commands/remotes/remove/remove.handler.ts
+++ b/apps/cli/src/next/commands/remotes/remove/remove.handler.ts
@@ -1,0 +1,9 @@
+import { Effect } from "effect";
+import { remotesRemove } from "../../../../shared/remotes/remotes-crud.ts";
+import { ProjectHome } from "../../../config/project-home.service.ts";
+import type { RemotesRemoveFlags } from "./remove.command.ts";
+
+export const remove = Effect.fn("remotes.remove")(function* (flags: RemotesRemoveFlags) {
+  const projectHome = yield* ProjectHome;
+  yield* remotesRemove(projectHome.projectRoot, flags.name);
+});

--- a/apps/cli/src/next/config/resolve-project-ref.ts
+++ b/apps/cli/src/next/config/resolve-project-ref.ts
@@ -1,0 +1,51 @@
+import { Effect, Option } from "effect";
+import { resolveRemoteFlag } from "../../shared/cli/global-flags.ts";
+import { emitRemoteTarget } from "../../shared/remotes/emit-remote-target.ts";
+import { resolveRemoteRef } from "../../shared/remotes/remote-lookup.ts";
+import { resolveRequestedRemoteName } from "../../shared/remotes/resolve-remote-selection.ts";
+import { ProjectHome } from "./project-home.service.ts";
+import { ProjectLinkState, ProjectNotLinkedError } from "./project-link-state.service.ts";
+
+/**
+ * Resolves `--remote`/`SUPABASE_REMOTE` ahead of an explicit `--project-ref`,
+ * substituting the named remote's ref in its place — the single seam both
+ * `resolveProjectRef` and `link`'s own `chooseProjectRef` go through,
+ * mirroring the legacy shell's identical central injection in `legacy-project-ref.layer.ts`.
+ */
+export const resolveEffectiveProjectRefFlag = Effect.fnUntraced(function* (
+  projectRef: Option.Option<string>,
+) {
+  const remoteFlag = yield* resolveRemoteFlag;
+  const requested = yield* resolveRequestedRemoteName({
+    remoteFlag,
+    remoteEnv: process.env["SUPABASE_REMOTE"],
+    conflictingRefFlagExplicit: Option.isSome(projectRef) && projectRef.value.trim().length > 0,
+  });
+  if (Option.isNone(requested)) {
+    return projectRef;
+  }
+  const projectHome = yield* ProjectHome;
+  const ref = yield* resolveRemoteRef(projectHome.projectRoot, requested.value);
+  yield* emitRemoteTarget(requested.value, ref);
+  return Option.some(ref);
+});
+
+export const resolveProjectRef = Effect.fnUntraced(function* (projectRef: Option.Option<string>) {
+  const effective = yield* resolveEffectiveProjectRefFlag(projectRef);
+  if (Option.isSome(effective)) {
+    return effective.value;
+  }
+
+  const projectLinkState = yield* ProjectLinkState;
+  const maybeLinkState = yield* projectLinkState.load;
+  if (Option.isNone(maybeLinkState)) {
+    return yield* Effect.fail(
+      new ProjectNotLinkedError({
+        detail: "No project is linked in this directory.",
+        suggestion: "Run `supabase link` first or pass `--project-ref`.",
+      }),
+    );
+  }
+
+  return maybeLinkState.value.project.ref;
+});

--- a/apps/cli/src/shared/cli/cobra-flag-groups.ts
+++ b/apps/cli/src/shared/cli/cobra-flag-groups.ts
@@ -118,6 +118,7 @@ export const PERSISTENT_VALUE_FLAG_NAMES: ReadonlySet<string> = new Set([
   "dns-resolver",
   "agent",
   "output-format",
+  "remote",
 ]);
 
 /**

--- a/apps/cli/src/shared/cli/cobra-flag-groups.unit.test.ts
+++ b/apps/cli/src/shared/cli/cobra-flag-groups.unit.test.ts
@@ -11,6 +11,14 @@ import {
 
 const COMMAND_PATH = ["functions", "deploy"] as const;
 
+describe("PERSISTENT_VALUE_FLAG_NAMES", () => {
+  // `--remote` is a value-taking global flag and must be scanned like `--workdir`/`--project-ref`,
+  // or a bare `--remote staging` would have its value mistaken for a positional operand.
+  test("includes remote", () => {
+    expect(PERSISTENT_VALUE_FLAG_NAMES.has("remote")).toBe(true);
+  });
+});
+
 describe("hasExplicitLongFlag", () => {
   test("finds a bare flag after the command path", () => {
     expect(hasExplicitLongFlag(["functions", "deploy", "--use-api"], COMMAND_PATH, "use-api")).toBe(

--- a/apps/cli/src/shared/cli/global-flags.ts
+++ b/apps/cli/src/shared/cli/global-flags.ts
@@ -1,3 +1,4 @@
+import { Effect, Option } from "effect";
 import { Flag, GlobalFlag } from "effect/unstable/cli";
 
 /**
@@ -18,3 +19,23 @@ export const OutputFormatFlag = GlobalFlag.setting("output-format")({
     Flag.optional,
   ),
 });
+
+/**
+ * `next`-shell counterpart of `LegacyRemoteFlag` same CLI flag name and semantics,
+ * but a distinct `GlobalFlag.setting` instance because `legacy/` and `next/`
+ * command trees are fully isolated and each registers its own global-flag set via
+ * `Command.withGlobalFlags`. Wired into `next/config/resolve-project-ref.ts`.
+ */
+export const RemoteFlag = GlobalFlag.setting("remote")({
+  flag: Flag.string("remote").pipe(
+    Flag.withDescription("target the named [remotes.<name>] entry from supabase/config.toml"),
+    Flag.optional,
+  ),
+});
+
+/**
+ * `RemoteFlag`, read via `Effect.serviceOption` so a caller that hasn't
+ * wired the global-flag context gets `None` instead of a missing-service defect.
+ * Production always provides it through `Command.withGlobalFlags` at the CLI root.
+ */
+export const resolveRemoteFlag = Effect.map(Effect.serviceOption(RemoteFlag), Option.flatten);

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -55,6 +55,7 @@ const globalFlagsWithValues = new Set([
   "--network-id",
   "--dns-resolver",
   "--agent",
+  "--remote",
 ]);
 
 // Commands that run their own foreground signal loop (serve/start daemons) and must

--- a/apps/cli/src/shared/cli/run.unit.test.ts
+++ b/apps/cli/src/shared/cli/run.unit.test.ts
@@ -39,6 +39,11 @@ describe("extractCommandPath", () => {
     ).toEqual(["functions", "serve"]);
   });
 
+  // Without this, `--remote staging db push` would wrongly resolve "staging" as command path.
+  it("skips --remote and its value", () => {
+    expect(extractCommandPath(["--remote", "staging", "db", "push"])).toEqual(["db", "push"]);
+  });
+
   it("treats --flag=value as a single token", () => {
     expect(extractCommandPath(["--output-format=json", "functions", "serve"])).toEqual([
       "functions",

--- a/apps/cli/src/shared/legacy/global-flags.ts
+++ b/apps/cli/src/shared/legacy/global-flags.ts
@@ -96,6 +96,30 @@ export const LegacyAgentFlag = GlobalFlag.setting("agent")({
 });
 
 /**
+ * Names a `[remotes.<name>]` entry in `supabase/config.{toml,json}` whose
+ * `project_id` becomes the effective ref for every command that resolves one
+ * — wired centrally into `LegacyProjectRefResolver`, NOT declared per-command, so
+ * it reaches all leaf commands from this single registration.
+ */
+export const LegacyRemoteFlag = GlobalFlag.setting("remote")({
+  flag: Flag.string("remote").pipe(
+    Flag.withDescription("target the named [remotes.<name>] entry from supabase/config.toml"),
+    Flag.optional,
+  ),
+});
+
+/**
+ * `LegacyRemoteFlag`, read via `Effect.serviceOption` so a caller that hasn't
+ * wired the global-flag context gets `None` instead of a missing-service defect,
+ * same pattern as `legacyGlobalFlagValues` above. Production always provides it
+ * through `Command.withGlobalFlags` at the CLI root (`legacy/cli/root.ts`).
+ */
+export const legacyResolveRemoteFlag = Effect.map(
+  Effect.serviceOption(LegacyRemoteFlag),
+  Option.flatten,
+);
+
+/**
  * Every global/persistent flag declared above, mirroring the set Go registers on
  * the root command (`apps/cli-go/cmd/root.go:344-354`).
  *
@@ -124,6 +148,7 @@ export const LEGACY_GLOBAL_FLAGS = [
   LegacyDnsResolverFlag,
   LegacyCreateTicketFlag,
   LegacyAgentFlag,
+  LegacyRemoteFlag,
 ] as const;
 
 /**
@@ -165,6 +190,7 @@ export const legacyGlobalFlagValues = Effect.gen(function* () {
   setIfPresent(LegacyProfileFlag.id, yield* Effect.serviceOption(LegacyProfileFlag));
   setIfPresent(LegacyWorkdirFlag.id, yield* Effect.serviceOption(LegacyWorkdirFlag));
   setIfPresent(LegacyYesFlag.id, yield* Effect.serviceOption(LegacyYesFlag));
+  setIfPresent(LegacyRemoteFlag.id, yield* Effect.serviceOption(LegacyRemoteFlag));
   return values;
 });
 

--- a/apps/cli/src/shared/legacy/global-flags.unit.test.ts
+++ b/apps/cli/src/shared/legacy/global-flags.unit.test.ts
@@ -11,6 +11,7 @@ import {
   LegacyNetworkIdFlag,
   LegacyOutputFlag,
   LegacyProfileFlag,
+  LegacyRemoteFlag,
   LegacyWorkdirFlag,
   LegacyYesFlag,
   legacyGlobalFlagValues,
@@ -30,6 +31,7 @@ describe("legacyGlobalFlagValues", () => {
         Layer.succeed(LegacyNetworkIdFlag, Option.some("my-network")),
         Layer.succeed(LegacyOutputFlag, Option.some("json" as const)),
         Layer.succeed(LegacyProfileFlag, "custom-profile"),
+        Layer.succeed(LegacyRemoteFlag, Option.some("staging")),
         Layer.succeed(LegacyWorkdirFlag, Option.some("/tmp/project")),
         Layer.succeed(LegacyYesFlag, true),
       );
@@ -53,6 +55,7 @@ describe("legacyGlobalFlagValues", () => {
               "network-id": Option.some("my-network"),
               output: Option.some("json"),
               profile: "custom-profile",
+              remote: Option.some("staging"),
               workdir: Option.some("/tmp/project"),
               yes: true,
             });

--- a/apps/cli/src/shared/remotes/emit-remote-target.ts
+++ b/apps/cli/src/shared/remotes/emit-remote-target.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect";
+import { Output } from "../output/output.service.ts";
+
+/**
+ * `Target: remote "<name>" (<ref>)` — via `Output.raw(..., "stderr")` so it
+ * survives text, json, AND stream-json. Called at both ref seams right
+ * before the resolved ref is handed back, so it always prints before the
+ * first mutation/network write a caller makes with it.
+ */
+export const emitRemoteTarget = Effect.fnUntraced(function* (name: string, ref: string) {
+  const output = yield* Output;
+  yield* output.raw(`Target: remote "${name}" (${ref})\n`, "stderr");
+});

--- a/apps/cli/src/shared/remotes/remote-lookup.ts
+++ b/apps/cli/src/shared/remotes/remote-lookup.ts
@@ -1,0 +1,30 @@
+import { findProjectPaths, listRemotes } from "@supabase/config";
+import { Effect } from "effect";
+import { NoProjectConfigError, UnknownRemoteError } from "./remotes.errors.ts";
+
+/**
+ * Resolves a `--remote`/`SUPABASE_REMOTE` NAME to its `project_id`, the one
+ * `RemoteRegistry` read path both shells share. Pure config read, no network.
+ */
+export const resolveRemoteRef = Effect.fnUntraced(function* (cwd: string, name: string) {
+  const remotes = yield* listRemotes(cwd);
+  if (remotes === null) {
+    return yield* Effect.fail(
+      new NoProjectConfigError({
+        message: "No supabase/config.toml or supabase/config.json found.",
+      }),
+    );
+  }
+  const match = remotes.find((remote) => remote.name === name);
+  if (match === undefined) {
+    const project = yield* findProjectPaths(cwd);
+    return yield* Effect.fail(
+      new UnknownRemoteError({
+        name,
+        registryPath: project?.configPath ?? "supabase/config.toml",
+        empty: remotes.length === 0,
+      }),
+    );
+  }
+  return match.projectRef;
+});

--- a/apps/cli/src/shared/remotes/remotes-crud.ts
+++ b/apps/cli/src/shared/remotes/remotes-crud.ts
@@ -1,0 +1,90 @@
+import { addRemote, listRemotes, removeRemote } from "@supabase/config";
+import { Effect } from "effect";
+import { columnWidths, formatTableRow } from "../output/table.ts";
+import { Output } from "../output/output.service.ts";
+import { NoProjectConfigError } from "./remotes.errors.ts";
+
+const LIST_HEADERS = ["NAME", "PROJECT REF"] as const;
+
+/** `remotes list` body — shared by `legacy/` and `next/`. */
+export const remotesList = Effect.fnUntraced(function* (cwd: string) {
+  const output = yield* Output;
+
+  const remotes = yield* listRemotes(cwd);
+  if (remotes === null) {
+    return yield* Effect.fail(
+      new NoProjectConfigError({
+        message: "No supabase/config.toml or supabase/config.json found.",
+      }),
+    );
+  }
+
+  if (output.format !== "text") {
+    yield* output.success("Remotes listed.", {
+      remotes: remotes.map((remote) => ({ name: remote.name, project_ref: remote.projectRef })),
+    });
+    return;
+  }
+
+  if (remotes.length === 0) {
+    yield* output.raw("No remotes configured.\n");
+    return;
+  }
+
+  const rows = remotes.map((remote) => [remote.name, remote.projectRef]);
+  const widths = columnWidths(LIST_HEADERS, rows);
+  const lines = [
+    formatTableRow(LIST_HEADERS, widths),
+    ...rows.map((row) => formatTableRow(row, widths)),
+  ];
+  yield* output.raw(`${lines.join("\n")}\n`);
+});
+
+/** `remotes add <name> --project-ref <ref>` body — shared by `legacy/` and `next/`. */
+export const remotesAdd = Effect.fnUntraced(function* (
+  cwd: string,
+  name: string,
+  projectRef: string,
+) {
+  const output = yield* Output;
+
+  const result = yield* addRemote({ cwd, name, projectRef });
+  if (result === null) {
+    return yield* Effect.fail(
+      new NoProjectConfigError({
+        message: "No supabase/config.toml or supabase/config.json found.",
+      }),
+    );
+  }
+
+  const message = result.wrote
+    ? `Added remote "${name}" -> ${projectRef}.`
+    : `Remote "${name}" already targets ${projectRef} — nothing to do.`;
+
+  if (output.format !== "text") {
+    yield* output.success(message, { name, project_ref: projectRef, wrote: result.wrote });
+    return;
+  }
+  yield* output.raw(`${message}\n`);
+});
+
+/** `remotes remove <name>` body — shared by `legacy/` and `next/`. */
+export const remotesRemove = Effect.fnUntraced(function* (cwd: string, name: string) {
+  const output = yield* Output;
+
+  const result = yield* removeRemote({ cwd, name });
+  if (result === null) {
+    return yield* Effect.fail(
+      new NoProjectConfigError({
+        message: "No supabase/config.toml or supabase/config.json found.",
+      }),
+    );
+  }
+
+  const message = `Removed remote "${name}".`;
+  if (output.format !== "text") {
+    yield* output.success(message, { name });
+    return;
+  }
+  yield* output.raw(`${message}\n`);
+});

--- a/apps/cli/src/shared/remotes/remotes.errors.ts
+++ b/apps/cli/src/shared/remotes/remotes.errors.ts
@@ -1,0 +1,49 @@
+import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+
+/**
+ * `--remote <name>` (or `SUPABASE_REMOTE=<name>`) named an entry absent from
+ * the project's `[remotes.*]` registry. `registryPath` names the config file
+ * that was searched; `empty` distinguishes "the registry has no entries at
+ * all" from "the registry has entries, just not this one".
+ */
+export class UnknownRemoteError extends Data.TaggedError("UnknownRemoteError")<{
+  readonly name: string;
+  readonly registryPath: string;
+  readonly empty: boolean;
+}> {
+  override get message(): string {
+    return this.empty
+      ? `No remotes are configured in ${this.registryPath}. Add one with \`supabase remotes add ${this.name} --project-ref <ref>\`.`
+      : `Unknown remote "${this.name}" in ${this.registryPath}. Add it with \`supabase remotes add ${this.name} --project-ref <ref>\`.`;
+  }
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+/**
+ * `--remote`/`SUPABASE_REMOTE` and `--project-ref`were both explicitly given
+ * there is no defined precedence between two explicit ref sources,
+ * so this is a hard error rather than one silently winning.
+ */
+export class RemoteFlagConflictError extends Data.TaggedError("RemoteFlagConflictError")<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+/** `supabase/config.{toml,json}` doesn't exist — `remotes *` never creates one. */
+export class NoProjectConfigError extends Data.TaggedError("NoProjectConfigError")<{
+  readonly message: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}

--- a/apps/cli/src/shared/remotes/resolve-remote-selection.ts
+++ b/apps/cli/src/shared/remotes/resolve-remote-selection.ts
@@ -1,0 +1,43 @@
+import { Effect, Option } from "effect";
+import { RemoteFlagConflictError } from "./remotes.errors.ts";
+
+export interface RemoteSelectionInputs {
+  /** The parsed `--remote` global flag value. */
+  readonly remoteFlag: Option.Option<string>;
+  /** Raw `SUPABASE_REMOTE` env value, or `undefined` if unset. */
+  readonly remoteEnv: string | undefined;
+  /** Whether a competing ref-selecting flag (`--project-ref`, …) was explicitly given, non-empty. */
+  readonly conflictingRefFlagExplicit: boolean;
+}
+
+/**
+ * Resolves precedence between `--remote`, `SUPABASE_REMOTE`, and a competing
+ * explicit ref flag, WITHOUT doing the actual name→ref registry lookup.
+ * Precedence: `--remote` > `SUPABASE_REMOTE`. A blank/whitespace-only `SUPABASE_REMOTE`
+ * is treated as unset. Returns `None` when neither source names a remote.
+ */
+export function resolveRequestedRemoteName(
+  inputs: RemoteSelectionInputs,
+): Effect.Effect<Option.Option<string>, RemoteFlagConflictError> {
+  const fromFlag =
+    Option.isSome(inputs.remoteFlag) && inputs.remoteFlag.value.length > 0
+      ? inputs.remoteFlag.value
+      : undefined;
+  const envTrimmed = inputs.remoteEnv?.trim();
+  const fromEnv = envTrimmed !== undefined && envTrimmed.length > 0 ? envTrimmed : undefined;
+  const requested = fromFlag ?? fromEnv;
+
+  if (requested === undefined) {
+    return Effect.succeed(Option.none());
+  }
+
+  if (inputs.conflictingRefFlagExplicit) {
+    return Effect.fail(
+      new RemoteFlagConflictError({
+        message: "--remote cannot be combined with an explicit --project-ref",
+      }),
+    );
+  }
+
+  return Effect.succeed(Option.some(requested));
+}

--- a/apps/cli/src/shared/remotes/resolve-remote-selection.unit.test.ts
+++ b/apps/cli/src/shared/remotes/resolve-remote-selection.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Option } from "effect";
+import { resolveRequestedRemoteName } from "./resolve-remote-selection.ts";
+
+describe("resolveRequestedRemoteName", () => {
+  it.live("returns None when neither --remote nor SUPABASE_REMOTE is set", () => {
+    return resolveRequestedRemoteName({
+      remoteFlag: Option.none(),
+      remoteEnv: undefined,
+      conflictingRefFlagExplicit: false,
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(Option.isNone(result)).toBe(true);
+        }),
+      ),
+    );
+  });
+
+  it.live("--remote wins over SUPABASE_REMOTE", () => {
+    return resolveRequestedRemoteName({
+      remoteFlag: Option.some("staging"),
+      remoteEnv: "prod",
+      conflictingRefFlagExplicit: false,
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result).toEqual(Option.some("staging"));
+        }),
+      ),
+    );
+  });
+
+  it.live("falls back to SUPABASE_REMOTE when --remote is absent", () => {
+    return resolveRequestedRemoteName({
+      remoteFlag: Option.none(),
+      remoteEnv: "prod",
+      conflictingRefFlagExplicit: false,
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result).toEqual(Option.some("prod"));
+        }),
+      ),
+    );
+  });
+
+  it.live("blank/whitespace-only SUPABASE_REMOTE is treated as unset", () => {
+    return resolveRequestedRemoteName({
+      remoteFlag: Option.none(),
+      remoteEnv: "   ",
+      conflictingRefFlagExplicit: false,
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(Option.isNone(result)).toBe(true);
+        }),
+      ),
+    );
+  });
+
+  it.live("fails with RemoteFlagConflictError when combined with an explicit ref flag", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        resolveRequestedRemoteName({
+          remoteFlag: Option.some("staging"),
+          remoteEnv: undefined,
+          conflictingRefFlagExplicit: true,
+        }),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    }),
+  );
+
+  it.live("does not conflict when no remote was actually requested", () => {
+    return resolveRequestedRemoteName({
+      remoteFlag: Option.none(),
+      remoteEnv: undefined,
+      conflictingRefFlagExplicit: true,
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(Option.isNone(result)).toBe(true);
+        }),
+      ),
+    );
+  });
+});

--- a/apps/cli/src/shared/telemetry/error-actionability.ts
+++ b/apps/cli/src/shared/telemetry/error-actionability.ts
@@ -1004,6 +1004,11 @@ const externalActionabilityByTag: Record<string, ErrorActionabilityAdapter> = {
   MissingProjectConfigValueError: () => actionability.invalidConfig,
   DuplicateRemoteProjectIdError: () => actionability.invalidConfig,
   InvalidRemoteProjectIdError: () => actionability.invalidConfig,
+  RemoteNameInvalidError: () => actionability.invalidInput,
+  RemoteRefInvalidError: () => actionability.invalidInput,
+  RemoteNameConflictError: () => actionability.invalidConfig,
+  RemoteNotFoundError: () => actionability.provideFlags,
+  RemoteBlockNotRemovableError: () => actionability.invalidConfig,
 
   // @supabase/api — client construction failed before any request (missing
   // access token / bad configuration); remediation is the token env var.

--- a/apps/cli/tests/helpers/mocks.ts
+++ b/apps/cli/tests/helpers/mocks.ts
@@ -874,7 +874,7 @@ export function mockProjectContext(
   );
 }
 
-function mockProjectHome(
+export function mockProjectHome(
   opts: {
     projectRoot?: string;
     supabaseDir?: string;

--- a/packages/config/src/errors.ts
+++ b/packages/config/src/errors.ts
@@ -82,3 +82,38 @@ export class DuplicateRemoteProjectIdError extends Data.TaggedError(
 export class InvalidRemoteProjectIdError extends Data.TaggedError("InvalidRemoteProjectIdError")<{
   readonly message: string;
 }> {}
+
+/** `remotes add`/`remotes remove` given a name outside the TOML-bare-key grammar. */
+export class RemoteNameInvalidError extends Data.TaggedError("RemoteNameInvalidError")<{
+  readonly name: string;
+  readonly message: string;
+}> {}
+
+/** `remotes add` given a `--project-ref` that isn't a valid 20-lowercase-letter ref. */
+export class RemoteRefInvalidError extends Data.TaggedError("RemoteRefInvalidError")<{
+  readonly ref: string;
+  readonly message: string;
+}> {}
+
+/** `remotes add <name>` where `<name>` already exists with a different `project_id`. */
+export class RemoteNameConflictError extends Data.TaggedError("RemoteNameConflictError")<{
+  readonly name: string;
+  readonly message: string;
+}> {}
+
+/** `remotes remove <name>` where `<name>` has no `[remotes.<name>]` block. */
+export class RemoteNotFoundError extends Data.TaggedError("RemoteNotFoundError")<{
+  readonly name: string;
+  readonly message: string;
+}> {}
+
+/**
+ * `remotes remove <name>` where the block declares keys beyond `project_id`,
+ * removing it would silently drop remote-specific config the user authored by
+ * hand, so the CLI refuses rather than deleting it.
+ */
+export class RemoteBlockNotRemovableError extends Data.TaggedError("RemoteBlockNotRemovableError")<{
+  readonly name: string;
+  readonly extraKeys: ReadonlyArray<string>;
+  readonly message: string;
+}> {}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,7 +10,25 @@ export {
   MissingProjectConfigValueError,
   ProjectConfigParseError,
   ProjectEnvParseError,
+  RemoteBlockNotRemovableError,
+  RemoteNameConflictError,
+  RemoteNameInvalidError,
+  RemoteNotFoundError,
+  RemoteRefInvalidError,
 } from "./errors.ts";
+export {
+  type RemoteAddResult,
+  type RemoteEntry,
+  type RemoteRemoveResult,
+  REMOTE_NAME_PATTERN,
+  REMOTE_PROJECT_REF_PATTERN,
+  addRemote,
+  listRemotes,
+  listRemotesFromDocument,
+  removeRemote,
+  validateRemoteName,
+  validateRemoteRef,
+} from "./remotes.ts";
 export {
   type ConfigFormat,
   type LoadedProjectConfig,

--- a/packages/config/src/io.ts
+++ b/packages/config/src/io.ts
@@ -869,7 +869,14 @@ const resolveSaveFormat = Effect.fnUntraced(function* (
   return "json" as const;
 });
 
-function writeFileAtomic(
+/**
+ * Writes `content` to `filePath` via a same-directory tmp file + rename, so a
+ * crash mid-write never leaves `filePath` partially written. Exported for
+ * `remotes.ts`, which needs the identical atomicity guarantee for its
+ * append-only TOML / structural JSON registry edits without going through
+ * `saveProjectConfig`'s full schema re-serialize.
+ */
+export function writeFileAtomic(
   filePath: string,
   content: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> {

--- a/packages/config/src/remotes.ts
+++ b/packages/config/src/remotes.ts
@@ -1,0 +1,266 @@
+import { Effect, FileSystem } from "effect";
+import * as SmolToml from "smol-toml";
+import { loadProjectConfig, writeFileAtomic } from "./io.ts";
+import {
+  RemoteBlockNotRemovableError,
+  RemoteNameConflictError,
+  RemoteNameInvalidError,
+  RemoteNotFoundError,
+  RemoteRefInvalidError,
+} from "./errors.ts";
+import { findProjectPaths } from "./paths.ts";
+
+/** TOML bare-key subset — no quoting, no dotted-key ambiguity. */
+export const REMOTE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+/** Same 20-lowercase-letter shape Go's `Config.Validate` checks (`REMOTE_PROJECT_ID_PATTERN`, `io.ts`). */
+export const REMOTE_PROJECT_REF_PATTERN = /^[a-z]{20}$/;
+
+export interface RemoteEntry {
+  readonly name: string;
+  readonly projectRef: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function validateRemoteName(name: string): Effect.Effect<void, RemoteNameInvalidError> {
+  if (REMOTE_NAME_PATTERN.test(name)) return Effect.void;
+  return Effect.fail(
+    new RemoteNameInvalidError({
+      name,
+      message: `Invalid remote name "${name}". Must match ${REMOTE_NAME_PATTERN.source}.`,
+    }),
+  );
+}
+
+export function validateRemoteRef(ref: string): Effect.Effect<void, RemoteRefInvalidError> {
+  if (REMOTE_PROJECT_REF_PATTERN.test(ref)) return Effect.void;
+  return Effect.fail(
+    new RemoteRefInvalidError({
+      ref,
+      message: `Invalid project ref format. Must be like: abcdefghijklmnopqrst`,
+    }),
+  );
+}
+
+/**
+ * Lists every `[remotes.<name>]` entry off an already-loaded, POST-`env()`-
+ * interpolation project config document (`LoadedProjectConfig.document`,
+ * loaded WITHOUT a `projectRef` so no remote gets merged/stripped — see
+ * `applyRemoteOverride` in `io.ts`). Reads the raw document rather than the
+ * decoded `ProjectConfig` because the decoded shape defaults every remote's
+ * full config subtree, which is irrelevant here and expensive to walk.
+ */
+export function listRemotesFromDocument(
+  document: Record<string, unknown> | undefined,
+): ReadonlyArray<RemoteEntry> {
+  const remotes = document?.["remotes"];
+  if (!isObject(remotes)) return [];
+  const entries: Array<RemoteEntry> = [];
+  for (const [name, remote] of Object.entries(remotes)) {
+    const projectRef =
+      isObject(remote) && typeof remote["project_id"] === "string" ? remote["project_id"] : "";
+    entries.push({ name, projectRef });
+  }
+  return entries;
+}
+
+/**
+ * Appends a `[remotes.<name>]\nproject_id = "<ref>"\n` block to raw TOML text
+ * — every byte before the append offset is untouched (comments, key order,
+ * whitespace), unlike `saveProjectConfig`'s full schema re-serialize, which
+ * would also silently strip any hand-authored `[remotes.*]` subsection this
+ * package's schema doesn't know about yet. Caller is responsible for the
+ * idempotency/conflict decision (see `addRemote`) — this always appends.
+ */
+export function appendRemoteBlockToml(content: string, name: string, ref: string): string {
+  const separator = content.length === 0 || content.endsWith("\n") ? "" : "\n";
+  const leadingBlank = content.trim().length === 0 ? "" : "\n";
+  return `${content}${separator}${leadingBlank}[remotes.${name}]\nproject_id = "${ref}"\n`;
+}
+
+/**
+ * Removes exactly the `[remotes.<name>]` section's lines from raw TOML text —
+ * from its header line up to (but not including) the next top-level-or-nested
+ * `[...]` table header, or EOF. Caller must have already verified (via the
+ * parsed document) that the block holds only `project_id`, so this line-based
+ * scan can never truncate a sibling remote's own subsection by mistake: a
+ * removable block by definition has no lines of its own beyond the header and
+ * the single `project_id` line.
+ */
+export function removeRemoteBlockToml(content: string, name: string): string {
+  const headerPattern = new RegExp(`^\\[remotes\\.${name}\\]\\s*$`);
+  const lines = content.split("\n");
+  const headerIndex = lines.findIndex((line) => headerPattern.test(line.trim()));
+  if (headerIndex === -1) return content;
+
+  let endIndex = lines.length;
+  for (let i = headerIndex + 1; i < lines.length; i += 1) {
+    if (lines[i]?.trimStart().startsWith("[")) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  // Drop a single leading blank line immediately before the removed block —
+  // `appendRemoteBlockToml` always inserts one — so repeated add/remove
+  // cycles don't accumulate blank lines.
+  const removeFrom =
+    headerIndex > 0 && (lines[headerIndex - 1]?.trim() ?? "") === ""
+      ? headerIndex - 1
+      : headerIndex;
+  const result = [...lines.slice(0, removeFrom), ...lines.slice(endIndex)];
+  // `content.split("\n")`'s trailing `""` element (present iff `content` ends
+  // in a newline) is lost when the removed block ran all the way to EOF
+  // (`endIndex === lines.length` consumes it too) — restore it so a
+  // newline-terminated file stays newline-terminated after removal.
+  if (
+    endIndex === lines.length &&
+    lines[lines.length - 1] === "" &&
+    result[result.length - 1] !== ""
+  ) {
+    result.push("");
+  }
+  return result.join("\n");
+}
+
+/** Extra keys (beyond `project_id`) a `[remotes.<name>]` block declares — a non-empty result blocks removal. */
+function extraRemoteBlockKeys(remote: unknown): ReadonlyArray<string> {
+  if (!isObject(remote)) return [];
+  return Object.keys(remote).filter((key) => key !== "project_id");
+}
+
+export interface RemoteAddResult {
+  readonly path: string;
+  /** `false` when the name already existed with the identical ref. */
+  readonly wrote: boolean;
+}
+
+export interface RemoteRemoveResult {
+  readonly path: string;
+}
+
+/**
+ * Adds `[remotes.<name>]` with `project_id = "<ref>"` to the project's config
+ * file (TOML: append-only; JSON: structural insert, key order preserved).
+ * Returns `null` when no `supabase/config.{toml,json}` exists — callers
+ * decide how to surface that.
+ */
+export const addRemote = Effect.fnUntraced(function* (options: {
+  readonly cwd: string;
+  readonly name: string;
+  readonly projectRef: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const project = yield* findProjectPaths(options.cwd);
+  if (project === null) return null;
+
+  yield* validateRemoteName(options.name);
+  yield* validateRemoteRef(options.projectRef);
+
+  const filePath = project.configPath;
+  const isJson = filePath.endsWith(".json");
+  const content = yield* fs.readFileString(filePath);
+
+  const parsed: unknown = isJson ? JSON.parse(content) : SmolToml.parse(content);
+  const remotes = isObject(parsed) && isObject(parsed["remotes"]) ? parsed["remotes"] : {};
+  const existing = remotes[options.name];
+  if (isObject(existing) && typeof existing["project_id"] === "string") {
+    if (existing["project_id"] === options.projectRef) {
+      return { path: filePath, wrote: false } satisfies RemoteAddResult;
+    }
+    return yield* Effect.fail(
+      new RemoteNameConflictError({
+        name: options.name,
+        message: `remote "${options.name}" already exists with a different project_id`,
+      }),
+    );
+  }
+
+  if (isJson) {
+    const doc = isObject(parsed) ? { ...parsed } : {};
+    const nextRemotes = { ...(isObject(doc["remotes"]) ? doc["remotes"] : {}) };
+    nextRemotes[options.name] = { project_id: options.projectRef };
+    doc["remotes"] = nextRemotes;
+    yield* writeFileAtomic(filePath, `${JSON.stringify(doc, null, 2)}\n`);
+  } else {
+    yield* writeFileAtomic(
+      filePath,
+      appendRemoteBlockToml(content, options.name, options.projectRef),
+    );
+  }
+
+  return { path: filePath, wrote: true } satisfies RemoteAddResult;
+});
+
+/**
+ * Removes `[remotes.<name>]`, refusing when the block declares keys beyond
+ * `project_id`. Returns `null` when no config file exists.
+ */
+export const removeRemote = Effect.fnUntraced(function* (options: {
+  readonly cwd: string;
+  readonly name: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const project = yield* findProjectPaths(options.cwd);
+  if (project === null) return null;
+
+  yield* validateRemoteName(options.name);
+
+  const filePath = project.configPath;
+  const isJson = filePath.endsWith(".json");
+  const content = yield* fs.readFileString(filePath);
+  const parsed: unknown = isJson ? JSON.parse(content) : SmolToml.parse(content);
+  const remotes = isObject(parsed) && isObject(parsed["remotes"]) ? parsed["remotes"] : {};
+  const remote = remotes[options.name];
+  if (remote === undefined) {
+    return yield* Effect.fail(
+      new RemoteNotFoundError({
+        name: options.name,
+        message: `remote "${options.name}" not found`,
+      }),
+    );
+  }
+
+  const extraKeys = extraRemoteBlockKeys(remote);
+  if (extraKeys.length > 0) {
+    return yield* Effect.fail(
+      new RemoteBlockNotRemovableError({
+        name: options.name,
+        extraKeys,
+        message: `remote "${options.name}" declares additional config beyond project_id (${extraKeys.join(", ")}); remove those keys first`,
+      }),
+    );
+  }
+
+  if (isJson) {
+    const doc = isObject(parsed) ? { ...parsed } : {};
+    const nextRemotes = { ...(isObject(doc["remotes"]) ? doc["remotes"] : {}) };
+    delete nextRemotes[options.name];
+    if (Object.keys(nextRemotes).length === 0) {
+      delete doc["remotes"];
+    } else {
+      doc["remotes"] = nextRemotes;
+    }
+    yield* writeFileAtomic(filePath, `${JSON.stringify(doc, null, 2)}\n`);
+  } else {
+    yield* writeFileAtomic(filePath, removeRemoteBlockToml(content, options.name));
+  }
+
+  return { path: filePath } satisfies RemoteRemoveResult;
+});
+
+/**
+ * Pure config read listing every `[remotes.*]` entry off the POST-`env()`-interpolation
+ * document, callers resolving a `--remote <name>` to a real ref need the ACTUAL value,
+ * not a literal `env(REF)` string. No `projectRef` is passed to `loadProjectConfig`,
+ * so no remote gets merged/stripped and every entry stays visible. Returns `null`
+ * when no config file exists.
+ */
+export const listRemotes = Effect.fnUntraced(function* (cwd: string) {
+  const loaded = yield* loadProjectConfig(cwd);
+  if (loaded === null) return null;
+  return listRemotesFromDocument(loaded.document);
+});

--- a/packages/config/src/remotes.unit.test.ts
+++ b/packages/config/src/remotes.unit.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+import { BunServices } from "@effect/platform-bun";
+import { mkdtempSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Exit, FileSystem, Path } from "effect";
+import {
+  addRemote,
+  appendRemoteBlockToml,
+  listRemotes,
+  listRemotesFromDocument,
+  removeRemote,
+  removeRemoteBlockToml,
+  validateRemoteName,
+  validateRemoteRef,
+} from "./remotes.ts";
+
+function makeTempProject(): string {
+  return mkdtempSync(join(tmpdir(), "supabase-remotes-"));
+}
+
+function runConfigEffect<A, E>(
+  effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>,
+): Promise<A> {
+  return Effect.runPromise(effect.pipe(Effect.provide(BunServices.layer)));
+}
+
+function runConfigExit<A, E>(
+  effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>,
+): Promise<Exit.Exit<A, E>> {
+  return Effect.runPromiseExit(effect.pipe(Effect.provide(BunServices.layer)));
+}
+
+const REF_A = "abcdefghijklmnopqrst";
+const REF_B = "zzzzzzzzzzzzzzzzzzzz";
+
+describe("appendRemoteBlockToml / removeRemoteBlockToml", () => {
+  test("append is byte-preserving before the appended block", () => {
+    const original = '# a comment\nproject_id = "local"\n';
+    const appended = appendRemoteBlockToml(original, "staging", REF_A);
+    expect(appended.startsWith(original)).toBe(true);
+    expect(appended).toContain('[remotes.staging]\nproject_id = "abcdefghijklmnopqrst"\n');
+  });
+
+  test("append + remove round-trips back to the original content", () => {
+    const original = '# a comment\nproject_id = "local"\n';
+    const appended = appendRemoteBlockToml(original, "staging", REF_A);
+    const removed = removeRemoteBlockToml(appended, "staging");
+    expect(removed).toBe(original);
+  });
+
+  test("remove stops at the next table header, leaving sibling remotes intact", () => {
+    const content =
+      '[remotes.staging]\nproject_id = "abcdefghijklmnopqrst"\n\n[remotes.prod]\nproject_id = "zzzzzzzzzzzzzzzzzzzz"\n';
+    const removed = removeRemoteBlockToml(content, "staging");
+    expect(removed).toContain('[remotes.prod]\nproject_id = "zzzzzzzzzzzzzzzzzzzz"');
+    expect(removed).not.toContain("[remotes.staging]");
+  });
+});
+
+describe("validateRemoteName / validateRemoteRef", () => {
+  test("accepts a bare-key-compatible name", async () => {
+    await expect(Effect.runPromise(validateRemoteName("staging-2"))).resolves.toBeUndefined();
+  });
+
+  test("rejects a dotted name", async () => {
+    const exit = await Effect.runPromiseExit(validateRemoteName("staging.prod"));
+    expect(exit._tag).toBe("Failure");
+  });
+
+  test("rejects a ref that isn't 20 lowercase letters", async () => {
+    const exit = await Effect.runPromiseExit(validateRemoteRef("not-a-ref"));
+    expect(exit._tag).toBe("Failure");
+  });
+});
+
+describe("listRemotesFromDocument", () => {
+  test("reads every [remotes.*] entry's project_id", () => {
+    const entries = listRemotesFromDocument({
+      remotes: { staging: { project_id: REF_A }, prod: { project_id: REF_B } },
+    });
+    expect(entries).toEqual([
+      { name: "staging", projectRef: REF_A },
+      { name: "prod", projectRef: REF_B },
+    ]);
+  });
+
+  test("returns empty for a document with no remotes", () => {
+    expect(listRemotesFromDocument({})).toEqual([]);
+    expect(listRemotesFromDocument(undefined)).toEqual([]);
+  });
+});
+
+describe("addRemote / removeRemote / listRemotes (TOML project)", () => {
+  test("add, list, then remove a remote end to end", async () => {
+    const cwd = makeTempProject();
+    try {
+      await mkdir(join(cwd, "supabase"), { recursive: true });
+      await writeFile(
+        join(cwd, "supabase", "config.toml"),
+        '# top comment\nproject_id = "local"\n',
+      );
+
+      const added = await runConfigEffect(addRemote({ cwd, name: "staging", projectRef: REF_A }));
+      expect(added?.wrote).toBe(true);
+
+      const raw = await readFile(join(cwd, "supabase", "config.toml"), "utf8");
+      expect(raw.startsWith('# top comment\nproject_id = "local"\n')).toBe(true);
+
+      const listed = await runConfigEffect(listRemotes(cwd));
+      expect(listed).toEqual([{ name: "staging", projectRef: REF_A }]);
+
+      // Idempotent re-add with the identical ref.
+      const readded = await runConfigEffect(addRemote({ cwd, name: "staging", projectRef: REF_A }));
+      expect(readded?.wrote).toBe(false);
+
+      // Conflicting re-add with a different ref fails, no write.
+      const conflictExit = await runConfigExit(
+        addRemote({ cwd, name: "staging", projectRef: REF_B }),
+      );
+      expect(Exit.isFailure(conflictExit)).toBe(true);
+      if (Exit.isFailure(conflictExit)) {
+        expect(String(conflictExit.cause)).toContain("already exists with a different project_id");
+      }
+
+      const removed = await runConfigEffect(removeRemote({ cwd, name: "staging" }));
+      expect(removed).not.toBeNull();
+      const afterRemove = await readFile(join(cwd, "supabase", "config.toml"), "utf8");
+      expect(afterRemove).toBe('# top comment\nproject_id = "local"\n');
+
+      const emptyList = await runConfigEffect(listRemotes(cwd));
+      expect(emptyList).toEqual([]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses to remove a block with extra keys", async () => {
+    const cwd = makeTempProject();
+    try {
+      await mkdir(join(cwd, "supabase"), { recursive: true });
+      await writeFile(
+        join(cwd, "supabase", "config.toml"),
+        `[remotes.staging]\nproject_id = "${REF_A}"\n\n[remotes.staging.auth]\nenabled = true\n`,
+      );
+
+      const exit = await runConfigExit(removeRemote({ cwd, name: "staging" }));
+      expect(Exit.isFailure(exit)).toBe(true);
+
+      const raw = await readFile(join(cwd, "supabase", "config.toml"), "utf8");
+      expect(raw).toContain("[remotes.staging]");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when no config file exists", async () => {
+    const cwd = makeTempProject();
+    try {
+      const listed = await runConfigEffect(listRemotes(cwd));
+      expect(listed).toBeNull();
+      const added = await runConfigEffect(addRemote({ cwd, name: "staging", projectRef: REF_A }));
+      expect(added).toBeNull();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("addRemote / removeRemote (JSON project)", () => {
+  test("structural insert then delete, preserving unrelated keys", async () => {
+    const cwd = makeTempProject();
+    try {
+      await mkdir(join(cwd, "supabase"), { recursive: true });
+      await writeFile(
+        join(cwd, "supabase", "config.json"),
+        `${JSON.stringify({ project_id: "local", db: { major_version: 16 } }, null, 2)}\n`,
+      );
+
+      await runConfigEffect(addRemote({ cwd, name: "staging", projectRef: REF_A }));
+      const afterAdd = JSON.parse(await readFile(join(cwd, "supabase", "config.json"), "utf8"));
+      expect(afterAdd).toEqual({
+        project_id: "local",
+        db: { major_version: 16 },
+        remotes: { staging: { project_id: REF_A } },
+      });
+
+      await runConfigEffect(removeRemote({ cwd, name: "staging" }));
+      const afterRemove = JSON.parse(await readFile(join(cwd, "supabase", "config.json"), "utf8"));
+      expect(afterRemove).toEqual({ project_id: "local", db: { major_version: 16 } });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `supabase remotes add|list|remove` — CRUD for named `[remotes.<name>]` entries (each holding a `project_id`) in `supabase/config.toml`, implemented once in shared logic and exposed as commands in both the `legacy` and `next` shells.
- Adds a `--remote <name>` global flag that resolves the named remote's project ref for a single invocation, without touching the linked project from `supabase link`. Wired into the central `LegacyProjectRefResolver` seam so every command that resolves a project ref picks it up automatically.
- Adds conflict guards so `--remote` can't be combined with flags that imply a different or Go-delegated target source: `--local`/`--db-url` on `db push`, `--use-pg-schema` on `db diff`, `--experimental` on `db pull`.
- Adds docs overlay pages for `remotes list|add|remove` and a golden-path e2e test

Closes #143.