### PR TITLE
test(stack): cover managed Git project-root contracts

### DIFF
--- a/packages/stack/docs/architecture.md
+++ b/packages/stack/docs/architecture.md
@@ -170,6 +170,12 @@ an explicit private marker under `.supabase/`. Git checkout markers and
 ordinary-folder markers are private, unreleased storage owned by the current
 build; there is no migration layer or parallel document format.
 
+Consuming applications resolve and pass the canonical local Supabase project
+root to the managed environment APIs. `workspacePath` is an identity input, not
+an arbitrary current working directory: the stack does not inspect
+`supabase/config.toml`, remote-link metadata, or CLI-specific project layout
+conventions.
+
 Moved checkouts can be repaired with `repairWorkspace`, preserving the identity
 and ports. Duplicate checkout adoption is intentionally unsupported and
 requires an explicit ownership decision. Read-only project discovery treats

--- a/packages/stack/src/managed-environment.integration.test.ts
+++ b/packages/stack/src/managed-environment.integration.test.ts
@@ -3,7 +3,14 @@ import { it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 import { afterEach, describe, expect } from "vitest";
 import { cpSync, renameSync } from "node:fs";
-import { git, makeRepository, temporaryRoots } from "../tests/helpers/git-workspace.ts";
+import { join } from "node:path";
+import {
+  git,
+  makeBareRepository,
+  makeRepository,
+  storedConfigValue,
+  temporaryRoots,
+} from "../tests/helpers/git-workspace.ts";
 import {
   discoverEnvironment,
   deriveStackId,
@@ -77,6 +84,36 @@ describe("managed environment identity", () => {
         expect(deriveStackId(first.identity, "default")).not.toBe(
           deriveStackId(second.identity, "default"),
         );
+      }),
+    ).pipe(Effect.provide(gitLayer)),
+  );
+
+  it.live("keeps bare-clone worktree identity stable across repeated discovery", () =>
+    withGitWorkspace((workspace) =>
+      Effect.gen(function* () {
+        const bare = makeBareRepository(workspace.root, workspace.primary);
+        const firstPath = join(workspace.root, "bare-first");
+        const secondPath = join(workspace.root, "bare-second");
+        git(bare, "worktree", "add", "-q", firstPath, "-b", "feature/first", "main");
+        git(bare, "worktree", "add", "-q", secondPath, "-b", "feature/second", "main");
+
+        // Git enables worktree-scoped config itself and relocates core.bare when
+        // sparse-checkout is initialized; the fixture must exercise that path.
+        git(firstPath, "sparse-checkout", "set", ".");
+        expect(git(bare, "config", "--get", "extensions.worktreeConfig").trim()).toBe("true");
+        expect(storedConfigValue(join(bare, "config"), "core.bare")).toBeUndefined();
+        expect(storedConfigValue(join(bare, "config.worktree"), "core.bare")).toBe("true");
+
+        const first = yield* ensureEnvironment(firstPath);
+        const second = yield* ensureEnvironment(secondPath);
+        const firstAgain = yield* discoverEnvironment(firstPath);
+
+        expect(first.workspace.checkoutKind).toBe("bare");
+        expect(second.workspace.checkoutKind).toBe("bare");
+        expect(first.identity.workspaceId).toBe(second.identity.workspaceId);
+        expect(first.identity.checkoutId).not.toBe(second.identity.checkoutId);
+        expect(first.identity.contextId).not.toBe(second.identity.contextId);
+        expect(firstAgain).toEqual(first);
       }),
     ).pipe(Effect.provide(gitLayer)),
   );

--- a/packages/stack/tests/helpers/git-workspace.ts
+++ b/packages/stack/tests/helpers/git-workspace.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import { join } from "node:path";
 
 /**
@@ -18,6 +18,7 @@ const GIT_ENV = {
   ...process.env,
   // Isolated from the developer's own git configuration, which could otherwise
   // decide the initial branch name or sign the fixture commits.
+  HOME: devNull,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_AUTHOR_NAME: "Managed Stack Test",


### PR DESCRIPTION
## Summary

- cover Git-managed `extensions.worktreeConfig` relocation through a real bare repository and two linked worktrees
- verify workspace stability and checkout/context isolation through the public managed environment APIs
- document that consumers pass the canonical local Supabase project root while `@supabase/stack` remains independent of CLI configuration layout

## Context

Git can move `core.bare` into worktree-scoped configuration when sparse checkout enables `extensions.worktreeConfig`. This journey protects managed identity discovery across that real Git topology without adding parser fixtures or coupling the stack package to `supabase/config.toml`.