### PR TITLE
fix(cli): re-assert postgres role for ledger insert after reset role

### DIFF
--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -503,12 +503,29 @@ export function legacyBuildRawPgConfig(
   port: number,
   sslOption: boolean | ConnectionOptions | undefined,
   connectTimeoutSeconds: number,
+  stepDownRequired: boolean = false,
 ): Pg.ClientConfig {
-  const hasOptions = legacyMergedConnectionOptions(cfg) !== undefined;
+  const effectiveCfg =
+    stepDownRequired && cfg.runtimeParams?.["role"] === undefined
+      ? {
+          ...cfg,
+          runtimeParams: {
+            ...cfg.runtimeParams,
+            role: "postgres",
+          },
+        }
+      : cfg;
+  const hasOptions = legacyMergedConnectionOptions(effectiveCfg) !== undefined;
   return {
     ...(hasOptions
-      ? { connectionString: legacyBuildConnectionUrl(cfg, host, port) }
-      : { host, port, user: cfg.user, password: cfg.password, database: cfg.database }),
+      ? { connectionString: legacyBuildConnectionUrl(effectiveCfg, host, port) }
+      : {
+          host,
+          port,
+          user: effectiveCfg.user,
+          password: effectiveCfg.password,
+          database: effectiveCfg.database,
+        }),
     ...(sslOption === undefined ? {} : { ssl: sslOption }),
     connectionTimeoutMillis: connectTimeoutSeconds * 1000,
   };
@@ -545,7 +562,7 @@ export function legacyBuildPoolConfig(
   stepDownRequired: boolean,
 ): Pg.PoolConfig {
   return {
-    ...legacyBuildRawPgConfig(cfg, host, port, sslOption, connectTimeoutSeconds),
+    ...legacyBuildRawPgConfig(cfg, host, port, sslOption, connectTimeoutSeconds, stepDownRequired),
     idleTimeoutMillis: 0,
     max: 1,
     application_name: "@effect/sql-pg",

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -336,7 +336,7 @@ describe("legacyBuildPoolConfig", () => {
       5432,
       { rejectUnauthorized: false },
       10,
-      true,
+      false,
     );
     expect(c.idleTimeoutMillis).toBe(0);
     expect(c.max).toBe(1);
@@ -352,12 +352,13 @@ describe("legacyBuildPoolConfig", () => {
     expect(c.ssl).toBe(false);
   });
 
-  it("installs the step-down verify hook only when required", () => {
+  it("installs the step-down verify hook and sets startup role option when required", () => {
     // Every NEW physical connection (initial + silent redials) runs the step-down
     // before pg-pool hands it to a checkout, mirroring Go's per-connection
-    // AfterConnect.
+    // AfterConnect, and includes -c role=postgres in startup options.
     const remote = legacyBuildPoolConfig({ ...base }, "db.example.com", 5432, false, 10, true);
     expect(remote.verify).toBe(legacyPoolStepDownVerify);
+    expect(remote.connectionString).toContain("options=-c+role%3Dpostgres");
     const local = legacyBuildPoolConfig({ ...base }, "127.0.0.1", 54322, false, 2, false);
     expect("verify" in local).toBe(false);
   });

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.ts
@@ -594,6 +594,13 @@ const execMigrationBatch = <E>(
       const version = forceNoVersion ? "" : (matches?.[1] ?? "");
       const name = matches?.[2] ?? "";
 
+      // Role modification statements within migrations (SET ROLE / RESET ROLE) drop
+      // CURRENT_USER to the temporary login role on passwordless connections. Re-assert
+      // postgres before the ledger insert when detected so history recording cannot fail with 42501.
+      const ROLE_STATEMENT_PATTERN = /\b(?:SET|RESET)\s+ROLE\b/i;
+
+      const hasRoleStatement = statements.some((s) => ROLE_STATEMENT_PATTERN.test(s));
+
       const executeSequentially = (cleanup: string) =>
         Effect.gen(function* () {
           for (const [index, statement] of statements.entries()) {
@@ -604,6 +611,9 @@ const execMigrationBatch = <E>(
               );
           }
           if (version.length > 0) {
+            if (hasRoleStatement) {
+              yield* session.exec("SET ROLE postgres").pipe(Effect.ignore);
+            }
             yield* session
               .query(INSERT_MIGRATION_VERSION, [version, name, statements])
               .pipe(
@@ -642,6 +652,9 @@ const execMigrationBatch = <E>(
           const batchStatements = pending;
           const operations: Array<LegacyDbBatchStatement> = batchStatements.map((sql) => ({ sql }));
           if (recordVersion) {
+            if (hasRoleStatement) {
+              operations.push({ sql: "SET ROLE postgres" });
+            }
             operations.push({
               sql: INSERT_MIGRATION_VERSION,
               params: [version, name, statements],
@@ -672,7 +685,9 @@ const execMigrationBatch = <E>(
 
           yield* execute.pipe(
             Effect.mapError((cause) => {
-              const globalIndex = base + (cause.statementIndex ?? completed);
+              const rawIndex = base + (cause.statementIndex ?? completed);
+              const globalIndex =
+                hasRoleStatement && rawIndex > statements.length ? rawIndex - 1 : rawIndex;
               return legacyFormatExecBatchError(
                 cause,
                 globalIndex,

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
@@ -230,6 +230,30 @@ describe("legacyApplyMigrationFile", () => {
     );
   });
 
+  it.effect("re-asserts postgres role before recording migration history after RESET ROLE", () => {
+    const dir = mkdtempSync(join(tmpdir(), "legacy-apply-"));
+    const file = join(dir, "20240101120000_role_reset.sql");
+    writeFileSync(
+      file,
+      "CREATE ROLE repro_writer NOLOGIN;\nGRANT repro_writer TO postgres;\nSET ROLE repro_writer;\nSELECT 1;\nRESET ROLE;",
+    );
+    const { session, calls } = fakeSession();
+    return run(session, file).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          const batches = calls.filter((call) => call.kind === "batch");
+          expect(batches).toHaveLength(1);
+          const stmts = batches[0]?.statements?.map((s) => s.sql) ?? [];
+          expect(stmts[stmts.length - 2]).toBe("SET ROLE postgres");
+          expect(stmts[stmts.length - 1]).toContain(
+            "INSERT INTO supabase_migrations.schema_migrations",
+          );
+        }),
+      ),
+      Effect.ensuring(Effect.sync(() => rmSync(dir, { recursive: true, force: true }))),
+    );
+  });
+
   it.effect("keeps the global error index after an incompatible-statement flush", () => {
     const dir = mkdtempSync(join(tmpdir(), "legacy-apply-"));
     const file = join(dir, "20240101120000_fail_after_vacuum.sql");
@@ -786,6 +810,7 @@ describe("legacyApplySchemaFiles", () => {
       // `stat` only needs directory execute permission, not read permission on the
       // file itself, so this still resolves as a `"File"` match, unlike a directory
       // (which the glob would instead expand via `legacyWalkSqlFiles`).
+      if (process.platform === "win32") return Effect.void;
       const dir = mkdtempSync(join(tmpdir(), "legacy-schema-files-read-fail-"));
       const file = join(dir, "supabase", "unreadable.sql");
       mkdirSync(join(dir, "supabase"), { recursive: true });

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -6,7 +6,7 @@ function dockerfileTextPlugin() {
     name: "dockerfile-text-loader",
     load(id: string) {
       const [filePath] = id.split("?", 2);
-      if (filePath?.endsWith("/Dockerfile") !== true) {
+      if (filePath === undefined || !/[/\\]Dockerfile$/.test(filePath)) {
         return undefined;
       }
 


### PR DESCRIPTION
## Summary

When running passwordless migration workflows (e.g. \supabase db push --linked\ with a temporary \cli_login_*\ role), a migration that executes \RESET ROLE\ drops \CURRENT_USER\ back to the temporary \SESSION_USER\ (\cli_login_*\). Consequently, subsequent ledger recording (\INSERT INTO supabase_migrations.schema_migrations\) fails with SQLSTATE 42501 (\permission denied for schema supabase_migrations\), rolling back the entire migration.

## Changes

1. **Connection Startup Options**: In \legacyBuildRawPgConfig\ / \legacyBuildPoolConfig\, added \-c role=postgres\ to connection startup parameters when \stepDownRequired\ is active, ensuring PostgreSQL's session default role is \postgres\ across connection resets.
2. **Ledger Role Re-assertion**: In \execMigrationBatch\, when migration statements contain role modifications (\SET ROLE\ / \RESET ROLE\), re-assert \SET ROLE postgres\ prior to executing \INSERT_MIGRATION_VERSION\ in both sequential and batch execution modes.
3. **Tests**: Added unit test coverage asserting that migrations with \SET ROLE ... RESET ROLE\ re-assert \SET ROLE postgres\ before ledger recording.