### PR TITLE
feat(cli): add supabase workers command family

### DIFF
--- a/apps/cli/src/next/cli/root.ts
+++ b/apps/cli/src/next/cli/root.ts
@@ -22,6 +22,7 @@ import { stopCommand } from "../commands/stop/stop.command.ts";
 import { telemetryCommand } from "../commands/telemetry/telemetry.command.ts";
 import { unlinkCommand } from "../commands/unlink/unlink.command.ts";
 import { updateCommand } from "../commands/update/update.command.ts";
+import { workersCommand } from "../commands/workers/workers.command.ts";
 import { outputLayerFor } from "../../shared/output/output.layer.ts";
 import { jsonCliOutputFormatter } from "../../shared/output/json-formatter.ts";
 
@@ -39,6 +40,7 @@ export const nextRoot = Command.make("supabase").pipe(
     telemetryCommand,
     issueCommand,
     functionsCommand,
+    workersCommand,
     branchesCommand,
     linkCommand,
     unlinkCommand,

--- a/apps/cli/src/next/commands/functions/delete/delete.handler.ts
+++ b/apps/cli/src/next/commands/functions/delete/delete.handler.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { PlatformApi } from "../../../auth/platform-api.service.ts";
 import { deleteFunction } from "../../../../shared/functions/delete.ts";
-import { resolveProjectRef } from "../functions.shared.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
 import type { FunctionsDeleteFlags } from "./delete.command.ts";
 
 export const functionsDelete = Effect.fn("functions.delete")(function* (

--- a/apps/cli/src/next/commands/functions/deploy/deploy.handler.ts
+++ b/apps/cli/src/next/commands/functions/deploy/deploy.handler.ts
@@ -5,7 +5,7 @@ import { ProjectHome } from "../../../config/project-home.service.ts";
 import { RuntimeInfo } from "../../../../shared/runtime/runtime-info.service.ts";
 import { deployFunctions } from "../../../../shared/functions/deploy.ts";
 import { resolveEdgeRuntimeVersionPin } from "../../../../shared/functions/functions.shared.ts";
-import { resolveProjectRef } from "../functions.shared.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
 import type { FunctionsDeployFlags } from "./deploy.command.ts";
 
 export const functionsDeploy = Effect.fn("functions.deploy")(function* (

--- a/apps/cli/src/next/commands/functions/download/download.handler.ts
+++ b/apps/cli/src/next/commands/functions/download/download.handler.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../../shared/functions/download.ts";
 import { resolveEdgeRuntimeVersionPin } from "../../../../shared/functions/functions.shared.ts";
 import { LegacyGoProxy } from "../../../../shared/legacy/go-proxy.service.ts";
-import { resolveProjectRef } from "../functions.shared.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
 import type { FunctionsDownloadFlags } from "./download.command.ts";
 
 export const functionsDownload = Effect.fnUntraced(function* (flags: FunctionsDownloadFlags) {

--- a/apps/cli/src/next/commands/workers/delete/delete.command.ts
+++ b/apps/cli/src/next/commands/workers/delete/delete.command.ts
@@ -1,0 +1,56 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { credentialsLayer } from "../../../auth/credentials.layer.ts";
+import { platformApiLayer } from "../../../auth/platform-api.layer.ts";
+import { projectLinkStateLayer } from "../../../config/project-link-state.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { workersDelete } from "./delete.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(
+    Argument.withDescription("Worker to delete. Inferred when run from inside its directory."),
+    Argument.optional,
+  ),
+  yes: Flag.boolean("yes").pipe(
+    Flag.withAlias("y"),
+    Flag.withDescription("Skip the confirmation prompt."),
+  ),
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref of the Supabase project."),
+    Flag.optional,
+  ),
+} as const;
+
+export type WorkersDeleteFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const workersDeleteCommand = Command.make("delete", config).pipe(
+  Command.withDescription(
+    "Delete a worker from the linked Supabase project. Irreversible; its local directory and supabase/config.toml entry are kept.",
+  ),
+  Command.withShortDescription("Delete a worker from Supabase"),
+  Command.withExamples([
+    {
+      command: "supabase workers delete api",
+      description: "Delete a worker, confirming by typing its name",
+    },
+    {
+      command: "supabase workers delete api --yes",
+      description: "Skip the confirmation prompt (scripts and CI)",
+    },
+  ]),
+  Command.withHandler((flags) =>
+    workersDelete(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(
+    Layer.mergeAll(
+      platformApiLayer.pipe(Layer.provide(credentialsLayer)),
+      projectLinkStateLayer,
+      commandRuntimeLayer(["workers", "delete"]),
+    ),
+  ),
+  Command.provide(BunServices.layer),
+);

--- a/apps/cli/src/next/commands/workers/delete/delete.handler.ts
+++ b/apps/cli/src/next/commands/workers/delete/delete.handler.ts
@@ -1,0 +1,92 @@
+import { Effect, Option } from "effect";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { PlatformApi } from "../../../auth/platform-api.service.ts";
+import { displayPath } from "../../../../shared/workers/worker-paths.ts";
+import { deleteWorker, getWorker } from "../../../../shared/workers/workers-api.ts";
+import {
+  WorkerDeleteNotConfirmedError,
+  WorkerNotDeployedError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
+import { describeWorker, loadWorkersProject, resolveWorkerName } from "../workers.shared.ts";
+import type { WorkersDeleteFlags } from "./delete.command.ts";
+
+/**
+ * `supabase workers delete [name]` — delete the worker; its instances and image
+ * are torn down asynchronously. Whether it exists is asked of the API, never of
+ * a local file.
+ *
+ * Note what it does *not* remove: the worker's directory and its `config.toml`
+ * entry stay on disk, so `push <name>` brings it straight back — which is why
+ * the command says so.
+ *
+ * Being irreversible, an interactive session has to type the worker's name back
+ * to proceed — the same "confirm by typing it" pattern as GitHub's own repo
+ * deletion, rather than a bare y/n that is too easy to reflexively confirm.
+ * `--yes` skips it for scripts, as does a non-interactive session, where there
+ * would be nothing to read.
+ */
+export const workersDelete = Effect.fn("workers.delete")(function* (flags: WorkersDeleteFlags) {
+  const output = yield* Output;
+  const api = yield* PlatformApi;
+
+  const project = yield* loadWorkersProject();
+  const name = yield* resolveWorkerName({ project, name: flags.name, command: "delete" });
+  const worker = describeWorker(project, name);
+  const projectRef = yield* resolveProjectRef(flags.projectRef);
+
+  const fetching = yield* output.task(`Reading "${name}"...`);
+  const found = yield* getWorker(api, projectRef, name).pipe(
+    Effect.tapError(() => fetching.fail()),
+  );
+  yield* fetching.clear();
+
+  if (Option.isNone(found)) {
+    return yield* Effect.fail(
+      new WorkerNotDeployedError({
+        detail: `Nothing is deployed for "${name}" in project ${projectRef}.`,
+        suggestion: `Deploy it with \`supabase workers push ${name}\`.`,
+      }),
+    );
+  }
+
+  if (!flags.yes && output.format === "text" && output.interactive) {
+    const instances = found.value.spec.instances;
+    yield* output.warn(
+      `This permanently deletes "${name}" from project ${projectRef}.` +
+        (instances > 0
+          ? ` ${instances} running instance${instances === 1 ? "" : "s"} will be terminated.`
+          : ""),
+    );
+    const typed = yield* output.promptText(`Type ${name} to confirm`);
+    // Trimmed: a trailing space from a paste is not a different answer, and
+    // making someone re-run a destructive command over one is just friction.
+    if (typed.trim() !== name) {
+      return yield* Effect.fail(
+        new WorkerDeleteNotConfirmedError({
+          detail: `The confirmation did not match "${name}", so nothing was deleted.`,
+          suggestion: `Re-run \`supabase workers delete ${name}\` and type the name exactly, or pass --yes.`,
+        }),
+      );
+    }
+  }
+
+  const deleting = yield* output.task(`Deleting "${name}"...`);
+  yield* deleteWorker(api, projectRef, name).pipe(Effect.tapError(() => deleting.fail()));
+  yield* deleting.succeed(`Deleted "${name}".`);
+
+  const sourceDisplay = displayPath(project.cwd, worker.sourceDir);
+
+  yield* output.success("Deleted worker.", {
+    worker_name: name,
+    project_ref: projectRef,
+    kept_source: sourceDisplay,
+  });
+
+  if (output.format === "text") {
+    // "Deleted" reads more final than it is: the source and its config entry are
+    // still here, and redeploying is one command away.
+    yield* output.info(`kept      ${sourceDisplay} · its supabase/config.toml entry`);
+    yield* output.outro(`Redeploy any time: supabase workers push ${name}`);
+  }
+});

--- a/apps/cli/src/next/commands/workers/delete/delete.integration.test.ts
+++ b/apps/cli/src/next/commands/workers/delete/delete.integration.test.ts
@@ -1,0 +1,187 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import {
+  makeWorkersProject,
+  messagesOfType,
+  setupWorkers,
+  workerResource,
+  workersRoute,
+  WORKERS_PROJECT_REF,
+} from "../../../../../tests/helpers/workers.ts";
+import {
+  WorkerDeleteNotConfirmedError,
+  WorkerNotDeployedError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { workersDelete } from "./delete.handler.ts";
+
+const CONFIG = `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsize = "2gb"\n`;
+
+function project() {
+  const created = makeWorkersProject({
+    "supabase/config.toml": CONFIG,
+    "supabase/workers/api/index.js": "export default {};\n",
+  });
+  return {
+    dir: created.dir,
+    cleanup: () => rmSync(created.dir, { recursive: true, force: true }),
+  };
+}
+
+const getRoute = `GET ${workersRoute("/api")}`;
+const deleteRoute = `DELETE ${workersRoute("/api")}`;
+
+const routes = {
+  [getRoute]: {
+    status: 200,
+    body: { data: workerResource({ name: "api", runtime: "node", instances: 3 }) },
+  },
+  [deleteRoute]: { status: 204 },
+};
+
+describe("workers delete", () => {
+  it.live("deletes after the name is typed back, and keeps the local files", () => {
+    const repo = project();
+    const { layer, out, http } = setupWorkers({
+      cwd: repo.dir,
+      routes,
+      promptTextResponses: ["api"],
+    });
+
+    return Effect.gen(function* () {
+      yield* workersDelete({
+        name: Option.some("api"),
+        yes: false,
+        projectRef: Option.none(),
+      });
+
+      expect(http.routeKeys).toEqual([getRoute, deleteRoute]);
+      expect(
+        messagesOfType(out, "warn").some(
+          (line) => line.includes("permanently deletes") && line.includes("3 running instances"),
+        ),
+      ).toBe(true);
+      expect(messagesOfType(out, "success")).toContain("Deleted worker.");
+
+      // Nothing local is touched — that is what makes `push` a one-command undo.
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "index.js"))).toBe(true);
+      expect(readFileSync(join(repo.dir, "supabase", "config.toml"), "utf8")).toBe(CONFIG);
+      expect(messagesOfType(out, "outro")).toContain(
+        "Redeploy any time: supabase workers push api",
+      );
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("deletes nothing when the confirmation does not match", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      routes,
+      promptTextResponses: ["nope"],
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersDelete({
+        name: Option.some("api"),
+        yes: false,
+        projectRef: Option.none(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerDeleteNotConfirmedError);
+      expect(http.routeKeys).toEqual([getRoute]);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("skips the confirmation with --yes", () => {
+    const repo = project();
+    const { layer, out, http } = setupWorkers({ cwd: repo.dir, routes });
+
+    return Effect.gen(function* () {
+      yield* workersDelete({ name: Option.some("api"), yes: true, projectRef: Option.none() });
+
+      expect(http.routeKeys).toEqual([getRoute, deleteRoute]);
+      expect(messagesOfType(out, "warn")).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("skips the confirmation when there is no interactive session to read from", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({ cwd: repo.dir, format: "json", routes });
+
+    return Effect.gen(function* () {
+      yield* workersDelete({ name: Option.some("api"), yes: false, projectRef: Option.none() });
+
+      expect(http.routeKeys).toEqual([getRoute, deleteRoute]);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("fails with `not deployed` before asking anything", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [getRoute]: { status: 404, body: { message: "worker not found" } } },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersDelete({
+        name: Option.some("api"),
+        yes: false,
+        projectRef: Option.none(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerNotDeployedError);
+      expect(out.messages.filter((message) => message.type === "warn")).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("treats a delete that races another one as done", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: { ...routes, [deleteRoute]: { status: 404, body: { message: "already gone" } } },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersDelete({ name: Option.some("api"), yes: true, projectRef: Option.none() });
+
+      expect(messagesOfType(out, "success")).toContain("Deleted worker.");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("surfaces an unexpected delete status", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: { ...routes, [deleteRoute]: { status: 500, body: { message: "boom" } } },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersDelete({
+        name: Option.some("api"),
+        yes: true,
+        projectRef: Option.none(),
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("WorkersApiUnexpectedStatusError");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("emits a structured result in json mode", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir, format: "json", routes });
+
+    return Effect.gen(function* () {
+      yield* workersDelete({ name: Option.some("api"), yes: true, projectRef: Option.none() });
+
+      const success = out.messages.findLast(
+        (message) => message.type === "success" && message.data !== undefined,
+      );
+      expect(success?.data).toEqual({
+        worker_name: "api",
+        project_ref: WORKERS_PROJECT_REF,
+        kept_source: join("supabase", "workers", "api"),
+      });
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+});

--- a/apps/cli/src/next/commands/workers/list/list.command.ts
+++ b/apps/cli/src/next/commands/workers/list/list.command.ts
@@ -1,0 +1,44 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { credentialsLayer } from "../../../auth/credentials.layer.ts";
+import { platformApiLayer } from "../../../auth/platform-api.layer.ts";
+import { projectLinkStateLayer } from "../../../config/project-link-state.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { workersList } from "./list.handler.ts";
+
+const config = {
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref of the Supabase project."),
+    Flag.optional,
+  ),
+} as const;
+
+export type WorkersListFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const workersListCommand = Command.make("list", config).pipe(
+  Command.withDescription(
+    "List this project's workers, deployed or not — the union of supabase/config.toml's entries and what the Workers API reports.",
+  ),
+  Command.withShortDescription("List this project's workers"),
+  Command.withExamples([
+    {
+      command: "supabase workers list",
+      description: "See every worker in the linked project",
+    },
+  ]),
+  Command.withHandler((flags) =>
+    workersList(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(
+    Layer.mergeAll(
+      platformApiLayer.pipe(Layer.provide(credentialsLayer)),
+      projectLinkStateLayer,
+      commandRuntimeLayer(["workers", "list"]),
+    ),
+  ),
+  Command.provide(BunServices.layer),
+);

--- a/apps/cli/src/next/commands/workers/list/list.handler.ts
+++ b/apps/cli/src/next/commands/workers/list/list.handler.ts
@@ -1,0 +1,134 @@
+import { Effect } from "effect";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { outputTable } from "../../../../shared/output/table.ts";
+import { PlatformApi } from "../../../auth/platform-api.service.ts";
+import { CliConfig } from "../../../config/cli-config.service.ts";
+import { formatApiSize } from "../../../../shared/workers/worker-runtimes.ts";
+import { workerUrl } from "../../../../shared/workers/worker-url.ts";
+import { listWorkers, type WorkerRecord } from "../../../../shared/workers/workers-api.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
+import { loadWorkersProject } from "../workers.shared.ts";
+import type { WorkersListFlags } from "./list.command.ts";
+
+/**
+ * `supabase workers list` — every worker in this project, deployed or not.
+ *
+ * A union of two sources, because either half alone is misleading: the
+ * project's `[workers.*]` entries (scaffolded, maybe never deployed) and what
+ * the API reports as deployed (including anything deployed from elsewhere, or
+ * from a directory since deleted). A worker in the config with nothing deployed
+ * shows as `not deployed`; a deployed worker with no local entry is called out,
+ * since pushing it from here would have to guess its runtime.
+ *
+ * The list endpoint deliberately makes no per-worker backend call, so it
+ * carries no live instance tally — the `INSTANCES` column is the declared
+ * count from the spec. `status` is where the live tally lives.
+ */
+
+const HEADERS = ["NAME", "RUNTIME", "SIZE", "STATE", "INSTANCES", "URL"] as const;
+
+interface WorkerRow {
+  readonly name: string;
+  readonly configured: boolean;
+  readonly deployed: WorkerRecord | undefined;
+  readonly localRuntime: string | undefined;
+  readonly url: string | undefined;
+}
+
+function stateLabel(row: WorkerRow): string {
+  if (row.deployed === undefined) {
+    return "not deployed";
+  }
+  if (row.deployed.deleting === true) {
+    return "deleting";
+  }
+  return row.deployed.buildState;
+}
+
+/**
+ * The API omits `spec.runtime` only for a context-only build, so for a deployed
+ * worker its absence *is* "dockerfile". For one that has never been deployed
+ * there is nothing to infer from — `push` would guess from marker files — so say
+ * unknown rather than assert a runtime it may not have.
+ */
+function runtimeLabel(row: WorkerRow): string {
+  if (row.deployed !== undefined) {
+    return row.deployed.spec.runtime ?? "dockerfile";
+  }
+  return row.localRuntime ?? "-";
+}
+
+function toCells(row: WorkerRow): ReadonlyArray<string> {
+  return [
+    row.name,
+    runtimeLabel(row),
+    row.deployed === undefined ? "-" : formatApiSize(row.deployed.spec.size),
+    stateLabel(row),
+    row.deployed === undefined ? "-" : String(row.deployed.spec.instances),
+    row.url ?? "-",
+  ];
+}
+
+export const workersList = Effect.fn("workers.list")(function* (flags: WorkersListFlags) {
+  const output = yield* Output;
+  const api = yield* PlatformApi;
+  const cliConfig = yield* CliConfig;
+
+  const project = yield* loadWorkersProject();
+  const projectRef = yield* resolveProjectRef(flags.projectRef);
+
+  const fetching = yield* output.task("Listing workers...");
+  const deployed = yield* listWorkers(api, projectRef).pipe(Effect.tapError(() => fetching.fail()));
+  yield* fetching.clear();
+
+  const byName = new Map(deployed.map((worker) => [worker.name, worker]));
+  const configuredNames = Object.keys(project.section.workers);
+  const names = [...new Set([...configuredNames, ...byName.keys()])].sort();
+
+  const rows: Array<WorkerRow> = names.map((name) => {
+    const record = byName.get(name);
+    return {
+      name,
+      configured: configuredNames.includes(name),
+      deployed: record,
+      localRuntime: project.section.workers[name]?.runtime,
+      url:
+        record !== undefined && record.spec.exposure === "public"
+          ? workerUrl(projectRef, cliConfig.projectHost, name)
+          : undefined,
+    };
+  });
+
+  if (output.format !== "text") {
+    yield* output.success("Listed workers.", {
+      project_ref: projectRef,
+      workers: rows.map((row) => ({
+        name: row.name,
+        configured: row.configured,
+        deployed: row.deployed !== undefined,
+        runtime: row.deployed?.spec.runtime ?? row.localRuntime,
+        size: row.deployed?.spec.size,
+        state: stateLabel(row),
+        instances: row.deployed?.spec.instances,
+        url: row.url,
+      })),
+    });
+    return;
+  }
+
+  if (rows.length === 0) {
+    yield* output.info("No workers yet. Scaffold one with `supabase workers new <name>`.");
+    return;
+  }
+
+  yield* outputTable([...HEADERS], rows, toCells);
+
+  const orphans = rows.filter((row) => !row.configured).map((row) => row.name);
+  if (orphans.length > 0) {
+    yield* output.warn(
+      `${orphans.join(", ")} ${
+        orphans.length === 1 ? "is" : "are"
+      } deployed but absent from supabase/config.toml — pushing from here would have to guess the runtime.`,
+    );
+  }
+});

--- a/apps/cli/src/next/commands/workers/list/list.integration.test.ts
+++ b/apps/cli/src/next/commands/workers/list/list.integration.test.ts
@@ -1,0 +1,232 @@
+import { rmSync } from "node:fs";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import {
+  makeWorkersProject,
+  messagesOfType,
+  setupWorkers,
+  workerResource,
+  workersRoute,
+  WORKERS_PROJECT_REF,
+} from "../../../../../tests/helpers/workers.ts";
+import { ProjectNotLinkedError } from "../../../config/project-link-state.service.ts";
+import { WorkersUnavailableError } from "../../../../shared/workers/workers.errors.ts";
+import { workersList } from "./list.handler.ts";
+
+const CONFIG = `project_id = "demo"
+
+[workers.api]
+runtime = "node"
+size = "2gb"
+
+[workers.old]
+runtime = "deno"
+`;
+
+function project(config = CONFIG) {
+  const created = makeWorkersProject({ "supabase/config.toml": config });
+  return {
+    dir: created.dir,
+    cleanup: () => rmSync(created.dir, { recursive: true, force: true }),
+  };
+}
+
+const listRoute = `GET ${workersRoute()}`;
+
+describe("workers list", () => {
+  it.live("shows configured and deployed workers as one inventory", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [listRoute]: {
+          status: 200,
+          body: {
+            data: [
+              workerResource({ name: "api", runtime: "node", imageVersion: "v3" }),
+              workerResource({
+                name: "box",
+                runtime: "sandbox",
+                exposure: "private",
+                instances: 2,
+              }),
+            ],
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.none() });
+
+      const lines = messagesOfType(out, "info");
+      const header = lines.find((line) => line.startsWith("NAME"));
+      expect(header).toBeDefined();
+
+      const rows = lines.filter((line) => /^(api|box|old)\s/.test(line));
+      expect(rows).toHaveLength(3);
+      // Sorted by name, so `api`, `box`, then the scaffolded-but-undeployed `old`.
+      expect(rows[0]).toContain("2gb · 1 vCPU");
+      expect(rows[0]).toContain(`https://${WORKERS_PROJECT_REF}.supabase.co/workers/v1/api`);
+      expect(rows[1]).toContain("sandbox");
+      expect(rows[2]).toContain("not deployed");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("does not assert a runtime for a worker that has never been deployed", () => {
+    const repo = project(`project_id = "demo"\n\n[workers.ghost]\n`);
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [listRoute]: { status: 200, body: { data: [] } } },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.none() });
+
+      const row = messagesOfType(out, "info").find((line) => line.startsWith("ghost"));
+      expect(row).toBeDefined();
+      expect(row).not.toContain("dockerfile");
+      expect(row).toContain("not deployed");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("calls out a deployed worker that config.toml does not know about", () => {
+    const repo = project(`project_id = "demo"\n`);
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [listRoute]: {
+          status: 200,
+          body: { data: [workerResource({ name: "stray", runtime: "node" })] },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.none() });
+
+      expect(
+        messagesOfType(out, "warn").some(
+          (line) => line.includes("stray") && line.includes("guess the runtime"),
+        ),
+      ).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("says so when the project has no workers at all", () => {
+    const repo = project(`project_id = "demo"\n`);
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [listRoute]: { status: 200, body: { data: [] } } },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain(
+        "No workers yet. Scaffold one with `supabase workers new <name>`.",
+      );
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("emits the inventory as structured data in json mode", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      format: "json",
+      routes: {
+        [listRoute]: {
+          status: 200,
+          body: { data: [workerResource({ name: "api", runtime: "node" })] },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.none() });
+
+      const success = out.messages.findLast(
+        (message) => message.type === "success" && message.data !== undefined,
+      );
+      expect(success?.data).toMatchObject({ project_ref: WORKERS_PROJECT_REF });
+      expect(success?.data?.["workers"]).toEqual([
+        {
+          name: "api",
+          configured: true,
+          deployed: true,
+          runtime: "node",
+          size: "2gb-1vcpu",
+          state: "active",
+          instances: 1,
+          url: `https://${WORKERS_PROJECT_REF}.supabase.co/workers/v1/api`,
+        },
+        {
+          name: "old",
+          configured: true,
+          deployed: false,
+          runtime: "deno",
+          size: undefined,
+          state: "not deployed",
+          instances: undefined,
+          url: undefined,
+        },
+      ]);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("reports a project outside the alpha as unavailable", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [listRoute]: { status: 404, body: { message: "not available" } } },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersList({ projectRef: Option.none() }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkersUnavailableError);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("surfaces an unexpected status rather than showing an empty list", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [listRoute]: { status: 500, body: { message: "boom" } } },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersList({ projectRef: Option.none() }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("WorkersApiUnexpectedStatusError");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("uses an explicit --project-ref without a linked project", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      linked: false,
+      routes: {
+        "GET /v2/projects/qrstuvwxyzabcdefghij/workers": { status: 200, body: { data: [] } },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersList({ projectRef: Option.some("qrstuvwxyzabcdefghij") });
+
+      expect(http.routeKeys).toEqual(["GET /v2/projects/qrstuvwxyzabcdefghij/workers"]);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("requires a linked project when no ref is given", () => {
+    const repo = project();
+    const { layer } = setupWorkers({ cwd: repo.dir, linked: false });
+
+    return Effect.gen(function* () {
+      const error = yield* workersList({ projectRef: Option.none() }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ProjectNotLinkedError);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+});

--- a/apps/cli/src/next/commands/workers/new/new.command.ts
+++ b/apps/cli/src/next/commands/workers/new/new.command.ts
@@ -1,0 +1,71 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { randomLayer } from "../../../../shared/runtime/random.layer.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { WORKER_RUNTIMES, WORKER_SIZES } from "../../../../shared/workers/worker-runtimes.ts";
+import { workersNew } from "./new.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(
+    Argument.withDescription("Worker name. Doubles as its directory; generated when omitted."),
+    Argument.optional,
+  ),
+  runtime: Flag.choice("runtime", WORKER_RUNTIMES).pipe(
+    Flag.withDescription(
+      "Runtime to scaffold and record in supabase/config.toml. Prompted when omitted.",
+    ),
+    Flag.optional,
+  ),
+  size: Flag.choice("size", WORKER_SIZES).pipe(
+    Flag.withDescription(
+      "Instance size to record in supabase/config.toml. Each size implies its own vCPU count, so there is no separate --cpu. Prompted when omitted.",
+    ),
+    Flag.optional,
+  ),
+  source: Flag.string("source").pipe(
+    Flag.withAlias("p"),
+    Flag.withDescription(
+      "Scaffold the worker here instead of the default workers directory, recorded as `source` in supabase/config.toml.",
+    ),
+    Flag.optional,
+  ),
+  force: Flag.boolean("force").pipe(
+    Flag.withDescription("Replace the destination if it already exists and is not empty."),
+  ),
+} as const;
+
+export type WorkersNewFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const workersNewCommand = Command.make("new", config).pipe(
+  Command.withDescription(
+    "Scaffold a worker directory from a runtime's starter files and record the choice in supabase/config.toml. Nothing is deployed.",
+  ),
+  Command.withShortDescription("Scaffold a worker locally"),
+  Command.withExamples([
+    {
+      command: "supabase workers new",
+      description: "Scaffold a worker, prompting for runtime and size",
+    },
+    {
+      command: "supabase workers new api --runtime node",
+      description: "Scaffold supabase/workers/api on the node runtime",
+    },
+    {
+      command: "supabase workers new api --runtime dockerfile",
+      description: "Bring your own Dockerfile",
+    },
+    {
+      command: "supabase workers new api --source packages/api",
+      description: "Scaffold the worker outside the workers directory",
+    },
+  ]),
+  Command.withHandler((flags) =>
+    workersNew(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(Layer.mergeAll(randomLayer, commandRuntimeLayer(["workers", "new"]))),
+  Command.provide(BunServices.layer),
+);

--- a/apps/cli/src/next/commands/workers/new/new.handler.ts
+++ b/apps/cli/src/next/commands/workers/new/new.handler.ts
@@ -1,0 +1,327 @@
+import { dirname, join, relative } from "node:path";
+import { Effect, FileSystem, Option } from "effect";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { Random } from "../../../../shared/runtime/random.service.ts";
+import { writeWorkerEntry } from "../../../../shared/workers/worker-config.ts";
+import { displayPath, resolveWorkerSource } from "../../../../shared/workers/worker-paths.ts";
+import {
+  DEFAULT_WORKER_RUNTIME,
+  DEFAULT_WORKER_SIZE,
+  parseWorkerRuntime,
+  parseWorkerSize,
+  validateWorkerNameMessage,
+  vcpuForSize,
+  WORKER_RUNTIME_DESCRIPTIONS,
+  WORKER_RUNTIMES,
+  WORKER_SIZES,
+  type WorkerRuntime,
+  type WorkerSize,
+} from "../../../../shared/workers/worker-runtimes.ts";
+import { WORKER_STACKS } from "../../../../shared/workers/worker-stacks.ts";
+import {
+  InvalidWorkerNameError,
+  UnknownWorkerRuntimeError,
+  UnknownWorkerSizeError,
+  WorkerDirectoryExistsError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { loadWorkersProject } from "../workers.shared.ts";
+import type { WorkersNewFlags } from "./new.command.ts";
+
+/**
+ * `supabase workers new [name]` — scaffold `supabase/<root>/<name>/` from the
+ * chosen runtime's starter files and record the choice in `config.toml`.
+ * Nothing is deployed; this is entirely local-disk work.
+ *
+ * The runtime and size are resolved *before* anything is written, so a
+ * cancelled prompt leaves nothing behind for this worker at all — including the
+ * name, which is only generated once both questions have been answered.
+ */
+
+/** Adjective pool for an auto-assigned name, when no name is given. */
+const NAME_WORDS = [
+  "agile",
+  "amber",
+  "apex",
+  "astral",
+  "atomic",
+  "aurora",
+  "bold",
+  "bright",
+  "brisk",
+  "calm",
+  "cipher",
+  "cobalt",
+  "cosmic",
+  "crimson",
+  "delta",
+  "echo",
+  "ember",
+  "flint",
+  "flux",
+  "frosty",
+  "glide",
+  "halo",
+  "helix",
+  "ionic",
+  "jade",
+  "keen",
+  "kinetic",
+  "lithe",
+  "lucid",
+  "lunar",
+  "maple",
+  "mist",
+  "mystic",
+  "neon",
+  "nimble",
+  "noble",
+  "nomad",
+  "nova",
+  "onyx",
+  "opal",
+  "orbit",
+  "prism",
+  "quartz",
+  "rapid",
+  "reef",
+  "rogue",
+  "sage",
+  "sharp",
+  "silver",
+  "solar",
+  "sonic",
+  "spark",
+  "steady",
+  "stellar",
+  "summit",
+  "surge",
+  "swift",
+] as const;
+
+const generateWorkerName = Effect.fnUntraced(function* () {
+  const random = yield* Random;
+  // Six bytes, split so the word and the number are drawn independently.
+  const hex = yield* random.randomHex(6);
+  const word = NAME_WORDS[Number.parseInt(hex.slice(0, 6), 16) % NAME_WORDS.length];
+  const suffix = 10000 + (Number.parseInt(hex.slice(6, 12), 16) % 90000);
+  return `worker-${word}-${suffix}`;
+});
+
+/** `values`, with `defaultValue` first, so a prompt pre-selects what it shows first. */
+function defaultFirst<T>(values: ReadonlyArray<T>, defaultValue: T): Array<T> {
+  return [defaultValue, ...values.filter((value) => value !== defaultValue)];
+}
+
+const resolveRuntime = Effect.fnUntraced(function* (options: {
+  readonly explicit: Option.Option<WorkerRuntime>;
+  readonly recorded: string | undefined;
+}) {
+  // `--runtime` is a choice flag, so the parser has already rejected anything
+  // outside the catalog by the time it gets here.
+  if (Option.isSome(options.explicit)) {
+    return options.explicit.value;
+  }
+
+  if (options.recorded !== undefined) {
+    const recorded = parseWorkerRuntime(options.recorded);
+    if (recorded === undefined) {
+      return yield* Effect.fail(
+        new UnknownWorkerRuntimeError({
+          detail: `supabase/config.toml records an unknown runtime "${options.recorded}".`,
+          suggestion: `Set it to one of: ${WORKER_RUNTIMES.join(", ")}, or pass --runtime.`,
+        }),
+      );
+    }
+    return recorded;
+  }
+
+  const output = yield* Output;
+  if (output.format === "text" && output.interactive) {
+    const selected = yield* output.promptSelect(
+      "Which runtime should this worker use?",
+      defaultFirst([...WORKER_RUNTIMES], DEFAULT_WORKER_RUNTIME).map((runtime) => ({
+        value: runtime,
+        label: runtime,
+        hint: WORKER_RUNTIME_DESCRIPTIONS[runtime],
+      })),
+    );
+    return parseWorkerRuntime(selected) ?? DEFAULT_WORKER_RUNTIME;
+  }
+
+  return DEFAULT_WORKER_RUNTIME;
+});
+
+const resolveSize = Effect.fnUntraced(function* (options: {
+  readonly explicit: Option.Option<WorkerSize>;
+  readonly recorded: string | undefined;
+}) {
+  if (Option.isSome(options.explicit)) {
+    return options.explicit.value;
+  }
+
+  if (options.recorded !== undefined) {
+    const recorded = parseWorkerSize(options.recorded);
+    if (recorded === undefined) {
+      return yield* Effect.fail(
+        new UnknownWorkerSizeError({
+          detail: `supabase/config.toml records an unknown size "${options.recorded}".`,
+          suggestion: `Set it to one of: ${WORKER_SIZES.join(", ")}, or pass --size.`,
+        }),
+      );
+    }
+    return recorded;
+  }
+
+  const output = yield* Output;
+  if (output.format === "text" && output.interactive) {
+    const selected = yield* output.promptSelect(
+      "Which instance size should this worker use?",
+      defaultFirst([...WORKER_SIZES], DEFAULT_WORKER_SIZE).map((size) => ({
+        value: size,
+        label: `${size} · ${vcpuForSize(size)} vCPU`,
+      })),
+    );
+    return parseWorkerSize(selected) ?? DEFAULT_WORKER_SIZE;
+  }
+
+  return DEFAULT_WORKER_SIZE;
+});
+
+const isNonEmptyDirectory = Effect.fnUntraced(function* (dir: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(() => []));
+  return entries.length > 0;
+});
+
+export const workersNew = Effect.fn("workers.new")(function* (flags: WorkersNewFlags) {
+  const fs = yield* FileSystem.FileSystem;
+  const output = yield* Output;
+
+  yield* output.intro("Create worker");
+
+  const project = yield* loadWorkersProject();
+
+  if (Option.isSome(flags.name)) {
+    const invalid = validateWorkerNameMessage(flags.name.value);
+    if (invalid !== undefined) {
+      return yield* Effect.fail(
+        new InvalidWorkerNameError({
+          detail: `"${flags.name.value}" is not a valid worker name. ${invalid}`,
+          suggestion: "Worker names become hostnames, so they must be DNS labels.",
+        }),
+      );
+    }
+  }
+
+  // A named worker may already have a `[workers.<name>]` entry — hand-written,
+  // or left over from a `new` whose directory was since deleted. Its recorded
+  // choices become this run's defaults instead of re-asking questions
+  // config.toml has already answered.
+  const recorded = Option.isSome(flags.name)
+    ? project.section.workers[flags.name.value]
+    : undefined;
+  // Only worth saying when a recorded value is actually about to answer for a
+  // flag the user omitted. An entry that is present but empty, or one whose
+  // every key was overridden on the command line, contributes nothing.
+  const inherits =
+    (recorded?.runtime !== undefined && Option.isNone(flags.runtime)) ||
+    (recorded?.size !== undefined && Option.isNone(flags.size)) ||
+    (recorded?.source !== undefined && Option.isNone(flags.source));
+  if (inherits && Option.isSome(flags.name)) {
+    yield* output.info(
+      `Reusing the existing config.toml entry for "${flags.name.value}". Pass --runtime/--size/--source to override.`,
+    );
+  }
+
+  // Resolved before anything is written, so cancelling either prompt leaves
+  // nothing behind — the name included.
+  const runtime = yield* resolveRuntime({ explicit: flags.runtime, recorded: recorded?.runtime });
+  const size = yield* resolveSize({ explicit: flags.size, recorded: recorded?.size });
+
+  const name = Option.isSome(flags.name) ? flags.name.value : yield* generateWorkerName();
+  if (Option.isNone(flags.name)) {
+    yield* output.info(`Auto-assigned the name "${name}".`);
+  }
+
+  // An explicit --source always wins; absent one, a recorded `source` keeps the
+  // scaffold where config.toml already says the code lives rather than
+  // defaulting to the workers directory out from under it.
+  // Validated before anything is written: `--force` deletes this directory
+  // outright, so a value naming the project root or `supabase/` must never get
+  // as far as the removal below.
+  const destination = Option.isSome(flags.source)
+    ? yield* resolveWorkerSource({
+        projectRoot: project.projectRoot,
+        cwd: project.cwd,
+        raw: flags.source.value,
+      })
+    : recorded?.source === undefined
+      ? join(project.rootDir, name)
+      : yield* resolveWorkerSource({
+          projectRoot: project.projectRoot,
+          cwd: project.projectRoot,
+          raw: recorded.source,
+        });
+
+  if (yield* isNonEmptyDirectory(destination)) {
+    if (!flags.force) {
+      return yield* Effect.fail(
+        new WorkerDirectoryExistsError({
+          detail: `${displayPath(project.cwd, destination)} already exists and is not empty.`,
+          suggestion: `Replace it with \`supabase workers new ${name} --force\`, or pick a different name.`,
+        }),
+      );
+    }
+    // Replaced wholesale rather than merged: a re-run with a different runtime
+    // would otherwise leave the previous runtime's files mixed in with the new
+    // ones.
+    yield* fs.remove(destination, { recursive: true });
+  }
+
+  yield* fs.makeDirectory(dirname(destination), { recursive: true });
+  yield* fs.makeDirectory(destination, { recursive: true });
+  // config.toml lives in supabase/, which may not exist yet when --source puts
+  // the worker elsewhere in the project.
+  yield* fs.makeDirectory(project.supabaseDir, { recursive: true });
+
+  for (const [filename, contents] of Object.entries(WORKER_STACKS[runtime])) {
+    yield* fs.writeFileString(join(destination, filename), contents);
+  }
+
+  const source = Option.isSome(flags.source)
+    ? relative(project.projectRoot, destination)
+    : recorded?.source;
+
+  yield* writeWorkerEntry({
+    configPath: project.configPath,
+    name,
+    existingWorkers: project.section.workers,
+    patch: {
+      runtime,
+      size,
+      ...(source === undefined ? {} : { source }),
+    },
+  });
+
+  const sourceDisplay = displayPath(project.cwd, destination);
+
+  yield* output.success("Created worker.", {
+    worker_name: name,
+    runtime,
+    size,
+    vcpu: vcpuForSize(size),
+    source: sourceDisplay,
+    config_path: project.configPath,
+  });
+
+  if (output.format === "text") {
+    yield* output.info(`source    ${sourceDisplay}`);
+    yield* output.info(`runtime   ${runtime}`);
+    yield* output.info(`size      ${size} · ${vcpuForSize(size)} vCPU`);
+    yield* output.info(
+      `access    ${runtime === "sandbox" ? "private (no HTTP endpoint)" : "public"}`,
+    );
+  }
+
+  yield* output.outro(`Next: supabase workers push ${name}`);
+});

--- a/apps/cli/src/next/commands/workers/new/new.integration.test.ts
+++ b/apps/cli/src/next/commands/workers/new/new.integration.test.ts
@@ -1,0 +1,308 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import {
+  makeWorkersProject,
+  messagesOfType,
+  setupWorkers,
+} from "../../../../../tests/helpers/workers.ts";
+import {
+  InvalidWorkerNameError,
+  InvalidWorkerSourceError,
+  UnknownWorkerRuntimeError,
+  UnknownWorkerSizeError,
+  WorkerDirectoryExistsError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { workersNew } from "./new.handler.ts";
+import type { WorkersNewFlags } from "./new.command.ts";
+
+const CONFIG_WITH_COMMENTS = `# hand-written, and it should stay that way
+project_id = "demo"
+
+[functions.hello]
+verify_jwt = false
+`;
+
+function flags(overrides: Partial<WorkersNewFlags> = {}): WorkersNewFlags {
+  return {
+    name: Option.none(),
+    runtime: Option.none(),
+    size: Option.none(),
+    source: Option.none(),
+    force: false,
+    ...overrides,
+  };
+}
+
+function project(files: Readonly<Record<string, string>> = {}) {
+  const created = makeWorkersProject({
+    "supabase/config.toml": CONFIG_WITH_COMMENTS,
+    ...files,
+  });
+  const configPath = join(created.dir, "supabase", "config.toml");
+  return {
+    dir: created.dir,
+    config: () => readFileSync(configPath, "utf8"),
+    cleanup: () => rmSync(created.dir, { recursive: true, force: true }),
+  };
+}
+
+describe("workers new", () => {
+  it.live("scaffolds the runtime's starter files and records the choice", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api"), runtime: Option.some("node") }));
+
+      const workerDir = join(repo.dir, "supabase", "workers", "api");
+      expect(existsSync(join(workerDir, "index.js"))).toBe(true);
+      expect(existsSync(join(workerDir, "package.json"))).toBe(true);
+
+      expect(repo.config()).toBe(
+        `${CONFIG_WITH_COMMENTS}\n[workers.api]\nruntime = "node"\nsize = "2gb"\n`,
+      );
+
+      expect(messagesOfType(out, "success")).toContain("Created worker.");
+      expect(messagesOfType(out, "outro")).toContain("Next: supabase workers push api");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("generates a valid worker name when none is given", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ runtime: Option.some("deno"), size: Option.some("2gb") }));
+
+      const match = /\[workers\.(?<name>[a-z0-9-]+)\]/.exec(repo.config());
+      const name = match?.groups?.["name"];
+      expect(name).toMatch(/^worker-[a-z]+-\d{5}$/);
+      expect(existsSync(join(repo.dir, "supabase", "workers", name ?? "", "main.ts"))).toBe(true);
+      expect(messagesOfType(out, "info").some((line) => line.includes("Auto-assigned"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("prompts for runtime and size when neither is given", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      promptSelectResponses: ["python", "4gb"],
+    });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api") }));
+
+      expect(out.promptSelectCalls.map((call) => call.message)).toEqual([
+        "Which runtime should this worker use?",
+        "Which instance size should this worker use?",
+      ]);
+      expect(repo.config()).toContain('runtime = "python"');
+      expect(repo.config()).toContain('size = "4gb"');
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "main.py"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("falls back to the defaults without prompting when not interactive", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir, format: "json" });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api") }));
+
+      expect(out.promptSelectCalls).toHaveLength(0);
+      expect(repo.config()).toContain('runtime = "deno"');
+      expect(repo.config()).toContain('size = "2gb"');
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("reuses an existing config entry instead of re-asking", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(
+        flags({ name: Option.some("api"), runtime: Option.some("bun"), size: Option.some("4gb") }),
+      );
+      // The second run gives no runtime or size at all: the recorded ones answer for it.
+      yield* workersNew(flags({ name: Option.some("api"), force: true }));
+
+      expect(out.promptSelectCalls).toHaveLength(0);
+      expect(repo.config()).toContain('runtime = "bun"');
+      expect(repo.config()).toContain('size = "4gb"');
+      expect(
+        messagesOfType(out, "info").some((line) => line.includes("Reusing the existing")),
+      ).toBe(true);
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "index.ts"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("records a --source worker relative to the project root", () => {
+    const repo = project();
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(
+        flags({
+          name: Option.some("api"),
+          runtime: Option.some("node"),
+          source: Option.some("packages/api"),
+        }),
+      );
+
+      expect(existsSync(join(repo.dir, "packages", "api", "index.js"))).toBe(true);
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api"))).toBe(false);
+      expect(repo.config()).toContain('source = "packages/api"');
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("refuses a --source that --force would delete outside the worker", () => {
+    const repo = project({ "README.md": "keep me", "src/app.ts": "keep me too" });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      for (const source of [".", "..", "supabase", "supabase/functions"]) {
+        const error = yield* workersNew(
+          flags({
+            name: Option.some("api"),
+            runtime: Option.some("node"),
+            source: Option.some(source),
+            force: true,
+          }),
+        ).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(InvalidWorkerSourceError);
+      }
+
+      // Nothing was removed: --force never reached a directory it should not own.
+      expect(existsSync(join(repo.dir, "README.md"))).toBe(true);
+      expect(existsSync(join(repo.dir, "src", "app.ts"))).toBe(true);
+      expect(repo.config()).toContain("project_id");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("does not claim to reuse an entry that has nothing recorded", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\n`,
+    });
+    const { layer, out } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api"), runtime: Option.some("node") }));
+
+      expect(messagesOfType(out, "info").some((line) => line.includes("Reusing"))).toBe(false);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("honours [workers] root", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers]\nroot = "services"\n`,
+    });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api"), runtime: Option.some("node") }));
+
+      expect(existsSync(join(repo.dir, "supabase", "services", "api", "index.js"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("scaffolds in a directory that has no Supabase project yet", () => {
+    const created = makeWorkersProject();
+    const { layer } = setupWorkers({ cwd: created.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(flags({ name: Option.some("api"), runtime: Option.some("node") }));
+
+      expect(existsSync(join(created.dir, "supabase", "workers", "api", "index.js"))).toBe(true);
+      expect(readFileSync(join(created.dir, "supabase", "config.toml"), "utf8")).toBe(
+        `[workers.api]\nruntime = "node"\nsize = "2gb"\n`,
+      );
+    }).pipe(
+      Effect.provide(layer),
+      Effect.ensuring(Effect.sync(() => rmSync(created.dir, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("refuses a non-empty destination unless --force is given", () => {
+    const repo = project({ "supabase/workers/api/leftover.txt": "old" });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const error = yield* workersNew(
+        flags({ name: Option.some("api"), runtime: Option.some("node") }),
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerDirectoryExistsError);
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "leftover.txt"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("replaces the destination wholesale with --force", () => {
+    const repo = project({ "supabase/workers/api/leftover.txt": "old" });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      yield* workersNew(
+        flags({ name: Option.some("api"), runtime: Option.some("node"), force: true }),
+      );
+
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "leftover.txt"))).toBe(false);
+      expect(existsSync(join(repo.dir, "supabase", "workers", "api", "index.js"))).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("rejects a name that could not become a hostname", () => {
+    const repo = project();
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const error = yield* workersNew(flags({ name: Option.some("My_Worker") })).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(InvalidWorkerNameError);
+      expect(existsSync(join(repo.dir, "supabase", "workers"))).toBe(false);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("rejects a config.toml that records an unknown runtime or size", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "rust"\n`,
+    });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const runtimeError = yield* workersNew(flags({ name: Option.some("api") })).pipe(Effect.flip);
+      expect(runtimeError).toBeInstanceOf(UnknownWorkerRuntimeError);
+      expect(existsSync(join(repo.dir, "supabase", "workers"))).toBe(false);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("rejects a config.toml that records an unknown size", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsize = "64gb"\n`,
+    });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const sizeError = yield* workersNew(flags({ name: Option.some("api") })).pipe(Effect.flip);
+      expect(sizeError).toBeInstanceOf(UnknownWorkerSizeError);
+      expect(existsSync(join(repo.dir, "supabase", "workers"))).toBe(false);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("refuses [workers] root pointed at a directory the CLI owns", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers]\nroot = "functions"\n`,
+    });
+    const { layer } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const error = yield* workersNew(
+        flags({ name: Option.some("api"), runtime: Option.some("node") }),
+      ).pipe(Effect.flip);
+
+      expect(error._tag).toBe("InvalidWorkersRootError");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+});

--- a/apps/cli/src/next/commands/workers/push/push.command.ts
+++ b/apps/cli/src/next/commands/workers/push/push.command.ts
@@ -1,0 +1,72 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { credentialsLayer } from "../../../auth/credentials.layer.ts";
+import { platformApiLayer } from "../../../auth/platform-api.layer.ts";
+import { projectLinkStateLayer } from "../../../config/project-link-state.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { workersPush } from "./push.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(
+    Argument.withDescription("Worker to deploy. Inferred when run from inside its directory."),
+    Argument.optional,
+  ),
+  instances: Flag.integer("instances").pipe(
+    Flag.withDescription("Number of instances to run."),
+    Flag.withDefault(1),
+  ),
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref of the Supabase project."),
+    Flag.optional,
+  ),
+} as const;
+
+export type WorkersPushFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+/**
+ * The build context is PUT straight at a presigned URL, so this command needs a
+ * plain HTTP client of its own alongside the authenticated Management API
+ * client — the bytes never pass through `api.supabase.com`.
+ */
+const workersPushRuntimeLayer = (commandPath: ReadonlyArray<string>) =>
+  Layer.mergeAll(
+    platformApiLayer.pipe(Layer.provide(credentialsLayer)),
+    projectLinkStateLayer,
+    FetchHttpClient.layer,
+    commandRuntimeLayer(commandPath),
+  );
+
+const description =
+  "Build and deploy a worker into the linked Supabase project. Reads its runtime, size and source directory from supabase/config.toml.";
+
+const examples = [
+  {
+    command: "supabase workers push api",
+    description: "Deploy supabase/workers/api to the linked project",
+  },
+  {
+    command: "supabase workers push",
+    description: "Deploy the worker whose directory you are inside",
+  },
+  {
+    command: "supabase workers push api --instances 3",
+    description: "Deploy with three instances",
+  },
+] as const;
+
+export const workersPushCommand = Command.make("push", config).pipe(
+  Command.withAlias("deploy"),
+  Command.withDescription(description),
+  Command.withShortDescription("Build and deploy a worker"),
+  Command.withExamples([...examples]),
+  Command.withHandler((flags) =>
+    workersPush(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(workersPushRuntimeLayer(["workers", "push"])),
+  Command.provide(BunServices.layer),
+);

--- a/apps/cli/src/next/commands/workers/push/push.handler.ts
+++ b/apps/cli/src/next/commands/workers/push/push.handler.ts
@@ -1,0 +1,244 @@
+import { Effect, FileSystem, type Schedule } from "effect";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { PlatformApi } from "../../../auth/platform-api.service.ts";
+import { CliConfig } from "../../../config/cli-config.service.ts";
+import { classifyWorkerDir } from "../../../../shared/workers/worker-classify.ts";
+import { formatBytes, packageWorkerDirectory } from "../../../../shared/workers/worker-package.ts";
+import { displayPath } from "../../../../shared/workers/worker-paths.ts";
+import {
+  apiSizeFor,
+  DEFAULT_WORKER_SIZE,
+  exposureFor,
+  formatApiSize,
+  parseWorkerRuntime,
+  parseWorkerSize,
+  WORKER_RUNTIMES,
+  WORKER_SIZES,
+} from "../../../../shared/workers/worker-runtimes.ts";
+import { workerUrl } from "../../../../shared/workers/worker-url.ts";
+import {
+  awaitWorkerBuild,
+  createWorkerUpload,
+  deployWorker,
+  uploadBuildContext,
+  type WorkerDeploySpec,
+} from "../../../../shared/workers/workers-api.ts";
+import {
+  UnknownWorkerRuntimeError,
+  UnknownWorkerSizeError,
+  WorkerBuildFailedError,
+  WorkerSourceMissingError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
+import { describeWorker, loadWorkersProject, resolveWorkerName } from "../workers.shared.ts";
+import type { WorkersPushFlags } from "./push.command.ts";
+
+/**
+ * `supabase workers push [name]` — build (when there is code to build) and
+ * deploy the worker into the linked project. Registered under `deploy` as an
+ * alias, for anyone reaching for the `supabase functions` verb out of habit.
+ *
+ * The runtime, size and source directory come from `[workers.<name>]` in
+ * `supabase/config.toml`. A directory pushed without ever running `new` gets
+ * its runtime guessed from marker files instead — reported, with a nudge to pin
+ * it down rather than re-guess on every push.
+ *
+ * A `dockerfile` worker is tarred and uploaded, and the build happens
+ * server-side from that context, never on your machine. A catalog runtime with
+ * code takes the same path, with the base image and a copy synthesized in place
+ * of your Dockerfile. Only `sandbox` skips packaging entirely and runs a
+ * pre-built image, so it has no URL.
+ */
+
+const resolveRuntime = Effect.fnUntraced(function* (options: {
+  readonly name: string;
+  readonly recorded: string | undefined;
+  readonly sourceDir: string;
+}) {
+  if (options.recorded !== undefined) {
+    const recorded = parseWorkerRuntime(options.recorded);
+    if (recorded === undefined) {
+      return yield* Effect.fail(
+        new UnknownWorkerRuntimeError({
+          detail: `supabase/config.toml records an unknown runtime "${options.recorded}" for "${options.name}".`,
+          suggestion: `Set [workers.${options.name}] runtime to one of: ${WORKER_RUNTIMES.join(", ")}.`,
+        }),
+      );
+    }
+    return recorded;
+  }
+
+  const output = yield* Output;
+  const classified = yield* classifyWorkerDir(options.sourceDir);
+  yield* output.warn(
+    `No runtime configured for "${options.name}" — guessed ${classified.runtime} (${classified.reason}). ` +
+      `Pin it down by adding [workers.${options.name}] runtime = "${classified.runtime}" to supabase/config.toml.`,
+  );
+  return classified.runtime;
+});
+
+const resolveSize = Effect.fnUntraced(function* (options: {
+  readonly name: string;
+  readonly recorded: string | undefined;
+}) {
+  if (options.recorded === undefined) {
+    return DEFAULT_WORKER_SIZE;
+  }
+  const recorded = parseWorkerSize(options.recorded);
+  if (recorded === undefined) {
+    return yield* Effect.fail(
+      new UnknownWorkerSizeError({
+        detail: `supabase/config.toml records an unknown size "${options.recorded}" for "${options.name}".`,
+        suggestion: `Set [workers.${options.name}] size to one of: ${WORKER_SIZES.join(", ")}.`,
+      }),
+    );
+  }
+  return recorded;
+});
+
+export const workersPush = Effect.fn("workers.push")(function* (
+  flags: WorkersPushFlags,
+  options: { readonly pollSchedule?: Schedule.Schedule<unknown> } = {},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const output = yield* Output;
+  const api = yield* PlatformApi;
+  const cliConfig = yield* CliConfig;
+
+  yield* output.intro("Deploy worker");
+
+  const project = yield* loadWorkersProject();
+  const name = yield* resolveWorkerName({ project, name: flags.name, command: "push" });
+  const worker = describeWorker(project, name);
+  const projectRef = yield* resolveProjectRef(flags.projectRef);
+
+  const runtime = yield* resolveRuntime({
+    name,
+    recorded: worker.entry?.runtime,
+    sourceDir: worker.sourceDir,
+  });
+
+  // A bare sandbox has no code to package, so it is the one runtime that does
+  // not need a source directory on disk at all.
+  const needsContext = runtime !== "sandbox";
+  const sourceDisplay = displayPath(project.cwd, worker.sourceDir);
+
+  if (needsContext) {
+    const stat = yield* fs.stat(worker.sourceDir).pipe(Effect.option);
+    if (stat._tag === "None" || stat.value.type !== "Directory") {
+      return yield* Effect.fail(
+        new WorkerSourceMissingError({
+          detail: `There is no worker source at ${sourceDisplay}.`,
+          suggestion: `Scaffold it with \`supabase workers new ${name}\`.`,
+        }),
+      );
+    }
+    // An empty directory packages and deploys perfectly happily, producing an
+    // image with nothing in it — a success message for a worker that cannot
+    // serve anything. Refuse before uploading rather than after.
+    const contents = yield* fs.readDirectory(worker.sourceDir).pipe(Effect.orElseSucceed(() => []));
+    if (contents.length === 0) {
+      return yield* Effect.fail(
+        new WorkerSourceMissingError({
+          detail: `${sourceDisplay} is empty, so there is nothing to deploy.`,
+          suggestion: `Add your code there, or re-scaffold it with \`supabase workers new ${name} --force\`.`,
+        }),
+      );
+    }
+  }
+
+  // Size: whatever `new --size` recorded, else the alpha envelope's own
+  // default. Never left unset, because a worker that is actually running always
+  // has some concrete size — and never silently coerced, because a size the CLI
+  // does not recognize is a config mistake worth naming.
+  const size = yield* resolveSize({ name, recorded: worker.entry?.size });
+
+  let contextUploadId: string | undefined;
+  if (needsContext) {
+    const packaging = yield* output.task(`Packaging ${sourceDisplay}...`);
+    const packaged = yield* packageWorkerDirectory(worker.sourceDir).pipe(
+      Effect.tapError(() => packaging.fail()),
+    );
+    yield* packaging.succeed(
+      `Packaged ${sourceDisplay} (${packaged.fileCount} files, ${formatBytes(
+        packaged.archive.length,
+      )}).`,
+    );
+
+    const uploading = yield* output.task("Uploading the build context...");
+    const slot = yield* createWorkerUpload(api, projectRef, name).pipe(
+      Effect.tapError(() => uploading.fail()),
+    );
+    yield* uploadBuildContext(slot, packaged.archive).pipe(Effect.tapError(() => uploading.fail()));
+    yield* uploading.succeed("Uploaded the build context.");
+    contextUploadId = slot.uploadId;
+  } else {
+    yield* output.info("Bare sandbox — no code is baked in.");
+  }
+
+  const spec: WorkerDeploySpec = {
+    // A plain Dockerfile build has no catalog runtime to name; the uploaded
+    // context carries its own Dockerfile and is built as-is.
+    ...(runtime === "dockerfile" ? {} : { runtime }),
+    size: apiSizeFor(size),
+    exposure: exposureFor(runtime),
+    instances: flags.instances,
+  };
+
+  const deploying = yield* output.task(`Deploying "${name}"...`);
+  yield* deployWorker(api, projectRef, name, { spec, contextUploadId }).pipe(
+    Effect.tapError(() => deploying.fail()),
+  );
+
+  const settled = yield* awaitWorkerBuild(api, projectRef, name, {
+    schedule: options.pollSchedule,
+    onPoll: (polled) =>
+      polled.buildState === "building" ? deploying.message(`Building "${name}"...`) : Effect.void,
+  }).pipe(Effect.tapError(() => deploying.fail()));
+
+  if (settled.buildState === "failed") {
+    yield* deploying.fail(`Deploying "${name}" failed.`);
+    return yield* Effect.fail(
+      new WorkerBuildFailedError({
+        detail: `The build for "${name}" failed${
+          settled.stateReason === undefined ? "" : `: ${settled.stateReason}`
+        }.`,
+        suggestion: `Fix the issue, then re-run \`supabase workers push ${name}\`.`,
+      }),
+    );
+  }
+
+  yield* deploying.succeed(`Deployed "${name}".`);
+
+  const url =
+    settled.spec.exposure === "public"
+      ? workerUrl(projectRef, cliConfig.projectHost, name)
+      : undefined;
+
+  yield* output.success("Deployed worker.", {
+    worker_name: name,
+    project_ref: projectRef,
+    runtime,
+    size: settled.spec.size,
+    exposure: settled.spec.exposure,
+    instances: settled.spec.instances,
+    image_version: settled.imageVersion,
+    build_state: settled.buildState,
+    ...(url === undefined ? {} : { url }),
+  });
+
+  if (output.format === "text") {
+    yield* output.info(`runtime   ${runtime}`);
+    yield* output.info(`size      ${formatApiSize(settled.spec.size)}`);
+    if (settled.imageVersion !== undefined) {
+      yield* output.info(`image     ${settled.imageVersion}`);
+    }
+    if (url === undefined) {
+      yield* output.info("access    private (no HTTP endpoint)");
+    } else {
+      yield* output.info(`url       ${url}`);
+    }
+  }
+
+  yield* output.outro(`Next: supabase workers status ${name}`);
+});

--- a/apps/cli/src/next/commands/workers/push/push.integration.test.ts
+++ b/apps/cli/src/next/commands/workers/push/push.integration.test.ts
@@ -1,0 +1,498 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Schedule } from "effect";
+import {
+  makeWorkersProject,
+  messagesOfType,
+  setupWorkers,
+  workerResource,
+  workersRoute,
+  WORKERS_PROJECT_REF,
+  type WorkersHttpRoutes,
+} from "../../../../../tests/helpers/workers.ts";
+import { ProjectNotLinkedError } from "../../../config/project-link-state.service.ts";
+import {
+  MissingWorkerNameError,
+  WorkerBuildFailedError,
+  WorkersUnavailableError,
+  WorkerSourceMissingError,
+  WorkerUploadFailedError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { workersPush } from "./push.handler.ts";
+import type { WorkersPushFlags } from "./push.command.ts";
+
+const UPLOAD_URL = "https://storage.example/deploy-context/api.tar.gz?signed";
+const UPLOAD_ID = "cafe0000000000000000000000000000";
+
+/** Polls run with no delay so a build sequence resolves at test speed. */
+const IMMEDIATE = Schedule.recurs(20);
+
+const uploadSlot = {
+  data: {
+    type: "project_worker_upload",
+    id: UPLOAD_ID,
+    attributes: { url: UPLOAD_URL, method: "PUT", expires_at: "2026-08-12T00:15:00Z" },
+  },
+};
+
+function flags(overrides: Partial<WorkersPushFlags> = {}): WorkersPushFlags {
+  return {
+    name: Option.some("api"),
+    instances: 1,
+    projectRef: Option.none(),
+    ...overrides,
+  };
+}
+
+function project(files: Readonly<Record<string, string>> = {}) {
+  const created = makeWorkersProject({
+    "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsize = "2gb"\n`,
+    "supabase/workers/api/index.js": "export default { fetch: () => new Response('ok') };\n",
+    ...files,
+  });
+  return {
+    dir: created.dir,
+    cleanup: () => rmSync(created.dir, { recursive: true, force: true }),
+  };
+}
+
+function routes(overrides: WorkersHttpRoutes = {}): WorkersHttpRoutes {
+  return {
+    [`POST ${workersRoute("/api/uploads")}`]: { status: 201, body: uploadSlot },
+    "PUT /deploy-context/api.tar.gz": { status: 200 },
+    [`POST ${workersRoute("/api/deploy")}`]: {
+      status: 202,
+      body: { data: workerResource({ name: "api", runtime: "node", buildState: "building" }) },
+    },
+    [`GET ${workersRoute("/api")}`]: {
+      status: 200,
+      body: {
+        data: workerResource({
+          name: "api",
+          runtime: "node",
+          buildState: "active",
+          imageVersion: "v1",
+        }),
+      },
+    },
+    ...overrides,
+  };
+}
+
+function push(flagOverrides: Partial<WorkersPushFlags> = {}) {
+  return workersPush(flags(flagOverrides), { pollSchedule: IMMEDIATE });
+}
+
+describe("workers push", () => {
+  it.live("packages, uploads, deploys and waits for the build to settle", () => {
+    const repo = project();
+    const { layer, out, http } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      expect(http.routeKeys).toEqual([
+        `POST ${workersRoute("/api/uploads")}`,
+        "PUT /deploy-context/api.tar.gz",
+        `POST ${workersRoute("/api/deploy")}`,
+        `GET ${workersRoute("/api")}`,
+      ]);
+
+      const deploy = http.requests.find((request) => request.url.endsWith("/deploy"));
+      expect(JSON.parse(deploy?.body ?? "{}")).toEqual({
+        data: {
+          type: "project_worker",
+          attributes: {
+            spec: {
+              runtime: "node",
+              size: "2gb-1vcpu",
+              exposure: "public",
+              instances: 1,
+            },
+            context_upload_id: UPLOAD_ID,
+          },
+        },
+      });
+
+      const upload = http.requests.find((request) => request.method === "PUT");
+      expect(upload?.byteLength).toBeGreaterThan(0);
+
+      expect(messagesOfType(out, "success")).toContain("Deployed worker.");
+      expect(messagesOfType(out, "info")).toContain(
+        `url       https://${WORKERS_PROJECT_REF}.supabase.co/workers/v1/api`,
+      );
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("omits the runtime for a Dockerfile worker and builds from the uploaded context", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "dockerfile"\n`,
+      "supabase/workers/api/Dockerfile": "FROM node:24-alpine\nEXPOSE 8080\n",
+    });
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`GET ${workersRoute("/api")}`]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", buildState: "active" }) },
+        },
+      }),
+    });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      const deploy = http.requests.find((request) => request.url.endsWith("/deploy"));
+      const attributes = JSON.parse(deploy?.body ?? "{}").data.attributes;
+      expect(attributes.spec).toEqual({
+        size: "2gb-1vcpu",
+        exposure: "public",
+        instances: 1,
+      });
+      expect(attributes.context_upload_id).toBe(UPLOAD_ID);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("skips packaging entirely for a bare sandbox and reports no URL", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.box]\nruntime = "sandbox"\n`,
+    });
+    const { layer, out, http } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [`POST ${workersRoute("/box/deploy")}`]: {
+          status: 202,
+          body: {
+            data: workerResource({
+              name: "box",
+              runtime: "sandbox",
+              exposure: "private",
+              buildState: "building",
+            }),
+          },
+        },
+        [`GET ${workersRoute("/box")}`]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "box",
+              runtime: "sandbox",
+              exposure: "private",
+              buildState: "active",
+            }),
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* push({ name: Option.some("box") });
+
+      expect(http.routeKeys).toEqual([
+        `POST ${workersRoute("/box/deploy")}`,
+        `GET ${workersRoute("/box")}`,
+      ]);
+
+      const deploy = http.requests[0];
+      expect(JSON.parse(deploy?.body ?? "{}").data.attributes).toEqual({
+        spec: {
+          runtime: "sandbox",
+          size: "2gb-1vcpu",
+          exposure: "private",
+          instances: 1,
+        },
+      });
+      expect(messagesOfType(out, "info")).toContain("access    private (no HTTP endpoint)");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("guesses the runtime for a directory with no config entry and says so", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n`,
+      "supabase/workers/api/package.json": "{}\n",
+    });
+    const { layer, out, http } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      expect(
+        messagesOfType(out, "warn").some(
+          (line) => line.includes("guessed node") && line.includes("found package.json"),
+        ),
+      ).toBe(true);
+
+      const deploy = http.requests.find((request) => request.url.endsWith("/deploy"));
+      expect(JSON.parse(deploy?.body ?? "{}").data.attributes.spec.runtime).toBe("node");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("sends the recorded size and the requested instance count", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsize = "4gb"\n`,
+    });
+    const { layer, http } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      yield* push({ instances: 3 });
+
+      const deploy = http.requests.find((request) => request.url.endsWith("/deploy"));
+      expect(JSON.parse(deploy?.body ?? "{}").data.attributes.spec).toEqual({
+        runtime: "node",
+        size: "4gb-2vcpu",
+        exposure: "public",
+        instances: 3,
+      });
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("polls until the build leaves `building`", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`GET ${workersRoute("/api")}`]: [
+          {
+            status: 200,
+            body: { data: workerResource({ name: "api", buildState: "building" }) },
+          },
+          {
+            status: 200,
+            body: { data: workerResource({ name: "api", buildState: "building" }) },
+          },
+          {
+            status: 200,
+            body: {
+              data: workerResource({ name: "api", buildState: "active", imageVersion: "v2" }),
+            },
+          },
+        ],
+      }),
+    });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      const polls = http.routeKeys.filter((key) => key === `GET ${workersRoute("/api")}`);
+      expect(polls).toHaveLength(3);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("fails with the build's own reason when the build fails", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`GET ${workersRoute("/api")}`]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "api",
+              buildState: "failed",
+              stateReason: "error building image: exit status 1",
+            }),
+          },
+        },
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerBuildFailedError);
+      expect((error as WorkerBuildFailedError).detail).toContain("error building image");
+      expect((error as WorkerBuildFailedError).suggestion).toContain("supabase workers push api");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("stops waiting on a build that never settles, and says where to look", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`GET ${workersRoute("/api")}`]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", buildState: "building" }) },
+        },
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersPush(flags(), { pollSchedule: Schedule.recurs(2) }).pipe(
+        Effect.flip,
+      );
+
+      expect(error._tag).toBe("WorkerBuildTimeoutError");
+      expect((error as { suggestion: string }).suggestion).toContain("supabase workers status api");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("fails before deploying when the presigned upload is rejected", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({ "PUT /deploy-context/api.tar.gz": { status: 403, body: "expired" } }),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerUploadFailedError);
+      expect(http.routeKeys).not.toContain(`POST ${workersRoute("/api/deploy")}`);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("reports a project outside the alpha as unavailable", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`POST ${workersRoute("/api/uploads")}`]: {
+          status: 404,
+          body: { message: "Workers are not available for this project" },
+        },
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkersUnavailableError);
+      expect((error as WorkersUnavailableError).suggestion).toContain("private alpha");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("fails when the worker has no source on disk", () => {
+    const repo = project({});
+    rmSync(join(repo.dir, "supabase", "workers", "api"), { recursive: true, force: true });
+    const { layer, http } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerSourceMissingError);
+      expect((error as WorkerSourceMissingError).suggestion).toContain("supabase workers new api");
+      expect(http.requests).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("refuses an empty source directory instead of deploying nothing", () => {
+    const repo = project({});
+    rmSync(join(repo.dir, "supabase", "workers", "api", "index.js"), { force: true });
+    const { layer, http } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerSourceMissingError);
+      expect((error as WorkerSourceMissingError).detail).toContain("is empty");
+      expect(http.requests).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("rides out a transient failure while polling the build", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: repo.dir,
+      routes: routes({
+        [`GET ${workersRoute("/api")}`]: [
+          { status: 500, body: { message: "blip" } },
+          {
+            status: 200,
+            body: { data: workerResource({ name: "api", buildState: "active" }) },
+          },
+        ],
+      }),
+    });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      // The blip was retried rather than aborting a deploy already in flight.
+      expect(
+        http.routeKeys.filter((key) => key === `GET ${workersRoute("/api")}`).length,
+      ).toBeGreaterThan(1);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("infers the worker from the current directory", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: join(repo.dir, "supabase", "workers", "api"),
+      routes: routes(),
+    });
+
+    return Effect.gen(function* () {
+      yield* push({ name: Option.none() });
+
+      expect(http.routeKeys).toContain(`POST ${workersRoute("/api/deploy")}`);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("asks for a name when the current directory is not a worker", () => {
+    const repo = project();
+    const { layer } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      const error = yield* push({ name: Option.none() }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(MissingWorkerNameError);
+      expect((error as MissingWorkerNameError).suggestion).toContain(
+        "supabase workers push <name>",
+      );
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("requires a linked project or an explicit --project-ref", () => {
+    const repo = project();
+    const { layer } = setupWorkers({ cwd: repo.dir, linked: false, routes: routes() });
+
+    return Effect.gen(function* () {
+      const error = yield* push().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ProjectNotLinkedError);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("packages a --source worker from where its code actually lives", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsource = "packages/api"\n`,
+      "packages/api/index.js": "export default {};\n",
+    });
+    rmSync(join(repo.dir, "supabase", "workers"), { recursive: true, force: true });
+    const { layer, out } = setupWorkers({ cwd: repo.dir, routes: routes() });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      expect(
+        messagesOfType(out, "success").some((line) => line.includes(join("packages", "api"))),
+      ).toBe(true);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("emits a structured result in json mode", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({ cwd: repo.dir, format: "json", routes: routes() });
+
+    return Effect.gen(function* () {
+      yield* push();
+
+      const success = out.messages.findLast(
+        (message) => message.type === "success" && message.data !== undefined,
+      );
+      expect(success?.data).toMatchObject({
+        worker_name: "api",
+        project_ref: WORKERS_PROJECT_REF,
+        runtime: "node",
+        size: "2gb-1vcpu",
+        exposure: "public",
+        instances: 1,
+        build_state: "active",
+        image_version: "v1",
+        url: `https://${WORKERS_PROJECT_REF}.supabase.co/workers/v1/api`,
+      });
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+});

--- a/apps/cli/src/next/commands/workers/status/status.command.ts
+++ b/apps/cli/src/next/commands/workers/status/status.command.ts
@@ -1,0 +1,52 @@
+import { BunServices } from "@effect/platform-bun";
+import { Layer } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import type * as CliCommand from "effect/unstable/cli/Command";
+import { credentialsLayer } from "../../../auth/credentials.layer.ts";
+import { platformApiLayer } from "../../../auth/platform-api.layer.ts";
+import { projectLinkStateLayer } from "../../../config/project-link-state.layer.ts";
+import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { commandRuntimeLayer } from "../../../../shared/runtime/command-runtime.layer.ts";
+import { withCommandInstrumentation } from "../../../../shared/telemetry/command-instrumentation.ts";
+import { workersStatus } from "./status.handler.ts";
+
+const config = {
+  name: Argument.string("name").pipe(
+    Argument.withDescription("Worker to inspect. Inferred when run from inside its directory."),
+    Argument.optional,
+  ),
+  projectRef: Flag.string("project-ref").pipe(
+    Flag.withDescription("Project ref of the Supabase project."),
+    Flag.optional,
+  ),
+} as const;
+
+export type WorkersStatusFlags = CliCommand.Command.Config.Infer<typeof config>;
+
+export const workersStatusCommand = Command.make("status", config).pipe(
+  Command.withDescription(
+    "Show one worker in detail: build state, size, access, image, live instance tally and source directory.",
+  ),
+  Command.withShortDescription("Show a worker in detail"),
+  Command.withExamples([
+    {
+      command: "supabase workers status api",
+      description: "Inspect a specific worker",
+    },
+    {
+      command: "supabase workers status",
+      description: "Inspect the worker whose directory you are inside",
+    },
+  ]),
+  Command.withHandler((flags) =>
+    workersStatus(flags).pipe(withCommandInstrumentation(), withJsonErrorHandling),
+  ),
+  Command.provide(
+    Layer.mergeAll(
+      platformApiLayer.pipe(Layer.provide(credentialsLayer)),
+      projectLinkStateLayer,
+      commandRuntimeLayer(["workers", "status"]),
+    ),
+  ),
+  Command.provide(BunServices.layer),
+);

--- a/apps/cli/src/next/commands/workers/status/status.handler.ts
+++ b/apps/cli/src/next/commands/workers/status/status.handler.ts
@@ -1,0 +1,107 @@
+import { Effect, Option } from "effect";
+import { Output } from "../../../../shared/output/output.service.ts";
+import { PlatformApi } from "../../../auth/platform-api.service.ts";
+import { CliConfig } from "../../../config/cli-config.service.ts";
+import { displayPath } from "../../../../shared/workers/worker-paths.ts";
+import { formatApiSize } from "../../../../shared/workers/worker-runtimes.ts";
+import { workerUrl } from "../../../../shared/workers/worker-url.ts";
+import { getWorker } from "../../../../shared/workers/workers-api.ts";
+import { WorkerNotDeployedError } from "../../../../shared/workers/workers.errors.ts";
+import { resolveProjectRef } from "../../../config/resolve-project-ref.ts";
+import { describeWorker, loadWorkersProject, resolveWorkerName } from "../workers.shared.ts";
+import type { WorkersStatusFlags } from "./status.command.ts";
+
+/**
+ * `supabase workers status [name]` — everything known about one worker.
+ *
+ * `list`'s companion: the size, image and URL a `push` printed once and then
+ * scrolled away, plus the live instance tally, which is the only place it is
+ * available — the list endpoint stays free of per-worker backend calls.
+ */
+export const workersStatus = Effect.fn("workers.status")(function* (flags: WorkersStatusFlags) {
+  const output = yield* Output;
+  const api = yield* PlatformApi;
+  const cliConfig = yield* CliConfig;
+
+  const project = yield* loadWorkersProject();
+  const name = yield* resolveWorkerName({ project, name: flags.name, command: "status" });
+  const worker = describeWorker(project, name);
+  const projectRef = yield* resolveProjectRef(flags.projectRef);
+
+  const fetching = yield* output.task(`Reading "${name}"...`);
+  const found = yield* getWorker(api, projectRef, name).pipe(
+    Effect.tapError(() => fetching.fail()),
+  );
+  yield* fetching.clear();
+
+  if (Option.isNone(found)) {
+    return yield* Effect.fail(
+      new WorkerNotDeployedError({
+        detail: `Nothing is deployed for "${name}" in project ${projectRef}.`,
+        suggestion: `Deploy it with \`supabase workers push ${name}\`.`,
+      }),
+    );
+  }
+
+  const record = found.value;
+  const url =
+    record.spec.exposure === "public"
+      ? workerUrl(projectRef, cliConfig.projectHost, name)
+      : undefined;
+  const sourceDisplay = displayPath(project.cwd, worker.sourceDir);
+
+  yield* output.success("Read worker.", {
+    worker_name: name,
+    project_ref: projectRef,
+    runtime: record.spec.runtime ?? "dockerfile",
+    size: record.spec.size,
+    exposure: record.spec.exposure,
+    build_state: record.buildState,
+    state_reason: record.stateReason,
+    image_version: record.imageVersion,
+    deleting: record.deleting,
+    declared_instances: record.spec.instances,
+    instances: record.instances,
+    instances_error: record.instancesError,
+    source: sourceDisplay,
+    ...(url === undefined ? {} : { url }),
+  });
+
+  if (output.format !== "text") {
+    return;
+  }
+
+  yield* output.info(`state     ${record.deleting === true ? "deleting" : record.buildState}`);
+  if (record.stateReason !== undefined) {
+    yield* output.info(`reason    ${record.stateReason}`);
+  }
+  // The deployed spec is the truth here, not `config.toml`: a worker deployed
+  // from its own Dockerfile carries no `spec.runtime`, and letting a stale local
+  // entry answer instead would report a runtime that is not what is running.
+  yield* output.info(`runtime   ${record.spec.runtime ?? "dockerfile"}`);
+  yield* output.info(`size      ${formatApiSize(record.spec.size)}`);
+  yield* output.info(`access    ${record.spec.exposure}`);
+  yield* output.info(`project   ${projectRef}`);
+  if (record.imageVersion !== undefined) {
+    yield* output.info(`image     ${record.imageVersion}`);
+  }
+
+  if (record.instances !== undefined) {
+    yield* output.info(
+      `instances ${record.instances.ready}/${record.spec.instances} ready · ${record.instances.live} live · ${record.instances.stale} stale`,
+    );
+  } else if (record.instancesError !== undefined) {
+    yield* output.warn(`Instance counts could not be read: ${record.instancesError}`);
+  } else {
+    yield* output.info(`instances ${record.spec.instances} declared`);
+  }
+
+  if (url !== undefined) {
+    yield* output.info(`url       ${url}`);
+  }
+  yield* output.info(`source    ${sourceDisplay}`);
+
+  if (record.buildState === "failed") {
+    yield* output.outro(`Try again: supabase workers push ${name}`);
+  }
+});

--- a/apps/cli/src/next/commands/workers/status/status.integration.test.ts
+++ b/apps/cli/src/next/commands/workers/status/status.integration.test.ts
@@ -1,0 +1,304 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import {
+  makeWorkersProject,
+  messagesOfType,
+  setupWorkers,
+  workerResource,
+  workersRoute,
+  WORKERS_PROJECT_REF,
+} from "../../../../../tests/helpers/workers.ts";
+import {
+  MissingWorkerNameError,
+  WorkerNotDeployedError,
+} from "../../../../shared/workers/workers.errors.ts";
+import { workersStatus } from "./status.handler.ts";
+
+const CONFIG = `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsize = "2gb"\n`;
+
+function project(files: Readonly<Record<string, string>> = {}) {
+  const created = makeWorkersProject({
+    "supabase/config.toml": CONFIG,
+    "supabase/workers/api/index.js": "export default {};\n",
+    ...files,
+  });
+  return {
+    dir: created.dir,
+    cleanup: () => rmSync(created.dir, { recursive: true, force: true }),
+  };
+}
+
+const getRoute = `GET ${workersRoute("/api")}`;
+
+describe("workers status", () => {
+  it.live("reports the deployment facts and the live instance tally", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "api",
+              runtime: "node",
+              imageVersion: "v3",
+              instances: 3,
+              instanceCounts: { declared: 3, live: 3, ready: 2, stale: 1 },
+            }),
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      const lines = messagesOfType(out, "info");
+      expect(lines).toContain("state     active");
+      expect(lines).toContain("runtime   node");
+      expect(lines).toContain("size      2gb · 1 vCPU");
+      expect(lines).toContain("access    public");
+      expect(lines).toContain(`project   ${WORKERS_PROJECT_REF}`);
+      expect(lines).toContain("image     v3");
+      expect(lines).toContain("instances 2/3 ready · 3 live · 1 stale");
+      expect(lines).toContain(
+        `url       https://${WORKERS_PROJECT_REF}.supabase.co/workers/v1/api`,
+      );
+      expect(lines).toContain(`source    ${join("supabase", "workers", "api")}`);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("reports the deployed runtime, not a stale config.toml entry", () => {
+    // config.toml says node; the deployment carries no spec.runtime, which the
+    // API only omits for a context-only (Dockerfile) build.
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: { data: workerResource({ name: "api" }) },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain("runtime   dockerfile");
+      expect(messagesOfType(out, "info")).not.toContain("runtime   node");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("falls back to the declared count when no tally came back", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", runtime: "node", instances: 2 }) },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain("instances 2 declared");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("warns rather than lying when the instance read-through failed", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "api",
+              runtime: "node",
+              instancesError: "backend unreachable",
+            }),
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "warn").some((line) => line.includes("backend unreachable"))).toBe(
+        true,
+      );
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("points a failed build at the retry, with the reason", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "api",
+              runtime: "node",
+              buildState: "failed",
+              stateReason: "exit status 1",
+            }),
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain("state     failed");
+      expect(messagesOfType(out, "info")).toContain("reason    exit status 1");
+      expect(messagesOfType(out, "outro")).toContain("Try again: supabase workers push api");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("shows a worker being torn down as deleting", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", runtime: "node", deleting: true }) },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain("state     deleting");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("fails with `not deployed` and points at push", () => {
+    const repo = project();
+    const { layer } = setupWorkers({
+      cwd: repo.dir,
+      routes: { [getRoute]: { status: 404, body: { message: "worker not found" } } },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* workersStatus({
+        name: Option.some("api"),
+        projectRef: Option.none(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(WorkerNotDeployedError);
+      expect((error as WorkerNotDeployedError).suggestion).toContain("supabase workers push api");
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("infers the worker from the current directory", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({
+      cwd: join(repo.dir, "supabase", "workers", "api"),
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", runtime: "node" }) },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.none(), projectRef: Option.none() });
+
+      expect(http.routeKeys).toEqual([getRoute]);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("asks for a name from a directory that is not a worker", () => {
+    const repo = project();
+    const { layer, http } = setupWorkers({ cwd: repo.dir });
+
+    return Effect.gen(function* () {
+      const error = yield* workersStatus({
+        name: Option.none(),
+        projectRef: Option.none(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(MissingWorkerNameError);
+      expect(http.requests).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("reports the worker's source directory even when it lives outside supabase/", () => {
+    const repo = project({
+      "supabase/config.toml": `project_id = "demo"\n\n[workers.api]\nruntime = "node"\nsource = "packages/api"\n`,
+      "packages/api/index.js": "export default {};\n",
+    });
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: { data: workerResource({ name: "api", runtime: "node" }) },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      expect(messagesOfType(out, "info")).toContain(`source    ${join("packages", "api")}`);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+
+  it.live("emits the same facts as structured data in json mode", () => {
+    const repo = project();
+    const { layer, out } = setupWorkers({
+      cwd: repo.dir,
+      format: "json",
+      routes: {
+        [getRoute]: {
+          status: 200,
+          body: {
+            data: workerResource({
+              name: "api",
+              runtime: "node",
+              imageVersion: "v3",
+              instanceCounts: { declared: 1, live: 1, ready: 1, stale: 0 },
+            }),
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      yield* workersStatus({ name: Option.some("api"), projectRef: Option.none() });
+
+      const success = out.messages.findLast(
+        (message) => message.type === "success" && message.data !== undefined,
+      );
+      expect(success?.data).toMatchObject({
+        worker_name: "api",
+        project_ref: WORKERS_PROJECT_REF,
+        runtime: "node",
+        size: "2gb-1vcpu",
+        exposure: "public",
+        build_state: "active",
+        image_version: "v3",
+        declared_instances: 1,
+        instances: { declared: 1, live: 1, ready: 1, stale: 0 },
+      });
+      // The detail lines are text-mode only.
+      expect(messagesOfType(out, "info")).toHaveLength(0);
+    }).pipe(Effect.provide(layer), Effect.ensuring(Effect.sync(repo.cleanup)));
+  });
+});

--- a/apps/cli/src/next/commands/workers/workers.command.ts
+++ b/apps/cli/src/next/commands/workers/workers.command.ts
@@ -1,0 +1,10 @@
+import { Command } from "effect/unstable/cli";
+import { workersNewCommand } from "./new/new.command.ts";
+
+export const workersCommand = Command.make("workers").pipe(
+  Command.withDescription(
+    "Manage Supabase Workers — containers that run your code next to your project, deployed from supabase/workers/<name>/.",
+  ),
+  Command.withShortDescription("Manage Supabase Workers"),
+  Command.withSubcommands([workersNewCommand]),
+);

--- a/apps/cli/src/next/commands/workers/workers.command.ts
+++ b/apps/cli/src/next/commands/workers/workers.command.ts
@@ -1,4 +1,5 @@
 import { Command } from "effect/unstable/cli";
+import { workersDeleteCommand } from "./delete/delete.command.ts";
 import { workersListCommand } from "./list/list.command.ts";
 import { workersNewCommand } from "./new/new.command.ts";
 import { workersPushCommand } from "./push/push.command.ts";
@@ -14,5 +15,6 @@ export const workersCommand = Command.make("workers").pipe(
     workersPushCommand,
     workersListCommand,
     workersStatusCommand,
+    workersDeleteCommand,
   ]),
 );

--- a/apps/cli/src/next/commands/workers/workers.command.ts
+++ b/apps/cli/src/next/commands/workers/workers.command.ts
@@ -1,4 +1,5 @@
 import { Command } from "effect/unstable/cli";
+import { workersListCommand } from "./list/list.command.ts";
 import { workersNewCommand } from "./new/new.command.ts";
 import { workersPushCommand } from "./push/push.command.ts";
 
@@ -7,5 +8,5 @@ export const workersCommand = Command.make("workers").pipe(
     "Manage Supabase Workers — containers that run your code next to your project, deployed from supabase/workers/<name>/.",
   ),
   Command.withShortDescription("Manage Supabase Workers"),
-  Command.withSubcommands([workersNewCommand, workersPushCommand]),
+  Command.withSubcommands([workersNewCommand, workersPushCommand, workersListCommand]),
 );

--- a/apps/cli/src/next/commands/workers/workers.command.ts
+++ b/apps/cli/src/next/commands/workers/workers.command.ts
@@ -2,11 +2,17 @@ import { Command } from "effect/unstable/cli";
 import { workersListCommand } from "./list/list.command.ts";
 import { workersNewCommand } from "./new/new.command.ts";
 import { workersPushCommand } from "./push/push.command.ts";
+import { workersStatusCommand } from "./status/status.command.ts";
 
 export const workersCommand = Command.make("workers").pipe(
   Command.withDescription(
     "Manage Supabase Workers — containers that run your code next to your project, deployed from supabase/workers/<name>/.",
   ),
   Command.withShortDescription("Manage Supabase Workers"),
-  Command.withSubcommands([workersNewCommand, workersPushCommand, workersListCommand]),
+  Command.withSubcommands([
+    workersNewCommand,
+    workersPushCommand,
+    workersListCommand,
+    workersStatusCommand,
+  ]),
 );

--- a/apps/cli/src/next/commands/workers/workers.command.ts
+++ b/apps/cli/src/next/commands/workers/workers.command.ts
@@ -1,10 +1,11 @@
 import { Command } from "effect/unstable/cli";
 import { workersNewCommand } from "./new/new.command.ts";
+import { workersPushCommand } from "./push/push.command.ts";
 
 export const workersCommand = Command.make("workers").pipe(
   Command.withDescription(
     "Manage Supabase Workers — containers that run your code next to your project, deployed from supabase/workers/<name>/.",
   ),
   Command.withShortDescription("Manage Supabase Workers"),
-  Command.withSubcommands([workersNewCommand]),
+  Command.withSubcommands([workersNewCommand, workersPushCommand]),
 );

--- a/apps/cli/src/next/commands/workers/workers.shared.ts
+++ b/apps/cli/src/next/commands/workers/workers.shared.ts
@@ -1,0 +1,134 @@
+import { join } from "node:path";
+import { findProjectPaths, loadProjectConfig } from "@supabase/config";
+import { Effect, Option } from "effect";
+import { RuntimeInfo } from "../../../shared/runtime/runtime-info.service.ts";
+import {
+  readWorkersSection,
+  type WorkerEntry,
+  type WorkersSection,
+} from "../../../shared/workers/worker-config.ts";
+import {
+  displayPath,
+  inferWorkerNameFromCwd,
+  resolveWorkersRoot,
+  workerDir,
+  workersRootDir,
+  workerSourceDir,
+} from "../../../shared/workers/worker-paths.ts";
+import {
+  validateWorkerNameMessage,
+  workerNameRequirement,
+} from "../../../shared/workers/worker-runtimes.ts";
+import {
+  InvalidWorkerNameError,
+  MissingWorkerNameError,
+} from "../../../shared/workers/workers.errors.ts";
+
+/**
+ * What every `supabase workers` command needs before it does anything: where
+ * the project is, what `[workers]` says, and which worker is being acted on.
+ *
+ * The project is found by walking up for `supabase/config.toml`, the same
+ * anchor `supabase functions new` uses — so the commands work from anywhere
+ * inside the project rather than only from its root. A directory with no
+ * project yet falls back to the current one, which is what lets `workers new`
+ * scaffold in a bare directory.
+ */
+
+export interface WorkersProject {
+  readonly cwd: string;
+  readonly projectRoot: string;
+  readonly supabaseDir: string;
+  readonly configPath: string;
+  readonly section: WorkersSection;
+  /** `[workers] root`, validated. */
+  readonly root: string;
+  /** `supabase/<root>/`. */
+  readonly rootDir: string;
+}
+
+export const loadWorkersProject = Effect.fnUntraced(function* () {
+  const runtimeInfo = yield* RuntimeInfo;
+  const paths = yield* findProjectPaths(runtimeInfo.cwd);
+  const projectRoot = paths === null ? runtimeInfo.cwd : paths.projectRoot;
+  const supabaseDir = paths?.supabaseDir ?? join(projectRoot, "supabase");
+  const configPath = paths?.configPath ?? join(supabaseDir, "config.toml");
+
+  const loaded = paths === null ? null : yield* loadProjectConfig(projectRoot);
+  const section = readWorkersSection(loaded?.config.workers);
+  const root = yield* resolveWorkersRoot(section.root);
+
+  return {
+    cwd: runtimeInfo.cwd,
+    projectRoot,
+    supabaseDir,
+    configPath,
+    section,
+    root,
+    rootDir: workersRootDir(projectRoot, root),
+  } satisfies WorkersProject;
+});
+
+export interface ResolvedWorker {
+  readonly name: string;
+  readonly entry: WorkerEntry | undefined;
+  /** The worker's default directory, `supabase/<root>/<name>/`. */
+  readonly defaultDir: string;
+  /** Where its code actually lives, honouring `[workers.<name>] source`. */
+  readonly sourceDir: string;
+}
+
+export function describeWorker(project: WorkersProject, name: string): ResolvedWorker {
+  const entry = project.section.workers[name];
+  const defaultDir = workerDir(project.projectRoot, project.root, name);
+  return {
+    name,
+    entry,
+    defaultDir,
+    sourceDir: workerSourceDir(project.projectRoot, defaultDir, entry?.source),
+  };
+}
+
+/**
+ * Which worker a command acts on: the name given, or the one inferred from the
+ * current directory when it sits directly inside the workers root. The
+ * directory is the mapping, so an unqualified invocation from inside a worker
+ * needs nothing else.
+ */
+export const resolveWorkerName = Effect.fnUntraced(function* (options: {
+  readonly project: WorkersProject;
+  readonly name: Option.Option<string>;
+  /** The subcommand, for the "pass one" suggestion. */
+  readonly command: string;
+}) {
+  if (Option.isSome(options.name)) {
+    const invalid = validateWorkerNameMessage(options.name.value);
+    if (invalid !== undefined) {
+      return yield* Effect.fail(
+        new InvalidWorkerNameError({
+          detail: `"${options.name.value}" is not a valid worker name. ${invalid}`,
+          suggestion: "Worker names become hostnames, so they must be DNS labels.",
+        }),
+      );
+    }
+    return options.name.value;
+  }
+
+  const inferred = inferWorkerNameFromCwd(options.project.cwd, options.project.rootDir);
+  if (inferred !== undefined && validateWorkerNameMessage(inferred) === undefined) {
+    return inferred;
+  }
+
+  return yield* Effect.fail(
+    new MissingWorkerNameError({
+      detail:
+        inferred === undefined
+          ? "No worker name was given, and this directory is not a worker directory."
+          : `No worker name was given, and "${inferred}" is not a usable one. ${workerNameRequirement}`,
+      suggestion: `Run it from inside ${displayPath(
+        options.project.cwd,
+        options.project.rootDir,
+      )}/<name>/, or pass a name: \`supabase workers ${options.command} <name>\`.`,
+    }),
+  );
+});

--- a/apps/cli/src/next/config/resolve-project-ref.ts
+++ b/apps/cli/src/next/config/resolve-project-ref.ts
@@ -1,9 +1,14 @@
 import { Effect, Option } from "effect";
-import {
-  ProjectLinkState,
-  ProjectNotLinkedError,
-} from "../../config/project-link-state.service.ts";
+import { ProjectLinkState, ProjectNotLinkedError } from "./project-link-state.service.ts";
 
+/**
+ * Which project a project-scoped command acts on: an explicit `--project-ref`
+ * when given, otherwise the linked project.
+ *
+ * Lives here rather than beside any one command because more than one command
+ * family needs it (`functions`, `workers`), and a command tree may not import
+ * another command tree's internals.
+ */
 export const resolveProjectRef = Effect.fnUntraced(function* (projectRef: Option.Option<string>) {
   if (Option.isSome(projectRef)) {
     return projectRef.value;

--- a/apps/cli/src/shared/workers/tar.ts
+++ b/apps/cli/src/shared/workers/tar.ts
@@ -1,0 +1,224 @@
+/**
+ * A minimal USTAR writer, for the `.tar.gz` build context `supabase workers
+ * push` uploads.
+ *
+ * Shelling out to `tar` would be shorter, but the CLI ships as a single
+ * compiled binary to machines where `tar` may be BSD tar, GNU tar, or absent
+ * (Windows), and each writes a different archive for the same directory. The
+ * server only ever untars what we send, so producing the bytes here keeps the
+ * upload identical on every platform and keeps packaging out of the process
+ * table.
+ */
+
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityFingerprintId,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+
+const BLOCK_SIZE = 512;
+
+export interface TarEntry {
+  /** Path inside the archive, always `/`-separated and relative. */
+  readonly path: string;
+  readonly contents: Uint8Array;
+  /** Unix mode bits. Defaults to `0o644`. */
+  readonly mode?: number;
+  /** Modification time in seconds since the epoch. Defaults to `0`. */
+  readonly mtime?: number;
+  /**
+   * Target of a symbolic link. When set the entry is stored as a link rather
+   * than as its contents, which is what keeps a symlink-dense tree (anything
+   * pnpm installed) from being inlined — and what stops a link to a directory
+   * from being walked into.
+   */
+  readonly linkTarget?: string;
+}
+
+/**
+ * The largest value an 11-digit octal field can hold: 8 GiB minus one byte for
+ * a size, and a little past the year 2242 for an mtime.
+ */
+const MAX_OCTAL_FIELD = 8 ** 11 - 1;
+
+/**
+ * USTAR stores numbers as zero-padded octal followed by a NUL.
+ *
+ * A value too large for the field renders one digit too long and spills into the
+ * next field, producing an archive that reads back with a plausible but wrong
+ * size — corruption no reader can detect. Real tars switch to base-256 here;
+ * this writer refuses instead, because a build context carrying an 8 GiB file is
+ * already a mistake worth naming rather than silently mangling.
+ */
+function writeOctal(block: Uint8Array, offset: number, length: number, value: number): void {
+  const text = Math.floor(value)
+    .toString(8)
+    .padStart(length - 1, "0");
+  if (text.length > length - 1) {
+    throw new TarFieldTooLargeError(value);
+  }
+  writeAscii(block, offset, text);
+}
+
+function writeAscii(block: Uint8Array, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    block[offset + index] = value.charCodeAt(index) & 0xff;
+  }
+}
+
+/**
+ * Split a path into USTAR's `prefix` (155 bytes) and `name` (100 bytes) fields.
+ * The split has to fall on a `/`, so a single path component longer than 100
+ * bytes cannot be represented at all.
+ */
+function splitPath(path: string): { name: string; prefix: string } | undefined {
+  if (byteLength(path) <= 100) {
+    return { name: path, prefix: "" };
+  }
+
+  for (let index = path.indexOf("/"); index !== -1; index = path.indexOf("/", index + 1)) {
+    const prefix = path.slice(0, index);
+    const name = path.slice(index + 1);
+    if (byteLength(prefix) <= 155 && byteLength(name) <= 100) {
+      return { name, prefix };
+    }
+  }
+
+  return undefined;
+}
+
+const encoder = new TextEncoder();
+
+function byteLength(value: string): number {
+  return encoder.encode(value).length;
+}
+
+/**
+ * Thrown for a path USTAR cannot represent. A plain `Error` rather than a
+ * tagged one because `createTar` is a pure synchronous function with no Effect
+ * semantics of its own; the caller's own error channel is where this surfaces.
+ * It is still user-actionable — renaming the offending file fixes it — so it
+ * carries its own classification, and the static identifier keeps the
+ * fingerprint stable through minification.
+ */
+export class TarPathTooLongError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "TarPathTooLongError";
+
+  constructor(path: string) {
+    super(
+      `"${path}" is too long for a tar archive (over 100 bytes with no directory boundary to split on)`,
+    );
+    this.name = "TarPathTooLongError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+/**
+ * Thrown for a number USTAR's octal fields cannot hold — see {@link writeOctal}.
+ * Untagged for the same reason as {@link TarPathTooLongError}: `createTar` is a
+ * pure function, and the caller's error channel is where this surfaces.
+ */
+export class TarFieldTooLargeError extends Error {
+  static readonly [ErrorActionabilityFingerprintId] = "TarFieldTooLargeError";
+
+  constructor(value: number) {
+    super(
+      `${value} is too large for a tar header field (the limit is ${MAX_OCTAL_FIELD} bytes per file)`,
+    );
+    this.name = "TarFieldTooLargeError";
+  }
+
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+function header(entry: TarEntry, typeflag: "0" | "2" | "5", size: number): Uint8Array {
+  const block = new Uint8Array(BLOCK_SIZE);
+  const split = splitPath(entry.path);
+  if (split === undefined) {
+    throw new TarPathTooLongError(entry.path);
+  }
+
+  const encodedName = encoder.encode(split.name);
+  block.set(encodedName, 0);
+  writeOctal(block, 100, 8, entry.mode ?? 0o644);
+  writeOctal(block, 108, 8, 0); // uid
+  writeOctal(block, 116, 8, 0); // gid
+  writeOctal(block, 124, 12, size);
+  writeOctal(block, 136, 12, entry.mtime ?? 0);
+  // The checksum field is treated as spaces while the checksum is computed.
+  block.fill(0x20, 148, 156);
+  block[156] = typeflag.charCodeAt(0);
+  if (entry.linkTarget !== undefined) {
+    const encodedTarget = encoder.encode(entry.linkTarget);
+    if (encodedTarget.length > 100) {
+      throw new TarPathTooLongError(entry.linkTarget);
+    }
+    block.set(encodedTarget, 157);
+  }
+  writeAscii(block, 257, "ustar");
+  writeAscii(block, 263, "00");
+  block.set(encoder.encode(split.prefix), 345);
+
+  let checksum = 0;
+  for (const byte of block) {
+    checksum += byte;
+  }
+  // Six octal digits, a NUL, then a space — the form every tar reads.
+  writeAscii(block, 148, checksum.toString(8).padStart(6, "0"));
+  block[154] = 0;
+  block[155] = 0x20;
+
+  return block;
+}
+
+function padding(size: number): number {
+  const remainder = size % BLOCK_SIZE;
+  return remainder === 0 ? 0 : BLOCK_SIZE - remainder;
+}
+
+/**
+ * Build a USTAR archive from `entries`, in the order given. An entry with a
+ * `linkTarget` is stored as a symbolic link, a path ending in `/` as a
+ * directory, and everything else as a regular file. The archive ends with the
+ * two zero blocks every reader expects.
+ */
+export function createTar(entries: ReadonlyArray<TarEntry>): Uint8Array {
+  const blocks: Array<Uint8Array> = [];
+  let total = 0;
+
+  const push = (block: Uint8Array) => {
+    blocks.push(block);
+    total += block.length;
+  };
+
+  for (const entry of entries) {
+    const isSymlink = entry.linkTarget !== undefined;
+    const isDirectory = !isSymlink && entry.path.endsWith("/");
+    // A link's target lives in the header, so it carries no content blocks.
+    const size = isDirectory || isSymlink ? 0 : entry.contents.length;
+    push(header(entry, isSymlink ? "2" : isDirectory ? "5" : "0", size));
+    if (size > 0) {
+      push(entry.contents);
+      const pad = padding(size);
+      if (pad > 0) {
+        push(new Uint8Array(pad));
+      }
+    }
+  }
+
+  push(new Uint8Array(BLOCK_SIZE * 2));
+
+  const archive = new Uint8Array(total);
+  let offset = 0;
+  for (const block of blocks) {
+    archive.set(block, offset);
+    offset += block.length;
+  }
+  return archive;
+}

--- a/apps/cli/src/shared/workers/tar.unit.test.ts
+++ b/apps/cli/src/shared/workers/tar.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import { createTar, TarFieldTooLargeError, TarPathTooLongError } from "./tar.ts";
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+function field(archive: Uint8Array, block: number, offset: number, length: number): string {
+  return decoder.decode(archive.subarray(block * 512 + offset, block * 512 + offset + length));
+}
+
+/** Trim a NUL-padded USTAR field down to its value. */
+function value(archive: Uint8Array, block: number, offset: number, length: number): string {
+  return (field(archive, block, offset, length).split("\u0000")[0] ?? "").trim();
+}
+
+describe("createTar", () => {
+  test("writes a readable ustar header for a file", () => {
+    const archive = createTar([
+      { path: "index.js", contents: encoder.encode("hello"), mode: 0o644, mtime: 1_700_000_000 },
+    ]);
+
+    expect(value(archive, 0, 0, 100)).toBe("index.js");
+    expect(value(archive, 0, 100, 8)).toBe("0000644");
+    expect(value(archive, 0, 124, 12)).toBe("00000000005");
+    expect(value(archive, 0, 136, 12)).toBe("14524770400");
+    expect(field(archive, 0, 156, 1)).toBe("0");
+    expect(value(archive, 0, 257, 6)).toBe("ustar");
+  });
+
+  test("computes a checksum the standard algorithm reproduces", () => {
+    const archive = createTar([{ path: "a.txt", contents: encoder.encode("a") }]);
+    const header = archive.subarray(0, 512);
+
+    const recorded = Number.parseInt(value(archive, 0, 148, 8), 8);
+    let computed = 0;
+    for (let index = 0; index < 512; index++) {
+      // The checksum field itself counts as spaces.
+      computed += index >= 148 && index < 156 ? 0x20 : (header[index] ?? 0);
+    }
+
+    expect(recorded).toBe(computed);
+  });
+
+  test("pads content to a 512-byte boundary and ends with two zero blocks", () => {
+    const archive = createTar([{ path: "a.txt", contents: encoder.encode("hello") }]);
+
+    // header + one padded content block + two trailing zero blocks
+    expect(archive.length).toBe(512 * 4);
+    expect(decoder.decode(archive.subarray(512, 517))).toBe("hello");
+    expect(archive.subarray(512 * 2).every((byte) => byte === 0)).toBe(true);
+  });
+
+  test("emits directory entries with no content and the directory typeflag", () => {
+    const archive = createTar([
+      { path: "nested/", contents: new Uint8Array(0), mode: 0o755 },
+      { path: "nested/a.txt", contents: encoder.encode("a") },
+    ]);
+
+    expect(field(archive, 0, 156, 1)).toBe("5");
+    expect(value(archive, 0, 124, 12)).toBe("00000000000");
+    // The directory has no content block, so the next header follows immediately.
+    expect(value(archive, 1, 0, 100)).toBe("nested/a.txt");
+  });
+
+  test("stores a symlink as a link entry with no content blocks", () => {
+    const archive = createTar([
+      { path: "link.txt", contents: new Uint8Array(0), linkTarget: "target.txt", mode: 0o777 },
+    ]);
+
+    expect(field(archive, 0, 156, 1)).toBe("2");
+    expect(value(archive, 0, 157, 100)).toBe("target.txt");
+    expect(value(archive, 0, 124, 12)).toBe("00000000000");
+    // Header plus the two trailing zero blocks — no content block in between.
+    expect(archive.length).toBe(512 * 3);
+  });
+
+  test("a symlink entry wins over the trailing-slash directory rule", () => {
+    const archive = createTar([{ path: "dir", contents: new Uint8Array(0), linkTarget: ".." }]);
+
+    expect(field(archive, 0, 156, 1)).toBe("2");
+  });
+
+  test("refuses a link target too long for the header field", () => {
+    expect(() =>
+      createTar([
+        { path: "link", contents: new Uint8Array(0), linkTarget: `${"t".repeat(120)}.txt` },
+      ]),
+    ).toThrow(TarPathTooLongError);
+  });
+
+  test("splits a long path across the prefix and name fields", () => {
+    const deep = `${"d".repeat(120)}/${"f".repeat(60)}.txt`;
+    const archive = createTar([{ path: deep, contents: new Uint8Array(0) }]);
+
+    expect(value(archive, 0, 345, 155)).toBe("d".repeat(120));
+    expect(value(archive, 0, 0, 100)).toBe(`${"f".repeat(60)}.txt`);
+  });
+
+  test("refuses a value too large for an octal header field rather than truncating it", () => {
+    // One past the 11-digit octal ceiling. Encoding it would spill a digit into
+    // the next field and read back as a plausible but wrong number.
+    expect(() =>
+      createTar([{ path: "a.txt", contents: new Uint8Array(1), mtime: 8 ** 11 }]),
+    ).toThrow(TarFieldTooLargeError);
+
+    expect(() =>
+      createTar([{ path: "a.txt", contents: new Uint8Array(1), mtime: 8 ** 11 - 1 }]),
+    ).not.toThrow();
+  });
+
+  test("refuses a path component too long to represent", () => {
+    expect(() =>
+      createTar([{ path: `${"f".repeat(120)}.txt`, contents: new Uint8Array(0) }]),
+    ).toThrow(TarPathTooLongError);
+  });
+});

--- a/apps/cli/src/shared/workers/toml-section.ts
+++ b/apps/cli/src/shared/workers/toml-section.ts
@@ -1,0 +1,221 @@
+/**
+ * Surgical edits to one `[section]` of a TOML file.
+ *
+ * `supabase/config.toml` belongs to the whole CLI: users hand-edit it, comment
+ * it, and commit it. Round-tripping it through `saveProjectConfig` preserves the
+ * data but discards every comment and normalizes the formatting the user chose
+ * — a surprising side effect of `supabase workers new`, and a noisy diff in a
+ * PR. So writes here are textual: locate the worker's own table, update the keys
+ * that changed in place, append the ones that are new, and leave every other
+ * byte of the file exactly as it was.
+ *
+ * Reading is still done with the real parser (`@supabase/config`); only writing
+ * is textual, and only ever inside the one table it owns.
+ */
+
+/** A TOML bare key needs no quoting; anything else does. */
+function isBareKey(key: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(key);
+}
+
+/** Escape a string for a TOML basic (double-quoted) string. */
+function quote(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Render `key` for use in a table header or key position. */
+export function tomlKey(key: string): string {
+  return isBareKey(key) ? key : quote(key);
+}
+
+/** `key = "value"` — every value the worker commands write is a string. */
+function renderPair(key: string, value: string): string {
+  return `${tomlKey(key)} = ${quote(value)}`;
+}
+
+/**
+ * Index of the standalone `[header]` line, or -1.
+ *
+ * TOML allows whitespace inside the brackets and a trailing comment, so
+ * `[ workers.api ]  # mine` is the same table as `[workers.api]`. Matching on
+ * the exact string would miss it and append a second table with the same name,
+ * which is not valid TOML.
+ */
+function findHeader(lines: ReadonlyArray<string>, header: string): number {
+  const pattern = new RegExp(`^\\s*\\[\\s*${escapeRegExp(header)}\\s*\\]\\s*(?:#.*)?$`);
+  return lines.findIndex((line) => pattern.test(line));
+}
+
+/** Whether `text` contains a standalone `[header]` table line. */
+export function sectionExists(text: string, header: string): boolean {
+  return findHeader(text.split("\n"), header) !== -1;
+}
+
+/** Whether a line opens a new table (`[x]` or `[[x]]`), ending the current one. */
+function opensTable(line: string): boolean {
+  return /^\s*\[/.test(line);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * What follows the `=` on a key's line: whether the value finishes there, and
+ * any trailing comment.
+ *
+ * Both matter for a rewrite. A value that spans lines (an array, an inline
+ * table, a `"""` string) cannot be replaced by swapping one line — doing so
+ * strands its continuation lines and leaves the file unparseable. And a trailing
+ * comment is the user's, so it survives the rewrite; a module that exists to
+ * preserve comments should not eat the one sitting next to the value it edits.
+ */
+interface ScannedValue {
+  /** `false` when the value continues onto the next line. */
+  readonly complete: boolean;
+  /** The trailing comment including its `#`, or `""`. */
+  readonly comment: string;
+}
+
+function scanValue(line: string, from: number): ScannedValue {
+  let depth = 0;
+  let index = from;
+
+  while (index < line.length) {
+    const char = line[index];
+
+    // A `#` outside any string or bracket starts the comment; everything from
+    // here to the end of the line belongs to the user.
+    if (char === "#" && depth === 0) {
+      return { complete: true, comment: line.slice(index) };
+    }
+
+    if (char === '"' || char === "'") {
+      const quote = char;
+      const triple = line.startsWith(quote.repeat(3), index);
+      const closer = triple ? quote.repeat(3) : quote;
+      // A basic string honours backslash escapes; a literal string does not.
+      const escapes = quote === '"';
+      let cursor = index + closer.length;
+      let closed = false;
+      while (cursor < line.length) {
+        if (escapes && line[cursor] === "\\") {
+          cursor += 2;
+          continue;
+        }
+        if (line.startsWith(closer, cursor)) {
+          cursor += closer.length;
+          closed = true;
+          break;
+        }
+        cursor += 1;
+      }
+      if (!closed) {
+        return { complete: false, comment: "" };
+      }
+      index = cursor;
+      continue;
+    }
+
+    if (char === "[" || char === "{") {
+      depth += 1;
+    } else if (char === "]" || char === "}") {
+      depth -= 1;
+    }
+    index += 1;
+  }
+
+  return { complete: depth === 0, comment: "" };
+}
+
+/**
+ * The outcome of an edit. A value that spans lines cannot be rewritten one line
+ * at a time, so rather than emit a broken file this reports which key it could
+ * not touch and lets the caller say so.
+ */
+export type TomlSectionEdit =
+  | { readonly _tag: "Edited"; readonly text: string }
+  | { readonly _tag: "Unsupported"; readonly key: string };
+
+/**
+ * Set each of `values` inside `[header]`, returning the new file text.
+ *
+ * An existing key is rewritten in place, preserving its position, any comment on
+ * the line above it, and any comment trailing the value itself; a new key is
+ * appended after the table's last non-blank line, so trailing blank lines stay
+ * between tables rather than being swallowed. A missing table is appended at the
+ * end of the file, separated by one blank line.
+ */
+export function upsertTomlSection(
+  text: string,
+  header: string,
+  values: Readonly<Record<string, string>>,
+): TomlSectionEdit {
+  const entries = Object.entries(values);
+  if (entries.length === 0) {
+    return { _tag: "Edited", text };
+  }
+
+  const lines = text.split("\n");
+  const start = findHeader(lines, header);
+
+  if (start === -1) {
+    const block = [`[${header}]`, ...entries.map(([key, value]) => renderPair(key, value))];
+    // A file that is empty (or only whitespace) gets no leading blank line; an
+    // existing one gets exactly one, however it happened to be terminated.
+    if (text.trim() === "") {
+      return { _tag: "Edited", text: `${block.join("\n")}\n` };
+    }
+    return {
+      _tag: "Edited",
+      text: `${text.replace(/\n*$/, "")}\n\n${block.join("\n")}\n`,
+    };
+  }
+
+  // The table runs to the next table header, or the end of the file.
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index++) {
+    if (opensTable(lines[index] ?? "")) {
+      end = index;
+      break;
+    }
+  }
+
+  const pending = new Map(entries);
+  for (let index = start + 1; index < end; index++) {
+    const line = lines[index] ?? "";
+    for (const [key, value] of pending) {
+      // Match `key =`, `"key" =`, with any leading indentation the user used.
+      const pattern = new RegExp(
+        `^(\\s*)(?:${escapeRegExp(key)}|${escapeRegExp(quote(key))})(\\s*)=`,
+      );
+      const match = pattern.exec(line);
+      if (match === null) {
+        continue;
+      }
+      const scanned = scanValue(line, match[0].length);
+      if (!scanned.complete) {
+        return { _tag: "Unsupported", key };
+      }
+      const trailing = scanned.comment === "" ? "" : ` ${scanned.comment}`;
+      lines[index] =
+        `${match[1] ?? ""}${tomlKey(key)}${match[2] ?? ""}= ${quote(value)}${trailing}`;
+      pending.delete(key);
+      break;
+    }
+  }
+
+  if (pending.size > 0) {
+    // Append after the last line with content, so a blank line separating this
+    // table from the next stays where it is.
+    let insertAt = start + 1;
+    for (let index = start + 1; index < end; index++) {
+      if ((lines[index] ?? "").trim() !== "") {
+        insertAt = index + 1;
+      }
+    }
+    lines.splice(insertAt, 0, ...[...pending].map(([key, value]) => renderPair(key, value)));
+  }
+
+  return { _tag: "Edited", text: lines.join("\n") };
+}

--- a/apps/cli/src/shared/workers/toml-section.unit.test.ts
+++ b/apps/cli/src/shared/workers/toml-section.unit.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import { sectionExists, tomlKey, upsertTomlSection } from "./toml-section.ts";
+
+/** The edited text, failing the test if the edit was refused. */
+function edited(text: string, header: string, values: Record<string, string>): string {
+  const result = upsertTomlSection(text, header, values);
+  if (result._tag !== "Edited") {
+    throw new Error(`expected an edit, got Unsupported(${result.key})`);
+  }
+  return result.text;
+}
+
+describe("upsertTomlSection", () => {
+  test("appends a new table to an existing file without disturbing it", () => {
+    const before = `# my project
+project_id = "demo"
+
+[functions.hello]
+verify_jwt = false
+`;
+
+    expect(edited(before, "workers.api", { runtime: "node", size: "2gb" })).toBe(
+      `# my project
+project_id = "demo"
+
+[functions.hello]
+verify_jwt = false
+
+[workers.api]
+runtime = "node"
+size = "2gb"
+`,
+    );
+  });
+
+  test("writes the table alone into an empty file", () => {
+    expect(edited("   \n", "workers.api", { runtime: "deno" })).toBe(
+      `[workers.api]
+runtime = "deno"
+`,
+    );
+  });
+
+  test("rewrites an existing key in place, preserving its comment and position", () => {
+    const before = `[workers.api]
+# the runtime this was scaffolded on
+runtime = "node"
+size = "2gb"
+
+[workers.other]
+runtime = "deno"
+`;
+
+    expect(edited(before, "workers.api", { runtime: "bun" })).toBe(
+      `[workers.api]
+# the runtime this was scaffolded on
+runtime = "bun"
+size = "2gb"
+
+[workers.other]
+runtime = "deno"
+`,
+    );
+  });
+
+  test("appends a new key after the table's last content line, keeping the blank separator", () => {
+    const before = `[workers.api]
+runtime = "node"
+
+[workers.other]
+runtime = "deno"
+`;
+
+    expect(edited(before, "workers.api", { size: "4gb" })).toBe(
+      `[workers.api]
+runtime = "node"
+size = "4gb"
+
+[workers.other]
+runtime = "deno"
+`,
+    );
+  });
+
+  test("matches a quoted key and the caller's own indentation", () => {
+    const before = `[workers.api]
+  "runtime"  = "node"
+`;
+
+    expect(edited(before, "workers.api", { runtime: "python" })).toBe(
+      `[workers.api]
+  runtime  = "python"
+`,
+    );
+  });
+
+  test("escapes quotes and backslashes in values", () => {
+    expect(edited("", "workers.api", { source: 'a"b\\c' })).toBe(
+      `[workers.api]
+source = "a\\"b\\\\c"
+`,
+    );
+  });
+
+  test("matches a header with whitespace inside the brackets and a trailing comment", () => {
+    // TOML treats these as the same table; appending a second one would make the
+    // file invalid.
+    expect(
+      edited('[ workers.api ]  # mine\nruntime = "node"\n', "workers.api", { runtime: "bun" }),
+    ).toBe('[ workers.api ]  # mine\nruntime = "bun"\n');
+  });
+
+  test("keeps a comment trailing the value it rewrites", () => {
+    expect(
+      edited('[workers.api]\nruntime = "node" # keep me\n', "workers.api", { runtime: "bun" }),
+    ).toBe('[workers.api]\nruntime = "bun" # keep me\n');
+  });
+
+  test("does not mistake a # inside a string for a comment", () => {
+    expect(edited('[workers.api]\nsource = "a#b"\n', "workers.api", { source: "c#d" })).toBe(
+      '[workers.api]\nsource = "c#d"\n',
+    );
+  });
+
+  test("refuses a value that spans lines rather than stranding its continuation", () => {
+    const before = '[workers.api]\nruntime = [\n  "a",\n]\n';
+    const result = upsertTomlSection(before, "workers.api", { runtime: "bun" });
+
+    expect(result._tag).toBe("Unsupported");
+    if (result._tag === "Unsupported") {
+      expect(result.key).toBe("runtime");
+    }
+  });
+
+  test("refuses an unterminated multi-line string the same way", () => {
+    const result = upsertTomlSection(
+      '[workers.api]\nsource = """\nstill going\n"""\n',
+      "workers.api",
+      { source: "packages/api" },
+    );
+
+    expect(result._tag).toBe("Unsupported");
+  });
+
+  test("returns the text untouched when there is nothing to set", () => {
+    expect(edited('project_id = "demo"\n', "workers.api", {})).toBe('project_id = "demo"\n');
+  });
+});
+
+describe("sectionExists", () => {
+  test("finds a standalone table header and ignores a dotted key of the same name", () => {
+    expect(sectionExists('[workers.api]\nruntime = "node"\n', "workers.api")).toBe(true);
+    expect(sectionExists('workers.api.runtime = "node"\n', "workers.api")).toBe(false);
+  });
+});
+
+describe("tomlKey", () => {
+  test("quotes only what TOML requires quoting", () => {
+    expect(tomlKey("my-worker_1")).toBe("my-worker_1");
+    expect(tomlKey("my worker")).toBe('"my worker"');
+  });
+});

--- a/apps/cli/src/shared/workers/worker-classify.ts
+++ b/apps/cli/src/shared/workers/worker-classify.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+import { Effect, FileSystem } from "effect";
+import { DEFAULT_WORKER_RUNTIME, type WorkerRuntime } from "./worker-runtimes.ts";
+
+/**
+ * Best-effort classification of a worker directory into a {@link WorkerRuntime}
+ * from common marker files, so `supabase workers push` can deploy a directory
+ * that has no `[workers.<name>] runtime` at all. The guess is always reported,
+ * with a nudge to pin it down, rather than applied silently.
+ */
+
+interface WorkerClassification {
+  readonly runtime: WorkerRuntime;
+  /** Human-readable reason, for the line `push` logs about the guess. */
+  readonly reason: string;
+}
+
+const MARKERS: ReadonlyArray<{
+  readonly runtime: WorkerRuntime;
+  readonly files: ReadonlyArray<string>;
+}> = [
+  // An explicit Dockerfile always wins: it is a deliberate signal, not an
+  // inference.
+  { runtime: "dockerfile", files: ["Dockerfile"] },
+  // Deno and Bun are checked before plain `package.json` because either can
+  // still have one (editor tooling, a stray dependency) while a plain Node
+  // project has no `deno.json`/`bun.lock`.
+  { runtime: "deno", files: ["deno.json", "deno.jsonc", "deno.lock"] },
+  { runtime: "bun", files: ["bun.lockb", "bun.lock"] },
+  { runtime: "node", files: ["package.json"] },
+  { runtime: "python", files: ["requirements.txt", "pyproject.toml", "Pipfile"] },
+];
+
+export const classifyWorkerDir = Effect.fnUntraced(function* (dir: string) {
+  const fs = yield* FileSystem.FileSystem;
+
+  for (const marker of MARKERS) {
+    for (const file of marker.files) {
+      const found = yield* fs.exists(join(dir, file)).pipe(Effect.orElseSucceed(() => false));
+      if (found) {
+        return { runtime: marker.runtime, reason: `found ${file}` } satisfies WorkerClassification;
+      }
+    }
+  }
+
+  return {
+    runtime: DEFAULT_WORKER_RUNTIME,
+    reason: `no recognized marker files, defaulting to ${DEFAULT_WORKER_RUNTIME}`,
+  } satisfies WorkerClassification;
+});

--- a/apps/cli/src/shared/workers/worker-config.ts
+++ b/apps/cli/src/shared/workers/worker-config.ts
@@ -1,0 +1,141 @@
+import { Data, Effect, FileSystem } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+import { sectionExists, tomlKey, upsertTomlSection } from "./toml-section.ts";
+
+/**
+ * The `[workers]` section of `supabase/config.toml`, read through the decoded
+ * project config and written back surgically.
+ *
+ * `[workers]` carries a project-wide `root` plus one `[workers.<name>]` table
+ * per worker. The schema in `@supabase/config` models exactly that, so reading
+ * is a matter of splitting the scalar off the record; writing goes through
+ * `./toml-section.ts` so a user's comments and formatting survive.
+ */
+
+/** One worker's recorded metadata. Every key is optional. */
+export interface WorkerEntry {
+  readonly runtime?: string;
+  readonly size?: string;
+  readonly source?: string;
+}
+
+export interface WorkersSection {
+  /** `[workers] root`, unvalidated — see `resolveWorkersRoot`. */
+  readonly root: string | undefined;
+  /** `[workers.<name>]` tables, keyed by worker name, in file order. */
+  readonly workers: Readonly<Record<string, WorkerEntry>>;
+}
+
+/**
+ * A worker is present in the config but not as its own `[workers.<name>]` table
+ * — an inline `workers = { … }`, or dotted `workers.<name>.runtime = …` keys.
+ * Appending a table would duplicate the key and leave the file invalid, and
+ * rewriting the whole file would cost the user every comment in it, so this
+ * asks for the one edit that makes a surgical write possible.
+ */
+export class WorkerEntryNotATableError extends Data.TaggedError("WorkerEntryNotATableError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
+
+/**
+ * A key the CLI wants to set is written across several lines (an array, an
+ * inline table, a `"""` string). Swapping one line would strand its
+ * continuation and leave the file unparseable, so the edit stops instead.
+ */
+export class WorkerEntryValueNotEditableError extends Data.TaggedError(
+  "WorkerEntryValueNotEditableError",
+)<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}
+
+const stringOrUndefined = (value: unknown): string | undefined =>
+  typeof value === "string" && value !== "" ? value : undefined;
+
+/**
+ * Split the decoded `[workers]` section into its project-wide `root` and its
+ * per-worker tables. A scalar written directly under `[workers]` parses as a
+ * sibling of the sub-tables, so anything that is not an object is dropped here
+ * rather than read as a worker named after it.
+ */
+export function readWorkersSection(workers: unknown): WorkersSection {
+  if (typeof workers !== "object" || workers === null || Array.isArray(workers)) {
+    return { root: undefined, workers: {} };
+  }
+
+  const entries: Record<string, WorkerEntry> = {};
+  for (const [key, value] of Object.entries(workers)) {
+    if (key === "root" || typeof value !== "object" || value === null || Array.isArray(value)) {
+      continue;
+    }
+    const entry = value as Record<string, unknown>;
+    entries[key] = {
+      runtime: stringOrUndefined(entry["runtime"]),
+      size: stringOrUndefined(entry["size"]),
+      source: stringOrUndefined(entry["source"]),
+    };
+  }
+
+  // `root` is passed through as written (empty string included) so an obviously
+  // wrong value reaches `resolveWorkersRoot` and gets named, rather than
+  // silently falling back to the default.
+  const root = (workers as Record<string, unknown>)["root"];
+  return {
+    root: typeof root === "string" ? root : undefined,
+    workers: entries,
+  };
+}
+
+/**
+ * Set `patch`'s keys on `[workers.<name>]` in `configPath`, leaving every other
+ * byte of the file untouched. Creates the file (and its `supabase/` directory)
+ * when it does not exist yet, so `new` works in a directory that has never been
+ * `supabase init`-ed.
+ */
+export const writeWorkerEntry = Effect.fnUntraced(function* (options: {
+  readonly configPath: string;
+  readonly name: string;
+  readonly patch: Readonly<Record<string, string>>;
+  /** The already-parsed config, used only to detect a non-table entry. */
+  readonly existingWorkers: Readonly<Record<string, WorkerEntry>>;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+
+  const exists = yield* fs.exists(options.configPath);
+  const text = exists ? yield* fs.readFileString(options.configPath) : "";
+  const header = `workers.${tomlKey(options.name)}`;
+
+  if (options.existingWorkers[options.name] !== undefined && !sectionExists(text, header)) {
+    return yield* Effect.fail(
+      new WorkerEntryNotATableError({
+        detail: `"${options.name}" is configured in ${options.configPath} but not as a standalone [${header}] table.`,
+        suggestion: `Move it into its own [${header}] table so the CLI can update it without rewriting the file.`,
+      }),
+    );
+  }
+
+  const edit = upsertTomlSection(text, header, options.patch);
+  if (edit._tag === "Unsupported") {
+    return yield* Effect.fail(
+      new WorkerEntryValueNotEditableError({
+        detail: `[${header}] ${edit.key} in ${options.configPath} spans multiple lines, so the CLI cannot rewrite it safely.`,
+        suggestion: `Put ${edit.key} on a single line, or remove it and let the CLI write it.`,
+      }),
+    );
+  }
+
+  yield* fs.writeFileString(options.configPath, edit.text);
+});

--- a/apps/cli/src/shared/workers/worker-config.unit.test.ts
+++ b/apps/cli/src/shared/workers/worker-config.unit.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunServices } from "@effect/platform-bun";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  readWorkersSection,
+  WorkerEntryNotATableError,
+  WorkerEntryValueNotEditableError,
+  writeWorkerEntry,
+} from "./worker-config.ts";
+
+describe("readWorkersSection", () => {
+  test("splits the project-wide root from the per-worker tables", () => {
+    expect(
+      readWorkersSection({
+        root: "services",
+        api: { runtime: "node", size: "2gb", source: "packages/api" },
+        box: { runtime: "sandbox" },
+      }),
+    ).toEqual({
+      root: "services",
+      workers: {
+        api: { runtime: "node", size: "2gb", source: "packages/api" },
+        box: { runtime: "sandbox", size: undefined, source: undefined },
+      },
+    });
+  });
+
+  test("drops non-object values so a stray scalar is not read as a worker", () => {
+    expect(readWorkersSection({ root: "services", stray: "oops", api: {} })).toEqual({
+      root: "services",
+      workers: { api: { runtime: undefined, size: undefined, source: undefined } },
+    });
+  });
+
+  test("treats a missing or malformed section as empty", () => {
+    expect(readWorkersSection(undefined)).toEqual({ root: undefined, workers: {} });
+    expect(readWorkersSection([])).toEqual({ root: undefined, workers: {} });
+    // An empty root is passed through so the validator can name it.
+    expect(readWorkersSection({ root: "" })).toEqual({ root: "", workers: {} });
+  });
+});
+
+describe("writeWorkerEntry", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "supabase-worker-config-"));
+    configPath = join(dir, "config.toml");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const run = (effect: Effect.Effect<void, unknown, never>) => Effect.runPromise(effect);
+
+  test("creates the file when there is none yet", async () => {
+    await run(
+      writeWorkerEntry({
+        configPath,
+        name: "api",
+        existingWorkers: {},
+        patch: { runtime: "node" },
+      }).pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(readFileSync(configPath, "utf8")).toBe('[workers.api]\nruntime = "node"\n');
+  });
+
+  test("updates an existing table without touching the rest of the file", async () => {
+    writeFileSync(
+      configPath,
+      '# keep me\nproject_id = "demo"\n\n[workers.api]\nruntime = "node"\n',
+    );
+
+    await run(
+      writeWorkerEntry({
+        configPath,
+        name: "api",
+        existingWorkers: { api: { runtime: "node" } },
+        patch: { runtime: "bun", size: "4gb" },
+      }).pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(readFileSync(configPath, "utf8")).toBe(
+      '# keep me\nproject_id = "demo"\n\n[workers.api]\nruntime = "bun"\nsize = "4gb"\n',
+    );
+  });
+
+  test("refuses a multi-line value instead of stranding its continuation lines", async () => {
+    const before = '[workers.api]\nruntime = [\n  "node",\n]\n';
+    writeFileSync(configPath, before);
+
+    const error = await run(
+      writeWorkerEntry({
+        configPath,
+        name: "api",
+        existingWorkers: { api: {} },
+        patch: { runtime: "bun" },
+      }).pipe(Effect.provide(BunServices.layer), Effect.flip),
+    );
+
+    expect(error).toBeInstanceOf(WorkerEntryValueNotEditableError);
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+  });
+
+  test("keeps a trailing comment on the value it rewrites", async () => {
+    writeFileSync(configPath, '[workers.api]\nruntime = "node" # hand-picked\n');
+
+    await run(
+      writeWorkerEntry({
+        configPath,
+        name: "api",
+        existingWorkers: { api: { runtime: "node" } },
+        patch: { runtime: "bun" },
+      }).pipe(Effect.provide(BunServices.layer)),
+    );
+
+    expect(readFileSync(configPath, "utf8")).toBe('[workers.api]\nruntime = "bun" # hand-picked\n');
+  });
+
+  test("refuses to rewrite a worker expressed as dotted keys rather than its own table", async () => {
+    writeFileSync(configPath, 'workers.api.runtime = "node"\n');
+
+    const error = await run(
+      writeWorkerEntry({
+        configPath,
+        name: "api",
+        existingWorkers: { api: { runtime: "node" } },
+        patch: { runtime: "bun" },
+      }).pipe(Effect.provide(BunServices.layer), Effect.flip),
+    );
+
+    expect(error).toBeInstanceOf(WorkerEntryNotATableError);
+    // The file is left exactly as it was rather than duplicated into invalid TOML.
+    expect(readFileSync(configPath, "utf8")).toBe('workers.api.runtime = "node"\n');
+  });
+});

--- a/apps/cli/src/shared/workers/worker-package.ts
+++ b/apps/cli/src/shared/workers/worker-package.ts
@@ -1,0 +1,115 @@
+import { gzipSync } from "node:zlib";
+import { Effect, FileSystem } from "effect";
+import { createTar, type TarEntry } from "./tar.ts";
+
+/**
+ * Package a worker's source directory into the `.tar.gz` build context the
+ * Workers API's upload slot expects.
+ *
+ * Nothing is excluded. For a `dockerfile` worker the archive is the build
+ * context, so it has to be what the user's own `Dockerfile` expects to find;
+ * for a catalog runtime the server synthesizes `FROM <base>` + `COPY` with no
+ * install step of its own, so an installed `node_modules/` is a dependency of
+ * the deploy rather than noise in it. The packaged size is reported back so a
+ * directory that has grown past what anyone meant to upload is visible before
+ * the upload rather than after it.
+ */
+
+interface PackagedWorker {
+  readonly archive: Uint8Array;
+  readonly fileCount: number;
+}
+
+const collectEntries = (
+  root: string,
+  relativeDir: string,
+): Effect.Effect<Array<TarEntry>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const absoluteDir = relativeDir === "" ? root : `${root}/${relativeDir}`;
+
+    const names = yield* fs
+      .readDirectory(absoluteDir)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+    const entries: Array<TarEntry> = [];
+
+    for (const name of [...names].sort()) {
+      const relativePath = relativeDir === "" ? name : `${relativeDir}/${name}`;
+      const absolutePath = `${root}/${relativePath}`;
+
+      // `readLink` succeeds only for symlinks, so it stands in for the `lstat`
+      // this FileSystem service does not expose (the same probe
+      // `legacy-sql-files-glob.ts` uses). Storing the link rather than following
+      // it is what keeps a pnpm-installed `node_modules` from being inlined file
+      // by file, keeps a broken link from vanishing, and stops a link pointing at
+      // an ancestor from being walked into.
+      const linkTarget = yield* fs.readLink(absolutePath).pipe(Effect.option);
+      if (linkTarget._tag === "Some") {
+        entries.push({
+          path: relativePath,
+          contents: new Uint8Array(0),
+          mode: 0o777,
+          mtime: 0,
+          linkTarget: linkTarget.value,
+        });
+        continue;
+      }
+
+      const info = yield* fs.stat(absolutePath).pipe(Effect.option);
+      if (info._tag === "None") {
+        continue;
+      }
+
+      const modified = info.value.mtime;
+      const mtime = modified._tag === "Some" ? Math.floor(modified.value.getTime() / 1000) : 0;
+
+      if (info.value.type === "Directory") {
+        entries.push({ path: `${relativePath}/`, contents: new Uint8Array(0), mode: 0o755, mtime });
+        entries.push(...(yield* collectEntries(root, relativePath)));
+        continue;
+      }
+
+      if (info.value.type !== "File") {
+        // Sockets, FIFOs and devices have nothing meaningful to send.
+        continue;
+      }
+
+      const contents = yield* fs
+        .readFile(absolutePath)
+        .pipe(Effect.orElseSucceed(() => new Uint8Array(0)));
+      // The executable bit is the only permission that changes what the image
+      // does; everything else is normalized so the same tree packages
+      // identically on every machine.
+      const executable = (Number(info.value.mode) & 0o111) !== 0;
+      entries.push({
+        path: relativePath,
+        contents: new Uint8Array(contents),
+        mode: executable ? 0o755 : 0o644,
+        mtime,
+      });
+    }
+
+    return entries;
+  });
+
+export const packageWorkerDirectory = Effect.fnUntraced(function* (dir: string) {
+  const entries = yield* collectEntries(dir, "");
+  const archive = gzipSync(createTar(entries));
+
+  return {
+    archive: new Uint8Array(archive),
+    fileCount: entries.filter((entry) => !entry.path.endsWith("/")).length,
+  } satisfies PackagedWorker;
+});
+
+/** `10 KiB` / `1.4 MiB` — the packaged size, as `push` reports it. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${Math.ceil(kib)} KiB`;
+  }
+  return `${(kib / 1024).toFixed(1)} MiB`;
+}

--- a/apps/cli/src/shared/workers/worker-package.unit.test.ts
+++ b/apps/cli/src/shared/workers/worker-package.unit.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunServices } from "@effect/platform-bun";
+import { gunzipSync } from "node:zlib";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { formatBytes, packageWorkerDirectory } from "./worker-package.ts";
+
+/** Entry paths and their USTAR typeflags, read back out of the archive. */
+function readEntries(archive: Uint8Array): Array<{ path: string; type: string; link: string }> {
+  const raw = new Uint8Array(gunzipSync(archive));
+  const decoder = new TextDecoder();
+  const trim = (value: string) => value.split("\u0000")[0] ?? "";
+  const entries: Array<{ path: string; type: string; link: string }> = [];
+
+  for (let offset = 0; offset + 512 <= raw.length;) {
+    const name = trim(decoder.decode(raw.subarray(offset, offset + 100)));
+    if (name === "") {
+      break;
+    }
+    const size = Number.parseInt(trim(decoder.decode(raw.subarray(offset + 124, offset + 136))), 8);
+    entries.push({
+      path: name,
+      type: decoder.decode(raw.subarray(offset + 156, offset + 157)),
+      link: trim(decoder.decode(raw.subarray(offset + 157, offset + 257))),
+    });
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+describe("packageWorkerDirectory", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "supabase-worker-package-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const pack = (root: string) =>
+    Effect.runPromise(packageWorkerDirectory(root).pipe(Effect.provide(BunServices.layer)));
+
+  test("packages files and nested directories in a stable order", async () => {
+    mkdirSync(join(dir, "nested"));
+    writeFileSync(join(dir, "b.txt"), "b");
+    writeFileSync(join(dir, "a.txt"), "a");
+    writeFileSync(join(dir, "nested", "c.txt"), "c");
+
+    const result = await pack(dir);
+
+    expect(readEntries(result.archive).map((entry) => entry.path)).toEqual([
+      "a.txt",
+      "b.txt",
+      "nested/",
+      "nested/c.txt",
+    ]);
+    expect(result.fileCount).toBe(3);
+  });
+
+  // Anything pnpm installs is symlink-dense, so following links would inline
+  // every dependency's real contents — and a link pointing at an ancestor would
+  // be walked into until the OS refused.
+  test("stores symlinks as links rather than following them", async () => {
+    writeFileSync(join(dir, "target.txt"), "hello");
+    symlinkSync("target.txt", join(dir, "link.txt"));
+
+    const entries = readEntries((await pack(dir)).archive);
+    const link = entries.find((entry) => entry.path === "link.txt");
+
+    expect(link?.type).toBe("2");
+    expect(link?.link).toBe("target.txt");
+  });
+
+  test("keeps a broken symlink instead of dropping it", async () => {
+    symlinkSync("/nowhere-at-all", join(dir, "broken.txt"));
+
+    const entries = readEntries((await pack(dir)).archive);
+
+    expect(entries.find((entry) => entry.path === "broken.txt")?.type).toBe("2");
+  });
+
+  test("does not recurse through a directory symlink that points at an ancestor", async () => {
+    mkdirSync(join(dir, "sub"));
+    writeFileSync(join(dir, "keep.txt"), "k");
+    symlinkSync("..", join(dir, "sub", "up"));
+
+    const entries = readEntries((await pack(dir)).archive);
+
+    expect(entries.map((entry) => entry.path).sort()).toEqual(["keep.txt", "sub/", "sub/up"]);
+    expect(entries.find((entry) => entry.path === "sub/up")?.type).toBe("2");
+  });
+
+  test("packages an empty directory to an archive with no entries", async () => {
+    const result = await pack(dir);
+
+    expect(readEntries(result.archive)).toEqual([]);
+    expect(result.fileCount).toBe(0);
+  });
+});
+
+describe("formatBytes", () => {
+  test("reports each magnitude in the unit a reader expects", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+    expect(formatBytes(1024)).toBe("1 KiB");
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MiB");
+    expect(formatBytes(1024 * 1024 * 1.5)).toBe("1.5 MiB");
+  });
+});

--- a/apps/cli/src/shared/workers/worker-paths.ts
+++ b/apps/cli/src/shared/workers/worker-paths.ts
@@ -1,0 +1,199 @@
+import { isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
+import { Effect } from "effect";
+import { InvalidWorkerSourceError, InvalidWorkersRootError } from "./workers.errors.ts";
+
+/**
+ * The project layout every worker command resolves against:
+ *
+ *   supabase/
+ *     config.toml          project config — workers record `[workers.<name>]` here
+ *     workers/<name>/      one directory per worker; the name IS the directory
+ *
+ * This mirrors `supabase/functions/<slug>/` on purpose: `supabase workers` is a
+ * sibling of `supabase functions`, not a separate tool with its own
+ * conventions. A worker's name and its directory are the same fact, so
+ * `push`/`status`/`delete <name>` needs no separate lookup, and running from
+ * inside the directory needs no name at all.
+ *
+ * `workers/` is the default, not a rule. Two keys move it, at two scopes:
+ * `[workers] root` moves the directory workers are grouped in (project-wide,
+ * relative to `supabase/`), and `[workers.<name>] source` moves one worker's
+ * code anywhere in the repo (relative to the project root). `source` wins
+ * wherever it is set.
+ *
+ * The root is validated once per command, by {@link resolveWorkersRoot}; every
+ * helper below takes the validated value, so a bad `[workers] root` fails in
+ * one place rather than at whichever path happens to be joined first.
+ */
+
+/** Where workers live under `supabase/` unless `[workers] root` says otherwise. */
+const DEFAULT_WORKERS_ROOT = "workers";
+
+/**
+ * Directories under `supabase/` the CLI already owns. Pointing `[workers] root`
+ * at one would make every Edge Function (or migration) look like a worker to
+ * `supabase workers list`, so it is refused rather than warned about.
+ */
+const RESERVED_ROOT_DIRS = ["functions", "migrations"];
+
+const rootSuggestion =
+  'Set `[workers] root` to a directory name inside supabase/, for example root = "services", ' +
+  "or move a single worker with `[workers.<name>] source`.";
+
+/**
+ * `[workers] root`, validated. Confined to `supabase/`: absolute paths, any
+ * `..` that would climb out, and `supabase/` itself are refused, as are the
+ * directories the CLI already owns. The per-worker `source` key is the one that
+ * can leave.
+ */
+export function resolveWorkersRoot(
+  configured: string | undefined,
+): Effect.Effect<string, InvalidWorkersRootError> {
+  if (configured === undefined) {
+    return Effect.succeed(DEFAULT_WORKERS_ROOT);
+  }
+
+  const refuse = (why: string) =>
+    Effect.fail(
+      new InvalidWorkersRootError({
+        detail: `[workers] root "${configured}" ${why}.`,
+        suggestion: rootSuggestion,
+      }),
+    );
+
+  // A trailing slash is how anyone would naturally write a directory.
+  const trimmed = configured.trim().replace(/[/\\]+$/, "");
+  if (trimmed === "" || trimmed === ".") {
+    return refuse("would make supabase/ itself the workers directory");
+  }
+  if (isAbsolute(trimmed)) {
+    return refuse("is an absolute path");
+  }
+
+  const normalized = normalize(trimmed);
+  if (normalized.startsWith("..")) {
+    return refuse("climbs outside supabase/");
+  }
+  const first = normalized.split(/[/\\]/)[0] ?? "";
+  if (RESERVED_ROOT_DIRS.includes(first)) {
+    return refuse(
+      `is a directory the Supabase CLI already owns — everything in supabase/${first}/ would be listed as a worker`,
+    );
+  }
+
+  return Effect.succeed(normalized);
+}
+
+/** `supabase/<root>/` — the validated root resolved against the project. */
+export function workersRootDir(projectRoot: string, root: string): string {
+  return join(projectRoot, "supabase", root);
+}
+
+/** Whether `candidate` is `parent` itself or sits underneath it. */
+function isAtOrUnder(parent: string, candidate: string): boolean {
+  const rel = relative(resolve(parent), resolve(candidate));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * `--source`, resolved against the directory the user typed it in and validated
+ * before anything is written.
+ *
+ * This one is load-bearing for safety, not just tidiness: the resolved path is
+ * the directory `--force` deletes outright, so a value naming the project root,
+ * `supabase/`, or anywhere outside the project would destroy work that has
+ * nothing to do with the worker. `source` is the key that is *allowed* to leave
+ * the workers directory, but not the project.
+ *
+ * `functions/` and `migrations/` are refused for the same reason `[workers] root`
+ * refuses them: they belong to other parts of the CLI.
+ */
+export function resolveWorkerSource(options: {
+  readonly projectRoot: string;
+  readonly cwd: string;
+  readonly raw: string;
+}): Effect.Effect<string, InvalidWorkerSourceError> {
+  const refuse = (why: string) =>
+    Effect.fail(
+      new InvalidWorkerSourceError({
+        detail: `--source "${options.raw}" ${why}.`,
+        suggestion:
+          "Point --source at a directory inside the project, for example --source packages/api.",
+      }),
+    );
+
+  const trimmed = options.raw.trim().replace(/[/\\]+$/, "");
+  if (trimmed === "") {
+    return refuse("is empty");
+  }
+
+  const destination = resolve(options.cwd, trimmed);
+  const projectRoot = resolve(options.projectRoot);
+  const supabaseDir = join(projectRoot, "supabase");
+
+  if (destination === projectRoot) {
+    return refuse("is the project root itself");
+  }
+  if (!isAtOrUnder(projectRoot, destination)) {
+    return refuse("is outside the project");
+  }
+  if (destination === supabaseDir) {
+    return refuse("is the supabase directory itself");
+  }
+  for (const reserved of RESERVED_ROOT_DIRS) {
+    if (isAtOrUnder(join(supabaseDir, reserved), destination)) {
+      return refuse(`is inside supabase/${reserved}/, which the Supabase CLI already owns`);
+    }
+  }
+
+  return Effect.succeed(destination);
+}
+
+/** A worker's default directory: `supabase/<root>/<name>/`. */
+export function workerDir(projectRoot: string, root: string, name: string): string {
+  return join(workersRootDir(projectRoot, root), name);
+}
+
+/**
+ * A worker's source directory: `[workers.<name>] source` when one is recorded,
+ * resolved against the project root, otherwise the default directory.
+ */
+export function workerSourceDir(
+  projectRoot: string,
+  defaultDir: string,
+  configuredSource: string | undefined,
+): string {
+  return configuredSource === undefined || configuredSource === ""
+    ? defaultDir
+    : resolve(projectRoot, configuredSource);
+}
+
+/**
+ * The worker `cwd` is inside, when it is directly inside one — the directory is
+ * the mapping, so there is nothing to look up. Compares resolved paths rather
+ * than directory names: with `[workers] root` in play there is no fixed name to
+ * match on, and an exact comparison never fires on some unrelated `workers/api/`
+ * elsewhere in the tree.
+ */
+export function inferWorkerNameFromCwd(cwd: string, rootDir: string): string | undefined {
+  const rel = relative(resolve(rootDir), resolve(cwd));
+  // Exactly one level under the root: a subdirectory of a worker is not the worker.
+  if (rel === "" || rel.startsWith("..") || rel.includes(sep)) {
+    return undefined;
+  }
+  return rel;
+}
+
+/**
+ * A path as it should be shown to the user: relative to the current directory,
+ * which is how they referred to it in the first place. Falls back to the
+ * absolute form when the relative one would climb out of the tree, where `../../`
+ * chains stop being clearer than the truth.
+ */
+export function displayPath(cwd: string, target: string): string {
+  const rel = relative(resolve(cwd), resolve(target));
+  if (rel === "") {
+    return ".";
+  }
+  return rel.startsWith("..") ? target : rel;
+}

--- a/apps/cli/src/shared/workers/worker-paths.unit.test.ts
+++ b/apps/cli/src/shared/workers/worker-paths.unit.test.ts
@@ -1,0 +1,130 @@
+import { join } from "node:path";
+import { Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+import {
+  displayPath,
+  resolveWorkerSource,
+  inferWorkerNameFromCwd,
+  resolveWorkersRoot,
+  workerDir,
+  workerSourceDir,
+  workersRootDir,
+} from "./worker-paths.ts";
+import { InvalidWorkerSourceError, InvalidWorkersRootError } from "./workers.errors.ts";
+
+const PROJECT = "/repo";
+
+function rootOf(configured: string | undefined) {
+  return Effect.runSyncExit(resolveWorkersRoot(configured));
+}
+
+function rootValue(configured: string | undefined): string {
+  const exit = rootOf(configured);
+  if (!Exit.isSuccess(exit)) {
+    throw new Error(`expected a root for ${String(configured)}`);
+  }
+  return exit.value;
+}
+
+describe("resolveWorkersRoot", () => {
+  test("defaults to workers/ and accepts a plain directory name", () => {
+    expect(rootValue(undefined)).toBe("workers");
+    expect(rootValue("services")).toBe("services");
+    expect(rootValue("services/")).toBe("services");
+    expect(rootValue("nested/services")).toBe(join("nested", "services"));
+  });
+
+  test.each([
+    ["", "supabase/ itself"],
+    [".", "supabase/ itself"],
+    ["/etc", "an absolute path"],
+    ["../elsewhere", "a climb out of supabase/"],
+    ["functions", "a directory the CLI owns"],
+    ["migrations", "a directory the CLI owns"],
+  ])("refuses %j — %s", (configured) => {
+    const error = Effect.runSync(resolveWorkersRoot(configured).pipe(Effect.flip));
+    expect(error).toBeInstanceOf(InvalidWorkersRootError);
+    expect(error.suggestion).toContain('root = "services"');
+  });
+});
+
+describe("worker directories", () => {
+  test("resolve under supabase/<root>/", () => {
+    expect(workersRootDir(PROJECT, "workers")).toBe(join(PROJECT, "supabase", "workers"));
+    expect(workerDir(PROJECT, "services", "api")).toBe(
+      join(PROJECT, "supabase", "services", "api"),
+    );
+  });
+
+  test("a recorded source wins and is anchored to the project root", () => {
+    const fallback = workerDir(PROJECT, "workers", "api");
+    expect(workerSourceDir(PROJECT, fallback, undefined)).toBe(fallback);
+    expect(workerSourceDir(PROJECT, fallback, "")).toBe(fallback);
+    expect(workerSourceDir(PROJECT, fallback, "packages/api")).toBe(
+      join(PROJECT, "packages", "api"),
+    );
+  });
+});
+
+describe("inferWorkerNameFromCwd", () => {
+  const rootDir = join(PROJECT, "supabase", "workers");
+
+  test("names the worker when cwd is exactly one level under the root", () => {
+    expect(inferWorkerNameFromCwd(join(rootDir, "api"), rootDir)).toBe("api");
+  });
+
+  test("declines the root itself, a nested subdirectory, and anywhere outside", () => {
+    expect(inferWorkerNameFromCwd(rootDir, rootDir)).toBeUndefined();
+    expect(inferWorkerNameFromCwd(join(rootDir, "api", "src"), rootDir)).toBeUndefined();
+    expect(inferWorkerNameFromCwd(join(PROJECT, "elsewhere", "api"), rootDir)).toBeUndefined();
+  });
+
+  test("does not fire on a same-named directory elsewhere in the tree", () => {
+    expect(inferWorkerNameFromCwd("/other/supabase/workers/api", rootDir)).toBeUndefined();
+  });
+});
+
+describe("displayPath", () => {
+  test("prefers the relative form, and falls back to absolute when it would climb out", () => {
+    expect(displayPath(PROJECT, join(PROJECT, "supabase", "workers", "api"))).toBe(
+      join("supabase", "workers", "api"),
+    );
+    expect(displayPath(PROJECT, PROJECT)).toBe(".");
+    expect(displayPath(join(PROJECT, "deep", "deeper"), "/elsewhere/api")).toBe("/elsewhere/api");
+  });
+});
+
+describe("resolveWorkerSource", () => {
+  const cwd = `${PROJECT}/apps/web`;
+
+  test("resolves a directory inside the project against the directory it was typed in", () => {
+    expect(
+      Effect.runSync(resolveWorkerSource({ projectRoot: PROJECT, cwd, raw: "../../packages/api" })),
+    ).toBe(join(PROJECT, "packages", "api"));
+    expect(
+      Effect.runSync(
+        resolveWorkerSource({ projectRoot: PROJECT, cwd: PROJECT, raw: "packages/api/" }),
+      ),
+    ).toBe(join(PROJECT, "packages", "api"));
+  });
+
+  // `--force` deletes whatever this resolves to, so each of these would destroy
+  // work belonging to the project or to the machine.
+  test.each([
+    [".", "the project root itself"],
+    ["", "empty"],
+    ["..", "outside the project"],
+    ["/etc", "outside the project"],
+    ["../elsewhere", "outside the project"],
+    ["supabase", "the supabase directory itself"],
+    ["supabase/functions", "supabase/functions/"],
+    ["supabase/functions/hello", "supabase/functions/"],
+    ["supabase/migrations", "supabase/migrations/"],
+  ])("refuses %j", (raw, reason) => {
+    const error = Effect.runSync(
+      resolveWorkerSource({ projectRoot: PROJECT, cwd: PROJECT, raw }).pipe(Effect.flip),
+    );
+    expect(error).toBeInstanceOf(InvalidWorkerSourceError);
+    expect(error.detail).toContain(reason);
+  });
+});

--- a/apps/cli/src/shared/workers/worker-runtimes.ts
+++ b/apps/cli/src/shared/workers/worker-runtimes.ts
@@ -1,0 +1,130 @@
+/**
+ * The alpha envelope a worker is described by: which runtime it is built on,
+ * and how big an instance it runs as.
+ *
+ * Both are deliberately small closed sets. The Workers API takes `spec.size` as
+ * one opaque string (`2gb-1vcpu`) rather than independent cpu/memory dials, so
+ * the CLI offers exactly the sizes that string has values for and derives the
+ * vCPU count from the memory the user picked — one choice, not two that could
+ * be combined into a shape the platform does not run.
+ */
+
+/** A worker's runtime: its own Dockerfile, or one of the catalog base images. */
+export const WORKER_RUNTIMES = ["dockerfile", "node", "bun", "deno", "python", "sandbox"] as const;
+
+export type WorkerRuntime = (typeof WORKER_RUNTIMES)[number];
+
+/**
+ * The runtime a worker gets when nobody names one: what `new`'s prompt
+ * pre-selects, and what the classifier falls back to for a directory it does
+ * not recognize. Deno, because it is the runtime the rest of the Supabase CLI's
+ * function tooling assumes.
+ */
+export const DEFAULT_WORKER_RUNTIME: WorkerRuntime = "deno";
+
+function isWorkerRuntime(value: string): value is WorkerRuntime {
+  return (WORKER_RUNTIMES as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * The runtime a user (or a config file) named, case-insensitively — so the
+ * `Dockerfile` this CLI displays is accepted by `--runtime`, which would
+ * otherwise reject the one value it shows you. The canonical lowercase form is
+ * what gets recorded.
+ */
+export function parseWorkerRuntime(value: string): WorkerRuntime | undefined {
+  const canonical = value.trim().toLowerCase();
+  return isWorkerRuntime(canonical) ? canonical : undefined;
+}
+
+/** One-line description of each runtime, for `--runtime`'s prompt and help. */
+export const WORKER_RUNTIME_DESCRIPTIONS: Record<WorkerRuntime, string> = {
+  dockerfile: "Build the directory's own Dockerfile.",
+  node: "Node.js runtime (Web-standard fetch handler).",
+  bun: "Bun runtime (Web-standard fetch handler).",
+  deno: "Deno runtime (Web-standard fetch handler).",
+  python: "Python runtime (ASGI app).",
+  sandbox: "Bare sandbox environment; no HTTP handler.",
+};
+
+/**
+ * The only instance sizes the alpha envelope offers, denominated by memory.
+ * There is no resize — a different size later means a new worker, not a flag on
+ * `push`.
+ */
+export const WORKER_SIZES = ["2gb", "4gb"] as const;
+
+export type WorkerSize = (typeof WORKER_SIZES)[number];
+
+/** The first available option — what `new` records when `--size` is omitted. */
+export const DEFAULT_WORKER_SIZE: WorkerSize = "2gb";
+
+function isWorkerSize(value: string): value is WorkerSize {
+  return (WORKER_SIZES as ReadonlyArray<string>).includes(value);
+}
+
+/** As {@link parseWorkerRuntime}, for instance sizes. */
+export function parseWorkerSize(value: string): WorkerSize | undefined {
+  const canonical = value.trim().toLowerCase();
+  return isWorkerSize(canonical) ? canonical : undefined;
+}
+
+const VCPU_FOR_SIZE: Record<WorkerSize, number> = { "2gb": 1, "4gb": 2 };
+
+/** The vCPU count that comes with `size` — not independently choosable. */
+export function vcpuForSize(size: WorkerSize): number {
+  return VCPU_FOR_SIZE[size];
+}
+
+/** `spec.size` as the Workers API spells it: `2gb-1vcpu`. */
+export function apiSizeFor(size: WorkerSize): string {
+  return `${size}-${vcpuForSize(size)}vcpu`;
+}
+
+/**
+ * How a size reads in output: `2gb · 1 vCPU`. Takes the API's own spelling so a
+ * worker deployed at a size this CLI never offered still renders, verbatim,
+ * rather than being forced into the local enum.
+ */
+export function formatApiSize(apiSize: string): string {
+  const match = /^(\d+gb)-(\d+)vcpu$/.exec(apiSize.trim().toLowerCase());
+  if (match === null) {
+    return apiSize;
+  }
+  return `${match[1]} · ${match[2]} vCPU`;
+}
+
+/**
+ * `spec.exposure`: whether the worker is reachable over HTTP. Every catalog
+ * runtime and every Dockerfile build serves traffic; a bare `sandbox` has no
+ * HTTP handler at all, so it is deployed private and reached another way.
+ */
+export function exposureFor(runtime: WorkerRuntime): "public" | "private" {
+  return runtime === "sandbox" ? "private" : "public";
+}
+
+/**
+ * Worker names end up in hostnames, so they are DNS labels — the same pattern
+ * the Management API validates the `:name` path parameter against.
+ */
+const WORKER_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * `root` is the one name a worker cannot have: `[workers] root` is the
+ * project-wide scalar in the same table, so `[workers.root]` would be a string
+ * key holding a table and the whole `config.toml` stops parsing — taking every
+ * other worker command down with it. Refuse it at the door rather than let the
+ * CLI write a file it can no longer read.
+ */
+const RESERVED_WORKER_NAMES = ["root"];
+
+export const workerNameRequirement =
+  "Use lowercase letters, digits and hyphens, starting and ending with a letter or digit.";
+
+/** `undefined` when `name` is a valid worker name, else why it is not. */
+export function validateWorkerNameMessage(name: string): string | undefined {
+  if (RESERVED_WORKER_NAMES.includes(name)) {
+    return `"${name}" is reserved by the [workers] table's own \`${name}\` key.`;
+  }
+  return WORKER_NAME_PATTERN.test(name) ? undefined : workerNameRequirement;
+}

--- a/apps/cli/src/shared/workers/worker-runtimes.unit.test.ts
+++ b/apps/cli/src/shared/workers/worker-runtimes.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import {
+  apiSizeFor,
+  exposureFor,
+  formatApiSize,
+  parseWorkerRuntime,
+  parseWorkerSize,
+  validateWorkerNameMessage,
+  vcpuForSize,
+} from "./worker-runtimes.ts";
+
+describe("parseWorkerRuntime", () => {
+  test("accepts the value it displays, case-insensitively, and canonicalizes it", () => {
+    expect(parseWorkerRuntime("Dockerfile")).toBe("dockerfile");
+    expect(parseWorkerRuntime("  NODE  ")).toBe("node");
+  });
+
+  test("rejects anything outside the catalog", () => {
+    expect(parseWorkerRuntime("rust")).toBeUndefined();
+    expect(parseWorkerRuntime("")).toBeUndefined();
+  });
+});
+
+describe("sizes", () => {
+  test("each size implies its own vCPU count", () => {
+    expect(vcpuForSize("2gb")).toBe(1);
+    expect(vcpuForSize("4gb")).toBe(2);
+  });
+
+  test("map onto the spelling the Workers API takes", () => {
+    expect(apiSizeFor("2gb")).toBe("2gb-1vcpu");
+    expect(apiSizeFor("4gb")).toBe("4gb-2vcpu");
+  });
+
+  test("render back for display, and pass through anything unrecognized verbatim", () => {
+    expect(formatApiSize("2gb-1vcpu")).toBe("2gb · 1 vCPU");
+    expect(formatApiSize("16gb-8vcpu")).toBe("16gb · 8 vCPU");
+    expect(formatApiSize("something-else")).toBe("something-else");
+  });
+
+  test("parse case-insensitively and reject sizes outside the alpha envelope", () => {
+    expect(parseWorkerSize("4GB")).toBe("4gb");
+    expect(parseWorkerSize("8gb")).toBeUndefined();
+  });
+});
+
+describe("exposureFor", () => {
+  test("is public for everything that serves HTTP and private for a bare sandbox", () => {
+    expect(exposureFor("node")).toBe("public");
+    expect(exposureFor("dockerfile")).toBe("public");
+    expect(exposureFor("sandbox")).toBe("private");
+  });
+});
+
+describe("validateWorkerNameMessage", () => {
+  test("accepts DNS labels", () => {
+    expect(validateWorkerNameMessage("api")).toBeUndefined();
+    expect(validateWorkerNameMessage("my-worker-1")).toBeUndefined();
+    expect(validateWorkerNameMessage("a")).toBeUndefined();
+  });
+
+  test("refuses `root`, which collides with the [workers] table's own key", () => {
+    expect(validateWorkerNameMessage("root")).toContain("reserved");
+  });
+
+  test.each(["My-Worker", "-leading", "trailing-", "under_score", "", "a".repeat(64)])(
+    "rejects %j",
+    (name) => {
+      expect(validateWorkerNameMessage(name)).toBeDefined();
+    },
+  );
+});

--- a/apps/cli/src/shared/workers/worker-stacks.ts
+++ b/apps/cli/src/shared/workers/worker-stacks.ts
@@ -1,0 +1,104 @@
+import type { WorkerRuntime } from "./worker-runtimes.ts";
+
+/**
+ * The starter files `supabase workers new` writes, per runtime.
+ *
+ * Held as source text rather than read from a directory on disk, the same way
+ * `supabase functions new` holds its entrypoint: the compiled binary ships no
+ * template tree, so the content has to travel in the module graph.
+ *
+ * The catalog runtimes all scaffold a Web-standard `fetch` handler (or, for
+ * python, an ASGI `app`) rather than binding a port themselves — the base
+ * image's own entrypoint does the binding in production.
+ */
+
+const packageJson = `${JSON.stringify(
+  {
+    name: "worker",
+    private: true,
+    type: "module",
+  },
+  null,
+  2,
+)}\n`;
+
+const fetchHandler = (
+  runtime: string,
+) => `// Starter for the "${runtime}" runtime — edit before deploying.
+// Export a default object with a Web-standard \`fetch\` handler; the runtime
+// binds the port and serves it.
+export default {
+  fetch() {
+    return new Response("hello from supabase workers\\n");
+  },
+};
+`;
+
+const dockerfile = `FROM node:24-alpine
+WORKDIR /app
+COPY . .
+EXPOSE 8080
+CMD ["node", "server.js"]
+`;
+
+/**
+ * Scaffolded alongside the Dockerfile above, because that Dockerfile's \`CMD\`
+ * names it. A starter whose only file references a second file that does not
+ * exist builds cleanly and then crash-loops on deploy — the one runtime whose
+ * scaffold could not run as written.
+ */
+const dockerfileServer = `// Starter for the "dockerfile" runtime — edit before deploying.
+// The Dockerfile's CMD runs this file; it binds the port itself, unlike the
+// catalog runtimes where the base image does the binding.
+import { createServer } from "node:http";
+
+const port = Number(process.env.PORT ?? 8080);
+
+createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/plain" });
+  response.end("hello from supabase workers\\n");
+}).listen(port, () => {
+  console.log(\`listening on \${port}\`);
+});
+`;
+
+const pythonApp = `# Starter for the "python" runtime — edit before deploying.
+# \`app\` is an ASGI application, so FastAPI/Starlette/etc. work too — just
+# assign your app to \`app\`. The runtime serves it on the ingress port.
+async def app(scope, receive, send):
+    if scope["type"] != "http":
+        return
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({"type": "http.response.body", "body": b"hello from supabase workers\\n"})
+`;
+
+const pythonRequirements = `# add your dependencies here
+`;
+
+const sandboxReadme = `# sandbox
+
+A bare sandbox runtime — no HTTP handler and no baked code. It is an environment
+to run things in, not a served app, so \`supabase workers push\` here provisions
+the environment and gives it no URL.
+`;
+
+/** Each runtime's starter files, keyed by the filename to write in the worker directory. */
+export const WORKER_STACKS: Record<WorkerRuntime, Readonly<Record<string, string>>> = {
+  // `package.json` is scaffolded for its `"type": "module"` alone: without it
+  // `server.js` is only ESM by Node's syntax detection, which is a heuristic to
+  // rely on for a file the image's CMD depends on.
+  dockerfile: {
+    Dockerfile: dockerfile,
+    "package.json": packageJson,
+    "server.js": dockerfileServer,
+  },
+  node: { "package.json": packageJson, "index.js": fetchHandler("node") },
+  bun: { "package.json": packageJson, "index.ts": fetchHandler("bun") },
+  deno: { "main.ts": fetchHandler("deno") },
+  python: { "main.py": pythonApp, "requirements.txt": pythonRequirements },
+  sandbox: { "README.md": sandboxReadme },
+};

--- a/apps/cli/src/shared/workers/worker-url.ts
+++ b/apps/cli/src/shared/workers/worker-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Where a worker is served.
+ *
+ * Every worker gets a path on the project's own API host, exactly like an Edge
+ * Function — `<ref>.supabase.co/workers/v1/<name>` next to
+ * `<ref>.supabase.co/functions/v1/<name>`. One host per project, one path per
+ * worker: nothing per-worker is provisioned in DNS, so the URL is derived from
+ * the name rather than returned by the API.
+ */
+
+/** Path prefix workers are served under, mirroring `functions/v1`. */
+const WORKERS_PATH_PREFIX = "/workers/v1";
+
+/** The canonical URL of a worker on its project's API host. */
+export function workerUrl(projectRef: string, projectHost: string, name: string): string {
+  return `https://${projectRef}.${projectHost}${WORKERS_PATH_PREFIX}/${name}`;
+}

--- a/apps/cli/src/shared/workers/workers-api.ts
+++ b/apps/cli/src/shared/workers/workers-api.ts
@@ -1,0 +1,361 @@
+import {
+  markSupabaseApiInputErrorAsUserInput,
+  operationDefinitions,
+  SupabaseApiInputError,
+  V2CreateWorkerUploadOutput,
+  V2DeployAWorkerOutput,
+  V2GetAWorkerOutput,
+  type ApiClient,
+} from "@supabase/api/effect";
+import { Effect, Option, Schedule, Schema } from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import {
+  WorkerBuildTimeoutError,
+  WorkersApiNetworkError,
+  WorkersApiUnexpectedStatusError,
+  WorkersUnavailableError,
+  WorkerUploadFailedError,
+} from "./workers.errors.ts";
+
+/**
+ * The seam every worker command talks to: `/v2/projects/{ref}/workers` on the
+ * Management API.
+ *
+ * The routes are deliberately few, so this module is thin and what it mostly
+ * adds is status handling. The alpha's allow-list answers 404 for a project
+ * that is not enrolled, which at the transport level is indistinguishable from
+ * "no such worker"; so a 404 where no worker name could have been wrong becomes
+ * {@link WorkersUnavailableError}, and a 404 on a named worker is reported by
+ * the caller as "not deployed".
+ */
+
+/** The worker shape the API returns, flattened out of its JSON:API envelope. */
+export interface WorkerRecord {
+  readonly name: string;
+  readonly spec: {
+    readonly runtime?: string;
+    readonly size: string;
+    readonly exposure: string;
+    readonly instances: number;
+    readonly backend?: string;
+  };
+  readonly buildState: "building" | "active" | "failed";
+  readonly stateReason?: string;
+  readonly imageVersion?: string;
+  readonly deleting?: boolean;
+  /** Present only on single-worker reads; a fresh deploy has nothing to report yet. */
+  readonly instances?: {
+    readonly declared: number;
+    readonly live: number;
+    readonly ready: number;
+    readonly stale: number;
+  };
+  /** Set instead of `instances` when the instance read-through failed. */
+  readonly instancesError?: string;
+}
+
+export interface WorkerUploadSlot {
+  readonly uploadId: string;
+  readonly url: string;
+  readonly method: string;
+  readonly expiresAt: string;
+}
+
+/** The `spec` a deploy sends. Mirrors the API's own field names exactly. */
+export interface WorkerDeploySpec {
+  readonly runtime?: string;
+  readonly size: string;
+  readonly exposure: string;
+  readonly instances: number;
+}
+
+type WorkerResourceData = typeof V2GetAWorkerOutput.Type extends { data: infer D } ? D : never;
+
+function toWorkerRecord(data: WorkerResourceData): WorkerRecord {
+  return {
+    name: data.id,
+    spec: data.attributes.spec,
+    buildState: data.attributes.build_state,
+    stateReason: data.attributes.state_reason,
+    imageVersion: data.attributes.image_version,
+    deleting: data.attributes.deleting,
+    instances: data.attributes.instances,
+    instancesError: data.attributes.instances_error,
+  };
+}
+
+const workersSuggestion =
+  "Workers are in private alpha. Ask in the Supabase dashboard to have this project enrolled.";
+
+/**
+ * Everything that can go wrong before a status code exists: the generated input
+ * schema rejecting the request, or the transport failing outright.
+ */
+function mapRequestError(operation: string) {
+  return (error: unknown) => {
+    if (error instanceof SupabaseApiInputError) {
+      // The only inputs these operations take are the resolved project ref and
+      // the prevalidated worker name, so a schema rejection is user-derived.
+      return markSupabaseApiInputErrorAsUserInput(error);
+    }
+    if (HttpClientError.isHttpClientError(error)) {
+      const description = error.reason.description ?? error.reason._tag;
+      return new WorkersApiNetworkError({
+        detail: `Could not reach the Workers API while trying to ${operation}: ${description}.`,
+        suggestion: "Check your network connection and retry.",
+      });
+    }
+    return new WorkersApiNetworkError({
+      detail: `Could not reach the Workers API while trying to ${operation}: ${String(error)}.`,
+      suggestion: "Check your network connection and retry.",
+    });
+  };
+}
+
+const unexpectedStatus = Effect.fnUntraced(function* (options: {
+  readonly operation: string;
+  readonly status: number;
+  readonly body: string;
+}) {
+  const trimmed = options.body.trim();
+  return yield* Effect.fail(
+    new WorkersApiUnexpectedStatusError({
+      status: options.status,
+      detail: `The Workers API answered ${options.status} while trying to ${options.operation}${
+        trimmed === "" ? "" : `: ${trimmed}`
+      }.`,
+      suggestion: "Retry shortly; if it persists, report it with `supabase issue`.",
+    }),
+  );
+});
+
+const decodeBody = <A, I>(
+  schema: Schema.Codec<A, I>,
+  operation: string,
+  body: unknown,
+  status: number,
+) =>
+  Schema.decodeUnknownEffect(schema)(body).pipe(
+    Effect.mapError(
+      (error) =>
+        new WorkersApiUnexpectedStatusError({
+          status,
+          detail: `The Workers API returned a response this CLI could not read while trying to ${operation}: ${error.message}.`,
+          suggestion: "Update the CLI with `supabase update`, then retry.",
+        }),
+    ),
+  );
+
+/**
+ * One worker, or `None` when the API has no record of it — which is also what a
+ * project outside the alpha's allow-list answers, so callers report it as "not
+ * deployed" and point at `push` rather than guessing which of the two it was.
+ */
+const getWorker = Effect.fnUntraced(function* (api: ApiClient, projectRef: string, name: string) {
+  const operation = `read worker "${name}"`;
+  const response = yield* api
+    .executeRaw(operationDefinitions.v2GetAWorker, { ref: projectRef, name })
+    .pipe(Effect.mapError(mapRequestError(operation)));
+
+  if (response.status === 404) {
+    return Option.none<WorkerRecord>();
+  }
+  if (response.status !== 200) {
+    return yield* unexpectedStatus({
+      operation,
+      status: response.status,
+      body: yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+    });
+  }
+
+  const body = yield* response.json.pipe(Effect.mapError(mapRequestError(operation)));
+  const decoded = yield* decodeBody(V2GetAWorkerOutput, operation, body, response.status);
+  return Option.some(toWorkerRecord(decoded.data));
+});
+
+export const createWorkerUpload = Effect.fnUntraced(function* (
+  api: ApiClient,
+  projectRef: string,
+  name: string,
+) {
+  const operation = `stage a build context for "${name}"`;
+  const response = yield* api
+    .executeRaw(operationDefinitions.v2CreateWorkerUpload, { ref: projectRef, name })
+    .pipe(Effect.mapError(mapRequestError(operation)));
+
+  if (response.status === 404) {
+    return yield* Effect.fail(
+      new WorkersUnavailableError({
+        detail: `Workers are not available for project ${projectRef}.`,
+        suggestion: workersSuggestion,
+      }),
+    );
+  }
+  if (response.status !== 201 && response.status !== 200) {
+    return yield* unexpectedStatus({
+      operation,
+      status: response.status,
+      body: yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+    });
+  }
+
+  const body = yield* response.json.pipe(Effect.mapError(mapRequestError(operation)));
+  const decoded = yield* decodeBody(V2CreateWorkerUploadOutput, operation, body, response.status);
+  return {
+    uploadId: decoded.data.id,
+    url: decoded.data.attributes.url,
+    method: decoded.data.attributes.method,
+    expiresAt: decoded.data.attributes.expires_at,
+  } satisfies WorkerUploadSlot;
+});
+
+/**
+ * PUT the archive straight at the presigned slot. The bytes never pass through
+ * the Management API, so this goes out on the plain HTTP client with no
+ * Supabase credentials attached — the signature in the URL is the authorization.
+ */
+export const uploadBuildContext = Effect.fnUntraced(function* (
+  slot: WorkerUploadSlot,
+  archive: Uint8Array,
+) {
+  const client = yield* HttpClient.HttpClient;
+
+  // The slot names its own method; the API documents `PUT` and nothing else is
+  // meaningful for a presigned object-store destination, so anything unexpected
+  // falls back to it rather than assembling a request we cannot build.
+  const request = (
+    slot.method.toUpperCase() === "POST"
+      ? HttpClientRequest.post(slot.url)
+      : HttpClientRequest.put(slot.url)
+  ).pipe(HttpClientRequest.bodyUint8Array(archive, "application/gzip"));
+
+  const response = yield* client.execute(request).pipe(
+    Effect.mapError(
+      (error) =>
+        new WorkerUploadFailedError({
+          detail: `Uploading the build context failed: ${
+            error.reason.description ?? error.reason._tag
+          }.`,
+          suggestion: "Check your network connection, then re-run the same command.",
+        }),
+    ),
+  );
+
+  if (response.status < 200 || response.status >= 300) {
+    const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
+    return yield* Effect.fail(
+      new WorkerUploadFailedError({
+        detail: `Uploading the build context failed with status ${response.status}${
+          body.trim() === "" ? "" : `: ${body.trim()}`
+        }.`,
+        suggestion: "Re-run the same command; the upload slot is minted fresh each time.",
+      }),
+    );
+  }
+});
+
+export const deployWorker = Effect.fnUntraced(function* (
+  api: ApiClient,
+  projectRef: string,
+  name: string,
+  attributes: { readonly spec: WorkerDeploySpec; readonly contextUploadId?: string },
+) {
+  const operation = `deploy worker "${name}"`;
+  const response = yield* api
+    .executeRaw(operationDefinitions.v2DeployAWorker, {
+      ref: projectRef,
+      name,
+      data: {
+        type: "project_worker",
+        attributes: {
+          spec: attributes.spec,
+          ...(attributes.contextUploadId === undefined
+            ? {}
+            : { context_upload_id: attributes.contextUploadId }),
+        },
+      },
+    })
+    .pipe(Effect.mapError(mapRequestError(operation)));
+
+  if (response.status === 404) {
+    return yield* Effect.fail(
+      new WorkersUnavailableError({
+        detail: `Workers are not available for project ${projectRef}.`,
+        suggestion: workersSuggestion,
+      }),
+    );
+  }
+  if (response.status !== 202 && response.status !== 200 && response.status !== 201) {
+    return yield* unexpectedStatus({
+      operation,
+      status: response.status,
+      body: yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+    });
+  }
+
+  const body = yield* response.json.pipe(Effect.mapError(mapRequestError(operation)));
+  const decoded = yield* decodeBody(V2DeployAWorkerOutput, operation, body, response.status);
+  return toWorkerRecord(decoded.data);
+});
+
+/**
+ * The build runs asynchronously — deploy answers 202 and the worker reaches
+ * `active` or `failed` later — so `push` polls `get` until `build_state` leaves
+ * `building`.
+ *
+ * The schedule is a parameter so tests can drive the same loop without waiting
+ * on wall-clock delays.
+ */
+const WORKER_BUILD_POLL_SCHEDULE = Schedule.spaced("2 seconds").pipe(
+  Schedule.upTo({ duration: "10 minutes" }),
+);
+
+export const awaitWorkerBuild = Effect.fnUntraced(function* (
+  api: ApiClient,
+  projectRef: string,
+  name: string,
+  options: {
+    readonly schedule?: Schedule.Schedule<unknown>;
+    /** Called with each poll's result, for progress reporting. */
+    readonly onPoll?: (worker: WorkerRecord) => Effect.Effect<void>;
+  } = {},
+) {
+  const poll = Effect.gen(function* () {
+    // A build can run for minutes, so a single blip on one read should not throw
+    // away a deploy that is progressing fine. A few immediate retries absorb
+    // that; anything that keeps failing is reported as the real error rather
+    // than silently waited out until the timeout.
+    const worker = yield* getWorker(api, projectRef, name).pipe(
+      Effect.retry({ schedule: Schedule.recurs(2) }),
+    );
+    if (Option.isNone(worker)) {
+      // The deploy was accepted, so the worker exists; a 404 here is the read
+      // racing the write. Report it as still building and poll again.
+      return undefined;
+    }
+    if (options.onPoll !== undefined) {
+      yield* options.onPoll(worker.value);
+    }
+    return worker.value.buildState === "building" ? undefined : worker.value;
+  });
+
+  const settled = yield* poll.pipe(
+    Effect.repeat({
+      schedule: options.schedule ?? WORKER_BUILD_POLL_SCHEDULE,
+      until: (result) => result !== undefined,
+    }),
+  );
+
+  if (settled === undefined) {
+    return yield* Effect.fail(
+      new WorkerBuildTimeoutError({
+        detail: `"${name}" was still building when this command stopped waiting.`,
+        suggestion: `Check on it with \`supabase workers status ${name}\`.`,
+      }),
+    );
+  }
+
+  return settled;
+});

--- a/apps/cli/src/shared/workers/workers-api.ts
+++ b/apps/cli/src/shared/workers/workers-api.ts
@@ -333,6 +333,29 @@ export const deployWorker = Effect.fnUntraced(function* (
   return toWorkerRecord(decoded.data);
 });
 
+export const deleteWorker = Effect.fnUntraced(function* (
+  api: ApiClient,
+  projectRef: string,
+  name: string,
+) {
+  const operation = `delete worker "${name}"`;
+  const response = yield* api
+    .executeRaw(operationDefinitions.v2DeleteAWorker, { ref: projectRef, name })
+    .pipe(Effect.mapError(mapRequestError(operation)));
+
+  // 404 is the caller's own "not deployed" verdict to report; a delete that
+  // races another one is still a delete that happened.
+  if (response.status === 204 || response.status === 200 || response.status === 404) {
+    return;
+  }
+
+  return yield* unexpectedStatus({
+    operation,
+    status: response.status,
+    body: yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+  });
+});
+
 /**
  * The build runs asynchronously — deploy answers 202 and the worker reaches
  * `active` or `failed` later — so `push` polls `get` until `build_state` leaves

--- a/apps/cli/src/shared/workers/workers-api.ts
+++ b/apps/cli/src/shared/workers/workers-api.ts
@@ -5,6 +5,7 @@ import {
   V2CreateWorkerUploadOutput,
   V2DeployAWorkerOutput,
   V2GetAWorkerOutput,
+  V2ListAllWorkersOutput,
   type ApiClient,
 } from "@supabase/api/effect";
 import { Effect, Option, Schedule, Schema } from "effect";
@@ -23,10 +24,11 @@ import {
  * The seam every worker command talks to: `/v2/projects/{ref}/workers` on the
  * Management API.
  *
- * The routes are deliberately few, so this module is thin and what it mostly
- * adds is status handling. The alpha's allow-list answers 404 for a project
- * that is not enrolled, which at the transport level is indistinguishable from
- * "no such worker"; so a 404 where no worker name could have been wrong becomes
+ * The routes are deliberately few — list, get, mint an upload slot, deploy,
+ * delete — so this module is thin, and what it mostly adds is status handling.
+ * The alpha's allow-list answers 404 for a project that is not enrolled, which
+ * at the transport level is indistinguishable from "no such worker"; so a 404
+ * on a collection endpoint (where no worker name could have been wrong) becomes
  * {@link WorkersUnavailableError}, and a 404 on a named worker is reported by
  * the caller as "not deployed".
  */
@@ -147,6 +149,33 @@ const decodeBody = <A, I>(
         }),
     ),
   );
+
+export const listWorkers = Effect.fnUntraced(function* (api: ApiClient, projectRef: string) {
+  const operation = "list workers";
+  const response = yield* api
+    .executeRaw(operationDefinitions.v2ListAllWorkers, { ref: projectRef })
+    .pipe(Effect.mapError(mapRequestError(operation)));
+
+  if (response.status === 404) {
+    return yield* Effect.fail(
+      new WorkersUnavailableError({
+        detail: `Workers are not available for project ${projectRef}.`,
+        suggestion: workersSuggestion,
+      }),
+    );
+  }
+  if (response.status !== 200) {
+    return yield* unexpectedStatus({
+      operation,
+      status: response.status,
+      body: yield* response.text.pipe(Effect.orElseSucceed(() => "")),
+    });
+  }
+
+  const body = yield* response.json.pipe(Effect.mapError(mapRequestError(operation)));
+  const decoded = yield* decodeBody(V2ListAllWorkersOutput, operation, body, response.status);
+  return decoded.data.map(toWorkerRecord);
+});
 
 /**
  * One worker, or `None` when the API has no record of it — which is also what a

--- a/apps/cli/src/shared/workers/workers-api.ts
+++ b/apps/cli/src/shared/workers/workers-api.ts
@@ -182,7 +182,11 @@ export const listWorkers = Effect.fnUntraced(function* (api: ApiClient, projectR
  * project outside the alpha's allow-list answers, so callers report it as "not
  * deployed" and point at `push` rather than guessing which of the two it was.
  */
-const getWorker = Effect.fnUntraced(function* (api: ApiClient, projectRef: string, name: string) {
+export const getWorker = Effect.fnUntraced(function* (
+  api: ApiClient,
+  projectRef: string,
+  name: string,
+) {
   const operation = `read worker "${name}"`;
   const response = yield* api
     .executeRaw(operationDefinitions.v2GetAWorker, { ref: projectRef, name })

--- a/apps/cli/src/shared/workers/workers.errors.ts
+++ b/apps/cli/src/shared/workers/workers.errors.ts
@@ -171,3 +171,15 @@ export class WorkersApiUnexpectedStatusError extends Data.TaggedError(
     return actionability.apiStatus;
   }
 }
+
+/** The user answered the `delete` confirmation with something other than the name. */
+export class WorkerDeleteNotConfirmedError extends Data.TaggedError(
+  "WorkerDeleteNotConfirmedError",
+)<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.cancelled;
+  }
+}

--- a/apps/cli/src/shared/workers/workers.errors.ts
+++ b/apps/cli/src/shared/workers/workers.errors.ts
@@ -132,6 +132,19 @@ export class WorkersApiNetworkError extends Data.TaggedError("WorkersApiNetworkE
 }
 
 /**
+ * The named worker is not deployed. `status`/`delete` share this verbatim: the
+ * question "does this exist?" is asked of the API, never of a local directory.
+ */
+export class WorkerNotDeployedError extends Data.TaggedError("WorkerNotDeployedError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+/**
  * Workers are in private alpha: the routes answer 404 for a project that is not
  * enrolled, which is indistinguishable from an unknown worker at the transport
  * level — so this is only raised for the collection endpoints, where there is

--- a/apps/cli/src/shared/workers/workers.errors.ts
+++ b/apps/cli/src/shared/workers/workers.errors.ts
@@ -1,0 +1,38 @@
+import { Data } from "effect";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../telemetry/error-actionability.ts";
+
+/**
+ * Every worker failure carries the same shape the rest of the next shell uses:
+ * a `detail` saying what happened and a `suggestion` naming the exact command
+ * that fixes it. The POC's `→` recovery lines are this, rendered by the shared
+ * output layer instead of by each command.
+ */
+
+/**
+ * `--source` names a directory it is not allowed to name. Worth its own error
+ * because the destination is a directory `--force` will delete outright, so a
+ * value that resolves to the project root, `supabase/`, or anywhere outside the
+ * project has to be refused before anything is removed.
+ */
+export class InvalidWorkerSourceError extends Data.TaggedError("InvalidWorkerSourceError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+/** `[workers] root` names a directory it is not allowed to name. */
+export class InvalidWorkersRootError extends Data.TaggedError("InvalidWorkersRootError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidConfig;
+  }
+}

--- a/apps/cli/src/shared/workers/workers.errors.ts
+++ b/apps/cli/src/shared/workers/workers.errors.ts
@@ -57,6 +57,15 @@ export class WorkerDirectoryExistsError extends Data.TaggedError("WorkerDirector
   }
 }
 
+export class WorkerSourceMissingError extends Data.TaggedError("WorkerSourceMissingError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
 /**
  * `--source` names a directory it is not allowed to name. Worth its own error
  * because the destination is a directory `--force` will delete outright, so a
@@ -79,5 +88,73 @@ export class InvalidWorkersRootError extends Data.TaggedError("InvalidWorkersRoo
 }> {
   get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
     return actionability.invalidConfig;
+  }
+}
+
+/** The deploy finished, and the build it started failed. */
+export class WorkerBuildFailedError extends Data.TaggedError("WorkerBuildFailedError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.invalidInput;
+  }
+}
+
+/** The build never left `building` inside the CLI's polling budget. */
+export class WorkerBuildTimeoutError extends Data.TaggedError("WorkerBuildTimeoutError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.apiStatus;
+  }
+}
+
+/** PUTting the build context to the presigned slot failed. */
+export class WorkerUploadFailedError extends Data.TaggedError("WorkerUploadFailedError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
+
+/** Transport failure talking to the Management API. */
+export class WorkersApiNetworkError extends Data.TaggedError("WorkersApiNetworkError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.externalNetwork;
+  }
+}
+
+/**
+ * Workers are in private alpha: the routes answer 404 for a project that is not
+ * enrolled, which is indistinguishable from an unknown worker at the transport
+ * level — so this is only raised for the collection endpoints, where there is
+ * no worker name that could have been wrong.
+ */
+export class WorkersUnavailableError extends Data.TaggedError("WorkersUnavailableError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.permission;
+  }
+}
+
+/** Any other status the Workers routes answered with. */
+export class WorkersApiUnexpectedStatusError extends Data.TaggedError(
+  "WorkersApiUnexpectedStatusError",
+)<{
+  readonly detail: string;
+  readonly suggestion: string;
+  readonly status: number;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.apiStatus;
   }
 }

--- a/apps/cli/src/shared/workers/workers.errors.ts
+++ b/apps/cli/src/shared/workers/workers.errors.ts
@@ -12,6 +12,51 @@ import {
  * output layer instead of by each command.
  */
 
+export class InvalidWorkerNameError extends Data.TaggedError("InvalidWorkerNameError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+export class MissingWorkerNameError extends Data.TaggedError("MissingWorkerNameError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+export class UnknownWorkerRuntimeError extends Data.TaggedError("UnknownWorkerRuntimeError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+export class UnknownWorkerSizeError extends Data.TaggedError("UnknownWorkerSizeError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
+export class WorkerDirectoryExistsError extends Data.TaggedError("WorkerDirectoryExistsError")<{
+  readonly detail: string;
+  readonly suggestion: string;
+}> {
+  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+    return actionability.provideFlags;
+  }
+}
+
 /**
  * `--source` names a directory it is not allowed to name. Worth its own error
  * because the destination is a directory `--force` will delete outright, so a

--- a/apps/cli/tests/helpers/workers.ts
+++ b/apps/cli/tests/helpers/workers.ts
@@ -1,0 +1,256 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { BunServices } from "@effect/platform-bun";
+import { makeApiClient } from "@supabase/api/effect";
+import { Effect, Layer, Option } from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { PlatformApi } from "../../src/next/auth/platform-api.service.ts";
+import type { ProjectLinkStateValue } from "../../src/next/config/project-link-state.service.ts";
+import { CliConfig } from "../../src/next/config/cli-config.service.ts";
+import { randomLayer } from "../../src/shared/runtime/random.layer.ts";
+import { mockOutput, mockProjectLinkState, mockRuntimeInfo } from "./mocks.ts";
+
+/**
+ * Shared scaffolding for the `supabase workers` command integration tests.
+ *
+ * Every worker command reads a real `supabase/config.toml` and a real worker
+ * directory, so these tests run against a per-test temp project rather than a
+ * mocked filesystem — the config-writing and packaging behaviour is most of
+ * what is worth asserting. Only the network is faked.
+ */
+
+export const WORKERS_PROJECT_REF = "abcdefghijklmnopqrst";
+
+export const WORKERS_LINK_STATE: ProjectLinkStateValue = {
+  project: {
+    ref: WORKERS_PROJECT_REF,
+    name: "Linked Project",
+    organization_id: "org-id",
+    organization_slug: "org-slug",
+  },
+  active_branch: { ref: "branchrefabcdefghij", name: "main", is_default: true },
+  fetchedAt: "2026-01-01T00:00:00.000Z",
+  versions: {},
+};
+
+export interface RecordedRequest {
+  readonly method: string;
+  readonly url: string;
+  /** The request body decoded as UTF-8 — meaningful for the JSON requests. */
+  readonly body: string;
+  /** Byte length of the body, which is what matters for the binary upload. */
+  readonly byteLength: number;
+}
+
+export interface StubResponse {
+  readonly status: number;
+  readonly body?: unknown;
+}
+
+/** How a test answers one request; sequential entries reply to repeated calls. */
+export type RouteHandler = StubResponse | ReadonlyArray<StubResponse>;
+
+export interface WorkersHttpRoutes {
+  /** Keyed `"<METHOD> <pathname>"`, e.g. `"GET /v2/projects/abc.../workers"`. */
+  readonly [route: string]: RouteHandler;
+}
+
+function respond(
+  request: HttpClientRequest.HttpClientRequest,
+  stub: StubResponse,
+): HttpClientResponse.HttpClientResponse {
+  const hasBody = stub.body !== undefined;
+  return HttpClientResponse.fromWeb(
+    request,
+    new Response(hasBody ? JSON.stringify(stub.body) : "", {
+      status: stub.status,
+      headers: hasBody ? { "content-type": "application/json" } : { "content-type": "text/plain" },
+    }),
+  );
+}
+
+/**
+ * A single HTTP stub shared by the Management API client and the presigned
+ * build-context upload, so a test can assert the whole request sequence — mint
+ * the slot, PUT the bytes, deploy, poll — in the order it happened.
+ */
+export function mockWorkersHttp(routes: WorkersHttpRoutes) {
+  const requests: Array<RecordedRequest> = [];
+  const remaining = new Map<string, Array<StubResponse>>(
+    Object.entries(routes).map(([route, handler]) => [
+      route,
+      Array.isArray(handler) ? [...handler] : [handler as StubResponse],
+    ]),
+  );
+
+  const handle = (
+    request: HttpClientRequest.HttpClientRequest,
+  ): Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError> =>
+    Effect.sync(() => {
+      const bytes = request.body._tag === "Uint8Array" ? request.body.body : new Uint8Array(0);
+      const url = new URL(request.url);
+      requests.push({
+        method: request.method,
+        url: request.url,
+        body: new TextDecoder().decode(bytes),
+        byteLength: bytes.length,
+      });
+
+      const key = `${request.method} ${url.pathname}`;
+      const queue = remaining.get(key);
+      if (queue === undefined || queue.length === 0) {
+        return respond(request, { status: 599, body: { error: `unstubbed route: ${key}` } });
+      }
+      // The last stub for a route keeps answering, so a poll loop does not have
+      // to be stubbed a fixed number of times.
+      const stub = queue.length === 1 ? queue[0]! : queue.shift()!;
+      return respond(request, stub);
+    });
+
+  const httpClientLayer = Layer.succeed(HttpClient.HttpClient, HttpClient.make(handle));
+
+  const apiLayer = Layer.effect(
+    PlatformApi,
+    makeApiClient({
+      baseUrl: "https://api.supabase.com",
+      accessToken: "test-token",
+      userAgent: "supabase",
+      headers: {
+        "X-Supabase-Command": "workers",
+        "X-Supabase-Command-Run-ID": "run-123",
+      },
+    }),
+  ).pipe(Layer.provide(httpClientLayer));
+
+  return {
+    layer: Layer.mergeAll(apiLayer, httpClientLayer),
+    requests,
+    get routeKeys(): Array<string> {
+      return requests.map((request) => `${request.method} ${new URL(request.url).pathname}`);
+    },
+  };
+}
+
+/** Worker resource JSON, as the Management API's JSON:API envelope wraps it. */
+export function workerResource(options: {
+  readonly name: string;
+  readonly runtime?: string;
+  readonly size?: string;
+  readonly exposure?: string;
+  readonly instances?: number;
+  readonly buildState?: "building" | "active" | "failed";
+  readonly stateReason?: string;
+  readonly imageVersion?: string;
+  readonly deleting?: boolean;
+  readonly instanceCounts?: {
+    declared: number;
+    live: number;
+    ready: number;
+    stale: number;
+  };
+  readonly instancesError?: string;
+}) {
+  return {
+    type: "project_worker",
+    id: options.name,
+    attributes: {
+      spec: {
+        ...(options.runtime === undefined ? {} : { runtime: options.runtime }),
+        size: options.size ?? "2gb-1vcpu",
+        exposure: options.exposure ?? "public",
+        instances: options.instances ?? 1,
+      },
+      build_state: options.buildState ?? "active",
+      secret_generation: "gen-1",
+      ...(options.stateReason === undefined ? {} : { state_reason: options.stateReason }),
+      ...(options.imageVersion === undefined ? {} : { image_version: options.imageVersion }),
+      ...(options.deleting === undefined ? {} : { deleting: options.deleting }),
+      ...(options.instanceCounts === undefined ? {} : { instances: options.instanceCounts }),
+      ...(options.instancesError === undefined ? {} : { instances_error: options.instancesError }),
+    },
+  };
+}
+
+export const workersRoute = (suffix = "") => `/v2/projects/${WORKERS_PROJECT_REF}/workers${suffix}`;
+
+/** A per-test temp project, optionally pre-seeded with files. */
+export function makeWorkersProject(files: Readonly<Record<string, string>> = {}): {
+  readonly dir: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "supabase-workers-"));
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const absolutePath = join(dir, relativePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+  return { dir };
+}
+
+export interface WorkersSetupOptions {
+  readonly cwd: string;
+  readonly format?: "text" | "json" | "stream-json";
+  readonly interactive?: boolean;
+  readonly linked?: boolean;
+  readonly promptTextResponses?: ReadonlyArray<string>;
+  readonly promptSelectResponses?: ReadonlyArray<string>;
+  readonly routes?: WorkersHttpRoutes;
+}
+
+const testCliConfigLayer = (cwd: string) =>
+  Layer.succeed(
+    CliConfig,
+    CliConfig.of({
+      apiUrl: "https://api.supabase.com",
+      dashboardUrl: "https://supabase.com/dashboard",
+      projectHost: "supabase.co",
+      telemetryPosthogHost: "https://us.i.posthog.com",
+      telemetryPosthogKey: Option.some("phc_test_key"),
+      accessToken: Option.none(),
+      noKeyring: Option.none(),
+      supabaseHome: join(cwd, ".cache", "supabase"),
+      debug: Option.none(),
+      telemetryDebug: Option.none(),
+      telemetryDisabled: Option.none(),
+      doNotTrack: Option.none(),
+    }),
+  );
+
+export function setupWorkers(options: WorkersSetupOptions) {
+  const out = mockOutput({
+    format: options.format ?? "text",
+    interactive: options.interactive ?? (options.format ?? "text") === "text",
+    ...(options.promptTextResponses === undefined
+      ? {}
+      : { promptTextResponses: options.promptTextResponses }),
+    ...(options.promptSelectResponses === undefined
+      ? {}
+      : { promptSelectResponses: options.promptSelectResponses }),
+  });
+  const http = mockWorkersHttp(options.routes ?? {});
+
+  return {
+    out,
+    http,
+    layer: Layer.mergeAll(
+      out.layer,
+      http.layer,
+      mockRuntimeInfo({ cwd: options.cwd }),
+      mockProjectLinkState(options.linked === false ? undefined : WORKERS_LINK_STATE),
+      testCliConfigLayer(options.cwd),
+      randomLayer,
+      BunServices.layer,
+    ),
+  };
+}
+
+/** Messages of a given kind, in the order the handler emitted them. */
+export function messagesOfType(
+  out: ReturnType<typeof mockOutput>,
+  type: "info" | "warn" | "error" | "success" | "intro" | "outro" | "fail",
+): Array<string> {
+  return out.messages.filter((message) => message.type === type).map((message) => message.message);
+}

--- a/packages/config/src/base.ts
+++ b/packages/config/src/base.ts
@@ -10,6 +10,7 @@ import { inbucket } from "./inbucket.ts";
 import { realtime } from "./realtime.ts";
 import { storage } from "./storage.ts";
 import { studio } from "./studio.ts";
+import { workers } from "./workers.ts";
 
 const projectId = Schema.optionalKey(
   Schema.String.annotate({
@@ -37,6 +38,7 @@ const baseProjectConfigFields = {
   realtime,
   storage,
   studio,
+  workers,
   experimental,
 };
 
@@ -52,6 +54,7 @@ const remoteProjectConfig = Schema.Struct({
   realtime,
   storage,
   studio,
+  workers,
   experimental,
 }).pipe(Schema.withDecodingDefault(Effect.succeed({})));
 

--- a/packages/config/src/workers.ts
+++ b/packages/config/src/workers.ts
@@ -1,0 +1,92 @@
+import dedent from "dedent";
+import { Effect, Schema } from "effect";
+
+const tags = ["workers"];
+
+const links = [
+  {
+    name: "`supabase workers` CLI subcommands",
+    link: "https://supabase.com/docs/reference/cli/supabase-workers",
+  },
+];
+
+/**
+ * Worker names end up in hostnames, so they are DNS labels — the same pattern
+ * the Management API validates `:name` against
+ * (`v2/projects/{ref}/workers/{name}`). `root` is excluded from the key pattern
+ * because `[workers]` carries both the project-wide `root` scalar and one
+ * sub-table per worker; without the exclusion the record's index signature also
+ * claims `root` and rejects its string value.
+ */
+const workerName = Schema.String.check(
+  Schema.isPattern(/^(?!root$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/),
+);
+
+const worker = Schema.Struct({
+  runtime: Schema.optionalKey(
+    Schema.String.annotate({
+      description: dedent`
+        Runtime the worker is built on: \`dockerfile\` to build the directory's own
+        Dockerfile, or one of the catalog runtimes (\`node\`, \`bun\`, \`deno\`,
+        \`python\`, \`sandbox\`). Guessed from marker files when unset.
+      `,
+      examples: ["node"],
+      tags,
+      links,
+    }),
+  ),
+  size: Schema.optionalKey(
+    Schema.String.annotate({
+      description: dedent`
+        Instance size, denominated by memory. Each size implies its own vCPU count,
+        so it is the one dial rather than two.
+      `,
+      examples: ["2gb"],
+      tags,
+      links,
+    }),
+  ),
+  source: Schema.optionalKey(
+    Schema.String.annotate({
+      description: dedent`
+        Directory holding the worker's code, relative to the project root, when it
+        does not live at \`supabase/<workers root>/<name>/\`.
+      `,
+      examples: ["packages/api"],
+      tags,
+      links,
+    }),
+  ),
+});
+
+/**
+ * `[workers]` — a project-wide `root` plus one `[workers.<name>]` table per
+ * worker, mirroring the `[functions.<slug>]` convention in the same file.
+ *
+ * `root` names the directory workers are grouped in, relative to `supabase/`;
+ * a single worker whose code lives somewhere else entirely uses its own
+ * `source` instead, which is anchored to the project root and so can leave
+ * `supabase/`.
+ */
+export const workers = Schema.StructWithRest(
+  Schema.Struct({
+    root: Schema.optionalKey(
+      Schema.String.annotate({
+        description: dedent`
+          Directory workers are grouped in, relative to \`supabase/\`. Defaults to
+          \`workers\`.
+        `,
+        examples: ["services"],
+        tags,
+        links,
+      }),
+    ),
+  }),
+  [Schema.Record(workerName, worker)],
+)
+  .annotate({
+    default: {},
+    description: "Worker-specific configuration keyed by worker name.",
+    tags,
+  })
+  .pipe(Schema.withDecodingDefault(Effect.succeed({})));

--- a/packages/config/src/workers.unit.test.ts
+++ b/packages/config/src/workers.unit.test.ts
@@ -1,0 +1,46 @@
+import { Schema } from "effect";
+import { describe, expect, test } from "vitest";
+import { workers } from "./workers.ts";
+
+const decode = Schema.decodeUnknownSync(workers);
+
+const workerNamePattern = "^(?!root$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$";
+
+describe("workers schema", () => {
+  test("decodes the project-wide root alongside per-worker tables", () => {
+    expect(
+      decode({
+        root: "services",
+        api: { runtime: "node", size: "4gb", source: "packages/api" },
+      }),
+    ).toEqual({
+      root: "services",
+      api: { runtime: "node", size: "4gb", source: "packages/api" },
+    });
+  });
+
+  test("defaults to an empty section when the key is absent", () => {
+    expect(Schema.decodeUnknownSync(Schema.Struct({ workers }))({})).toEqual({ workers: {} });
+  });
+
+  // Keys outside the DNS-label pattern fall outside the record's index
+  // signature and are dropped, the same way `[functions.<slug>]` treats a slug
+  // its own pattern does not match. `supabase workers new` validates the name
+  // up front so the CLI never writes one that would vanish here.
+  test("drops worker names that are not DNS labels", () => {
+    expect(decode({ Not_A_Label: {}, api: { runtime: "node" } })).toEqual({
+      api: { runtime: "node" },
+    });
+  });
+
+  test("includes worker properties in the generated JSON schema", () => {
+    const json = JSON.parse(JSON.stringify(Schema.toJsonSchemaDocument(workers).schema));
+    const objectSchema = json.anyOf?.find((entry: { type?: string }) => entry?.type === "object");
+    const workerSchema = objectSchema?.patternProperties?.[workerNamePattern];
+
+    expect(objectSchema?.properties?.root).toBeDefined();
+    expect(workerSchema?.properties?.runtime).toBeDefined();
+    expect(workerSchema?.properties?.size).toBeDefined();
+    expect(workerSchema?.properties?.source).toBeDefined();
+  });
+});


### PR DESCRIPTION
Introduces `supabase workers` for building and deploying containerized workers alongside Edge Functions, backed by a new `[workers]` section in `config.toml` and a Management API client for the alpha Workers endpoints.

- Add `new`, `push` (aliased `deploy`), `list`, `status`, and `delete` subcommands, sharing project/worker resolution helpers in `workers.shared.ts`
- Add the `[workers]` config schema (`packages/config`), modeled with `StructWithRest` to carry both the project-wide `root` scalar and per-worker sub-tables, published to `schema.json`
- Add `worker-paths.ts` to resolve the `supabase/<root>/<name>/` layout (with `[workers] root` and `[workers.<name>] source` overrides), validated so `workers new --force` can never delete outside its own worker directory
- Add `toml-section.ts` to edit a single `[section]` of `config.toml` textually, preserving user comments and formatting instead of round-tripping the whole file
- Add an in-process USTAR/gzip packager (`tar.ts`, `worker-package.ts`) so the build context is produced identically across platforms without shelling out to `tar`
- Add the Workers API client (`workers-api.ts`) for minting a presigned upload, deploying, and polling build state until it leaves `building`
- Hoist `resolveProjectRef` out of the `functions` command tree into `next/config/`, so both `functions` and `workers` can use it without crossing command-tree boundaries