### PR TITLE
fix(stack): force IPv4 resolution for realtime DB connection

### DIFF
--- a/packages/stack/src/services/realtime.ts
+++ b/packages/stack/src/services/realtime.ts
@@ -50,6 +50,7 @@ export const makeRealtimeServiceDocker = (opts: DockerRealtimeOptions): ServiceD
       DB_USER: "postgres",
       DB_PASSWORD: "postgres",
       DB_NAME: "postgres",
+      DB_IP_VERSION: "ipv4",
       DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime",
       DB_ENC_KEY: opts.encryptionKey,
       API_JWT_SECRET: opts.jwtSecret,

--- a/packages/stack/src/services/services.unit.test.ts
+++ b/packages/stack/src/services/services.unit.test.ts
@@ -594,6 +594,28 @@ describe("docker-backed auxiliary services", () => {
     );
   });
 
+  it("forces IPv4 resolution for the realtime database connection", () => {
+    const dependencies = [{ service: "postgres", condition: "healthy" }] as const;
+    const def = makeRealtimeServiceDocker({
+      image: dockerImageForService("realtime", DEFAULT_VERSIONS.realtime),
+      identity: EPHEMERAL_IDENTITY,
+      port: 54330,
+      dbHost: "host.docker.internal",
+      dbPort: DB_PORT,
+      jwtSecret: JWT_SECRET,
+      jwtJwks: "test-jwks",
+      tenantId: "realtime-dev",
+      encryptionKey: "supabaserealtime",
+      secretKeyBase: "test-secret-key-base",
+      maxHeaderLength: 4096,
+      platformOs: "linux",
+      dependencies,
+    });
+
+    expect(def.args).toContain("DB_IP_VERSION=ipv4");
+    expect(def.args).toContain("DB_HOST=host.docker.internal");
+  });
+
   it("defines storage mounts, cleanup, topology, and readiness locally", () => {
     const dependencies = [{ service: "postgres-init", condition: "completed" }] as const;
     const def = makeStorageServiceDocker({


### PR DESCRIPTION
## What

Forces IPv4 resolution for the realtime database connection by setting `DB_IP_VERSION=ipv4` in the realtime service container env.

## Why

The realtime service cannot run (or be consumed) in docker mode when Docker resolves `host.docker.internal` to an IPv6 address — the service fails to connect to the local Postgres. See #5788.

## How

- `packages/stack/src/services/realtime.ts`: added `DB_IP_VERSION: "ipv4"` to the realtime container environment.
- `packages/stack/src/services/services.unit.test.ts`: test asserting `DB_IP_VERSION=ipv4` and `DB_HOST=host.docker.internal` are present in the container args.

Fixes #5788
