### PR TITLE
feat(cli): support SUPABASE_HIDE_VERSION_MESSAGE

### DIFF
--- a/apps/cli-go/cmd/root.go
+++ b/apps/cli-go/cmd/root.go
@@ -190,7 +190,7 @@ func Execute() {
 		if err != nil {
 			fmt.Fprintln(utils.GetDebugLogger(), err)
 		}
-		if semver.Compare(version, "v"+utils.Version) > 0 {
+		if semver.Compare(version, "v"+utils.Version) > 0 && !utils.HideVersionMessage() {
 			fmt.Fprintln(os.Stderr, suggestUpgrade(version))
 		}
 	}

--- a/apps/cli-go/cmd/root_test.go
+++ b/apps/cli-go/cmd/root_test.go
@@ -135,3 +135,15 @@ func TestUpdateNotifierEnabled(t *testing.T) {
 		assert.Equal(t, wantEnabled, updateNotifierEnabled(), "value %q", value)
 	}
 }
+
+func TestHideVersionMessage(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		t.Setenv("SUPABASE_HIDE_VERSION_MESSAGE", "")
+		assert.False(t, utils.HideVersionMessage())
+	})
+
+	t.Run("is true when env var is set", func(t *testing.T) {
+		t.Setenv("SUPABASE_HIDE_VERSION_MESSAGE", "true")
+		assert.True(t, utils.HideVersionMessage())
+	})
+}

--- a/apps/cli-go/internal/utils/misc.go
+++ b/apps/cli-go/internal/utils/misc.go
@@ -30,6 +30,12 @@ var (
 	PostHogEndpoint string
 )
 
+// HideVersionMessage returns true when SUPABASE_HIDE_VERSION_MESSAGE is set,
+// suppressing the "A new version of Supabase CLI is available" upgrade hint.
+func HideVersionMessage() bool {
+	return os.Getenv("SUPABASE_HIDE_VERSION_MESSAGE") != ""
+}
+
 func ShortContainerImageName(imageName string) string {
 	matches := ImageNamePattern.FindStringSubmatch(imageName)
 	if len(matches) < 2 {


### PR DESCRIPTION
## What

Adds `SUPABASE_HIDE_VERSION_MESSAGE` support: when set (any truthy value), the "A new version of Supabase CLI is available" upgrade hint is suppressed.

## Why

Users in CI/scripts who pin a CLI version (or who simply find the hint noisy) currently have no opt-out. See #5853.

## How

- `apps/cli-go/cmd/root.go`: guard the upgrade hint with `!utils.HideVersionMessage()`.
- `apps/cli-go/internal/utils/misc.go`: `HideVersionMessage()` reads `SUPABASE_HIDE_VERSION_MESSAGE`.
- `apps/cli-go/cmd/root_test.go`: unit tests for both default and set cases.

Fixes #5853
