### PR TITLE
fix(cli): run DROP INDEX CONCURRENTLY outside the migration transaction (CLI-2218)

### DIFF
--- a/apps/cli-go/pkg/migration/file.go
+++ b/apps/cli-go/pkg/migration/file.go
@@ -30,6 +30,7 @@ var (
 	migrateFilePattern = regexp.MustCompile(`^([0-9]+)_(.*)\.sql$`)
 	typeNamePattern    = regexp.MustCompile(`type "([^"]+)" does not exist`)
 	createIndexPattern = regexp.MustCompile(`^CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY(\s|\z)`)
+	dropIndexPattern   = regexp.MustCompile(`^DROP\s+INDEX\s+CONCURRENTLY(\s|\z)`)
 	reindexPattern     = regexp.MustCompile(`^REINDEX(\s|\().*\sCONCURRENTLY(\s|\z)`)
 	vacuumPattern      = regexp.MustCompile(`^VACUUM(\s|\(|\z)`)
 	alterSystemPattern = regexp.MustCompile(`^ALTER\s+SYSTEM(\s|\z)`)
@@ -80,6 +81,7 @@ func NewMigrationFromReader(sql io.Reader) (*MigrationFile, error) {
 func isPipelineIncompatible(sql string) bool {
 	upper := strings.ToUpper(trimLeadingSQLComments(sql))
 	return createIndexPattern.MatchString(upper) ||
+		dropIndexPattern.MatchString(upper) ||
 		reindexPattern.MatchString(upper) ||
 		vacuumPattern.MatchString(upper) ||
 		alterSystemPattern.MatchString(upper) ||

--- a/apps/cli-go/pkg/migration/file_test.go
+++ b/apps/cli-go/pkg/migration/file_test.go
@@ -241,6 +241,16 @@ func TestIsPipelineIncompatible(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "drop index concurrently",
+			sql:  "DROP INDEX CONCURRENTLY public.widgets_id_idx",
+			want: true,
+		},
+		{
+			name: "drop index concurrently if exists",
+			sql:  "drop index concurrently if exists api.idx_rx_orders_clinic_id",
+			want: true,
+		},
+		{
 			name: "reindex table concurrently",
 			sql:  "REINDEX TABLE CONCURRENTLY public.widgets",
 			want: true,
@@ -273,6 +283,11 @@ func TestIsPipelineIncompatible(t *testing.T) {
 		{
 			name: "ordinary create index",
 			sql:  "CREATE INDEX widgets_id_idx ON public.widgets(id)",
+			want: false,
+		},
+		{
+			name: "ordinary drop index",
+			sql:  "DROP INDEX IF EXISTS public.widgets_id_idx",
 			want: false,
 		},
 		{

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.ts
@@ -59,6 +59,7 @@ const BOM_CODE_POINT = 0xfeff;
 // pipeline-incompatible here but wouldn't under that narrower definition. Not worth
 // changing behaviour over — flagging so a future review doesn't rediscover it.
 const CREATE_INDEX_CONCURRENTLY_PATTERN = /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY(?:\s|$)/u;
+const DROP_INDEX_CONCURRENTLY_PATTERN = /^DROP\s+INDEX\s+CONCURRENTLY(?:\s|$)/u;
 const REINDEX_CONCURRENTLY_PATTERN = /^REINDEX(?:\s|\().*\sCONCURRENTLY(?:\s|$)/u;
 const VACUUM_PATTERN = /^VACUUM(?:\s|\(|$)/u;
 const ALTER_SYSTEM_PATTERN = /^ALTER\s+SYSTEM(?:\s|$)/u;
@@ -95,8 +96,9 @@ const legacyTrimLeadingSqlComments = (sql: string): string => {
 
 /**
  * Whether a migration statement cannot run inside a transaction block — `CREATE
- * [UNIQUE] INDEX CONCURRENTLY`, `REINDEX … CONCURRENTLY`, `VACUUM`, `ALTER SYSTEM`,
- * `CLUSTER`. Such statements fail with SQLSTATE 25001 inside the implicit transaction
+ * [UNIQUE] INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, `REINDEX … CONCURRENTLY`,
+ * `VACUUM`, `ALTER SYSTEM`, `CLUSTER`. Such statements fail with SQLSTATE 25001
+ * inside the implicit transaction
  * created by a migration batch, so `execMigrationBatch` runs them standalone.
  * Port of `isPipelineIncompatible` (`pkg/migration/file.go`, supabase/cli#5156).
  */
@@ -104,6 +106,7 @@ export const legacyIsPipelineIncompatible = (sql: string): boolean => {
   const upper = legacyTrimLeadingSqlComments(sql).toUpperCase();
   return (
     CREATE_INDEX_CONCURRENTLY_PATTERN.test(upper) ||
+    DROP_INDEX_CONCURRENTLY_PATTERN.test(upper) ||
     REINDEX_CONCURRENTLY_PATTERN.test(upper) ||
     VACUUM_PATTERN.test(upper) ||
     ALTER_SYSTEM_PATTERN.test(upper) ||

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
@@ -1072,6 +1072,12 @@ describe("legacyIsPipelineIncompatible", () => {
       "-- cannot run in a transaction\n/* generated */\nCREATE INDEX CONCURRENTLY widgets_id_idx ON public.widgets(id)",
       true,
     ],
+    ["drop index concurrently", "DROP INDEX CONCURRENTLY public.widgets_id_idx", true],
+    [
+      "drop index concurrently if exists",
+      "drop index concurrently if exists api.idx_rx_orders_clinic_id",
+      true,
+    ],
     ["reindex table concurrently", "REINDEX TABLE CONCURRENTLY public.widgets", true],
     [
       "reindex with options concurrently",
@@ -1091,6 +1097,7 @@ describe("legacyIsPipelineIncompatible", () => {
     ["bom before vacuum", "\uFEFFVACUUM", true],
     // Negatives — compatible statements that must keep running inside the batch transaction.
     ["plain create index", "CREATE INDEX widgets_id_idx ON public.widgets(id)", false],
+    ["plain drop index", "DROP INDEX IF EXISTS public.widgets_id_idx", false],
     [
       "concurrently in string literal",
       "SELECT 'CREATE INDEX CONCURRENTLY widgets_id_idx ON public.widgets(id)'",


### PR DESCRIPTION
Fixes [CLI-2218](https://linear.app/supabase/issue/CLI-2218/support-drop-index-concurrently-in-migrations).

The v2.109.0 fix for pipeline-incompatible statements (#5671, design from #5156) classifies statements that cannot run inside a transaction block and runs them standalone outside the migration batch. Its pattern list covers `CREATE [UNIQUE] INDEX CONCURRENTLY`, `REINDEX … CONCURRENTLY`, `VACUUM`, `ALTER SYSTEM`, and `CLUSTER` — but not `DROP INDEX CONCURRENTLY`, which was missed. A migration containing one still gets batched into the implicit transaction and PostgreSQL rejects it:

```
ERROR: DROP INDEX CONCURRENTLY cannot run inside a transaction block (SQLSTATE 25001)
```

This adds the missing `DROP INDEX CONCURRENTLY` pattern to `legacyIsPipelineIncompatible` in the TS legacy shell, and mirrors it in the Go sidecar's `isPipelineIncompatible` (`pkg/migration/file.go`), which is still reachable through the remaining Go-delegated paths that apply migrations (`db remote commit`, `db branch`). Reported by an enterprise customer running `db push` on v2.111.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)