### PR TITLE
fix(cli): detect dead db connections (CLI-2207)

### DIFF
--- a/apps/cli/docs/go-cli-divergences.md
+++ b/apps/cli/docs/go-cli-divergences.md
@@ -236,5 +236,7 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
   (`apps/cli-go/pkg/migration/file.go:126-147`) renders every `ExecBatch` failure —
   dead connection included — as `<err>\nAt statement: N\n<sql>`. Naming a statement
   that provably never ran sent users debugging their own SQL for a transport failure,
-  so the TS shell reports the connectivity failure instead. A batch that was written
-  keeps Go's rendering unchanged.
+  so the TS shell reports the connectivity failure instead. This covers batches only: a
+  batch that was written, and the pipeline-incompatible statements the same loop runs
+  standalone through `exec` (`CREATE INDEX CONCURRENTLY`, `VACUUM`, …), both keep Go's
+  `At statement: N` rendering for every failure, transport included.

--- a/apps/cli/docs/go-cli-divergences.md
+++ b/apps/cli/docs/go-cli-divergences.md
@@ -230,3 +230,11 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
   pull."). An in-sync database is a finding, not a failure to troubleshoot, so the
   debug hint sent users chasing a non-existent bug. Message text and exit code — the
   parts scripts depend on — are unchanged.
+- A migration batch that never reached the wire (the connection died before or during
+  submit) fails as a connection error carrying the driver's reason, with no
+  `At statement: N` line and no statement echo. Go's `formatError`
+  (`apps/cli-go/pkg/migration/file.go:126-147`) renders every `ExecBatch` failure —
+  dead connection included — as `<err>\nAt statement: N\n<sql>`. Naming a statement
+  that provably never ran sent users debugging their own SQL for a transport failure,
+  so the TS shell reports the connectivity failure instead. A batch that was written
+  keeps Go's rendering unchanged.

--- a/apps/cli/docs/go-cli-divergences.md
+++ b/apps/cli/docs/go-cli-divergences.md
@@ -246,13 +246,3 @@ These commands exist in the TS CLI today but have no direct top-level equivalent
   an output channel, and in managed mode inside the daemon process, so a user-visible warning
   there needs a diagnostics channel on `BuildResult` first; the applied value stays visible via
   `docker inspect`.
-- A migration batch that never reached the wire (the connection died before or during
-  submit) fails as a connection error carrying the driver's reason, with no
-  `At statement: N` line and no statement echo. Go's `formatError`
-  (`apps/cli-go/pkg/migration/file.go:126-147`) renders every `ExecBatch` failure —
-  dead connection included — as `<err>\nAt statement: N\n<sql>`. Naming a statement
-  that provably never ran sent users debugging their own SQL for a transport failure,
-  so the TS shell reports the connectivity failure instead. This covers batches only: a
-  batch that was written, and the pipeline-incompatible statements the same loop runs
-  standalone through `exec` (`CREATE INDEX CONCURRENTLY`, `VACUUM`, …), both keep Go's
-  `At statement: N` rendering for every failure, transport included.

--- a/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
+++ b/apps/cli/src/legacy/commands/db/reset/SIDE_EFFECTS.md
@@ -144,6 +144,16 @@ the whole reset** (not just "skip buckets").
 | `SUPABASE_DB_PORT` / `SUPABASE_DB_MAJOR_VERSION` / `SUPABASE_DB_HEALTH_TIMEOUT` / `SUPABASE_DB_SETTINGS_*` | local-path container-recreate config overrides, same as `db start`                                                                                                                                                                                                         | no                                                      |
 | `SUPABASE_NETWORK_ID` (`--network-id`)                                                                     | forces the recreated container/network onto an existing Docker network                                                                                                                                                                                                     | no                                                      |
 
+## Connection loss during migration apply
+
+A migration file's statements and its history insert are sent as one batch. If the connection is
+already gone when that batch is handed to the driver, nothing reaches the server, so the failure is
+reported as a lost connection (with the driver's own reason and, locally, the hint to restart the
+stack) rather than against a statement that never ran. Once any part of the batch has been written,
+and for the pipeline-incompatible statements the same loop runs on their own (`CREATE INDEX
+CONCURRENTLY`, `VACUUM`, ...), a failure still reports as `At statement: N` with the statement
+echoed, because those may genuinely have reached the server.
+
 ## Exit Codes
 
 | Code | Condition                                                                                                                                  |

--- a/apps/cli/src/legacy/shared/legacy-db-connection.service.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.service.ts
@@ -113,9 +113,10 @@ export interface LegacyDbSession {
    * statements that completed before the error.
    *
    * A batch runs on its own pooled connection, which the driver checks out per
-   * call. Failing to acquire it raises `LegacyDbConnectError` (a connection-setup
-   * failure, surfaced verbatim — not masked as an exec error), consistent with
-   * {@link queryRaw}; only the batch's own execution raises `LegacyDbExecError`.
+   * call. Failing to acquire it, or losing it before any of the batch reaches the
+   * wire, raises `LegacyDbConnectError` (a connection failure, surfaced verbatim —
+   * not masked as an exec error), consistent with {@link queryRaw}; only a batch
+   * that was actually written raises `LegacyDbExecError`.
    */
   readonly execBatch: (
     statements: ReadonlyArray<LegacyDbBatchStatement>,

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -183,6 +183,7 @@ const fakeBatchServer = (
   readonly port: number;
   readonly close: () => void;
   readonly state: FakeBatchServerState;
+  readonly sockets: ReadonlyArray<net.Socket>;
 }> =>
   new Promise((resolve) => {
     const state: FakeBatchServerState = {
@@ -191,7 +192,9 @@ const fakeBatchServer = (
       params: [],
       syncs: 0,
     };
+    const sockets: Array<net.Socket> = [];
     const server = net.createServer((socket) => {
+      sockets.push(socket);
       let sawStartup = false;
       let pending = Buffer.alloc(0);
       let failed = false;
@@ -294,7 +297,7 @@ const fakeBatchServer = (
     });
     server.listen(0, "127.0.0.1", () => {
       const address = server.address() as net.AddressInfo;
-      resolve({ port: address.port, close: () => server.close(), state });
+      resolve({ port: address.port, close: () => server.close(), state, sockets });
     });
   });
 
@@ -675,6 +678,42 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
           expect(error._tag).toBe("LegacyDbExecError");
           expect(asBatchExecError(error).message).toContain("Connection terminated unexpectedly");
           yield* session.execBatch([{ sql: "SELECT 3" }]);
+        }),
+      );
+    }),
+  );
+
+  it.live("survives an idle raw-client socket death and redials for the next query", () =>
+    // node-postgres emits `error` on an idle client; with no listener that terminates the
+    // process, so a database that dies between two `queryRaw` calls must fail that call
+    // rather than the CLI, and must not leave the corpse cached for the call after it.
+    Effect.gen(function* () {
+      const server = yield* Effect.promise(() => fakeBatchServer());
+      yield* runWithBatchServer(server, (session) =>
+        Effect.gen(function* () {
+          yield* session.queryRaw("SELECT 1");
+          // `queryRaw` runs on its own client, opened after the pool's, so it is the
+          // newest connection the server has accepted.
+          const rawSocket = server.sockets.at(-1);
+          const openedBeforeRedial = server.sockets.length;
+
+          const closed = new Promise<void>((resolve) => {
+            rawSocket?.on("close", () => resolve());
+          });
+          yield* Effect.sync(() => rawSocket?.destroy());
+          yield* Effect.promise(() => closed);
+
+          const failed = yield* session.queryRaw("SELECT 1").pipe(
+            Effect.flip,
+            Effect.timeoutOrElse({
+              duration: Duration.seconds(10),
+              orElse: () => Effect.die("queryRaw never settled after the idle socket died"),
+            }),
+          );
+          expect(failed._tag).toBe("LegacyDbExecError");
+
+          yield* session.queryRaw("SELECT 1");
+          expect(server.sockets.length).toBeGreaterThan(openedBeforeRedial);
         }),
       );
     }),

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -686,8 +686,8 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
 
   it.live("survives an idle raw-client socket death and redials for the next query", () =>
     // node-postgres emits `error` on an idle client; with no listener that terminates the
-    // process, so a database that dies between two `queryRaw` calls must fail that call
-    // rather than the CLI, and must not leave the corpse cached for the call after it.
+    // process, so a database dying between two `queryRaw` calls must not take the CLI with it,
+    // and must not leave the corpse cached for the calls after it.
     Effect.gen(function* () {
       const server = yield* Effect.promise(() => fakeBatchServer());
       yield* runWithBatchServer(server, (session) =>
@@ -704,14 +704,15 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
           yield* Effect.sync(() => rawSocket?.destroy());
           yield* Effect.promise(() => closed);
 
-          const failed = yield* session.queryRaw("SELECT 1").pipe(
-            Effect.flip,
+          // Whether the client has already noticed the death decides if this call redials or
+          // fails on the corpse, and that ordering is not ours to control, so accept either.
+          yield* session.queryRaw("SELECT 1").pipe(
+            Effect.exit,
             Effect.timeoutOrElse({
               duration: Duration.seconds(10),
               orElse: () => Effect.die("queryRaw never settled after the idle socket died"),
             }),
           );
-          expect(failed._tag).toBe("LegacyDbExecError");
 
           yield* session.queryRaw("SELECT 1");
           expect(server.sockets.length).toBeGreaterThan(openedBeforeRedial);

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   legacyAcquirePgPool,
   legacyDbConnectionSqlPgLayer,
+  LegacyPgBatchQuery,
 } from "./legacy-db-connection.sql-pg.layer.ts";
 
 const SUGGESTION_CONTEXT = {
@@ -662,8 +663,8 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
   );
 
   it.live("fails a batch whose connection drops after it was written, then recovers", () =>
-    // Guards the driver path that already worked: a socket dropped after the batch was
-    // written must surface as a batch failure, and its client must not be recycled.
+    // A socket dropped after the batch was written must fail that batch and must not leave
+    // the client to be handed to the next one.
     Effect.gen(function* () {
       const server = yield* Effect.promise(() => fakeBatchServer({ destroyOnFirstSync: true }));
       yield* runWithBatchServer(server, (session) =>
@@ -716,6 +717,42 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
           expect(server.sockets.length).toBeGreaterThan(openedBeforeRedial);
         }),
       );
+    }),
+  );
+
+  it.live("refuses to write a batch onto a real pooled client whose socket is already gone", () =>
+    // The unit test drives `submit` through a hand-built connection; this pins the same
+    // refusal against a real node-postgres client, so a driver change that stops making the
+    // socket unwritable would be caught rather than mocked over. Destroying the socket and
+    // submitting in one synchronous block keeps the window deterministic: `writable` flips
+    // immediately, while pg only marks the client unqueryable on the next tick's close.
+    Effect.gen(function* () {
+      const server = yield* Effect.promise(() => fakeBatchServer());
+      yield* Effect.gen(function* () {
+        const pool = yield* legacyAcquirePgPool(
+          {
+            host: "127.0.0.1",
+            port: server.port,
+            user: "postgres",
+            password: SENTINEL_PASSWORD,
+            database: "postgres",
+            sslmode: "disable",
+          },
+          { isLocal: true, dnsResolver: "native" },
+        );
+        const client = yield* Effect.promise(() => pool.connect());
+        const batch = new LegacyPgBatchQuery([{ sql: "SELECT 1" }], () => {});
+
+        const refusal = yield* Effect.sync(() => {
+          client.connection.stream.destroy();
+          return batch.submit(client.connection);
+        });
+
+        expect(refusal?.message).toBe("the connection's socket is no longer writable");
+        expect(batch.outcome).toBe("unsent");
+        expect(server.state.frameTypes).toEqual([]);
+        client.release(new Error("done"));
+      }).pipe(Effect.scoped, Effect.ensuring(Effect.sync(server.close)));
     }),
   );
 

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.integration.test.ts
@@ -176,6 +176,8 @@ const fakeBatchServer = (
     readonly emptyAt?: number;
     /** Never answer an extended-protocol frame, so a batch hangs until interrupted. */
     readonly stall?: boolean;
+    /** Drop the connection on the first Sync, so a batch dies mid-flight. */
+    readonly destroyOnFirstSync?: boolean;
   } = {},
 ): Promise<{
   readonly port: number;
@@ -268,6 +270,10 @@ const fakeBatchServer = (
             }
           } else if (type === "S") {
             state.syncs += 1;
+            if (options.destroyOnFirstSync === true && state.syncs === 1) {
+              socket.destroy();
+              return;
+            }
             if (options.failOnSync === true && !failed) {
               socket.write(
                 errorResponse({
@@ -648,6 +654,28 @@ describe("legacyDbConnectionSqlPgLayer extended batches", () => {
             }),
           ),
         ),
+      );
+    }),
+  );
+
+  it.live("fails a batch whose connection drops after it was written, then recovers", () =>
+    // Guards the driver path that already worked: a socket dropped after the batch was
+    // written must surface as a batch failure, and its client must not be recycled.
+    Effect.gen(function* () {
+      const server = yield* Effect.promise(() => fakeBatchServer({ destroyOnFirstSync: true }));
+      yield* runWithBatchServer(server, (session) =>
+        Effect.gen(function* () {
+          const error = yield* session.execBatch([{ sql: "SELECT 1" }, { sql: "SELECT 2" }]).pipe(
+            Effect.flip,
+            Effect.timeoutOrElse({
+              duration: Duration.seconds(10),
+              orElse: () => Effect.die("execBatch never settled after the connection died"),
+            }),
+          );
+          expect(error._tag).toBe("LegacyDbExecError");
+          expect(asBatchExecError(error).message).toContain("Connection terminated unexpectedly");
+          yield* session.execBatch([{ sql: "SELECT 3" }]);
+        }),
       );
     }),
   );

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -202,6 +202,62 @@ export function legacyToExecError(error: unknown): LegacyDbExecError {
   return new LegacyDbExecError({ message: String(error), code: legacyExtractSqlState(error) });
 }
 
+const LEGACY_BATCH_CONNECTION_LOST =
+  "connection to the database was lost before the batch could be sent";
+
+/**
+ * pgconn's keepalive period (its default dialer, 5 minutes). Go applies that period to both
+ * the idle time and the probe interval; Node can only set the idle time, leaving interval and
+ * count at OS defaults, so a silently dead peer surfaces roughly 11 minutes later on Linux —
+ * sooner than Go's own window, not later.
+ */
+const LEGACY_PGCONN_KEEPALIVE_MILLIS = 300_000;
+
+/**
+ * Maps a failed migration batch to its public error. A batch that never reached the wire
+ * is a connectivity failure, not a statement failure, so it reports as one instead of
+ * blaming the batch's first statement; anything else keeps `legacyToExecError`'s
+ * server-error rendering plus the number of statements that completed.
+ */
+export function legacyBatchFailureError(
+  error: Error,
+  batch:
+    | { readonly completed: number; readonly submitted: boolean; readonly poisoned: boolean }
+    | undefined,
+): LegacyDbExecError | LegacyDbConnectError {
+  if (batch === undefined || (!batch.submitted && !batch.poisoned)) {
+    return new LegacyDbConnectError({
+      message:
+        error.message === LEGACY_BATCH_CONNECTION_LOST
+          ? LEGACY_BATCH_CONNECTION_LOST
+          : `${LEGACY_BATCH_CONNECTION_LOST}: ${error.message}`,
+    });
+  }
+  const mapped = legacyToExecError(error);
+  return new LegacyDbExecError({
+    message: mapped.message,
+    code: mapped.code,
+    detail: mapped.detail,
+    position: mapped.position,
+    statementIndex: batch.completed,
+  });
+}
+
+/**
+ * Whether a batch's pooled client must be destroyed rather than returned to the pool. A
+ * batch that never reached the wire leaves the client looking healthy to pg-pool while its
+ * socket is already gone, so the next checkout would write into the same dead connection.
+ */
+export function legacyShouldDiscardBatchClient(
+  batch: { readonly submitted: boolean } | undefined,
+  exit: Exit.Exit<unknown, unknown>,
+): boolean {
+  return (
+    batch?.submitted === false ||
+    (Exit.isFailure(exit) && (Cause.hasInterrupts(exit.cause) || Cause.hasDies(exit.cause)))
+  );
+}
+
 const legacyEncodeTextArray = (values: ReadonlyArray<string>): string =>
   `{${values
     .map((value) => `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`)
@@ -210,7 +266,7 @@ const legacyEncodeTextArray = (values: ReadonlyArray<string>): string =>
 const legacyEncodeBatchValue = (value: LegacyDbBatchValue): string | null =>
   value === null ? null : typeof value === "string" ? value : legacyEncodeTextArray(value);
 
-class LegacyPgBatchQuery implements Pg.Submittable {
+export class LegacyPgBatchQuery implements Pg.Submittable {
   readonly statements: ReadonlyArray<{
     readonly sql: string;
     readonly params: ReadonlyArray<string | null>;
@@ -218,6 +274,7 @@ class LegacyPgBatchQuery implements Pg.Submittable {
   callback: (error: Error | undefined) => void;
   completed = 0;
   poisoned = false;
+  submitted = false;
 
   constructor(
     statements: ReadonlyArray<LegacyDbBatchStatement>,
@@ -231,6 +288,9 @@ class LegacyPgBatchQuery implements Pg.Submittable {
   }
 
   submit(connection: Pg.Connection): Error | null {
+    if (!connection.stream.writable) {
+      return new Error(LEGACY_BATCH_CONNECTION_LOST);
+    }
     let started = false;
     connection.stream.cork?.();
     try {
@@ -242,6 +302,7 @@ class LegacyPgBatchQuery implements Pg.Submittable {
         connection.execute({ portal: "" }, true);
       }
       connection.sync();
+      this.submitted = true;
       return null;
     } catch (error) {
       this.poisoned = started;
@@ -511,6 +572,8 @@ export function legacyBuildRawPgConfig(
       : { host, port, user: cfg.user, password: cfg.password, database: cfg.database }),
     ...(sslOption === undefined ? {} : { ssl: sslOption }),
     connectionTimeoutMillis: connectTimeoutSeconds * 1000,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: LEGACY_PGCONN_KEEPALIVE_MILLIS,
   };
 }
 
@@ -964,11 +1027,12 @@ const connect = (
     // Checking a connection out of the pool for a batch is a connection-setup
     // concern, so it fails with `LegacyDbConnectError` — the same classification
     // `acquireRawClient` uses above, and for the same reason: the pool may have to
-    // redial (its single connection is discarded after an interrupted or poisoned
-    // batch), and a refused/auth/DNS failure there is not a statement failure. Mapping
-    // it to `LegacyDbExecError` would lose the connect suggestion and make the
+    // redial (its single connection is discarded after an interrupted, poisoned, or
+    // unsent batch), and a refused/auth/DNS failure there is not a statement failure.
+    // Mapping it to `LegacyDbExecError` would lose the connect suggestion and make the
     // migration-apply formatter blame the batch's first statement for a connectivity
-    // problem. Only the batch's own execution (below) raises `LegacyDbExecError`.
+    // problem — which is also why a batch that never reached the wire reports the same
+    // way (below). Only a batch that was actually written raises `LegacyDbExecError`.
     const acquireBatchClient = Effect.callback<Pg.PoolClient, LegacyDbConnectError>((resume) => {
       let done = false;
       try {
@@ -1007,7 +1071,7 @@ const connect = (
         (activeClient) => {
           const onConnectionError = () => {};
           activeClient.on("error", onConnectionError);
-          return Effect.callback<void, LegacyDbExecError>((resume) => {
+          return Effect.callback<void, LegacyDbExecError | LegacyDbConnectError>((resume) => {
             let done = false;
             const finish = (error: Error | undefined) => {
               if (done) return;
@@ -1016,18 +1080,7 @@ const connect = (
                 resume(Effect.void);
                 return;
               }
-              const mapped = legacyToExecError(error);
-              resume(
-                Effect.fail(
-                  new LegacyDbExecError({
-                    message: mapped.message,
-                    code: mapped.code,
-                    detail: mapped.detail,
-                    position: mapped.position,
-                    statementIndex: batchQuery?.completed ?? 0,
-                  }),
-                ),
-              );
+              resume(Effect.fail(legacyBatchFailureError(error, batchQuery)));
             };
             batchQuery = new LegacyPgBatchQuery(statements, finish);
             try {
@@ -1046,11 +1099,8 @@ const connect = (
         },
         (activeClient, exit) =>
           Effect.sync(() => {
-            const discard =
-              batchQuery?.poisoned === true ||
-              (Exit.isFailure(exit) &&
-                (Cause.hasInterrupts(exit.cause) || Cause.hasDies(exit.cause)));
-            activeClient.release(discard ? new Error("batch execution interrupted") : undefined);
+            const discard = legacyShouldDiscardBatchClient(batchQuery, exit);
+            activeClient.release(discard ? new Error("batch connection discarded") : undefined);
           }),
       );
     };

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -1009,6 +1009,12 @@ const connect = (
     const acquireRawClient = Effect.gen(function* () {
       if (rawClient !== undefined) return rawClient;
       const fresh = new Pg.Client(winningRawConfig);
+      // node-postgres emits `error` on a cached client whose socket dies while idle; with
+      // no listener that terminates the process, so absorb it and drop the dead client so
+      // the next acquisition redials instead of reusing it.
+      fresh.on("error", () => {
+        if (rawClient === fresh) rawClient = undefined;
+      });
       yield* Effect.tryPromise({
         try: () => fresh.connect(),
         catch: (error) => legacyToConnectError(cfg, options.isLocal, error),

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -210,11 +210,11 @@ const LEGACY_BATCH_CONNECTION_LOST =
 export type LegacyBatchOutcome = "unsent" | "poisoned" | "submitted";
 
 /**
- * pgconn's keepalive period (its default dialer, 5 minutes). Go applies that period to both
- * the idle time and the probe interval; Node only sets the idle time and leaves the probe
- * schedule to the runtime and OS, so a silently dead peer surfaces sooner here than under Go.
+ * Idle time before TCP starts probing a silent peer. Node applies this as the idle delay only,
+ * leaving the probe interval and count to the runtime and OS, so a connection whose peer died
+ * without a FIN or RST surfaces some minutes after this elapses rather than when it elapses.
  */
-const LEGACY_PGCONN_KEEPALIVE_MILLIS = 300_000;
+const LEGACY_DB_KEEPALIVE_IDLE_MILLIS = 300_000;
 
 /**
  * Maps a failed migration batch to its public error. A batch that never reached the wire
@@ -580,7 +580,7 @@ export function legacyBuildRawPgConfig(
     ...(sslOption === undefined ? {} : { ssl: sslOption }),
     connectionTimeoutMillis: connectTimeoutSeconds * 1000,
     keepAlive: true,
-    keepAliveInitialDelayMillis: LEGACY_PGCONN_KEEPALIVE_MILLIS,
+    keepAliveInitialDelayMillis: LEGACY_DB_KEEPALIVE_IDLE_MILLIS,
   };
 }
 

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -12,6 +12,7 @@ import { ConnectionError, SqlError } from "effect/unstable/sql/SqlError";
 import * as Pg from "pg";
 import { to as pgCopyTo } from "pg-copy-streams";
 import {
+  LEGACY_SUGGEST_LOCAL_STACK,
   legacyConnectFailureMessage,
   legacyConnectSuggestion,
   legacyIsDialFailure,
@@ -225,10 +226,14 @@ const LEGACY_PGCONN_KEEPALIVE_MILLIS = 300_000;
 export function legacyBatchFailureError(
   error: Error,
   batch: { readonly completed: number; readonly outcome: LegacyBatchOutcome } | undefined,
+  isLocal: boolean,
 ): LegacyDbExecError | LegacyDbConnectError {
   if (batch === undefined || batch.outcome === "unsent") {
     return new LegacyDbConnectError({
       message: `${LEGACY_BATCH_CONNECTION_LOST}: ${error.message}`,
+      // The checkout failure a tick earlier carries this same hint, so losing the
+      // connection mid-batch must not silently drop it.
+      ...(isLocal ? { suggestion: LEGACY_SUGGEST_LOCAL_STACK } : {}),
     });
   }
   const mapped = legacyToExecError(error);
@@ -1083,7 +1088,7 @@ const connect = (
                 resume(Effect.void);
                 return;
               }
-              resume(Effect.fail(legacyBatchFailureError(error, batchQuery)));
+              resume(Effect.fail(legacyBatchFailureError(error, batchQuery, options.isLocal)));
             };
             batchQuery = new LegacyPgBatchQuery(statements, finish);
             try {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -211,9 +211,8 @@ export type LegacyBatchOutcome = "unsent" | "poisoned" | "submitted";
 
 /**
  * pgconn's keepalive period (its default dialer, 5 minutes). Go applies that period to both
- * the idle time and the probe interval; Node can only set the idle time, leaving interval and
- * count at OS defaults, so a silently dead peer surfaces roughly 11 minutes later on Linux —
- * sooner than Go's own window, not later.
+ * the idle time and the probe interval; Node only sets the idle time and leaves the probe
+ * schedule to the runtime and OS, so a silently dead peer surfaces sooner here than under Go.
  */
 const LEGACY_PGCONN_KEEPALIVE_MILLIS = 300_000;
 
@@ -250,6 +249,12 @@ export function legacyBatchFailureError(
  * Whether a batch's pooled client must be destroyed rather than returned to the pool. A
  * batch that never reached the wire leaves the client looking healthy to pg-pool while its
  * socket is already gone, so the next checkout would write into the same dead connection.
+ *
+ * A batch that WAS written keeps its client: a statement failure should not cost a redial and
+ * a fresh step-down on a single-connection pool. Recovering from a socket that died after the
+ * write is left to pg-pool, which drops a released client whose private `_queryable` flag is
+ * false — so that is the behavior to re-check if a pg-pool bump ever breaks the recovery this
+ * layer's integration tests assert.
  */
 export function legacyShouldDiscardBatchClient(
   batch: { readonly outcome: LegacyBatchOutcome } | undefined,

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -309,14 +309,20 @@ export class LegacyPgBatchQuery implements Pg.Submittable {
         connection.execute({ portal: "" }, true);
       }
       connection.sync();
-      this.outcome = "submitted";
-      return null;
     } catch (error) {
       this.outcome = started ? "poisoned" : "unsent";
       return error instanceof Error ? error : new Error(String(error));
     } finally {
       connection.stream.uncork?.();
     }
+    // The corked frames only hit the socket at uncork, and a dead peer destroys the
+    // stream synchronously during that flush — so only now does writable prove the
+    // batch actually left the process.
+    if (!connection.stream.writable) {
+      return new Error("the connection's socket became unwritable while the batch was flushing");
+    }
+    this.outcome = "submitted";
+    return null;
   }
 
   handleRowDescription(): void {}

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.layer.ts
@@ -205,6 +205,9 @@ export function legacyToExecError(error: unknown): LegacyDbExecError {
 const LEGACY_BATCH_CONNECTION_LOST =
   "connection to the database was lost before the batch could be sent";
 
+/** How far a batch got on the wire: nothing sent, a partial write, or fully written. */
+export type LegacyBatchOutcome = "unsent" | "poisoned" | "submitted";
+
 /**
  * pgconn's keepalive period (its default dialer, 5 minutes). Go applies that period to both
  * the idle time and the probe interval; Node can only set the idle time, leaving interval and
@@ -221,16 +224,11 @@ const LEGACY_PGCONN_KEEPALIVE_MILLIS = 300_000;
  */
 export function legacyBatchFailureError(
   error: Error,
-  batch:
-    | { readonly completed: number; readonly submitted: boolean; readonly poisoned: boolean }
-    | undefined,
+  batch: { readonly completed: number; readonly outcome: LegacyBatchOutcome } | undefined,
 ): LegacyDbExecError | LegacyDbConnectError {
-  if (batch === undefined || (!batch.submitted && !batch.poisoned)) {
+  if (batch === undefined || batch.outcome === "unsent") {
     return new LegacyDbConnectError({
-      message:
-        error.message === LEGACY_BATCH_CONNECTION_LOST
-          ? LEGACY_BATCH_CONNECTION_LOST
-          : `${LEGACY_BATCH_CONNECTION_LOST}: ${error.message}`,
+      message: `${LEGACY_BATCH_CONNECTION_LOST}: ${error.message}`,
     });
   }
   const mapped = legacyToExecError(error);
@@ -249,11 +247,11 @@ export function legacyBatchFailureError(
  * socket is already gone, so the next checkout would write into the same dead connection.
  */
 export function legacyShouldDiscardBatchClient(
-  batch: { readonly submitted: boolean } | undefined,
+  batch: { readonly outcome: LegacyBatchOutcome } | undefined,
   exit: Exit.Exit<unknown, unknown>,
 ): boolean {
   return (
-    batch?.submitted === false ||
+    (batch !== undefined && batch.outcome !== "submitted") ||
     (Exit.isFailure(exit) && (Cause.hasInterrupts(exit.cause) || Cause.hasDies(exit.cause)))
   );
 }
@@ -273,8 +271,7 @@ export class LegacyPgBatchQuery implements Pg.Submittable {
   }>;
   callback: (error: Error | undefined) => void;
   completed = 0;
-  poisoned = false;
-  submitted = false;
+  outcome: LegacyBatchOutcome = "unsent";
 
   constructor(
     statements: ReadonlyArray<LegacyDbBatchStatement>,
@@ -289,7 +286,7 @@ export class LegacyPgBatchQuery implements Pg.Submittable {
 
   submit(connection: Pg.Connection): Error | null {
     if (!connection.stream.writable) {
-      return new Error(LEGACY_BATCH_CONNECTION_LOST);
+      return new Error("the connection's socket is no longer writable");
     }
     let started = false;
     connection.stream.cork?.();
@@ -302,10 +299,10 @@ export class LegacyPgBatchQuery implements Pg.Submittable {
         connection.execute({ portal: "" }, true);
       }
       connection.sync();
-      this.submitted = true;
+      this.outcome = "submitted";
       return null;
     } catch (error) {
-      this.poisoned = started;
+      this.outcome = started ? "poisoned" : "unsent";
       return error instanceof Error ? error : new Error(String(error));
     } finally {
       connection.stream.uncork?.();

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -591,15 +591,23 @@ describe("legacyToExecError (pg server-error extraction)", () => {
 });
 
 describe("LegacyPgBatchQuery.submit", () => {
-  const fakeConnection = (writable: boolean) => {
+  const fakeConnection = (writable: boolean, opts: { dieOnUncork?: boolean } = {}) => {
     const frames: Array<string> = [];
     const record = (frame: string) => () => {
       frames.push(frame);
     };
+    const stream = {
+      writable,
+      cork: record("cork"),
+      uncork: () => {
+        frames.push("uncork");
+        if (opts.dieOnUncork === true) stream.writable = false;
+      },
+    };
     return {
       frames,
       connection: {
-        stream: { writable, cork: record("cork"), uncork: record("uncork") },
+        stream,
         parse: record("parse"),
         bind: record("bind"),
         describe: record("describe"),
@@ -618,6 +626,19 @@ describe("LegacyPgBatchQuery.submit", () => {
     expect(error?.message).toBe("the connection's socket is no longer writable");
     expect(batch.outcome).toBe("unsent");
     expect(frames).toEqual([]);
+  });
+
+  it("reports a batch whose stream died during the uncork flush as unsent", () => {
+    const { connection, frames } = fakeConnection(true, { dieOnUncork: true });
+    const batch = new LegacyPgBatchQuery([{ sql: "select 1" }], () => {});
+
+    const error = batch.submit(connection);
+
+    expect(error?.message).toBe(
+      "the connection's socket became unwritable while the batch was flushing",
+    );
+    expect(batch.outcome).toBe("unsent");
+    expect(frames).toEqual(["cork", "parse", "bind", "describe", "execute", "sync", "uncork"]);
   });
 
   it("writes parse/bind/describe/execute per statement and one sync while writable", () => {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -5,6 +5,7 @@ import type * as Pg from "pg";
 import { describe, expect, it } from "vitest";
 
 import { ErrorActionabilityId } from "../../shared/telemetry/error-actionability.ts";
+import { LEGACY_SUGGEST_LOCAL_STACK } from "./legacy-connect-errors.ts";
 import {
   legacyAcquireProbedPool,
   legacyBatchFailureError,
@@ -647,6 +648,7 @@ describe("legacyBatchFailureError", () => {
     const error = legacyBatchFailureError(
       new Error("the connection's socket is no longer writable"),
       { completed: 0, outcome: "unsent" },
+      true,
     );
 
     expect(error._tag).toBe("LegacyDbConnectError");
@@ -661,6 +663,7 @@ describe("legacyBatchFailureError", () => {
     const error = legacyBatchFailureError(
       new Error("Client has encountered a connection error and is not queryable"),
       { completed: 0, outcome: "unsent" },
+      true,
     );
 
     expect(error._tag).toBe("LegacyDbConnectError");
@@ -670,8 +673,31 @@ describe("legacyBatchFailureError", () => {
     );
   });
 
+  it("carries the local-stack hint, matching the checkout failure it races with", () => {
+    const local = legacyBatchFailureError(
+      new Error("socket died"),
+      {
+        completed: 0,
+        outcome: "unsent",
+      },
+      true,
+    );
+    const remote = legacyBatchFailureError(
+      new Error("socket died"),
+      {
+        completed: 0,
+        outcome: "unsent",
+      },
+      false,
+    );
+
+    expect(local).toMatchObject({ suggestion: LEGACY_SUGGEST_LOCAL_STACK });
+    expect(remote._tag).toBe("LegacyDbConnectError");
+    expect("suggestion" in remote).toBe(false);
+  });
+
   it("reports a batch that never reached the driver the same way", () => {
-    const error = legacyBatchFailureError(new Error("client was closed"), undefined);
+    const error = legacyBatchFailureError(new Error("client was closed"), undefined, true);
 
     expect(error._tag).toBe("LegacyDbConnectError");
     expect(error.message).toContain(
@@ -682,10 +708,14 @@ describe("legacyBatchFailureError", () => {
   it("keeps a partially written batch on the statement path, blaming statement 0", () => {
     // A poisoned batch is corked, so the server acknowledged nothing and `completed`
     // is always 0 — the failure can only be reported against the batch's first statement.
-    const error = legacyBatchFailureError(new Error("serialization blew up"), {
-      completed: 0,
-      outcome: "poisoned",
-    });
+    const error = legacyBatchFailureError(
+      new Error("serialization blew up"),
+      {
+        completed: 0,
+        outcome: "poisoned",
+      },
+      true,
+    );
 
     expect(error._tag).toBe("LegacyDbExecError");
     expect(error).toMatchObject({ message: "Error: serialization blew up", statementIndex: 0 });
@@ -706,6 +736,7 @@ describe("legacyBatchFailureError", () => {
         }),
       }),
       { completed: 3, outcome: "submitted" },
+      true,
     );
 
     expect(error._tag).toBe("LegacyDbExecError");

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -1,14 +1,19 @@
 import { EventEmitter } from "node:events";
 import { Effect, Exit } from "effect";
 import { SqlError, SqlSyntaxError, UnknownError } from "effect/unstable/sql/SqlError";
+import type * as Pg from "pg";
 import { describe, expect, it } from "vitest";
 
+import { ErrorActionabilityId } from "../../shared/telemetry/error-actionability.ts";
 import {
   legacyAcquireProbedPool,
+  legacyBatchFailureError,
   legacyBuildConnectionUrl,
   legacyBuildPoolConfig,
   legacyBuildRawPgConfig,
   legacyInstallPoolErrorSwallow,
+  LegacyPgBatchQuery,
+  legacyShouldDiscardBatchClient,
   legacyPoolStepDownVerify,
   legacyIsTerminalConnectError,
   legacyIsUnixSocketHost,
@@ -322,6 +327,22 @@ describe("legacyBuildRawPgConfig", () => {
     const c = legacyBuildRawPgConfig({ ...base }, "h", 5432, undefined, 5);
     expect("ssl" in c).toBe(false);
   });
+
+  it("enables TCP keepalive with pgconn's five-minute idle delay on both config forms", () => {
+    const discrete = legacyBuildRawPgConfig({ ...base }, "db.example.com", 5432, false, 10);
+    expect(discrete.keepAlive).toBe(true);
+    expect(discrete.keepAliveInitialDelayMillis).toBe(300_000);
+
+    const url = legacyBuildRawPgConfig(
+      { ...base, options: "reference=abc" },
+      "db.example.com",
+      6543,
+      false,
+      2,
+    );
+    expect(url.keepAlive).toBe(true);
+    expect(url.keepAliveInitialDelayMillis).toBe(300_000);
+  });
 });
 
 describe("legacyBuildPoolConfig", () => {
@@ -350,6 +371,12 @@ describe("legacyBuildPoolConfig", () => {
     expect(c.idleTimeoutMillis).toBe(0);
     expect(c.max).toBe(1);
     expect(c.ssl).toBe(false);
+  });
+
+  it("carries the raw client's TCP keepalive through to every pooled connection", () => {
+    const c = legacyBuildPoolConfig({ ...base }, "127.0.0.1", 54322, false, 2, false);
+    expect(c.keepAlive).toBe(true);
+    expect(c.keepAliveInitialDelayMillis).toBe(300_000);
   });
 
   it("installs the step-down verify hook only when required", () => {
@@ -559,5 +586,161 @@ describe("legacyToExecError (pg server-error extraction)", () => {
     expect(error.code).toBe("ECONNRESET");
     expect(error.detail).toBeUndefined();
     expect(error.position).toBeUndefined();
+  });
+});
+
+describe("LegacyPgBatchQuery.submit", () => {
+  const fakeConnection = (writable: boolean) => {
+    const frames: Array<string> = [];
+    const record = (frame: string) => () => {
+      frames.push(frame);
+    };
+    return {
+      frames,
+      connection: {
+        stream: { writable, cork: record("cork"), uncork: record("uncork") },
+        parse: record("parse"),
+        bind: record("bind"),
+        describe: record("describe"),
+        execute: record("execute"),
+        sync: record("sync"),
+      } as unknown as Pg.Connection,
+    };
+  };
+
+  it("refuses to write a batch onto a stream that is no longer writable", () => {
+    const { connection, frames } = fakeConnection(false);
+    const batch = new LegacyPgBatchQuery([{ sql: "select 1" }], () => {});
+
+    const error = batch.submit(connection);
+
+    expect(error?.message).toBe(
+      "connection to the database was lost before the batch could be sent",
+    );
+    expect(batch.submitted).toBe(false);
+    expect(batch.poisoned).toBe(false);
+    expect(frames).toEqual([]);
+  });
+
+  it("writes parse/bind/describe/execute per statement and one sync while writable", () => {
+    const { connection, frames } = fakeConnection(true);
+    const batch = new LegacyPgBatchQuery([{ sql: "select 1" }, { sql: "select 2" }], () => {});
+
+    expect(batch.submit(connection)).toBeNull();
+
+    expect(frames).toEqual([
+      "cork",
+      "parse",
+      "bind",
+      "describe",
+      "execute",
+      "parse",
+      "bind",
+      "describe",
+      "execute",
+      "sync",
+      "uncork",
+    ]);
+    expect(batch.submitted).toBe(true);
+  });
+});
+
+describe("legacyBatchFailureError", () => {
+  it("reports an unsent batch as a lost connection rather than a statement failure", () => {
+    const error = legacyBatchFailureError(
+      new Error("connection to the database was lost before the batch could be sent"),
+      { completed: 0, submitted: false, poisoned: false },
+    );
+
+    expect(error._tag).toBe("LegacyDbConnectError");
+    expect(error.message).toBe(
+      "connection to the database was lost before the batch could be sent",
+    );
+    expect(error[ErrorActionabilityId]).toMatchObject({ error_category: "db_connection" });
+  });
+
+  it("keeps the driver's own reason when pg refused the batch before submit", () => {
+    const error = legacyBatchFailureError(
+      new Error("Client has encountered a connection error and is not queryable"),
+      { completed: 0, submitted: false, poisoned: false },
+    );
+
+    expect(error._tag).toBe("LegacyDbConnectError");
+    expect(error.message).toBe(
+      "connection to the database was lost before the batch could be sent: " +
+        "Client has encountered a connection error and is not queryable",
+    );
+  });
+
+  it("reports a batch that never reached the driver the same way", () => {
+    const error = legacyBatchFailureError(new Error("client was closed"), undefined);
+
+    expect(error._tag).toBe("LegacyDbConnectError");
+    expect(error.message).toContain(
+      "connection to the database was lost before the batch could be sent",
+    );
+  });
+
+  it("keeps a partially written batch on the statement path", () => {
+    const error = legacyBatchFailureError(new Error("serialization blew up"), {
+      completed: 1,
+      submitted: false,
+      poisoned: true,
+    });
+
+    expect(error._tag).toBe("LegacyDbExecError");
+  });
+
+  it("keeps server-error mapping and the completed count for a statement failure", () => {
+    const error = legacyBatchFailureError(
+      new SqlError({
+        reason: new SqlSyntaxError({
+          cause: Object.assign(new Error('type "ltree" does not exist'), {
+            severity: "ERROR",
+            code: "42704",
+            detail: "Some detail line.",
+            position: "25",
+          }),
+          message: "Failed to execute statement",
+          operation: "execute",
+        }),
+      }),
+      { completed: 3, submitted: true, poisoned: false },
+    );
+
+    expect(error._tag).toBe("LegacyDbExecError");
+    expect(error).toMatchObject({
+      message: 'ERROR: type "ltree" does not exist (SQLSTATE 42704)',
+      code: "42704",
+      detail: "Some detail line.",
+      position: 25,
+      statementIndex: 3,
+    });
+  });
+});
+
+describe("legacyShouldDiscardBatchClient", () => {
+  it("discards a client whose batch never reached the wire", () => {
+    expect(legacyShouldDiscardBatchClient({ submitted: false }, Exit.succeed(undefined))).toBe(
+      true,
+    );
+  });
+
+  it("returns a client to the pool once its batch was written, error or not", () => {
+    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.succeed(undefined))).toBe(
+      false,
+    );
+    expect(
+      legacyShouldDiscardBatchClient({ submitted: true }, Exit.fail(new Error("server said no"))),
+    ).toBe(false);
+  });
+
+  it("discards a client whose batch was interrupted or died mid-flight", () => {
+    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.interrupt(1))).toBe(true);
+    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.die("boom"))).toBe(true);
+  });
+
+  it("keeps a client that was checked out but never used", () => {
+    expect(legacyShouldDiscardBatchClient(undefined, Exit.succeed(undefined))).toBe(false);
   });
 });

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -614,11 +614,8 @@ describe("LegacyPgBatchQuery.submit", () => {
 
     const error = batch.submit(connection);
 
-    expect(error?.message).toBe(
-      "connection to the database was lost before the batch could be sent",
-    );
-    expect(batch.submitted).toBe(false);
-    expect(batch.poisoned).toBe(false);
+    expect(error?.message).toBe("the connection's socket is no longer writable");
+    expect(batch.outcome).toBe("unsent");
     expect(frames).toEqual([]);
   });
 
@@ -641,20 +638,21 @@ describe("LegacyPgBatchQuery.submit", () => {
       "sync",
       "uncork",
     ]);
-    expect(batch.submitted).toBe(true);
+    expect(batch.outcome).toBe("submitted");
   });
 });
 
 describe("legacyBatchFailureError", () => {
   it("reports an unsent batch as a lost connection rather than a statement failure", () => {
     const error = legacyBatchFailureError(
-      new Error("connection to the database was lost before the batch could be sent"),
-      { completed: 0, submitted: false, poisoned: false },
+      new Error("the connection's socket is no longer writable"),
+      { completed: 0, outcome: "unsent" },
     );
 
     expect(error._tag).toBe("LegacyDbConnectError");
     expect(error.message).toBe(
-      "connection to the database was lost before the batch could be sent",
+      "connection to the database was lost before the batch could be sent: " +
+        "the connection's socket is no longer writable",
     );
     expect(error[ErrorActionabilityId]).toMatchObject({ error_category: "db_connection" });
   });
@@ -662,7 +660,7 @@ describe("legacyBatchFailureError", () => {
   it("keeps the driver's own reason when pg refused the batch before submit", () => {
     const error = legacyBatchFailureError(
       new Error("Client has encountered a connection error and is not queryable"),
-      { completed: 0, submitted: false, poisoned: false },
+      { completed: 0, outcome: "unsent" },
     );
 
     expect(error._tag).toBe("LegacyDbConnectError");
@@ -681,14 +679,16 @@ describe("legacyBatchFailureError", () => {
     );
   });
 
-  it("keeps a partially written batch on the statement path", () => {
+  it("keeps a partially written batch on the statement path, blaming statement 0", () => {
+    // A poisoned batch is corked, so the server acknowledged nothing and `completed`
+    // is always 0 — the failure can only be reported against the batch's first statement.
     const error = legacyBatchFailureError(new Error("serialization blew up"), {
-      completed: 1,
-      submitted: false,
-      poisoned: true,
+      completed: 0,
+      outcome: "poisoned",
     });
 
     expect(error._tag).toBe("LegacyDbExecError");
+    expect(error).toMatchObject({ message: "Error: serialization blew up", statementIndex: 0 });
   });
 
   it("keeps server-error mapping and the completed count for a statement failure", () => {
@@ -705,7 +705,7 @@ describe("legacyBatchFailureError", () => {
           operation: "execute",
         }),
       }),
-      { completed: 3, submitted: true, poisoned: false },
+      { completed: 3, outcome: "submitted" },
     );
 
     expect(error._tag).toBe("LegacyDbExecError");
@@ -721,23 +721,26 @@ describe("legacyBatchFailureError", () => {
 
 describe("legacyShouldDiscardBatchClient", () => {
   it("discards a client whose batch never reached the wire", () => {
-    expect(legacyShouldDiscardBatchClient({ submitted: false }, Exit.succeed(undefined))).toBe(
+    expect(legacyShouldDiscardBatchClient({ outcome: "unsent" }, Exit.succeed(undefined))).toBe(
       true,
     );
   });
 
   it("returns a client to the pool once its batch was written, error or not", () => {
-    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.succeed(undefined))).toBe(
+    expect(legacyShouldDiscardBatchClient({ outcome: "submitted" }, Exit.succeed(undefined))).toBe(
       false,
     );
     expect(
-      legacyShouldDiscardBatchClient({ submitted: true }, Exit.fail(new Error("server said no"))),
+      legacyShouldDiscardBatchClient(
+        { outcome: "submitted" },
+        Exit.fail(new Error("server said no")),
+      ),
     ).toBe(false);
   });
 
   it("discards a client whose batch was interrupted or died mid-flight", () => {
-    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.interrupt(1))).toBe(true);
-    expect(legacyShouldDiscardBatchClient({ submitted: true }, Exit.die("boom"))).toBe(true);
+    expect(legacyShouldDiscardBatchClient({ outcome: "submitted" }, Exit.interrupt(1))).toBe(true);
+    expect(legacyShouldDiscardBatchClient({ outcome: "submitted" }, Exit.die("boom"))).toBe(true);
   });
 
   it("keeps a client that was checked out but never used", () => {

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -678,6 +678,10 @@ describe("legacyBatchFailureError", () => {
         "the connection's socket is no longer writable",
     );
     expect(error[ErrorActionabilityId]).toMatchObject({ error_category: "db_connection" });
+    // A batch pg refused before construction reaches the mapper as undefined; same class.
+    expect(legacyBatchFailureError(new Error("client was closed"), undefined, true)._tag).toBe(
+      "LegacyDbConnectError",
+    );
   });
 
   it("keeps the driver's own reason when pg refused the batch before submit", () => {
@@ -715,15 +719,6 @@ describe("legacyBatchFailureError", () => {
     expect(local).toMatchObject({ suggestion: LEGACY_SUGGEST_LOCAL_STACK });
     expect(remote._tag).toBe("LegacyDbConnectError");
     expect("suggestion" in remote).toBe(false);
-  });
-
-  it("reports a batch that never reached the driver the same way", () => {
-    const error = legacyBatchFailureError(new Error("client was closed"), undefined, true);
-
-    expect(error._tag).toBe("LegacyDbConnectError");
-    expect(error.message).toContain(
-      "connection to the database was lost before the batch could be sent",
-    );
   });
 
   it("keeps a partially written batch on the statement path, blaming statement 0", () => {
@@ -793,9 +788,7 @@ describe("legacyShouldDiscardBatchClient", () => {
   it("discards a client whose batch was interrupted or died mid-flight", () => {
     expect(legacyShouldDiscardBatchClient({ outcome: "submitted" }, Exit.interrupt(1))).toBe(true);
     expect(legacyShouldDiscardBatchClient({ outcome: "submitted" }, Exit.die("boom"))).toBe(true);
-  });
-
-  it("keeps a client that was checked out but never used", () => {
-    expect(legacyShouldDiscardBatchClient(undefined, Exit.succeed(undefined))).toBe(false);
+    // Interrupted before the batch was even constructed: no batch, still discard.
+    expect(legacyShouldDiscardBatchClient(undefined, Exit.interrupt(1))).toBe(true);
   });
 });

--- a/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-db-connection.sql-pg.unit.test.ts
@@ -329,7 +329,7 @@ describe("legacyBuildRawPgConfig", () => {
     expect("ssl" in c).toBe(false);
   });
 
-  it("enables TCP keepalive with pgconn's five-minute idle delay on both config forms", () => {
+  it("enables TCP keepalive with a five-minute idle delay on both config forms", () => {
     const discrete = legacyBuildRawPgConfig({ ...base }, "db.example.com", 5432, false, 10);
     expect(discrete.keepAlive).toBe(true);
     expect(discrete.keepAliveInitialDelayMillis).toBe(300_000);

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.ts
@@ -744,9 +744,9 @@ const execMigrationBatch = <E>(
           const base = executed;
           yield* session.execBatch(operations).pipe(
             Effect.mapError((cause) => {
-              // Acquiring the batch's connection failed: there is no failing
-              // statement to name, so the connect error (and its suggestion) is
-              // surfaced verbatim instead of being rendered as `At statement: N`.
+              // The batch's connection failed, either on checkout or before any of
+              // it reached the wire: there is no failing statement to name, so the
+              // connect error is surfaced verbatim instead of `At statement: N`.
               if (cause instanceof LegacyDbConnectError) return cause;
               // `statementIndex` is set by every batch failure the driver raises; a
               // session that omits it can only have failed before the first statement.

--- a/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-migration-apply.unit.test.ts
@@ -11,7 +11,7 @@ import {
   type CliErrorActionabilityDeclaration,
   ErrorActionabilityId,
 } from "../../shared/telemetry/error-actionability.ts";
-import type { LegacyDbConnectError } from "./legacy-db-connection.errors.ts";
+import { LegacyDbConnectError } from "./legacy-db-connection.errors.ts";
 import type { LegacyDbBatchStatement, LegacyDbSession } from "./legacy-db-connection.service.ts";
 import {
   legacyApplyMigrationFile,
@@ -43,6 +43,7 @@ function fakeSession(
     failAfterBatch?: boolean;
     failWith?: { message: string; code?: string; detail?: string; position?: number };
     restoreRoleSql?: string;
+    batchConnectionLost?: string;
   } = {},
 ) {
   const calls: Array<{
@@ -65,6 +66,9 @@ function fakeSession(
         sql: statements.map(({ sql }) => sql).join(";\n"),
         statements,
       });
+      if (opts.batchConnectionLost !== undefined) {
+        return Effect.fail(new LegacyDbConnectError({ message: opts.batchConnectionLost }));
+      }
       const statementIndex = opts.failAfterBatch
         ? statements.length
         : statements.findIndex(({ sql }) =>
@@ -211,6 +215,30 @@ describe("legacyApplyMigrationFile", () => {
             expect(msg).toContain("At statement: 0");
             expect(msg).toContain("ALTER TABLE a ADD COLUMN b int");
           }
+          rmSync(dir, { recursive: true, force: true });
+        }),
+      ),
+    );
+  });
+
+  it.effect("surfaces a lost batch connection verbatim, never as a failing statement", () => {
+    const dir = mkdtempSync(join(tmpdir(), "legacy-apply-"));
+    const file = join(dir, "20240101120000_lost.sql");
+    writeFileSync(file, "ALTER TABLE a ADD COLUMN b int;");
+    const { session } = fakeSession({
+      batchConnectionLost: "connection to the database was lost before the batch could be sent",
+    });
+    return run(session, file).pipe(
+      Effect.flip,
+      Effect.tap((error) =>
+        Effect.sync(() => {
+          expect(error).toBeInstanceOf(LegacyDbConnectError);
+          expect(error.message).toBe(
+            "connection to the database was lost before the batch could be sent",
+          );
+          const rendered = JSON.stringify(error);
+          expect(rendered).not.toContain("At statement:");
+          expect(rendered).not.toContain("ALTER TABLE a ADD COLUMN b int");
           rmSync(dir, { recursive: true, force: true });
         }),
       ),


### PR DESCRIPTION
## TL;DR

fixes `supabase db reset` and `supabase start` hanging forever with no error when the database connection dies while migrations are being applied

## whats broken?

node-postgres silently discards every protocol frame once a socket stops being writable, while still reporting the write as successful, so the whole batch goes nowhere and the CLI waits forever on a reply the server was never asked for

it also leaves TCP keepalive off by default, where the Go CLI's driver had it on, so a peer that dies without a FIN or RST is never noticed either

## fixed now by:

- failing a batch that never reached the wire as a connection error, carrying the driver's own reason instead of blaming the migration's first statement
- discarding that pooled connection, so the next batch redials instead of writing into the same dead socket
- turning TCP keepalive on for every connection the CLI opens, so a silently dead peer is eventually detected instead of waited on

a server that stays alive but never answers still waits, matching the Go CLI, since that is indistinguishable from a long running statement

## ref:
- closes: https://github.com/supabase/cli/issues/6244
