### PR TITLE
fix(cli): bound piped stdin buffering (CLI-2223)

### DIFF
--- a/apps/cli/src/shared/runtime/stdin.integration.test.ts
+++ b/apps/cli/src/shared/runtime/stdin.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Deferred, Effect, Layer, Option, Queue, Stdio, Stream } from "effect";
+import { Deferred, Duration, Effect, Fiber, Layer, Option, Queue, Stdio, Stream } from "effect";
+import { TestClock } from "effect/testing";
 
 import { mockTty } from "../../../tests/helpers/mocks.ts";
 import { Stdin } from "./stdin.service.ts";
@@ -101,11 +102,13 @@ describe("stdinLayer readLine", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.live("times out to None on a TTY when the user does not answer in time", () => {
+  it.effect("times out to None on a TTY when the user does not answer in time", () => {
     const layer = withStdin(Stream.never, true);
     return Effect.gen(function* () {
       const stdin = yield* Stdin;
-      expect(yield* stdin.readLine(100)).toStrictEqual(Option.none());
+      const reading = yield* Effect.forkChild(stdin.readLine(100));
+      yield* TestClock.adjust(Duration.millis(100));
+      expect(yield* Fiber.join(reading)).toStrictEqual(Option.none());
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/cli/src/shared/runtime/stdin.integration.test.ts
+++ b/apps/cli/src/shared/runtime/stdin.integration.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Stdio, Stream } from "effect";
+import { Deferred, Effect, Layer, Option, Queue, Stdio, Stream } from "effect";
 
 import { mockTty } from "../../../tests/helpers/mocks.ts";
 import { Stdin } from "./stdin.service.ts";
 import { stdinLayer } from "./stdin.layer.ts";
 
 const enc = (s: string) => new TextEncoder().encode(s);
+const dec = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
 
 // Exercises the real `stdinLayer` (its persistent, lazily-opened line reader) over a
 // controllable `Stdio` stream, instead of the array-indexing `mockStdin` double.
 // `Stdio.layerTest` lets us drive stdin as a byte Stream with deliberate chunking /
 // delays; `stdinLayer` also needs `Tty`, satisfied by `mockTty`.
-const withStdin = (stdin: Stream.Stream<Uint8Array>) =>
+const withStdin = (stdin: Stream.Stream<Uint8Array>, stdinIsTty = false) =>
   stdinLayer.pipe(
     Layer.provide(Stdio.layerTest({ stdin })),
-    Layer.provide(mockTty({ stdinIsTty: false, stdoutIsTty: false })),
+    Layer.provide(mockTty({ stdinIsTty, stdoutIsTty: false })),
   );
 
 describe("stdinLayer readLine", () => {
@@ -49,6 +50,59 @@ describe("stdinLayer readLine", () => {
     // console.go:36): readLine must give up with None so the prompt takes its default
     // instead of blocking on EOF.
     const layer = withStdin(Stream.never);
+    return Effect.gen(function* () {
+      const stdin = yield* Stdin;
+      expect(yield* stdin.readLine(100)).toStrictEqual(Option.none());
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("keeps a piped stdin consumed once the reader is open", () =>
+    Effect.gen(function* () {
+      const pipe = yield* Queue.unbounded<Uint8Array>();
+      const taken = yield* Deferred.make<boolean>();
+      const layer = withStdin(
+        Stream.fromQueue(pipe).pipe(
+          Stream.tap((chunk) =>
+            dec(chunk) === "b\n" ? Deferred.succeed(taken, true) : Effect.succeed(false),
+          ),
+        ),
+      );
+      yield* Effect.gen(function* () {
+        const stdin = yield* Stdin;
+        yield* Queue.offer(pipe, enc("a\n"));
+        expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("a"));
+
+        yield* Queue.offer(pipe, enc("b\n"));
+        yield* Deferred.await(taken);
+
+        expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("b"));
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.live("answers prompts from the earliest lines when a producer floods the pipe", () => {
+    const flood = Array.from({ length: 5_000 }, (_, index) => enc(`line-${index}\n`));
+    const layer = withStdin(Stream.fromIterable(flood).pipe(Stream.concat(Stream.never)));
+    return Effect.gen(function* () {
+      const stdin = yield* Stdin;
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("line-0"));
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("line-1"));
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("dispenses successive lines on a TTY, which is read only when prompted", () => {
+    const layer = withStdin(Stream.fromIterable([enc("a\n"), enc("b\nc\n")]), true);
+    return Effect.gen(function* () {
+      const stdin = yield* Stdin;
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("a"));
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("b"));
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.some("c"));
+      expect(yield* stdin.readLine(10_000)).toStrictEqual(Option.none());
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("times out to None on a TTY when the user does not answer in time", () => {
+    const layer = withStdin(Stream.never, true);
     return Effect.gen(function* () {
       const stdin = yield* Stdin;
       expect(yield* stdin.readLine(100)).toStrictEqual(Option.none());

--- a/apps/cli/src/shared/runtime/stdin.layer.ts
+++ b/apps/cli/src/shared/runtime/stdin.layer.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Layer, Option, Pull, Ref, Scope, Stdio, Stream } from "effect";
+import { Duration, Effect, Layer, Option, Pull, Queue, Ref, Scope, Stdio, Stream } from "effect";
 
 import { Tty } from "./tty.service.ts";
 import { Stdin } from "./stdin.service.ts";
@@ -8,23 +8,65 @@ const makeStdin = Effect.gen(function* () {
   const tty = yield* Tty;
   const textDecoder = new TextDecoder();
 
+  const scope = yield* Effect.scope;
+  const lineStream = stdio.stdin.pipe(Stream.decodeText(), Stream.splitLines);
+
+  // A TTY answers at human speed, so it keeps the on-demand pull: nothing is read
+  // between prompts, leaving the keyboard to whatever reads stdin next.
+  const ttyLineReader = Effect.gen(function* () {
+    const pull = yield* Stream.toPull(lineStream).pipe(Scope.provide(scope));
+    // Leftover lines from the last pulled chunk (a single pull may yield several).
+    const bufferRef = yield* Ref.make<ReadonlyArray<string>>([]);
+    return Effect.gen(function* () {
+      const buffered = yield* Ref.get(bufferRef);
+      if (buffered.length > 0) {
+        yield* Ref.set(bufferRef, buffered.slice(1));
+        return Option.some(buffered[0] ?? "");
+      }
+      return yield* Pull.matchEffect(pull, {
+        onSuccess: (chunk) =>
+          Ref.set(bufferRef, chunk.slice(1)).pipe(Effect.as(Option.some(chunk[0] ?? ""))),
+        onFailure: () => Effect.succeedNone,
+        onDone: () => Effect.succeedNone,
+      });
+    });
+  });
+
+  // A pipe is read ahead into a bounded queue instead, because Bun's `process.stdin`
+  // cannot be throttled: one prompt is enough to start a read of the pipe that `pause`,
+  // `destroy` and detaching the listener all fail to stop. Everything left unconsumed
+  // accumulates for the rest of the command, which an unbounded producer turns into an
+  // OOM kill; consuming as fast as the pipe fills keeps memory flat. `dropping` discards
+  // the newest overflow, so the lines prompts read stay in pipe order.
+  // Ref: https://github.com/supabase/cli/issues/6287
+  const pipedLineReader = Stream.toQueue(lineStream, {
+    // The pump reads at pipe speed, so this is in effect how many piped answers one run
+    // can use. `seed buckets` and `storage rm` prompt once per bucket, so it is sized to
+    // a project's bucket count rather than to a fixed handful of confirmations.
+    capacity: 1024,
+    strategy: "dropping",
+  }).pipe(
+    Scope.provide(scope),
+    Effect.map((queue) =>
+      // EOF and read errors arrive as typed failures and become the prompt's default;
+      // a defect or an interrupt propagates rather than silently answering a prompt.
+      Queue.take(queue).pipe(
+        Effect.map(Option.some),
+        Effect.orElseSucceed(() => Option.none<string>()),
+      ),
+    ),
+  );
+
   // Persistent, lazily-opened line reader shared by every `readLine` call, so a
   // command issuing several prompts (config push, seed buckets) reads the *next*
   // piped line each time — one `bufio.Scanner` over os.Stdin, as in Go
-  // (`internal/utils/console.go:20,50`). `Stream.toPull` is deferred behind
+  // (`internal/utils/console.go:20,50`). Opening it is deferred behind
   // `Effect.cached` and tied to this layer's scope: stdin is not touched until the
   // first `readLine`, so a TTY command that only prompts via clack never grabs the
-  // keyboard (no contention with clack's own stdin capture), and the pull outlives
+  // keyboard (no contention with clack's own stdin capture), and the reader outlives
   // individual prompts. `splitLines` preserves interior blank lines so answers stay
   // aligned across prompts.
-  const scope = yield* Effect.scope;
-  const getPull = yield* Effect.cached(
-    Stream.toPull(stdio.stdin.pipe(Stream.decodeText(), Stream.splitLines)).pipe(
-      Scope.provide(scope),
-    ),
-  );
-  // Leftover lines from the last pulled chunk (a single pull may yield several).
-  const bufferRef = yield* Ref.make<ReadonlyArray<string>>([]);
+  const nextLine = yield* Effect.cached(tty.stdinIsTty ? ttyLineReader : pipedLineReader);
 
   const readPipedBytes = Effect.gen(function* () {
     const chunks = yield* stdio.stdin.pipe(Stream.runCollect);
@@ -56,26 +98,11 @@ const makeStdin = Effect.gen(function* () {
   // the default instead of blocking on EOF.
   const readLine = (timeoutMillis: number): Effect.Effect<Option.Option<string>> =>
     Effect.gen(function* () {
-      const buffered = yield* Ref.get(bufferRef);
-      if (buffered.length > 0) {
-        yield* Ref.set(bufferRef, buffered.slice(1));
-        return Option.some((buffered[0] ?? "").trim());
-      }
-      const pull = yield* getPull;
-      const readChunk = Pull.matchEffect(pull, {
-        onSuccess: (chunk) => Effect.succeed(Option.some(chunk)),
-        onFailure: () => Effect.succeedNone,
-        onDone: () => Effect.succeedNone,
-      });
+      const take = yield* nextLine;
       // Outer `None` = timed out; inner `None` = EOF / read error; either way the
       // prompt takes its default.
-      const pulled = yield* readChunk.pipe(Effect.timeoutOption(Duration.millis(timeoutMillis)));
-      if (Option.isNone(pulled) || Option.isNone(pulled.value)) {
-        return Option.none<string>();
-      }
-      const chunk = pulled.value.value;
-      yield* Ref.set(bufferRef, chunk.slice(1));
-      return Option.some((chunk[0] ?? "").trim());
+      const line = yield* take.pipe(Effect.timeoutOption(Duration.millis(timeoutMillis)));
+      return Option.map(Option.flatten(line), (value) => value.trim());
     });
 
   // Stream piped stdin without collecting it (constant memory). Read errors PROPAGATE on

--- a/apps/cli/src/shared/runtime/stdin.layer.ts
+++ b/apps/cli/src/shared/runtime/stdin.layer.ts
@@ -58,14 +58,13 @@ const makeStdin = Effect.gen(function* () {
   );
 
   // Persistent, lazily-opened line reader shared by every `readLine` call, so a
-  // command issuing several prompts (config push, seed buckets) reads the *next*
-  // piped line each time — one `bufio.Scanner` over os.Stdin, as in Go
-  // (`internal/utils/console.go:20,50`). Opening it is deferred behind
-  // `Effect.cached` and tied to this layer's scope: stdin is not touched until the
-  // first `readLine`, so a TTY command that only prompts via clack never grabs the
-  // keyboard (no contention with clack's own stdin capture), and the reader outlives
-  // individual prompts. `splitLines` preserves interior blank lines so answers stay
-  // aligned across prompts.
+  // command issuing several prompts (config push, seed buckets) reads the *next* piped
+  // line each time instead of restarting from the top of the pipe. Opening it is
+  // deferred behind `Effect.cached` and tied to this layer's scope: stdin is not
+  // touched until the first `readLine`, so a TTY command that only prompts via clack
+  // never grabs the keyboard (no contention with clack's own stdin capture), and the
+  // reader outlives individual prompts. `splitLines` preserves interior blank lines so
+  // answers stay aligned across prompts.
   const nextLine = yield* Effect.cached(tty.stdinIsTty ? ttyLineReader : pipedLineReader);
 
   const readPipedBytes = Effect.gen(function* () {

--- a/apps/cli/src/shared/runtime/stdin.service.ts
+++ b/apps/cli/src/shared/runtime/stdin.service.ts
@@ -27,6 +27,10 @@ interface StdinShape {
    * keyboard. Returns `None` on timeout, EOF, or a read error (Go treats all of these
    * as no input). Unlike {@link readPipedText} (a whole-stream collect), this reads
    * line by line, so it works for an interactive terminal as well as a pipe.
+   *
+   * On a PIPE lines are read ahead into a bounded buffer rather than on demand, so only
+   * the first N piped lines are answerable and anything past them is dropped. See
+   * `stdin.layer.ts` for N and for why reading ahead is required at all.
    */
   readonly readLine: (timeoutMillis: number) => Effect.Effect<Option.Option<string>>;
 }

--- a/apps/cli/src/shared/runtime/stdin.service.ts
+++ b/apps/cli/src/shared/runtime/stdin.service.ts
@@ -17,16 +17,15 @@ interface StdinShape {
   readonly pipedBytesStream: Stream.Stream<Uint8Array, PlatformError>;
   readonly readPipedText: Effect.Effect<Option.Option<string>>;
   /**
-   * Reads the *next* line from stdin (trimmed), bounded by `timeoutMillis`. Port of
-   * Go's `Console.ReadLine` (`internal/utils/console.go:38-61`), which reads one line
-   * with a 10-minute timeout on a TTY and 100 ms otherwise. Backed by a single
-   * persistent, lazily-opened reader, so successive calls return successive lines —
-   * a command issuing several confirmations answers each from the next piped line,
-   * exactly as Go's one `bufio.Scanner` does. stdin is not opened until the first
-   * call, so a command that only prompts on a TTY (via clack) never grabs the
-   * keyboard. Returns `None` on timeout, EOF, or a read error (Go treats all of these
-   * as no input). Unlike {@link readPipedText} (a whole-stream collect), this reads
-   * line by line, so it works for an interactive terminal as well as a pipe.
+   * Reads the *next* line from stdin (trimmed), bounded by `timeoutMillis` — callers
+   * pass 10 minutes on a TTY and 100 ms otherwise. Backed by a single persistent,
+   * lazily-opened reader, so successive calls return successive lines: a command
+   * issuing several confirmations answers each from the next piped line. stdin is not
+   * opened until the first call, so a command that only prompts on a TTY (via clack)
+   * never grabs the keyboard. A timeout, EOF, or a read error all return `None`, which
+   * every caller treats as no input and answers with the prompt's default. Unlike
+   * {@link readPipedText} (a whole-stream collect), this reads line by line, so it
+   * works for an interactive terminal as well as a pipe.
    *
    * On a PIPE lines are read ahead into a bounded buffer rather than on demand, so only
    * the first N piped lines are answerable and anything past them is dropped. See


### PR DESCRIPTION
## TL;DR

fixes the CLI being OOM killed when a long running command is fed by an unbounded pipe such as `yes | supabase db push` which was caused by the line reader holding stdin open but idle between prompts 
and is now fixed by reading piped stdin ahead into a bounded queue instead of on demand....

## what's biting the user?

Go read stdin on demand with one `bufio.Scanner`, which was safe because the pipe pushed back and `yes` simply blocked. The port kept that shape, but Bun's `process.stdin` cannot be throttled:
 once a reader is attached Bun keeps reading the pipe, and `pause`, `destroy`, `unref` and detaching the listener all fail to stop it. 
An idle reader therefore buffers for the whole migration, reaching 5 to 6 GB RSS in seconds. `--yes` escapes it only because the reader is lazy and never opens stdin....

## fixed now by:

Piped stdin is drained continuously into a bounded queue of 1024 lines, which holds memory flat at around 120-140MB Overflow drops newest first, so the lines prompts read stay in pipe order. 
A TTY keeps the on demand reader, since a keyboard cannot outrun the prompts and a drainer would take keystrokes a later prompt needs.....

> [!NOTE]
> The line cap and the drop on overflow are deliberate, not an oversight 
a source that honors backpressure needs no cap at all
 but it replaces the platform `Stdio` service rather than one consumer of it, so it is better to be tracked separately.

<details>
<summary>alt approach considered: backpressured fd 0 (maybe a later followup) </summary>

Bun's `process.stdin` cannot be throttled, but `fs.createReadStream("", { fd: 0 })` can. 
Measured with the same reader logic and the same `yes |` producer:

| source | RSS under `yes \|`, 8s idle |
| --- | --- |
| `process.stdin`, on demand (before) | 5 to 6 GB, climbing |
| `process.stdin`, bounded queue (this PR) | ~150 MB |
| `fs.createReadStream("", { fd: 0 })` | ~100 MB |

With real backpressure nothing is read ahead, so the queue, 
the cap and the drop all disappear and the TTY and pipe paths collapse back into one reader. 
It is not taken here because it means providing a replacement `Stdio` service across its 23 provision sites, 
three of which sit inline next to `stdinLayer`, so it touches production layer wiring rather than a single consumer....

It also does not close everything on its own.
 A line with no terminator still accumulates inside `splitLines` and needs a separate length bound,
 and a paused fd 0 stream reads far enough ahead to matter for a child later spawned with inherited stdin. 
Both need settling before it can replace this...

</details>

## ref:

- closes: https://github.com/supabase/cli/issues/6287
