### PR TITLE
chore(cli): structure docker binds

### DIFF
--- a/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
+++ b/apps/cli/src/legacy/commands/functions/serve/serve.integration.test.ts
@@ -1359,60 +1359,48 @@ describe("legacy functions serve integration", () => {
       const projectRoot = join(workspaceRoot, "infra", "my-project");
       const rootDenoJson = join(workspaceRoot, "deno.json");
       const libsDir = join(workspaceRoot, "libs");
-      const thingDir = join(libsDir, "thing");
-      const functionDir = join(projectRoot, "supabase", "functions", "hello");
 
       yield* Effect.promise(() => mkdir(join(workspaceRoot, ".git"), { recursive: true }));
-      yield* Effect.promise(() => mkdir(join(projectRoot, "supabase"), { recursive: true }));
-      yield* Effect.promise(() => writeFile(join(projectRoot, ".git"), "gitdir: ignored\n"));
-      yield* Effect.promise(() =>
-        writeFile(
-          rootDenoJson,
+      yield* Effect.promise(async () => {
+        await writeProjectFile(join("infra", "my-project", ".git"), "gitdir: ignored\n");
+        await writeProjectFile(
+          "deno.json",
           JSON.stringify({
             workspace: ["./libs/*", "./infra/*/supabase/functions/*"],
             imports: { "@acme/thing": "./libs/thing/index.ts" },
           }),
-        ),
-      );
-      yield* Effect.promise(() =>
-        writeFile(join(projectRoot, "supabase", "config.toml"), 'project_id = "test-project"\n'),
-      );
-      yield* Effect.promise(() => mkdir(thingDir, { recursive: true }));
-      yield* Effect.promise(() =>
-        writeFile(
-          join(thingDir, "deno.json"),
+        );
+        await writeProjectFile(
+          join("infra", "my-project", "supabase", "config.toml"),
+          'project_id = "test-project"\n',
+        );
+        await writeProjectFile(
+          join("libs", "thing", "deno.json"),
           JSON.stringify({ name: "@acme/thing", version: "1.0.0", exports: "./index.ts" }),
-        ),
-      );
-      yield* Effect.promise(() =>
-        writeFile(join(thingDir, "index.ts"), "export const thing = 1\n"),
-      );
-      yield* Effect.promise(() => mkdir(functionDir, { recursive: true }));
-      yield* Effect.promise(() =>
-        writeFile(
-          join(functionDir, "index.ts"),
+        );
+        await writeProjectFile(join("libs", "thing", "index.ts"), "export const thing = 1\n");
+        const functionRelative = join("infra", "my-project", "supabase", "functions", "hello");
+        await writeProjectFile(
+          join(functionRelative, "index.ts"),
           'import { thing } from "@acme/thing"\nDeno.serve(() => new Response(String(thing)))\n',
-        ),
-      );
-      const sharedDenoJson = JSON.stringify({
-        imports: { "@std/assert": "jsr:@std/assert@1" },
-        scopes: {
-          __local: {
-            __workspace: "../../../../../deno.json",
-            __libs: "../../../../../libs",
+        );
+        const sharedDenoJson = JSON.stringify({
+          imports: { "@std/assert": "jsr:@std/assert@1" },
+          scopes: {
+            __local: {
+              __workspace: "../../../../../deno.json",
+              __libs: "../../../../../libs",
+            },
           },
-        },
-      });
-      yield* Effect.promise(() => writeFile(join(functionDir, "deno.json"), sharedDenoJson));
-      const worldDir = join(projectRoot, "supabase", "functions", "world");
-      yield* Effect.promise(() => mkdir(worldDir, { recursive: true }));
-      yield* Effect.promise(() =>
-        writeFile(
-          join(worldDir, "index.ts"),
+        });
+        await writeProjectFile(join(functionRelative, "deno.json"), sharedDenoJson);
+        const worldRelative = join("infra", "my-project", "supabase", "functions", "world");
+        await writeProjectFile(
+          join(worldRelative, "index.ts"),
           'import { thing } from "@acme/thing"\nDeno.serve(() => new Response(String(thing)))\n',
-        ),
-      );
-      yield* Effect.promise(() => writeFile(join(worldDir, "deno.json"), sharedDenoJson));
+        );
+        await writeProjectFile(join(worldRelative, "deno.json"), sharedDenoJson);
+      });
 
       const resolvedWorkspaceRoot = realpathSync(workspaceRoot);
       const resolvedLibsDir = realpathSync(libsDir);

--- a/apps/cli/src/shared/functions/deploy.ts
+++ b/apps/cli/src/shared/functions/deploy.ts
@@ -313,23 +313,15 @@ function toBundledFileUrl(hostPath: string) {
   return url.toString();
 }
 
-const DOCKER_BIND_MODE_PATTERN = /:(?:ro|rw)(?:,[zZ])?$/;
-
-export function dockerBindHostPath(bind: string) {
-  const withoutMode = bind.replace(DOCKER_BIND_MODE_PATTERN, "");
-  const separatorIndex = withoutMode.lastIndexOf(":");
-  return separatorIndex === -1 ? withoutMode : withoutMode.slice(0, separatorIndex);
+export interface DockerBind {
+  readonly hostPath: string;
+  readonly containerPath: string;
+  readonly mode: "ro" | "rw";
+  readonly externalScope: boolean;
 }
 
-/**
- * Container side of a `host:container[:mode]` bind. Unlike {@link dockerBindHostPath},
- * a bind with no separator yields `""` rather than the whole string, so a malformed
- * entry can never prefix-match a real container path.
- */
-export function dockerBindContainerPath(bind: string) {
-  const withoutMode = bind.replace(DOCKER_BIND_MODE_PATTERN, "");
-  const separatorIndex = withoutMode.lastIndexOf(":");
-  return separatorIndex === -1 ? "" : withoutMode.slice(separatorIndex + 1);
+export function formatDockerBind(bind: DockerBind) {
+  return `${bind.hostPath}:${bind.containerPath}:${bind.mode}`;
 }
 
 function dockerNpmEnv(env: NodeJS.ProcessEnv = process.env): ReadonlyArray<string> {
@@ -1172,26 +1164,26 @@ function createBundledMetadata(
 }
 
 function sanitizeDockerBinds(
-  binds: ReadonlyArray<string>,
+  binds: ReadonlyArray<DockerBind>,
   functionsDir: string,
   outputDir: string,
 ) {
   const normalizedFunctionsDir = `${toSlash(resolve(functionsDir))}/`;
   const normalizedOutputDir = `${toSlash(resolve(outputDir))}/`;
   const seen = new Set<string>();
-  const result: string[] = [];
+  const result: DockerBind[] = [];
 
   for (const bind of binds) {
-    const hostPath = dockerBindHostPath(bind);
-    const normalizedHostPath = `${toSlash(resolve(hostPath))}${bind.endsWith(":rw") || bind.endsWith(":ro") ? "" : "/"}`;
+    const normalizedHostPath = toSlash(resolve(bind.hostPath));
     if (
       normalizedHostPath.startsWith(normalizedFunctionsDir) ||
       normalizedHostPath.startsWith(normalizedOutputDir)
     ) {
       continue;
     }
-    if (!seen.has(bind)) {
-      seen.add(bind);
+    const key = formatDockerBind(bind);
+    if (!seen.has(key)) {
+      seen.add(key);
       result.push(bind);
     }
   }
@@ -1207,10 +1199,9 @@ export async function buildDockerBinds(
   options: {
     readonly additionalModuleRoots?: ReadonlyArray<string>;
     readonly onWarning?: (message: string) => Promise<void>;
-    readonly onScopeBindOutsideRoots?: (bind: string) => void;
     readonly skipMissingImportMapTargets?: boolean;
   } = {},
-) {
+): Promise<ReadonlyArray<DockerBind>> {
   const hostFunctionsDir = resolve(functionsDir);
   const hostOutputDir = resolve(outputDir);
   const projectRoot = resolve(functionsDir, "..", "..");
@@ -1231,31 +1222,57 @@ export async function buildDockerBinds(
     ).flatMap((root) => (root === undefined ? [] : [root])),
   ];
   const importMapAllowedRoots = await resolveImportMapAllowedRoots(sourceRoot, config.importMap);
-  const binds = [`${hostFunctionsDir}:${toDockerPath(hostFunctionsDir)}:ro`];
+  const binds: DockerBind[] = [
+    {
+      hostPath: hostFunctionsDir,
+      containerPath: toDockerPath(hostFunctionsDir),
+      mode: "ro",
+      externalScope: false,
+    },
+  ];
   if (process.env["BITBUCKET_CLONE_DIR"] === undefined) {
-    binds.unshift(`${localDockerId("edge_runtime", projectId)}:/root/.cache/deno:rw`);
+    binds.unshift({
+      hostPath: localDockerId("edge_runtime", projectId),
+      containerPath: "/root/.cache/deno",
+      mode: "rw",
+      externalScope: false,
+    });
   }
 
   if (!hostOutputDir.startsWith(hostFunctionsDir)) {
-    binds.push(`${hostOutputDir}:${toDockerPath(hostOutputDir)}:rw`);
+    binds.push({
+      hostPath: hostOutputDir,
+      containerPath: toDockerPath(hostOutputDir),
+      mode: "rw",
+      externalScope: false,
+    });
   }
 
   const warn = options.onWarning ?? (async () => {});
-  const extraBinds: string[] = [];
-  const explicitScopeBinds = new Set<string>();
+  const extraBinds: DockerBind[] = [];
+  const explicitScopeBinds = new Map<string, DockerBind>();
   const appendBindWithinRoots = async (roots: ReadonlyArray<string>, pathname: string) => {
     const hostPath = await realpath(pathname);
-    if (!isContainedInAnyPath(roots, hostPath)) {
-      return;
+    const contained = isContainedInAnyPath(roots, hostPath);
+    if (contained) {
+      extraBinds.push({
+        hostPath,
+        containerPath: toDockerPath(hostPath),
+        mode: "ro",
+        externalScope: false,
+      });
     }
-    extraBinds.push(`${hostPath}:${toDockerPath(hostPath)}:ro`);
+    return { hostPath, contained };
   };
-  const appendProjectBind = async (pathname: string, _contents: Uint8Array) =>
-    appendBindWithinRoots([realSourceRoot], pathname);
-  const appendModuleBind = async (pathname: string, _contents: Uint8Array) =>
-    appendBindWithinRoots(moduleRoots, pathname);
-  const appendImportMapBind = async (pathname: string, _contents: Uint8Array) =>
-    appendBindWithinRoots(importMapAllowedRoots, pathname);
+  const appendProjectBind = async (pathname: string, _contents: Uint8Array) => {
+    await appendBindWithinRoots([realSourceRoot], pathname);
+  };
+  const appendModuleBind = async (pathname: string, _contents: Uint8Array) => {
+    await appendBindWithinRoots(moduleRoots, pathname);
+  };
+  const appendImportMapBind = async (pathname: string, _contents: Uint8Array) => {
+    await appendBindWithinRoots(importMapAllowedRoots, pathname);
+  };
   const importMap =
     config.importMap.length > 0
       ? await loadImportMapFile(config.importMap, appendImportMapBind)
@@ -1270,14 +1287,16 @@ export async function buildDockerBinds(
   );
   await forEachLocalImportMapTarget(importMap, async (target, kind) => {
     try {
-      const hostPath = await realpath(target);
-      const contained = isContainedInAnyPath(importMapAllowedRoots, hostPath);
-      if (contained) {
-        extraBinds.push(`${hostPath}:${toDockerPath(hostPath)}:ro`);
-      }
+      const { hostPath, contained } = await appendBindWithinRoots(importMapAllowedRoots, target);
       const isDirectory = (await stat(target)).isDirectory();
       if (!contained && kind === "scope") {
-        explicitScopeBinds.add(`${hostPath}:${toDockerPath(target)}:ro`);
+        const scopeBind: DockerBind = {
+          hostPath,
+          containerPath: toDockerPath(target),
+          mode: "ro",
+          externalScope: true,
+        };
+        explicitScopeBinds.set(formatDockerBind(scopeBind), scopeBind);
       }
       if (isDirectory) {
         return;
@@ -1325,19 +1344,17 @@ export async function buildDockerBinds(
 
   const sanitizedExtraBinds = sanitizeDockerBinds(extraBinds, hostFunctionsDir, hostOutputDir);
   const occupiedContainerPaths = new Set(
-    [...binds, ...sanitizedExtraBinds].map(dockerBindContainerPath),
+    [...binds, ...sanitizedExtraBinds].map((bind) => bind.containerPath),
   );
-  const uniqueScopeBinds: string[] = [];
-  for (const bind of explicitScopeBinds) {
-    const containerPath = dockerBindContainerPath(bind);
-    if (occupiedContainerPaths.has(containerPath)) {
+  const uniqueScopeBinds: DockerBind[] = [];
+  for (const bind of explicitScopeBinds.values()) {
+    if (occupiedContainerPaths.has(bind.containerPath)) {
       continue;
     }
-    occupiedContainerPaths.add(containerPath);
+    occupiedContainerPaths.add(bind.containerPath);
     uniqueScopeBinds.push(bind);
-    options.onScopeBindOutsideRoots?.(bind);
     await warn(
-      `WARN: Mounting import map scope target outside the project root: ${dockerBindHostPath(bind)}\n`,
+      `WARN: Mounting import map scope target outside the project root: ${bind.hostPath}\n`,
     );
   }
 
@@ -1462,7 +1479,7 @@ const bundleFunctionWithDocker = Effect.fnUntraced(function* (
       image,
       projectId,
       networkMode,
-      binds,
+      binds: binds.map(formatDockerBind),
       env,
       // Go: `WorkingDir: utils.ToDockerPath(cwd)` (`bundle.go:79`), where
       // `cwd` is the post-`ChangeWorkDir` workdir — `functionsDir` is

--- a/apps/cli/src/shared/functions/deploy.unit.test.ts
+++ b/apps/cli/src/shared/functions/deploy.unit.test.ts
@@ -4,12 +4,7 @@ import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import {
-  buildDockerBinds,
-  dockerBindContainerPath,
-  dockerBindHostPath,
-  type ResolvedDeployFunctionConfig,
-} from "./deploy.ts";
+import { buildDockerBinds, formatDockerBind, type ResolvedDeployFunctionConfig } from "./deploy.ts";
 import { FunctionImportNotDirectoryError } from "./deploy.errors.ts";
 
 /**
@@ -122,8 +117,8 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
 
       // The vendor file is still bound via the import-map target walk
       // (independent of whether the entrypoint's own specifier matched).
-      expect(binds.some((bind) => dockerBindHostPath(bind) === vendorIndexPath)).toBe(true);
-      expect(binds.some((bind) => bind.includes("index.mjs/core"))).toBe(false);
+      expect(binds.some((bind) => bind.hostPath === vendorIndexPath)).toBe(true);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("index.mjs/core"))).toBe(false);
       expect(warnings).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -178,7 +173,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         },
       });
 
-      expect(binds.some((bind) => bind.includes("extra.ts"))).toBe(false);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("extra.ts"))).toBe(false);
       expect(warnings).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -203,7 +198,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         },
       });
 
-      expect(binds.some((bind) => dockerBindHostPath(bind) === vendorIndexPath)).toBe(true);
+      expect(binds.some((bind) => bind.hostPath === vendorIndexPath)).toBe(true);
       expect(warnings).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -257,7 +252,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         },
       });
 
-      expect(binds.some((bind) => bind.includes("index.mjs/core"))).toBe(false);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("index.mjs/core"))).toBe(false);
       expect(warnings.some((warning) => warning.includes("index.mjs/core"))).toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -305,7 +300,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         },
       });
 
-      expect(binds.some((bind) => bind.includes("index.mjs"))).toBe(false);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("index.mjs"))).toBe(false);
       expect(
         warnings.some((warning) =>
           warning.includes("Skipping import map target that is not a directory"),
@@ -339,7 +334,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         skipMissingImportMapTargets: true,
       });
 
-      expect(binds.some((bind) => bind.includes("does-not-exist"))).toBe(false);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("does-not-exist"))).toBe(false);
       expect(
         warnings.some((warning) => warning.includes("Skipping missing import map target")),
       ).toBe(true);
@@ -367,7 +362,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         skipMissingImportMapTargets: true,
       });
 
-      expect(binds.some((bind) => bind.includes("does-not-exist"))).toBe(false);
+      expect(binds.some((bind) => formatDockerBind(bind).includes("does-not-exist"))).toBe(false);
       expect(
         warnings.some((warning) => warning.includes("Skipping missing import map target")),
       ).toBe(true);
@@ -394,7 +389,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
 
     try {
       const binds = await buildDockerBinds("test-project", functionsDir, outputDir, config);
-      const hostPaths = binds.map(dockerBindHostPath);
+      const hostPaths = binds.map((bind) => bind.hostPath);
 
       expect(hostPaths).toContain(scopeEntrypoint);
       expect(hostPaths).toContain(scopeDependency);
@@ -446,7 +441,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
           warnings.push(message);
         },
       });
-      const hostPaths = binds.map(dockerBindHostPath);
+      const hostPaths = binds.map((bind) => bind.hostPath);
 
       expect(hostPaths).toContain(scopeEntrypoint);
       expect(hostPaths).not.toContain(scopeDependency);
@@ -476,25 +471,19 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
       await rename(functionsDir, externalFunctionsDir);
       await symlink(externalFunctionsDir, functionsDir, "dir");
 
-      const reportedScopeBinds: Array<string> = [];
       const warnings: Array<string> = [];
 
       try {
         const binds = await buildDockerBinds("test-project", functionsDir, outputDir, config, {
-          onScopeBindOutsideRoots: (bind) => {
-            reportedScopeBinds.push(bind);
-          },
           onWarning: async (message) => {
             warnings.push(message);
           },
         });
-        const functionsBinds = binds.filter(
-          (bind) => dockerBindContainerPath(bind) === resolve(functionsDir),
-        );
+        const functionsBinds = binds.filter((bind) => bind.containerPath === resolve(functionsDir));
 
         expect(functionsBinds).toHaveLength(1);
-        expect(dockerBindHostPath(functionsBinds[0] ?? "")).toBe(resolve(functionsDir));
-        expect(reportedScopeBinds).toHaveLength(0);
+        expect(functionsBinds[0]?.hostPath).toBe(resolve(functionsDir));
+        expect(binds.filter((bind) => bind.externalScope)).toHaveLength(0);
         expect(
           warnings.filter((warning) => warning.includes("Mounting import map scope target")),
         ).toHaveLength(0);
@@ -554,7 +543,7 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
         },
       });
 
-      expect(binds.some((bind) => dockerBindHostPath(bind) === vendorIndexPath)).toBe(true);
+      expect(binds.some((bind) => bind.hostPath === vendorIndexPath)).toBe(true);
       expect(warnings).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -588,8 +577,10 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
       // "@v/deep/mod.ts" through dirB and bound the resolved FILE. Had the
       // shorter key incorrectly won, the walker would have tried
       // "<dirA>/deep/mod.ts" instead (which does not exist).
-      expect(binds.some((bind) => dockerBindHostPath(bind) === modPath)).toBe(true);
-      expect(binds.some((bind) => bind.includes(join("dirA", "deep")))).toBe(false);
+      expect(binds.some((bind) => bind.hostPath === modPath)).toBe(true);
+      expect(binds.some((bind) => formatDockerBind(bind).includes(join("dirA", "deep")))).toBe(
+        false,
+      );
       expect(warnings).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/apps/cli/src/shared/functions/deploy.unit.test.ts
+++ b/apps/cli/src/shared/functions/deploy.unit.test.ts
@@ -22,6 +22,7 @@ const VENDOR_TARGET_RELATIVE_SLASH = "../../_vendor/package/dist/index.mjs/";
 async function createFunctionProjectWithDenoJson(
   denoJson: Readonly<Record<string, unknown>>,
   indexTsContents: string,
+  options: { readonly nestedProject?: boolean } = {},
 ) {
   // realpath the temp dir up front: on macOS `TMPDIR` resolves through a
   // `/var` -> `/private/var` symlink, and `buildDockerBinds` compares
@@ -30,12 +31,17 @@ async function createFunctionProjectWithDenoJson(
   // make every path below "outside the source root" and mask the real
   // assertions this file is testing.
   const root = await realpath(await mkdtemp(join(tmpdir(), "deploy-import-scanner-")));
-  const functionsDir = join(root, "supabase", "functions");
+  const projectRoot = options.nestedProject ? join(root, "infra", "my-project") : root;
+  const functionsDir = join(projectRoot, "supabase", "functions");
   const functionDir = join(functionsDir, "hello");
-  const outputDir = join(root, "out");
+  const outputDir = join(projectRoot, "out");
 
   await mkdir(functionDir, { recursive: true });
   await mkdir(outputDir, { recursive: true });
+  if (options.nestedProject) {
+    await mkdir(join(root, ".git"), { recursive: true });
+    await writeFile(join(projectRoot, ".git"), "gitdir: ignored\n");
+  }
 
   const entrypoint = join(functionDir, "index.ts");
   const importMap = join(functionDir, "deno.json");
@@ -399,43 +405,23 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
   });
 
   it("mounts an out-of-root file-valued scope target itself, warns, and does not follow its imports", async () => {
-    const workspaceRoot = await realpath(await mkdtemp(join(tmpdir(), "deploy-external-scope-")));
-    const libsDir = join(workspaceRoot, "libs", "thing");
-    const projectRoot = join(workspaceRoot, "infra", "my-project");
-    const functionsDir = join(projectRoot, "supabase", "functions");
-    const functionDir = join(functionsDir, "hello");
-    const outputDir = join(projectRoot, "out");
+    const { root, functionsDir, outputDir, config } = await createFunctionProjectWithDenoJson(
+      {
+        scopes: { __local: { __mod: "../../../../../libs/thing/mod.ts" } },
+      },
+      'Deno.serve(() => new Response("ok"));\n',
+      { nestedProject: true },
+    );
+    const libsDir = join(root, "libs", "thing");
     const scopeEntrypoint = join(libsDir, "mod.ts");
     const scopeDependency = join(libsDir, "util.ts");
     const warnings: Array<string> = [];
 
     try {
-      await mkdir(join(workspaceRoot, ".git"), { recursive: true });
       await mkdir(libsDir, { recursive: true });
-      await mkdir(functionDir, { recursive: true });
-      await mkdir(outputDir, { recursive: true });
-      await writeFile(join(projectRoot, ".git"), "gitdir: ignored\n");
       await writeFile(scopeEntrypoint, 'export { util } from "./util.ts";\n');
       await writeFile(scopeDependency, 'export const util = "thing";\n');
 
-      const entrypoint = join(functionDir, "index.ts");
-      const importMap = join(functionDir, "deno.json");
-      await writeFile(entrypoint, 'Deno.serve(() => new Response("ok"));\n');
-      await writeFile(
-        importMap,
-        JSON.stringify({
-          scopes: { __local: { __mod: "../../../../../libs/thing/mod.ts" } },
-        }),
-      );
-
-      const config: ResolvedDeployFunctionConfig = {
-        slug: "hello",
-        enabled: true,
-        entrypoint,
-        importMap,
-        staticFiles: [],
-        env: {},
-      };
       const binds = await buildDockerBinds("test-project", functionsDir, outputDir, config, {
         onWarning: async (message) => {
           warnings.push(message);
@@ -445,11 +431,14 @@ describe("buildDockerBinds — import-map key matching (spec-strict) and the fil
 
       expect(hostPaths).toContain(scopeEntrypoint);
       expect(hostPaths).not.toContain(scopeDependency);
+      expect(binds.filter((bind) => bind.externalScope).map((bind) => bind.hostPath)).toEqual([
+        scopeEntrypoint,
+      ]);
       expect(warnings).toContainEqual(
         `WARN: Mounting import map scope target outside the project root: ${scopeEntrypoint}\n`,
       );
     } finally {
-      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/shared/functions/functions-docker.unit.test.ts
+++ b/apps/cli/src/shared/functions/functions-docker.unit.test.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 import { describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Layer, Sink, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -8,6 +10,7 @@ import {
   localDockerId,
   resolveDockerNetworkMode,
   runChildProcess,
+  toDockerPath,
 } from "./functions-docker.ts";
 
 /**
@@ -45,6 +48,32 @@ function mockStreamingChildProcessLayer(
   );
   return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
 }
+
+describe("toDockerPath", () => {
+  it("keeps a posix absolute path unchanged", () => {
+    expect(toDockerPath("/home/u/p/supabase/functions")).toBe("/home/u/p/supabase/functions");
+  });
+
+  it.runIf(process.platform === "win32")(
+    "strips the drive letter and flips separators for a Windows path",
+    () => {
+      // The container path is constructed here and never re-parsed, so this is
+      // the single guard for supabase/cli#6035's Windows `--workdir` behavior:
+      // a drive-letter colon surviving into the container path would corrupt
+      // every `host:container:mode` bind built from it. `resolve()` only
+      // treats a drive-letter path as absolute on Windows, so the guard is
+      // exercisable only there.
+      const containerPath = toDockerPath("C:\\Users\\u\\p\\supabase\\functions");
+      expect(containerPath).toBe("/Users/u/p/supabase/functions");
+      expect(containerPath).not.toContain(":");
+    },
+  );
+
+  it("never leaves a separator-breaking colon in a locally resolvable path", () => {
+    const containerPath = toDockerPath("/home/u/repo:with:colons/supabase/functions");
+    expect(containerPath).toBe("/home/u/repo:with:colons/supabase/functions");
+  });
+});
 
 describe("buildFunctionsDockerRunArgs", () => {
   it("assembles run/--rm, binds, network, env, labels, image, and container args in order", () => {

--- a/apps/cli/src/shared/functions/serve.ts
+++ b/apps/cli/src/shared/functions/serve.ts
@@ -54,8 +54,8 @@ import { ProcessControl } from "../runtime/process-control.service.ts";
 import {
   buildDockerBinds,
   discoverFunctionSlugs,
-  dockerBindContainerPath,
-  dockerBindHostPath,
+  type DockerBind,
+  formatDockerBind,
   dockerWorkdirLabel,
   rawFunctionConfigRecord,
   resolveFunctionConfigs,
@@ -1153,21 +1153,25 @@ const loadServeProjectEnvironment = Effect.fnUntraced(function* (projectRoot: st
  * but Podman rejects the container outright (supabase/cli#6035), so the flag can
  * only be set for a path a bind actually materializes.
  */
-function hasBindUnder(binds: Iterable<string>, containerPath: string): boolean {
+function hasBindUnder(binds: Iterable<DockerBind>, containerPath: string): boolean {
   for (const bind of binds) {
-    const target = dockerBindContainerPath(bind);
-    if (target === containerPath || target.startsWith(`${containerPath}/`)) {
+    if (
+      bind.containerPath === containerPath ||
+      bind.containerPath.startsWith(`${containerPath}/`)
+    ) {
       return true;
     }
   }
   return false;
 }
 
-async function buildWatchSpecs(binds: ReadonlyArray<string>): Promise<ReadonlyArray<WatchSpec>> {
+async function buildWatchSpecs(
+  binds: ReadonlyArray<DockerBind>,
+): Promise<ReadonlyArray<WatchSpec>> {
   const specs = new Map<string, WatchSpec>();
 
   for (const bind of binds) {
-    const hostPath = dockerBindHostPath(bind);
+    const hostPath = bind.hostPath;
     if (!isAbsolute(hostPath)) {
       continue;
     }
@@ -1565,7 +1569,7 @@ export const resolveFunctionBindMounts = Effect.fn("functions.resolveFunctionBin
           },
         }),
       )) {
-        binds.add(bind);
+        binds.add(formatDockerBind(bind));
       }
       const missingSourceWarning = bindWarnings.find((warning) =>
         warning.includes("failed to read file:"),
@@ -1643,8 +1647,8 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
     );
 
     const functionsDir = join(input.projectRoot, functionsDirName);
-    const functionBinds = new Set<string>();
-    const watchableBinds = new Set<string>();
+    const functionBinds = new Map<string, DockerBind>();
+    const watchableBinds = new Map<string, DockerBind>();
     const emittedScopeWarnings = new Set<string>();
     const functionsConfig: Record<string, ServeFunctionContainerConfig> = {};
 
@@ -1655,7 +1659,6 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
       }
 
       const bindWarnings: string[] = [];
-      const scopeBinds = new Set<string>();
       for (const bind of yield* Effect.promise(() =>
         buildDockerBinds(projectId, functionsDir, functionsDir, config, {
           additionalModuleRoots: [input.flagCwd],
@@ -1663,14 +1666,12 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
           onWarning: async (message) => {
             bindWarnings.push(message);
           },
-          onScopeBindOutsideRoots: (bind) => {
-            scopeBinds.add(bind);
-          },
         }),
       )) {
-        functionBinds.add(bind);
-        if (!scopeBinds.has(bind)) {
-          watchableBinds.add(bind);
+        const key = formatDockerBind(bind);
+        functionBinds.set(key, bind);
+        if (!bind.externalScope) {
+          watchableBinds.set(key, bind);
         }
       }
       const missingSourceWarning = bindWarnings.find((warning) =>
@@ -1701,7 +1702,7 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
       );
     }
 
-    const binds = new Set(functionBinds);
+    const binds = [...functionBinds.values()];
 
     yield* ensureDockerNamedVolume(localDockerId("edge_runtime", projectId), projectId);
     yield* ensureDockerNetwork(networkMode, projectId);
@@ -1795,7 +1796,7 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
         `com.docker.compose.project=${labels["com.docker.compose.project"]}`,
         "--label",
         `${dockerWorkdirLabel}=${input.projectRoot}`,
-        ...([...binds] as ReadonlyArray<string>).flatMap((bind) => ["-v", bind]),
+        ...binds.flatMap((bind) => ["-v", formatDockerBind(bind)]),
         ...(dockerMultilineEnvScript === undefined ? [] : ["-v", dockerMultilineEnvScript.bind]),
         ...(dockerEnvFile === undefined ? [] : ["--env-file", dockerEnvFile.path]),
         ...(input.platform === "linux" ? ["--add-host", "host.docker.internal:host-gateway"] : []),
@@ -1821,7 +1822,7 @@ export const startEdgeRuntimeContainer = Effect.fn("functions.startEdgeRuntimeCo
       return {
         containerId,
         cleanup: removeRuntimeArtifacts.pipe(Effect.orDie),
-        watchSpecs: yield* Effect.promise(() => buildWatchSpecs([...watchableBinds])),
+        watchSpecs: yield* Effect.promise(() => buildWatchSpecs([...watchableBinds.values()])),
       } satisfies StartedRuntime;
     }).pipe(Effect.onError(() => bestEffortCleanupRuntimeArtifacts));
   },

--- a/apps/cli/src/shared/functions/serve.unit.test.ts
+++ b/apps/cli/src/shared/functions/serve.unit.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import { bundleServeMainTemplate } from "./serve-main-bundler.ts";
-import { dockerBindContainerPath } from "./deploy.ts";
 import { buildServeEntrypointCommand } from "./serve.ts";
 
 describe("buildServeEntrypointCommand", () => {
@@ -21,35 +20,5 @@ describe("buildServeEntrypointCommand", () => {
     const script = buildServeEntrypointCommand(["edge-runtime", "start"]);
     expect(bundled.length).toBeGreaterThan(20_000);
     expect(script.length).toBeLessThan(128);
-  });
-});
-
-describe("dockerBindContainerPath", () => {
-  it("takes the container side of a posix bind", () => {
-    expect(
-      dockerBindContainerPath("/home/u/p/supabase/functions:/home/u/p/supabase/functions:ro"),
-    ).toBe("/home/u/p/supabase/functions");
-  });
-
-  it("takes the container side when the host path carries a Windows drive letter", () => {
-    // `split(":")[1]` returns the host-path tail here, which silently dropped
-    // `--workdir` for every Windows project that had functions.
-    expect(
-      dockerBindContainerPath(
-        "C:\\Users\\u\\p\\supabase\\functions:/Users/u/p/supabase/functions:ro",
-      ),
-    ).toBe("/Users/u/p/supabase/functions");
-  });
-
-  it("strips the SELinux relabel suffix this file emits", () => {
-    expect(dockerBindContainerPath("/tmp/x/multiline-env:/root/.supabase/multiline-env:ro,Z")).toBe(
-      "/root/.supabase/multiline-env",
-    );
-  });
-
-  it("takes the container side of a named-volume bind", () => {
-    expect(dockerBindContainerPath("supabase_edge_runtime_x:/root/.cache/deno:rw")).toBe(
-      "/root/.cache/deno",
-    );
   });
 });


### PR DESCRIPTION
## TL;DR

Bind mounts now flow between deploy, serve, and start as a structured `DockerBind` value and are formatted into `-v` strings only at the docker edges.

## whats improved

- `buildDockerBinds` returns `{ hostPath, containerPath, mode, externalScope }` entries instead of pre-formatted strings, so consumers read fields instead of re-parsing
- `dockerBindHostPath`, `dockerBindContainerPath`, and the mode-suffix pattern are deleted; nothing splits a bind on `:` anymore, which also fixes `--workdir` detection for host paths containing colons
- the serve watch exclusion checks `externalScope` directly instead of subtracting byte-identical strings across modules, so a bind format change can no longer silently re-add external workspace roots to the watch set
- the out-of-root fixture moved onto `createFunctionProjectWithDenoJson` via a `nestedProject` option, the serve scope test onto `writeProjectFile`
- `toDockerPath` drive-letter stripping is pinned directly

## ref:
- extends: https://github.com/supabase/cli/pull/6309