### PR TITLE
chore(ci): configure Dependabot development dependency titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,10 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 * * *"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       npm-major:
         patterns:


### PR DESCRIPTION
## Summary

- preserve fix(deps) for npm production dependency updates
- use chore(deps-dev) for npm development dependency updates

Dependabot previously inferred both prefixes from repository history, so development dependency PR titles required manual correction.