### PR TITLE
fix(cli): cap kong dns cache ttls

### DIFF
--- a/apps/cli/src/legacy/commands/start/services/kong.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/kong.service.ts
@@ -302,6 +302,9 @@ export function legacyBuildKongContainerSpec(
       KONG_DECLARATIVE_CONFIG: "/home/kong/kong.yml",
       // Ref: https://github.com/supabase/cli/issues/14
       KONG_DNS_ORDER: "LAST,A,CNAME",
+      // Ref: https://github.com/supabase/supabase/pull/47846
+      KONG_DNS_NOT_FOUND_TTL: "1",
+      KONG_DNS_VALID_TTL: "5",
       KONG_PLUGINS: "request-transformer,cors",
       KONG_PORT_MAPS: `${input.apiPort}:8000`,
       // Ref: https://github.com/Kong/kong/issues/3974#issuecomment-482105126

--- a/apps/cli/src/legacy/commands/start/services/kong.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/kong.service.unit.test.ts
@@ -167,12 +167,14 @@ describe("legacyBuildKongContainerSpec", () => {
     expect(spec.healthcheck).toBeUndefined();
   });
 
-  test("emits the fixed KONG_* env vars, including the resolved worker-process count (start.go:568-587)", () => {
+  test("emits the fixed KONG_* env vars, including the resolved worker-process count", () => {
     const spec = legacyBuildKongContainerSpec(base);
     expect(spec.env).toEqual({
       KONG_DATABASE: "off",
       KONG_DECLARATIVE_CONFIG: "/home/kong/kong.yml",
       KONG_DNS_ORDER: "LAST,A,CNAME",
+      KONG_DNS_NOT_FOUND_TTL: "1",
+      KONG_DNS_VALID_TTL: "5",
       KONG_PLUGINS: "request-transformer,cors",
       KONG_PORT_MAPS: "54321:8000",
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: "160k",


### PR DESCRIPTION
- extends: https://github.com/supabase/cli/pull/6017
- follows the same pattern as: https://github.com/supabase/supabase/pull/47846