### PR TITLE
docs(config): document the CliConfig/ProjectConfig/CliSettings naming convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,26 @@ Expected exceptions:
 }
 ```
 
+## Config Naming Vocabulary
+
+`@supabase/config` and its CLI consumer use three settled names:
+
+- `CliConfig` — the full config-file document (`supabase/config.toml`/`.json`), the local superset
+  including local-only sections.
+- `ProjectConfig` — the hosted-project subset: a sparse overlay of the hosted sections (api, auth,
+  db, realtime, storage, workers, experimental) describing what a Supabase project looks like on
+  the platform.
+- `CliSettings` — the CLI's own runtime settings (platform `apiUrl`, access token, telemetry flags,
+  `supabaseHome`, …), owned by `apps/cli`.
+
+Use the `Cli*` prefix for the local checkout side and a bare `Project*` name for the hosted
+Supabase project. Config-value helpers follow the config family regardless of their inputs (e.g.
+`resolveCliConfigValue`, `MissingCliConfigValueError`).
+
+See [`docs/adr/0020-config-naming-vocabulary.md`](docs/adr/0020-config-naming-vocabulary.md) and
+[`packages/config/docs/cli-config-loading.md`](packages/config/docs/cli-config-loading.md) for the
+full vocabulary.
+
 ## Effect
 
 The complete source code for the `effect` library (V4) is in `.repos/effect/`. Study types, APIs, and patterns there instead of `node_modules/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ Expected exceptions:
 Use the `Cli*` prefix for the local checkout side and a bare `Project*` name for the hosted
 Supabase project. Config-value helpers follow the config family regardless of their inputs (e.g.
 `resolveCliConfigValue`, `MissingCliConfigValueError`). A symbol that deliberately spans both
-families takes a family-neutral name instead of a misleading prefix (e.g. `EffectiveConfig`, the
-comparison operand accepting both `CliConfig` and `ProjectConfig`).
+families takes a family-neutral name instead of a misleading prefix (see the ADR 0020 addendum for
+the `EffectiveConfig` precedent).
 
 See [`docs/adr/0020-config-naming-vocabulary.md`](docs/adr/0020-config-naming-vocabulary.md) and
 [`packages/config/docs/cli-config-loading.md`](packages/config/docs/cli-config-loading.md) for the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,9 @@ Expected exceptions:
 
 Use the `Cli*` prefix for the local checkout side and a bare `Project*` name for the hosted
 Supabase project. Config-value helpers follow the config family regardless of their inputs (e.g.
-`resolveCliConfigValue`, `MissingCliConfigValueError`).
+`resolveCliConfigValue`, `MissingCliConfigValueError`). A symbol that deliberately spans both
+families takes a family-neutral name instead of a misleading prefix (e.g. `EffectiveConfig`, the
+comparison operand accepting both `CliConfig` and `ProjectConfig`).
 
 See [`docs/adr/0020-config-naming-vocabulary.md`](docs/adr/0020-config-naming-vocabulary.md) and
 [`packages/config/docs/cli-config-loading.md`](packages/config/docs/cli-config-loading.md) for the

--- a/docs/adr/0020-config-naming-vocabulary.md
+++ b/docs/adr/0020-config-naming-vocabulary.md
@@ -131,3 +131,14 @@ text itself being rewritten in place.
 - CLI-2230 — introduces `ProjectConfig`/`toProjectConfig` (in flight)
 - CLI-2238 — this ticket
 - supabase/supabase#48906 — Studio's drift-detection work, waiting on the published package
+
+## Addendum (2026-08-26): family-neutral names for cross-family operands (`EffectiveConfig`)
+
+CLI-2230's implementation surfaced the prefix rule's one deliberate exception. The operand type of
+the sparse comparison core (`subtractCliConfig`/`omitDefaultValues`) accepts both families — the
+`CliConfig` document and the sparse `ProjectConfig` overlay — so either prefix would misdescribe
+it. It is named `EffectiveConfig` (`DeepPartial<Omit<CliConfig, "remotes">>`, exported from the
+pure entrypoint), replacing the earlier `BaseCliConfig`, whose `Cli*` name wrongly claimed the
+local-checkout side for a type that `ProjectConfig` values must also satisfy. The general rule: a
+symbol that genuinely spans both families takes a family-neutral name rather than a misleading
+prefix. Ruled on CLI-2230 (2026-08-26); ADR 0018 gains a sibling addendum in that work.

--- a/docs/adr/0020-config-naming-vocabulary.md
+++ b/docs/adr/0020-config-naming-vocabulary.md
@@ -137,8 +137,9 @@ text itself being rewritten in place.
 CLI-2230's implementation surfaced the prefix rule's one deliberate exception. The operand type of
 the sparse comparison core (`subtractCliConfig`/`omitDefaultValues`) accepts both families — the
 `CliConfig` document and the sparse `ProjectConfig` overlay — so either prefix would misdescribe
-it. It is named `EffectiveConfig` (`DeepPartial<Omit<CliConfig, "remotes">>`, exported from the
-pure entrypoint), replacing the earlier `BaseCliConfig`, whose `Cli*` name wrongly claimed the
-local-checkout side for a type that `ProjectConfig` values must also satisfy. The general rule: a
-symbol that genuinely spans both families takes a family-neutral name rather than a misleading
-prefix. Ruled on CLI-2230 (2026-08-26); ADR 0018 gains a sibling addendum in that work.
+it. CLI-2230 (in flight) names it `EffectiveConfig` (`DeepPartial<Omit<CliConfig, "remotes">>`,
+exported from the pure entrypoint) and deletes today's `BaseCliConfig` export, whose `Cli*` name
+wrongly claims the local-checkout side for a type that `ProjectConfig` values must also satisfy;
+until that lands, `BaseCliConfig` remains the export on `develop`. The general rule: a symbol that
+genuinely spans both families takes a family-neutral name rather than a misleading prefix. Ruled
+on CLI-2230 (2026-08-26); ADR 0018 gains a sibling addendum in that work.

--- a/docs/adr/0020-config-naming-vocabulary.md
+++ b/docs/adr/0020-config-naming-vocabulary.md
@@ -1,0 +1,133 @@
+# 0020. Config naming vocabulary: `CliConfig`, `ProjectConfig`, `CliSettings`, and the `Cli*` prefix rule
+
+**Status**: accepted
+**Date**: 2026-08-24
+
+## Problem Statement
+
+Before CLI-2235 (PR supabase/cli#6328), the config vocabulary had already drifted once, silently.
+`CliConfig` named the CLI's own runtime settings service — platform `apiUrl`, access token,
+telemetry flags, `supabaseHome` — what this decision now calls `CliSettings`. `ProjectConfig` named
+the config-file document (`supabase/config.toml`/`.json`), the full local superset the CLI reads and
+writes — what this decision now calls `CliConfig`. Neither name meant what its own words suggest,
+and nothing recorded that either meaning had been chosen on purpose; the collision surfaced only
+when CLI-2230 needed to introduce a genuinely new, third thing and no name was left to give it —
+the rename CLI-2235 executed is what freed one.
+
+That third thing is a hosted-project subset. `config diff` (CLI-2156), `config pull` (CLI-2064), and
+Studio's own drift detection all need a shape that describes what a Supabase project looks like on
+the platform — a sparse overlay of the hosted sections (`api`, `auth`, `db`, `realtime`, `storage`,
+`workers`, `experimental`), never the full document with local-only sections stripped out and
+defaults applied. CLI-2230 is introducing that mapping now, in a parallel branch (`toProjectConfig`,
+exported from `@supabase/config`'s root entrypoint). Studio is already an external consumer waiting
+on it: supabase/supabase#48906 builds Studio's config-drift page against the shapes this package
+will publish.
+
+The renames CLI-2235 made were free only because `packages/config` is still `private: true`; nothing
+outside this monorepo could have imported the old names. CLI-2169 will flip the package to `public`,
+and every rename after that point breaks a real external consumer instead of nothing. Once that
+window closes, a name chosen carelessly — or left undocumented, the way `CliConfig`/`ProjectConfig`
+were before this decision — is a breaking change to fix, not a search-and-replace. Recording the
+vocabulary now, while it is still free to fix, is the point of this ADR.
+
+## Decision
+
+This decision fixes three names and one prefix rule as the settled vocabulary for `@supabase/config`
+and its CLI consumer:
+
+| Name            | Meaning                                                                                                                                                                                                                                             | Owner              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `CliConfig`     | The full config-file document (`supabase/config.toml`/`.json`) — the local superset, including local-only sections (`studio`, ports, `edge_runtime`, `analytics`, `[remotes.*]`, …).                                                                | `@supabase/config` |
+| `ProjectConfig` | The hosted-project subset: a sparse overlay of the hosted sections (`api`, `auth`, `db`, `realtime`, `storage`, `workers`, `experimental`) describing what a Supabase project looks like on the platform. Being introduced by CLI-2230 (in flight). | `@supabase/config` |
+| `CliSettings`   | The CLI's own runtime settings — platform `apiUrl`, access token, telemetry flags, `supabaseHome`, ….                                                                                                                                               | `apps/cli`         |
+
+Prefix rule: `Cli*` names the local checkout side — what the CLI reads, writes, or resolves about
+itself on disk. A bare `Project*` name is reserved for the hosted Supabase project. Helpers that
+operate on config values follow the config family regardless of their inputs, not the shape of
+whatever they're passed — `resolveCliConfigValue` and `MissingCliConfigValueError` are `Cli*`-named
+even though both operate on plain config values, because the config they resolve or complain about
+is the local-checkout document.
+
+This convention is documented normatively in three places, so it is available wherever a session —
+human or agent — starts working in this repo:
+
+- repo-root `AGENTS.md`, in a "Config Naming Vocabulary" section
+- `packages/config/README.md`, in a "Naming" section
+- `packages/config/docs/cli-config-loading.md`, in its "Vocabulary" section
+
+ADRs 0000–0019 are historical records of the decisions made at the time and are not rewritten to
+reflect this vocabulary. ADR 0009 and ADR 0018 each carry a 2026-08-25 addendum mapping their
+pre-rename symbol names — their own `ProjectConfig*`-prefixed exports — onto the settled
+`CliConfig*` names; a reader applies those mappings when reading the ADR body, rather than the ADR
+text itself being rewritten in place.
+
+## Rationale
+
+- Record-now-or-drift-again: the vocabulary already drifted once, silently, with no ADR to catch it;
+  the only fix available after CLI-2169 publishes is a breaking rename, so the cost of not recording
+  this now only increases with time.
+- The private-to-public publish window (CLI-2169) is the real deadline: every day `packages/config`
+  stays private is a day these names can still change for free.
+- Both humans and agents load `AGENTS.md` at the start of a session, not any individual ADR, so the
+  convention has to live where sessions start, not only in a decision record consulted by whoever
+  happens to remember it exists.
+
+## Consequences
+
+### Positive
+
+- A single documented meaning per name removes the ambiguity that let `CliConfig`/`ProjectConfig`
+  drift once already.
+- The convention lives in three places that are actually read at the point of use — `AGENTS.md` at
+  session start, the package `README.md` and `cli-config-loading.md` when working directly in
+  `@supabase/config` — rather than only in an ADR.
+- The `Cli*`/bare `Project*` prefix rule generalizes past these three names, giving future symbols
+  (helpers, error classes, services) a rule to apply instead of a name to look up case by case.
+
+### Negative
+
+- One more pair of names to keep straight for anyone new to the codebase, on top of the pre-existing
+  `CliConfig`/`ProjectConfig` collision history they may need to unlearn if they've seen the old
+  meanings elsewhere.
+- ADR 0009 and ADR 0018 stay unrewritten with their pre-rename names; a reader who doesn't notice
+  the addendum before reading either ADR's body will read stale symbol names.
+- `ProjectConfig` is not implemented as of this decision — CLI-2230 is still in flight — so the name
+  is reserved in documentation ahead of the exports landing, and a reader can find the name before
+  finding it in code.
+
+## Alternatives Considered
+
+1. **Leave the convention in PR history only** (CLI-2235's PR description/commits): rejected. The
+   vocabulary drifted once already without anyone deciding to drift it; PR history is not consulted
+   before naming a new symbol, so nothing here would have prevented a second drift.
+2. **Defer the renames until after `packages/config` publishes**, once every affected name is known
+   for certain: rejected. Renames are free only before publish (CLI-2169); waiting converts every
+   one of them from a search-and-replace into a breaking change for Studio and any other external
+   consumer.
+3. **Keep `ProjectConfig` naming the document and coin a longer name for the hosted subset**:
+   rejected. A bare `Project*` name should read as the hosted Supabase project, not the local
+   checkout, and the document is genuinely CLI-side — it carries sections (`studio`, ports,
+   `edge_runtime`, `analytics`, `[remotes.*]`) that only make sense for a local checkout and have no
+   hosted-project meaning at all — so `ProjectConfig` is the wrong bare name for it even before the
+   collision history is considered.
+
+## Related Decisions
+
+- [ADR 0009](0009-configuration-schema-and-validation.md): Configuration Schema & Validation — the
+  entrypoint architecture whose document-schema symbols this decision's `CliConfig` name applies to;
+  carries a CLI-2235 addendum mapping its `ProjectConfig*` symbols.
+- [ADR 0018](0018-sparse-config-subtraction.md): Sparse Config Subtraction — the subtraction core
+  whose symbols this decision's `CliConfig` name applies to; carries a CLI-2235 addendum mapping its
+  `ProjectConfig*` symbols.
+- [ADR 0019](0019-config-api-response-passthrough.md): Raw API-Response Passthrough — the ADR that
+  first assigns `ProjectConfig` its hosted meaning (`_apiResponse` is attached to API-sourced
+  `ProjectConfig` values); this decision generalizes that assignment into the settled vocabulary.
+
+## See Also
+
+- [`packages/config/docs/cli-config-loading.md`](../../packages/config/docs/cli-config-loading.md)
+- [`packages/config/README.md`](../../packages/config/README.md)
+- CLI-2235 (PR supabase/cli#6328) — the rename that surfaced the collision this ADR records
+- CLI-2230 — introduces `ProjectConfig`/`toProjectConfig` (in flight)
+- CLI-2238 — this ticket
+- supabase/supabase#48906 — Studio's drift-detection work, waiting on the published package

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -3,11 +3,6 @@
 Supabase project configuration package built on Effect V4 Schema — owns the canonical `CliConfig`
 document schema, config file loading/saving, and JSON Schema generation.
 
-> `CliConfig` is the config _document_ (`supabase/config.toml`/`.json`) — the full local
-> superset the CLI reads and writes. `ProjectConfig` is reserved for the hosted-project
-> subset (not implemented yet). `CliSettings` is the CLI's own runtime settings and lives
-> in the CLI, not this package.
-
 It owns:
 
 - the canonical `CliConfig` schema
@@ -15,6 +10,21 @@ It owns:
 - JSON Schema generation at `@supabase/config/schema.json`
 - config file loading/saving for `supabase/config.json`
 - backward-compatible TOML support for `supabase/config.toml`
+
+## Naming
+
+- `CliConfig` — the config _document_ (`supabase/config.toml`/`.json`) — the full local superset
+  the CLI reads and writes.
+- `ProjectConfig` — the hosted-project subset: a sparse overlay of the hosted sections (api, auth,
+  db, realtime, storage, workers, experimental) describing what a Supabase project looks like on
+  the platform. Being introduced by CLI-2230 (in flight); once it lands, this package exports a
+  mapping function (`toProjectConfig`) that produces it from a Management API response.
+- `CliSettings` — the CLI's own runtime settings; lives in `apps/cli`, not this package.
+
+Use the `Cli*` prefix for the local checkout side and a bare `Project*` name for the hosted
+Supabase project. Helpers that operate on config values follow the config family regardless of
+their inputs (`resolveCliConfigValue`, `MissingCliConfigValueError`). See
+[ADR 0020](../../docs/adr/0020-config-naming-vocabulary.md) for the full decision record.
 
 ## Entrypoints
 

--- a/packages/config/docs/cli-config-loading.md
+++ b/packages/config/docs/cli-config-loading.md
@@ -22,6 +22,13 @@ This document explains how the CLI's on-disk config document loading works, acro
   scoped to the legacy shell, and pending deletion once the legacy/next shells consolidate.
   Defined at `apps/cli/src/legacy/config/legacy-cli-settings.service.ts`.
 
+The `Cli*` prefix is a rule, not a per-name coincidence: it names the local checkout side — what
+the CLI reads, writes, or resolves about itself on disk. A bare `Project*` name is reserved for the
+hosted Supabase project. Value-helpers follow the config family regardless of their inputs, not the
+shape of whatever they're passed — `resolveCliConfigValue` and `MissingCliConfigValueError` are
+`Cli*`-named for this reason. See [ADR 0020](../../../docs/adr/0020-config-naming-vocabulary.md)
+for the full decision record.
+
 Within `CliConfig` itself, `project_id` is overloaded by position: the root-scope `project_id` is
 a local identifier that defaults to the working directory name when running `supabase init` (see
 `packages/config/src/base.ts`), while a `[remotes.<label>].project_id` is the hosted project's


### PR DESCRIPTION
## What changed

Records the `@supabase/config` naming convention (decided 2026-08-24, applied mechanically by CLI-2235 / #6328) as normative documentation:

- **New [ADR 0020](docs/adr/0020-config-naming-vocabulary.md)** — the vocabulary decision and rationale: `CliConfig` = the full config-file document (`supabase/config.toml`/`.json`, the local superset), `ProjectConfig` = the hosted-project subset (a sparse overlay of the hosted sections, being introduced by CLI-2230), `CliSettings` = the CLI's own runtime settings (formerly named `CliConfig`), plus the prefix rule: `Cli*` = the local checkout side, bare `Project*` = the hosted Supabase project, and value-helpers follow the config family regardless of their inputs (`resolveCliConfigValue`, `MissingCliConfigValueError`).
- **Repo-root `AGENTS.md`** — new "Config Naming Vocabulary" section so agent/human sessions load the convention at start instead of re-deriving it from PR history.
- **`packages/config/README.md`** — the intro blockquote becomes a proper "Naming" section (public contract documentation once the package publishes).
- **`packages/config/docs/cli-config-loading.md`** — the Vocabulary section already *used* the settled names; this adds the prefix rule stated *as a rule*, linking ADR 0020. (The issue referenced this file by its pre-CLI-2235 name `project-config-loading.md`.)

Stale-vocabulary sweep across `*.md` came back clean: ADRs 0009/0018 already carry CLI-2235 rename addendums and stay untouched as historical records, and every remaining `CliConfig` hit (including legacy `SIDE_EFFECTS.md` files) uses the current document-family meaning.

## Why

Renames are free only while `packages/config` is `private: true` — CLI-2169 flips it public, and Studio is already an external consumer waiting on the package (supabase/supabase#48906). The vocabulary drifted once before (`CliConfig` meant the settings service, `ProjectConfig` meant the document); without a recorded decision it would drift again.

## Reviewer context

Coordinated with the in-flight CLI-2230 branch: it owns the `ProjectConfig: reserved…` vocabulary bullet in `cli-config-loading.md` and will add a "ProjectConfig mapping" README subsection after this PR's "Naming" section, updating the "introduced by CLI-2230 (in flight)" sentence when it lands. `BaseCliConfig` is deliberately never cited as a prefix-rule example — its name is under an open ruling on CLI-2230.

Fixes CLI-2238