### PR TITLE
chore(repo): migrate build tasks to Turborepo

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -123,7 +123,7 @@ jobs:
 
       # The ts-legacy harness runs the compiled supabase binary from apps/cli/dist.
       - name: Build CLI
-        run: pnpm exec nx run supabase:build
+        run: pnpm exec turbo run supabase#build
 
       # Docker is a hard requirement for the --use-docker bundler cell.
       - name: Docker preflight

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
       # binary in `apps/cli/dist/`. Build the CLI explicitly before invoking
       # every package-local e2e suite.
       - name: Build CLI
-        run: pnpm exec nx run supabase:build
+        run: pnpm exec turbo run supabase#build
 
       - name: Run end-to-end tests
         run: pnpm exec turbo run test:e2e:run --only --concurrency=1 -- --shard=${{ matrix.shard }}/3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,8 @@ This repo uses pnpm and Turbo for root-owned quality checks and ordinary unit,
 integration, and e2e tests. Package scripts are the source of truth for those
 workflows; package-local quality work is limited to `types:check` and the
 declared test scripts.
-Nx remains scoped to the CLI build/live graph and its dependency inspection.
+Nx remains scoped to live and auxiliary workflows and dependency inspection.
+Turbo owns the repository build and generation workflows.
 
 ### Exploring the workspace
 
@@ -259,18 +260,24 @@ nx graph
 ### Running build/live workflows
 
 ```sh
-# Build the CLI and its Go sidecar
-nx run supabase:build
+# Build all migrated workspaces and their dependencies
+pnpm run build
+
+# Generate API, then documentation artifacts
+pnpm run generate
+
+# Build only the CLI and its Go sidecar
+pnpm exec turbo run supabase#build
 
 # Run the live CLI suite
 nx run supabase:test:live
 ```
 
-Use `nx show project <name> --json` to inspect build/live targets, dependencies,
-and outputs before running them — do not guess target names. Run repo-wide
-quality checks from the repository root (`pnpm check:all`, `pnpm fix:all`), which
-delegate quality orchestration to Turbo; run ordinary tests with the relevant
-package's declared `pnpm test` scripts.
+Use `nx show project <name> --json` to inspect retained live/auxiliary targets,
+dependencies, and outputs before running them — do not guess target names. Run
+repo-wide quality checks from the repository root (`pnpm check:all`,
+`pnpm fix:all`), which delegate quality orchestration to Turbo; run ordinary
+tests with the relevant package's declared `pnpm test` scripts.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,8 @@ Root-level scripts:
 ```sh
 pnpm run repos:install
 pnpm run repos:pull
+pnpm run build       # build CLI, config, and docs artifacts with Turbo
+pnpm run generate    # generate API, then documentation artifacts with Turbo
 pnpm run check:all   # run all checks across every project
 pnpm run fix:all     # run all fixers across every project
 ```
@@ -344,22 +346,39 @@ supabase --version
 | `npm` / `pnpm` tries to fetch from `localhost:4873` when no registry is running | Stale global registry override left behind by an older version of `local-registry.ts` (the current script never modifies global config). Run `npm config delete registry` and `pnpm config delete registry`. Note that pnpm stores the override in its own global config (`~/Library/Preferences/pnpm/auth.ini` on macOS, `~/.config/pnpm/` on Linux), not `~/.npmrc` — check there if the delete command fails |
 | `npx` resolves from npm instead of local                                        | Pass `--registry http://localhost:4873` explicitly to `npx` / `npm install`                                                                                                                                                                                                                                                                                                                                     |
 
-## Using Nx
+## Using Turbo and Nx
 
-Nx remains the task runner for the CLI build and live-test workflows. Quality
-checks are root-owned `check:all`/`fix:all` scripts orchestrated with Turbo,
-while ordinary unit, integration, and e2e tests remain package-local scripts;
-see [Standard package scripts](#standard-package-scripts).
+Turbo owns repository build and generation orchestration. Quality checks are
+root-owned `check:all`/`fix:all` scripts orchestrated with Turbo, while ordinary
+unit, integration, and e2e tests remain package-local scripts; see [Standard
+package scripts](#standard-package-scripts).
 
-**Build the CLI and its Go sidecar:**
+**Build all migrated workspaces:**
 
 ```sh
-pnpm exec nx run supabase:build
+pnpm run build
 ```
 
-**Run the live suite:**
+**Generate API and documentation artifacts:**
 
-The target's build dependency prepares the CLI artifacts before Vitest starts:
+```sh
+pnpm run generate
+```
+
+**Build only the CLI and its Go sidecar:**
+
+```sh
+pnpm exec turbo run supabase#build
+```
+
+The CLI build names its config and Go build prerequisites explicitly. The
+remaining CLI workspace dependencies intentionally have no build script, so
+strict Turbo task selection does not synthesize no-op `^build` tasks for them.
+
+Nx remains for live and auxiliary workflows. **Run the live suite:**
+
+The target's uncached build dependency prepares the CLI artifacts before Vitest
+starts; use Turbo for cacheable build outputs.
 
 ```sh
 pnpm exec nx run supabase:test:live

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -123,19 +123,6 @@
   },
   "nx": {
     "targets": {
-      "build": {
-        "outputs": [
-          "{projectRoot}/dist"
-        ],
-        "dependsOn": [
-          {
-            "projects": [
-              "cli-go"
-            ],
-            "target": "build"
-          }
-        ]
-      },
       "test:smoke": {
         "cache": false
       }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "bun run generate && next dev",
     "generate": "bun ../../apps/cli/scripts/generate-docs.ts",
-    "build": "bun run generate && next build",
+    "build": "next build",
     "types:check": "pnpm exec fumadocs-mdx source.config.ts .source && tsc --noEmit --incremental false"
   },
   "dependencies": {
@@ -28,36 +28,6 @@
       "supabase"
     ],
     "targets": {
-      "generate": {
-        "executor": "nx:run-commands",
-        "options": {
-          "command": "pnpm run generate",
-          "cwd": "{projectRoot}"
-        },
-        "inputs": [
-          "{projectRoot}/**/*",
-          "{workspaceRoot}/apps/cli/src/**/*",
-          "{workspaceRoot}/apps/cli/scripts/generate-docs.ts",
-          "sharedGlobals"
-        ],
-        "outputs": [
-          "{workspaceRoot}/apps/docs/content/docs/commands",
-          "{workspaceRoot}/apps/docs/public"
-        ]
-      },
-      "build": {
-        "executor": "nx:run-commands",
-        "options": {
-          "command": "pnpm run build",
-          "cwd": "{projectRoot}"
-        },
-        "dependsOn": [
-          "generate"
-        ],
-        "outputs": [
-          "{projectRoot}/.next"
-        ]
-      },
       "types:check": {
         "executor": "nx:run-commands",
         "cache": true,

--- a/docs/nx-inference-plugins.md
+++ b/docs/nx-inference-plugins.md
@@ -2,8 +2,8 @@
 
 This repository keeps one local Nx inference plugin for the Go CLI sidecar.
 TypeScript workspaces declare their `types:check` scripts explicitly, and
-Turbo orchestrates the repository quality checks. Nx is retained for the CLI
-build and live-test graph.
+Turbo orchestrates repository build, generation, and quality checks. Nx is
+retained for live and auxiliary workflows and dependency inspection.
 
 ## Current plugin
 
@@ -17,13 +17,14 @@ default binary output is `supabase-go`.
 
 | Target       | Command                          | Cached |
 | ------------ | -------------------------------- | ------ |
-| `build`      | `go build -o supabase-go .`      | Yes    |
+| `build`      | `go build -o supabase-go .`      | No     |
 | `lint:check` | `golangci-lint run --timeout 5m` | Yes    |
 | `lint:fix`   | `golangci-lint run --fix`        | No     |
 
 These are the plugin's inferred defaults. The explicit package scripts take
-precedence in the final Nx target configuration; Turbo's cache policy is
-defined in `turbo.json`.
+precedence in the final Nx target configuration, and the retained Nx build
+bridge is uncached so live runs always prepare fresh artifacts. Turbo's cache
+policy for ordinary builds is defined in `turbo.json`.
 
 The same Go lint commands are also declared in `apps/cli-go/package.json` so
 they can be invoked directly and by Turbo quality workflows.
@@ -36,10 +37,11 @@ To see the Go project's inferred Nx targets and their configuration:
 nx show project cli-go
 ```
 
-Build and live workflows can invoke the inferred targets through Nx:
+Use Turbo for builds and generation; use Nx for the retained live workflow:
 
 ```sh
-nx run cli-go:build
+pnpm exec turbo run @supabase/cli-go#build
+pnpm exec turbo run supabase#build
 nx run supabase:test:live
 ```
 

--- a/docs/self-documenting-cli.md
+++ b/docs/self-documenting-cli.md
@@ -116,7 +116,11 @@ A [Fumadocs](https://fumadocs.dev) site at `apps/docs` serves the command refere
 
 ### How generation works
 
-The script `apps/docs/scripts/generate-docs.ts` runs at build time (`bun run generate`) and:
+The script `apps/cli/scripts/generate-docs.ts` runs as the docs `generate`
+task before the docs `build` task when invoked through Turbo (for example,
+`pnpm run build` from the repository root). The package's `build` script is a
+leaf `next build`; running `pnpm run generate` directly remains available for
+local docs development. The generator:
 
 1. Walks the command tree via `collectCommands()` to find all leaf commands
 2. For each command, extracts a `HelpDoc` (description, flags, args, examples)
@@ -124,6 +128,7 @@ The script `apps/docs/scripts/generate-docs.ts` runs at build time (`bun run gen
 4. Writes each command as `content/docs/commands/<slug>.mdx` with frontmatter
 5. Generates `content/docs/commands/index.mdx` — a command reference index with a table linking to every command page
 6. Generates `content/docs/commands/meta.json` to control page ordering in the sidebar
+7. Generates `public/cli/config.schema.json` for the CLI configuration reference
 
 ### Site structure
 
@@ -143,18 +148,20 @@ apps/docs/
 │       ├── index.mdx           ← Command table (generated)
 │       ├── meta.json           ← Command page order (generated)
 │       └── login.mdx           ← Individual command page (generated)
-├── scripts/
-│   └── generate-docs.ts        ← Docs generation script
 └── lib/
     └── source.ts               ← Fumadocs content source loader
 ```
+
+The generator is maintained alongside the CLI at
+`apps/cli/scripts/generate-docs.ts` and writes the generated command content
+and schema asset into `apps/docs`.
 
 ### Running the docs site
 
 ```sh
 cd apps/docs
-bun run generate   # Generate command pages from CLI source
-bun run dev        # Start dev server (also runs generate first)
+pnpm run generate   # Generate command pages from CLI source
+pnpm run dev        # Start dev server (also runs generate first)
 ```
 
 ## Adding a new command's documentation
@@ -163,4 +170,4 @@ bun run dev        # Start dev server (also runs generate first)
 2. Optionally create a `<command>.guide.md` with narrative content and injection markers
 3. If a guide exists, register it in `guide-registry.ts` with a skill name and description
 4. Run `supabase <command> --skill-dir /tmp/test` to verify the generated skill output
-5. Run `cd apps/docs && bun run generate` to regenerate the docs website — the new command appears automatically in the command index and sidebar
+5. Run `cd apps/docs && pnpm run generate` to regenerate the docs website — the new command appears automatically in the command index and sidebar

--- a/nx.json
+++ b/nx.json
@@ -5,25 +5,12 @@
   "plugins": ["./tools/nx-plugins/src/go.plugin.ts"],
   "namedInputs": {
     "sharedGlobals": ["{workspaceRoot}/package.json", "{workspaceRoot}/pnpm-workspace.yaml"],
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "production": [
-      "default",
-      "!{projectRoot}/**/*.test.ts",
-      "!{projectRoot}/**/*.integration.test.ts",
-      "!{projectRoot}/**/*.e2e.test.ts",
-      "!{projectRoot}/vitest.config*",
-      "!{projectRoot}/tests/**/*"
-    ]
+    "default": ["{projectRoot}/**/*", "sharedGlobals"]
   },
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "cache": true
-    },
-    "generate": {
-      "inputs": ["default"],
-      "cache": true
+      "cache": false
     },
     "test:live": {
       "parallelism": false,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@supabase/root",
   "private": true,
   "scripts": {
+    "build": "pnpm exec turbo run build",
+    "generate": "pnpm exec turbo run @supabase/api#generate && pnpm exec turbo run @supabase/docs#generate",
     "test:unit": "pnpm exec turbo run test:unit:run --filter=!@supabase/cli-go --",
     "test:integration": "pnpm exec turbo run test:integration:run --",
     "test:e2e": "pnpm exec turbo run supabase#build && pnpm exec turbo run test:e2e:run --only --concurrency=1 --",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,19 +32,5 @@
     "@vitest/coverage-istanbul": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "nx": {
-    "targets": {
-      "generate": {
-        "executor": "nx:run-commands",
-        "options": {
-          "command": "pnpm run generate",
-          "cwd": "{projectRoot}"
-        },
-        "outputs": [
-          "{projectRoot}/src/generated"
-        ]
-      }
-    }
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -47,14 +47,5 @@
     "@effect/platform-node": {
       "optional": true
     }
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "outputs": [
-          "{projectRoot}/dist"
-        ]
-      }
-    }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -42,11 +42,57 @@
       "passThroughEnv": ["*"]
     },
     "@supabase/cli-go#build": {
-      "cache": false
+      "cache": true,
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/mise.toml", "$TURBO_ROOT$/mise.lock"],
+      "outputs": ["supabase-go"],
+      "env": ["GO*", "CGO_*", "CC", "CXX"]
     },
     "supabase#build": {
+      "cache": true,
+      "dependsOn": ["@supabase/config#build", "@supabase/cli-go#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.bun-version",
+        "$TURBO_ROOT$/mise.lock",
+        "$TURBO_ROOT$/packages/api/**",
+        "$TURBO_ROOT$/packages/process-compose/**",
+        "$TURBO_ROOT$/packages/stack/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@supabase/config#build": {
+      "cache": true,
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/.bun-version", "$TURBO_ROOT$/mise.lock"],
+      "outputs": ["dist/schema.json"]
+    },
+    "@supabase/api#generate": {
       "cache": false,
-      "dependsOn": ["@supabase/cli-go#build"]
+      "outputs": ["src/generated/**", "scripts/openapi-source.json"],
+      "env": ["SUPABASE_API_URL"]
+    },
+    "@supabase/docs#generate": {
+      "cache": true,
+      "dependsOn": ["supabase#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!content/docs/commands/**",
+        "!public/cli/config.schema.json",
+        "$TURBO_ROOT$/.bun-version",
+        "$TURBO_ROOT$/mise.lock"
+      ],
+      "outputs": ["content/docs/commands/**", "public/cli/config.schema.json"]
+    },
+    "@supabase/docs#build": {
+      "cache": true,
+      "dependsOn": ["generate"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!content/docs/commands/**",
+        "!public/cli/config.schema.json",
+        "$TURBO_ROOT$/.bun-version",
+        "$TURBO_ROOT$/mise.lock"
+      ],
+      "outputs": [".next/**"]
     },
     "supabase#test:e2e:run": {
       "cache": false,


### PR DESCRIPTION
## Summary

- move Go CLI, TypeScript CLI, config, API, and docs build/generation orchestration from Nx to root-owned Turbo tasks
- model explicit cross-workspace dependencies, toolchain inputs, and generated/build outputs for safe local cache restoration
- replace workflow CLI builds and update contributor docs while retaining the uncached Nx live/auxiliary bridge for the follow-up migration

## Context

This follows the root quality migration merged in #6336 and preserves its root-only quality architecture. Deterministic Go, CLI, config, and docs tasks cache exact outputs; API generation remains uncached because it fetches live OpenAPI documents, and the root generation entrypoint orders API generation before docs generation.