### PR TITLE
fix(auth): accept sbp_v0_ format personal access tokens

### DIFF
--- a/apps/cli/src/legacy/auth/legacy-access-token.ts
+++ b/apps/cli/src/legacy/auth/legacy-access-token.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { legacyAqua } from "../shared/legacy-colors.ts";
 import { LegacyInvalidAccessTokenError } from "./legacy-errors.ts";
 
-export const LEGACY_ACCESS_TOKEN_PATTERN = /^sbp_(oauth_)?[a-f0-9]{40}$/;
+export const LEGACY_ACCESS_TOKEN_PATTERN = /^sbp_(oauth_|v\d+_)?[a-f0-9]{40}$/;
 
 /**
  * Message shown when no access token is available, passing `supabase login`

--- a/apps/cli/src/next/auth/token.ts
+++ b/apps/cli/src/next/auth/token.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { InvalidTokenError } from "./errors.ts";
 
-const TOKEN_PATTERN = /^sbp_(oauth_)?[a-f0-9]{40}$/;
+const TOKEN_PATTERN = /^sbp_(oauth_|v\d+_)?[a-f0-9]{40}$/;
 
 export const validateToken = Effect.fnUntraced(function* (
   token: string,

--- a/apps/cli/src/next/auth/token.unit.test.ts
+++ b/apps/cli/src/next/auth/token.unit.test.ts
@@ -28,6 +28,12 @@ describe("validateToken", () => {
       }),
     );
 
+    it.live("accepts sbp_v0_ prefix with 40 lowercase hex chars", () =>
+      Effect.gen(function* () {
+        yield* validateToken(`sbp_v0_${VALID_HEX_40}`);
+      }),
+    );
+
     it.live("accepts all valid hex characters (a-f, 0-9)", () =>
       Effect.gen(function* () {
         yield* validateToken("sbp_abcdef0123456789abcdef0123456789abcdef01");


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The CLI token validation regexes only accept legacy `sbp_<hex>` and `sbp_oauth_<hex>` tokens, rejecting the newer `sbp_v0_<hex>` format that the Supabase dashboard now generates by default with `LegacyInvalidAccessTokenError` / `InvalidTokenError`.

## What is the new behavior?
Updated both the next and legacy access token pattern regexes to allow optional versioned prefixes (`v\d+_`):
```ts
/^sbp_(oauth_|v\d+_)?[a-f0-9]{40}$/
```
Added unit test coverage for `sbp_v0_` token validation.

Fixes #6348