### PR TITLE
ci(repo): fix ai-review gh repo inference and scripts-ci timeout

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -156,8 +156,12 @@ jobs:
           PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
           mkdir -p /tmp/ai-review
-          gh pr diff "$PR" > /tmp/ai-review/pr.diff
-          gh pr view "$PR" --json number,title,body,baseRefName,headRefName,additions,deletions,changedFiles \
+          # `gh` infers the repo from the current directory's git remote, but this
+          # job checks out into `pr/` and `trusted/` subdirs, so $GITHUB_WORKSPACE
+          # itself is not a git repo — pass --repo explicitly.
+          gh pr diff "$PR" --repo "$GITHUB_REPOSITORY" > /tmp/ai-review/pr.diff
+          gh pr view "$PR" --repo "$GITHUB_REPOSITORY" \
+            --json number,title,body,baseRefName,headRefName,additions,deletions,changedFiles \
             > /tmp/ai-review/pr.json
 
       # Pin the exact published version so a new Claude Code release can't
@@ -303,7 +307,8 @@ jobs:
           PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
           mkdir -p /tmp/ai-review
-          gh pr diff "$PR" > /tmp/ai-review/pr.diff
+          # Pass --repo explicitly so `gh` never depends on cwd being a git repo.
+          gh pr diff "$PR" --repo "$GITHUB_REPOSITORY" > /tmp/ai-review/pr.diff
 
       - name: Prepare merged-review output schema
         run: |

--- a/.github/workflows/github-scripts-ci.yml
+++ b/.github/workflows/github-scripts-ci.yml
@@ -21,7 +21,11 @@ jobs:
   test:
     name: Test and type-check
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The shared setup installs the full workspace + Go toolchain via mise, which
+    # runs ~9-10 min; a 10-minute cap raced the install and got cancelled on a
+    # cold cache. 20 gives that install headroom. (This check is heavier than it
+    # needs to be for two scripts — slimming the setup is a possible follow-up.)
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Two CI fixes for the AI-review pipeline (#6358), both surfaced immediately after merge.

## 1. `Claude review` job fails at "Fetch PR diff and metadata"

The first live `/ai-review` run failed with `fatal: not a git repository`. The `claude-review` job checks out into **subdirectories** (`pr/` for the PR head, `trusted/` for the base), so `$GITHUB_WORKSPACE` itself isn't a git repo — and `gh pr diff`/`gh pr view` infer the repo from the current directory's git remote. Fix: pass `--repo "$GITHUB_REPOSITORY"` explicitly at both `gh` call sites (claude-review and, defensively, codex-review) so `gh` never depends on cwd.

## 2. `Test and type-check` (github-scripts-ci) times out

The shared `./.github/actions/setup` installs the full workspace + Go toolchain via mise (~9–10 min), which raced the job's `timeout-minutes: 10` and got cancelled on a cold cache (the setup step never finished; tests/type-check never ran). Raised to 20 min. Noted inline that the check is heavier than it needs to be for two scripts — slimming the setup is a possible follow-up.