### PR TITLE
Use wget healthchecks on slim Elixir images

### DIFF
--- a/apps/cli/src/legacy/commands/start/services/logflare.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/logflare.service.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 
 import { legacyServiceContainerName } from "../../../shared/legacy-docker-ids.ts";
 import type { LegacyStartContainerSpec } from "../../../shared/db-bootstrap/docker-create-args.ts";
+import { legacyUsesSlimRuntime } from "../../../shared/legacy-docker-registry.ts";
 
 /** The Logflare network alias — also this service's `containerSuffix` in `LEGACY_SERVICE_CATALOG`. */
 const LEGACY_LOGFLARE_CONTAINER_SUFFIX = "analytics";
@@ -157,7 +158,9 @@ export function legacyBuildLogflareContainerSpec(
     exposedPorts: [{ containerPort: "4000" }],
     ports: [{ hostPort: String(input.port), containerPort: "4000" }],
     healthcheck: {
-      test: ["CMD", "curl", "-sSfL", "--head", "-o", "/dev/null", "http://127.0.0.1:4000/health"],
+      test: legacyUsesSlimRuntime(input.image)
+        ? ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:4000/health"]
+        : ["CMD", "curl", "-sSfL", "--head", "-o", "/dev/null", "http://127.0.0.1:4000/health"],
       intervalSeconds: 10,
       timeoutSeconds: 2,
       retries: 3,

--- a/apps/cli/src/legacy/commands/start/services/logflare.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/logflare.service.unit.test.ts
@@ -57,6 +57,21 @@ describe("legacyBuildLogflareContainerSpec", () => {
     expect(spec.networkId).toBe("supabase_network_proj");
   });
 
+  test("uses wget --spider on slim images and keeps the run.sh override", () => {
+    const spec = legacyBuildLogflareContainerSpec({
+      ...base,
+      image: "ghcr.io/supabase/cli/analytics:v1.50.4",
+    });
+    expect(spec.entrypoint).toBe("sh");
+    expect(spec.healthcheck?.test).toEqual([
+      "CMD",
+      "wget",
+      "-q",
+      "--spider",
+      "http://127.0.0.1:4000/health",
+    ]);
+  });
+
   test("emits the common DB_*/LOGFLARE_* env vars regardless of backend (start.go:315-330)", () => {
     const spec = legacyBuildLogflareContainerSpec(base);
     expect(spec.env).toMatchObject({

--- a/apps/cli/src/legacy/commands/start/services/realtime.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/realtime.service.ts
@@ -17,6 +17,7 @@ import {
   legacyBuildRealtimeEnv,
 } from "../../../shared/db-bootstrap/realtime-env.ts";
 import type { LegacyStartContainerSpec } from "../../../shared/db-bootstrap/docker-create-args.ts";
+import { legacyUsesSlimRuntime } from "../../../shared/legacy-docker-registry.ts";
 import { legacyStartInternalDbPassword } from "../../../shared/db-bootstrap/internal-db-connection.ts";
 
 export interface LegacyRealtimeContainerSpecInput {
@@ -59,18 +60,27 @@ export function legacyBuildRealtimeContainerSpec(
     exposedPorts: [{ containerPort: "4000" }],
     healthcheck: {
       // Podman splits command by spaces unless quoted, but curl's header can't be
-      // quoted, hence this exec-form `test` array.
-      test: [
-        "CMD",
-        "curl",
-        "-sSfL",
-        "--head",
-        "-o",
-        "/dev/null",
-        "-H",
-        `Host:${LEGACY_REALTIME_TENANT_ID}`,
-        "http://127.0.0.1:4000/api/ping",
-      ],
+      // quoted, hence this exec-form `test` array. Slim has wget, not curl.
+      test: legacyUsesSlimRuntime(input.image)
+        ? [
+            "CMD",
+            "wget",
+            "-q",
+            "--spider",
+            `--header=Host:${LEGACY_REALTIME_TENANT_ID}`,
+            "http://127.0.0.1:4000/api/ping",
+          ]
+        : [
+            "CMD",
+            "curl",
+            "-sSfL",
+            "--head",
+            "-o",
+            "/dev/null",
+            "-H",
+            `Host:${LEGACY_REALTIME_TENANT_ID}`,
+            "http://127.0.0.1:4000/api/ping",
+          ],
       intervalSeconds: 10,
       timeoutSeconds: 2,
       retries: 3,

--- a/apps/cli/src/legacy/commands/start/services/realtime.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/realtime.service.unit.test.ts
@@ -50,6 +50,21 @@ describe("legacyBuildRealtimeContainerSpec", () => {
     });
   });
 
+  test("uses wget --spider on slim images", () => {
+    const spec = legacyBuildRealtimeContainerSpec({
+      ...input,
+      image: "ghcr.io/supabase/cli/realtime:v2.129.3",
+    });
+    expect(spec.healthcheck?.test).toEqual([
+      "CMD",
+      "wget",
+      "-q",
+      "--spider",
+      "--header=Host:realtime-dev",
+      "http://127.0.0.1:4000/api/ping",
+    ]);
+  });
+
   test("network aliases are 'realtime' and the tenant id", () => {
     const spec = legacyBuildRealtimeContainerSpec(input);
     expect(spec.networkAliases).toEqual(["realtime", "realtime-dev"]);

--- a/apps/cli/src/legacy/commands/start/services/supavisor.service.ts
+++ b/apps/cli/src/legacy/commands/start/services/supavisor.service.ts
@@ -40,6 +40,7 @@
 
 import { legacyServiceContainerName } from "../../../shared/legacy-docker-ids.ts";
 import type { LegacyStartContainerSpec } from "../../../shared/db-bootstrap/docker-create-args.ts";
+import { legacyUsesSlimRuntime } from "../../../shared/legacy-docker-registry.ts";
 import {
   legacyRenderStartPoolerExs,
   type LegacyStartPoolerExsFields,
@@ -181,15 +182,17 @@ export function legacyBuildSupavisorContainerSpec(
     ],
     ports: [{ hostPort: String(input.port), containerPort: dockerPort }],
     healthcheck: {
-      test: [
-        "CMD",
-        "curl",
-        "-sSfL",
-        "--head",
-        "-o",
-        "/dev/null",
-        "http://127.0.0.1:4000/api/health",
-      ],
+      test: legacyUsesSlimRuntime(input.image)
+        ? ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:4000/api/health"]
+        : [
+            "CMD",
+            "curl",
+            "-sSfL",
+            "--head",
+            "-o",
+            "/dev/null",
+            "http://127.0.0.1:4000/api/health",
+          ],
       intervalSeconds: 10,
       timeoutSeconds: 2,
       retries: 3,

--- a/apps/cli/src/legacy/commands/start/services/supavisor.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/supavisor.service.unit.test.ts
@@ -127,4 +127,18 @@ describe("legacyBuildSupavisorContainerSpec", () => {
     expect(spec.networkId).toBe("supabase_network_proj");
     expect(spec.networkAliases).toEqual(["pooler"]);
   });
+
+  test("uses wget --spider on slim images", () => {
+    const spec = legacyBuildSupavisorContainerSpec({
+      ...base,
+      image: "ghcr.io/supabase/cli/pooler:v2.9.10",
+    });
+    expect(spec.healthcheck?.test).toEqual([
+      "CMD",
+      "wget",
+      "-q",
+      "--spider",
+      "http://127.0.0.1:4000/api/health",
+    ]);
+  });
 });

--- a/apps/cli/src/legacy/shared/legacy-docker-registry.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-registry.ts
@@ -19,6 +19,8 @@ const DEFAULT_SUPABASE_REGISTRY = `${DEFAULT_REGISTRY}/supabase`;
 const GHCR_REGISTRY = "ghcr.io";
 const GHCR_SUPABASE_REGISTRY = `${GHCR_REGISTRY}/supabase`;
 const DOCKER_HUB_REGISTRY = "docker.io";
+/** Slim images live under the supabase/cli image namespace. */
+const SLIM_IMAGE_REPO = "/supabase/cli/";
 
 function dedupe(values: ReadonlyArray<string>): ReadonlyArray<string> {
   return [...new Set(values)];
@@ -51,6 +53,11 @@ function legacyGetRegistryOverride(
 
 function legacyGetRegistry(projectEnvValues?: Readonly<Record<string, string>>): string {
   return legacyGetRegistryOverride(projectEnvValues) ?? DEFAULT_REGISTRY;
+}
+
+/** True when `image` is a slim-services image (`ghcr.io/supabase/cli/…`). */
+export function legacyUsesSlimRuntime(image: string): boolean {
+  return image.includes(SLIM_IMAGE_REPO) || image.startsWith("supabase/cli/");
 }
 
 export function legacyGetRegistryImageUrl(

--- a/apps/cli/src/legacy/shared/legacy-docker-registry.unit.test.ts
+++ b/apps/cli/src/legacy/shared/legacy-docker-registry.unit.test.ts
@@ -3,7 +3,21 @@ import { describe, expect, it } from "vitest";
 import {
   legacyGetRegistryImageUrl,
   legacyGetRegistryImageUrlCandidates,
+  legacyUsesSlimRuntime,
 } from "./legacy-docker-registry.ts";
+
+describe("legacyUsesSlimRuntime", () => {
+  it("matches slim-services GHCR images", () => {
+    expect(legacyUsesSlimRuntime("ghcr.io/supabase/cli/realtime:v2.129.3")).toBe(true);
+    expect(legacyUsesSlimRuntime("supabase/cli/analytics:v1.50.4")).toBe(true);
+  });
+
+  it("does not match docker.io family mirrors", () => {
+    expect(legacyUsesSlimRuntime("supabase/realtime:v2.129.3")).toBe(false);
+    expect(legacyUsesSlimRuntime("ghcr.io/supabase/gotrue:v2.196.0")).toBe(false);
+    expect(legacyUsesSlimRuntime("public.ecr.aws/supabase/logflare:1.50.4")).toBe(false);
+  });
+});
 
 describe("legacyGetRegistryImageUrl", () => {
   const withRegistry = <T>(value: string | undefined, fn: () => T): T => {


### PR DESCRIPTION
## Summary
- Detect slim images (`ghcr.io/supabase/cli/…`) via `legacyUsesSlimRuntime`.
- Realtime, analytics, and pooler use `wget -q --spider` on slim (busybox) and keep curl on docker.io.
- Logflare `run.sh` override stays for both families.

Depends on [slim-services#287](https://github.com/supabase/slim-services/pull/287) publishing wget-on-PATH images. Do not merge until those force rebuilds finish.

## Test plan
- [ ] Unit tests for `legacyUsesSlimRuntime` and the three Elixir specs
- [ ] After slim-services publishes, `supabase start` against slim realtime/analytics/pooler becomes healthy via wget


Made with [Cursor](https://cursor.com)