### PR TITLE
fix(stack): prepare slim postgres socket directory

### DIFF
--- a/packages/stack/src/services/postgres.ts
+++ b/packages/stack/src/services/postgres.ts
@@ -154,6 +154,9 @@ export const makePostgresServiceDocker = (opts: DockerPostgresOptions): ServiceD
     hostUser === undefined
       ? ""
       : `printf 'supabase_cli:x:${hostUid}:${hostGid}:Supabase CLI:/tmp:/usr/bin/sh\\n' >> /etc/passwd
+busybox mkdir -p /run/postgresql
+busybox chown ${hostUid}:${hostGid} /run/postgresql
+busybox chmod 2775 /run/postgresql
 busybox chown ${hostUid}:${hostGid} /var/lib/postgresql/data
 busybox chown ${hostUid}:${hostGid} /opt/postgres/share/supabase-cli/config/pgsodium_getkey.sh
 `;

--- a/packages/stack/src/services/services.unit.test.ts
+++ b/packages/stack/src/services/services.unit.test.ts
@@ -185,6 +185,31 @@ describe("makePostgresServiceDocker", () => {
     expect(def.restart).toBe("unless-stopped");
     expect(def.supervision?.orphanCleanup).toBeDefined();
   });
+
+  it("prepares the Linux postgres socket directory before dropping privileges", () => {
+    const def = makePostgresServiceDocker({
+      runtime: "docker",
+      image: dockerImageForService("postgres", DEFAULT_VERSIONS.postgres),
+      dataDir: "/tmp/supabase/data",
+      port: DB_PORT,
+      platformOs: "linux",
+      identity: EPHEMERAL_IDENTITY,
+      dependencies: [],
+    });
+    const command = def.args?.at(-1) ?? "";
+    const mkdirIndex = command.indexOf("busybox mkdir -p /run/postgresql");
+    const chownIndex = command.indexOf("busybox chown ", mkdirIndex);
+    const chmodIndex = command.indexOf("busybox chmod 2775 /run/postgresql");
+    const suIndex = command.indexOf("exec busybox su -s /usr/bin/sh supabase_cli");
+
+    expect(mkdirIndex).toBeGreaterThanOrEqual(0);
+    expect(chownIndex).toBeGreaterThan(mkdirIndex);
+    expect(chmodIndex).toBeGreaterThan(chownIndex);
+    expect(suIndex).toBeGreaterThan(chmodIndex);
+    expect(command.slice(mkdirIndex, chmodIndex)).toMatch(
+      /busybox chown \d+:\d+ \/run\/postgresql/,
+    );
+  });
 });
 
 describe("makePostgrestService", () => {


### PR DESCRIPTION
## Summary

- prepare `/run/postgresql` for the Linux host UID/GID before the Docker stack drops privileges
- preserve the existing root and non-Linux startup paths
- cover the privilege-drop ordering with a Linux-specific regression test

## Context

The refreshed slim Postgres image listens on a Unix socket under `/run/postgresql`. The stack wrapper bypassed the image root setup when switching to the host user on Linux, so Postgres restarted with a socket lock-file permission error. That readiness failure cascaded into the three e2e startup timeouts visible on #6400.