### PR TITLE
chore: bump postgres-meta to v0.99.0

### DIFF
--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -4,7 +4,7 @@ FROM supabase/postgres:17.6.1.167 AS pg
 FROM library/kong:2.8.1 AS kong
 FROM axllent/mailpit:v1.30.2 AS mailpit
 FROM postgrest/postgrest:v16.2 AS postgrest
-FROM supabase/postgres-meta:v0.98.0 AS pgmeta
+FROM supabase/postgres-meta:v0.99.0 AS pgmeta
 FROM supabase/studio:2026.08.24-sha-8ec45b2 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.74.3 AS edgeruntime

--- a/packages/stack/src/ServiceCatalog.ts
+++ b/packages/stack/src/ServiceCatalog.ts
@@ -253,7 +253,7 @@ export const SERVICE_CATALOG = {
   pgmeta: {
     name: "pgmeta",
     configKey: "pgmeta",
-    defaultVersion: "0.98.0",
+    defaultVersion: "0.99.0",
     runtimeSupport: "docker-only",
     artifact: {
       docker: { repository: "pgmeta", tagPrefix: "v" },

--- a/packages/stack/src/prefetch.unit.test.ts
+++ b/packages/stack/src/prefetch.unit.test.ts
@@ -410,7 +410,7 @@ describe("prefetch", () => {
 
     expect(result.pgmeta).toEqual({
       type: "docker",
-      image: "ghcr.io/supabase/cli/pgmeta:v0.98.0",
+      image: "ghcr.io/supabase/cli/pgmeta:v0.99.0",
     });
   });
 


### PR DESCRIPTION
## Summary

Bumps the pinned pg-meta image from `v0.98.0` to `v0.99.0` in the shared service-image manifest (`apps/cli-go/pkg/config/templates/Dockerfile`, imported by the TypeScript CLI as its image source).

postgres-meta v0.99.0 replaces the embedded type-generation templates with the shared [`@supabase/postgrest-typegen`](https://github.com/supabase/sdk/tree/main/packages/postgrest-typegen) package (supabase/postgres-meta#1084). This is part of a coordinated rollout with the hosted path (supabase/platform#37764) so `gen types` produces the same output locally and via `--project-id`.

## Relationship to #6404

#6404 makes `gen types` run postgrest-typegen in-process, removing the pg-meta container from that command entirely. This pin still matters independently of it: the same manifest entry provides the `pgmeta` service that `supabase start` runs for Studio's local API, and it covers `gen types` for any release cut before #6404 lands. The two do not conflict (different files), and output is consistent either way since v0.99.0 serves the same generator package that #6404 embeds.

## What changes for users

Generated TypeScript output changes in two deliberate ways: deterministic metadata ordering (a one-time reordering diff when regenerating existing types) and oxfmt formatting instead of prettier (style-only). Content is otherwise unchanged.

## Validation

- `go build ./...` passes in both modules.
- The pre-existing `gen types` e2e tests pull this image tag directly, so CI exercises the new release; the image is published on Docker Hub and ECR Public.
