### PR TITLE
test(stack): derive image assertions from the service catalog

### DIFF
--- a/packages/stack/src/prefetch.unit.test.ts
+++ b/packages/stack/src/prefetch.unit.test.ts
@@ -410,7 +410,7 @@ describe("prefetch", () => {
 
     expect(result.pgmeta).toEqual({
       type: "docker",
-      image: "ghcr.io/supabase/cli/pgmeta:v0.98.0",
+      image: dockerImageForService("pgmeta", DEFAULT_VERSIONS.pgmeta),
     });
   });
 

--- a/packages/stack/src/versions.unit.test.ts
+++ b/packages/stack/src/versions.unit.test.ts
@@ -111,7 +111,7 @@ describe("dockerImageForService", () => {
 
   it("uses the upstream mirror repositories for vector and pooler", () => {
     expect(dockerImageForService("vector", DEFAULT_VERSIONS.vector)).toBe(
-      "ghcr.io/supabase/vector:0.53.0-alpine",
+      `ghcr.io/supabase/vector:${DEFAULT_VERSIONS.vector}`,
     );
     expect(dockerImageForService("pooler", DEFAULT_VERSIONS.pooler)).toBe(
       `ghcr.io/supabase/supavisor:${DEFAULT_VERSIONS.pooler}`,


### PR DESCRIPTION
## Summary

Prefetch and version unit tests were pinning published pgmeta and vector image tags. Those assertions fail whenever `ServiceCatalog.ts` and the template Dockerfile are bumped.

The tests now derive the expected images from `DEFAULT_VERSIONS` / `dockerImageForService`, matching the other catalog-backed cases in the same files.

## Linked issue

No linked issue — test-only maintenance so image bumps do not fail unrelated unit tests.

Made with [Cursor](https://cursor.com)