### PR TITLE
test(cli): cover db query, lint and advisors (CLI-1949)

### DIFF
--- a/apps/cli/src/legacy/commands/db/advisors/advisors.live.test.ts
+++ b/apps/cli/src/legacy/commands/db/advisors/advisors.live.test.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+import { expect } from "vitest";
+
+import { queryLiveDb, test, throwWithCleanup } from "../../../../../tests/helpers/live.ts";
+
+// A table in `public` without row level security deterministically raises the
+// `rls_disabled_in_public` security lint.
+test("reads advisor findings over the database connection", async ({ cli, project }) => {
+  const table = `e2e_advisors_${randomUUID().slice(0, 8)}`;
+  let targetError: unknown;
+  const cleanupErrors: Array<unknown> = [];
+  try {
+    await queryLiveDb(project.dbUrl, `create table public.${table} (id int)`);
+
+    const result = await cli(["db", "advisors", "--db-url", project.dbUrl]);
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout, result.stderr).not.toBe("");
+    const findings = JSON.parse(result.stdout) as Array<{ name: string }>;
+    const finding = findings.find(
+      (candidate) =>
+        candidate.name === "rls_disabled_in_public" && JSON.stringify(candidate).includes(table),
+    );
+    expect(finding, result.stdout).toBeDefined();
+  } catch (error) {
+    targetError = error;
+  } finally {
+    try {
+      await queryLiveDb(project.dbUrl, `drop table if exists public.${table}`);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  throwWithCleanup(targetError, cleanupErrors);
+});

--- a/apps/cli/src/legacy/commands/db/lint/lint.live.test.ts
+++ b/apps/cli/src/legacy/commands/db/lint/lint.live.test.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { expect } from "vitest";
+
+import { queryLiveDb, test, throwWithCleanup } from "../../../../../tests/helpers/live.ts";
+
+// A plpgsql function reading from a missing table is a deterministic schema
+// error for `db lint` to report, independent of existing project state.
+test("reports schema issues from the remote database", async ({ cli, project }) => {
+  const name = `e2e_lint_${randomUUID().slice(0, 8)}`;
+  let targetError: unknown;
+  const cleanupErrors: Array<unknown> = [];
+  try {
+    await queryLiveDb(
+      project.dbUrl,
+      `create function public.${name}() returns void language plpgsql as $$ begin perform id from ${name}_missing; end $$`,
+    );
+
+    const result = await cli(["db", "lint", "--db-url", project.dbUrl]);
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout, result.stderr).not.toBe("");
+    const results = JSON.parse(result.stdout) as Array<{ function: string }>;
+    const entry = results.find((candidate) => candidate.function === `public.${name}`);
+    expect(entry, result.stdout).toBeDefined();
+    expect(JSON.stringify(entry)).toContain(`${name}_missing`);
+  } catch (error) {
+    targetError = error;
+  } finally {
+    try {
+      await queryLiveDb(project.dbUrl, `drop function if exists public.${name}()`);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  throwWithCleanup(targetError, cleanupErrors);
+});

--- a/apps/cli/src/legacy/commands/db/query/query.live.test.ts
+++ b/apps/cli/src/legacy/commands/db/query/query.live.test.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from "node:crypto";
+import { expect } from "vitest";
+
+import { test } from "../../../../../tests/helpers/live.ts";
+
+test("runs SQL against the remote database and returns its rows", async ({ cli, project }) => {
+  const marker = `e2e_query_${randomUUID().slice(0, 8)}`;
+  const result = await cli([
+    "db",
+    "query",
+    `select '${marker}' as marker`,
+    "--db-url",
+    project.dbUrl,
+    "-o",
+    "json",
+    "--agent",
+    "no",
+  ]);
+  expect(result.exitCode, result.stderr).toBe(0);
+  expect(result.stdout, result.stderr).not.toBe("");
+  expect(JSON.parse(result.stdout)).toEqual([{ marker }]);
+});


### PR DESCRIPTION
## TL;DR

adds live e2e coverage for `db query`, `db lint`, and `db advisors`
 completing the db family (push, pull, reset, and dump already have it)

## whats introduced?

- `db query`: runs a marker select over the real connection and proves the row comes back as the `-o json` payload
- `db lint`: seeds a plpgsql function referencing a missing table and proves the reported finding names both the function and the missing relation
- `db advisors`: seeds a public table without row level security and proves the `rls_disabled_in_public` finding names it

## ref:
- closes: CLI-1949