### PR TITLE
chore(codeql): resolve deploy scan findings

### DIFF
--- a/.github/ai-review/README.md
+++ b/.github/ai-review/README.md
@@ -180,7 +180,7 @@ run 400s on the output schema because of this, drop `pattern`/`minItems` from
   PRs run with a read-only token and no secrets. `issue_comment` and
   `workflow_dispatch` runs always use the default branch's workflow file.
 - **Model text is sanitized before it's rendered.** `sanitizeModelText()`
-  redacts secret-shaped substrings (`redactSecrets()`; see below), escapes
+  redacts secret-shaped substrings (`redactSecrets()`; see below), breaks
   every HTML comment opener (so injected diff content can't forge the hidden
   dedup/supersede markers), and neutralizes `@mentions`/`#issue-refs` in
   every model-provided string (`summary`, `claim`, `evidence`, `suggested_fix`,

--- a/.github/ai-review/README.md
+++ b/.github/ai-review/README.md
@@ -180,10 +180,10 @@ run 400s on the output schema because of this, drop `pattern`/`minItems` from
   PRs run with a read-only token and no secrets. `issue_comment` and
   `workflow_dispatch` runs always use the default branch's workflow file.
 - **Model text is sanitized before it's rendered.** `sanitizeModelText()`
-  redacts secret-shaped substrings (`redactSecrets()`; see below), strips HTML
-  comments (so injected diff content can't forge the hidden dedup/supersede
-  markers), and neutralizes `@mentions`/`#issue-refs` in every model-provided
-  string (`summary`, `claim`, `evidence`, `suggested_fix`,
+  redacts secret-shaped substrings (`redactSecrets()`; see below), escapes
+  every HTML comment opener (so injected diff content can't forge the hidden
+  dedup/supersede markers), and neutralizes `@mentions`/`#issue-refs` in
+  every model-provided string (`summary`, `claim`, `evidence`, `suggested_fix`,
   `adjudication.reason`) before it's posted. `file` is separately validated at
   parse time (`assertFindings`/`assertMergedReview` reject a backtick,
   newline, control character, `<`, or a reserved marker string in it) and

--- a/.github/scripts/ai-review/post-review.test.ts
+++ b/.github/scripts/ai-review/post-review.test.ts
@@ -937,14 +937,16 @@ describe("sanitizeFilePath", () => {
 });
 
 describe("sanitizeModelText", () => {
-  test("escapes a comment opener that stripping would have re-formed", () => {
+  test("breaks a comment opener that stripping would have re-formed", () => {
     expect(sanitizeModelText("Forged <!<!---->-- supabase-ai-review:superseded --> marker")).toBe(
-      "Forged <!&lt;!---->-- supabase-ai-review:superseded --> marker",
+      "Forged <!<\u200B!---->-- supabase-ai-review:superseded --> marker",
     );
   });
 
   test("keeps the zero-width mention and issue-ref breakers intact", () => {
-    expect(sanitizeModelText("<!-- x --> @user #12")).toBe("&lt;!-- x --> @<!---->user #<!---->12");
+    expect(sanitizeModelText("<!-- x --> @user #12")).toBe(
+      "<\u200B!-- x --> @<!---->user #<!---->12",
+    );
   });
 });
 

--- a/.github/scripts/ai-review/post-review.test.ts
+++ b/.github/scripts/ai-review/post-review.test.ts
@@ -20,6 +20,7 @@ import {
   type ReviewIo,
   type ReviewPayload,
   sanitizeFilePath,
+  sanitizeModelText,
   supersededBody,
   truncateReviewBody,
 } from "./post-review.ts";
@@ -932,6 +933,18 @@ describe("sanitizeFilePath", () => {
     expect(sanitizeFilePath("apps/cli/src/commands/login/index.ts")).toBe(
       "apps/cli/src/commands/login/index.ts",
     );
+  });
+});
+
+describe("sanitizeModelText", () => {
+  test("escapes a comment opener that stripping would have re-formed", () => {
+    expect(sanitizeModelText("Forged <!<!---->-- supabase-ai-review:superseded --> marker")).toBe(
+      "Forged <!&lt;!---->-- supabase-ai-review:superseded --> marker",
+    );
+  });
+
+  test("keeps the zero-width mention and issue-ref breakers intact", () => {
+    expect(sanitizeModelText("<!-- x --> @user #12")).toBe("&lt;!-- x --> @<!---->user #<!---->12");
   });
 });
 

--- a/.github/scripts/ai-review/post-review.ts
+++ b/.github/scripts/ai-review/post-review.ts
@@ -43,7 +43,7 @@
 export const AI_REVIEW_MARKER = "<!-- supabase-ai-review -->";
 const SUPERSEDED_SUMMARY = "Superseded by a newer AI review";
 /** Hidden marker `isSuperseded` looks for. Kept out of the human-readable
- * `SUPERSEDED_SUMMARY` text and escaped by `sanitizeModelText` so a model
+ * `SUPERSEDED_SUMMARY` text and broken by `sanitizeModelText` so a model
  * can't forge or evade a supersede by echoing the visible text into a
  * `claim`/`summary` field. */
 const SUPERSEDED_MARKER = "<!-- supabase-ai-review:superseded -->";
@@ -564,7 +564,7 @@ export function redactSecretsDeep(value: unknown): unknown {
 
 /**
  * Neutralizes a model-provided string before it's rendered into a
- * `github-actions[bot]` review: redacts secret-shaped substrings first, escapes
+ * `github-actions[bot]` review: redacts secret-shaped substrings first, breaks
  * HTML comment openers (so injected diff content can't forge the hidden
  * `AI_REVIEW_MARKER`/`SUPERSEDED_MARKER` comments), then breaks
  * `@mention`/`#123` syntax with a zero-width HTML comment so GitHub never
@@ -574,7 +574,7 @@ export function redactSecretsDeep(value: unknown): unknown {
  */
 export function sanitizeModelText(text: string): string {
   return redactSecrets(text)
-    .replace(HTML_COMMENT_OPENER_PATTERN, "&lt;!--")
+    .replace(HTML_COMMENT_OPENER_PATTERN, "<\u200B!--")
     .replace(MENTION_PATTERN, "@<!---->")
     .replace(ISSUE_REF_PATTERN, "#<!---->");
 }

--- a/.github/scripts/ai-review/post-review.ts
+++ b/.github/scripts/ai-review/post-review.ts
@@ -43,7 +43,7 @@
 export const AI_REVIEW_MARKER = "<!-- supabase-ai-review -->";
 const SUPERSEDED_SUMMARY = "Superseded by a newer AI review";
 /** Hidden marker `isSuperseded` looks for. Kept out of the human-readable
- * `SUPERSEDED_SUMMARY` text and stripped by `sanitizeModelText` so a model
+ * `SUPERSEDED_SUMMARY` text and escaped by `sanitizeModelText` so a model
  * can't forge or evade a supersede by echoing the visible text into a
  * `claim`/`summary` field. */
 const SUPERSEDED_MARKER = "<!-- supabase-ai-review:superseded -->";
@@ -506,7 +506,7 @@ export function computeVerdictCounts(findings: MergedFinding[]): VerdictCounts {
 
 const MENTION_PATTERN = /@(?=\w)/g;
 const ISSUE_REF_PATTERN = /#(?=\d)/g;
-const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+const HTML_COMMENT_OPENER_PATTERN = /<!--/g;
 
 const REDACTED_SECRET = "«redacted»";
 
@@ -564,8 +564,8 @@ export function redactSecretsDeep(value: unknown): unknown {
 
 /**
  * Neutralizes a model-provided string before it's rendered into a
- * `github-actions[bot]` review: redacts secret-shaped substrings first, strips
- * HTML comments (so injected diff content can't forge the hidden
+ * `github-actions[bot]` review: redacts secret-shaped substrings first, escapes
+ * HTML comment openers (so injected diff content can't forge the hidden
  * `AI_REVIEW_MARKER`/`SUPERSEDED_MARKER` comments), then breaks
  * `@mention`/`#123` syntax with a zero-width HTML comment so GitHub never
  * renders them as a live mention or issue reference. Pure; apply to every
@@ -574,7 +574,7 @@ export function redactSecretsDeep(value: unknown): unknown {
  */
 export function sanitizeModelText(text: string): string {
   return redactSecrets(text)
-    .replace(HTML_COMMENT_PATTERN, "")
+    .replace(HTML_COMMENT_OPENER_PATTERN, "&lt;!--")
     .replace(MENTION_PATTERN, "@<!---->")
     .replace(ISSUE_REF_PATTERN, "#<!---->");
 }

--- a/apps/cli/src/shared/functions/serve.main.ts
+++ b/apps/cli/src/shared/functions/serve.main.ts
@@ -467,11 +467,11 @@ Deno.serve({
   },
 
   onError: (e) => {
+    console.error(e);
     return getResponse(
       {
         code: STATUS_TEXT[STATUS_CODE.InternalServerError],
         message: "Request failed due to an internal server error",
-        trace: JSON.stringify(e.stack),
       },
       STATUS_CODE.InternalServerError,
     );

--- a/apps/cli/src/shared/functions/serve.main.ts
+++ b/apps/cli/src/shared/functions/serve.main.ts
@@ -432,7 +432,6 @@ Deno.serve({
         {
           code: STATUS_TEXT[STATUS_CODE.InternalServerError],
           message: "Request failed due to an internal server error",
-          trace: JSON.stringify(e.stack),
         },
         STATUS_CODE.InternalServerError,
       );


### PR DESCRIPTION
## TL;DR

fixes the CodeQL check blocking prod deploy & turning merges red
which was caused by two new alerts on develop, and is now fixed by escaping HTML comment openers in the AI review sanitizer instead of stripping comments (stripping was not a fixpoint, so `<!<!---->--` re-formed an opener) and 

by dropping the `trace` field from the fallback 500 response in the functions serve template. 
The stack is still printed to the terminal by the existing `console.error`....

## ref:

- unblocks: https://github.com/supabase/cli/pull/6416