### PR TITLE
fix(config): align pgdelta format_options example with the 180 default

### DIFF
--- a/apps/cli-go/pkg/api/types.gen.go
+++ b/apps/cli-go/pkg/api/types.gen.go
@@ -8113,20 +8113,20 @@ type UpdateCustomHostnameResponseOutput struct {
 			CustomOriginServer    string `json:"custom_origin_server"`
 			Hostname              string `json:"hostname"`
 			Id                    string `json:"id"`
-			OwnershipVerification struct {
+			OwnershipVerification *struct {
 				Name  string `json:"name"`
 				Type  string `json:"type"`
 				Value string `json:"value"`
-			} `json:"ownership_verification"`
+			} `json:"ownership_verification,omitempty"`
 			Ssl struct {
 				Status           string `json:"status"`
 				ValidationErrors *[]struct {
 					Message string `json:"message"`
 				} `json:"validation_errors,omitempty"`
-				ValidationRecords []struct {
+				ValidationRecords *[]struct {
 					TxtName  string `json:"txt_name"`
 					TxtValue string `json:"txt_value"`
-				} `json:"validation_records"`
+				} `json:"validation_records,omitempty"`
 			} `json:"ssl"`
 			Status             string    `json:"status"`
 			VerificationErrors *[]string `json:"verification_errors,omitempty"`

--- a/apps/cli-go/pkg/config/templates/config.toml
+++ b/apps/cli-go/pkg/config/templates/config.toml
@@ -410,5 +410,7 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 enabled = {{ .Experimental.PgDeltaInitEnabled }}
 # Directory under `supabase/` where declarative files are written.
 # declarative_schema_path = "./schemas"
-# JSON string passed through to pg-delta SQL formatting.
+# JSON string passed through to pg-delta SQL formatting. When omitted, SQL is
+# formatted with uppercase keywords, indent 2, max width 180, trailing commas,
+# and column/key alignment. Set to "null" to emit raw, unformatted SQL.
 # format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":180,\"commaStyle\":\"trailing\"}"

--- a/apps/cli-go/pkg/config/templates/config.toml
+++ b/apps/cli-go/pkg/config/templates/config.toml
@@ -411,4 +411,4 @@ enabled = {{ .Experimental.PgDeltaInitEnabled }}
 # Directory under `supabase/` where declarative files are written.
 # declarative_schema_path = "./schemas"
 # JSON string passed through to pg-delta SQL formatting.
-# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":180,\"commaStyle\":\"trailing\"}"

--- a/apps/cli/src/shared/init/project-init.templates.ts
+++ b/apps/cli/src/shared/init/project-init.templates.ts
@@ -409,7 +409,9 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 enabled = true
 # Directory under \`supabase/\` where declarative files are written.
 # declarative_schema_path = "./schemas"
-# JSON string passed through to pg-delta SQL formatting.
+# JSON string passed through to pg-delta SQL formatting. When omitted, SQL is
+# formatted with uppercase keywords, indent 2, max width 180, trailing commas,
+# and column/key alignment. Set to "null" to emit raw, unformatted SQL.
 # format_options = "{\\"keywordCase\\":\\"upper\\",\\"indent\\":2,\\"maxWidth\\":180,\\"commaStyle\\":\\"trailing\\"}"
 `;
 

--- a/apps/cli/src/shared/init/project-init.templates.ts
+++ b/apps/cli/src/shared/init/project-init.templates.ts
@@ -410,7 +410,7 @@ enabled = true
 # Directory under \`supabase/\` where declarative files are written.
 # declarative_schema_path = "./schemas"
 # JSON string passed through to pg-delta SQL formatting.
-# format_options = "{\\"keywordCase\\":\\"upper\\",\\"indent\\":2,\\"maxWidth\\":80,\\"commaStyle\\":\\"trailing\\"}"
+# format_options = "{\\"keywordCase\\":\\"upper\\",\\"indent\\":2,\\"maxWidth\\":180,\\"commaStyle\\":\\"trailing\\"}"
 `;
 
 export const INIT_GITIGNORE_TEMPLATE = `# Supabase

--- a/apps/docs/public/cli/config.schema.json
+++ b/apps/docs/public/cli/config.schema.json
@@ -2390,9 +2390,9 @@
             },
             "format_options": {
               "type": "string",
-              "description": "JSON string passed through to pg-delta SQL formatting.",
+              "description": "JSON string passed through to pg-delta SQL formatting. When omitted, SQL is formatted with uppercase keywords, indent 2, max width 180, trailing commas, and column/key alignment. Set to \"null\" to emit raw, unformatted SQL.",
               "examples": [
-                "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+                "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":180,\"commaStyle\":\"trailing\"}"
               ]
             }
           },
@@ -4829,9 +4829,9 @@
                           },
                           "format_options": {
                             "type": "string",
-                            "description": "JSON string passed through to pg-delta SQL formatting.",
+                            "description": "JSON string passed through to pg-delta SQL formatting. When omitted, SQL is formatted with uppercase keywords, indent 2, max width 180, trailing commas, and column/key alignment. Set to \"null\" to emit raw, unformatted SQL.",
                             "examples": [
-                              "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+                              "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":180,\"commaStyle\":\"trailing\"}"
                             ]
                           }
                         },

--- a/apps/docs/public/cli/project-config.schema.json
+++ b/apps/docs/public/cli/project-config.schema.json
@@ -1923,9 +1923,9 @@
             },
             "format_options": {
               "type": "string",
-              "description": "JSON string passed through to pg-delta SQL formatting.",
+              "description": "JSON string passed through to pg-delta SQL formatting. When omitted, SQL is formatted with uppercase keywords, indent 2, max width 180, trailing commas, and column/key alignment. Set to \"null\" to emit raw, unformatted SQL.",
               "examples": [
-                "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+                "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":180,\"commaStyle\":\"trailing\"}"
               ]
             }
           },

--- a/packages/config/src/experimental.ts
+++ b/packages/config/src/experimental.ts
@@ -92,8 +92,9 @@ export const experimental = Schema.Struct({
       ),
       format_options: Schema.optionalKey(
         Schema.String.annotate({
-          description: "JSON string passed through to pg-delta SQL formatting.",
-          examples: ['{"keywordCase":"upper","indent":2,"maxWidth":80,"commaStyle":"trailing"}'],
+          description:
+            'JSON string passed through to pg-delta SQL formatting. When omitted, SQL is formatted with uppercase keywords, indent 2, max width 180, trailing commas, and column/key alignment. Set to "null" to emit raw, unformatted SQL.',
+          examples: ['{"keywordCase":"upper","indent":2,"maxWidth":180,"commaStyle":"trailing"}'],
           tags,
         }),
       ),


### PR DESCRIPTION
## Summary

The commented `format_options` example in the `supabase init` config template (TypeScript and Go variants) and the `examples` annotation on `experimental.pgdelta.format_options` in `@supabase/config` showed `"maxWidth":80`. The runtime default is 180: the pg-delta adapter layer and the Deno diff templates apply `maxWidth: 180` when the option is omitted, and the `db diff` / `db pull` / `db schema declarative generate` docs already describe 180. A user who uncommented the example to tweak one setting silently narrowed their SQL from 180 to 80 columns.

This change:

- Uses `180` in the example in both init templates and in the config schema so it matches the runtime default.
- Expands the `format_options` schema description to state the default formatting (uppercase keywords, indent 2, max width 180, trailing commas, column/key alignment) and the `"null"` opt-out for raw SQL.
- Regenerates `apps/docs/public/cli/config.schema.json` and `project-config.schema.json` from the config package build so the published schemas carry the corrected example and description.

No runtime behavior changes; the actual formatting defaults are untouched.

**Also included:** the second commit ports the regenerated `apps/cli-go/pkg/api/types.gen.go` from the pending API sync in #6434, because the `Codegen` check regenerates that file from the live Management API spec and was red on this branch for a drift this PR did not cause. It is the same one-file diff as #6434 and becomes a no-op once that sync lands on `develop`.

## Linked issue

Reported internally; no GitHub issue.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(cli): …`).
- [x] Tests added or updated for the change (not applicable: comment text and schema annotations only).
- [x] From the repository root, `pnpm check:all` passes; relevant package tests pass for every touched workspace, and `pnpm types:check` passes for each touched TypeScript workspace (or workspace declaring it). All checks pass locally except `@supabase/cli-go#lint:check`, which could not run in the authoring environment because its golangci-lint build predates the module's Go 1.26 target; the Go diff is one digit in a comment line of the embedded config template, so CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq8az2X32Fh4UWvRxKUjAR