### PR TITLE
ci(config): add Slack notifications to the config release pipeline

### DIFF
--- a/.github/workflows/release-config.yml
+++ b/.github/workflows/release-config.yml
@@ -82,9 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           # Push events are never dry; workflow_dispatch dry-runs unless the
-          # operator explicitly unticks the input. Recorded before the planner
-          # runs so even a planner crash exposes dry_run to the failure-notify
-          # jobs.
+          # operator explicitly unticks the input.
           if [[ "$EVENT" == "workflow_dispatch" && "$DISPATCH_DRY_RUN" == "true" ]]; then
             echo "dry_run=true" >> "$GITHUB_OUTPUT"
           else
@@ -302,24 +300,27 @@ jobs:
 
       # "Published successfully" for the notification jobs below means
       # REGISTRY-VISIBLE with the reviewed bytes: probe npm until the version
-      # resolves (the registry can lag a publish by a few seconds), then
-      # require integrity and dist-tag to match. Runs before the tag push so
-      # a tag is never blessed for bytes this run couldn't confirm on the
-      # registry; a transient failure here is safe to re-run — the publish
-      # step's registry probe skips the republish and this check repeats,
-      # though a re-run of this job re-arms the config-release approval gate
-      # and costs a second human approval — hence the generous (~2 minute)
-      # visibility budget.
+      # resolves (the registry can lag a publish by a few seconds) and its
+      # integrity matches the reviewed tarball. Runs before the tag push so a
+      # tag is never blessed for bytes this run couldn't confirm on the
+      # registry; the dist-tag assertion deliberately lives AFTER the tag push
+      # so a dist-tag propagation hiccup can't strand the release live on npm
+      # with origin untagged. A transient failure here is safe to re-run — the
+      # publish step's registry probe skips the republish and this check
+      # repeats — though a re-run of this job re-arms the config-release
+      # approval gate and costs a second human approval — hence the generous
+      # (~2 minute) visibility budget.
       - name: Verify the release is live on npm
         working-directory: ${{ runner.temp }}/config-release
         run: |
           set -euo pipefail
           tarball="supabase-config-${VERSION}.tgz"
           reviewed_integrity="sha512-$(openssl dgst -sha512 -binary "${tarball}" | base64 -w0)"
+          npm_err="$RUNNER_TEMP/npm-view-err.log"
           registry_integrity=""
           for delay in 0 2 3 5 8 13 21 30 30; do
             sleep "$delay"
-            if registry_integrity="$(npm view --prefer-online "@supabase/config@${VERSION}" dist.integrity 2>/dev/null)" \
+            if registry_integrity="$(npm view --prefer-online "@supabase/config@${VERSION}" dist.integrity 2>"$npm_err")" \
               && [[ -n "$registry_integrity" ]]; then
               break
             fi
@@ -327,6 +328,10 @@ jobs:
           done
           if [[ -z "$registry_integrity" ]]; then
             echo "@supabase/config@${VERSION} is not visible on the registry after publishing." >&2
+            if [[ -s "$npm_err" ]]; then
+              echo "Last npm error output:" >&2
+              cat "$npm_err" >&2
+            fi
             exit 1
           fi
           if [[ "$registry_integrity" != "$reviewed_integrity" ]]; then
@@ -335,21 +340,7 @@ jobs:
             echo "  reviewed: ${reviewed_integrity}" >&2
             exit 1
           fi
-          tagged=""
-          for delay in 0 2 5; do
-            sleep "$delay"
-            if tagged="$(npm view --prefer-online "@supabase/config" "dist-tags.${NPM_TAG}" 2>/dev/null)" \
-              && [[ -n "$tagged" ]]; then
-              break
-            fi
-            tagged=""
-          done
-          if [[ "$tagged" != "$VERSION" ]]; then
-            echo "dist-tag '${NPM_TAG}' points at ${tagged:-nothing}, expected ${VERSION}." >&2
-            echo "If a newer release has since moved the tag, this is a stale re-run rather than registry corruption." >&2
-            exit 1
-          fi
-          echo "@supabase/config@${VERSION} verified on npm (dist-tag ${NPM_TAG}, integrity match)."
+          echo "@supabase/config@${VERSION} live on npm with the reviewed bytes."
 
       - name: Configure git for release pushes
         run: |
@@ -372,6 +363,34 @@ jobs:
             git tag -a "${tag}" -m "Release ${tag}"
             git push origin "${tag}"
           fi
+
+      # Asserted after the tag push on purpose: npm already holds the reviewed
+      # bytes (verified above), so a dist-tag propagation hiccup must not
+      # strand the release npm-published but origin-untagged. Retries until
+      # the tag points at THIS version — a stale packument still echoing the
+      # previous version is a retryable state, not a terminal mismatch.
+      - name: Verify the npm dist-tag
+        run: |
+          set -euo pipefail
+          npm_err="$RUNNER_TEMP/npm-view-err.log"
+          tagged=""
+          for delay in 0 2 3 5 8 13; do
+            sleep "$delay"
+            tagged="$(npm view --prefer-online "@supabase/config" "dist-tags.${NPM_TAG}" 2>"$npm_err")" || tagged=""
+            if [[ "$tagged" == "$VERSION" ]]; then
+              break
+            fi
+          done
+          if [[ "$tagged" != "$VERSION" ]]; then
+            echo "dist-tag '${NPM_TAG}' points at ${tagged:-nothing}, expected ${VERSION}." >&2
+            echo "If a newer release has since moved the tag, this is a stale re-run rather than registry corruption." >&2
+            if [[ -s "$npm_err" ]]; then
+              echo "Last npm error output:" >&2
+              cat "$npm_err" >&2
+            fi
+            exit 1
+          fi
+          echo "dist-tag ${NPM_TAG} -> ${VERSION} confirmed."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -430,11 +449,14 @@ jobs:
   # pipeline failure before paging the channel: a rejection marks the publish
   # job failed, and announcing that as a broken release would page people
   # about a deliberate decision. The run's approvals record is the only place
-  # the distinction is visible from inside the workflow.
+  # the distinction is visible from inside the workflow. The dry-run guard
+  # reads the dispatch input directly rather than plan's output, so a plan
+  # job that dies before recording dry_run still can't page for an
+  # operator-watched dry run.
   classify-failure:
     name: Classify failure
     needs: [plan, publish]
-    if: failure() && needs.plan.outputs.dry_run != 'true'
+    if: ${{ failure() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # The approvals endpoint needs actions: read, which the workflow-level
@@ -447,18 +469,23 @@ jobs:
       - id: classify
         env:
           GH_TOKEN: ${{ github.token }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
         run: |
           set -euo pipefail
-          # Fold ONLY a definite rejection into `declined`; an API error stays a
-          # plain failure so a broken release is never misreported as a calm
-          # "not approved". The approvals record spans every attempt of this run
-          # in append order, so the LAST review is the operative decision — a
-          # rejection followed by a re-run and an approval is an approved
-          # deployment that failed for some other reason.
-          if approvals="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" 2>/dev/null)"; then
-            last_state="$(jq -r 'if type == "array" and length > 0 then .[-1].state else "" end' <<<"$approvals")"
-          else
-            last_state=""
+          # Fold ONLY a definite rejection into `declined`; an API error stays
+          # a plain failure so a broken release is never misreported as a
+          # calm "not approved". Two guards: the publish job itself must be
+          # the failed job (a rejection can only manifest there — a plan
+          # failure in a run whose earlier attempt was rejected is a plain
+          # failure), and the approvals record spans every attempt of this
+          # run in append order, so the LAST review is the operative
+          # decision — a rejection followed by a re-run and an approval is an
+          # approved deployment that failed for some other reason.
+          last_state=""
+          if [[ "$PUBLISH_RESULT" == "failure" ]]; then
+            if approvals="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" 2>/dev/null)"; then
+              last_state="$(jq -r 'if type == "array" and length > 0 then .[-1].state else "" end' <<<"$approvals")"
+            fi
           fi
           if [[ "$last_state" == "rejected" ]]; then
             echo "status=declined" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-config.yml
+++ b/.github/workflows/release-config.yml
@@ -81,6 +81,15 @@ jobs:
           DISPATCH_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
+          # Push events are never dry; workflow_dispatch dry-runs unless the
+          # operator explicitly unticks the input. Recorded before the planner
+          # runs so even a planner crash exposes dry_run to the failure-notify
+          # jobs.
+          if [[ "$EVENT" == "workflow_dispatch" && "$DISPATCH_DRY_RUN" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
           # semantic-release echoes commit-derived text (messages, notes) to
           # this step's log; a commit message line starting with `::` would
           # otherwise be interpreted as a workflow command (e.g. `::add-mask::`
@@ -93,13 +102,6 @@ jobs:
           echo "::stop-commands::${resume_token}"
           trap 'echo "::${resume_token}::"' EXIT
           pnpm exec bun packages/config/scripts/release-plan.ts --notes-out "$RUNNER_TEMP/config-release-notes.md"
-          # Push events are never dry; workflow_dispatch dry-runs unless the
-          # operator explicitly unticks the input.
-          if [[ "$EVENT" == "workflow_dispatch" && "$DISPATCH_DRY_RUN" == "true" ]]; then
-            echo "dry_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "dry_run=false" >> "$GITHUB_OUTPUT"
-          fi
 
       # The build, gate, and pack steps also run on private-blocked pushes
       # (should_release=false, version set): if `private` were ever flipped
@@ -298,6 +300,57 @@ jobs:
             npm publish "./${tarball}" --ignore-scripts --provenance --tag "${NPM_TAG}"
           fi
 
+      # "Published successfully" for the notification jobs below means
+      # REGISTRY-VISIBLE with the reviewed bytes: probe npm until the version
+      # resolves (the registry can lag a publish by a few seconds), then
+      # require integrity and dist-tag to match. Runs before the tag push so
+      # a tag is never blessed for bytes this run couldn't confirm on the
+      # registry; a transient failure here is safe to re-run — the publish
+      # step's registry probe skips the republish and this check repeats,
+      # though a re-run of this job re-arms the config-release approval gate
+      # and costs a second human approval — hence the generous (~2 minute)
+      # visibility budget.
+      - name: Verify the release is live on npm
+        working-directory: ${{ runner.temp }}/config-release
+        run: |
+          set -euo pipefail
+          tarball="supabase-config-${VERSION}.tgz"
+          reviewed_integrity="sha512-$(openssl dgst -sha512 -binary "${tarball}" | base64 -w0)"
+          registry_integrity=""
+          for delay in 0 2 3 5 8 13 21 30 30; do
+            sleep "$delay"
+            if registry_integrity="$(npm view --prefer-online "@supabase/config@${VERSION}" dist.integrity 2>/dev/null)" \
+              && [[ -n "$registry_integrity" ]]; then
+              break
+            fi
+            registry_integrity=""
+          done
+          if [[ -z "$registry_integrity" ]]; then
+            echo "@supabase/config@${VERSION} is not visible on the registry after publishing." >&2
+            exit 1
+          fi
+          if [[ "$registry_integrity" != "$reviewed_integrity" ]]; then
+            echo "@supabase/config@${VERSION} on npm does not match the reviewed tarball:" >&2
+            echo "  registry: ${registry_integrity}" >&2
+            echo "  reviewed: ${reviewed_integrity}" >&2
+            exit 1
+          fi
+          tagged=""
+          for delay in 0 2 5; do
+            sleep "$delay"
+            if tagged="$(npm view --prefer-online "@supabase/config" "dist-tags.${NPM_TAG}" 2>/dev/null)" \
+              && [[ -n "$tagged" ]]; then
+              break
+            fi
+            tagged=""
+          done
+          if [[ "$tagged" != "$VERSION" ]]; then
+            echo "dist-tag '${NPM_TAG}' points at ${tagged:-nothing}, expected ${VERSION}." >&2
+            echo "If a newer release has since moved the tag, this is a stale re-run rather than registry corruption." >&2
+            exit 1
+          fi
+          echo "@supabase/config@${VERSION} verified on npm (dist-tag ${NPM_TAG}, integrity match)."
+
       - name: Configure git for release pushes
         run: |
           git config user.name "github-actions[bot]"
@@ -333,3 +386,103 @@ jobs:
           # releases/latest/download/..., so a config release must never
           # become the repo's "latest" release.
           make_latest: "false"
+
+  # Pages the release Slack channel the moment a real run arms the
+  # config-release approval gate. This job only needs `plan`, so it runs in
+  # parallel with the publish job's `waiting` state — the ping and the pending
+  # deployment appear together. The approval itself stays on GitHub: the run
+  # page hosts the Approve button and the plan job's evidence summary; the
+  # webhook is one-way and cannot host an interactive approval. Nothing
+  # depends on this job, so a Slack/webhook failure can't block the release.
+  notify-slack-approval:
+    name: Notify Slack (approval needed)
+    needs: plan
+    if: needs.plan.outputs.should_release == 'true' && needs.plan.outputs.dry_run != 'true'
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      package: "@supabase/config"
+      status: awaiting-approval
+      version: ${{ needs.plan.outputs.version }}
+      tag_prefix: config-v
+    secrets:
+      SLACK_RELEASE_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+
+  # Posts once the publish job has verified the release is registry-visible
+  # with the reviewed bytes. No `if:` needed: the implicit success() gate
+  # means this only runs when plan and publish both succeeded, and publish
+  # itself only runs for real (non-dry) releases — dry runs and no-release
+  # pushes skip publish, which skips this too. Nothing depends on this job,
+  # so a Slack/webhook failure can't affect the already-completed release.
+  notify-slack:
+    name: Notify Slack
+    needs: [plan, publish]
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      package: "@supabase/config"
+      status: success
+      version: ${{ needs.plan.outputs.version }}
+      tag_prefix: config-v
+      npm_package: "@supabase/config"
+    secrets:
+      SLACK_RELEASE_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+
+  # Distinguishes "a reviewer rejected the pending deployment" from a real
+  # pipeline failure before paging the channel: a rejection marks the publish
+  # job failed, and announcing that as a broken release would page people
+  # about a deliberate decision. The run's approvals record is the only place
+  # the distinction is visible from inside the workflow.
+  classify-failure:
+    name: Classify failure
+    needs: [plan, publish]
+    if: failure() && needs.plan.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The approvals endpoint needs actions: read, which the workflow-level
+    # `contents: read` block would otherwise zero out.
+    permissions:
+      actions: read
+    outputs:
+      status: ${{ steps.classify.outputs.status }}
+    steps:
+      - id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Fold ONLY a definite rejection into `declined`; an API error stays a
+          # plain failure so a broken release is never misreported as a calm
+          # "not approved". The approvals record spans every attempt of this run
+          # in append order, so the LAST review is the operative decision — a
+          # rejection followed by a re-run and an approval is an approved
+          # deployment that failed for some other reason.
+          if approvals="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" 2>/dev/null)"; then
+            last_state="$(jq -r 'if type == "array" and length > 0 then .[-1].state else "" end' <<<"$approvals")"
+          else
+            last_state=""
+          fi
+          if [[ "$last_state" == "rejected" ]]; then
+            echo "status=declined" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Reports a failed (or reviewer-declined) release. `failure()` on the
+  # classify job evaluates against its `needs` chain, so this pair fires
+  # whenever `plan` or `publish` fails — including an approval rejection —
+  # but stays quiet for dry runs and no-release pushes (skipped needs don't
+  # count as failures). When `plan` fails its outputs are empty, so the
+  # message falls back to the workflow run link as the actionable detail.
+  # Fails open: if the classifier itself breaks, the page still goes out as a
+  # plain failure (its status output is empty, so the expression falls back).
+  notify-slack-failure:
+    name: Notify Slack (failure)
+    needs: [plan, publish, classify-failure]
+    if: ${{ !cancelled() && needs.classify-failure.result != 'skipped' }}
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      package: "@supabase/config"
+      status: ${{ needs.classify-failure.outputs.status || 'failure' }}
+      version: ${{ needs.plan.outputs.version }}
+      tag_prefix: config-v
+    secrets:
+      SLACK_RELEASE_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,13 +308,15 @@ jobs:
   # `needs` chain, so this fires whenever `plan` or `release` (and anything in
   # the reusable release-shared workflow) fails. Skipped jobs — e.g. the
   # fast-forward path or a release that never started — don't count as failures,
-  # so this stays quiet there. Dry runs are excluded; an operator running one is
-  # already watching it live. When `plan` fails its outputs are empty, so the
-  # message falls back to the workflow run link as the actionable detail.
+  # so this stays quiet there. Dry runs are excluded — the guard reads the
+  # dispatch input directly, so even a plan job that dies before recording its
+  # dry_run output stays quiet; an operator running one is already watching it
+  # live. When `plan` fails its outputs are empty, so the message falls back to
+  # the workflow run link as the actionable detail.
   notify-slack-failure:
     name: Notify Slack (failure)
     needs: [plan, release]
-    if: failure() && needs.plan.outputs.dry_run != 'true'
+    if: ${{ failure() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     uses: ./.github/workflows/slack-notify.yml
     with:
       package: Supabase CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,7 @@ jobs:
       needs.plan.outputs.channel == 'stable'
     uses: ./.github/workflows/slack-notify.yml
     with:
+      package: Supabase CLI
       status: success
       version: ${{ needs.plan.outputs.version }}
       channel: ${{ needs.plan.outputs.channel }}
@@ -316,6 +317,7 @@ jobs:
     if: failure() && needs.plan.outputs.dry_run != 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
+      package: Supabase CLI
       status: failure
       version: ${{ needs.plan.outputs.version }}
       channel: ${{ needs.plan.outputs.channel }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -3,19 +3,34 @@ name: Reusable Slack Notification
 on:
   workflow_call:
     inputs:
+      package:
+        description: Display name of the released package (e.g. "Supabase CLI" or "@supabase/config")
+        required: true
+        type: string
       version:
         description: Released version (without the leading v, e.g. 1.2.3)
         required: true
         type: string
       channel:
-        description: Release channel (alpha | beta | stable), used to label the message
+        description: Release channel (alpha | beta | stable), used to label the message. Omit for packages that release without channels.
         required: false
         type: string
+        default: ""
       status:
-        description: Notification kind (success | failure). Failure messages report a broken release on any channel.
+        description: Notification kind (success | failure | awaiting-approval | declined)
         required: false
         type: string
         default: success
+      tag_prefix:
+        description: Git tag prefix used to build the changelog link (e.g. "v" or "config-v")
+        required: false
+        type: string
+        default: v
+      npm_package:
+        description: npm package name. When set, success messages link the npm version page.
+        required: false
+        type: string
+        default: ""
     secrets:
       SLACK_RELEASE_WEBHOOK:
         required: true
@@ -30,9 +45,12 @@ jobs:
         # untrusted strings into the shell — only github.run_id/github.sha are
         # inlined, and those are GitHub-controlled.
         env:
+          PACKAGE: ${{ inputs.package }}
           VERSION: ${{ inputs.version }}
           CHANNEL: ${{ inputs.channel }}
           STATUS: ${{ inputs.status }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          NPM_PACKAGE: ${{ inputs.npm_package }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.sha }}
@@ -43,18 +61,64 @@ jobs:
           SHORT_SHA="${SHA:0:7}"
           COMMIT_URL="https://github.com/${REPO}/commit/${SHA}"
           RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          CHANGELOG_URL="https://github.com/${REPO}/releases/tag/${TAG_PREFIX}${VERSION}"
 
-          if [[ "$STATUS" == "failure" ]]; then
-            # Failure pings fire on every channel. version/channel may be empty
-            # when the planning step itself failed, so fall back gracefully and
-            # lean on the workflow run link as the actionable detail.
-            HEADER="❌ Supabase CLI release failed (${CHANNEL:-unknown} channel)"
-            FALLBACK_TEXT="❌ Supabase CLI release failed on the ${CHANNEL:-unknown} channel"
-            DETAILS="*Channel:* ${CHANNEL:-unknown}\n*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Workflow run:* <${RUN_URL}|view failed run>"
-            if [[ -n "$VERSION" ]]; then
-              DETAILS="*Version:* v${VERSION}\n${DETAILS}"
-            fi
-            payload=$(cat <<EOF
+          CONTEXT_TEXT="${REPO}"
+          if [[ -n "$CHANNEL" ]]; then
+            CONTEXT_TEXT="Channel: ${CHANNEL} • ${REPO}"
+          fi
+
+          case "$STATUS" in
+            success)
+              HEADER="🚀 ${PACKAGE} v${VERSION} released"
+              if [[ "$CHANNEL" == "beta" ]]; then
+                HEADER="🚀 ${PACKAGE} v${VERSION} released (beta)"
+              fi
+              FALLBACK_TEXT="🚀 ${PACKAGE} v${VERSION} has been released"
+              DETAILS="*Changelog:* <${CHANGELOG_URL}|${TAG_PREFIX}${VERSION} release notes>\n*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Workflow run:* <${RUN_URL}|view run>"
+              if [[ -n "$NPM_PACKAGE" ]]; then
+                DETAILS="*npm:* <https://www.npmjs.com/package/${NPM_PACKAGE}/v/${VERSION}|${NPM_PACKAGE}@${VERSION}>\n${DETAILS}"
+              fi
+              ;;
+            failure)
+              # version/channel may be empty when the planning job itself failed, so
+              # fall back gracefully and lean on the workflow run link as the
+              # actionable detail.
+              HEADER="❌ ${PACKAGE} release failed"
+              FALLBACK_TEXT="❌ ${PACKAGE} release failed"
+              if [[ -n "$CHANNEL" ]]; then
+                HEADER="❌ ${PACKAGE} release failed (${CHANNEL} channel)"
+                FALLBACK_TEXT="❌ ${PACKAGE} release failed on the ${CHANNEL} channel"
+              fi
+              DETAILS="*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Workflow run:* <${RUN_URL}|view failed run>"
+              if [[ -n "$CHANNEL" ]]; then
+                DETAILS="*Channel:* ${CHANNEL}\n${DETAILS}"
+              fi
+              if [[ -n "$VERSION" ]]; then
+                DETAILS="*Version:* v${VERSION}\n${DETAILS}"
+              fi
+              ;;
+            awaiting-approval)
+              # The approval itself happens on the workflow run page (Approve button +
+              # the plan job's evidence summary) — an incoming webhook is one-way and
+              # cannot host an interactive approval, so this message is the pager, not
+              # the gate.
+              HEADER="⏳ ${PACKAGE} v${VERSION} awaiting release approval"
+              FALLBACK_TEXT="⏳ ${PACKAGE} v${VERSION} is awaiting release approval"
+              DETAILS="*Version:* v${VERSION}\n*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Review and approve:* <${RUN_URL}|workflow run>"
+              ;;
+            declined)
+              HEADER="🛑 ${PACKAGE} v${VERSION} release not approved"
+              FALLBACK_TEXT="🛑 ${PACKAGE} v${VERSION} release was not approved"
+              DETAILS="A reviewer rejected the pending deployment.\n*Version:* v${VERSION}\n*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Workflow run:* <${RUN_URL}|view run>"
+              ;;
+            *)
+              echo "Unknown status: ${STATUS}" >&2
+              exit 1
+              ;;
+          esac
+
+          payload=$(cat <<EOF
           {
             "text": "${FALLBACK_TEXT}",
             "blocks": [
@@ -69,46 +133,11 @@ jobs:
               {
                 "type": "context",
                 "elements": [
-                  { "type": "mrkdwn", "text": "${REPO}" }
+                  { "type": "mrkdwn", "text": "${CONTEXT_TEXT}" }
                 ]
               }
             ]
           }
           EOF
-            )
-          else
-            HEADER="🚀 Supabase CLI v${VERSION} released"
-            if [[ "$CHANNEL" == "beta" ]]; then
-              HEADER="🚀 Supabase CLI v${VERSION} released (beta)"
-            fi
-
-            CHANGELOG_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
-
-            payload=$(cat <<EOF
-          {
-            "text": "🚀 Supabase CLI Version ${VERSION} has been released",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "${HEADER}", "emoji": true }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Changelog:* <${CHANGELOG_URL}|v${VERSION} release notes>\n*Commit:* <${COMMIT_URL}|${SHORT_SHA}>\n*Workflow run:* <${RUN_URL}|view run>"
-                }
-              },
-              {
-                "type": "context",
-                "elements": [
-                  { "type": "mrkdwn", "text": "Channel: ${CHANNEL:-n/a} • ${REPO}" }
-                ]
-              }
-            ]
-          }
-          EOF
-            )
-          fi
-
+          )
           curl -fsSL -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK"

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -149,7 +149,9 @@ elsewhere in the monorepo never releases `@supabase/config`, and vice versa.
   a human approves the `config-release` GitHub environment (reviewing the plan job's step summary:
   release notes + type-surface diff); then an OIDC/provenance publish job publishes **that exact
   tarball** (`npm publish <tgz> --ignore-scripts` — no rebuild, no repack, no lifecycle scripts:
-  the approved bytes are the published bytes).
+  the approved bytes are the published bytes). After publishing, the job verifies the version is
+  registry-visible with the reviewed tarball's integrity and the expected dist-tag before pushing
+  the `config-v*` tag.
 - **`package.json`'s committed `version` (`0.1.0`) is a placeholder.** The real version is stamped
   into the tarball at pack time (`npm pkg set version` in the plan job) from the computed version —
   never hand-bump the committed field, and never hand-push a `config-v*` tag.
@@ -182,3 +184,7 @@ release fails unexpectedly, and restore them if repo or npm settings are ever re
    tokens from). The last `config-v*` tag is the version oracle: a stray hand-pushed tag
    permanently skews versioning, and a deleted tag wedges the next plan on an already-published
    version.
+5. **The `SLACK_RELEASE_WEBHOOK` repo secret** (shared with the CLI release train — the
+   cli-deployer-notifier Slack app) backs the release notifications: approval-needed ping, success,
+   and failure/declined. If it's missing or rotated, the notify jobs fail and the run shows red, but
+   the release itself still completes since nothing depends on the notify jobs.


### PR DESCRIPTION
Reuses the CLI release train's Slack webhook (`SLACK_RELEASE_WEBHOOK`, the cli-deployer-notifier app) for the `@supabase/config` release pipeline, covering both halves of the release lifecycle: paging reviewers when a release is awaiting approval, and confirming the publish actually landed.

## What changed

- **`slack-notify.yml`** is generalized beyond the CLI: a required `package` display-name input, `tag_prefix` so changelog links can point at `config-v*` tags, an optional `npm_package` input that adds an npm version-page link to success messages, and two new statuses — `awaiting-approval` and `declined`. Unknown statuses now fail the step instead of silently rendering as success.
- **`release.yml`** passes the new required `package` input at both call sites. CLI notification firing conditions are unchanged; payload deltas are cosmetic copy only.
- **`release-config.yml`**:
  - `notify-slack-approval` pings the channel when a real (non-dry) release arms the `config-release` environment gate. It needs only `plan`, so it runs while the publish job sits in `waiting` — the message links to the run, where the Approve button and the plan job's evidence summary live. The webhook is one-way, so the approval click itself deliberately stays on GitHub.
  - A new **"Verify the release is live on npm"** step runs after `npm publish` and before the tag push: it probes the registry with backoff (~2 min budget, `--prefer-online`) until the version resolves, then requires the packument's `dist.integrity` to match the reviewed tarball and the dist-tag to point at the published version. The success notification therefore means registry-visible with the approved bytes, not merely "the job didn't error". The step runs no package-controlled code, preserving the publish job's `id-token: write` boundary.
  - `notify-slack` posts the success message (npm + changelog links) via the implicit `success()` gate — dry runs and no-release pushes skip publish and stay silent.
  - `classify-failure` + `notify-slack-failure` report broken releases. The classifier reads the run's approvals record (`GET .../actions/runs/{run_id}/approvals`) and classifies on the **last** review's state, so a reviewer rejection is announced as "release not approved" instead of a broken release, while a reject → re-run → approve → genuine-failure sequence still pages as a real failure. The notify job fails open: if the classifier itself breaks, the page still goes out as a plain failure.
- **`packages/config/AGENTS.md`** documents the webhook secret as standing invariant 5 (notify jobs are terminal — a missing/rotated webhook reddens the run but cannot affect the release) and the verify step in the publish sequence.

## Reviewer notes

- Rejection semantics were verified against GitHub docs: rejecting a pending deployment marks the waiting job **failed**, so `failure()` fires and the declined path is reachable; the approvals endpoint returns `state ∈ approved|rejected|pending` and is readable with the default token plus job-level `permissions: actions: read`.
- The Slack payload stays heredoc-built rather than `jq --arg`: every new input is a workflow-file literal at all five call sites, and a `jq --arg` migration would re-escape the literal `\n` sequences the message bodies rely on. Considered and deliberately not done here.
- There is no automated exercise of these workflows in CI (actionlint config exists but nothing runs it — possible follow-up); this diff was validated with actionlint locally and by executing the notifier script offline for every status/input combination.
