### PR TITLE
test(config): stop a broken pipe preempting the exit-code diagnosis

### DIFF
--- a/packages/config/scripts/semantic-release-path-filter.ts
+++ b/packages/config/scripts/semantic-release-path-filter.ts
@@ -51,6 +51,19 @@ const releaseNotesGenerator: ReleaseNotesGeneratorPlugin = require("@semantic-re
 export const PACKAGE_PATH_PREFIX = "packages/config/";
 
 /**
+ * Whether a write failed because the reader is gone.
+ *
+ * Node and Bun both tag this as `EPIPE` on the error object; the message text
+ * differs between them and is not matched.
+ */
+function isBrokenPipe(cause: unknown): boolean {
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+  return cause.code === "EPIPE";
+}
+
+/**
  * Resolves which of `commits` touch a path under {@link PACKAGE_PATH_PREFIX},
  * using ONE batched `git diff-tree --stdin -r --root --name-only -z`
  * subprocess rather than one per commit — the first release analyzes the
@@ -107,8 +120,21 @@ export async function filterCommitsToPackage<T extends { hash: string }>(
   // is one runtime port away — don't rely on the buffering behavior.
   const stdoutText = new Response(proc.stdout).text();
   const stderrText = new Response(proc.stderr).text();
-  await proc.stdin.write(`${hashes.join("\n")}\n`);
-  await proc.stdin.end();
+  // A `git` that rejects its arguments — a `cwd` outside any repository, say —
+  // exits before it reads a single hash, and writing to a process that has
+  // already gone raises EPIPE. Whether that happens is a race against process
+  // startup, so surfacing it would make the failure mode nondeterministic:
+  // sometimes `EPIPE: broken pipe, send`, sometimes the real diagnosis. The
+  // exit code and stderr below are the diagnosis, so a broken pipe here is
+  // dropped and the reporting left to them.
+  try {
+    await proc.stdin.write(`${hashes.join("\n")}\n`);
+    await proc.stdin.end();
+  } catch (cause) {
+    if (!isBrokenPipe(cause)) {
+      throw cause;
+    }
+  }
 
   const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutText, stderrText]);
   if (exitCode !== 0) {


### PR DESCRIPTION
## Summary

`filterCommitsToPackage` feeds commit hashes to `git diff-tree --stdin` over the subprocess's stdin. A `git` that rejects its arguments — a `cwd` outside any repository, say — exits before it reads a single hash, so the write that follows can land on a process that has already gone and raise `EPIPE: broken pipe, send`.

Which error surfaces is a race against process startup: green on an idle machine, red on a loaded CI runner. The exit code and stderr below the write are the real diagnosis, so a broken pipe on stdin is now dropped and the reporting left to them. Any other write failure still throws.

`isBrokenPipe` matches on the `EPIPE` code rather than the message text, since Node and Bun word it differently.

## Context

Split out of the workers stack. This landed on `FUNC-853/workers-logs-command` (#6410) to stabilise that branch's CI, but it has nothing to do with workers — it is a `packages/config` release-script fix, and it should not merge or revert with the workers work. Raised in review on #6410.

Carries one fix on top of the original commit: `isBrokenPipe` had been inserted between `filterCommitsToPackage`'s JSDoc and the function itself, orphaning the doc. The helper now sits above it.
