### PR TITLE
chore: relax `devEngines.packageManager` requirements

### DIFF
--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -131,9 +131,6 @@ jobs:
           PREVIEW_URL: ${{ steps.preview-metadata.outputs.preview_url }}
         run: |
           set -euo pipefail
-          # Run outside the checkout: npm enforces the root package.json's
-          # devEngines.packageManager (pnpm) against itself and would refuse.
-          cd "${RUNNER_TEMP}"
           npx --yes "${PREVIEW_URL}" --version
 
   comment:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "12.3.0",
-      "onFail": "error"
+      "onFail": "warn"
     }
   }
 }


### PR DESCRIPTION
<!--
Before opening this PR, confirm the linked issue is open and carries the
`open-for-contribution` label. PRs from external contributors that don't follow
the workflow in CONTRIBUTING.md are closed automatically.
@supabase members working from Linear tickets are exempt.
-->

## Summary

In https://github.com/supabase/cli/pull/6424, I added a strict `onFail: 'error'` property so any time someone uses `npm`, `yarn,` or an incorrect `pnpm` version, those CLIs error out.

This was a bit aggressive — we use the `npm` CLI for a variety of things related to our release process. Rather than backport all of those `npm` usages to `pnpm`, I opted to update `onFail` to be `warn`.

That should unblock one error in our release process, hopefully that's all of them? I'm not sure what to make of [this error](https://github.com/supabase/cli/actions/runs/33785688700/job/100750659098) 🤔