### PR TITLE
chore: force LF line endings for pnpm patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# pnpm 12 parses patch files with a Rust patch parser that rejects a carriage
+# return in the `---`/`+++` header lines. Git for Windows checks text files out
+# with CRLF by default, which broke `pnpm install` on the Windows release
+# smoke-test. Keep patch files LF everywhere.
+patches/*.patch text eol=lf


### PR DESCRIPTION
## What

Adds a root `.gitattributes` that pins `patches/*.patch` to LF line endings on checkout.

## Why

The Windows `smoke-test` job in the Release workflow has failed on every release attempt since #6424 bumped pnpm from 11.4.0 to 12.3.0 (first failure: [run 33785688700](https://github.com/supabase/cli/actions/runs/33785688700/job/100750659098)):

```
ERR_PNPM_INVALID_PATCH
Applying patch "patches/@libpg-query__parser@17.6.10.patch" failed:
error parsing patch: invalid char in unquoted filename
```

pnpm 12 is the Rust CLI and parses `patchedDependencies` files with the [`diffy`](https://github.com/bmwill/diffy) crate. The pinned version (0.5.1) splits the `---`/`+++` header lines at `\n` only, so a CRLF file leaves a carriage return attached to the filename and the parser rejects it. Git for Windows defaults to `core.autocrlf=true` and this repo had no `.gitattributes`, so the patch file was checked out as CRLF on the Windows runner. pnpm 11's JavaScript parser tolerated this, which is why the same job passed before the bump.

Reproduced locally with a minimal project and a fresh store: pnpm 12.3.0 fails on a CRLF patch and succeeds on the same file with LF; pnpm 11.4.0 accepts both.

`diffy` fixed this in 0.5.2 ([bmwill/diffy#87](https://github.com/bmwill/diffy/pull/87)), but pnpm 12.3.0, 12.3.1, and `main` still pin 0.5.1, so a pnpm bump does not help yet. Forcing LF for patch files fixes the checkout on every platform, including contributors on Windows.

Because the smoke-test gates `publish`, this failure has also blocked the last three feature releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)