### PR TITLE
ci(cli): analyze releases from commit titles

### DIFF
--- a/apps/cli/docs/release-process.md
+++ b/apps/cli/docs/release-process.md
@@ -220,7 +220,7 @@ Production releases live in a single `[.github/workflows/release.yml](../../../.
 
 `alpha` is reserved for the v3 rewrite (`next` shell), released only on demand. `beta` auto-publishes on every merge to `develop` (legacy shell). `stable` auto-publishes after a develop→main fast-forward, which itself happens when the weekly `[deploy.yml](../../../.github/workflows/deploy.yml)` cron PR is approved (the FF push to `main` re-fires `release.yml` via the `push: branches: [main]` trigger).
 
-Beta + stable versions are computed by `cycjimmy/semantic-release-action` from conventional commits (`feat:` → minor, `fix:` → patch, `BREAKING CHANGE` → major). The `release` config lives in `apps/cli/package.json` and is configured with `prerelease: beta` on the `develop` branch, so develop pushes emit `X.Y.Z-beta.N` and main pushes emit `X.Y.Z` (suffix dropped).
+Beta + stable versions are computed by `cycjimmy/semantic-release-action` from the first line of each squash commit (the PR title). Conventional commit titles use `feat:` → minor, `fix:`, `perf:`, or `revert:` → patch, and `!` after the type or scope (`feat!:` / `fix(scope)!:`) → major. Commit bodies, including `BREAKING CHANGE` notes, are ignored for version calculation. The `release` config lives in `apps/cli/package.json` and is configured with `prerelease: beta` on the `develop` branch, so develop pushes emit `X.Y.Z-beta.N` and main pushes emit `X.Y.Z` (suffix dropped).
 
 ```mermaid
 flowchart TD

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -118,7 +118,7 @@
       }
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      "./scripts/analyze-commits-title.js",
       "@semantic-release/release-notes-generator"
     ]
   }

--- a/apps/cli/scripts/analyze-commits-title.js
+++ b/apps/cli/scripts/analyze-commits-title.js
@@ -1,0 +1,63 @@
+const titlePattern = /^(?<type>\w+)(?:\((?<scope>.*)\))?(?<breaking>!)?: (.*)$/;
+
+const releaseRank = {
+  patch: 1,
+  minor: 2,
+  major: 3,
+};
+
+function highestRelease(current, candidate) {
+  if (!current || releaseRank[candidate] > releaseRank[current]) {
+    return candidate;
+  }
+
+  return current;
+}
+
+export function analyzeCommits(_pluginConfig, context) {
+  let releaseType = null;
+
+  for (const commit of context.commits) {
+    const title = typeof commit.message === "string" ? commit.message.split(/\r?\n/, 1)[0] : "";
+    if (!title.trim()) {
+      context.logger.log("Skipping commit %s with empty title", commit.hash);
+      continue;
+    }
+
+    context.logger.log("Analyzing commit: %s", title);
+    const match = titlePattern.exec(title);
+    if (!match) {
+      context.logger.log("The commit should not trigger a release");
+      continue;
+    }
+
+    const { type, breaking } = match.groups;
+    const commitReleaseType =
+      breaking === "!"
+        ? "major"
+        : type === "feat" || type === "FEAT"
+          ? "minor"
+          : type === "fix" || type === "FIX" || type === "perf" || type === "revert"
+            ? "patch"
+            : null;
+
+    if (!commitReleaseType) {
+      context.logger.log("The commit should not trigger a release");
+      continue;
+    }
+
+    context.logger.log("The release type for the commit is %s", commitReleaseType);
+    releaseType = highestRelease(releaseType, commitReleaseType);
+    if (releaseType === "major") {
+      break;
+    }
+  }
+
+  context.logger.log(
+    "Analysis of %s commits complete: %s release",
+    context.commits.length,
+    releaseType || "no",
+  );
+
+  return releaseType;
+}

--- a/apps/cli/scripts/backfill-release-notes.ts
+++ b/apps/cli/scripts/backfill-release-notes.ts
@@ -21,7 +21,7 @@
 //   --apply  Update the GitHub Release body via `gh release edit`.
 //            Without it, raw markdown notes are printed to stdout.
 import { $ } from "bun";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -47,6 +47,37 @@ const repoRoot = (await $`git rev-parse --show-toplevel`.text()).trim();
 const cliDir = path.join(repoRoot, "apps/cli");
 
 const rootPkg = JSON.parse(await readFile(path.join(cliDir, "package.json"), "utf8"));
+
+function releasePluginSpecifier(plugin: unknown): string | undefined {
+  if (typeof plugin === "string") return plugin;
+  if (Array.isArray(plugin) && typeof plugin[0] === "string") return plugin[0];
+  return undefined;
+}
+
+async function copyLocalReleasePlugins(clone: string): Promise<void> {
+  const plugins = Array.isArray(rootPkg.release?.plugins) ? rootPkg.release.plugins : [];
+  const historicalCliDir = path.join(clone, "apps/cli");
+
+  for (const plugin of plugins) {
+    const specifier = releasePluginSpecifier(plugin);
+    if (!specifier || path.isAbsolute(specifier) || !specifier.startsWith(".")) continue;
+
+    const sourcePath = path.resolve(cliDir, specifier);
+    const relativePath = path.relative(cliDir, sourcePath);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
+      throw new Error(`Local release plugin must stay inside apps/cli: ${specifier}`);
+    }
+
+    const destinationPath = path.join(historicalCliDir, relativePath);
+    await mkdir(path.dirname(destinationPath), { recursive: true });
+    await copyFile(sourcePath, destinationPath);
+  }
+}
+
 const repoField = rootPkg.repository?.url ?? rootPkg.repository ?? "";
 const repoUrl = `${String(repoField)
   .replace(/^git\+/, "")
@@ -163,6 +194,7 @@ try {
   const clonePkg = JSON.parse(await readFile(clonePkgPath, "utf8"));
   clonePkg.release = rootPkg.release;
   await writeFile(clonePkgPath, `${JSON.stringify(clonePkg, null, 2)}\n`);
+  await copyLocalReleasePlugins(clone);
 
   // semantic-release runs `git ls-remote <repositoryUrl> <branch>` and
   // silently exits with "behind remote" when the remote tip differs from

--- a/knip.json
+++ b/knip.json
@@ -13,7 +13,8 @@
         "src/shared/cli/bin.ts",
         "src/**/*.test.ts",
         "src/**/*.e2e.test.ts",
-        "src/**/*.live.test.ts"
+        "src/**/*.live.test.ts",
+        "scripts/analyze-commits-title.js"
       ],
       "ignore": [
         "scripts/*.ts",


### PR DESCRIPTION
## Summary

- calculate CLI release significance from the squash commit title only
- keep conventional title semantics for patch, minor, and explicit breaking changes
- ignore commit bodies when determining versions

## Context

A maintenance commit body was interpreted as a breaking-change note and incorrectly started a v3 beta line. PR titles are already enforced and become squash commit titles, so they are the intended versioning boundary.