### PR TITLE
test(cli): narrow `config pull` live pin (CLI-2324)

### DIFF
--- a/apps/cli/src/legacy/commands/config/pull/pull.live.test.ts
+++ b/apps/cli/src/legacy/commands/config/pull/pull.live.test.ts
@@ -5,19 +5,25 @@ import { requireLiveSuccess, test } from "../../../../../tests/helpers/live.ts";
 // Golden path only: the one thing mocks cannot prove is a real
 // `GET /v2/projects/{ref}/config` response decoding, planning, and writing
 // cleanly against a real (freshly-initialized) `supabase/config.toml`, and
-// that a second run against the SAME project converges to nothing (the
+// that a second run against the SAME project leaves nothing to write (the
 // convergence check's own real-world counterpart — branch coverage lives in
 // pull.integration.test.ts). The `workspace` fixture behind `cli` is a fresh
 // `supabase init` project directory.
-test("pulls remote config into a fresh project, converging to nothing on a second run", async ({
+test("pulls remote config into a fresh project, leaving nothing to write on a second run", async ({
   cli,
   project,
 }) => {
-  const first = await cli(["config", "pull", "--project-ref", project.ref, "--yes"]);
-  expect(`${first.stdout}${first.stderr}`).not.toContain("Unauthorized");
+  const args = ["config", "pull", "--project-ref", project.ref, "--yes", "--output-format", "json"];
+  const first = await cli(args);
   requireLiveSuccess(first, "config pull");
+  expect(JSON.parse(first.stdout)).toEqual(expect.objectContaining({ wrote: true }));
 
-  const second = await cli(["config", "pull", "--project-ref", project.ref, "--yes"]);
+  const second = await cli(args);
   requireLiveSuccess(second, "config pull");
-  expect(second.stdout).toContain("No config differences found.");
+  expect(JSON.parse(second.stdout)).toEqual(
+    expect.objectContaining({
+      wrote: false,
+      scope: expect.objectContaining({ present: expect.arrayContaining(["auth"]) }),
+    }),
+  );
 });


### PR DESCRIPTION
## TL;DR 

spotted in: https://github.com/supabase/cli/actions/runs/33807759564/job/100822219503
passes now: https://github.com/supabase/cli/actions/runs/33867343063

## ref:
- closes: CLI-2324
- same as: https://github.com/supabase/cli/pull/6437