### PR TITLE
ci(cli): cache only the pnpm content store, not the virtual store

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,21 +23,34 @@ runs:
       with:
         version: 2026.9.0
 
-    # actions/cache-restored pnpm global virtual-store links are unusable on Windows; fresh installs reconstruct them.
     - name: Resolve pnpm store path
-      if: inputs.dependency-cache == 'true' && runner.os != 'Windows'
+      if: inputs.dependency-cache == 'true'
       id: pnpm-store
       shell: bash
       run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
+    # Cache only the content-addressable half of the store (package files plus
+    # the SQLite index), never the global virtual store under links/. That
+    # directory is a web of directory links between packages: symlinks on
+    # POSIX, NTFS junctions on Windows. actions/cache round-trips it through
+    # tar, and on Windows the junctions do not come back as traversable
+    # directories. pnpm then trusts every restored links/ directory as complete
+    # and skips relinking, so the first dependency resolved through a restored
+    # junction fails (release smoke-test, Sept 2026). Rebuilding links/ from the
+    # cached files is hardlink-only and needs no network, and pnpm itself notes
+    # the global virtual store has little value in CI. The key prefix is bumped
+    # so restores never match the earlier whole-store archives, which still
+    # carry a links/ tree.
     - name: Configure pnpm dependency cache
-      if: inputs.dependency-cache == 'true' && runner.os != 'Windows'
+      if: inputs.dependency-cache == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ${{ steps.pnpm-store.outputs.path }}
-        key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+        path: |
+          ${{ steps.pnpm-store.outputs.path }}/files
+          ${{ steps.pnpm-store.outputs.path }}/index*
+        key: pnpm-store-files-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          pnpm-store-${{ runner.os }}-${{ runner.arch }}-
+          pnpm-store-files-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Resolve Go cache paths
       if: inputs.dependency-cache == 'true'


### PR DESCRIPTION
## Summary

Since #6424 enabled `virtualStoreType: global`, `pnpm store path` includes `links/`, the global virtual store. It is a tree of directory links between packages: symlinks on POSIX, NTFS junctions on Windows. The shared setup action cached that whole directory, and on Windows the junctions do not survive the actions/cache tar round trip as traversable directories. pnpm then trusts every restored `links/` directory as complete and skips relinking, so the first dependency resolved through a restored junction fails. That is the `DiscoveryError: Unable to resolve @typescript/typescript-win32-x64` from the root `prepare` script in [this release run](https://github.com/supabase/cli/actions/runs/33854068778/job/100967241418).

The failure was deterministic, not transient: every Windows release smoke-test with a pnpm-store cache hit failed, and the only success with the new store layout was the cache-miss run that populated the cache. The earlier Windows failures that week were the unrelated CRLF patch-file problem fixed in #6461.

## Changes

- Cache only `files/` and the SQLite index of the pnpm store, never `links/`. pnpm rebuilds the virtual store from the cached files with hardlinks and no network. The first Linux jobs after #6424 already demonstrated this path when they restored an older files-only archive via `restore-keys`.
- Bump the cache key prefix to `pnpm-store-files-…`. actions/cache restores whatever an archive contains regardless of the current `path` input, so without the bump Windows would keep restoring the existing archive that carries `links/` until the lockfile changed.
- Remove the Windows-only cache exclusion from #6464, restoring dependency caching on the Windows release jobs.

## Reviewer context

The release workflow only runs on `develop`, so PR CI exercises the new caching on Linux but not the Windows smoke-test job. The first run on each OS will be a cache miss under the new prefix. The second Windows release run after merge is the real confirmation, since it is the first cache hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
