### PR TITLE
fix: bump vector to 0.58.0-alpine

### DIFF
--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -8,7 +8,7 @@ FROM supabase/postgres-meta:v0.99.0 AS pgmeta
 FROM supabase/studio:2026.08.24-sha-8ec45b2 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.74.3 AS edgeruntime
-FROM timberio/vector:0.53.0-alpine AS vector
+FROM timberio/vector:0.58.0-alpine AS vector
 FROM supabase/supavisor:2.9.12 AS supavisor
 FROM supabase/gotrue:v2.196.0 AS gotrue
 FROM supabase/realtime:v2.130.0 AS realtime

--- a/packages/stack/src/ServiceCatalog.ts
+++ b/packages/stack/src/ServiceCatalog.ts
@@ -289,7 +289,7 @@ export const SERVICE_CATALOG = {
   vector: {
     name: "vector",
     configKey: "vector",
-    defaultVersion: "0.53.0-alpine",
+    defaultVersion: "0.58.0-alpine",
     runtimeSupport: "docker-only",
     artifact: {
       docker: { registry: SUPABASE_GHCR_REGISTRY, repository: "vector" },


### PR DESCRIPTION
## TL;DR
bumps vector to `0.58.0-alpine` — `0.53.0-alpine` segfaults during `execve` on native arm64 with newer Docker Desktop kernels.

## ref
- closes #6479