### PR TITLE
fix(cli): bump vector image pin to 0.58.0-alpine

### DIFF
--- a/apps/cli-go/pkg/config/templates/Dockerfile
+++ b/apps/cli-go/pkg/config/templates/Dockerfile
@@ -8,7 +8,7 @@ FROM supabase/postgres-meta:v0.99.0 AS pgmeta
 FROM supabase/studio:2026.08.24-sha-8ec45b2 AS studio
 FROM darthsim/imgproxy:v3.8.0 AS imgproxy
 FROM supabase/edge-runtime:v1.74.3 AS edgeruntime
-FROM timberio/vector:0.53.0-alpine AS vector
+FROM timberio/vector:0.58.0-alpine AS vector
 FROM supabase/supavisor:2.9.12 AS supavisor
 FROM supabase/gotrue:v2.196.0 AS gotrue
 FROM supabase/realtime:v2.130.0 AS realtime

--- a/apps/cli/src/legacy/commands/start/services/vector.service.unit.test.ts
+++ b/apps/cli/src/legacy/commands/start/services/vector.service.unit.test.ts
@@ -305,7 +305,7 @@ describe("legacyBuildVectorContainerSpec", () => {
     vi.stubEnv("SUPABASE_USE_SLIM_IMAGES", "1");
     const spec = legacyBuildVectorContainerSpec({
       ...base,
-      image: "ghcr.io/supabase/cli/vector:0.53.0",
+      image: "ghcr.io/supabase/cli/vector:0.58.0",
     });
     expect(spec.entrypoint).toBe("sh");
     expect(spec.secretFiles).toBeUndefined();

--- a/apps/cli/src/shared/services/slim-images.unit.test.ts
+++ b/apps/cli/src/shared/services/slim-images.unit.test.ts
@@ -71,8 +71,8 @@ describe("toSlimImage", () => {
   });
 
   it("strips vector's docker.io -alpine variant suffix", () => {
-    expect(toSlimImage("vector", "timberio/vector:0.53.0-alpine")).toBe(
-      "ghcr.io/supabase/cli/vector:0.53.0",
+    expect(toSlimImage("vector", "timberio/vector:0.58.0-alpine")).toBe(
+      "ghcr.io/supabase/cli/vector:0.58.0",
     );
   });
 

--- a/packages/stack/src/ServiceCatalog.ts
+++ b/packages/stack/src/ServiceCatalog.ts
@@ -289,7 +289,7 @@ export const SERVICE_CATALOG = {
   vector: {
     name: "vector",
     configKey: "vector",
-    defaultVersion: "0.53.0-alpine",
+    defaultVersion: "0.58.0-alpine",
     runtimeSupport: "docker-only",
     artifact: {
       docker: { registry: SUPABASE_GHCR_REGISTRY, repository: "vector" },


### PR DESCRIPTION
## Summary
- Bump the hardcoded Vector image from `timberio/vector:0.53.0-alpine` to `0.58.0-alpine` in the Go Dockerfile template and `@supabase/stack` `ServiceCatalog` default, targeting the native arm64 segfault / `execve` EFAULT on Apple Silicon reported in #6479.
- Update unit tests that asserted the old pin (`slim-images` alpine-strip example and vector slim-image container-spec fixture).

Closes #6479

## Contribution gate
Commented on #6479 requesting the `open-for-contribution` label per CONTRIBUTING.md. Opening this PR so the fix is reviewable; please add the label so the Contribution Gate does not auto-close it.

## Test plan
- [x] `bun --bun vitest run --project unit src/versions.unit.test.ts` in `packages/stack` (20 passed)
- [x] `bun --bun vitest run --project unit` for `slim-images.unit.test.ts` and `vector.service.unit.test.ts` in `apps/cli` (69 passed)
- [x] `bun run packages/stack/scripts/sync-versions-from-dockerfile.ts --check` (in sync)
- [ ] On Apple Silicon: `docker run --rm --platform linux/arm64 --entrypoint vector public.ecr.aws/supabase/vector:0.58.0-alpine --version` (or the timberio tag) exits 0
- [ ] `supabase start` with analytics enabled completes without vector health-check failure