### PR TITLE
refactor(config): consolidate command-family helpers (CLI-2292)

### DIFF
--- a/apps/cli/src/commands/config/config.paths.ts
+++ b/apps/cli/src/commands/config/config.paths.ts
@@ -1,0 +1,106 @@
+/**
+ * Generic path/value helpers for the `config` command family — read a value at a path,
+ * test whether a path is DECLARED, compare two values structurally, key a path for a
+ * Set/Map, and deep-copy-with-replacement at a path. Pure, synchronous, dependency-free
+ * (no Effect, no services, no imports at all), so every module in the family that walks a
+ * `ConfigChange.path` walks it the same way.
+ *
+ * Two deliberate non-consolidations:
+ *
+ *  - `@supabase/config`'s `config-edit.ts` keeps its OWN copies of `isPlainRecord`,
+ *    `pathKey`, `valueAtPath`, `isDeclaredAtPath`, and `deepEqualValue`. That module is
+ *    pinned to `smol-toml` as its only runtime import (ADR 0023) so it stays independently
+ *    embeddable, and its `deepEqualValue` additionally special-cases `SmolToml.TomlDate`
+ *    because it compares raw `smol-toml` parse trees. Never make it import this file, and
+ *    never "unify" the two.
+ *  - `push/push.paths.ts` keeps its own `legacyValueAtPath`: that one deliberately omits
+ *    this file's `Object.hasOwn` guard, so the two are not interchangeable.
+ */
+
+export function legacyConfigPathKey(path: ReadonlyArray<string>): string {
+  return JSON.stringify(path);
+}
+
+export function legacyConfigIsRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function legacyConfigValueAtPath(root: unknown, path: ReadonlyArray<string>): unknown {
+  let current: unknown = root;
+  for (const segment of path) {
+    if (!legacyConfigIsRecord(current) || !Object.hasOwn(current, segment)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+/** Whether `path`'s LAST segment is an own key of its parent — true even when the declared
+ *  value is `undefined`, which is exactly what distinguishes it from
+ *  {@link legacyConfigValueAtPath} returning `undefined`. */
+export function legacyConfigIsDeclaredAtPath(root: unknown, path: ReadonlyArray<string>): boolean {
+  let current: unknown = root;
+  for (const [index, segment] of path.entries()) {
+    if (!legacyConfigIsRecord(current) || !Object.hasOwn(current, segment)) {
+      return false;
+    }
+    if (index < path.length - 1) {
+      current = current[segment];
+    }
+  }
+  return true;
+}
+
+export function legacyConfigDeepEqualValue(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return (
+      a.length === b.length &&
+      a.every((value, index) => legacyConfigDeepEqualValue(value, b[index]))
+    );
+  }
+  if (legacyConfigIsRecord(a) && legacyConfigIsRecord(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every((key) => Object.hasOwn(b, key) && legacyConfigDeepEqualValue(a[key], b[key]))
+    );
+  }
+  return false;
+}
+
+/**
+ * Deep-copies `root`, replacing the value at `path`. Two consumers today: `pull.plan.ts`'s
+ * fixpoint expansion (projecting a round's writes onto `{config, document}` before
+ * re-diffing) and `pull.handler.ts`'s schema-validation gate (projecting the plan's writes
+ * onto the raw on-disk document shape before decoding it). Never used to produce bytes
+ * written to disk — that is `applyConfigEdits`'s job. The exported-shaped overload preserves
+ * the input's own type (a deep-set never changes an object's shape, only a leaf value); the
+ * implementation itself is intentionally untyped, mirroring `@supabase/config`'s own split
+ * between a typed overload contract and a structurally-unverifiable recursive implementation.
+ */
+export function legacyConfigDeepSetAtPath<T>(
+  root: T,
+  path: ReadonlyArray<string>,
+  value: unknown,
+): T;
+export function legacyConfigDeepSetAtPath(
+  root: unknown,
+  path: ReadonlyArray<string>,
+  value: unknown,
+): unknown {
+  if (path.length === 0) {
+    return value;
+  }
+  const head = path[0];
+  if (head === undefined) {
+    return value;
+  }
+  const rest = path.slice(1);
+  const base: Record<string, unknown> = legacyConfigIsRecord(root) ? root : {};
+  return { ...base, [head]: legacyConfigDeepSetAtPath(base[head], rest, value) };
+}

--- a/apps/cli/src/commands/config/config.paths.unit.test.ts
+++ b/apps/cli/src/commands/config/config.paths.unit.test.ts
@@ -47,6 +47,10 @@ describe("legacyConfigValueAtPath", () => {
   it("returns undefined when the path walks through a non-record intermediate value", () => {
     expect(legacyConfigValueAtPath({ a: 1 }, ["a", "b"])).toBeUndefined();
   });
+
+  it("returns undefined for an inherited (prototype-chain) key, not just an absent own key", () => {
+    expect(legacyConfigValueAtPath({}, ["toString"])).toBeUndefined();
+  });
 });
 
 describe("legacyConfigIsDeclaredAtPath", () => {
@@ -57,6 +61,10 @@ describe("legacyConfigIsDeclaredAtPath", () => {
 
   it("is false for a genuinely absent key", () => {
     expect(legacyConfigIsDeclaredAtPath({}, ["a"])).toBe(false);
+  });
+
+  it("is false for an inherited (prototype-chain) key", () => {
+    expect(legacyConfigIsDeclaredAtPath({}, ["toString"])).toBe(false);
   });
 });
 
@@ -86,5 +94,14 @@ describe("legacyConfigDeepSetAtPath", () => {
   it("creates missing intermediate tables along the path", () => {
     const result = legacyConfigDeepSetAtPath({}, ["a", "b", "c"], 1);
     expect(result).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  it("replaces the whole root when the path is empty", () => {
+    expect(legacyConfigDeepSetAtPath({ a: 1 }, [], { z: 9 })).toEqual({ z: 9 });
+  });
+
+  it("discards an existing scalar at an intermediate segment and replaces it with a table", () => {
+    const result = legacyConfigDeepSetAtPath({ a: 5 }, ["a", "b"], "x");
+    expect(result).toEqual({ a: { b: "x" } });
   });
 });

--- a/apps/cli/src/commands/config/config.paths.unit.test.ts
+++ b/apps/cli/src/commands/config/config.paths.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for config.paths.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  legacyConfigDeepEqualValue,
+  legacyConfigDeepSetAtPath,
+  legacyConfigIsDeclaredAtPath,
+  legacyConfigIsRecord,
+  legacyConfigPathKey,
+  legacyConfigValueAtPath,
+} from "./config.paths.ts";
+
+describe("legacyConfigPathKey", () => {
+  it("distinguishes a single dotted segment from two separate segments", () => {
+    expect(legacyConfigPathKey(["a.b"])).not.toBe(legacyConfigPathKey(["a", "b"]));
+  });
+});
+
+describe("legacyConfigIsRecord", () => {
+  it("accepts plain objects only", () => {
+    expect(legacyConfigIsRecord({})).toBe(true);
+    expect(legacyConfigIsRecord({ a: 1 })).toBe(true);
+  });
+
+  it("rejects arrays, null, primitives", () => {
+    expect(legacyConfigIsRecord([])).toBe(false);
+    expect(legacyConfigIsRecord(null)).toBe(false);
+    expect(legacyConfigIsRecord(undefined)).toBe(false);
+    expect(legacyConfigIsRecord("x")).toBe(false);
+    expect(legacyConfigIsRecord(1)).toBe(false);
+  });
+});
+
+describe("legacyConfigValueAtPath", () => {
+  it("walks nested records", () => {
+    expect(legacyConfigValueAtPath({ a: { b: { c: 1 } } }, ["a", "b", "c"])).toBe(1);
+  });
+
+  it("returns undefined for a missing segment", () => {
+    expect(legacyConfigValueAtPath({ a: { b: 1 } }, ["a", "b", "c"])).toBeUndefined();
+    expect(legacyConfigValueAtPath({}, ["a"])).toBeUndefined();
+  });
+
+  it("returns undefined when the path walks through a non-record intermediate value", () => {
+    expect(legacyConfigValueAtPath({ a: 1 }, ["a", "b"])).toBeUndefined();
+  });
+});
+
+describe("legacyConfigIsDeclaredAtPath", () => {
+  it("is true for a key declared with an explicit undefined value", () => {
+    expect(legacyConfigIsDeclaredAtPath({ a: undefined }, ["a"])).toBe(true);
+    expect(legacyConfigValueAtPath({ a: undefined }, ["a"])).toBeUndefined();
+  });
+
+  it("is false for a genuinely absent key", () => {
+    expect(legacyConfigIsDeclaredAtPath({}, ["a"])).toBe(false);
+  });
+});
+
+describe("legacyConfigDeepEqualValue", () => {
+  it("compares nested records and arrays for equality", () => {
+    expect(legacyConfigDeepEqualValue({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+  });
+
+  it("finds nested records and arrays unequal", () => {
+    expect(legacyConfigDeepEqualValue({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] })).toBe(false);
+    expect(legacyConfigDeepEqualValue([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it("is false for objects with differing key counts", () => {
+    expect(legacyConfigDeepEqualValue({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+});
+
+describe("legacyConfigDeepSetAtPath", () => {
+  it("does not mutate its input object", () => {
+    const original = { a: { b: 1 } };
+    const result = legacyConfigDeepSetAtPath(original, ["a", "b"], 2);
+    expect(original).toEqual({ a: { b: 1 } });
+    expect(result).toEqual({ a: { b: 2 } });
+  });
+
+  it("creates missing intermediate tables along the path", () => {
+    const result = legacyConfigDeepSetAtPath({}, ["a", "b", "c"], 1);
+    expect(result).toEqual({ a: { b: { c: 1 } } });
+  });
+});

--- a/apps/cli/src/commands/config/config.target.ts
+++ b/apps/cli/src/commands/config/config.target.ts
@@ -1,22 +1,31 @@
 import type { SupabaseApiError } from "@supabase/api/effect";
-import { Effect, Option, Predicate } from "effect";
+import { Data, Effect, Option } from "effect";
 
 import { LegacyProjectRefResolver } from "../../config/legacy-project-ref.service.ts";
 import {
+  legacyParentNotLinkedMessage,
+  legacyParentRefInvalidMessage,
+  legacyParentRefTypoHint,
   legacyResolveLinkedParentRef,
   legacyResolveParentScopedProjectRef,
 } from "../../command-internal/legacy-parent-project-ref.ts";
 import { Output } from "../../shared/output/output.service.ts";
 import { legacyResolveBranchProjectRef } from "../../command-internal/legacy-branch-ref.resolver.ts";
+import { legacySanitizeInlineName } from "../../command-internal/legacy-http-errors.ts";
 import {
   LEGACY_BRANCH_PROJECT_REF_PATTERN,
   LEGACY_BRANCH_UUID_PATTERN,
 } from "../../command-internal/legacy-ref-patterns.ts";
+import {
+  actionability,
+  type CliErrorActionabilityDeclaration,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
 
 /**
  * The resolved comparison/pull target for the `config` command family
- * (`diff`, `pull`): a project ref, plus the branch name/UUID `--project-ref`
- * carried when it named one — `undefined` for a ref-shaped or
+ * (`diff`, `pull`, `push`): a project ref, plus the branch name/UUID
+ * `--project-ref` carried when it named one — `undefined` for a ref-shaped or
  * linked-fallback target.
  */
 export interface LegacyConfigTarget {
@@ -25,33 +34,123 @@ export interface LegacyConfigTarget {
 }
 
 /**
- * Per-family error construction for {@link legacyResolveConfigTarget}: every
- * caller keeps its own tagged error classes (built with `mapLegacyHttpError`
- * for the network/status pair) so error identities, messages, and
- * actionability stay family-owned — mirrors `LegacyBranchRefResolveMappers`
- * (`legacy-branch-ref.resolver.ts`). Every constructor receives the raw
- * `target` value the user passed, so each family builds its own
- * message text (`legacyParentNotLinkedMessage`, etc.) itself.
+ * Builds the four target-resolution failures {@link legacyResolveConfigTarget} can raise.
+ * One type parameter, not four: every family's builder set is produced by
+ * {@link legacyConfigTargetErrorsFor}, whose return type unions the four minted classes, so
+ * the resolver never has to infer them position-by-position.
  */
-export interface LegacyConfigTargetErrors<A, B, C, D, E> {
+export interface LegacyConfigTargetErrors<TError> {
   /**
    * `target` was named as a branch, but no project is linked to search for
    * branches under — none of `SUPABASE_PROJECT_ID`,
    * `supabase/.temp/linked-project.json`, or `supabase/.temp/project-ref`
    * yielded a candidate.
    */
-  readonly notLinked: (target: string) => A;
+  readonly notLinked: (target: string) => TError;
   /**
    * `target` was named as a branch, and a parent-project candidate exists
    * but is not ref-shaped — corrupt or stale linked state.
    */
-  readonly parentRefInvalid: (target: string) => B;
+  readonly parentRefInvalid: (target: string) => TError;
   /** `target` named a branch the parent project does not have. */
-  readonly branchNotFound: (target: string) => C;
+  readonly branchNotFound: (target: string) => TError;
   /** The resolved branch has no project ref yet (still provisioning). */
-  readonly branchNotReady: (target: string) => D;
-  /** Maps a branch-lookup (`GET`-by-UUID or `FIND`-by-name) transport/status failure. */
-  readonly mapResolveError: (cause: SupabaseApiError) => Effect.Effect<never, E>;
+  readonly branchNotReady: (target: string) => TError;
+}
+
+/** The constructor shape every minted target-error class has. */
+type LegacyConfigTargetErrorClass<E> = new (args: { readonly message: string }) => E;
+
+/**
+ * Mints one `config` command family's four target-resolution error classes from its name
+ * prefix (`"LegacyConfigDiff"`, `"LegacyConfigPull"`, `"LegacyConfigPush"`). The classes
+ * stay per-family so `_tag`, telemetry fingerprint, and actionability remain family-owned
+ * and distinct; only their (identical) definitions live here.
+ *
+ * The tags are template-interpolated, so `error-actionability-coverage.unit.test.ts`'s
+ * static AST scan cannot see them in THIS file — which is why every caller must re-export
+ * each minted class from its own `*.errors.ts` under the family-prefixed name. That file
+ * still declares other string-literal tags, so its coverage `it()` still registers, and the
+ * runtime half of the guard walks `Object.entries(module)` and verifies these four there.
+ */
+export function legacyMintConfigTargetErrors<Prefix extends string>(prefix: Prefix) {
+  class BranchNotFoundError extends Data.TaggedError(`${prefix}BranchNotFoundError`)<{
+    readonly message: string;
+  }> {
+    get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+      return actionability.invalidInput;
+    }
+  }
+  class BranchNotLinkedError extends Data.TaggedError(`${prefix}BranchNotLinkedError`)<{
+    readonly message: string;
+  }> {
+    get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+      return actionability.projectNotLinked;
+    }
+  }
+  class ParentRefInvalidError extends Data.TaggedError(`${prefix}ParentRefInvalidError`)<{
+    readonly message: string;
+  }> {
+    get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+      return actionability.relinkProject;
+    }
+  }
+  class BranchNotReadyError extends Data.TaggedError(`${prefix}BranchNotReadyError`)<{
+    readonly message: string;
+  }> {
+    get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
+      return { ...actionability.apiStatus, fingerprint_suffix: "branch_not_ready" };
+    }
+  }
+  return { BranchNotFoundError, BranchNotLinkedError, ParentRefInvalidError, BranchNotReadyError };
+}
+
+/**
+ * Wraps a family's four minted classes as the `errors` bundle
+ * {@link legacyResolveConfigTarget} takes. The message text is identical across every
+ * family that resolves a branch-shaped `--project-ref`, so it lives here rather than being
+ * restated in each handler. Four type parameters purely so the declared return type can
+ * UNION them — the resolver itself then needs only one.
+ */
+export function legacyConfigTargetErrorsFor<
+  TNotLinked,
+  TParentRefInvalid,
+  TBranchNotFound,
+  TBranchNotReady,
+>(classes: {
+  readonly notLinked: LegacyConfigTargetErrorClass<TNotLinked>;
+  readonly parentRefInvalid: LegacyConfigTargetErrorClass<TParentRefInvalid>;
+  readonly branchNotFound: LegacyConfigTargetErrorClass<TBranchNotFound>;
+  readonly branchNotReady: LegacyConfigTargetErrorClass<TBranchNotReady>;
+}): LegacyConfigTargetErrors<TNotLinked | TParentRefInvalid | TBranchNotFound | TBranchNotReady> {
+  return {
+    notLinked: (target) => new classes.notLinked({ message: legacyParentNotLinkedMessage(target) }),
+    parentRefInvalid: (target) =>
+      new classes.parentRefInvalid({ message: legacyParentRefInvalidMessage(target) }),
+    branchNotFound: (target) =>
+      new classes.branchNotFound({
+        message: `Branch "${legacySanitizeInlineName(target)}" not found. Run \`supabase branches list\` to see available branches.${legacyParentRefTypoHint(target)}`,
+      }),
+    branchNotReady: (target) =>
+      new classes.branchNotReady({
+        message: `Branch "${legacySanitizeInlineName(target)}" has no project ref yet. Wait for it to finish provisioning, then retry.`,
+      }),
+  };
+}
+
+/**
+ * What {@link legacyResolveConfigTarget} needs to know about a branch-lookup failure to
+ * decide whether it was a 404. Every family's `mapResolveError` comes from
+ * `mapLegacyHttpError`, whose failure union has exactly ONE arm carrying an HTTP status
+ * (its `statusError` class, `{ status, body, message }`); the transport, request-validation,
+ * and request-body arms carry none, and neither do the parent-ref resolver's failures.
+ * Modelling `status` as optional is what lets that whole union satisfy this bound, and turns
+ * the 404 test below into an ordinary typed field read instead of a `Predicate` duck-type
+ * probe. `_tag` is required only so this is not a weak type.
+ */
+export interface LegacyConfigTargetResolveFailure {
+  readonly _tag: string;
+  readonly status?: number | undefined;
 }
 
 /**
@@ -61,14 +160,17 @@ export interface LegacyConfigTargetErrors<A, B, C, D, E> {
  * refinement passed to `Effect.catchIf`) so its own return type — a union of
  * two different `Effect` instantiations — is inferred directly from this
  * function's body instead of backward through `Effect.catch`'s inference.
+ *
+ * Deliberately NOT baked into `mapResolveError`: `config pull` shares ONE mapper across two
+ * call sites (the branch lookup AND the `/v2/projects/{ref}/config` read — see
+ * `pull.errors.ts`'s `LegacyConfigPullReadNetworkError` doc comment), so folding the 404 rule
+ * into the mapper would misreport a 404 from the unrelated config read as "branch not found".
  */
-function reclassifyBranchNotFoundError<E, C>(
+function reclassifyBranchNotFoundError<E extends LegacyConfigTargetResolveFailure, C>(
   cause: E,
   notFoundError: C,
 ): Effect.Effect<never, C | E> {
-  return Predicate.hasProperty("status")(cause) && cause.status === 404
-    ? Effect.fail(notFoundError)
-    : Effect.fail(cause);
+  return cause.status === 404 ? Effect.fail(notFoundError) : Effect.fail(cause);
 }
 
 /**
@@ -90,9 +192,14 @@ function reclassifyBranchNotFoundError<E, C>(
  * interactive project picker rendering under a live "Resolving branch..."
  * spinner.
  */
-export function legacyResolveConfigTarget<A, B, C, D, E>(
+export function legacyResolveConfigTarget<
+  TError,
+  EResolve extends LegacyConfigTargetResolveFailure,
+>(
   requested: Option.Option<string>,
-  errors: LegacyConfigTargetErrors<A, B, C, D, E>,
+  errors: LegacyConfigTargetErrors<TError>,
+  /** Maps a branch-lookup (`GET`-by-UUID or `FIND`-by-name) transport/status failure. */
+  mapResolveError: (cause: SupabaseApiError) => Effect.Effect<never, EResolve>,
 ) {
   return Effect.gen(function* () {
     const output = yield* Output;
@@ -121,8 +228,8 @@ export function legacyResolveConfigTarget<A, B, C, D, E>(
       const resolving =
         output.format === "text" ? yield* output.task("Resolving branch...") : undefined;
       ref = yield* legacyResolveBranchProjectRef(target, parentRef, {
-        mapGetError: errors.mapResolveError,
-        mapFindError: errors.mapResolveError,
+        mapGetError: mapResolveError,
+        mapFindError: mapResolveError,
       }).pipe(
         Effect.tapError(() => resolving?.fail() ?? Effect.void),
         Effect.catch((cause) =>

--- a/apps/cli/src/commands/config/config.target.unit.test.ts
+++ b/apps/cli/src/commands/config/config.target.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for config.target.ts's `legacyMintConfigTargetErrors` factory and
+ * `legacyConfigTargetErrorsFor` builder — independent of any family's own
+ * `*.errors.ts` file, so this test keeps verifying the minting mechanism even
+ * if diff/pull/push's error files change shape entirely (see
+ * `error-actionability-coverage.unit.test.ts`'s runtime/AST-scan split).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  actionability,
+  ErrorActionabilityId,
+} from "../../shared/telemetry/error-actionability.ts";
+import { legacyConfigTargetErrorsFor, legacyMintConfigTargetErrors } from "./config.target.ts";
+
+const PREFIX = "LegacyConfigTestMint";
+
+describe("legacyMintConfigTargetErrors", () => {
+  const classes = legacyMintConfigTargetErrors(PREFIX);
+
+  it("tags BranchNotFoundError as `${prefix}BranchNotFoundError`", () => {
+    expect(new classes.BranchNotFoundError({ message: "x" })._tag).toBe(
+      "LegacyConfigTestMintBranchNotFoundError",
+    );
+  });
+
+  it("tags BranchNotLinkedError as `${prefix}BranchNotLinkedError`", () => {
+    expect(new classes.BranchNotLinkedError({ message: "x" })._tag).toBe(
+      "LegacyConfigTestMintBranchNotLinkedError",
+    );
+  });
+
+  it("tags ParentRefInvalidError as `${prefix}ParentRefInvalidError`", () => {
+    expect(new classes.ParentRefInvalidError({ message: "x" })._tag).toBe(
+      "LegacyConfigTestMintParentRefInvalidError",
+    );
+  });
+
+  it("tags BranchNotReadyError as `${prefix}BranchNotReadyError`", () => {
+    expect(new classes.BranchNotReadyError({ message: "x" })._tag).toBe(
+      "LegacyConfigTestMintBranchNotReadyError",
+    );
+  });
+
+  it("declares BranchNotFoundError as actionability.invalidInput", () => {
+    const instance = new classes.BranchNotFoundError({ message: "x" });
+    expect(instance[ErrorActionabilityId]).toEqual(actionability.invalidInput);
+  });
+
+  it("declares BranchNotLinkedError as actionability.projectNotLinked", () => {
+    const instance = new classes.BranchNotLinkedError({ message: "x" });
+    expect(instance[ErrorActionabilityId]).toEqual(actionability.projectNotLinked);
+  });
+
+  it("declares ParentRefInvalidError as actionability.relinkProject", () => {
+    const instance = new classes.ParentRefInvalidError({ message: "x" });
+    expect(instance[ErrorActionabilityId]).toEqual(actionability.relinkProject);
+  });
+
+  it("declares BranchNotReadyError as actionability.apiStatus with a branch_not_ready fingerprint suffix", () => {
+    const instance = new classes.BranchNotReadyError({ message: "x" });
+    expect(instance[ErrorActionabilityId]).toEqual({
+      ...actionability.apiStatus,
+      fingerprint_suffix: "branch_not_ready",
+    });
+  });
+
+  it("mints genuinely per-call classes, not a cached/shared set, across different prefixes", () => {
+    const a = legacyMintConfigTargetErrors("LegacyConfigTestMintA");
+    const b = legacyMintConfigTargetErrors("LegacyConfigTestMintB");
+    const aTag = new a.BranchNotFoundError({ message: "x" })._tag;
+    const bTag = new b.BranchNotFoundError({ message: "x" })._tag;
+    expect(aTag).toBe("LegacyConfigTestMintABranchNotFoundError");
+    expect(bTag).toBe("LegacyConfigTestMintBBranchNotFoundError");
+    expect(aTag).not.toBe(bTag);
+  });
+});
+
+describe("legacyConfigTargetErrorsFor", () => {
+  it("wraps a minted class set into constructors that produce working, correctly tagged instances", () => {
+    const classes = legacyMintConfigTargetErrors(PREFIX);
+    const errors = legacyConfigTargetErrorsFor({
+      notLinked: classes.BranchNotLinkedError,
+      parentRefInvalid: classes.ParentRefInvalidError,
+      branchNotFound: classes.BranchNotFoundError,
+      branchNotReady: classes.BranchNotReadyError,
+    });
+
+    const error = errors.branchNotFound("some-target");
+    expect(error._tag).toBe("LegacyConfigTestMintBranchNotFoundError");
+    expect(error.message).toContain("some-target");
+  });
+});

--- a/apps/cli/src/commands/config/config.target.unit.test.ts
+++ b/apps/cli/src/commands/config/config.target.unit.test.ts
@@ -8,10 +8,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  actionability,
-  ErrorActionabilityId,
-} from "../../shared/telemetry/error-actionability.ts";
+import { actionability, ErrorActionabilityId } from "../../shared/telemetry/error-actionability.ts";
 import { legacyConfigTargetErrorsFor, legacyMintConfigTargetErrors } from "./config.target.ts";
 
 const PREFIX = "LegacyConfigTestMint";

--- a/apps/cli/src/commands/config/diff/diff.errors.ts
+++ b/apps/cli/src/commands/config/diff/diff.errors.ts
@@ -44,6 +44,9 @@ const targetErrors = legacyMintConfigTargetErrors("LegacyConfigDiff");
 
 /** `--project-ref` named a branch the parent project does not have. */
 export const LegacyConfigDiffBranchNotFoundError = targetErrors.BranchNotFoundError;
+export type LegacyConfigDiffBranchNotFoundError = InstanceType<
+  typeof LegacyConfigDiffBranchNotFoundError
+>;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
@@ -53,6 +56,9 @@ export const LegacyConfigDiffBranchNotFoundError = targetErrors.BranchNotFoundEr
  * classification (link.errors.ts).
  */
 export const LegacyConfigDiffBranchNotLinkedError = targetErrors.BranchNotLinkedError;
+export type LegacyConfigDiffBranchNotLinkedError = InstanceType<
+  typeof LegacyConfigDiffBranchNotLinkedError
+>;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
@@ -60,6 +66,9 @@ export const LegacyConfigDiffBranchNotLinkedError = targetErrors.BranchNotLinked
  * `LegacyLinkParentRefInvalidError`'s classification (link.errors.ts).
  */
 export const LegacyConfigDiffParentRefInvalidError = targetErrors.ParentRefInvalidError;
+export type LegacyConfigDiffParentRefInvalidError = InstanceType<
+  typeof LegacyConfigDiffParentRefInvalidError
+>;
 
 /**
  * The resolved branch has no project ref yet (still provisioning) — guards
@@ -67,6 +76,9 @@ export const LegacyConfigDiffParentRefInvalidError = targetErrors.ParentRefInval
  * `LegacyLinkBranchNotReadyError`'s classification (link.errors.ts).
  */
 export const LegacyConfigDiffBranchNotReadyError = targetErrors.BranchNotReadyError;
+export type LegacyConfigDiffBranchNotReadyError = InstanceType<
+  typeof LegacyConfigDiffBranchNotReadyError
+>;
 
 export class LegacyConfigDiffBranchResolveNetworkError extends Data.TaggedError(
   "LegacyConfigDiffBranchResolveNetworkError",

--- a/apps/cli/src/commands/config/diff/diff.errors.ts
+++ b/apps/cli/src/commands/config/diff/diff.errors.ts
@@ -5,6 +5,7 @@ import {
   ErrorActionabilityId,
   statusCodeActionability,
 } from "../../../shared/telemetry/error-actionability.ts";
+import { legacyMintConfigTargetErrors } from "../config.target.ts";
 
 interface NetworkErrorArgs {
   readonly message: string;
@@ -39,14 +40,10 @@ export class LegacyConfigDiffOutputFlagUnsupportedError extends Data.TaggedError
   }
 }
 
+const targetErrors = legacyMintConfigTargetErrors("LegacyConfigDiff");
+
 /** `--project-ref` named a branch the parent project does not have. */
-export class LegacyConfigDiffBranchNotFoundError extends Data.TaggedError(
-  "LegacyConfigDiffBranchNotFoundError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.invalidInput;
-  }
-}
+export const LegacyConfigDiffBranchNotFoundError = targetErrors.BranchNotFoundError;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
@@ -55,39 +52,21 @@ export class LegacyConfigDiffBranchNotFoundError extends Data.TaggedError(
  * yielded a candidate. Mirrors `LegacyLinkBranchNotLinkedError`'s
  * classification (link.errors.ts).
  */
-export class LegacyConfigDiffBranchNotLinkedError extends Data.TaggedError(
-  "LegacyConfigDiffBranchNotLinkedError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.projectNotLinked;
-  }
-}
+export const LegacyConfigDiffBranchNotLinkedError = targetErrors.BranchNotLinkedError;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
  * exists but is not ref-shaped — corrupt or stale linked state. Mirrors
  * `LegacyLinkParentRefInvalidError`'s classification (link.errors.ts).
  */
-export class LegacyConfigDiffParentRefInvalidError extends Data.TaggedError(
-  "LegacyConfigDiffParentRefInvalidError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.relinkProject;
-  }
-}
+export const LegacyConfigDiffParentRefInvalidError = targetErrors.ParentRefInvalidError;
 
 /**
  * The resolved branch has no project ref yet (still provisioning) — guards
  * against an empty/placeholder ref reaching `/v2/projects//config`. Mirrors
  * `LegacyLinkBranchNotReadyError`'s classification (link.errors.ts).
  */
-export class LegacyConfigDiffBranchNotReadyError extends Data.TaggedError(
-  "LegacyConfigDiffBranchNotReadyError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return { ...actionability.apiStatus, fingerprint_suffix: "branch_not_ready" };
-  }
-}
+export const LegacyConfigDiffBranchNotReadyError = targetErrors.BranchNotReadyError;
 
 export class LegacyConfigDiffBranchResolveNetworkError extends Data.TaggedError(
   "LegacyConfigDiffBranchResolveNetworkError",

--- a/apps/cli/src/commands/config/diff/diff.handler.ts
+++ b/apps/cli/src/commands/config/diff/diff.handler.ts
@@ -18,6 +18,7 @@ import {
   mapLegacyHttpError,
   sanitizeLegacyErrorBody,
 } from "../../../command-internal/legacy-http-errors.ts";
+import { legacyConfigIsRecord } from "../config.paths.ts";
 import { legacyLoadLocalConfig } from "../config.load.ts";
 import { legacyConfigTargetErrorsFor, legacyResolveConfigTarget } from "../config.target.ts";
 import { legacyConfigApiScope, legacyConfigScopeLine } from "../config.format.ts";
@@ -62,10 +63,6 @@ const configTargetErrors = legacyConfigTargetErrorsFor({
   branchNotFound: LegacyConfigDiffBranchNotFoundError,
   branchNotReady: LegacyConfigDiffBranchNotReadyError,
 });
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export const legacyConfigDiff = Effect.fn("legacy.config.diff")(function* (
   flags: LegacyConfigDiffFlags,
@@ -126,8 +123,8 @@ export const legacyConfigDiff = Effect.fn("legacy.config.diff")(function* (
     let loaded = yield* loadLocalConfig(undefined);
 
     // 3. Resolve the comparison target — hoisted into `legacyResolveConfigTarget`
-    // (`../config.target.ts`, shared with `config pull`, CLI-2064). See that
-    // function's doc comment for the full eager-parent-ref-before-any-spinner
+    // (`../config.target.ts`, shared with `config pull`/`config push`, CLI-2064). See
+    // that function's doc comment for the full eager-parent-ref-before-any-spinner
     // and lazy-UUID-parent-resolution rules this preserves.
     const { ref, branch } = yield* legacyResolveConfigTarget(
       requested,
@@ -223,9 +220,11 @@ export const legacyConfigDiff = Effect.fn("legacy.config.diff")(function* (
       diffProjectConfig({ local: loaded, remote }),
     );
 
-    const data = isRecord(responseJson) ? responseJson["data"] : undefined;
+    const data = legacyConfigIsRecord(responseJson) ? responseJson["data"] : undefined;
     const scope = legacyConfigApiScope(
-      isRecord(data) && isRecord(data["attributes"]) ? data["attributes"] : {},
+      legacyConfigIsRecord(data) && legacyConfigIsRecord(data["attributes"])
+        ? data["attributes"]
+        : {},
     );
     yield* output.raw(legacyConfigScopeLine(scope), "stderr");
 

--- a/apps/cli/src/commands/config/diff/diff.handler.ts
+++ b/apps/cli/src/commands/config/diff/diff.handler.ts
@@ -9,22 +9,16 @@ import { Effect, Option } from "effect";
 
 import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
 import { LegacyCliSettings } from "../../../config/legacy-cli-settings.service.ts";
-import {
-  legacyParentNotLinkedMessage,
-  legacyParentRefInvalidMessage,
-  legacyParentRefTypoHint,
-} from "../../../command-internal/legacy-parent-project-ref.ts";
 import { LegacyLinkedProjectCache } from "../../../telemetry/legacy-linked-project-cache.service.ts";
 import { LegacyTelemetryState } from "../../../telemetry/legacy-telemetry-state.service.ts";
 import { LegacyOutputFlag } from "../../../shared/legacy/global-flags.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { ProcessControl } from "../../../shared/runtime/process-control.service.ts";
 import {
-  legacySanitizeInlineName,
   mapLegacyHttpError,
   sanitizeLegacyErrorBody,
 } from "../../../command-internal/legacy-http-errors.ts";
-import { legacyResolveConfigTarget } from "../config.target.ts";
+import { legacyConfigTargetErrorsFor, legacyResolveConfigTarget } from "../config.target.ts";
 import { legacyConfigApiScope, legacyConfigScopeLine } from "../config.format.ts";
 import { legacyConfigProjectConfigTry } from "../config.project-config.ts";
 import {
@@ -59,23 +53,14 @@ const mapBranchResolveError = mapLegacyHttpError({
   statusMessage: legacyUnexpectedStatusMessage,
 });
 
-/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`),
- * keeping `config diff`'s own tagged error classes and message wording. */
-const configTargetErrors = {
-  notLinked: (target: string) =>
-    new LegacyConfigDiffBranchNotLinkedError({ message: legacyParentNotLinkedMessage(target) }),
-  parentRefInvalid: (target: string) =>
-    new LegacyConfigDiffParentRefInvalidError({ message: legacyParentRefInvalidMessage(target) }),
-  branchNotFound: (target: string) =>
-    new LegacyConfigDiffBranchNotFoundError({
-      message: `Branch "${legacySanitizeInlineName(target)}" not found. Run \`supabase branches list\` to see available branches.${legacyParentRefTypoHint(target)}`,
-    }),
-  branchNotReady: (target: string) =>
-    new LegacyConfigDiffBranchNotReadyError({
-      message: `Branch "${legacySanitizeInlineName(target)}" has no project ref yet. Wait for it to finish provisioning, then retry.`,
-    }),
-  mapResolveError: mapBranchResolveError,
-};
+/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`), keeping
+ *  `config diff`'s own tagged error classes; the message wording is shared there. */
+const configTargetErrors = legacyConfigTargetErrorsFor({
+  notLinked: LegacyConfigDiffBranchNotLinkedError,
+  parentRefInvalid: LegacyConfigDiffParentRefInvalidError,
+  branchNotFound: LegacyConfigDiffBranchNotFoundError,
+  branchNotReady: LegacyConfigDiffBranchNotReadyError,
+});
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -170,7 +155,11 @@ export const legacyConfigDiff = Effect.fn("legacy.config.diff")(function* (
     // (`../config.target.ts`, shared with `config pull`, CLI-2064). See that
     // function's doc comment for the full eager-parent-ref-before-any-spinner
     // and lazy-UUID-parent-resolution rules this preserves.
-    const { ref, branch } = yield* legacyResolveConfigTarget(requested, configTargetErrors);
+    const { ref, branch } = yield* legacyResolveConfigTarget(
+      requested,
+      configTargetErrors,
+      mapBranchResolveError,
+    );
     resolvedRef = ref;
 
     // 4. Apply the matching `[remotes.*]` overlay (ADR 0018) now that the

--- a/apps/cli/src/commands/config/pull/pull.errors.ts
+++ b/apps/cli/src/commands/config/pull/pull.errors.ts
@@ -44,6 +44,9 @@ const targetErrors = legacyMintConfigTargetErrors("LegacyConfigPull");
 
 /** `--project-ref` named a branch the parent project does not have. */
 export const LegacyConfigPullBranchNotFoundError = targetErrors.BranchNotFoundError;
+export type LegacyConfigPullBranchNotFoundError = InstanceType<
+  typeof LegacyConfigPullBranchNotFoundError
+>;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
@@ -51,6 +54,9 @@ export const LegacyConfigPullBranchNotFoundError = targetErrors.BranchNotFoundEr
  * `LegacyConfigDiffBranchNotLinkedError`.
  */
 export const LegacyConfigPullBranchNotLinkedError = targetErrors.BranchNotLinkedError;
+export type LegacyConfigPullBranchNotLinkedError = InstanceType<
+  typeof LegacyConfigPullBranchNotLinkedError
+>;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
@@ -58,12 +64,18 @@ export const LegacyConfigPullBranchNotLinkedError = targetErrors.BranchNotLinked
  * `config diff`'s `LegacyConfigDiffParentRefInvalidError`.
  */
 export const LegacyConfigPullParentRefInvalidError = targetErrors.ParentRefInvalidError;
+export type LegacyConfigPullParentRefInvalidError = InstanceType<
+  typeof LegacyConfigPullParentRefInvalidError
+>;
 
 /**
  * The resolved branch has no project ref yet (still provisioning). Mirrors
  * `config diff`'s `LegacyConfigDiffBranchNotReadyError`.
  */
 export const LegacyConfigPullBranchNotReadyError = targetErrors.BranchNotReadyError;
+export type LegacyConfigPullBranchNotReadyError = InstanceType<
+  typeof LegacyConfigPullBranchNotReadyError
+>;
 
 /**
  * A transport failure reading remote state over HTTP — shared by BOTH the

--- a/apps/cli/src/commands/config/pull/pull.errors.ts
+++ b/apps/cli/src/commands/config/pull/pull.errors.ts
@@ -5,6 +5,7 @@ import {
   ErrorActionabilityId,
   statusCodeActionability,
 } from "../../../shared/telemetry/error-actionability.ts";
+import { legacyMintConfigTargetErrors } from "../config.target.ts";
 
 interface NetworkErrorArgs {
   readonly message: string;
@@ -39,52 +40,30 @@ export class LegacyConfigPullOutputFlagUnsupportedError extends Data.TaggedError
   }
 }
 
+const targetErrors = legacyMintConfigTargetErrors("LegacyConfigPull");
+
 /** `--project-ref` named a branch the parent project does not have. */
-export class LegacyConfigPullBranchNotFoundError extends Data.TaggedError(
-  "LegacyConfigPullBranchNotFoundError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.invalidInput;
-  }
-}
+export const LegacyConfigPullBranchNotFoundError = targetErrors.BranchNotFoundError;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
  * search for branches under. Mirrors `config diff`'s
  * `LegacyConfigDiffBranchNotLinkedError`.
  */
-export class LegacyConfigPullBranchNotLinkedError extends Data.TaggedError(
-  "LegacyConfigPullBranchNotLinkedError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.projectNotLinked;
-  }
-}
+export const LegacyConfigPullBranchNotLinkedError = targetErrors.BranchNotLinkedError;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
  * exists but is not ref-shaped — corrupt or stale linked state. Mirrors
  * `config diff`'s `LegacyConfigDiffParentRefInvalidError`.
  */
-export class LegacyConfigPullParentRefInvalidError extends Data.TaggedError(
-  "LegacyConfigPullParentRefInvalidError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.relinkProject;
-  }
-}
+export const LegacyConfigPullParentRefInvalidError = targetErrors.ParentRefInvalidError;
 
 /**
  * The resolved branch has no project ref yet (still provisioning). Mirrors
  * `config diff`'s `LegacyConfigDiffBranchNotReadyError`.
  */
-export class LegacyConfigPullBranchNotReadyError extends Data.TaggedError(
-  "LegacyConfigPullBranchNotReadyError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return { ...actionability.apiStatus, fingerprint_suffix: "branch_not_ready" };
-  }
-}
+export const LegacyConfigPullBranchNotReadyError = targetErrors.BranchNotReadyError;
 
 /**
  * A transport failure reading remote state over HTTP — shared by BOTH the

--- a/apps/cli/src/commands/config/pull/pull.format.ts
+++ b/apps/cli/src/commands/config/pull/pull.format.ts
@@ -1,6 +1,7 @@
 import type { ConfigChange, ConfigChangeSet, ConfigFormat } from "@supabase/config";
 
 import { legacySanitizeInlineName } from "../../../command-internal/legacy-http-errors.ts";
+import { legacyConfigPathKey } from "../config.paths.ts";
 import {
   LEGACY_CONFIG_CLASS_LABELS,
   legacyConfigChangePayloadEntry,
@@ -77,10 +78,6 @@ export interface LegacyConfigPullContext {
   readonly destination: LegacyConfigPullDestination;
 }
 
-function pathKey(path: ReadonlyArray<string>): string {
-  return JSON.stringify(path);
-}
-
 /** The destination-echo line, printed to stderr before any network call —
  * shares `config diff`'s target-naming phrase so the two commands read the
  * same target the same way. */
@@ -129,14 +126,14 @@ function buildChangeStatus(
       : undefined;
   for (const write of plan.writes) {
     status.set(
-      pathKey(write.change.path),
+      legacyConfigPathKey(write.change.path),
       writeSkipReason === undefined
         ? { written: true }
         : { written: false, reason: writeSkipReason },
     );
   }
   for (const skip of plan.skipped) {
-    status.set(pathKey(skip.change.path), { written: false, reason: skip.reason });
+    status.set(legacyConfigPathKey(skip.change.path), { written: false, reason: skip.reason });
   }
   return status;
 }
@@ -216,10 +213,10 @@ function changeMarker(
   writePaths: ReadonlySet<string>,
   skipReasonByPath: ReadonlyMap<string, LegacyConfigPullSkipReason>,
 ): string {
-  if (writePaths.has(pathKey(change.path))) {
+  if (writePaths.has(legacyConfigPathKey(change.path))) {
     return "write";
   }
-  const reason = skipReasonByPath.get(pathKey(change.path));
+  const reason = skipReasonByPath.get(legacyConfigPathKey(change.path));
   if (reason === undefined || reason === change.class) {
     return "not pulled";
   }
@@ -246,9 +243,9 @@ export function legacyRenderConfigPullText(
   projectRef: string,
   configPath: string,
 ): string {
-  const writePaths = new Set(plan.writes.map((write) => pathKey(write.change.path)));
+  const writePaths = new Set(plan.writes.map((write) => legacyConfigPathKey(write.change.path)));
   const skipReasonByPath = new Map(
-    plan.skipped.map((skip) => [pathKey(skip.change.path), skip.reason] as const),
+    plan.skipped.map((skip) => [legacyConfigPathKey(skip.change.path), skip.reason] as const),
   );
 
   const lines: Array<string> = [];
@@ -404,7 +401,9 @@ export function legacyConfigPullPayload(
   const status = buildChangeStatus(plan, outcome);
   const written = writtenCount(plan, outcome);
   const documentPathByKey = new Map(
-    plan.writes.map((write) => [pathKey(write.change.path), write.documentPath] as const),
+    plan.writes.map(
+      (write) => [legacyConfigPathKey(write.change.path), write.documentPath] as const,
+    ),
   );
   // A block-only run (`plan.createdTable` set, no value writes) still WROTE —
   // the new block itself — even though `written` (a count of VALUE writes)
@@ -429,9 +428,9 @@ export function legacyConfigPullPayload(
     wrote,
     scope: { present: scope.present, missing: scope.missing },
     changes: changeSet.changes.map((change) => {
-      const entry = status.get(pathKey(change.path));
+      const entry = status.get(legacyConfigPathKey(change.path));
       const changeWritten = entry?.written ?? false;
-      const documentPath = documentPathByKey.get(pathKey(change.path));
+      const documentPath = documentPathByKey.get(legacyConfigPathKey(change.path));
       return {
         ...legacyConfigChangePayloadEntry(change),
         written: changeWritten,

--- a/apps/cli/src/commands/config/pull/pull.handler.ts
+++ b/apps/cli/src/commands/config/pull/pull.handler.ts
@@ -1077,7 +1077,7 @@ export const legacyConfigPull = Effect.fn("legacy.config.pull")(function* (
     const source = yield* legacyOpenConfigPullSource();
 
     // 4. Resolve the pull target — hoisted into `legacyResolveConfigTarget`
-    // (`../config.target.ts`, shared with `config diff`, CLI-2064).
+    // (`../config.target.ts`, shared with `config diff`/`config push`, CLI-2064).
     const { ref, branch } = yield* legacyResolveConfigTarget(
       requested,
       configTargetErrors,

--- a/apps/cli/src/commands/config/pull/pull.handler.ts
+++ b/apps/cli/src/commands/config/pull/pull.handler.ts
@@ -21,11 +21,6 @@ import { Effect, FileSystem, Option, Result, Schema, SchemaIssue } from "effect"
 
 import { LegacyPlatformApi } from "../../../auth/legacy-platform-api.service.ts";
 import { LegacyCliSettings } from "../../../config/legacy-cli-settings.service.ts";
-import {
-  legacyParentNotLinkedMessage,
-  legacyParentRefInvalidMessage,
-  legacyParentRefTypoHint,
-} from "../../../command-internal/legacy-parent-project-ref.ts";
 import { legacyConfigFileHasUncommittedChanges } from "../../../command-internal/legacy-git-status.ts";
 import {
   legacySanitizeInlineName,
@@ -39,7 +34,16 @@ import { legacyResolveYes, LegacyOutputFlag } from "../../../shared/legacy/globa
 import { legacyPromptYesNo } from "../../../shared/legacy/legacy-prompt-yes-no.ts";
 import { Output } from "../../../shared/output/output.service.ts";
 import { Tty } from "../../../shared/runtime/tty.service.ts";
-import { legacyResolveConfigTarget, type LegacyConfigTarget } from "../config.target.ts";
+import {
+  legacyConfigDeepSetAtPath,
+  legacyConfigIsRecord,
+  legacyConfigPathKey,
+} from "../config.paths.ts";
+import {
+  legacyConfigTargetErrorsFor,
+  legacyResolveConfigTarget,
+  type LegacyConfigTarget,
+} from "../config.target.ts";
 import {
   legacyConfigApiScope,
   legacyConfigRenderPath,
@@ -60,7 +64,6 @@ import {
   type LegacyConfigPullOutcome,
 } from "./pull.format.ts";
 import {
-  deepSetAtPath,
   legacyConfigPullEnvVariableAtPath,
   legacyConfigPullFamilyRootForPath,
   legacyDropConfigPullUnvalidatableFamilies,
@@ -127,24 +130,14 @@ const mapBranchResolveError = mapLegacyHttpError({
   statusMessage: legacyUnexpectedStatusMessage,
 });
 
-/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`),
- * keeping `config pull`'s own tagged error classes and message wording
- * (mirrors `config diff`'s `configTargetErrors`). */
-const configTargetErrors = {
-  notLinked: (target: string) =>
-    new LegacyConfigPullBranchNotLinkedError({ message: legacyParentNotLinkedMessage(target) }),
-  parentRefInvalid: (target: string) =>
-    new LegacyConfigPullParentRefInvalidError({ message: legacyParentRefInvalidMessage(target) }),
-  branchNotFound: (target: string) =>
-    new LegacyConfigPullBranchNotFoundError({
-      message: `Branch "${legacySanitizeInlineName(target)}" not found. Run \`supabase branches list\` to see available branches.${legacyParentRefTypoHint(target)}`,
-    }),
-  branchNotReady: (target: string) =>
-    new LegacyConfigPullBranchNotReadyError({
-      message: `Branch "${legacySanitizeInlineName(target)}" has no project ref yet. Wait for it to finish provisioning, then retry.`,
-    }),
-  mapResolveError: mapBranchResolveError,
-};
+/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`), keeping
+ *  `config pull`'s own tagged error classes; the message wording is shared there. */
+const configTargetErrors = legacyConfigTargetErrorsFor({
+  notLinked: LegacyConfigPullBranchNotLinkedError,
+  parentRefInvalid: LegacyConfigPullParentRefInvalidError,
+  branchNotFound: LegacyConfigPullBranchNotFoundError,
+  branchNotReady: LegacyConfigPullBranchNotReadyError,
+});
 
 /**
  * The collision message (`LegacyConfigPullRemoteLabelCollisionError`) —
@@ -216,14 +209,6 @@ function legacyConfigPullRefusalRemediation(reason: ConfigEditRefusalReason): st
   }
 }
 
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function pathKey(path: ReadonlyArray<string>): string {
-  return JSON.stringify(path);
-}
-
 /**
  * Plan §1.9's convergence check — run once the fixpoint expansion
  * (`legacyExpandConfigPullChangeSet`, `pull.plan.ts`) has settled, and BEFORE
@@ -277,9 +262,11 @@ function legacyConfigPullDefectAndUnpushableCheck(
   if (plan.writes.length === 0) {
     return Effect.succeed(plan);
   }
-  const writtenPathKeys = new Set(plan.writes.map((write) => pathKey(write.change.path)));
+  const writtenPathKeys = new Set(
+    plan.writes.map((write) => legacyConfigPathKey(write.change.path)),
+  );
   const stillDrifting = residual.changes.filter((change) =>
-    writtenPathKeys.has(pathKey(change.path)),
+    writtenPathKeys.has(legacyConfigPathKey(change.path)),
   );
   if (stillDrifting.length > 0) {
     return new LegacyConfigPullPlanDefectError({
@@ -292,7 +279,7 @@ function legacyConfigPullDefectAndUnpushableCheck(
   }
 
   const unpushableWarnings: ReadonlyArray<LegacyConfigPullWarning> = residual.unmanaged
-    .filter((path) => writtenPathKeys.has(pathKey(path)))
+    .filter((path) => writtenPathKeys.has(legacyConfigPathKey(path)))
     .map((path) => ({ kind: "unpushable", path }));
 
   return Effect.succeed(
@@ -317,12 +304,12 @@ function legacyConfigPullValidationDocument(
   projectRef: string,
 ): Record<string, unknown> {
   const withWrites = writes.reduce(
-    (document, write) => deepSetAtPath(document, write.documentPath, write.value),
+    (document, write) => legacyConfigDeepSetAtPath(document, write.documentPath, write.value),
     rawDocument,
   );
   return createdTable === undefined
     ? withWrites
-    : deepSetAtPath(withWrites, [...createdTable, "project_id"], projectRef);
+    : legacyConfigDeepSetAtPath(withWrites, [...createdTable, "project_id"], projectRef);
 }
 
 /**
@@ -341,8 +328,8 @@ function legacyConfigPullChangeRelativeValue(
   if (destination.kind === "root") {
     return document;
   }
-  const remotes = isRecord(document) ? document["remotes"] : undefined;
-  return isRecord(remotes) ? remotes[destination.label] : undefined;
+  const remotes = legacyConfigIsRecord(document) ? document["remotes"] : undefined;
+  return legacyConfigIsRecord(remotes) ? remotes[destination.label] : undefined;
 }
 
 /**
@@ -418,7 +405,7 @@ function legacyConfigPullFamiliesForChangePaths(
   >();
   for (const changePath of changePaths) {
     const root = legacyConfigPullFamilyRootForPath(changePath, relativeValidation);
-    const key = pathKey(root);
+    const key = legacyConfigPathKey(root);
     const envVariable = legacyConfigPullEnvVariableAtPath(changePath, relativeRaw);
     const field: LegacyConfigPullMissingField = {
       path: changePath,
@@ -426,9 +413,12 @@ function legacyConfigPullFamiliesForChangePaths(
     };
     const existing = families.get(key);
     if (existing === undefined) {
-      families.set(key, { root, missingFields: new Map([[pathKey(changePath), field]]) });
+      families.set(key, {
+        root,
+        missingFields: new Map([[legacyConfigPathKey(changePath), field]]),
+      });
     } else {
-      existing.missingFields.set(pathKey(changePath), field);
+      existing.missingFields.set(legacyConfigPathKey(changePath), field);
     }
   }
   return [...families.values()].map((family) => ({
@@ -459,7 +449,7 @@ function decodeConfigPullValidation(
 }
 
 /**
- * The change-path keys ({@link pathKey}) that already fail
+ * The change-path keys ({@link legacyConfigPathKey}) that already fail
  * {@link decodeCliConfigDocumentForValidationEffect} in `rawDocument` AS IT
  * SITS ON DISK RIGHT NOW — before this pull's own writes are projected onto
  * it. {@link legacyValidateConfigPullPlan} excludes every one of these from
@@ -488,7 +478,7 @@ const legacyConfigPullPreExistingFailingChangePathKeys = Effect.fnUntraced(funct
       rawDecoded.failure,
       input.destination.kind === "remote",
     )) {
-      keys.add(pathKey(path));
+      keys.add(legacyConfigPathKey(path));
     }
   }
   if (input.destination.kind === "remote") {
@@ -500,7 +490,7 @@ const legacyConfigPullPreExistingFailingChangePathKeys = Effect.fnUntraced(funct
     });
     if (Result.isFailure(mergedDecoded)) {
       for (const path of legacyConfigPullSchemaIssueChangePaths(mergedDecoded.failure, false)) {
-        keys.add(pathKey(path));
+        keys.add(legacyConfigPathKey(path));
       }
     }
   }
@@ -594,7 +584,9 @@ const legacyValidateConfigPullPlan = Effect.fnUntraced(function* (input: {
         ? legacyConfigPullSchemaIssueChangePaths(mergedDecoded.failure, false)
         : [];
     const allChangePaths = [...rawChangePaths, ...mergedChangePaths];
-    const newChangePaths = allChangePaths.filter((path) => !preExisting.has(pathKey(path)));
+    const newChangePaths = allChangePaths.filter(
+      (path) => !preExisting.has(legacyConfigPathKey(path)),
+    );
 
     if (allChangePaths.length > 0 && newChangePaths.length === 0) {
       // Every attributable failure traces back to a problem that already
@@ -840,9 +832,11 @@ export const legacyRunConfigPull = Effect.fnUntraced(function* (input: LegacyCon
     diffProjectConfig({ local: loaded, remote }),
   );
 
-  const data = isRecord(responseJson) ? responseJson["data"] : undefined;
+  const data = legacyConfigIsRecord(responseJson) ? responseJson["data"] : undefined;
   const scope = legacyConfigApiScope(
-    isRecord(data) && isRecord(data["attributes"]) ? data["attributes"] : {},
+    legacyConfigIsRecord(data) && legacyConfigIsRecord(data["attributes"])
+      ? data["attributes"]
+      : {},
   );
   yield* output.raw(legacyConfigScopeLine(scope), "stderr");
 
@@ -1104,7 +1098,11 @@ export const legacyConfigPull = Effect.fn("legacy.config.pull")(function* (
 
     // 4. Resolve the pull target — hoisted into `legacyResolveConfigTarget`
     // (`../config.target.ts`, shared with `config diff`, CLI-2064).
-    const { ref, branch } = yield* legacyResolveConfigTarget(requested, configTargetErrors);
+    const { ref, branch } = yield* legacyResolveConfigTarget(
+      requested,
+      configTargetErrors,
+      mapBranchResolveError,
+    );
     resolvedRef = ref;
 
     yield* legacyRunConfigPull({

--- a/apps/cli/src/commands/config/pull/pull.plan.ts
+++ b/apps/cli/src/commands/config/pull/pull.plan.ts
@@ -12,6 +12,14 @@ import {
   ENV_CAPTURE_REGEX,
 } from "@supabase/config/internal";
 
+import {
+  legacyConfigDeepEqualValue,
+  legacyConfigDeepSetAtPath,
+  legacyConfigIsDeclaredAtPath,
+  legacyConfigIsRecord,
+  legacyConfigPathKey,
+  legacyConfigValueAtPath,
+} from "../config.paths.ts";
 import type { LegacyConfigPullDestination } from "./pull.scope.ts";
 
 /**
@@ -151,56 +159,6 @@ export interface LegacyPlanConfigPullInput {
   readonly projectRef: string;
 }
 
-function pathKey(path: ReadonlyArray<string>): string {
-  return JSON.stringify(path);
-}
-
-function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function valueAtPath(root: unknown, path: ReadonlyArray<string>): unknown {
-  let current: unknown = root;
-  for (const segment of path) {
-    if (!isPlainRecord(current) || !Object.hasOwn(current, segment)) {
-      return undefined;
-    }
-    current = current[segment];
-  }
-  return current;
-}
-
-function isDeclaredAtPath(root: unknown, path: ReadonlyArray<string>): boolean {
-  let current: unknown = root;
-  for (const [index, segment] of path.entries()) {
-    if (!isPlainRecord(current) || !Object.hasOwn(current, segment)) {
-      return false;
-    }
-    if (index < path.length - 1) {
-      current = current[segment];
-    }
-  }
-  return true;
-}
-
-function deepEqualValue(a: unknown, b: unknown): boolean {
-  if (a === b) {
-    return true;
-  }
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((value, index) => deepEqualValue(value, b[index]));
-  }
-  if (isPlainRecord(a) && isPlainRecord(b)) {
-    const aKeys = Object.keys(a);
-    const bKeys = Object.keys(b);
-    return (
-      aKeys.length === bKeys.length &&
-      aKeys.every((key) => Object.hasOwn(b, key) && deepEqualValue(a[key], b[key]))
-    );
-  }
-  return false;
-}
-
 function isConfigEditValue(value: unknown): value is ConfigEditValue {
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return true;
@@ -210,7 +168,7 @@ function isConfigEditValue(value: unknown): value is ConfigEditValue {
       (item) => typeof item === "string" || typeof item === "number" || typeof item === "boolean",
     );
   }
-  if (isPlainRecord(value)) {
+  if (legacyConfigIsRecord(value)) {
     return Object.values(value).every((child) => isConfigEditValue(child));
   }
   return false;
@@ -244,7 +202,9 @@ function containsRemoteEnvReference(value: ConfigEditValue): boolean {
   return Object.values(value).some((child) => containsRemoteEnvReference(child));
 }
 
-const dualScopePathKeys: ReadonlySet<string> = new Set(dualScopeProjectConfigPaths.map(pathKey));
+const dualScopePathKeys: ReadonlySet<string> = new Set(
+  dualScopeProjectConfigPaths.map(legacyConfigPathKey),
+);
 
 /**
  * Prefix-aware, mirroring `isComparableProjectConfigPath` — a mapped
@@ -253,7 +213,7 @@ const dualScopePathKeys: ReadonlySet<string> = new Set(dualScopeProjectConfigPat
  */
 function isDualScopePath(path: ReadonlyArray<string>): boolean {
   for (let length = path.length; length >= 1; length--) {
-    if (dualScopePathKeys.has(pathKey(path.slice(0, length)))) {
+    if (dualScopePathKeys.has(legacyConfigPathKey(path.slice(0, length)))) {
       return true;
     }
   }
@@ -328,14 +288,14 @@ export function legacyPlanConfigPull(input: LegacyPlanConfigPullInput): LegacyCo
     if (input.destination.kind !== "remote") {
       continue;
     }
-    const rootValue = valueAtPath(input.rootDocument, write.change.path);
-    if (deepEqualValue(write.value, rootValue)) {
+    const rootValue = legacyConfigValueAtPath(input.rootDocument, write.change.path);
+    if (legacyConfigDeepEqualValue(write.value, rootValue)) {
       warnings.push({ kind: "duplicates_root", path: write.change.path });
     }
     if (
       write.change.class === "remote_only" &&
       Array.isArray(write.value) &&
-      isDeclaredAtPath(input.rootDocument, write.change.path)
+      legacyConfigIsDeclaredAtPath(input.rootDocument, write.change.path)
     ) {
       // Arrays REPLACE wholesale on override, never merge — giving
       // `[remotes.*]` its own copy of a path the config root ALSO declares
@@ -350,32 +310,6 @@ export function legacyPlanConfigPull(input: LegacyPlanConfigPullInput): LegacyCo
       : undefined;
 
   return { writes, skipped, warnings, createdTable };
-}
-
-/**
- * Deep-copies `root`, replacing the value at `path` — shared by the fixpoint
- * expansion below (projecting a round's writes onto `{config, document}`
- * before re-diffing) and `pull.handler.ts`'s schema-validation gate
- * (projecting the plan's writes onto the raw on-disk document shape before
- * decoding it). Never used to produce bytes written to disk — that is
- * `applyConfigEdits`'s job. The exported-shaped overload preserves the
- * input's own type (a deep-set never changes an object's shape, only a leaf
- * value); the implementation itself is intentionally untyped, mirroring
- * `@supabase/config`'s own split between a typed overload contract and a
- * structurally-unverifiable recursive implementation.
- */
-export function deepSetAtPath<T>(root: T, path: ReadonlyArray<string>, value: unknown): T;
-export function deepSetAtPath(root: unknown, path: ReadonlyArray<string>, value: unknown): unknown {
-  if (path.length === 0) {
-    return value;
-  }
-  const head = path[0];
-  if (head === undefined) {
-    return value;
-  }
-  const rest = path.slice(1);
-  const base: Record<string, unknown> = isPlainRecord(root) ? root : {};
-  return { ...base, [head]: deepSetAtPath(base[head], rest, value) };
 }
 
 /**
@@ -480,7 +414,7 @@ export function legacyExpandConfigPullChangeSet(
 ): LegacyConfigPullFixpointResult {
   const seen = new Map<string, ConfigChange>();
   for (const change of input.initialChangeSet.changes) {
-    seen.set(pathKey(change.path), change);
+    seen.set(legacyConfigPathKey(change.path), change);
   }
 
   let config: EffectiveConfig = input.baseConfig;
@@ -490,22 +424,23 @@ export function legacyExpandConfigPullChangeSet(
 
   for (let round = 0; round < LEGACY_CONFIG_PULL_FIXPOINT_ROUND_CAP; round++) {
     const newlyWritable = [...seen.values()].filter(
-      (change) => isWritableChange(change) && !projectedPathKeys.has(pathKey(change.path)),
+      (change) =>
+        isWritableChange(change) && !projectedPathKeys.has(legacyConfigPathKey(change.path)),
     );
     if (newlyWritable.length === 0) {
       break;
     }
     for (const change of newlyWritable) {
-      config = deepSetAtPath(config, change.path, change.remote);
-      document = deepSetAtPath(document, change.path, change.remote);
-      projectedPathKeys.add(pathKey(change.path));
+      config = legacyConfigDeepSetAtPath(config, change.path, change.remote);
+      document = legacyConfigDeepSetAtPath(document, change.path, change.remote);
+      projectedPathKeys.add(legacyConfigPathKey(change.path));
     }
     residual = diffProjectConfig({
       local: { config, document, valueOrigins: input.valueOrigins },
       remote: input.remote,
     });
     for (const change of residual.changes) {
-      const key = pathKey(change.path);
+      const key = legacyConfigPathKey(change.path);
       if (!seen.has(key)) {
         seen.set(key, change);
       }
@@ -544,8 +479,8 @@ export function legacyConfigPullFamilyRootForPath(
 ): ReadonlyArray<string> {
   for (let length = path.length - 1; length >= 1; length--) {
     const candidate = path.slice(0, length);
-    const value = valueAtPath(document, candidate);
-    if (isPlainRecord(value) && Object.hasOwn(value, "enabled")) {
+    const value = legacyConfigValueAtPath(document, candidate);
+    if (legacyConfigIsRecord(value) && Object.hasOwn(value, "enabled")) {
       return candidate;
     }
   }
@@ -562,7 +497,7 @@ export function legacyConfigPullEnvVariableAtPath(
   path: ReadonlyArray<string>,
   document: unknown,
 ): string | undefined {
-  const value = valueAtPath(document, path);
+  const value = legacyConfigValueAtPath(document, path);
   if (typeof value !== "string") {
     return undefined;
   }
@@ -618,7 +553,7 @@ export function legacyDropConfigPullUnvalidatableFamilies(
       writes.push(write);
       continue;
     }
-    const key = pathKey(family.root);
+    const key = legacyConfigPathKey(family.root);
     const bucket = droppedByRoot.get(key);
     if (bucket === undefined) {
       droppedByRoot.set(key, [write]);
@@ -635,7 +570,9 @@ export function legacyDropConfigPullUnvalidatableFamilies(
       .flat()
       .map((write) => ({ change: write.change, reason: "would_invalidate" as const })),
   ];
-  const droppedFamilies = families.filter((family) => droppedByRoot.has(pathKey(family.root)));
+  const droppedFamilies = families.filter((family) =>
+    droppedByRoot.has(legacyConfigPathKey(family.root)),
+  );
   const survivingWarnings = plan.warnings.filter((warning) => {
     const path = warning.path;
     return (

--- a/apps/cli/src/commands/config/push/push.errors.ts
+++ b/apps/cli/src/commands/config/push/push.errors.ts
@@ -5,6 +5,7 @@ import {
   ErrorActionabilityId,
   statusCodeActionability,
 } from "../../../shared/telemetry/error-actionability.ts";
+import { legacyMintConfigTargetErrors } from "../config.target.ts";
 
 /**
  * Tagged errors for `supabase config push`.
@@ -57,14 +58,10 @@ export class LegacyConfigPushLoadConfigError extends Data.TaggedError(
 // branches — mirrors `config diff`'s own error set 1:1, under push's own
 // names (`diff.errors.ts`).
 
+const targetErrors = legacyMintConfigTargetErrors("LegacyConfigPush");
+
 /** `--project-ref` named a branch the parent project does not have. */
-export class LegacyConfigPushBranchNotFoundError extends Data.TaggedError(
-  "LegacyConfigPushBranchNotFoundError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.invalidInput;
-  }
-}
+export const LegacyConfigPushBranchNotFoundError = targetErrors.BranchNotFoundError;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
@@ -72,37 +69,19 @@ export class LegacyConfigPushBranchNotFoundError extends Data.TaggedError(
  * `supabase/.temp/linked-project.json`, or `supabase/.temp/project-ref`
  * yielded a candidate.
  */
-export class LegacyConfigPushBranchNotLinkedError extends Data.TaggedError(
-  "LegacyConfigPushBranchNotLinkedError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.projectNotLinked;
-  }
-}
+export const LegacyConfigPushBranchNotLinkedError = targetErrors.BranchNotLinkedError;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
  * exists but is not ref-shaped — corrupt or stale linked state.
  */
-export class LegacyConfigPushParentRefInvalidError extends Data.TaggedError(
-  "LegacyConfigPushParentRefInvalidError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return actionability.relinkProject;
-  }
-}
+export const LegacyConfigPushParentRefInvalidError = targetErrors.ParentRefInvalidError;
 
 /**
  * The resolved branch has no project ref yet (still provisioning) — guards
  * against an empty/placeholder ref reaching a push target.
  */
-export class LegacyConfigPushBranchNotReadyError extends Data.TaggedError(
-  "LegacyConfigPushBranchNotReadyError",
-)<{ readonly message: string }> {
-  get [ErrorActionabilityId](): CliErrorActionabilityDeclaration {
-    return { ...actionability.apiStatus, fingerprint_suffix: "branch_not_ready" };
-  }
-}
+export const LegacyConfigPushBranchNotReadyError = targetErrors.BranchNotReadyError;
 
 export class LegacyConfigPushBranchResolveNetworkError extends Data.TaggedError(
   "LegacyConfigPushBranchResolveNetworkError",

--- a/apps/cli/src/commands/config/push/push.errors.ts
+++ b/apps/cli/src/commands/config/push/push.errors.ts
@@ -62,6 +62,9 @@ const targetErrors = legacyMintConfigTargetErrors("LegacyConfigPush");
 
 /** `--project-ref` named a branch the parent project does not have. */
 export const LegacyConfigPushBranchNotFoundError = targetErrors.BranchNotFoundError;
+export type LegacyConfigPushBranchNotFoundError = InstanceType<
+  typeof LegacyConfigPushBranchNotFoundError
+>;
 
 /**
  * `--project-ref` named a branch (by name), but no project is linked to
@@ -70,18 +73,27 @@ export const LegacyConfigPushBranchNotFoundError = targetErrors.BranchNotFoundEr
  * yielded a candidate.
  */
 export const LegacyConfigPushBranchNotLinkedError = targetErrors.BranchNotLinkedError;
+export type LegacyConfigPushBranchNotLinkedError = InstanceType<
+  typeof LegacyConfigPushBranchNotLinkedError
+>;
 
 /**
  * `--project-ref` named a branch (by name), and a parent-project candidate
  * exists but is not ref-shaped — corrupt or stale linked state.
  */
 export const LegacyConfigPushParentRefInvalidError = targetErrors.ParentRefInvalidError;
+export type LegacyConfigPushParentRefInvalidError = InstanceType<
+  typeof LegacyConfigPushParentRefInvalidError
+>;
 
 /**
  * The resolved branch has no project ref yet (still provisioning) — guards
  * against an empty/placeholder ref reaching a push target.
  */
 export const LegacyConfigPushBranchNotReadyError = targetErrors.BranchNotReadyError;
+export type LegacyConfigPushBranchNotReadyError = InstanceType<
+  typeof LegacyConfigPushBranchNotReadyError
+>;
 
 export class LegacyConfigPushBranchResolveNetworkError extends Data.TaggedError(
   "LegacyConfigPushBranchResolveNetworkError",

--- a/apps/cli/src/commands/config/push/push.handler.ts
+++ b/apps/cli/src/commands/config/push/push.handler.ts
@@ -18,12 +18,7 @@ import {
   legacyAssertDecryptableSecrets,
   legacyLoadProjectEnv,
 } from "../../../command-internal/legacy-db-config.toml-read.ts";
-import {
-  legacyParentNotLinkedMessage,
-  legacyParentRefInvalidMessage,
-  legacyParentRefTypoHint,
-  legacyResolveLinkedParentRef,
-} from "../../../command-internal/legacy-parent-project-ref.ts";
+import { legacyResolveLinkedParentRef } from "../../../command-internal/legacy-parent-project-ref.ts";
 import { LEGACY_BRANCH_UUID_PATTERN } from "../../../command-internal/legacy-ref-patterns.ts";
 import {
   legacySanitizeInlineName,
@@ -38,7 +33,7 @@ import {
   legacyConfigReadStatusMessage,
   legacyUnexpectedStatusMessage,
 } from "../config.read-status.ts";
-import { legacyResolveConfigTarget } from "../config.target.ts";
+import { legacyConfigTargetErrorsFor, legacyResolveConfigTarget } from "../config.target.ts";
 import { legacyLoadAuthEmailContent } from "./push.auth-email-content.ts";
 import {
   type LegacyConfigPushKnownBranch,
@@ -146,24 +141,15 @@ const mapPushBranchResolveError = mapLegacyHttpError({
   statusMessage: legacyUnexpectedStatusMessage,
 });
 
-/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`,
- * shared with `config diff`/`config pull`), keeping `config push`'s own
- * tagged error classes and message wording. */
-const configTargetErrors = {
-  notLinked: (target: string) =>
-    new LegacyConfigPushBranchNotLinkedError({ message: legacyParentNotLinkedMessage(target) }),
-  parentRefInvalid: (target: string) =>
-    new LegacyConfigPushParentRefInvalidError({ message: legacyParentRefInvalidMessage(target) }),
-  branchNotFound: (target: string) =>
-    new LegacyConfigPushBranchNotFoundError({
-      message: `Branch "${legacySanitizeInlineName(target)}" not found. Run \`supabase branches list\` to see available branches.${legacyParentRefTypoHint(target)}`,
-    }),
-  branchNotReady: (target: string) =>
-    new LegacyConfigPushBranchNotReadyError({
-      message: `Branch "${legacySanitizeInlineName(target)}" has no project ref yet. Wait for it to finish provisioning, then retry.`,
-    }),
-  mapResolveError: mapPushBranchResolveError,
-};
+/** Error construction for `legacyResolveConfigTarget` (`../config.target.ts`, shared with
+ *  `config diff`/`config pull`), keeping `config push`'s own tagged error classes; the
+ *  message wording is shared there. */
+const configTargetErrors = legacyConfigTargetErrorsFor({
+  notLinked: LegacyConfigPushBranchNotLinkedError,
+  parentRefInvalid: LegacyConfigPushParentRefInvalidError,
+  branchNotFound: LegacyConfigPushBranchNotFoundError,
+  branchNotReady: LegacyConfigPushBranchNotReadyError,
+});
 
 export const legacyConfigPush = Effect.fn("legacy.config.push")(function* (
   flags: LegacyConfigPushFlags,
@@ -236,7 +222,11 @@ export const legacyConfigPush = Effect.fn("legacy.config.push")(function* (
     // before a malformed `config.toml` is caught — an accepted, narrow
     // tradeoff (matches this command's own pre-CLI-2168 behavior, which
     // always resolved before loading).
-    const { ref, branch } = yield* legacyResolveConfigTarget(requestedRef, configTargetErrors);
+    const { ref, branch } = yield* legacyResolveConfigTarget(
+      requestedRef,
+      configTargetErrors,
+      mapPushBranchResolveError,
+    );
     resolvedRef = ref;
 
     // 2. Load config.toml with the resolved ref (TOML parse error aborts

--- a/apps/cli/src/commands/config/push/push.paths.ts
+++ b/apps/cli/src/commands/config/push/push.paths.ts
@@ -7,14 +7,14 @@
 
 import type { ProjectConfig } from "@supabase/config";
 
-export function legacyIsRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import { legacyConfigIsRecord } from "../config.paths.ts";
+
+export const legacyIsRecord = legacyConfigIsRecord;
 
 export function legacyValueAtPath(root: unknown, path: ReadonlyArray<string>): unknown {
   let current: unknown = root;
   for (const segment of path) {
-    if (!legacyIsRecord(current)) return undefined;
+    if (!legacyConfigIsRecord(current)) return undefined;
     current = current[segment];
   }
   return current;
@@ -71,7 +71,7 @@ export function legacyContainerEnabled(
   path: ReadonlyArray<string>,
 ): boolean | undefined {
   const container = legacyValueAtPath(local, path);
-  if (!legacyIsRecord(container)) {
+  if (!legacyConfigIsRecord(container)) {
     return undefined;
   }
   const enabled = container["enabled"];

--- a/packages/config/src/config-edit.ts
+++ b/packages/config/src/config-edit.ts
@@ -95,6 +95,21 @@ export type ConfigEditOutcome =
     }
   | { readonly kind: "refused"; readonly refusal: ConfigEditRefusal };
 
+/**
+ * The `[remotes.<label>]` placement exception's two literals (this file's header comment,
+ * rule 4): a newly created remote block always lands at EOF, preceded by one blank line,
+ * with `project_id` written first. Named here rather than spelled inline at the sites that
+ * test them (`renderMissingTableCluster`, `planTomlSplices`) so the exception reads as one
+ * rule instead of four bare strings.
+ */
+const REMOTES_TABLE_NAME = "remotes";
+const REMOTE_PROJECT_ID_KEY = "project_id";
+
+/** A `[remotes.<label>]` block root — the one table this module places by a hardcoded rule. */
+function isRemotesLabelRoot(path: ReadonlyArray<string>): boolean {
+  return path.length === 2 && path[0] === REMOTES_TABLE_NAME;
+}
+
 // ---------------------------------------------------------------------------
 // Small generic helpers shared by both format arms.
 // ---------------------------------------------------------------------------
@@ -967,11 +982,10 @@ function renderMissingTableCluster(
 ): string {
   return entries
     .map((entry, index) => {
-      const isRemotesLabelRoot = entry.path.length === 2 && entry.path[0] === "remotes";
-      const orderedLeaves = isRemotesLabelRoot
+      const orderedLeaves = isRemotesLabelRoot(entry.path)
         ? [...entry.leaves].sort((a, b) => {
-            const aRank = lastSegmentOf(a.path) === "project_id" ? 0 : 1;
-            const bRank = lastSegmentOf(b.path) === "project_id" ? 0 : 1;
+            const aRank = lastSegmentOf(a.path) === REMOTE_PROJECT_ID_KEY ? 0 : 1;
+            const bRank = lastSegmentOf(b.path) === REMOTE_PROJECT_ID_KEY ? 0 : 1;
             return aRank - bRank;
           })
         : entry.leaves;
@@ -1115,8 +1129,7 @@ function planTomlSplices(scan: TomlScanResult, leaves: ReadonlyArray<LeafEdit>):
       continue;
     }
     const rootPath = rootEntry.path;
-    const isRemotesLabelRoot = rootPath.length === 2 && rootPath[0] === "remotes";
-    const offset = isRemotesLabelRoot
+    const offset = isRemotesLabelRoot(rootPath)
       ? scan.source.length
       : placementOffsetForNewTable(scan, rootPath);
     const text = renderMissingTableCluster(ordered, scan.newline);


### PR DESCRIPTION
## Current Behavior

Follow-up debt recorded by the CLI-2064 architecture review (explicitly ruled a follow-up, not a pre-merge fix):

1. `pathKey` has separate definitions across the config command family's `pull/` modules; `deepEqualValue`/`valueAtPath`/`isDeclaredAtPath` are each implemented twice (`pull.plan.ts`); `deepSetAtPath` is a third deep-set concept, only reachable through the planner.
2. `LegacyConfigTargetErrors<A,B,C,D,E>` in `config.target.ts` hand-injects five generic constructors per command, and reclassifies a 404 via a `Predicate.hasProperty("status")` duck-type check.
3. `config diff` and `config pull` render change classes through a shared label map in `config.format.ts`.
4. `config-edit.ts`'s `[remotes.<label>]` placement logic hardcodes the `"remotes"`/`"project_id"` literals inline at each use site.

## Expected Behavior

1. One `config.paths.ts` at the command family root holds the shared path/value helpers; the three `pull/` modules that duplicated them now import from it. `config-edit.ts` (in `@supabase/config`, pinned to `smol-toml` as its only import per ADR 0023) keeps its own independent copies — deliberately out of scope.
2. `config.target.ts` now mints each family's four target-resolution error classes from a prefix (`legacyMintConfigTargetErrors`) and builds their shared message-template bundle in one place (`legacyConfigTargetErrorsFor`), collapsing `LegacyConfigTargetErrors`/`legacyResolveConfigTarget` from five generics to two and replacing the duck-typed 404 check with a typed `LegacyConfigTargetResolveFailure` bound. `diff`, `pull`, and `push` now all route through this factory — `push` adopted the shared resolver since the CLI-2064 review, meeting the precondition this item was waiting on.
3. Already done in #6454 (CLI-2313) — `diff.format.ts` already renders through `config.format.ts`'s shared label map. No changes needed; confirmed while implementing this issue.
4. `config-edit.ts` now names the two literals (`REMOTES_TABLE_NAME`, `REMOTE_PROJECT_ID_KEY`) and a shared `isRemotesLabelRoot` predicate next to the doc comment that already describes the exception.

No user-observable behavior changes — every renamed/relocated helper keeps its exact prior implementation, and the four minted error classes keep their original tags, actionability, and message text (verified against the existing `diff`/`pull`/`push` integration test suites and the `error-actionability-coverage` drift guard).