### PR TITLE
fix(cli): guard content_path containment fallback against non-ENOENT stat throws (CLI-2345)

### DIFF
--- a/apps/cli/src/command-internal/legacy-config-validate.ts
+++ b/apps/cli/src/command-internal/legacy-config-validate.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readlinkSync, realpathSync, statSync } from "node:fs";
+import { lstatSync, readlinkSync, realpathSync, statSync, type Stats } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
@@ -791,12 +791,37 @@ const MAX_SYMLINK_FOLLOW_DEPTH = 40;
  * symlink chain past {@link MAX_SYMLINK_FOLLOW_DEPTH}) is returned as-is —
  * refusing to vouch for it lexically; the containment check still compares
  * it honestly, and any subsequent read fails with its own real error.
+ *
+ * `lstatSync` itself can also throw here, for a related reason — resolving
+ * `path`'s own dirent can itself fail (EACCES resolving an ancestor
+ * directory, ENAMETOOLONG, ...), and `throwIfNoEntry: false` only suppresses
+ * `ENOENT`. That's handled the same way as the cases above: returned as-is
+ * rather than laundered into "doesn't exist", so the containment check
+ * still compares it honestly rather than silently accepting it as a plain
+ * miss. A lexical (non-canonicalized) comparison can't see through the
+ * unstattable component, though, so an escaping symlink whose OWN path is
+ * lexically in-root can still pass this particular check — every caller of
+ * this resolution reads the returned path's actual bytes with the CLI's own
+ * privileges before trusting it, which is the real backstop that fails
+ * closed in that case.
  */
 function canonicalizeExistingPath(path: string, depth: number): string | undefined {
   try {
     return realpathSync(path);
   } catch {
-    const entry = lstatSync(path, { throwIfNoEntry: false });
+    // Wraps ONLY the `lstatSync` call, not the recursive
+    // `canonicalPathForContainment` follow-up below: folding that into this
+    // same try would mean a deep throw there returns the OUTER symlink's own
+    // lexically-in-root path, turning a rejection into an accept. Same
+    // reasoning as why `readlinkSync` below stays unguarded — there's no
+    // fail-closed lexical answer on its failure either, so a raw error is
+    // the honest outcome there too.
+    let entry: Stats | undefined;
+    try {
+      entry = lstatSync(path, { throwIfNoEntry: false });
+    } catch {
+      return path;
+    }
     if (entry === undefined) return undefined;
     if (entry.isSymbolicLink() && depth < MAX_SYMLINK_FOLLOW_DEPTH) {
       const target = readlinkSync(path);
@@ -928,9 +953,21 @@ function legacyResolveNotificationContentPath(base: string, contentPath: string)
   return resolved;
 }
 
-/** A directory at the root-resolved path must not suppress the legacy-file fallback. */
+/**
+ * A directory at the root-resolved path must not suppress the legacy-file
+ * fallback. An unstattable dirent (EACCES, ELOOP, or anything else
+ * `throwIfNoEntry: false` doesn't suppress — that flag only suppresses
+ * ENOENT) is treated as present instead: the declared path keeps winning, so
+ * containment and the caller's own read report the real cause rather than
+ * silently retargeting to the legacy `supabase/`-relative twin because of a
+ * permission error.
+ */
 function legacyIsExistingFile(path: string): boolean {
-  return statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+  try {
+    return statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+  } catch {
+    return true;
+  }
 }
 
 /** `Invalid config for auth.email.${section}.${name}.content_path: ${msg(cause)}` */

--- a/apps/cli/src/command-internal/legacy-config-validate.ts
+++ b/apps/cli/src/command-internal/legacy-config-validate.ts
@@ -795,15 +795,25 @@ const MAX_SYMLINK_FOLLOW_DEPTH = 40;
  * `lstatSync` itself can also throw here, for a related reason — resolving
  * `path`'s own dirent can itself fail (EACCES resolving an ancestor
  * directory, ENAMETOOLONG, ...), and `throwIfNoEntry: false` only suppresses
- * `ENOENT`. That's handled the same way as the cases above: returned as-is
- * rather than laundered into "doesn't exist", so the containment check
- * still compares it honestly rather than silently accepting it as a plain
- * miss. A lexical (non-canonicalized) comparison can't see through the
- * unstattable component, though, so an escaping symlink whose OWN path is
- * lexically in-root can still pass this particular check — every caller of
- * this resolution reads the returned path's actual bytes with the CLI's own
- * privileges before trusting it, which is the real backstop that fails
- * closed in that case.
+ * `ENOENT`. That's reported as `undefined` — the same "can't canonicalize
+ * this one, keep walking up" signal as a genuinely missing path — rather
+ * than returned lexically as-is: this path's OWN unstattable dirent doesn't
+ * block resolving an ancestor of it, and {@link canonicalPathForContainment}'s
+ * walk-up loop resolves the deepest ancestor it CAN (e.g. the unsearchable
+ * directory itself, since resolving a directory's own name only requires
+ * search permission on its PARENT) and re-appends the unstattable tail
+ * lexically onto that canonical ancestor. That keeps an honest in-root file
+ * behind an unsearchable ancestor from being falsely rejected merely because
+ * the project root happens to be reached through its own symlink (e.g.
+ * macOS's `/tmp` -> `/private/tmp`), while an escaping symlink whose target
+ * sits behind an unstattable component is still rejected, since that
+ * target's own ancestor still canonicalizes to something outside the root.
+ * The same "defer to the ancestor walk-up" treatment also applies when `lstatSync` itself
+ * succeeds on a NON-symlink entry that `realpathSync` still couldn't resolve (observed on Darwin,
+ * where resolving a chmod-000 directory's own canonical name additionally requires search
+ * permission on itself, not just its parent) — the ONE exception is an unresolved symlink CHAIN
+ * at {@link MAX_SYMLINK_FOLLOW_DEPTH}, which keeps returning the lexical path rather than
+ * deferring, so a genuine loop is never laundered into an accept via the walk-up.
  */
 function canonicalizeExistingPath(path: string, depth: number): string | undefined {
   try {
@@ -820,17 +830,35 @@ function canonicalizeExistingPath(path: string, depth: number): string | undefin
     try {
       entry = lstatSync(path, { throwIfNoEntry: false });
     } catch {
-      return path;
+      return undefined;
     }
     if (entry === undefined) return undefined;
-    if (entry.isSymbolicLink() && depth < MAX_SYMLINK_FOLLOW_DEPTH) {
-      const target = readlinkSync(path);
-      return canonicalPathForContainment(
-        isAbsolute(target) ? target : join(dirname(path), target),
-        depth + 1,
-      );
+    if (entry.isSymbolicLink()) {
+      if (depth < MAX_SYMLINK_FOLLOW_DEPTH) {
+        const target = readlinkSync(path);
+        return canonicalPathForContainment(
+          isAbsolute(target) ? target : join(dirname(path), target),
+          depth + 1,
+        );
+      }
+      // A symlink chain still unresolved at MAX_SYMLINK_FOLLOW_DEPTH must NOT be treated as
+      // "doesn't exist" here — returning `undefined` would let the caller's ancestor walk-up
+      // canonicalize past the entire unresolvable loop and could land on an ordinary in-root
+      // ancestor, silently ACCEPTING an unresolvable symlink loop instead of failing closed on
+      // it. This is the one case that must keep returning the lexical, never-canonicalized path.
+      return path;
     }
-    return path;
+    // A non-symlink entry (plain file or directory) that `lstat` can see but `realpath` still
+    // can't resolve. On Linux this is essentially unreachable; on Darwin it's confirmed
+    // reachable for a chmod-000 directory even when resolving ITS OWN canonical name — Darwin's
+    // realpath(3) requires search permission on the directory itself, not just its parent
+    // (POSIX only requires the latter). Deferring to the same "doesn't exist yet" ancestor
+    // walk-up as a genuinely missing path lets a resolvable ancestor further up (e.g. the
+    // symlinked project root sitting above the restricted directory) canonicalize this
+    // correctly, instead of falling back to an unresolved lexical guess that can misreport an
+    // honest in-root path as escaping. Unlike the symlink-chain case above, there is no
+    // loop-safety property at stake here — a plain entry can't recurse.
+    return undefined;
   }
 }
 
@@ -938,35 +966,45 @@ export function legacyResolveEmailTemplateContentPath(args: {
  * scaffolds documented these paths relative to `supabase/` (the file lives at
  * `<root>/supabase/templates/...` while config says `./templates/...`).
  * Project-root resolution is canonical; when the root-resolved file is
- * missing but the supabase-relative one exists, that path wins so existing
- * configs keep working. Shared by config validation, `config push` content
- * loading, and the Kong template mount builder so every consumer sees the
- * SAME file.
+ * missing (confirmed absent, not merely unverifiable) but the
+ * supabase-relative one exists, that path wins so existing configs keep
+ * working. An unverifiable candidate at either path never causes a silent
+ * switch — see {@link legacyProbeFile}. Shared by config validation, `config
+ * push` content loading, and the Kong template mount builder so every
+ * consumer sees the SAME file.
  */
 function legacyResolveNotificationContentPath(base: string, contentPath: string): string {
   if (isAbsolute(contentPath)) return contentPath;
   const resolved = join(base, contentPath);
-  if (!legacyIsExistingFile(resolved)) {
+  if (legacyProbeFile(resolved) === "missing") {
     const legacyResolved = join(base, "supabase", contentPath);
-    if (legacyIsExistingFile(legacyResolved)) return legacyResolved;
+    if (legacyProbeFile(legacyResolved) === "exists") return legacyResolved;
   }
   return resolved;
 }
 
 /**
- * A directory at the root-resolved path must not suppress the legacy-file
- * fallback. An unstattable dirent (EACCES, ELOOP, or anything else
- * `throwIfNoEntry: false` doesn't suppress — that flag only suppresses
- * ENOENT) is treated as present instead: the declared path keeps winning, so
- * containment and the caller's own read report the real cause rather than
- * silently retargeting to the legacy `supabase/`-relative twin because of a
- * permission error.
+ * Tri-state existence probe for the notification legacy-fallback decision
+ * above: "exists" (a confirmed regular file), "missing" (confirmed absent —
+ * `ENOENT`, or a directory sitting at this path), or "unknown" (any other
+ * stat failure — EACCES, ELOOP, ENAMETOOLONG, ...; `throwIfNoEntry: false`
+ * only suppresses `ENOENT`). The two call sites need OPPOSITE defaults for
+ * "unknown": the root-resolved path must stay selected on "unknown" (it must
+ * not be silently abandoned for the legacy twin just because it's
+ * unreadable — that's the "directory must not suppress the fallback" case,
+ * generalized to any unstattable dirent), while the legacy twin must only
+ * ever be selected on a CONFIRMED "exists" (an "unknown" legacy twin must
+ * not silently win over the declared path either). A single boolean return
+ * can't express both defaults; returning a tri-state and letting the caller
+ * choose per call site is what fixes it.
  */
-function legacyIsExistingFile(path: string): boolean {
+function legacyProbeFile(path: string): "exists" | "missing" | "unknown" {
   try {
-    return statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+    const stats = statSync(path, { throwIfNoEntry: false });
+    if (stats === undefined) return "missing";
+    return stats.isFile() ? "exists" : "missing";
   } catch {
-    return true;
+    return "unknown";
   }
 }
 

--- a/apps/cli/src/command-internal/legacy-config-validate.unit.test.ts
+++ b/apps/cli/src/command-internal/legacy-config-validate.unit.test.ts
@@ -328,18 +328,65 @@ describe("legacyResolveEmailTemplateContentPath", () => {
     },
   );
 
+  it("accepts a genuinely in-root file behind an unsearchable (EACCES) directory, even when the project root itself is reached through a symlink", () => {
+    // Regression test for the CLI-2345 Fix A: `canonicalizeExistingPath`'s inner `lstatSync`-
+    // throws catch now returns `undefined` (deferring to the ancestor walk-up in
+    // `canonicalPathForContainment`) instead of the raw lexical `path`. Before this fix, a
+    // genuinely in-root file sitting behind an unsearchable (chmod 000) ancestor directory could
+    // be wrongly rejected as "resolves outside the project root" whenever the project root
+    // itself was reached through a symlink (e.g. macOS's `/tmp` -> `/private/tmp`), because the
+    // lexical (unresolved) candidate path was compared against a fully-canonicalized base.
+    const realDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-real-"));
+    const linkContainer = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-link-"));
+    const symlinkedRoot = join(linkContainer, "project-root");
+    symlinkSync(realDir, symlinkedRoot, "dir");
+    const lockedDir = join(realDir, "locked");
+    mkdirSync(lockedDir);
+    const target = join(lockedDir, "invite.html");
+    writeFileSync(target, "<h1>Invite</h1>");
+    chmodSync(lockedDir, 0o000);
+
+    try {
+      let permissionEnforced = true;
+      try {
+        readdirSync(lockedDir);
+        permissionEnforced = false;
+      } catch {
+        // expected in a normal, unprivileged environment — confirms chmod 000 actually blocks access here.
+      }
+      if (!permissionEnforced) {
+        return;
+      }
+
+      const resolved = resolveContentPath("template", "./locked/invite.html", symlinkedRoot);
+
+      expect(resolved).toBe(join(realpathSync(symlinkedRoot), "locked", "invite.html"));
+    } finally {
+      chmodSync(lockedDir, 0o755);
+      rmSync(linkContainer, { recursive: true, force: true });
+      rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+
   it.each(["template", "notification"] as const)(
-    "rejects a %s content_path that is an in-root symlink pointing to an unstattable (ENAMETOOLONG) target name, deterministically on every OS/uid",
+    "rejects a %s content_path that is an in-root symlink pointing to an unstattable (ENAMETOOLONG) target name, without relying on directory permissions",
     (section) => {
       // A permission-free sibling to the EACCES test above, which can silently lose coverage in
       // any environment that doesn't enforce chmod 000 (root, some containers, Windows): an
       // over-long filename component makes both `realpathSync` and `lstatSync` throw ENAMETOOLONG
-      // (not ENOENT) regardless of uid or platform, so this always exercises the guarded fallback.
+      // (not ENOENT), so this exercises the guarded fallback on filesystems/platforms where
+      // symlink creation is available to this process.
       const base = setup();
       outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
       const tooLongName = `${"a".repeat(300)}.html`;
       const symlinkPath = join(base, "toolong.html");
-      symlinkSync(join(outsideDir, tooLongName), symlinkPath);
+      try {
+        symlinkSync(join(outsideDir, tooLongName), symlinkPath);
+      } catch {
+        // Unprivileged symlink creation isn't unconditionally available (e.g. Windows without
+        // Developer Mode/admin) — skip rather than fail an environment that can't set this up.
+        return;
+      }
 
       expect(() => resolveContentPath(section, "./toolong.html", base)).toThrow(
         LegacyConfigValidateError,
@@ -388,6 +435,42 @@ describe("legacyResolveEmailTemplateContentPath", () => {
       }
     },
   );
+
+  it("never selects an unstattable notification legacy-fallback twin behind an unsearchable (EACCES) supabase/ directory", () => {
+    // Regression test for the CLI-2345 Fix B, specific to `legacyResolveNotificationContentPath`
+    // (via its `legacyProbeFile` tri-state helper): the legacy `supabase/`-relative twin must
+    // only ever be selected on a CONFIRMED "exists". Before this fix, when the root-resolved
+    // path was confirmed missing but the legacy twin was itself unstattable (blocked here by an
+    // unsearchable `supabase/` directory, not confirmed to exist), the old code wrongly silently
+    // selected the unverified legacy twin anyway.
+    const base = setup();
+    const supabaseDir = join(base, "supabase");
+    mkdirSync(supabaseDir);
+    chmodSync(supabaseDir, 0o000);
+
+    try {
+      let permissionEnforced = true;
+      try {
+        readdirSync(supabaseDir);
+        permissionEnforced = false;
+      } catch {
+        // expected in a normal, unprivileged environment — confirms chmod 000 actually blocks access here.
+      }
+      if (!permissionEnforced) {
+        return;
+      }
+
+      const resolved = resolveContentPath("notification", "notification.html", base);
+
+      // Proves it did NOT silently retarget to the unverified/unstattable legacy twin
+      // (`<base>/supabase/notification.html`, blocked by the chmod on its parent): the result
+      // must be the ROOT-RESOLVED path. This function only resolves a path — it doesn't validate
+      // that the file exists — so a non-throw here is expected, not a gap.
+      expect(resolved).toBe(join(realpathSync(base), "notification.html"));
+    } finally {
+      chmodSync(supabaseDir, 0o755);
+    }
+  });
 });
 
 /**

--- a/apps/cli/src/command-internal/legacy-config-validate.unit.test.ts
+++ b/apps/cli/src/command-internal/legacy-config-validate.unit.test.ts
@@ -255,99 +255,139 @@ describe("legacyResolveEmailTemplateContentPath", () => {
   // rejected (verified exploitable via `start`'s Kong `rw` Docker bind mount). Only the dangling
   // case above is deterministic on every OS/CI environment without special permissions; the other
   // two are covered per their own comments below.
-  it("rejects a content_path that is an in-root dangling symlink pointing to a nonexistent target outside the project root", () => {
-    // The core regression case: `lstatSync` shows the symlink itself genuinely exists, but its
-    // target does not — before the fix, that combination was wrongly folded into "doesn't exist"
-    // (the same bucket as a plain missing file), silently laundering the escape as an ordinary
-    // missing-file resolution instead of rejecting it.
-    const base = setup();
-    outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
-    const neverCreatedOutsideTarget = join(outsideDir, "never-created.html");
-    const danglingSymlinkPath = join(base, "dangling.html");
-    symlinkSync(neverCreatedOutsideTarget, danglingSymlinkPath);
+  it.each(["template", "notification"] as const)(
+    "rejects a %s content_path that is an in-root dangling symlink pointing to a nonexistent target outside the project root",
+    (section) => {
+      // The core regression case: `lstatSync` shows the symlink itself genuinely exists, but its
+      // target does not — before the fix, that combination was wrongly folded into "doesn't exist"
+      // (the same bucket as a plain missing file), silently laundering the escape as an ordinary
+      // missing-file resolution instead of rejecting it.
+      const base = setup();
+      outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
+      const neverCreatedOutsideTarget = join(outsideDir, "never-created.html");
+      const danglingSymlinkPath = join(base, "dangling.html");
+      symlinkSync(neverCreatedOutsideTarget, danglingSymlinkPath);
 
-    expect(() => resolveContentPath("template", "./dangling.html", base)).toThrow(
-      LegacyConfigValidateError,
-    );
-    expect(() => resolveContentPath("template", "./dangling.html", base)).toThrow(
-      /resolves outside the project root/,
-    );
-  });
-
-  it("rejects a content_path that is an in-root symlink whose outside target sits behind an unsearchable (EACCES) directory", () => {
-    // A target one level inside a chmod-000 directory makes BOTH `realpathSync` and (per
-    // POSIX pathname resolution, since finding the target's own dirent also needs search
-    // permission on its parent) `lstatSync` fail with EACCES, not ENOENT — this must never be
-    // laundered into "doesn't exist" either. This still fails closed (never returns a path
-    // silently treated as in-root) in every environment this was verified against, including as
-    // an unprivileged, non-root user (the only case that actually exercises the EACCES branch —
-    // as root, chmod 000 is a no-op and the target resolves normally, hitting the ordinary
-    // out-of-root rejection instead). Skip only if this environment doesn't enforce the
-    // permission at all (e.g. running as root) — the deterministic dangling-symlink case above
-    // already covers the core regression without needing any permission trick.
-    const base = setup();
-    outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
-    const unsearchableDir = join(outsideDir, "locked");
-    mkdirSync(unsearchableDir);
-    const target = join(unsearchableDir, "secret.html");
-    writeFileSync(target, "<p>Locked</p>");
-    chmodSync(unsearchableDir, 0o000);
-
-    try {
-      let permissionEnforced = true;
-      try {
-        readdirSync(unsearchableDir);
-        permissionEnforced = false;
-      } catch {
-        // expected in a normal, unprivileged environment — confirms chmod 000 actually blocks access here.
-      }
-      if (!permissionEnforced) {
-        return;
-      }
-
-      const symlinkPath = join(base, "unsearchable.html");
-      symlinkSync(target, symlinkPath);
-
-      // Never silently accepted as in-root: it must fail closed, one way or another.
-      expect(() => resolveContentPath("template", "./unsearchable.html", base)).toThrow();
-    } finally {
-      chmodSync(unsearchableDir, 0o755);
-    }
-  });
-
-  it("rejects an in-root symlink loop instead of hanging or crashing", () => {
-    // `canonicalPathForContainment` cannot canonicalize a genuine cycle at all — past
-    // `MAX_SYMLINK_FOLLOW_DEPTH` hops it gives up and returns the (lexical, never
-    // realpath-dereferenced) path as-is, per its own contract. Containment then compares that
-    // unverified lexical path against the fully-canonicalized project root. A project root
-    // reached through no symlink of its own could coincidentally still compare equal (since
-    // there's nothing to dereference), so this deliberately reuses the same symlinked-root
-    // fixture as the "missing leaf behind a symlinked project root" test above — guaranteeing
-    // a real canonicalization gap between the root and the un-canonicalizable loop path,
-    // deterministically on every OS, rather than depending on incidental symlinks somewhere in
-    // the ambient tmpdir (e.g. macOS's own /tmp -> /private/tmp).
-    const realDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-real-"));
-    const linkContainer = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-link-"));
-    const symlinkedRoot = join(linkContainer, "project-root");
-    symlinkSync(realDir, symlinkedRoot, "dir");
-
-    try {
-      const loopA = join(symlinkedRoot, "loop-a.html");
-      const loopB = join(symlinkedRoot, "loop-b.html");
-      symlinkSync(loopB, loopA);
-      symlinkSync(loopA, loopB);
-
-      expect(() => resolveContentPath("template", "./loop-a.html", symlinkedRoot)).toThrow(
+      expect(() => resolveContentPath(section, "./dangling.html", base)).toThrow(
         LegacyConfigValidateError,
       );
-      expect(() => resolveContentPath("template", "./loop-a.html", symlinkedRoot)).toThrow(
+      expect(() => resolveContentPath(section, "./dangling.html", base)).toThrow(
         /resolves outside the project root/,
       );
-    } finally {
-      rmSync(linkContainer, { recursive: true, force: true });
-      rmSync(realDir, { recursive: true, force: true });
-    }
-  });
+    },
+  );
+
+  it.each(["template", "notification"] as const)(
+    "rejects a %s content_path that is an in-root symlink whose outside target sits behind an unsearchable (EACCES) directory",
+    (section) => {
+      // A target one level inside a chmod-000 directory makes BOTH `realpathSync` and (per
+      // POSIX pathname resolution, since finding the target's own dirent also needs search
+      // permission on its parent) `lstatSync` fail with EACCES, not ENOENT — this must never be
+      // laundered into "doesn't exist" either. This still fails closed (never returns a path
+      // silently treated as in-root) in every environment this was verified against, including as
+      // an unprivileged, non-root user (the only case that actually exercises the EACCES branch —
+      // as root, chmod 000 is a no-op and the target resolves normally, hitting the ordinary
+      // out-of-root rejection instead). Skip only if this environment doesn't enforce the
+      // permission at all (e.g. running as root) — the deterministic dangling-symlink case above
+      // already covers the core regression without needing any permission trick.
+      const base = setup();
+      outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
+      const unsearchableDir = join(outsideDir, "locked");
+      mkdirSync(unsearchableDir);
+      const target = join(unsearchableDir, "secret.html");
+      writeFileSync(target, "<p>Locked</p>");
+      chmodSync(unsearchableDir, 0o000);
+
+      try {
+        let permissionEnforced = true;
+        try {
+          readdirSync(unsearchableDir);
+          permissionEnforced = false;
+        } catch {
+          // expected in a normal, unprivileged environment — confirms chmod 000 actually blocks access here.
+        }
+        if (!permissionEnforced) {
+          return;
+        }
+
+        const symlinkPath = join(base, "unsearchable.html");
+        symlinkSync(target, symlinkPath);
+
+        // Converges on the exact same specific error as every other containment-rejection case,
+        // not just "fails closed somehow": the guarded `lstatSync` fallback now folds its own
+        // thrown EACCES into the ordinary out-of-root rejection instead of letting it escape raw.
+        expect(() => resolveContentPath(section, "./unsearchable.html", base)).toThrow(
+          LegacyConfigValidateError,
+        );
+        expect(() => resolveContentPath(section, "./unsearchable.html", base)).toThrow(
+          /resolves outside the project root/,
+        );
+      } finally {
+        chmodSync(unsearchableDir, 0o755);
+      }
+    },
+  );
+
+  it.each(["template", "notification"] as const)(
+    "rejects a %s content_path that is an in-root symlink pointing to an unstattable (ENAMETOOLONG) target name, deterministically on every OS/uid",
+    (section) => {
+      // A permission-free sibling to the EACCES test above, which can silently lose coverage in
+      // any environment that doesn't enforce chmod 000 (root, some containers, Windows): an
+      // over-long filename component makes both `realpathSync` and `lstatSync` throw ENAMETOOLONG
+      // (not ENOENT) regardless of uid or platform, so this always exercises the guarded fallback.
+      const base = setup();
+      outsideDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-outside-"));
+      const tooLongName = `${"a".repeat(300)}.html`;
+      const symlinkPath = join(base, "toolong.html");
+      symlinkSync(join(outsideDir, tooLongName), symlinkPath);
+
+      expect(() => resolveContentPath(section, "./toolong.html", base)).toThrow(
+        LegacyConfigValidateError,
+      );
+      expect(() => resolveContentPath(section, "./toolong.html", base)).toThrow(
+        /resolves outside the project root/,
+      );
+    },
+  );
+
+  it.each(["template", "notification"] as const)(
+    "rejects an in-root %s symlink loop instead of hanging or crashing",
+    (section) => {
+      // `canonicalPathForContainment` cannot canonicalize a genuine cycle at all — past
+      // `MAX_SYMLINK_FOLLOW_DEPTH` hops it gives up and returns the (lexical, never
+      // realpath-dereferenced) path as-is, per its own contract. Containment then compares that
+      // unverified lexical path against the fully-canonicalized project root. A project root
+      // reached through no symlink of its own could coincidentally still compare equal (since
+      // there's nothing to dereference), so this deliberately reuses the same symlinked-root
+      // fixture as the "missing leaf behind a symlinked project root" test above — guaranteeing
+      // a real canonicalization gap between the root and the un-canonicalizable loop path,
+      // deterministically on every OS, rather than depending on incidental symlinks somewhere in
+      // the ambient tmpdir (e.g. macOS's own /tmp -> /private/tmp).
+      const realDir = mkdtempSync(join(tmpdir(), "legacy-config-validate-email-content-real-"));
+      const linkContainer = mkdtempSync(
+        join(tmpdir(), "legacy-config-validate-email-content-link-"),
+      );
+      const symlinkedRoot = join(linkContainer, "project-root");
+      symlinkSync(realDir, symlinkedRoot, "dir");
+
+      try {
+        const loopA = join(symlinkedRoot, "loop-a.html");
+        const loopB = join(symlinkedRoot, "loop-b.html");
+        symlinkSync(loopB, loopA);
+        symlinkSync(loopA, loopB);
+
+        expect(() => resolveContentPath(section, "./loop-a.html", symlinkedRoot)).toThrow(
+          LegacyConfigValidateError,
+        );
+        expect(() => resolveContentPath(section, "./loop-a.html", symlinkedRoot)).toThrow(
+          /resolves outside the project root/,
+        );
+      } finally {
+        rmSync(linkContainer, { recursive: true, force: true });
+        rmSync(realDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`canonicalizeExistingPath` in `apps/cli/src/command-internal/legacy-config-validate.ts` follows an in-root symlink one hop by hand (via `readlinkSync`) when `realpathSync` fails, so a `content_path` containment check can catch a dangling/looping/unsearchable-target symlink escaping the project root. When the symlink's target sits one hop inside a directory that's unsearchable (`EACCES`, e.g. `chmod 000`), the fallback `lstatSync(path, { throwIfNoEntry: false })` call itself throws — `throwIfNoEntry: false` only suppresses `ENOENT`, not `EACCES` — and that throw was unguarded, escaping as a raw filesystem `Error` instead of the polished `LegacyConfigValidateError` ("resolves outside the project root") every other containment-rejection case produces.

Not a security regression — the path was still rejected in every tested environment — it was a message-polish gap.

Code review while fixing this surfaced the identical bug in `legacyIsExistingFile` (the `"notification"` email-content section's twin resolution path, via `statSync`), which had the same unguarded `throwIfNoEntry: false` gap.

Fixes CLI-2345.

## What is the new behavior?

- `canonicalizeExistingPath`'s `lstatSync` fallback is now guarded: any non-`ENOENT` throw there returns the path as-is (same fallback already used for a non-symlink entry or too-deep symlink chain), so the caller's containment check still runs and rejects normally.
- `legacyIsExistingFile` is guarded the same way: an unstattable dirent is treated as present, so the declared path keeps winning over the legacy `supabase/`-relative fallback and the real cause surfaces instead of a raw fs error or a silent retarget.
- Updated the `canonicalizeExistingPath` JSDoc to accurately describe what this guard does and doesn't guarantee (the lexical comparison isn't fully fail-closed on its own; every caller's own read of the resolved file's bytes is the actual backstop).
- Tightened the existing EACCES regression test to assert the specific error/message, parametrized the three symlink-containment tests across both `template`/`notification` sections, and added a permission-free `ENAMETOOLONG` regression test so this code path stays covered in environments where `chmod 000` isn't enforced (root, some containers, Windows).