### PR TITLE
ci(repo): publish preview packages only with run-preview-packages label

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -51,25 +51,37 @@ issue directly (from the GitHub UI, or from the Linear-linked issue).
 ## `run-ci`: full develop CI on stacked or draft PRs
 
 Ready (non-draft) PRs targeting `develop` already get the default suite: Test
-(check / unit+integration / e2e), preview CLI packages, and PR-title lint.
+(check / unit+integration / e2e) and PR-title lint.
 
 Stacked PRs (base is another PR branch) and drafts do **not** get that suite
 unless they carry the **`run-ci`** label. [`run-ci.yml`](./workflows/run-ci.yml)
-then calls Test and preview-package publish as reusable workflows, including
-while the PR is still a draft.
+then calls Test as a reusable workflow, including while the PR is still a draft.
 
 - Add `run-ci` to start (or resume) the suite; remove it to cancel in-progress
   `run-ci` runs via that workflow's concurrency group.
-- Other labels do not start or cancel Test / preview. PR-title lint may
-  retrigger because that check is cheap.
+- Other labels do not start or cancel Test. PR-title lint may retrigger because
+  that check is cheap.
 - After a stacked PR is retargeted onto `develop`, push or reopen so the
   native required checks (`Check code quality`, etc.) populate. The opt-in
   suite uses different check names (`Test / Check code quality`).
-- This is independent of `run-live-e2e-ci`, which opts into the separate
-  supabox live e2e dispatch.
+- This is independent of `run-preview-packages` and `run-live-e2e-ci`.
 
 The `run-ci` label must exist as a repository label; create it from
 **Issues → Labels** if it is missing.
+
+## `run-preview-packages`: on-demand pkg.pr.new preview
+
+CLI preview packages are large, so they are **not** published on every PR.
+Add the **`run-preview-packages`** label to publish via
+[`publish-preview-cli-packages.yml`](./workflows/publish-preview-cli-packages.yml)
+(any base branch, including drafts). While the label stays on, each subsequent
+push re-publishes; remove it to cancel in-progress runs.
+
+The workflow posts (or updates) a PR comment with an `npx` install command for
+the preview. This is independent of `run-ci` and `run-live-e2e-ci`.
+
+The `run-preview-packages` label must exist as a repository label; create it
+from **Issues → Labels** if it is missing.
 
 ## Deferred: automatic Linear → GitHub label sync
 

--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -3,9 +3,9 @@ name: Lint Pull Request
 # Release-notes PRs (head ref `release-notes/*`) skip CI; only
 # apply-release-notes.yml runs for those.
 #
-# Draft PRs skip this check unless they carry `run-ci` (same opt-in as Test
-# and preview packages). Label events retrigger this cheap check so adding
-# `run-ci` on a draft starts lint without waiting for a push.
+# Draft PRs skip this check unless they carry `run-ci` (same opt-in as Test).
+# Label events retrigger this cheap check so adding `run-ci` on a draft starts
+# lint without waiting for a push.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -3,44 +3,44 @@ name: Publish Preview CLI Packages
 # Release-notes PRs (head ref `release-notes/*`) are markdown-only and are not
 # meant to produce installable preview packages.
 #
-# Default path: ready (non-draft) PRs targeting `develop`.
-# `run-ci.yml` calls this workflow for drafts and stacked / non-develop PRs.
+# Opt-in by label: pkg.pr.new hosts large CLI binaries, so publish only when
+# someone needs a shareable install. Add `run-preview-packages` to publish
+# (and re-publish on each subsequent push while labeled); remove it to cancel
+# in-progress runs via this workflow's concurrency group.
 on:
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
-      - converted_to_draft
-    branches:
-      - develop
-  workflow_call:
-    inputs:
-      force:
-        description: Publish even when the PR is a draft (used by run-ci.yml)
-        type: boolean
-        default: false
-    secrets:
-      DF_FIREWALL_TOKEN:
-        required: true
+      - labeled
+      - unlabeled
 
 permissions:
   actions: read
   contents: read
 
-# Literal prefix: called workflows inherit github.workflow from the caller
-# (`run-ci`). `inputs.force` separates this call from a skipped native run on
-# a develop draft.
+# Unrelated label events still start a run; give them a unique group so they
+# cannot cancel an in-progress publish. Removing `run-preview-packages` stays
+# on the main group and cancels via cancel-in-progress.
 concurrency:
-  group: publish-preview-cli-packages.yml-${{ github.event.pull_request.number || github.head_ref }}-${{ inputs.force && 'run-ci' || 'direct' }}
+  group: >-
+    publish-preview-cli-packages.yml-${{ github.event.pull_request.number || github.ref }}${{
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled')
+        && github.event.label.name != 'run-preview-packages'
+        && format('-noop-{0}', github.run_id))
+      || ''
+    }}
   cancel-in-progress: true
 
 jobs:
   build:
     if: |
       !startsWith(github.head_ref, 'release-notes/') &&
-      (inputs.force || github.event.pull_request.draft == false)
+      contains(github.event.pull_request.labels.*.name, 'run-preview-packages') &&
+      ((github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled') ||
+        github.event.label.name == 'run-preview-packages')
     name: Build preview CLI packages
     uses: ./.github/workflows/build-cli-artifacts.yml
     with:
@@ -53,7 +53,10 @@ jobs:
     needs: build
     if: |
       !startsWith(github.head_ref, 'release-notes/') &&
-      (inputs.force || github.event.pull_request.draft == false) &&
+      contains(github.event.pull_request.labels.*.name, 'run-preview-packages') &&
+      ((github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled') ||
+        github.event.label.name == 'run-preview-packages') &&
       needs.build.result == 'success'
     name: Publish preview package
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -137,7 +140,10 @@ jobs:
     needs: publish
     if: |
       !startsWith(github.head_ref, 'release-notes/') &&
-      (inputs.force || github.event.pull_request.draft == false) &&
+      contains(github.event.pull_request.labels.*.name, 'run-preview-packages') &&
+      ((github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled') ||
+        github.event.label.name == 'run-preview-packages') &&
       needs.publish.result == 'success'
     name: Post preview command comment
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-preview-cli-packages.yml
+++ b/.github/workflows/publish-preview-cli-packages.yml
@@ -51,13 +51,7 @@ jobs:
 
   publish:
     needs: build
-    if: |
-      !startsWith(github.head_ref, 'release-notes/') &&
-      contains(github.event.pull_request.labels.*.name, 'run-preview-packages') &&
-      ((github.event.action != 'labeled' &&
-          github.event.action != 'unlabeled') ||
-        github.event.label.name == 'run-preview-packages') &&
-      needs.build.result == 'success'
+    if: needs.build.result == 'success'
     name: Publish preview package
     runs-on: blacksmith-8vcpu-ubuntu-2404
     outputs:
@@ -138,13 +132,7 @@ jobs:
 
   comment:
     needs: publish
-    if: |
-      !startsWith(github.head_ref, 'release-notes/') &&
-      contains(github.event.pull_request.labels.*.name, 'run-preview-packages') &&
-      ((github.event.action != 'labeled' &&
-          github.event.action != 'unlabeled') ||
-        github.event.label.name == 'run-preview-packages') &&
-      needs.publish.result == 'success'
+    if: needs.publish.result == 'success'
     name: Post preview command comment
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
 
 # Unrelated label events still start a run; give them a unique group so they
 # cannot cancel an in-progress suite. Removing `run-ci` stays on the main

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -1,11 +1,12 @@
 name: run-ci
 
-# Opt-in full develop CI for PRs that Test.yml / preview do not already cover:
-# stacked PRs (base is not develop) and drafts. Ready develop PRs stay on the
-# existing workflows so required check names and concurrency are unchanged.
+# Opt-in full develop CI for PRs that Test.yml does not already cover: stacked
+# PRs (base is not develop) and drafts. Ready develop PRs stay on the existing
+# workflows so required check names and concurrency are unchanged.
 #
 # Add the `run-ci` label to start the suite; remove it to cancel in-progress
 # runs via this workflow's concurrency group. Other labels do not retrigger.
+# Preview packages are a separate opt-in (`run-preview-packages`).
 on:
   pull_request:
     types:
@@ -46,21 +47,6 @@ jobs:
           github.event.action != 'unlabeled') ||
         github.event.label.name == 'run-ci')
     uses: ./.github/workflows/test.yml
-    with:
-      force: true
-    secrets:
-      DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
-
-  preview:
-    name: Preview packages
-    if: |
-      !startsWith(github.head_ref, 'release-notes/') &&
-      contains(github.event.pull_request.labels.*.name, 'run-ci') &&
-      (github.event.pull_request.draft || github.base_ref != 'develop') &&
-      ((github.event.action != 'labeled' &&
-          github.event.action != 'unlabeled') ||
-        github.event.label.name == 'run-ci')
-    uses: ./.github/workflows/publish-preview-cli-packages.yml
     with:
       force: true
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,8 @@ permissions:
   actions: read
 
 # Literal prefix: called workflows inherit github.workflow from the caller
-# (`run-ci`), which would cancel the caller and the preview call. `inputs.force`
-# keeps a skipped native Test run on a develop draft from cancelling the
-# forced run-ci call.
+# (`run-ci`), which would cancel the caller. `inputs.force` keeps a skipped
+# native Test run on a develop draft from cancelling the forced run-ci call.
 concurrency:
   group: test.yml-${{ github.event.pull_request.number || github.head_ref || github.ref }}-${{ inputs.force && 'run-ci' || 'direct' }}
   cancel-in-progress: true


### PR DESCRIPTION
<!--
Before opening this PR, confirm the linked issue is open and carries the
`open-for-contribution` label. PRs from external contributors that don't follow
the workflow in CONTRIBUTING.md are closed automatically.
@supabase members working from Linear tickets are exempt.
-->

## Summary

- Gate `pkg.pr.new` preview CLI package publishes behind the `run-preview-packages` label (re-publish on push while labeled; remove label to cancel).
- Stop publishing on every ready `develop` PR and remove preview from the `run-ci` suite so large binaries are only uploaded when someone needs a shareable install.
- Document the opt-in in `MAINTAINERS.md` and sync related workflow comments.

## Linked issue

No linked GitHub issue (maintainer follow-up from Slack).

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(cli): …`).
- [x] Tests added or updated for the change.
- [x] From the repository root, `pnpm check:all` passes; relevant package tests pass for every touched workspace, and `pnpm types:check` passes for each touched TypeScript workspace (or workspace declaring it).