### PR TITLE
ci(repo): re-pin codex-action to v1.11, block future auto-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,17 +11,24 @@ updates:
       actions-major:
         patterns:
           - "*"
+        exclude-patterns:
+          - "openai/codex-action"
     ignore:
       - dependency-name: "supabase/setup-cli"
         update-types:
           - "version-update:semver-major"
       - dependency-name: "openai/codex-action"
+        versions:
+          - "1.12.x"
         # Deliberately pinned to v1.11 in ai-review.yml — v1.12 has two
-        # confirmed, still-open upstream hangs (openai/codex-action#151,
-        # #160) that a grouped Dependabot bump already silently reintroduced
-        # once (PR #6484, 2026-09-07). Any future bump of this action needs a
-        # deliberate PR that checks the upstream changelog/issue tracker
-        # first, not an automated one bundled into the actions-major group.
+        # confirmed, still-open upstream regressions: a wrapper-level hang
+        # (openai/codex-action#151) and a runner-killing failure
+        # (openai/codex-action#160). A grouped Dependabot bump already
+        # silently reintroduced v1.12 once (PR #6484, 2026-09-07). Scoped to
+        # 1.12.x (not a blanket ignore) so Dependabot still proposes v1.13+
+        # once a fix ships; evaluate any such proposal in its own deliberate
+        # PR, checking the upstream changelog/issue tracker first — never
+        # bundle it into the actions-major group.
     cooldown:
       default-days: 7
   - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       - dependency-name: "supabase/setup-cli"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "openai/codex-action"
+        # Deliberately pinned to v1.11 in ai-review.yml — v1.12 has two
+        # confirmed, still-open upstream hangs (openai/codex-action#151,
+        # #160) that a grouped Dependabot bump already silently reintroduced
+        # once (PR #6484, 2026-09-07). Any future bump of this action needs a
+        # deliberate PR that checks the upstream changelog/issue tracker
+        # first, not an automated one bundled into the actions-major group.
     cooldown:
       default-days: 7
   - package-ecosystem: "gomod"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -344,7 +344,7 @@ jobs:
         # specifically to stop that from happening again. There is no
         # released fix above v1.12 as of 2026-09-09; re-verify both issues
         # are closed before ever re-bumping this pin.
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        uses: &codex-action-pin openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/ai-review/codex-review-prompt.md
@@ -506,24 +506,11 @@ jobs:
       # untrusted AGENTS.md/config; it reads the PR from `pr/` and executes
       # nothing from it.
       - name: Run Codex adjudication
-        # Pinned to v1.11 (52fe01ec…), NOT v1.12 (86365089…): v1.12 has two
-        # confirmed, still-open upstream regressions that hang or kill the job
-        # on exactly this workflow's config (safety-strategy: drop-sudo,
-        # sandbox: read-only, output-schema-file) — openai/codex-action#151
-        # (the wrapper waits on the child process's `close` event with
-        # inherited stdio, so a lingering descendant keeps the step alive
-        # forever after Codex has already written its output) and
-        # openai/codex-action#160 (drop-sudo's v1.12 rewrite chmods
-        # root-owned /run service sockets, breaking systemd-resolved on the
-        # GitHub-hosted runner itself, which kills the job ~52-65 minutes in
-        # regardless of job timeout-minutes). Both are independent of the
-        # pinned Codex CLI version. This pin was silently regressed to v1.12
-        # once already by a grouped Dependabot bump (#6484) — see the
-        # dependabot.yml ignore entry for openai/codex-action, which exists
-        # specifically to stop that from happening again. There is no
-        # released fix above v1.12 as of 2026-09-09; re-verify both issues
-        # are closed before ever re-bumping this pin.
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        # Same v1.11 pin as codex-review's "Run Codex independent review"
+        # step above — see that step's comment for the full v1.11-vs-v1.12
+        # rationale (openai/codex-action#151, #160). YAML-aliased so the SHA
+        # only needs to change in one place.
+        uses: *codex-action-pin
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: trusted/.github/ai-review/adjudicate-prompt.md

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -327,12 +327,24 @@ jobs:
       # a non-sudo-capable user, in a sandbox with no filesystem writes and no
       # network, with no `codex-args`/`--sandbox` duplication.
       - name: Run Codex independent review
-        # Pinned to v1.11, NOT v1.12: v1.12 has a confirmed regression where a
-        # heavy Linux run never returns after Codex finishes the turn and writes
-        # its output file — the step sits idle until the job timeout, discarding
-        # a completed review (openai/codex-action#150). v1.11 handles the same
-        # heavy workload cleanly. There is no released fix above v1.12 yet.
-        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
+        # Pinned to v1.11 (52fe01ec…), NOT v1.12 (86365089…): v1.12 has two
+        # confirmed, still-open upstream regressions that hang or kill the job
+        # on exactly this workflow's config (safety-strategy: drop-sudo,
+        # sandbox: read-only, output-schema-file) — openai/codex-action#151
+        # (the wrapper waits on the child process's `close` event with
+        # inherited stdio, so a lingering descendant keeps the step alive
+        # forever after Codex has already written its output) and
+        # openai/codex-action#160 (drop-sudo's v1.12 rewrite chmods
+        # root-owned /run service sockets, breaking systemd-resolved on the
+        # GitHub-hosted runner itself, which kills the job ~52-65 minutes in
+        # regardless of job timeout-minutes). Both are independent of the
+        # pinned Codex CLI version. This pin was silently regressed to v1.12
+        # once already by a grouped Dependabot bump (#6484) — see the
+        # dependabot.yml ignore entry for openai/codex-action, which exists
+        # specifically to stop that from happening again. There is no
+        # released fix above v1.12 as of 2026-09-09; re-verify both issues
+        # are closed before ever re-bumping this pin.
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/ai-review/codex-review-prompt.md
@@ -494,12 +506,24 @@ jobs:
       # untrusted AGENTS.md/config; it reads the PR from `pr/` and executes
       # nothing from it.
       - name: Run Codex adjudication
-        # Pinned to v1.11, NOT v1.12: v1.12 has a confirmed regression where a
-        # heavy Linux run never returns after Codex finishes the turn and writes
-        # its output file — the step sits idle until the job timeout, discarding
-        # a completed review (openai/codex-action#150). v1.11 handles the same
-        # heavy workload cleanly. There is no released fix above v1.12 yet.
-        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
+        # Pinned to v1.11 (52fe01ec…), NOT v1.12 (86365089…): v1.12 has two
+        # confirmed, still-open upstream regressions that hang or kill the job
+        # on exactly this workflow's config (safety-strategy: drop-sudo,
+        # sandbox: read-only, output-schema-file) — openai/codex-action#151
+        # (the wrapper waits on the child process's `close` event with
+        # inherited stdio, so a lingering descendant keeps the step alive
+        # forever after Codex has already written its output) and
+        # openai/codex-action#160 (drop-sudo's v1.12 rewrite chmods
+        # root-owned /run service sockets, breaking systemd-resolved on the
+        # GitHub-hosted runner itself, which kills the job ~52-65 minutes in
+        # regardless of job timeout-minutes). Both are independent of the
+        # pinned Codex CLI version. This pin was silently regressed to v1.12
+        # once already by a grouped Dependabot bump (#6484) — see the
+        # dependabot.yml ignore entry for openai/codex-action, which exists
+        # specifically to stop that from happening again. There is no
+        # released fix above v1.12 as of 2026-09-09; re-verify both issues
+        # are closed before ever re-bumping this pin.
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: trusted/.github/ai-review/adjudicate-prompt.md


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI reliability fix.

## What is the current behavior?

AI Review's Codex jobs (`codex-review`, `adjudicate`) intermittently hang and get killed on job timeout, discarding a completed review. Most recently: [run 34323125644](https://github.com/supabase/cli/actions/runs/34323125644) on #6535 died at ~55 minutes against a 45-minute timeout.

This is a regression. #6380 deliberately pinned `openai/codex-action` to v1.11 because v1.12 had a confirmed hang bug (openai/codex-action#150). #6484 — a Dependabot `actions-major` group bump bundling 6 unrelated action updates — silently reverted that pin back to v1.12; the workflow's own comments (still saying "pinned to v1.11, NOT v1.12") went stale rather than catching the drift, since nothing diffed them against the actual `uses:` line.

Checking upstream today turned up two separate, still-open v1.12 regressions, both matching this workflow's exact config (`safety-strategy: drop-sudo`, `sandbox: read-only`, `output-schema-file`):
- openai/codex-action#151 — the v1.12 wrapper waits on the child process's `close` event with inherited stdio; a lingering descendant keeps the step alive forever after Codex has already written its output and finished.
- openai/codex-action#160 — v1.12's `drop-sudo` rewrite chmods root-owned `/run` service sockets, breaking `systemd-resolved` on the GitHub-hosted runner itself, which kills the job 52-65 minutes in regardless of the job's own timeout — matching our job's 55-minute death exactly.

Neither has a released fix. Both are action-level bugs independent of the pinned Codex CLI version (reproduced across CLI versions 0.147.0-0.150.1 in the upstream threads). This is not a diff-size or token-limit problem: #6535's diff was only ~2200 lines, and v1.11 has cleanly handled 130k-270k-token diffs in under 15 minutes per the upstream reports and our own prior testing.

## What is the new behavior?

- Re-pin `openai/codex-action` to v1.11 (`52fe01ec70a42f454c9d2ebd47598f9fd6893d56`) in both Codex jobs — verified it's a safe drop-in, since v1.11's `action.yml` supports every input this workflow uses.
- Refresh the stale inline comments to cite the actual issues (#151, #160) instead of just the original #150.
- Add `openai/codex-action` to `.github/dependabot.yml`'s `ignore` list (no `update-types` restriction, so it blocks all automated bumps) so a grouped bump can't silently regress this pin again. Any future bump now requires a deliberate PR that checks the upstream changelog/issue tracker first.