### PR TITLE
ci(repo): fix dependabot ignore syntax for openai/codex-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,17 +18,23 @@ updates:
         update-types:
           - "version-update:semver-major"
       - dependency-name: "openai/codex-action"
+        # NOTE: this ecosystem's `versions` strings are parsed as Ruby
+        # Gem::Requirement (RubyGems comparator syntax), NOT npm-style semver
+        # ranges — "1.12.x" is not a wildcard here, it parses as a literal
+        # (and never-matching) version string, which is why the prior attempt
+        # at this silently failed to block v1.12 (PR #6541, 2026-09-09). Use
+        # real comparators instead.
         versions:
-          - "1.12.x"
+          - ">= 1.12, < 1.13"
         # Deliberately pinned to v1.11 in ai-review.yml — v1.12 has two
         # confirmed, still-open upstream regressions: a wrapper-level hang
         # (openai/codex-action#151) and a runner-killing failure
         # (openai/codex-action#160). A grouped Dependabot bump already
         # silently reintroduced v1.12 once (PR #6484, 2026-09-07). Scoped to
-        # 1.12.x (not a blanket ignore) so Dependabot still proposes v1.13+
-        # once a fix ships; evaluate any such proposal in its own deliberate
-        # PR, checking the upstream changelog/issue tracker first — never
-        # bundle it into the actions-major group.
+        # the 1.12 line (not a blanket ignore) so Dependabot still proposes
+        # v1.13+ once a fix ships; evaluate any such proposal in its own
+        # deliberate PR, checking the upstream changelog/issue tracker first
+        # — never bundle it into the actions-major group.
     cooldown:
       default-days: 7
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI reliability fix (follow-up to #6538).

## What is the current behavior?

#6538 re-pinned `openai/codex-action` to v1.11 and added a Dependabot ignore entry scoped to `versions: ["1.12.x"]`, intending to still let Dependabot propose v1.13+ once the upstream hang bugs (openai/codex-action#151, #160) are fixed, while blocking the known-bad v1.12 line specifically.

That scoping never actually worked. 9 minutes after #6538 merged, Dependabot opened #6541 proposing the exact v1.12 bump we were trying to block — config propagation wasn't the issue; the `versions` syntax was. The `github-actions` ecosystem's `ignore.versions` strings are parsed as Ruby `Gem::Requirement` (RubyGems comparator syntax: `>= x`, `~> x`, etc.), not npm-style semver ranges. `"1.12.x"` isn't a wildcard in that grammar — it parses as a literal version string with an implicit `=` operator, which never equals the real dependency version (`"1.12"`), so the ignore condition silently never matched anything.

Verified directly against the actual parsing logic dependabot-core uses (`Dependabot::GithubActions::Requirement`, a thin wrapper around `Gem::Requirement`):
```
GithubActionsRequirement.new("1.12.x").satisfied_by?(Gem::Version.new("1.12"))   # => false (bug)
GithubActionsRequirement.new(">= 1.12, < 1.13").satisfied_by?(Gem::Version.new("1.12"))    # => true
GithubActionsRequirement.new(">= 1.12, < 1.13").satisfied_by?(Gem::Version.new("1.12.5"))  # => true
GithubActionsRequirement.new(">= 1.12, < 1.13").satisfied_by?(Gem::Version.new("1.11"))    # => false
GithubActionsRequirement.new(">= 1.12, < 1.13").satisfied_by?(Gem::Version.new("1.13"))    # => false
```

## What is the new behavior?

Replace `versions: ["1.12.x"]` with `versions: [">= 1.12, < 1.13"]` — a real Gem::Requirement comparator range, confirmed to correctly match the 1.12 line (including any 1.12.x patch) while excluding v1.11 and v1.13+. #6541 should be closed as superseded once this merges.