### PR TITLE
ci(release): gate stable publishing on live e2e tests

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -83,6 +83,31 @@ the preview. This is independent of `run-ci` and `run-live-e2e-ci`.
 The `run-preview-packages` label must exist as a repository label; create it
 from **Issues → Labels** if it is missing.
 
+## Live e2e coverage and stable releases
+
+[`Live E2E`](./workflows/live-e2e.yml) exercises managed staging after every push
+to `develop`, daily at 06:23 UTC, and on manual dispatch. New `develop` pushes
+cancel superseded push runs; nightly and manual runs execute independently.
+Nightly runs do not depend on a new beta version: they also detect staging
+changes between CLI releases.
+
+Stable publishing requires a passing live suite for the exact release commit.
+The release workflow reuses a verified successful staging run on `develop` for
+that commit when available; otherwise it runs the suite before publishing.
+Lookup errors and live-test failures block publication. This also applies to
+manual stable releases. Beta publication keeps its existing build and smoke-test
+gates.
+
+Live-test failures and recoveries are sent to the channel configured by
+`SLACK_RELEASE_WEBHOOK`, with commit and workflow links. Routine successful runs
+stay quiet. GitHub Actions logs contain the test failures; notification delivery
+does not determine whether the suite passed.
+
+PR live coverage remains opt-in through `run-live-e2e-ci`. That label dispatches
+the PR commit to the separate Supabox harness, which also has its own nightly
+schedule against pinned submodules. A Supabox result does not replace the
+managed-staging gate for stable publication.
+
 ## Deferred: automatic Linear → GitHub label sync
 
 We considered auto-applying `open-for-contribution` when a Linear issue moves out of

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -94,7 +94,10 @@ changes between CLI releases.
 Stable publishing requires a passing live suite for the exact release commit.
 The release workflow reuses a verified successful staging run on `develop` for
 that commit when available; otherwise it runs the suite before publishing.
-Lookup errors and live-test failures block publication. This also applies to
+Normal promotion fast-forwards that commit from `develop` to `main`. The gate
+deliberately queries `develop` runs of `live-e2e.yml`; renaming the workflow
+requires updating that selector. Actions API lookup errors and live-test
+failures block publication. This also applies to
 manual stable releases. Beta publication keeps its existing build and smoke-test
 gates.
 
@@ -107,6 +110,18 @@ PR live coverage remains opt-in through `run-live-e2e-ci`. That label dispatches
 the PR commit to the separate Supabox harness, which also has its own nightly
 schedule against pinned submodules. A Supabox result does not replace the
 managed-staging gate for stable publication.
+
+The gate and notifier identify the reusable suite by the `Live e2e` job name (or
+the exact ` / Live e2e` suffix). The gate also checks the `Run live e2e` step
+name. Keep these names aligned with their consumers. Push, scheduled, manual, and stable-gate runs
+use separate concurrency groups because they own independent temporary project
+sets; this is intentional and does not imply a global concurrency quota.
+Notification history inspects at most 25 recent runs of the same workflow and
+branch. It suppresses repeated outcomes and results superseded by a newer run
+or attempt. Recovery requires a known prior failure. History lookup errors
+produce warnings; a confirmed current failure can still be reported if its
+prior outcome is unknown. Release failures use the existing release notification
+to avoid a second failure alert from the live notifier.
 
 ## Deferred: automatic Linear → GitHub label sync
 

--- a/.github/workflows/live-e2e-gate.yml
+++ b/.github/workflows/live-e2e-gate.yml
@@ -1,0 +1,79 @@
+name: Live E2E Gate
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: Exact commit to verify
+        required: true
+        type: string
+    secrets:
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  lookup:
+    name: Find exact-SHA live result
+    runs-on: ubuntu-latest
+    outputs:
+      reuse: ${{ steps.lookup.outputs.reuse }}
+    steps:
+      - name: Check latest relevant run
+        id: lookup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          response="$(gh api --paginate "/repos/${REPOSITORY}/actions/workflows/live-e2e.yml/runs?branch=develop&head_sha=${SHA}&per_page=100")"
+          latest="$(jq -s -c 'map(.workflow_runs[]) | sort_by(.run_number) | reverse | .[0] // empty' <<< "$response")"
+          if [[ -z "$latest" ]]; then
+            echo "No live run exists for ${SHA}; the stable gate will run the suite."
+            echo "reuse=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          status="$(jq -r '.status' <<< "$latest")"
+          conclusion="$(jq -r '.conclusion // empty' <<< "$latest")"
+          run_id="$(jq -r '.id' <<< "$latest")"
+          echo "Latest live run ${run_id}: status=${status}, conclusion=${conclusion}"
+          jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")"
+          executed="$(jq -s -r 'any(.[].jobs[]; (.name | endswith("Live e2e")) and .conclusion == "success" and any(.steps[]?; .name == "Run live e2e" and .conclusion == "success"))' <<< "$jobs")"
+          if [[ "$status" == completed && "$conclusion" == success && "$executed" == true ]]; then
+            echo "reuse=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest live run did not pass; the stable gate will run the suite."
+            echo "reuse=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    name: Run live e2e for stable gate
+    needs: lookup
+    if: needs.lookup.outputs.reuse != 'true'
+    uses: ./.github/workflows/live-e2e-suite.yml
+    with:
+      ref: ${{ inputs.sha }}
+      concurrency_group: live-e2e-stable-${{ inputs.sha }}
+    secrets: inherit
+
+  result:
+    name: Verify live e2e gate
+    needs: [lookup, run]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a successful result
+        env:
+          REUSE: ${{ needs.lookup.outputs.reuse }}
+          RUN_RESULT: ${{ needs.run.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$REUSE" == true || "$RUN_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "::error::live e2e did not produce a successful result"
+          exit 1

--- a/.github/workflows/live-e2e-gate.yml
+++ b/.github/workflows/live-e2e-gate.yml
@@ -19,6 +19,7 @@ jobs:
   lookup:
     name: Find exact-SHA live result
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       reuse: ${{ steps.lookup.outputs.reuse }}
     steps:
@@ -42,7 +43,9 @@ jobs:
           run_id="$(jq -r '.id' <<< "$latest")"
           echo "Latest live run ${run_id}: status=${status}, conclusion=${conclusion}"
           jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")"
-          executed="$(jq -s -r 'any(.[].jobs[]; (.name | endswith("Live e2e")) and .conclusion == "success" and any(.steps[]?; .name == "Run live e2e" and .conclusion == "success"))' <<< "$jobs")"
+          # Keep this exact job suffix and step name aligned with the producer
+          # and notifier; renaming either changes reuse semantics.
+          executed="$(jq -s -r 'any(.[].jobs[]; (.name == "Live e2e" or (.name | endswith(" / Live e2e"))) and .conclusion == "success" and any(.steps[]?; .name == "Run live e2e" and .conclusion == "success"))' <<< "$jobs")"
           if [[ "$status" == completed && "$conclusion" == success && "$executed" == true ]]; then
             echo "reuse=true" >> "$GITHUB_OUTPUT"
           else
@@ -58,13 +61,16 @@ jobs:
     with:
       ref: ${{ inputs.sha }}
       concurrency_group: live-e2e-stable-${{ inputs.sha }}
-    secrets: inherit
+    # Forward the one secret required by live-e2e-suite.yml.
+    secrets:
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
 
   result:
     name: Verify live e2e gate
     needs: [lookup, run]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Require a successful result
         env:

--- a/.github/workflows/live-e2e-notify.yml
+++ b/.github/workflows/live-e2e-notify.yml
@@ -13,6 +13,7 @@ jobs:
   notify:
     if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     continue-on-error: true
     steps:
       - name: Notify Slack
@@ -31,46 +32,89 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A reusable suite job is named "Live e2e" or ends with "/ Live e2e".
-          # A reused gate has no such job and is intentionally ignored.
+          # A reusable suite job is named "Live e2e" or ends with the exact
+          # " / Live e2e" suffix. Keep this aligned with the producer and gate.
           suite_conclusion() {
-            jq -r '([.jobs[]? | select(.name == "Live e2e" or (.name | endswith("/ Live e2e"))) | .conclusion] | if any(.[]; . == "failure") then "failure" elif any(.[]; . == "success") then "success" else "none" end)'
+            jq -r '([.jobs[]? | select(.name == "Live e2e" or (.name | endswith(" / Live e2e"))) | .conclusion] | if any(.[]; . == "failure") then "failure" elif any(.[]; . == "success") then "success" else "none" end)'
           }
 
-          current_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100")"
+          if ! current_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100")"; then
+            echo "::warning::Could not inspect jobs for ${WORKFLOW_NAME} run ${RUN_ID}; suppressing notification because the suite result is unknown."
+            exit 0
+          fi
           current_suite="$(printf '%s\n' "$current_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
-          if [[ "$current_suite" == none ]]; then
+          startup_failure=false
+          if [[ "$current_suite" == none && "$WORKFLOW_NAME" == "Live E2E" && "$CONCLUSION" == failure ]]; then
+            current_suite=failure
+            startup_failure=true
+          elif [[ "$current_suite" == none || ("$current_suite" == failure && "$WORKFLOW_NAME" == "Release") ]]; then
+            # Release's generic notification covers release failures and runs
+            # that reused a staging result without creating a suite job.
             exit 0
           fi
 
-          if [[ "$current_suite" == success ]]; then
-            prior_conclusion=""
-            if (( RUN_ATTEMPT > 1 )); then
-              prior_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/$((RUN_ATTEMPT - 1))/jobs?per_page=100")"
-              prior_conclusion="$(printf '%s\n' "$prior_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+          prior_conclusion=""
+          if (( RUN_ATTEMPT > 1 )); then
+            if ! prior_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/$((RUN_ATTEMPT - 1))/jobs?per_page=100")"; then
+              echo "::warning::Could not inspect the prior attempt for ${WORKFLOW_NAME} run ${RUN_ID}; suppressing transition notification."
+              exit 0
             fi
-            if [[ "$prior_conclusion" != failure && "$prior_conclusion" != success ]]; then
-              previous_runs="$(gh api --paginate "/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs?per_page=100" | jq -s -r --arg branch "$BRANCH" --argjson current_number "$RUN_NUMBER" 'map(.workflow_runs[]) | map(select(.run_number < $current_number and .head_branch == $branch and .status == "completed" and (.conclusion == "failure" or .conclusion == "success"))) | sort_by(.run_number) | reverse | .[] | [.id, (.run_attempt // 1)] | @tsv')"
-            else
-              previous_runs=""
+            prior_conclusion="$(printf '%s\n' "$prior_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+            [[ "$prior_conclusion" != none ]] || prior_conclusion=""
+          fi
+
+          if ! history="$(gh api -X GET "/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs" -f "branch=${BRANCH}" -F per_page=25)"; then
+            if [[ "$current_suite" == success && -z "$prior_conclusion" ]]; then
+              echo "::warning::Could not inspect recent ${WORKFLOW_NAME} history; suppressing recovery notification."
+              exit 0
             fi
-            while IFS=$'\t' read -r prior_id prior_attempt; do
-              [[ -z "$prior_id" ]] && continue
-              prior_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${prior_id}/attempts/${prior_attempt}/jobs?per_page=100")"
-              prior_suite="$(printf '%s\n' "$prior_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
-              if [[ "$prior_suite" == failure || "$prior_suite" == success ]]; then
-                prior_conclusion="$prior_suite"
-                break
+            echo "::warning::Could not inspect recent ${WORKFLOW_NAME} history; continuing with the confirmed current result."
+          else
+            candidates="$(jq -r --argjson current_number "$RUN_NUMBER" --argjson current_attempt "$RUN_ATTEMPT" '(.workflow_runs // []) | map(select((.run_number != $current_number or (.run_attempt // 1) != $current_attempt) and .status == "completed" and (.conclusion == "failure" or .conclusion == "success"))) | sort_by(.run_number, (.run_attempt // 1)) | reverse | .[] | [.id, (.run_attempt // 1), .run_number, .conclusion] | @tsv' <<< "$history")"
+            while IFS=$'\t' read -r candidate_id candidate_attempt candidate_number candidate_conclusion; do
+              [[ -z "$candidate_id" ]] && continue
+              if (( candidate_number > RUN_NUMBER || (candidate_number == RUN_NUMBER && candidate_attempt > RUN_ATTEMPT) )); then
+                relation=newer
+              else
+                relation=older
               fi
-            done <<< "$previous_runs"
+              if [[ "$relation" == newer || -z "$prior_conclusion" ]]; then
+                if ! candidate_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${candidate_id}/attempts/${candidate_attempt}/jobs?per_page=100")"; then
+                  echo "::warning::Could not inspect candidate run ${candidate_id}; suppressing notification because history is incomplete."
+                  exit 0
+                fi
+                candidate_suite="$(printf '%s\n' "$candidate_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+                if [[ "$candidate_suite" == none && "$WORKFLOW_NAME" == "Live E2E" && "$candidate_conclusion" == failure ]]; then
+                  candidate_suite=failure
+                fi
+                if [[ "$candidate_suite" == failure || "$candidate_suite" == success ]]; then
+                  if [[ "$relation" == newer ]]; then
+                    echo "A newer completed relevant suite exists; suppressing stale notification."
+                    exit 0
+                  fi
+                  prior_conclusion="$candidate_suite"
+                  break
+                fi
+              fi
+            done <<< "$candidates"
+          fi
+
+          if [[ "$current_suite" == success ]]; then
             [[ "$prior_conclusion" == failure ]] || exit 0
             header="✅ Live E2E recovered"
             text="Live E2E recovered"
-            detail="The previous relevant staging run failed; this run passed."
+            detail="The previous relevant ${WORKFLOW_NAME} live suite failed; this run passed."
           else
-            header="❌ Live E2E failed"
-            text="Live E2E failed"
-            detail="The staging suite failed."
+            [[ "$prior_conclusion" != failure ]] || exit 0
+            if [[ "$startup_failure" == true ]]; then
+              header="❌ Live E2E failed to start"
+              text="Live E2E failed to start"
+              detail="The Live E2E workflow failed before it produced a Live e2e job."
+            else
+              header="❌ Live E2E failed"
+              text="Live E2E failed"
+              detail="The ${WORKFLOW_NAME} live suite failed."
+            fi
           fi
 
           run_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"

--- a/.github/workflows/live-e2e-notify.yml
+++ b/.github/workflows/live-e2e-notify.yml
@@ -1,0 +1,79 @@
+name: Live E2E Notifications
+
+on:
+  workflow_run:
+    workflows: [Live E2E, Release]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  notify:
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Notify Slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+        run: |
+          set -euo pipefail
+
+          # A reusable suite job is named "Live e2e" or ends with "/ Live e2e".
+          # A reused gate has no such job and is intentionally ignored.
+          suite_conclusion() {
+            jq -r '([.jobs[]? | select(.name == "Live e2e" or (.name | endswith("/ Live e2e"))) | .conclusion] | if any(.[]; . == "failure") then "failure" elif any(.[]; . == "success") then "success" else "none" end)'
+          }
+
+          current_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100")"
+          current_suite="$(printf '%s\n' "$current_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+          if [[ "$current_suite" == none ]]; then
+            exit 0
+          fi
+
+          if [[ "$current_suite" == success ]]; then
+            prior_conclusion=""
+            if (( RUN_ATTEMPT > 1 )); then
+              prior_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/$((RUN_ATTEMPT - 1))/jobs?per_page=100")"
+              prior_conclusion="$(printf '%s\n' "$prior_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+            fi
+            if [[ "$prior_conclusion" != failure && "$prior_conclusion" != success ]]; then
+              previous_runs="$(gh api --paginate "/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs?per_page=100" | jq -s -r --arg branch "$BRANCH" --argjson current_number "$RUN_NUMBER" 'map(.workflow_runs[]) | map(select(.run_number < $current_number and .head_branch == $branch and .status == "completed" and (.conclusion == "failure" or .conclusion == "success"))) | sort_by(.run_number) | reverse | .[] | [.id, (.run_attempt // 1)] | @tsv')"
+            else
+              previous_runs=""
+            fi
+            while IFS=$'\t' read -r prior_id prior_attempt; do
+              [[ -z "$prior_id" ]] && continue
+              prior_jobs="$(gh api --paginate "/repos/${REPOSITORY}/actions/runs/${prior_id}/attempts/${prior_attempt}/jobs?per_page=100")"
+              prior_suite="$(printf '%s\n' "$prior_jobs" | jq -s '{jobs: map(.jobs[])}' | suite_conclusion)"
+              if [[ "$prior_suite" == failure || "$prior_suite" == success ]]; then
+                prior_conclusion="$prior_suite"
+                break
+              fi
+            done <<< "$previous_runs"
+            [[ "$prior_conclusion" == failure ]] || exit 0
+            header="✅ Live E2E recovered"
+            text="Live E2E recovered"
+            detail="The previous relevant staging run failed; this run passed."
+          else
+            header="❌ Live E2E failed"
+            text="Live E2E failed"
+            detail="The staging suite failed."
+          fi
+
+          run_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
+          commit_url="https://github.com/${REPOSITORY}/commit/${SHA}"
+          payload="$(jq -n --arg text "$text" --arg header "$header" --arg detail "$detail" --arg run_url "$run_url" --arg commit_url "$commit_url" --arg branch "$BRANCH" --arg sha "${SHA:0:7}" '{text:$text,blocks:[{type:"header",text:{type:"plain_text",text:$header,emoji:true}},{type:"section",text:{type:"mrkdwn",text:($detail + "\n*Branch:* `" + $branch + "`\n*Commit:* <" + $commit_url + "|" + $sha + ">\n*Workflow run:* <" + $run_url + "|view logs and failed tests>")}}]}')"
+          curl -fsSL -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK"

--- a/.github/workflows/live-e2e-suite.yml
+++ b/.github/workflows/live-e2e-suite.yml
@@ -26,8 +26,11 @@ permissions:
 
 jobs:
   live-e2e:
+    # Consumers identify this reusable job by the exact " / Live e2e" suffix.
+    # Keep the suffix aligned with live-e2e-gate.yml and live-e2e-notify.yml.
     name: Live e2e
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
     concurrency:
       group: ${{ inputs.concurrency_group }}
       cancel-in-progress: ${{ inputs.cancel_in_progress }}
@@ -47,6 +50,7 @@ jobs:
       - name: Docker preflight
         run: docker info
 
+      # Consumers also use this exact step name when deciding whether a suite ran.
       - name: Run live e2e
         timeout-minutes: 20
         env:

--- a/.github/workflows/live-e2e-suite.yml
+++ b/.github/workflows/live-e2e-suite.yml
@@ -1,0 +1,60 @@
+name: Live E2E Suite
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to test
+        required: true
+        type: string
+      concurrency_group:
+        description: Concurrency group for this suite
+        required: false
+        type: string
+        default: live-e2e
+      cancel_in_progress:
+        description: Cancel an older run in the same group
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  live-e2e:
+    name: Live e2e
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    concurrency:
+      group: ${{ inputs.concurrency_group }}
+      cancel-in-progress: ${{ inputs.cancel_in_progress }}
+    env:
+      SUPABASE_LIVE_API_URL: https://api.supabase.green
+      SUPABASE_LIVE_PROJECT_NAME: supabase-cli-live
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Docker preflight
+        run: docker info
+
+      - name: Run live e2e
+        timeout-minutes: 20
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
+        run: pnpm run test:live
+
+      - name: Cleanup leftover projects
+        if: always()
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
+        run: bash apps/cli/scripts/sweep-live-projects.sh "supabase-cli-live-${GITHUB_RUN_ID}-"

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -12,10 +12,15 @@ permissions:
 
 jobs:
   live-e2e:
+    # The reusable suite requires only this explicitly forwarded secret.
     name: Live e2e
     uses: ./.github/workflows/live-e2e-suite.yml
     with:
       ref: ${{ github.sha }}
+      # Pushes to develop share a branch group and cancel superseded pushes.
+      # Manual, scheduled, and stable-gate runs use independent groups because
+      # they each own separate temporary projects and may run concurrently.
       concurrency_group: live-e2e-${{ github.event_name == 'push' && github.ref || github.run_id }}
       cancel_in_progress: ${{ github.event_name == 'push' }}
-    secrets: inherit
+    secrets:
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,139 +1,21 @@
 name: Live E2E
 
-# Live e2e suite. Runs the collocated `apps/cli` tests against the real staging
-# Management API + Docker bundler, then invokes deployed functions over HTTP.
-#
-# Non-blocking by construction: this is a standalone workflow, NOT part of the
-# required-checks set, and it never runs on the default PR path of test.yml.
-#
-# Triggers:
-#   - workflow_dispatch — manual run. The Actions UI branch picker selects the
-#     ref (github.ref), always a same-repo branch. We deliberately take NO
-#     free-form `ref` input: that would let a manual run check out arbitrary
-#     (e.g. external PR) code while the staging token is in the job env.
-#   - schedule (daily) — exercises the `@beta` channel. `develop` is the default
-#     branch AND the beta release source, so a scheduled run checks it out and
-#     builds from source. The `gate` job skips the run unless the published
-#     `supabase@beta` version changed since the last green run (an actions/cache
-#     marker keyed on the version), so we only spend a staging project when there
-#     is actually a new beta to test.
-#
-# Secrets: workflow_dispatch and schedule both run on trusted same-repo refs, so
-# the staging token is never exposed to fork code.
 on:
+  push:
+    branches: [develop]
   workflow_dispatch:
   schedule:
-    # Daily, offset from other scheduled workflows. Cron timing is best-effort.
     - cron: "23 6 * * *"
 
 permissions:
   contents: read
 
 jobs:
-  # Decide whether to run. Manual dispatch always runs. Scheduled runs only fire
-  # when the latest published `@beta` is newer than the last one we tested green.
-  gate:
-    name: Gate (newer @beta?)
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.decide.outputs.should_run }}
-      version: ${{ steps.ver.outputs.version }}
-    steps:
-      - name: Resolve latest @beta version
-        id: ver
-        run: |
-          set -euo pipefail
-          version="$(npm view supabase@beta version)"
-          # Validate the shape before it becomes a cache key (defense-in-depth
-          # against a garbage/poisoned registry value).
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::unexpected supabase@beta version '$version'"; exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      # Marker presence == "this beta already tested green". lookup-only so we
-      # download nothing; the marker is written by `finalize` after a green run.
-      - name: Check tested marker
-        id: cache
-        if: github.event_name == 'schedule'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .beta-marker
-          key: live-e2e-beta-${{ steps.ver.outputs.version }}
-          lookup-only: true
-
-      - name: Decide
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "manual dispatch -> run"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
-            echo "beta ${{ steps.ver.outputs.version }} already tested green -> skip"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "new beta ${{ steps.ver.outputs.version }} -> run"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          fi
-
   live-e2e:
-    needs: gate
-    if: needs.gate.outputs.should_run == 'true'
     name: Live e2e
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    # Serialize the job against itself across runs. Per-job-scoped project names
-    # mean this is mostly belt-and-braces.
-    concurrency:
-      group: live-e2e-${{ github.ref }}
-      cancel-in-progress: true
-    # Non-secret config is job-level; the staging token is scoped to only the two
-    # steps that need it (run + cleanup) so build/checkout/docker never see it.
-    env:
-      SUPABASE_LIVE_API_URL: https://api.supabase.green
-      SUPABASE_LIVE_PROJECT_NAME: supabase-cli-live
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      # Docker is a hard requirement for the --use-docker bundler cell.
-      - name: Docker preflight
-        run: docker info
-
-      - name: Run live e2e
-        timeout-minutes: 20
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
-        run: pnpm run test:live
-
-      # Backstop: delete any project this job created that survived a crash.
-      # The script exits non-zero (failing this step) if any delete failed.
-      - name: Cleanup leftover projects
-        if: always()
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
-        run: bash apps/cli/scripts/sweep-live-projects.sh "supabase-cli-live-${GITHUB_RUN_ID}-"
-
-  # Record that this beta tested green so the next scheduled run skips it. The
-  # marker is saved only if the live job passed (a red run leaves no marker, so
-  # the next day re-runs the same beta).
-  finalize:
-    needs: [gate, live-e2e]
-    if: github.event_name == 'schedule' && needs.live-e2e.result == 'success'
-    name: Mark @beta tested
-    runs-on: ubuntu-latest
-    steps:
-      - name: Write marker
-        run: |
-          mkdir -p .beta-marker
-          echo "${{ needs.gate.outputs.version }}" > .beta-marker/version
-
-      - name: Save tested marker
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .beta-marker
-          key: live-e2e-beta-${{ needs.gate.outputs.version }}
+    uses: ./.github/workflows/live-e2e-suite.yml
+    with:
+      ref: ${{ github.sha }}
+      concurrency_group: live-e2e-${{ github.event_name == 'push' && github.ref || github.run_id }}
+      cancel_in_progress: ${{ github.event_name == 'push' }}
+    secrets: inherit

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -55,6 +55,8 @@ on:
         required: false
       LINEAR_CLI_BETA_RELEASE_ACCESS_KEY:
         required: false
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN:
+        required: false
 jobs:
   build-blacksmith:
     name: Build CLI artifacts (Blacksmith)
@@ -261,12 +263,21 @@ jobs:
         run: pnpm run test:smoke -- --version "${VERSION}" --tag "${NPM_TAG}"
         working-directory: apps/cli
 
+  live-e2e-gate:
+    name: Verify live e2e before stable publication
+    if: ${{ inputs.channel == 'stable' && !inputs.dry_run }}
+    uses: ./.github/workflows/live-e2e-gate.yml
+    with:
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   publish:
     needs:
       - build-github
       - smoke-test
       - smoke-test-macos
-    if: ${{ !inputs.dry_run }}
+      - live-e2e-gate
+    if: ${{ !cancelled() && !inputs.dry_run && needs.build-github.result == 'success' && needs.smoke-test.result == 'success' && needs.smoke-test-macos.result == 'success' && (inputs.channel != 'stable' || needs.live-e2e-gate.result == 'success') }}
     # npm provenance verification rejects non-GitHub-hosted runners with
     # E422 ("Unsupported GitHub Actions runner environment: self-hosted").
     # Blacksmith runners count as self-hosted from sigstore's POV, so the
@@ -362,12 +373,11 @@ jobs:
         run: |
           set -euo pipefail
           tag="v${VERSION}"
-          channel="${CHANNEL}"
           note_ref="refs/notes/semantic-release-${tag}"
           if git ls-remote origin "${note_ref}" | grep -q .; then
             echo "Channel note ${note_ref} already on origin; skipping push."
           else
-            git notes --ref="${note_ref}" add -f -m "{\"channels\":[\"${channel}\"]}" "${tag}^{commit}"
+            git notes --ref="${note_ref}" add -f -m "{\"channels\":[\"${CHANNEL}\"]}" "${tag}^{commit}"
             git push origin "${note_ref}"
           fi
 

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -269,7 +269,9 @@ jobs:
     uses: ./.github/workflows/live-e2e-gate.yml
     with:
       sha: ${{ github.sha }}
-    secrets: inherit
+    # Forward the one secret required by live-e2e-gate.yml.
+    secrets:
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
 
   publish:
     needs:

--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -21,8 +21,10 @@ on:
 permissions:
   # release-shared.yml declares privileged publish jobs. They are gated by
   # dry_run here, but GitHub validates nested-workflow permissions at startup.
+  actions: read
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   smoke:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
     # to the calling job, so this must be declared here even though the propose
     # job uses an App token for its actual PR creation.
     permissions:
+      actions: read
       contents: write
       id-token: write
       pull-requests: write
@@ -213,6 +214,7 @@ jobs:
       DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
       LINEAR_CLI_STABLE_RELEASE_ACCESS_KEY: ${{ secrets.LINEAR_CLI_STABLE_RELEASE_ACCESS_KEY }}
       LINEAR_CLI_BETA_RELEASE_ACCESS_KEY: ${{ secrets.LINEAR_CLI_BETA_RELEASE_ACCESS_KEY }}
+      SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN: ${{ secrets.SUPABASE_E2E_CLI_LIVE_STAGING_ACCESS_TOKEN }}
 
   # Republishes the supabase.com CLI reference, restoring the job the Go
   # `tools/bumpdoc` ran before the monorepo merge (71b543255) deleted it — the


### PR DESCRIPTION
Live staging tests currently run independently of stable publication, so a stable release can ship without a passing live suite for its commit.

Run the suite after every push to `develop` and every night, with superseded push runs cancelled independently of scheduled and manual runs. Stable publication, including manual releases, requires a passing suite for the exact release commit: reuse a verified successful run on `develop`, or run the suite before publishing. Beta releases retain their existing gates.

Send staging startup failures and failure/recovery transitions through the existing Slack release webhook, linking the commit and logs. A bounded history lookup suppresses repeated outcomes and notifications superseded by newer runs or attempts. Stable-gate failures use the existing release-failure notification to avoid duplicate alerts; notification delivery remains independent of publication.

Forward only the staging access token through the live workflow calls, bound job runtimes, and document the reuse and concurrency policy in the maintainers guide. Existing opt-in PR Supabox coverage is unchanged.
