### PR TITLE
fix(cli): improve stack startup defaults and clean managed state

### DIFF
--- a/apps/cli/src/commands/experimental/stack/stack-config-environment.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/stack-config-environment.integration.test.ts
@@ -4,6 +4,7 @@ import { encrypt, PrivateKey } from "eciesjs";
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Option, Redacted } from "effect";
+import { compileStack } from "../../../../../../packages/stack/src/model/Compiler.ts";
 
 import { withEnvVar } from "../../../../tests/helpers/command-mocks.ts";
 import { StackConfigError, loadStackConfig } from "./stack-config.ts";
@@ -537,7 +538,9 @@ auto_expose_new_tables = true
         !("settings" in absentImage.capabilities.storage)
       )
         throw new Error("absent-image storage settings missing");
-      expect(absentImage.capabilities.storage.settings?.image_transformation).toBeUndefined();
+      expect(absentImage.capabilities.storage.settings?.image_transformation).toEqual({
+        enabled: true,
+      });
 
       const absentApi = yield* load(absentApiRoot);
       if (
@@ -588,7 +591,6 @@ openai_api_key = "config-studio-key"
         supabaseEnv: [
           "SUPABASE_API_SCHEMAS=public,storage",
           "SUPABASE_ANALYTICS_BACKEND=bigquery",
-          "SUPABASE_ANALYTICS_VECTOR_PORT=54328",
           "SUPABASE_ANALYTICS_GCP_PROJECT_ID=env-project",
           "SUPABASE_DB_MAJOR_VERSION=17",
           "SUPABASE_STUDIO_OPENAI_API_KEY=env-studio-key",
@@ -610,7 +612,6 @@ openai_api_key = "config-studio-key"
       )
         throw new Error("analytics settings missing");
       expect(config.capabilities.analytics.settings?.backend).toBe("bigquery");
-      expect(config.capabilities.analytics.settings?.vector_port).toBe(54328);
       expect(config.capabilities.analytics.settings?.gcp_project_id).toBe("env-project");
       expect(config.capabilities.studio.settings?.openai_api_key).toBeDefined();
       if (config.capabilities.studio.settings?.openai_api_key === undefined)
@@ -657,6 +658,108 @@ openai_api_key = "config-studio-key"
       );
     },
   );
+
+  it.effect("defers omitted and empty pooler settings to the stack package", () => {
+    const omitted = project('project_id = "stack-config-omitted-pooler"\n');
+    const empty = project('project_id = "stack-config-empty-pooler"\n[db.pooler]\n');
+    return Effect.gen(function* () {
+      expect((yield* load(omitted)).capabilities?.pooler).toEqual({
+        settings: { pool_mode: "transaction", default_pool_size: 20, max_client_conn: 100 },
+      });
+      expect((yield* load(empty)).capabilities?.pooler).toEqual({
+        settings: { pool_mode: "transaction", default_pool_size: 20, max_client_conn: 100 },
+      });
+    });
+  });
+
+  it.effect("compiles package defaults from the CLI adapter", () => {
+    const root = project('project_id = "stack-config-compiler-defaults"\n');
+    return Effect.gen(function* () {
+      const config = yield* load(root);
+      const compiled = yield* compileStack({
+        projectRoot: root,
+        runtime: { kind: "native" },
+        config,
+      }).pipe(Effect.provide(BunServices.layer));
+      expect(compiled.definition.capabilities.pooler.enabled).toBe(true);
+      expect(compiled.definition.capabilities.pooler.activation).toBe("lazy");
+      expect(compiled.definition.capabilities.storage.settings.image_transformation?.enabled).toBe(
+        true,
+      );
+      expect(compiled.definition.capabilities.storage.activation).toBe("lazy");
+      expect(compiled.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy")).toBe(
+        true,
+      );
+      expect(compiled.executionPlan.workloads.some(({ id }) => id === "analytics:vector")).toBe(
+        true,
+      );
+    });
+  });
+
+  it.effect("keeps pooler tuning while inheriting its enabled default", () => {
+    const root = project(
+      'project_id = "stack-config-compiler-pooler-tuning"\n[db.pooler]\ndefault_pool_size = 37\n',
+    );
+    return Effect.gen(function* () {
+      const config = yield* load(root);
+      const compiled = yield* compileStack({
+        projectRoot: root,
+        runtime: { kind: "native" },
+        config,
+      }).pipe(Effect.provide(BunServices.layer));
+      expect(compiled.definition.capabilities.pooler.enabled).toBe(true);
+      expect(compiled.definition.capabilities.pooler.settings.default_pool_size).toBe(37);
+      expect(compiled.definition.listeners.pooler.enabled).toBe(true);
+    });
+  });
+
+  it.effect("honors explicit capability overrides through compilation", () => {
+    const enabled = project(
+      `project_id = "stack-config-compiler-overrides"
+[db.pooler]
+enabled = false
+[storage.image_transformation]
+enabled = false
+`,
+      {
+        supabaseEnv:
+          "SUPABASE_DB_POOLER_ENABLED=true\nSUPABASE_STORAGE_IMAGE_TRANSFORMATION_ENABLED=true\n",
+      },
+    );
+    const disabled = project('project_id = "stack-config-compiler-disabled"\n', {
+      supabaseEnv:
+        "SUPABASE_DB_POOLER_ENABLED=false\nSUPABASE_STORAGE_IMAGE_TRANSFORMATION_ENABLED=false\n",
+    });
+    return Effect.gen(function* () {
+      const enabledConfig = yield* load(enabled);
+      const enabledCompiled = yield* compileStack({
+        projectRoot: enabled,
+        runtime: { kind: "native" },
+        config: enabledConfig,
+      }).pipe(Effect.provide(BunServices.layer));
+      expect(enabledCompiled.definition.capabilities.pooler.enabled).toBe(true);
+      expect(
+        enabledCompiled.definition.capabilities.storage.settings.image_transformation?.enabled,
+      ).toBe(true);
+      expect(
+        enabledCompiled.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy"),
+      ).toBe(true);
+
+      const disabledConfig = yield* load(disabled);
+      const disabledCompiled = yield* compileStack({
+        projectRoot: disabled,
+        runtime: { kind: "native" },
+        config: disabledConfig,
+      }).pipe(Effect.provide(BunServices.layer));
+      expect(disabledCompiled.definition.capabilities.pooler.enabled).toBe(false);
+      expect(
+        disabledCompiled.definition.capabilities.storage.settings.image_transformation?.enabled,
+      ).toBe(false);
+      expect(
+        disabledCompiled.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy"),
+      ).toBe(false);
+    });
+  });
 
   it.effect("keeps an absent raw Studio section disabled through env overrides", () => {
     const root = project('project_id = "stack-config-absent-studio-disabled"\n');

--- a/apps/cli/src/commands/experimental/stack/stack-config-environment.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/stack-config-environment.integration.test.ts
@@ -514,7 +514,7 @@ auto_expose_new_tables = true
       const config = yield* load(root);
       if (config.capabilities?.rest === undefined || !("settings" in config.capabilities.rest))
         throw new Error("REST settings missing");
-      expect(config.capabilities.rest.settings?.auto_expose_new_tables).toBe(true);
+      expect(config.capabilities.rest.settings).not.toHaveProperty("auto_expose_new_tables");
       if (config.capabilities.storage === undefined || !("settings" in config.capabilities.storage))
         throw new Error("storage settings missing");
       expect(config.capabilities.storage.settings?.image_transformation).toEqual({ enabled: true });
@@ -545,7 +545,7 @@ auto_expose_new_tables = true
         !("settings" in absentApi.capabilities.rest)
       )
         throw new Error("absent-api REST settings missing");
-      expect(absentApi.capabilities.rest.settings?.auto_expose_new_tables).toBeUndefined();
+      expect(absentApi.capabilities.rest.settings).not.toHaveProperty("auto_expose_new_tables");
 
       const explicitFalseApi = yield* load(explicitFalseApiRoot);
       if (
@@ -553,7 +553,9 @@ auto_expose_new_tables = true
         !("settings" in explicitFalseApi.capabilities.rest)
       )
         throw new Error("explicit-false REST settings missing");
-      expect(explicitFalseApi.capabilities.rest.settings?.auto_expose_new_tables).toBe(false);
+      expect(explicitFalseApi.capabilities.rest.settings).not.toHaveProperty(
+        "auto_expose_new_tables",
+      );
     });
   });
 

--- a/apps/cli/src/commands/experimental/stack/stack-config.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/stack-config.integration.test.ts
@@ -149,6 +149,40 @@ secret = "figma-secret"
     });
   });
 
+  it.effect("accepts hosted-only settings without forwarding them to the local stack", () => {
+    const root = project(`project_id = "stack-config-hosted-only"
+[api]
+auto_expose_new_tables = true
+[api.tls]
+enabled = true
+cert_path = "./server.crt"
+key_path = "./server.key"
+[storage.analytics]
+enabled = true
+max_namespaces = 9
+max_tables = 12
+max_catalogs = 4
+`);
+    return Effect.gen(function* () {
+      const config = yield* load(root);
+      if (config.capabilities?.rest === undefined || !("settings" in config.capabilities.rest))
+        throw new Error("REST settings missing");
+      expect(config.capabilities.rest.settings).toMatchObject({
+        schemas: ["public", "graphql_public"],
+        extra_search_path: ["public", "extensions"],
+        max_rows: 1000,
+      });
+      expect(config.capabilities.rest.settings).not.toHaveProperty("auto_expose_new_tables");
+      expect(config.capabilities.rest.settings).not.toHaveProperty("tls");
+      if (
+        config.capabilities?.storage === undefined ||
+        !("settings" in config.capabilities.storage)
+      )
+        throw new Error("Storage settings missing");
+      expect(config.capabilities.storage.settings).not.toHaveProperty("analytics");
+    });
+  });
+
   it.effect("keeps disabled unsupported providers harmless", () => {
     const root = project(`project_id = "stack-config-disabled-figma"
 [auth.external.figma]
@@ -481,12 +515,12 @@ enabled = false
     });
   });
 
-  it.effect("fails clearly when the project has not been initialized", () => {
+  it.effect("uses default stack settings when no project config exists", () => {
     const root = stackConfigTempRoot.current;
     return Effect.gen(function* () {
-      const exit = yield* loadStackConfig(root).pipe(Effect.exit);
-      expect(Exit.isFailure(exit)).toBe(true);
-      if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain("supabase init");
+      const config = yield* loadStackConfig(root);
+      expect(config.listeners).toEqual({});
+      expect(config.capabilities?.database).toMatchObject({ settings: { health_timeout: "2m" } });
     }).pipe(Effect.provide(BunServices.layer));
   });
 });

--- a/apps/cli/src/commands/experimental/stack/stack-config.ts
+++ b/apps/cli/src/commands/experimental/stack/stack-config.ts
@@ -1219,10 +1219,6 @@ const configInput = (
         schemas: apiResolved.schemas,
         extra_search_path: apiResolved.extra_search_path,
         max_rows: apiResolved.max_rows,
-        ...(apiResolved.auto_expose_new_tables === undefined
-          ? {}
-          : { auto_expose_new_tables: apiResolved.auto_expose_new_tables }),
-        tls: apiResolved.tls,
         external_url: apiResolved.external_url,
       }),
       auth:
@@ -1238,7 +1234,6 @@ const configInput = (
         image_transformation: storageResolved.image_transformation,
         buckets: storageResolved.buckets,
         s3_protocol: storageResolved.s3_protocol,
-        analytics: storageResolved.analytics,
         vector: storageResolved.vector,
       }),
       functions: capability(
@@ -1389,15 +1384,13 @@ export const loadStackConfig = (projectRoot: string): StackConfigEffect =>
       projectRoot,
       (message) => new StackConfigError({ message }),
     );
-    const loaded = context.loaded;
-    if (loaded === null)
-      return yield* new StackConfigError({
-        message: `No Supabase project configuration found in ${projectRoot}. Run supabase init first.`,
-      });
-
     const effectiveInput = yield* Effect.try({
       try: () =>
-        resolveEffectiveCliConfig(context.config, loaded.document, context.projectEnvValues),
+        resolveEffectiveCliConfig(
+          context.config,
+          context.loaded?.document,
+          context.projectEnvValues,
+        ),
       catch: (cause) =>
         new StackConfigError({
           message: cause instanceof Error ? cause.message : "invalid config overrides",
@@ -1446,7 +1439,13 @@ export const loadStackConfig = (projectRoot: string): StackConfigEffect =>
     );
     const input = yield* Effect.try({
       try: () =>
-        configInput(projectRoot, path, validatedConfig, loaded.document, context.projectEnvValues),
+        configInput(
+          projectRoot,
+          path,
+          validatedConfig,
+          context.loaded?.document,
+          context.projectEnvValues,
+        ),
       catch: (cause) =>
         new StackConfigError({
           message:

--- a/apps/cli/src/commands/experimental/stack/stack-config.ts
+++ b/apps/cli/src/commands/experimental/stack/stack-config.ts
@@ -866,7 +866,14 @@ const resolveEffectiveCliConfig = (
   const edge = config.edge_runtime;
   const apiSchemasOverride = envOverride("SUPABASE_API_SCHEMAS", undefined, env);
   const apiExtraSearchPathOverride = envOverride("SUPABASE_API_EXTRA_SEARCH_PATH", undefined, env);
-  const imagePresent = section(section(document, "storage"), "image_transformation") !== undefined;
+  const imageDocument = section(section(document, "storage"), "image_transformation");
+  const imageEnabledOverride = envOverride(
+    "SUPABASE_STORAGE_IMAGE_TRANSFORMATION_ENABLED",
+    undefined,
+    env,
+  );
+  const imageEnabledExplicit =
+    imageDocument?.enabled !== undefined || imageEnabledOverride !== undefined;
   const resolvedApi = {
     ...api,
     enabled: envOverrideBool("SUPABASE_API_ENABLED", api.enabled, "api.enabled", env),
@@ -903,7 +910,7 @@ const resolveEffectiveCliConfig = (
       String(storage.file_size_limit),
       env,
     ),
-    image_transformation: imagePresent
+    image_transformation: imageEnabledExplicit
       ? {
           ...storage.image_transformation,
           enabled: envOverrideBool(
@@ -998,13 +1005,6 @@ const resolveEffectiveCliConfig = (
       env,
     ),
     backend: envOverrideAnalyticsBackend(analytics.backend, env),
-    vector_port:
-      resolvedPort(
-        "SUPABASE_ANALYTICS_VECTOR_PORT",
-        analytics.vector_port ?? 0,
-        "analytics.vector_port",
-        env,
-      ) || undefined,
     gcp_project_id: envOverride("SUPABASE_ANALYTICS_GCP_PROJECT_ID", analytics.gcp_project_id, env),
     gcp_project_number: envOverride(
       "SUPABASE_ANALYTICS_GCP_PROJECT_NUMBER",
@@ -1135,9 +1135,12 @@ const configInput = (
   const dbMajorVersion = db.major_version;
   const dbSettings = db.settings;
   const realtimeResolved = realtime;
-  const imageTransformationPresent =
-    section(section(document, "storage"), "image_transformation") !== undefined;
-  const storageResolved = imageTransformationPresent
+  const imageTransformationDocument = section(section(document, "storage"), "image_transformation");
+  const imageTransformationExplicit =
+    imageTransformationDocument?.enabled !== undefined ||
+    envOverride("SUPABASE_STORAGE_IMAGE_TRANSFORMATION_ENABLED", undefined, listenerEnvValues) !==
+      undefined;
+  const storageResolved = imageTransformationExplicit
     ? storage
     : { ...storage, image_transformation: undefined };
   const edgeEnabled = config.edge_runtime.enabled;
@@ -1179,7 +1182,15 @@ const configInput = (
     mail.pop3_port ?? 0,
     listenerEnvValues,
   );
-  const poolerEnabled = pooler.enabled;
+  const poolerDocument = section(section(document, "db"), "pooler");
+  const poolerEnabledOverride = envOverride(
+    "SUPABASE_DB_POOLER_ENABLED",
+    undefined,
+    listenerEnvValues,
+  );
+  const poolerEnabledExplicit =
+    poolerDocument?.enabled !== undefined || poolerEnabledOverride !== undefined;
+  const poolerEnabled = poolerEnabledExplicit ? pooler.enabled : undefined;
   const poolerPort = envNestedPortOrConfigured(
     "SUPABASE_DB_POOLER_PORT",
     document,
@@ -1252,16 +1263,20 @@ const configInput = (
       }),
       analytics: capability(analyticsEnabled, {
         backend: analyticsResolved.backend,
-        vector_port: analyticsResolved.vector_port,
         gcp_project_id: analyticsResolved.gcp_project_id,
         gcp_project_number: analyticsResolved.gcp_project_number,
         gcp_jwt_path: analyticsResolved.gcp_jwt_path,
       }),
-      pooler: capability(poolerEnabled, {
-        pool_mode: poolerResolved.pool_mode,
-        default_pool_size: poolerResolved.default_pool_size,
-        max_client_conn: poolerResolved.max_client_conn,
-      }),
+      pooler:
+        poolerEnabled !== false
+          ? {
+              settings: {
+                pool_mode: poolerResolved.pool_mode,
+                default_pool_size: poolerResolved.default_pool_size,
+                max_client_conn: poolerResolved.max_client_conn,
+              },
+            }
+          : { enabled: false as const },
     },
     listeners: {
       api: apiListener(

--- a/apps/cli/src/commands/experimental/stack/start/SIDE_EFFECTS.md
+++ b/apps/cli/src/commands/experimental/stack/start/SIDE_EFFECTS.md
@@ -2,7 +2,9 @@
 
 This command creates or resumes the managed stack identified by the current
 project and optional `--stack`, or opens an existing stack with `--stack-id`.
-It loads `supabase/config.toml` for the target project and resolves explicit
+It loads `supabase/config.toml` for the target project when present and uses
+default settings when it is absent; starting the stack does not create a config
+file. It resolves explicit
 `env(NAME)` references plus supported automatic `SUPABASE_*` overrides. Shell
 values take precedence over values from `supabase/` dotenv files, which take
 precedence over project-root dotenv files. Empty automatic overrides are
@@ -46,9 +48,11 @@ capabilities. Structured output includes the same status fields. The command rea
 credentials and function/provider secrets to pass them to the stack runtime, but
 never emits those values.
 
-`--stack` and `--stack-id` are mutually exclusive. `--runtime auto` uses the
-package default; `docker` selects the Docker container runtime; `native`
-selects the native runtime. `--preparation` controls background versus
+`--stack` and `--stack-id` are mutually exclusive. For a new stack, `--runtime auto`
+selects Docker when a Docker executable is available on `PATH` and native otherwise;
+a stopped Docker daemon still selects Docker. Existing stacks reuse their persisted
+runtime. `docker` and `native` select the requested runtime without fallback.
+`--preparation` controls background versus
 on-demand artifact preparation, and `--eager` requests enabled capabilities be
 activated before the command returns.
 

--- a/apps/cli/src/commands/experimental/stack/start/start.command.ts
+++ b/apps/cli/src/commands/experimental/stack/start/start.command.ts
@@ -28,8 +28,10 @@ export type StackStartFlags = CliCommand.Command.Config.Infer<typeof config>;
 
 export const stackStartCommand = Command.make("start", config).pipe(
   Command.withDescription(
-    "Create or resume a managed local Supabase stack from supabase/config.toml. " +
-      "Values support explicit env(NAME) references and automatic SUPABASE_* overrides.",
+    "Create or resume a managed local Supabase stack using supabase/config.toml when present. " +
+      "Without a config file, default settings are used and no file is created. " +
+      "For a new stack, auto selects Docker when its client is installed and native otherwise; a stopped daemon still selects Docker. " +
+      "Explicit runtime choices are honored. Values support explicit env(NAME) references and automatic SUPABASE_* overrides.",
   ),
   Command.withShortDescription("Start a managed local stack"),
   Command.withExamples([

--- a/apps/cli/src/commands/experimental/stack/start/start.handler.ts
+++ b/apps/cli/src/commands/experimental/stack/start/start.handler.ts
@@ -171,7 +171,8 @@ const stackStartError = (error: unknown) => {
       : Match.value(stackError).pipe(
           Match.tag("ContainerEngineError", () => ({
             reason: "runtime" as const,
-            suggestion: "Ensure the selected container engine is running and retry the command.",
+            suggestion:
+              "Check that the selected container engine is installed and its daemon is running, then retry the command.",
           })),
           Match.tag("ContainerPullError", () => ({
             reason: "registry" as const,

--- a/apps/cli/src/commands/experimental/stack/start/start.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/start/start.integration.test.ts
@@ -1,5 +1,5 @@
 // oxlint-disable-next-line effecttsgo/node-builtin-import -- filesystem test fixture uses the host adapter at this boundary
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 // oxlint-disable-next-line effecttsgo/node-builtin-import -- filesystem test fixture uses the host adapter at this boundary
 import { join } from "node:path";
@@ -49,6 +49,9 @@ const project = (): string => {
   writeFileSync(join(root, "supabase", "config.toml"), 'project_id = "start-test"\n');
   return root;
 };
+
+const emptyProject = (): string =>
+  mkdtempSync(join(tmpdir(), "supabase-experimental-stack-start-empty-"));
 
 const resolverLayer = stackTargetResolverLayer.pipe(
   Layer.provideMerge(stackApiLayer),
@@ -112,7 +115,12 @@ const flags = (overrides: Partial<Parameters<typeof stackStart>[0]> = {}) => ({
 
 function handlerLayer(opts: {
   root: string;
-  target: { projectRoot: string; name?: string; id?: string; runtime?: { kind: "native" } };
+  target: {
+    projectRoot: string;
+    name?: string;
+    id?: string;
+    runtime?: { kind: "native" } | { kind: "container"; engine: "docker" };
+  };
   stack: EffectStack;
   onCreate?: (options: unknown) => void;
   onOpen?: () => void;
@@ -153,6 +161,56 @@ function handlerLayer(opts: {
 }
 
 describe("stack start targeting", () => {
+  it.live("leaves auto runtime selection to the package for a new stack", () => {
+    const root = project();
+    let createOptions: unknown;
+    const stack = fakeStack("f".repeat(64), () => Effect.succeed(status("f".repeat(64))));
+    const setup = handlerLayer({
+      root,
+      target: { projectRoot: root },
+      stack,
+      onCreate: (options) => {
+        createOptions = options;
+      },
+    });
+    return Effect.gen(function* () {
+      yield* stackStart(flags({ runtime: "auto" }));
+      expect(createOptions).toEqual({ projectRoot: root });
+    }).pipe(
+      Effect.provide(setup.layer),
+      Effect.ensuring(Effect.sync(() => rmSync(root, { recursive: true, force: true }))),
+    );
+  });
+
+  it.live("forwards an explicit Docker runtime to the package", () => {
+    const root = project();
+    let createOptions: unknown;
+    const stack = fakeStack("d".repeat(64), () => Effect.succeed(status("d".repeat(64))));
+    const setup = handlerLayer({
+      root,
+      target: {
+        projectRoot: root,
+        name: "feature-docker",
+        runtime: { kind: "container", engine: "docker" },
+      },
+      stack,
+      onCreate: (options) => {
+        createOptions = options;
+      },
+    });
+    return Effect.gen(function* () {
+      yield* stackStart(flags({ stack: Option.some("feature-docker"), runtime: "docker" }));
+      expect(createOptions).toEqual({
+        projectRoot: root,
+        name: "feature-docker",
+        runtime: { kind: "container", engine: "docker" },
+      });
+    }).pipe(
+      Effect.provide(setup.layer),
+      Effect.ensuring(Effect.sync(() => rmSync(root, { recursive: true, force: true }))),
+    );
+  });
+
   it.effect("resolves the current project target", () => {
     const root = project();
     return Effect.gen(function* () {
@@ -332,7 +390,8 @@ describe("stack start targeting", () => {
       expect(failure).toBeInstanceOf(StackCommandStartError);
       if (failure instanceof StackCommandStartError) {
         expect(failure.reason).toBe("runtime");
-        expect(failure.suggestion).toContain("container engine");
+        expect(failure.suggestion).toContain("container engine is installed");
+        expect(failure.suggestion).toContain("daemon is running");
         expect(failure[ErrorActionabilityId]).toEqual(actionability.dockerNotRunning);
       }
       expect(stopped).toBe(false);
@@ -436,17 +495,21 @@ describe("stack start targeting", () => {
     );
   });
 
-  it.live("classifies a missing project configuration as invalid config", () => {
-    const root = mkdtempSync(join(tmpdir(), "supabase-experimental-stack-start-invalid-"));
-    const stack = fakeStack("9".repeat(64), () => Effect.succeed(status("9".repeat(64))));
+  it.live("starts with default configuration when no project config exists", () => {
+    const root = emptyProject();
+    let started = false;
+    const stack = fakeStack("9".repeat(64), (config) => {
+      started = true;
+      expect(config).toMatchObject({
+        config: { capabilities: { database: { settings: { health_timeout: "2m" } } } },
+      });
+      return Effect.succeed(status("9".repeat(64)));
+    });
     const setup = handlerLayer({ root, target: { projectRoot: root }, stack });
     return Effect.gen(function* () {
-      const failure = yield* stackStart(flags()).pipe(Effect.flip);
-      expect(failure).toBeInstanceOf(StackCommandStartError);
-      if (failure instanceof StackCommandStartError) {
-        expect(failure.reason).toBe("invalid-config");
-        expect(failure[ErrorActionabilityId]).toEqual(actionability.invalidConfig);
-      }
+      yield* stackStart(flags());
+      expect(started).toBe(true);
+      expect(existsSync(join(root, "supabase", "config.toml"))).toBe(false);
     }).pipe(
       Effect.provide(setup.layer),
       Effect.ensuring(Effect.sync(() => rmSync(root, { recursive: true, force: true }))),

--- a/docs/adr/0017-simplified-managed-stack-architecture.md
+++ b/docs/adr/0017-simplified-managed-stack-architecture.md
@@ -154,6 +154,12 @@ may launch the current Supervisor and start again. The first admitted lifecycle 
 to completion; concurrent lifecycle mutations fail immediately with a conflict
 rather than joining or queueing.
 
+Capability modules own the new stack's defaults. All capabilities are enabled
+by default, including Pooler, with image transformation available through
+Storage's imgproxy workload and Vector included with Analytics. The CLI preserves
+explicit enablement overrides while leaving omitted values to the package;
+the shared CLI configuration's defaults remain unchanged for other commands.
+
 PostgreSQL is the only eager capability by default. Start prepares and launches
 only the eager dependency closure, so the PostgreSQL readiness barrier remains
 the default startup path. Capabilities configured for lazy activation start when

--- a/docs/adr/0017-simplified-managed-stack-architecture.md
+++ b/docs/adr/0017-simplified-managed-stack-architecture.md
@@ -58,6 +58,9 @@ in the materialized definition only when the local runtime implements them;
 hosted-only database network restrictions, SSL enforcement, and vault settings
 are excluded.
 
+Disabling a capability releases its automatic port assignment; re-enabling it may
+select a new port.
+
 Stack handles are lightweight identity-scoped clients. Creating or opening one
 does not launch a Supervisor. Successful stop drains ingress, removes every
 ephemeral runtime resource, persists stopped state, delivers its response, then

--- a/docs/adr/0017-simplified-managed-stack-architecture.md
+++ b/docs/adr/0017-simplified-managed-stack-architecture.md
@@ -55,8 +55,11 @@ Port assignments describe usable routes and workload bindings. Disabled
 capabilities do not reserve public listener ports, and the Functions inspector
 reserves a private port only when debugging is enabled. Service settings belong
 in the materialized definition only when the local runtime implements them;
-hosted-only database network restrictions, SSL enforcement, and vault settings
-are excluded.
+hosted-only database network restrictions, SSL enforcement, vault, REST
+auto-exposure, and Storage Analytics settings are excluded. API TLS is locally
+meaningful but unsupported by the stack gateway, so it is excluded too.
+Analytics' Vector port is assigned by the runtime rather than stored as a
+service setting.
 
 Disabling a capability releases its automatic port assignment; re-enabling it may
 select a new port.

--- a/docs/adr/0017-simplified-managed-stack-architecture.md
+++ b/docs/adr/0017-simplified-managed-stack-architecture.md
@@ -44,6 +44,20 @@ monorepo project roots, and named stacks while keeping identity resolution
 read-only. Project relocation is not supported: a moved project resolves to a
 new identity.
 
+The managed directory supplies the stack ID; `state.json` stores the identity
+tuple and validates its digest against that directory instead of duplicating
+the ID. `control.json` stores the owner session, lease port, and RPC release.
+The control endpoint is derived from the directory ID, lease port, and runtime
+environment. The ownership lock remains separate: it protects acquisition
+before the owner publishes its ready control metadata.
+
+Port assignments describe usable routes and workload bindings. Disabled
+capabilities do not reserve public listener ports, and the Functions inspector
+reserves a private port only when debugging is enabled. Service settings belong
+in the materialized definition only when the local runtime implements them;
+hosted-only database network restrictions, SSL enforcement, and vault settings
+are excluded.
+
 Stack handles are lightweight identity-scoped clients. Creating or opening one
 does not launch a Supervisor. Successful stop drains ingress, removes every
 ephemeral runtime resource, persists stopped state, delivers its response, then
@@ -107,11 +121,13 @@ numbers while the stack is stopped. Focused port coverage runs on macOS,
 Linux, and Windows in CI.
 
 Every managed document records one concrete runtime selection. Native and
-container runtimes never mix. An omitted runtime selects native; when a
-container runtime is selected, an omitted engine defaults to Docker. Callers
-may explicitly select Docker or Podman. There is no probing or auto-detection;
-Podman is supported only on local Linux hosts. Persisted state records the
-resolved exact engine. Capability releases and
+container runtimes never mix. For a new stack, an omitted runtime runs
+`docker --version` and selects Docker when the client is installed, or native
+when it is absent; this checks only the client and does not require a running
+daemon. Existing state is reused without probing. Callers may explicitly select
+native, Docker, or Podman, and an omitted engine for an explicit container
+runtime defaults to Docker. Podman is supported only on local Linux hosts.
+Persisted state records the resolved exact engine. Capability releases and
 workload artifacts are persisted as exact version pins (including their
 concrete native release and container image) rather than ranges or floating
 tags. Services with derived low-memory image profiles inherit those same

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -92,7 +92,10 @@ projects in a monorepo, and named stacks therefore receive separate managed stat
 resolution is read-only; moving a project creates a new identity.
 
 `createTestStack` gives each test stack a unique temporary project root and identity while sharing
-the managed state root used by ordinary package callers. Automatic ports therefore
+the managed state root used by ordinary package callers. It uses the same runtime selection as
+`createStack`: an installed Docker client selects Docker even when its daemon is stopped. Pass
+`runtime: { kind: "native" }` or an explicit container runtime for reproducible test environments.
+Automatic ports therefore
 coordinate across all default callers. Helper project roots and identities remain isolated; a
 temporary test stack is excluded from listings scoped to another project root but appears in an
 unfiltered package `listStacks()` result. A failed destroy retains the affected project root and

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -80,8 +80,10 @@ Docker modes. It begins from the PostgreSQL-only default, progressively activate
 realistic traffic, and verifies stop/start cycles, stable ports, and persistent data. The
 CLI is not involved in these runtime tests.
 
-Podman is supported only on local Linux hosts and must be selected explicitly; the runtime does not
-auto-detect container engines.
+When `runtime` is omitted for a new stack, the package selects Docker when the Docker client is
+installed and native otherwise. The check runs `docker --version`, so a stopped Docker daemon still
+selects Docker. Existing stacks reuse their persisted runtime without probing; native, Docker, and
+Podman preferences remain explicit when supplied. Podman is supported only on local Linux hosts.
 
 Stack identity is the length-delimited SHA-256 tuple of the canonical project root, Git branch
 context (or `ordinary-workspace` outside Git), and stack name. Separate worktree roots, branches,

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -18,8 +18,9 @@ Stacks are managed identities: closing a handle does not stop a running stack. C
 handle starts nothing, and a stopped stack retains no Supervisor, workload, container, network, or
 listener. Status and retained logs remain available directly from durable state while stopped; a
 later start on the same handle launches a fresh Supervisor.
-With no configuration override, all capabilities are enabled, PostgreSQL is the only eager
-capability, and every other capability is lazy. Starting the stack therefore launches only
+With no configuration override, all capabilities and their companion workloads (including
+imgproxy and Vector) are enabled, PostgreSQL is the only eager capability, and every other
+capability is lazy. Starting the stack therefore launches only
 PostgreSQL by default; capabilities configured as eager join its startup dependency closure.
 The remaining lazy capabilities activate through the stack's listeners on demand for the current
 running session.

--- a/packages/stack/src/identity/GitBranchContext.ts
+++ b/packages/stack/src/identity/GitBranchContext.ts
@@ -49,21 +49,10 @@ const hasGitRepositoryMarkers = (
 ): Effect.Effect<boolean, PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const head = yield* fs.exists(path.join(gitDirectory, "HEAD"));
-    const hasLocalObjectsAndRefs =
-      (yield* fs.exists(path.join(gitDirectory, "objects"))) &&
-      (yield* fs.exists(path.join(gitDirectory, "refs")));
-    if (hasLocalObjectsAndRefs) return true;
-
-    if (!(yield* fs.exists(path.join(gitDirectory, "commondir")))) return false;
-    if (!head) return false;
-    const commonDirectory = (yield* fs.readFileString(path.join(gitDirectory, "commondir"))).trim();
-    if (commonDirectory.length === 0) return false;
-    const canonicalCommonDirectory = yield* fs.realPath(
-      path.resolve(gitDirectory, commonDirectory),
-    );
+    if (head) return true;
     return (
-      (yield* fs.exists(path.join(canonicalCommonDirectory, "objects"))) &&
-      (yield* fs.exists(path.join(canonicalCommonDirectory, "refs")))
+      (yield* fs.exists(path.join(gitDirectory, "objects"))) &&
+      (yield* fs.exists(path.join(gitDirectory, "refs")))
     );
   });
 

--- a/packages/stack/src/identity/GitBranchContext.ts
+++ b/packages/stack/src/identity/GitBranchContext.ts
@@ -42,6 +42,31 @@ const canonicalGitDirectory = (
     ),
   );
 
+const hasGitRepositoryMarkers = (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  gitDirectory: string,
+): Effect.Effect<boolean, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const head = yield* fs.exists(path.join(gitDirectory, "HEAD"));
+    const hasLocalObjectsAndRefs =
+      (yield* fs.exists(path.join(gitDirectory, "objects"))) &&
+      (yield* fs.exists(path.join(gitDirectory, "refs")));
+    if (hasLocalObjectsAndRefs) return true;
+
+    if (!(yield* fs.exists(path.join(gitDirectory, "commondir")))) return false;
+    if (!head) return false;
+    const commonDirectory = (yield* fs.readFileString(path.join(gitDirectory, "commondir"))).trim();
+    if (commonDirectory.length === 0) return false;
+    const canonicalCommonDirectory = yield* fs.realPath(
+      path.resolve(gitDirectory, commonDirectory),
+    );
+    return (
+      (yield* fs.exists(path.join(canonicalCommonDirectory, "objects"))) &&
+      (yield* fs.exists(path.join(canonicalCommonDirectory, "refs")))
+    );
+  });
+
 const locateGitDirectory = (
   fs: FileSystem.FileSystem,
   path: Path.Path,
@@ -52,7 +77,14 @@ const locateGitDirectory = (
     while (true) {
       const gitEntry = path.join(directory, ".git");
       if (yield* fs.exists(gitEntry)) {
-        return yield* canonicalGitDirectory(fs, path, directory, gitEntry);
+        const entryInfo = yield* fs.stat(gitEntry);
+        const gitDirectory = yield* canonicalGitDirectory(fs, path, directory, gitEntry);
+        if (
+          entryInfo.type !== "Directory" ||
+          (yield* hasGitRepositoryMarkers(fs, path, gitDirectory))
+        ) {
+          return gitDirectory;
+        }
       }
       const parent = path.dirname(directory);
       if (parent === directory) {

--- a/packages/stack/src/identity/identity.integration.test.ts
+++ b/packages/stack/src/identity/identity.integration.test.ts
@@ -157,6 +157,23 @@ describe("deterministic stack identity and state paths", () => {
     ),
   );
 
+  it.live("rejects a malformed HEAD marker in an otherwise empty git directory", () =>
+    withScope(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-git-marker-" });
+        const project = path.join(root, "project");
+        yield* fs.makeDirectory(path.join(project, ".git"), { recursive: true });
+        yield* fs.writeFileString(path.join(project, ".git", "HEAD"), "not-a-commit\n");
+
+        const error = yield* resolveStackIdentity({ projectRoot: project }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(InvalidStackIdentityError);
+      }),
+    ),
+  );
+
   it.live("preserves errors for an explicit gitdir target with missing HEAD", () =>
     withScope(
       Effect.gen(function* () {

--- a/packages/stack/src/identity/identity.integration.test.ts
+++ b/packages/stack/src/identity/identity.integration.test.ts
@@ -157,6 +157,27 @@ describe("deterministic stack identity and state paths", () => {
     ),
   );
 
+  it.live("preserves errors for an explicit gitdir target with missing HEAD", () =>
+    withScope(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-gitdir-" });
+        const project = path.join(root, "project");
+        const gitDirectory = path.join(root, "git-directory");
+        yield* fs.makeDirectory(project);
+        yield* fs.makeDirectory(path.join(gitDirectory, "objects"), { recursive: true });
+        yield* fs.makeDirectory(path.join(gitDirectory, "refs"));
+        yield* fs.writeFileString(path.join(project, ".git"), `gitdir: ${gitDirectory}\n`);
+
+        const error = yield* resolveStackIdentity({ projectRoot: project }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(InvalidStackIdentityError);
+        expect(error.message).toContain("Unable to read HEAD");
+      }),
+    ),
+  );
+
   it.live("preserves Git exit diagnostics when setup fails", () =>
     withScope(
       Effect.gen(function* () {
@@ -205,6 +226,41 @@ describe("deterministic stack identity and state paths", () => {
 
         expect(identity.branchContext).toBe("ordinary-workspace");
         expect(after).toEqual(before);
+      }),
+    ),
+  );
+
+  it.live("ignores a stray ancestor .git directory that is not a repository", () =>
+    withScope(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-stray-git-" });
+        const project = path.join(root, "project");
+        yield* fs.makeDirectory(path.join(root, ".git", "gk"), { recursive: true });
+        yield* fs.makeDirectory(project);
+
+        const identity = yield* resolveStackIdentity({ projectRoot: project });
+
+        expect(identity.branchContext).toBe("ordinary-workspace");
+      }),
+    ),
+  );
+
+  it.live("continues past a stray ancestor to find the enclosing repository", () =>
+    withScope(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const { repository } = yield* makeGitWorkspace;
+        const container = path.join(repository, "apps");
+        const project = path.join(container, "web");
+        yield* fs.makeDirectory(path.join(container, ".git", "gk"), { recursive: true });
+        yield* fs.makeDirectory(project, { recursive: true });
+
+        const identity = yield* resolveStackIdentity({ projectRoot: project });
+
+        expect(identity.branchContext).toBe("refs/heads/main");
       }),
     ),
   );

--- a/packages/stack/src/model/capabilities/analytics.ts
+++ b/packages/stack/src/model/capabilities/analytics.ts
@@ -1,14 +1,12 @@
 import { Schema } from "effect";
 import { release, workload, type CapabilityModule } from "../CapabilityModule.ts";
 import { catalogEntryFor } from "../WorkloadCatalog.ts";
-import { NetworkPortSchema } from "../../public/Status.ts";
 
 const version = catalogEntryFor("analytics:analytics").defaultVersion;
 
 const Secret = Schema.Redacted(Schema.String);
 export const AnalyticsSettingsSchema = Schema.Struct({
   backend: Schema.optionalKey(Schema.Literals(["postgres", "bigquery"] as const)),
-  vector_port: Schema.optionalKey(NetworkPortSchema),
   gcp_project_id: Schema.optionalKey(Schema.String),
   gcp_project_number: Schema.optionalKey(Schema.String),
   gcp_jwt_path: Schema.optionalKey(Schema.String),
@@ -20,7 +18,6 @@ export const AnalyticsModule: CapabilityModule<AnalyticsSettings> = {
   settings: AnalyticsSettingsSchema,
   defaultSettings: {
     backend: "postgres",
-    vector_port: undefined,
     gcp_project_id: "local",
     gcp_project_number: "0",
     gcp_jwt_path: undefined,
@@ -45,8 +42,4 @@ export const AnalyticsModule: CapabilityModule<AnalyticsSettings> = {
   routes: [{ listener: "api", protocol: "http" }],
   secretPolicy: () => "managed",
   managedSecretSlots: ["analytics.settings.api_key"],
-  selectWorkloads: (settings, workloads) => {
-    const enabled = typeof settings.vector_port === "number";
-    return workloads.filter((entry) => enabled || entry.name !== "vector");
-  },
 };

--- a/packages/stack/src/model/capabilities/database.ts
+++ b/packages/stack/src/model/capabilities/database.ts
@@ -31,19 +31,9 @@ const settingsFields = {
 };
 
 const settingsSchema = Schema.Struct(settingsFields);
-const networkSchema = Schema.Struct({
-  enabled: Schema.optionalKey(Schema.Boolean),
-  allowed_cidrs: Schema.optionalKey(Schema.Array(Schema.String)),
-  allowed_cidrs_v6: Schema.optionalKey(Schema.Array(Schema.String)),
-});
-const sslSchema = Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) });
-
 export const DatabaseSettingsSchema = Schema.Struct({
   health_timeout: Schema.optionalKey(Schema.String),
   settings: Schema.optionalKey(settingsSchema),
-  network_restrictions: Schema.optionalKey(networkSchema),
-  ssl_enforcement: Schema.optionalKey(sslSchema),
-  vault: Schema.optionalKey(Schema.Record(Schema.String, Schema.Redacted(Schema.String))),
 });
 export type DatabaseSettings = Schema.Schema.Type<typeof DatabaseSettingsSchema>;
 
@@ -127,13 +117,6 @@ const defaults: DatabaseSettings = {
     wal_sender_timeout: undefined,
     work_mem: undefined,
   },
-  network_restrictions: {
-    enabled: false,
-    allowed_cidrs: ["0.0.0.0/0"],
-    allowed_cidrs_v6: ["::/0"],
-  },
-  ssl_enforcement: { enabled: false },
-  vault: {},
 };
 
 const databaseCatalog = catalogEntryFor("database:database");

--- a/packages/stack/src/model/capabilities/rest.ts
+++ b/packages/stack/src/model/capabilities/rest.ts
@@ -8,14 +8,6 @@ export const RestSettingsSchema = Schema.Struct({
   schemas: Schema.optionalKey(Schema.Array(Schema.String)),
   extra_search_path: Schema.optionalKey(Schema.Array(Schema.String)),
   max_rows: Schema.optionalKey(Schema.Finite),
-  auto_expose_new_tables: Schema.optionalKey(Schema.Boolean),
-  tls: Schema.optionalKey(
-    Schema.Struct({
-      enabled: Schema.optionalKey(Schema.Boolean),
-      cert_path: Schema.optionalKey(Schema.String),
-      key_path: Schema.optionalKey(Schema.String),
-    }),
-  ),
   external_url: Schema.optionalKey(Schema.String),
 });
 export type RestSettings = Schema.Schema.Type<typeof RestSettingsSchema>;
@@ -27,8 +19,6 @@ export const RestModule: CapabilityModule<RestSettings> = {
     schemas: ["public", "graphql_public"],
     extra_search_path: ["public", "extensions"],
     max_rows: 1000,
-    auto_expose_new_tables: undefined,
-    tls: { enabled: false, cert_path: undefined, key_path: undefined },
     external_url: undefined,
   },
   defaultEnabled: true,

--- a/packages/stack/src/model/capabilities/storage.ts
+++ b/packages/stack/src/model/capabilities/storage.ts
@@ -11,13 +11,6 @@ const Bucket = Schema.Struct({
   objects_path: Schema.optionalKey(Schema.String),
 });
 const Secret = Schema.Redacted(Schema.String);
-const Analytics = Schema.Struct({
-  enabled: Schema.optionalKey(Schema.Boolean),
-  max_namespaces: Schema.optionalKey(Schema.Finite),
-  max_tables: Schema.optionalKey(Schema.Finite),
-  max_catalogs: Schema.optionalKey(Schema.Finite),
-  buckets: Schema.optionalKey(Schema.Record(Schema.String, Schema.Struct({}))),
-});
 const Vector = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   max_buckets: Schema.optionalKey(Schema.Finite),
@@ -38,7 +31,6 @@ export const StorageSettingsSchema = Schema.Struct({
       secret_access_key: Schema.optionalKey(Secret),
     }),
   ),
-  analytics: Schema.optionalKey(Analytics),
   vector: Schema.optionalKey(Vector),
 });
 export type StorageSettings = Schema.Schema.Type<typeof StorageSettingsSchema>;
@@ -98,7 +90,6 @@ export const StorageModule: CapabilityModule<StorageSettings> = {
       // Managed by the compiler so every stack receives a fresh credential.
       secret_access_key: undefined,
     },
-    analytics: { enabled: false, max_namespaces: 5, max_tables: 10, max_catalogs: 2, buckets: {} },
     vector: { enabled: true, max_buckets: 10, max_indexes: 5, buckets: {} },
   },
   defaultEnabled: true,

--- a/packages/stack/src/model/capabilities/storage.ts
+++ b/packages/stack/src/model/capabilities/storage.ts
@@ -81,7 +81,7 @@ export const StorageModule: CapabilityModule<StorageSettings> = {
   settings: StorageSettingsSchema,
   defaultSettings: {
     file_size_limit: "50MiB",
-    image_transformation: { enabled: false },
+    image_transformation: { enabled: true },
     buckets: {},
     s3_protocol: {
       enabled: true,

--- a/packages/stack/src/model/catalog.integration.test.ts
+++ b/packages/stack/src/model/catalog.integration.test.ts
@@ -122,7 +122,7 @@ describe("complete workload catalog", () => {
       const result = yield* compile({
         capabilities: {
           storage: { settings: { image_transformation: { enabled: true } } },
-          analytics: { settings: { vector_port: 9001 } },
+          analytics: { settings: {} },
         },
       });
       expect(result.executionPlan.workloads.length).toBeGreaterThan(10);
@@ -143,7 +143,7 @@ describe("complete workload catalog", () => {
       const result = yield* compile({
         capabilities: {
           storage: { settings: { image_transformation: { enabled: true } } },
-          analytics: { settings: { vector_port: 9001 } },
+          analytics: { settings: {} },
         },
       });
       for (const id of ["studio:pgmeta", "analytics:vector"] as const) {
@@ -166,25 +166,28 @@ describe("complete workload catalog", () => {
     }),
   );
 
-  it.live("materialized settings control optional companion workloads", () =>
+  it.live("enables companion workloads by default and honors explicit disablement", () =>
     Effect.gen(function* () {
       const defaults = yield* compile({});
       expect(defaults.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy")).toBe(
-        false,
+        true,
       );
       expect(defaults.executionPlan.workloads.some(({ id }) => id === "analytics:vector")).toBe(
-        false,
+        true,
       );
       expect(defaults.executionPlan.workloads).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: "storage:storage", dependencies: ["database:database"] }),
+          expect.objectContaining({
+            id: "storage:storage",
+            dependencies: ["database:database", "storage:imgproxy"],
+          }),
         ]),
       );
 
       const enabled = yield* compile({
         capabilities: {
           storage: { settings: { image_transformation: { enabled: true } } },
-          analytics: { settings: { vector_port: 9001 } },
+          analytics: { settings: {} },
         },
       });
       expect(enabled.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy")).toBe(
@@ -210,6 +213,20 @@ describe("complete workload catalog", () => {
           }),
         ]),
       );
+
+      const disabled = yield* compile({
+        capabilities: {
+          storage: { settings: { image_transformation: { enabled: false } } },
+          analytics: { enabled: false },
+          studio: { enabled: false },
+        },
+      });
+      expect(disabled.executionPlan.workloads.some(({ id }) => id === "storage:imgproxy")).toBe(
+        false,
+      );
+      expect(disabled.executionPlan.workloads.some(({ id }) => id === "analytics:vector")).toBe(
+        false,
+      );
     }),
   );
 
@@ -218,7 +235,7 @@ describe("complete workload catalog", () => {
       const result = yield* compileContainer({
         capabilities: {
           storage: { settings: { image_transformation: { enabled: true } } },
-          analytics: { settings: { vector_port: 9001 } },
+          analytics: { settings: {} },
         },
       });
       const images = new Map(

--- a/packages/stack/src/model/compiler.integration.test.ts
+++ b/packages/stack/src/model/compiler.integration.test.ts
@@ -131,6 +131,27 @@ describe("closed capability compiler", () => {
     }),
   );
 
+  it.live("rejects settings without a local runtime consumer", () =>
+    Effect.gen(function* () {
+      const unsupported = yield* compile({
+        capabilities: {
+          rest: {
+            settings: { auto_expose_new_tables: true, tls: { enabled: true } },
+          },
+          storage: { settings: { analytics: { enabled: true } } },
+        },
+      } as never).pipe(Effect.exit);
+      expect(failureOf(unsupported)).toBeInstanceOf(InvalidStackConfigError);
+
+      const defaults = yield* compile({});
+      expect(defaults.definition.capabilities.rest.settings).not.toHaveProperty(
+        "auto_expose_new_tables",
+      );
+      expect(defaults.definition.capabilities.rest.settings).not.toHaveProperty("tls");
+      expect(defaults.definition.capabilities.storage.settings).not.toHaveProperty("analytics");
+    }),
+  );
+
   it.live("persists defaults consumed by workload runtimes", () =>
     Effect.gen(function* () {
       const result = yield* compile({});

--- a/packages/stack/src/preparation/runtime-artifacts.integration.test.ts
+++ b/packages/stack/src/preparation/runtime-artifacts.integration.test.ts
@@ -164,6 +164,7 @@ describe("runtime artifact preparation", () => {
         const fs = yield* FileSystem.FileSystem;
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-artifact-engine-" });
         const resolver = {
+          isInstalled: () => Effect.succeed(false),
           resolve: () =>
             Effect.fail(
               new ContainerEngineProtocolError({

--- a/packages/stack/src/public/EffectStack.ts
+++ b/packages/stack/src/public/EffectStack.ts
@@ -110,8 +110,10 @@ import {
 } from "../supervisor/Launcher.ts";
 import {
   ContainerEngineResolver,
+  defaultContainerEngineResolver,
   type ContainerEngineResolverShape,
 } from "../runtime/ContainerEngineResolver.ts";
+import type { ContainerEngineFailure } from "../runtime/ContainerEngine.ts";
 import { statusFor } from "../supervisor/StatusProjection.ts";
 import { EMPTY_LOG_CURSOR, readRetainedLogs, selectLogBatch } from "../supervisor/LogStore.ts";
 import {
@@ -145,6 +147,25 @@ export interface PreparedCapability {
   readonly version: string;
   readonly outcome: "cached" | "downloaded" | "pulled";
 }
+
+const selectDefaultRuntime = (
+  resolver: ContainerEngineResolverShape | undefined,
+): Effect.Effect<StackRuntime, ContainerEngineError, ChildProcessSpawnerService> => {
+  return (resolver ?? defaultContainerEngineResolver).isInstalled("docker").pipe(
+    Effect.map((installed): StackRuntime =>
+      installed ? { kind: "container", engine: "docker" } : { kind: "native" },
+    ),
+    Effect.mapError(
+      (error: ContainerEngineFailure) =>
+        new ContainerEngineError({
+          engine: "docker",
+          message: `Unable to determine whether Docker is installed: ${error.message}`,
+          cause: error,
+        }),
+    ),
+  );
+};
+
 export interface PrepareStackResult {
   readonly capabilities: ReadonlyArray<PreparedCapability>;
 }
@@ -175,8 +196,8 @@ export interface EffectStack {
 const optionOf = <A>(value: A | undefined): Option.Option<A> =>
   value === undefined ? Option.none() : Option.some(value);
 
-const descriptor = (state: PersistedStackState): StackDescriptor => ({
-  id: StackIdSchema.make(state.identity.stackId),
+const descriptor = (state: PersistedStackState, id: StackId): StackDescriptor => ({
+  id,
   projectRoot: state.identity.projectRoot,
   name: state.identity.stackName,
   branchContext: state.identity.branchContext,
@@ -525,7 +546,7 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
               Option.isNone(state)
                 ? Effect.fail(stackNotFound())
                 : isStoppedState(state.value)
-                  ? statusFor(state.value, [], new Set<CapabilityName>(), "stopped").pipe(
+                  ? statusFor(id, state.value, [], new Set<CapabilityName>(), "stopped").pipe(
                       Effect.mapError(statusError),
                     )
                   : Effect.fail(
@@ -705,7 +726,7 @@ const stateInitial = (
   runtime: StackRuntime,
 ): PersistedStackState => ({
   format: "supabase-stack-state-v1",
-  identity: toPersistedIdentity(identity, stackId),
+  identity: toPersistedIdentity(identity),
   runtime,
   desiredLifecycle: "unconfigured",
   ports: [],
@@ -966,10 +987,24 @@ export const createStack = (
     });
     const stackId = yield* deriveStackId(identity);
     const store = yield* makeStackStateStore({ stateRoot: env.stateRoot });
+    const persisted = yield* store
+      .read(stackId)
+      .pipe(
+        Effect.catch((error) =>
+          isMissingStateRemnantError(error)
+            ? Effect.map(Effect.void, () => undefined)
+            : Effect.fail(error),
+        ),
+      );
+    const resolverOption = yield* Effect.serviceOption(ContainerEngineResolver).pipe(
+      Effect.map(Option.getOrUndefined),
+    );
     const requestedRuntime: StackRuntime =
       options.runtime?.kind === "container"
         ? { kind: "container", engine: options.runtime.engine ?? "docker" }
-        : { kind: "native" };
+        : options.runtime?.kind === "native"
+          ? { kind: "native" }
+          : (persisted?.runtime ?? (yield* selectDefaultRuntime(resolverOption)));
     const current = yield* store.initialize(
       stackId,
       stateInitial(identity, stackId, requestedRuntime),
@@ -988,9 +1023,6 @@ export const createStack = (
     const path = yield* Path.Path;
     const crypto = yield* Crypto.Crypto;
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const containerEngineResolver = yield* Effect.serviceOption(ContainerEngineResolver).pipe(
-      Effect.map(Option.getOrUndefined),
-    );
     const dependencies = handleDependencies({
       environment: env,
       store,
@@ -999,7 +1031,7 @@ export const createStack = (
       path,
       crypto,
       spawner,
-      containerEngineResolver,
+      containerEngineResolver: resolverOption,
     });
     return yield* makeHandle(stackId, dependencies);
   });
@@ -1052,7 +1084,7 @@ export const findStack = (
     });
     const id = yield* deriveStackId(identity);
     const state = yield* (yield* makeStackStateStore({ stateRoot: env.stateRoot })).read(id);
-    return state === undefined ? Option.none() : Option.some(descriptor(state));
+    return state === undefined ? Option.none() : Option.some(descriptor(state, id));
   });
 
 export const listStacks = (
@@ -1093,7 +1125,7 @@ export const listStacks = (
         state !== undefined &&
         (projectRoot === undefined || state.identity.projectRoot === projectRoot)
       )
-        result.push(descriptor(state));
+        result.push(descriptor(state, entry));
     }
     return result;
   });
@@ -1114,11 +1146,11 @@ export const inspectStack = (
     const metadata = yield* readOwnerMetadata(env.stateRoot, id, env);
     if (metadata === undefined)
       return {
-        descriptor: descriptor(state),
+        descriptor: descriptor(state, id),
         owner: (yield* ownerLockExists(env.stateRoot, id)) ? "unreachable" : "absent",
       };
     if (metadata.rpcRelease !== STACK_RPC_RELEASE)
-      return { descriptor: descriptor(state), owner: "incompatible" };
+      return { descriptor: descriptor(state, id), owner: "incompatible" };
     const status = yield* Effect.scoped(
       Effect.gen(function* () {
         const client = makeControlClient(metadata.endpoint, {
@@ -1132,8 +1164,8 @@ export const inspectStack = (
     if (Exit.isFailure(status)) {
       const failure = Cause.findErrorOption(status.cause);
       if (Option.isSome(failure) && isOwnerUnreachable(failure.value))
-        return { descriptor: descriptor(state), owner: "unreachable" };
-      return { descriptor: descriptor(state), owner: "running" };
+        return { descriptor: descriptor(state, id), owner: "unreachable" };
+      return { descriptor: descriptor(state, id), owner: "running" };
     }
-    return { descriptor: descriptor(state), owner: "running", status: status.value };
+    return { descriptor: descriptor(state, id), owner: "running", status: status.value };
   });

--- a/packages/stack/src/public/EffectStack.ts
+++ b/packages/stack/src/public/EffectStack.ts
@@ -536,23 +536,20 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
           Option.isNone(state) ? Effect.fail(stackNotFound()) : destroyAndAwaitOwner,
         ),
       );
-    const status = () => {
+    const status = (): Effect.Effect<StackStatus, StackStatusError> => {
       const rpcStatus = invoke((rpc) => rpc.status(undefined), statusError);
       return rpcStatus.pipe(
         Effect.catchTag("StackOwnershipConflictError", (ownershipError) =>
           options.readOfflineState.pipe(
             Effect.mapError(statusError),
-            Effect.flatMap((state) =>
-              Option.isNone(state)
-                ? Effect.fail(stackNotFound())
-                : isStoppedState(state.value)
-                  ? statusFor(id, state.value, [], new Set<CapabilityName>(), "stopped").pipe(
-                      Effect.mapError(statusError),
-                    )
-                  : Effect.fail(
-                      new StackOwnershipConflictError({ message: "No Supervisor owns this stack" }),
-                    ),
-            ),
+            Effect.flatMap((state): Effect.Effect<StackStatus, StackStatusError> => {
+              if (Option.isNone(state)) return Effect.fail(stackNotFound());
+              if (isStoppedState(state.value))
+                return statusFor(id, state.value, [], new Set<CapabilityName>(), "stopped");
+              return Effect.fail(
+                new StackOwnershipConflictError({ message: "No Supervisor owns this stack" }),
+              );
+            }),
             Effect.catchTag("StackOwnershipConflictError", () => Effect.fail(ownershipError)),
           ),
         ),
@@ -720,11 +717,7 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
     } satisfies EffectStack;
   });
 
-const stateInitial = (
-  identity: StackIdentity,
-  stackId: StackId,
-  runtime: StackRuntime,
-): PersistedStackState => ({
+const stateInitial = (identity: StackIdentity, runtime: StackRuntime): PersistedStackState => ({
   format: "supabase-stack-state-v1",
   identity: toPersistedIdentity(identity),
   runtime,
@@ -1005,10 +998,7 @@ export const createStack = (
         : options.runtime?.kind === "native"
           ? { kind: "native" }
           : (persisted?.runtime ?? (yield* selectDefaultRuntime(resolverOption)));
-    const current = yield* store.initialize(
-      stackId,
-      stateInitial(identity, stackId, requestedRuntime),
-    );
+    const current = yield* store.initialize(stackId, stateInitial(identity, requestedRuntime));
     const runtimeMismatch =
       options.runtime !== undefined &&
       (current.runtime.kind !== requestedRuntime.kind ||

--- a/packages/stack/src/public/effect-stack.integration.test.ts
+++ b/packages/stack/src/public/effect-stack.integration.test.ts
@@ -122,7 +122,6 @@ const credentials = {
 const stoppedState = (): PersistedStackState => ({
   format: "supabase-stack-state-v1",
   identity: {
-    stackId,
     projectRoot: "/tmp/project",
     branchContext: "branch",
     stackName: "stack",
@@ -1257,6 +1256,7 @@ describe("Effect stack lifecycle handoff", () => {
           runtime: { kind: "container", engine: "docker" },
         }).pipe(
           Effect.provideService(ContainerEngineResolver, {
+            isInstalled: () => Effect.succeed(true),
             resolve: () => Effect.succeed(engine),
           }),
         );
@@ -1513,6 +1513,7 @@ describe("Effect stack lifecycle handoff", () => {
           platform: { os: "linux" },
         });
         const resolver = {
+          isInstalled: () => Effect.succeed(true),
           resolve: () => Effect.succeed(engine),
         };
         const stack = yield* createStack({
@@ -1924,7 +1925,7 @@ describe("Effect stack lifecycle handoff", () => {
                   : undefined;
               const initialState: PersistedStackState = {
                 format: "supabase-stack-state-v1",
-                identity: toPersistedIdentity(identity, id),
+                identity: toPersistedIdentity(identity),
                 runtime: { kind: "native" },
                 desiredLifecycle,
                 ports: [],

--- a/packages/stack/src/public/effect-stack.integration.test.ts
+++ b/packages/stack/src/public/effect-stack.integration.test.ts
@@ -77,7 +77,10 @@ import {
   type ContainerCommandResult,
   type ContainerCommandRunner,
 } from "../runtime/ContainerEngine.ts";
-import { ContainerEngineResolver } from "../runtime/ContainerEngineResolver.ts";
+import {
+  ContainerEngineResolver,
+  defaultContainerEngineResolver,
+} from "../runtime/ContainerEngineResolver.ts";
 import { runGit } from "../../tests/helpers/git.ts";
 
 const defaultDatabaseVersion = catalogEntryFor("database:database").defaultVersion;
@@ -166,7 +169,13 @@ const withRuntimeRoot = <A, E, R>(effect: (project: string) => Effect.Effect<A, 
         tempRoot: "/tmp",
         platform: "posix",
       };
-      return yield* effect(project).pipe(Effect.provideService(StackRuntimeEnvironment, runtime));
+      return yield* effect(project).pipe(
+        Effect.provideService(StackRuntimeEnvironment, runtime),
+        Effect.provideService(ContainerEngineResolver, {
+          isInstalled: () => Effect.succeed(false),
+          resolve: (kind) => defaultContainerEngineResolver.resolve(kind),
+        }),
+      );
     }),
   ).pipe(Effect.provide(NodeServices.layer));
 

--- a/packages/stack/src/public/promise.integration.test.ts
+++ b/packages/stack/src/public/promise.integration.test.ts
@@ -268,7 +268,6 @@ describe("Promise stack facade", () => {
     const stack = adaptEffectStack(source);
     const config = {
       capabilities: {
-        database: { settings: { vault: { DB_PASSWORD: "vault-secret" } } },
         storage: { settings: { buckets: { assets: { public: false } } } },
         auth: { settings: { external: { github: { secret: "github-secret" } } } },
         functions: {
@@ -285,13 +284,11 @@ describe("Promise stack facade", () => {
     await stack.prepare({ config });
     await stack.start({ config });
     for (const value of [preparedConfig, startedConfig]) {
-      const database = value?.capabilities?.database?.settings;
       const auth = value?.capabilities?.auth;
       const functions = value?.capabilities?.functions;
       const authSettings = auth !== undefined && "settings" in auth ? auth.settings : undefined;
       const functionSettings =
         functions !== undefined && "settings" in functions ? functions.settings : undefined;
-      expect(Redacted.isRedacted(database?.vault?.DB_PASSWORD)).toBe(true);
       expect(Redacted.isRedacted(authSettings?.external?.github?.secret)).toBe(true);
       expect(Redacted.isRedacted(functionSettings?.edge_runtime?.secrets?.EDGE_TOKEN)).toBe(true);
       expect(Redacted.isRedacted(functionSettings?.functions?.hello?.env?.FUNCTION_TOKEN)).toBe(

--- a/packages/stack/src/public/whole-stack.e2e.test.ts
+++ b/packages/stack/src/public/whole-stack.e2e.test.ts
@@ -565,7 +565,7 @@ const optionalWorkloadConfig = (
   capabilities: {
     storage: { settings: { image_transformation: { enabled: true } } },
     functions: { settings: { functions: { [functionSlug]: { verify_jwt: false } } } },
-    analytics: { settings: { vector_port: 9001, api_key: analyticsApiKey } },
+    analytics: { settings: { api_key: analyticsApiKey } },
   },
   listeners: { smtp: { enabled: true } },
 });
@@ -584,7 +584,7 @@ const allEagerConfig = (analyticsApiKey: string): PromiseStackConfig => ({
     mail: { activation: "eager" },
     analytics: {
       activation: "eager",
-      settings: { vector_port: 9001, api_key: analyticsApiKey },
+      settings: { api_key: analyticsApiKey },
     },
     pooler: { activation: "eager" },
   },

--- a/packages/stack/src/public/whole-stack.e2e.test.ts
+++ b/packages/stack/src/public/whole-stack.e2e.test.ts
@@ -61,6 +61,7 @@ const NON_DEFAULT_DATABASE_RELEASES = Object.keys(databaseCatalog.releases).filt
 );
 const BASE_WORKLOAD_IDS = [
   "analytics:analytics",
+  "analytics:vector",
   "auth:auth",
   "database:database",
   "functions:edge-runtime",
@@ -68,6 +69,7 @@ const BASE_WORKLOAD_IDS = [
   "pooler:pooler",
   "realtime:realtime",
   "rest:rest",
+  "storage:imgproxy",
   "storage:storage",
   "studio:pgmeta",
   "studio:studio",

--- a/packages/stack/src/runtime/ContainerEngineResolver.ts
+++ b/packages/stack/src/runtime/ContainerEngineResolver.ts
@@ -3,6 +3,7 @@ import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSp
 import {
   makeProcessCommandRunner,
   type ContainerEngine,
+  ContainerCommandError,
   type ContainerEngineFailure,
   type ContainerEngineKind,
   type ContainerPlatform,
@@ -16,11 +17,16 @@ import { makePodmanEngine } from "./PodmanEngine.ts";
  * adapters.
  */
 export interface ContainerEngineResolverShape {
+  /** Checks for an installed client without requiring a running daemon. */
+  readonly isInstalled: (
+    kind: ContainerEngineKind,
+  ) => Effect.Effect<boolean, ContainerEngineFailure, ChildProcessSpawner>;
   readonly resolve: (
     preference: ContainerEngineKind,
   ) => Effect.Effect<ContainerEngine, ContainerEngineFailure, ChildProcessSpawner>;
 }
 
+/** @effect-expect-leaking ChildProcessSpawner */
 export class ContainerEngineResolver extends Context.Service<
   ContainerEngineResolver,
   ContainerEngineResolverShape
@@ -32,7 +38,18 @@ const hostContainerPlatform = (): ContainerPlatform => {
   return { os: "linux", desktop: false };
 };
 
-const defaultResolver: ContainerEngineResolverShape = {
+export const defaultContainerEngineResolver: ContainerEngineResolverShape = {
+  isInstalled: (kind) =>
+    Effect.gen(function* () {
+      const runner = yield* makeProcessCommandRunner({ executable: kind });
+      const result = yield* runner.run({ args: ["--version"] });
+      if (result.exitCode !== 0)
+        return yield* new ContainerCommandError({
+          operation: "version",
+          message: `${kind} --version exited (${String(result.exitCode)})`,
+        });
+      return true;
+    }).pipe(Effect.catchTag("ContainerExecutableNotFoundError", () => Effect.succeed(false))),
   resolve: (kind) =>
     Effect.gen(function* () {
       const runner = yield* makeProcessCommandRunner({ executable: kind });
@@ -47,4 +64,4 @@ export const resolveContainerEngine = (
   kind: ContainerEngineKind,
   resolver?: ContainerEngineResolverShape,
 ): Effect.Effect<ContainerEngine, ContainerEngineFailure, ChildProcessSpawner> =>
-  (resolver ?? defaultResolver).resolve(kind);
+  (resolver ?? defaultContainerEngineResolver).resolve(kind);

--- a/packages/stack/src/runtime/ProductionRuntime.ts
+++ b/packages/stack/src/runtime/ProductionRuntime.ts
@@ -787,9 +787,11 @@ export const makeProductionRuntime = (
           yield* Ref.set(hostRoute, route);
         }
         if (input.state.runtime.kind === "native") {
+          const usableListeners = new Set(input.plan.routes.map(({ listener }) => listener));
           for (const assignment of input.state.ports) {
             const listener = input.definition.listeners[assignment.field];
             if (
+              !usableListeners.has(assignment.field) ||
               !listener.enabled ||
               (listener.port === "automatic"
                 ? assignment.intent !== "automatic"
@@ -809,7 +811,7 @@ export const makeProductionRuntime = (
             );
           }
           const requestedPrivate = new Set(
-            privateBindingIntentsFor(input.plan).map(privateBindingKey),
+            privateBindingIntentsFor(input.plan, candidateState).map(privateBindingKey),
           );
           for (const assignment of input.state.privatePorts) {
             if (!requestedPrivate.has(privateBindingKey(assignment))) continue;

--- a/packages/stack/src/runtime/RuntimeInputOwner.ts
+++ b/packages/stack/src/runtime/RuntimeInputOwner.ts
@@ -485,11 +485,8 @@ export const makeRuntimeInputOwner = (
               const gcpPath = isRecord(analyticsSettings)
                 ? settingValue(state, analyticsSettings.gcp_jwt_path)
                 : "";
-              const vectorPort = isRecord(analyticsSettings)
-                ? settingValue(state, analyticsSettings.vector_port)
-                : "";
               const vectorConfigPath =
-                vectorPort.length > 0 ? yield* writeVectorConfig(state) : undefined;
+                workloadId === "analytics:vector" ? yield* writeVectorConfig(state) : undefined;
               return gcpPath.length === 0 && vectorConfigPath === undefined
                 ? undefined
                 : {

--- a/packages/stack/src/runtime/WorkloadRuntimeSpec.ts
+++ b/packages/stack/src/runtime/WorkloadRuntimeSpec.ts
@@ -402,11 +402,6 @@ const functionsConfigEnvironment = (state: PersistedStackState): string => {
   return JSON.stringify(result);
 };
 
-const common = (workload: PlannedWorkload, port: number): Record<string, string> => ({
-  SUPABASE_STACK_WORKLOAD: workload.id,
-  SUPABASE_STACK_PRIVATE_PORT: String(port),
-});
-
 const functionsRoot = (state: PersistedStackState): string =>
   valueAt(state, "functions", "functions_root");
 
@@ -548,8 +543,6 @@ const withRestSettings = (
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> =>
   compactEnvironment({
-    ...common(workload, port),
-    ...capabilityEnv(state, "rest", "PGRST"),
     PGRST_DB_URI: dbUrl(state, "authenticator", runtime),
     PGRST_DB_SCHEMAS: valueAt(state, "rest", "schemas"),
     PGRST_DB_EXTRA_SEARCH_PATH: valueAt(state, "rest", "extra_search_path"),
@@ -706,7 +699,6 @@ const withAuthSettings = (
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> =>
   compactEnvironment({
-    ...common(workload, port),
     ...capabilityEnv(
       state,
       "auth",
@@ -857,7 +849,6 @@ const withStorageSettings = (
 ): Record<string, string> => {
   const fileSizeLimit = parseFileSize(valueAt(state, "storage", "file_size_limit"));
   return compactEnvironment({
-    ...common(workload, port),
     ...capabilityEnv(
       state,
       "storage",
@@ -943,7 +934,6 @@ const analyticsEnv = (
   const backend = valueAt(state, "analytics", "backend");
   const gcpJwtPath = inputs.analytics?.gcpJwtPath ?? "";
   return compactEnvironment({
-    ...common(workload, port),
     ...capabilityEnv(state, "analytics", "ANALYTICS", (key) => key === "ANALYTICS_GCP_JWT_PATH"),
     PORT: String(port),
     PHX_HTTP_PORT: String(port),
@@ -984,8 +974,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     args: (state, _workload, port) => databaseArgs(state, port, "native"),
     env: (state, workload, port, runtime = "native", inputs = {}) =>
       compactEnvironment({
-        ...common(workload, port),
-        ...capabilityEnv(state, "database", "POSTGRES"),
         PGDATA:
           runtime === "container"
             ? "/var/lib/postgresql/data"
@@ -1020,7 +1008,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     args: () => [],
     env: (state, workload, port, runtime = "native", inputs = {}) =>
       compactEnvironment({
-        ...common(workload, port),
         ...capabilityEnv(state, "realtime", "REALTIME"),
         PORT: String(port),
         DB_HOST: dbHost(runtime),
@@ -1062,7 +1049,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     bindings: { primary: { containerPort: 5001 } },
     args: () => [],
     env: (state, workload, port, runtime = "native") => ({
-      ...common(workload, port),
       IMGPROXY_BIND: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${port}`,
       IMGPROXY_LOCAL_FILESYSTEM_ROOT: "/",
     }),
@@ -1080,7 +1066,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
       ...functionsInspectorArgs(state, runtime),
     ],
     env: (state, workload, port, runtime = "native", inputs = {}) => ({
-      ...common(workload, port),
       ...edgeRuntimeJwtEnvironment(state, inputs),
       EDGE_RUNTIME_PORT: String(port),
       FUNCTIONS_CONTAINER_ROOT,
@@ -1110,7 +1095,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     args: () => [],
     env: (state, workload, port, runtime = "native", inputs = {}) =>
       compactEnvironment({
-        ...common(workload, port),
         ...capabilityEnv(state, "studio", "STUDIO"),
         PORT: String(port),
         HOSTNAME: "0.0.0.0",
@@ -1149,10 +1133,9 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     readiness: { protocol: "http", path: "/api/platform/profile" },
   },
   "studio:pgmeta": {
-    bindings: { primary: { containerPort: 8080 }, admin: { containerPort: 8081 } },
+    bindings: { primary: { containerPort: 8080 } },
     args: () => [],
     env: (state, workload, port, runtime = "native") => ({
-      ...common(workload, port),
       ...capabilityEnv(state, "studio", "PG_META"),
       PG_META_PORT: String(port),
       PG_META_DB_HOST: dbHost(runtime),
@@ -1172,7 +1155,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     },
     args: () => [],
     env: (state, workload, port, runtime = "native") => ({
-      ...common(workload, port),
       ...capabilityEnv(state, "mail", "MAIL"),
       MP_UI_BIND_ADDR: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${workloadPort(state, "mail:mail", "ui", runtime, 8025)}`,
       MP_SMTP_BIND_ADDR: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${workloadPort(state, "mail:mail", "smtp", runtime, 1025)}`,
@@ -1208,7 +1190,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
     bindings: { primary: { containerPort: 9001 } },
     args: (_state, _workload, _port) => ["--config", "share/doc/vector/config/vector.yaml"],
     env: (state, workload, port, runtime = "native") => ({
-      ...common(workload, port),
       ...capabilityEnv(state, "analytics", "VECTOR"),
       VECTOR_API_ADDRESS: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${port}`,
       VECTOR_API_PORT: String(port),
@@ -1244,7 +1225,6 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
       if (adminPort === undefined || primaryPort === undefined)
         throw new Error("Pooler private port assignments must be validated before env resolution");
       return {
-        ...common(workload, port),
         ...capabilityEnv(state, "pooler", "POOLER"),
         // `port` is the readiness binding (admin); proxy listeners use the primary SQL binding.
         // validatePrivateAssignments guarantees both native bindings are assigned.
@@ -1301,18 +1281,30 @@ const declaredBindings = (
     return binding === undefined ? [] : [[name, binding] as const];
   });
 
+const selectedBindings = (
+  state: Pick<PersistedStackState, "definition">,
+  bindings: WorkloadBindings,
+): ReadonlyArray<readonly [WorkloadBindingName, WorkloadBinding]> => {
+  const inspectorSettings = state.definition?.capabilities.functions.settings.inspector;
+  const inspectorRequested =
+    isRecord(inspectorSettings) || state.definition?.listeners.functionsInspector.enabled === true;
+  return declaredBindings(bindings).filter(
+    ([binding]) => binding !== "inspector" || inspectorRequested,
+  );
+};
+
 /** Derive the exact private endpoint reservations required by a compiled plan. */
 export const privateBindingIntentsFor = (
   plan: ExecutionPlan,
+  state: Pick<PersistedStackState, "definition">,
 ): ReadonlyArray<WorkloadBindingIntent> =>
   plan.workloads.flatMap((workload) => {
     const spec = specs[workload.id];
-    return spec === undefined
-      ? []
-      : declaredBindings(spec.bindings).map(([binding]) => ({
-          workloadId: workload.id,
-          binding,
-        }));
+    if (spec === undefined) return [];
+    return selectedBindings(state, spec.bindings).map(([binding]) => ({
+      workloadId: workload.id,
+      binding,
+    }));
   });
 
 export const validatePrivateAssignments = (
@@ -1322,7 +1314,7 @@ export const validatePrivateAssignments = (
   const spec = specs[workload.id];
   if (spec === undefined) return Effect.void;
   // Runtime env resolution assumes every declared binding was assigned here.
-  for (const [binding] of declaredBindings(spec.bindings)) {
+  for (const [binding] of selectedBindings(state, spec.bindings)) {
     if (
       !state.privatePorts.some(
         (assignment) => assignment.workloadId === workload.id && assignment.binding === binding,
@@ -1403,7 +1395,7 @@ export const containerResolutionFor = (
     ),
     mounts: spec.containerMounts?.(state, workload, inputs) ?? [],
     networkAliases: [catalog.containerAlias],
-    publications: declaredBindings(spec.bindings).flatMap(([binding, definition]) => {
+    publications: selectedBindings(state, spec.bindings).flatMap(([binding, definition]) => {
       const assignment = state.privatePorts.find(
         (entry) => entry.workloadId === workload.id && entry.binding === binding,
       );

--- a/packages/stack/src/runtime/WorkloadRuntimeSpec.ts
+++ b/packages/stack/src/runtime/WorkloadRuntimeSpec.ts
@@ -450,14 +450,19 @@ const nativeFunctionsDirectory = (
   return bootstrapPath.slice(0, bootstrapPath.lastIndexOf("/")) || bootstrapPath;
 };
 
+const functionsInspectorRequested = (state: Pick<PersistedStackState, "definition">): boolean => {
+  const inspectorSettings = state.definition?.capabilities.functions.settings.inspector;
+  return (
+    isRecord(inspectorSettings) || state.definition?.listeners.functionsInspector.enabled === true
+  );
+};
+
 const functionsInspectorArgs = (
   state: PersistedStackState,
   runtime: WorkloadRuntimeKind,
 ): ReadonlyArray<string> => {
   const configuredMode = valueAt(state, "functions", "inspector.mode");
-  const inspectorSettings = state.definition?.capabilities.functions.settings.inspector;
-  const inspectorRequested =
-    isRecord(inspectorSettings) || state.definition?.listeners.functionsInspector.enabled === true;
+  const inspectorRequested = functionsInspectorRequested(state);
   const mode =
     configuredMode === "run" || configuredMode === "brk" || configuredMode === "wait"
       ? configuredMode
@@ -493,6 +498,7 @@ const nativeProcessFor = (
     .map((arg) =>
       arg.startsWith("app/") || arg.startsWith("share/") ? artifactPath(artifactRoot, arg) : arg,
     );
+
   const nativeArgs = nativeArgsFor(workload, args, inputs);
   return {
     executable:
@@ -539,7 +545,6 @@ const withRestSettings = (
   state: PersistedStackState,
   runtime: WorkloadRuntimeKind,
   port: number,
-  workload: PlannedWorkload,
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> =>
   compactEnvironment({
@@ -695,7 +700,6 @@ const withAuthSettings = (
   state: PersistedStackState,
   runtime: WorkloadRuntimeKind,
   port: number,
-  workload: PlannedWorkload,
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> =>
   compactEnvironment({
@@ -844,7 +848,6 @@ const withStorageSettings = (
   state: PersistedStackState,
   runtime: WorkloadRuntimeKind,
   port: number,
-  workload: PlannedWorkload,
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> => {
   const fileSizeLimit = parseFileSize(valueAt(state, "storage", "file_size_limit"));
@@ -928,7 +931,6 @@ const analyticsEnv = (
   state: PersistedStackState,
   runtime: WorkloadRuntimeKind,
   port: number,
-  workload: PlannedWorkload,
   inputs: WorkloadRuntimeInputs = {},
 ): Record<string, string> => {
   const backend = valueAt(state, "analytics", "backend");
@@ -972,7 +974,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "database:database": {
     bindings: { primary: { containerPort: 5432 } },
     args: (state, _workload, port) => databaseArgs(state, port, "native"),
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
+    env: (state, _workload, _port, runtime = "native", inputs = {}) =>
       compactEnvironment({
         PGDATA:
           runtime === "container"
@@ -989,16 +991,16 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "rest:rest": {
     bindings: { primary: { containerPort: 3000 }, admin: { containerPort: 3001 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
-      withRestSettings(state, runtime, port, workload, inputs),
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
+      withRestSettings(state, runtime, port, inputs),
     containerArgs: () => [],
     readiness: { protocol: "http", path: "/" },
   },
   "auth:auth": {
     bindings: { primary: { containerPort: 9999 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
-      withAuthSettings(state, runtime, port, workload, inputs),
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
+      withAuthSettings(state, runtime, port, inputs),
     containerArgs: () => [],
     containerStartupProcesses: () => [{ entrypoint: "/usr/local/bin/auth", command: ["migrate"] }],
     readiness: { protocol: "http", path: "/health" },
@@ -1006,7 +1008,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "realtime:realtime": {
     bindings: { primary: { containerPort: 4000 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
       compactEnvironment({
         ...capabilityEnv(state, "realtime", "REALTIME"),
         PORT: String(port),
@@ -1039,8 +1041,8 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "storage:storage": {
     bindings: { primary: { containerPort: 5000 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
-      withStorageSettings(state, runtime, port, workload, inputs),
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
+      withStorageSettings(state, runtime, port, inputs),
     containerArgs: () => [],
     containerStartupProcesses: () => [{ entrypoint: "/slim-runtime/bin/prepare", command: [] }],
     readiness: { protocol: "http", path: "/status" },
@@ -1048,7 +1050,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "storage:imgproxy": {
     bindings: { primary: { containerPort: 5001 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native") => ({
+    env: (_state, _workload, port, runtime = "native") => ({
       IMGPROXY_BIND: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${port}`,
       IMGPROXY_LOCAL_FILESYSTEM_ROOT: "/",
     }),
@@ -1065,7 +1067,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
       `--policy=${valueAt(state, "functions", "edge_runtime.policy")}`,
       ...functionsInspectorArgs(state, runtime),
     ],
-    env: (state, workload, port, runtime = "native", inputs = {}) => ({
+    env: (state, _workload, port, runtime = "native", inputs = {}) => ({
       ...edgeRuntimeJwtEnvironment(state, inputs),
       EDGE_RUNTIME_PORT: String(port),
       FUNCTIONS_CONTAINER_ROOT,
@@ -1093,7 +1095,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "studio:studio": {
     bindings: { primary: { containerPort: 3000 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
       compactEnvironment({
         ...capabilityEnv(state, "studio", "STUDIO"),
         PORT: String(port),
@@ -1135,7 +1137,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "studio:pgmeta": {
     bindings: { primary: { containerPort: 8080 } },
     args: () => [],
-    env: (state, workload, port, runtime = "native") => ({
+    env: (state, _workload, port, runtime = "native") => ({
       ...capabilityEnv(state, "studio", "PG_META"),
       PG_META_PORT: String(port),
       PG_META_DB_HOST: dbHost(runtime),
@@ -1154,7 +1156,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
       pop3: { containerPort: 1110 },
     },
     args: () => [],
-    env: (state, workload, port, runtime = "native") => ({
+    env: (state, _workload, _port, runtime = "native") => ({
       ...capabilityEnv(state, "mail", "MAIL"),
       MP_UI_BIND_ADDR: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${workloadPort(state, "mail:mail", "ui", runtime, 8025)}`,
       MP_SMTP_BIND_ADDR: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${workloadPort(state, "mail:mail", "smtp", runtime, 1025)}`,
@@ -1167,8 +1169,8 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "analytics:analytics": {
     bindings: { primary: { containerPort: 4000 } },
     args: () => ["start"],
-    env: (state, workload, port, runtime = "native", inputs = {}) =>
-      analyticsEnv(state, runtime, port, workload, inputs),
+    env: (state, _workload, port, runtime = "native", inputs = {}) =>
+      analyticsEnv(state, runtime, port, inputs),
     // The slim container entrypoint performs Logflare migrations before start.
     containerArgs: () => [],
     containerMounts: (state, _workload, inputs = {}) => {
@@ -1189,7 +1191,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "analytics:vector": {
     bindings: { primary: { containerPort: 9001 } },
     args: (_state, _workload, _port) => ["--config", "share/doc/vector/config/vector.yaml"],
-    env: (state, workload, port, runtime = "native") => ({
+    env: (state, _workload, port, runtime = "native") => ({
       ...capabilityEnv(state, "analytics", "VECTOR"),
       VECTOR_API_ADDRESS: `${runtime === "container" ? "0.0.0.0" : "127.0.0.1"}:${port}`,
       VECTOR_API_PORT: String(port),
@@ -1218,7 +1220,7 @@ const specs: Readonly<Record<string, WorkloadRuntimeSpecDefinition>> = {
   "pooler:pooler": {
     bindings: { primary: { containerPort: 6543 }, admin: { containerPort: 4000 } },
     args: () => ["start"],
-    env: (state, workload, port, runtime = "native", _inputs = {}) => {
+    env: (state, _workload, _port, runtime = "native") => {
       const adminPort =
         runtime === "container" ? 4000 : privatePortFor(state, "pooler:pooler", "admin");
       const primaryPort = privatePortFor(state, "pooler:pooler", "primary");
@@ -1285,11 +1287,8 @@ const selectedBindings = (
   state: Pick<PersistedStackState, "definition">,
   bindings: WorkloadBindings,
 ): ReadonlyArray<readonly [WorkloadBindingName, WorkloadBinding]> => {
-  const inspectorSettings = state.definition?.capabilities.functions.settings.inspector;
-  const inspectorRequested =
-    isRecord(inspectorSettings) || state.definition?.listeners.functionsInspector.enabled === true;
   return declaredBindings(bindings).filter(
-    ([binding]) => binding !== "inspector" || inspectorRequested,
+    ([binding]) => binding !== "inspector" || functionsInspectorRequested(state),
   );
 };
 

--- a/packages/stack/src/runtime/container-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/container-runtime.integration.test.ts
@@ -10,9 +10,11 @@ import {
   Option,
   Path,
   Stream,
+  Sink,
 } from "effect";
 import * as TestClock from "effect/testing/TestClock";
 import { NodeServices } from "@effect/platform-node";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type { PlannedWorkload } from "../model/ExecutionPlan.ts";
 import type { ContainerArtifact } from "../model/CapabilityModule.ts";
 import { StackIdSchema } from "../public/StackId.ts";
@@ -31,6 +33,7 @@ import {
   type ContainerVolumeSpec,
 } from "./ContainerEngine.ts";
 import { makeDockerEngine, serializeDockerCommand } from "./DockerEngine.ts";
+import { defaultContainerEngineResolver } from "./ContainerEngineResolver.ts";
 import { makePodmanEngine, serializePodmanCommand } from "./PodmanEngine.ts";
 import { makeContainerRuntime } from "./ContainerRuntime.ts";
 import { RuntimeDriverError, type RuntimeWorkloadKey } from "./RuntimeDriver.ts";
@@ -265,6 +268,33 @@ const pendingStartRace = (operation: "stop" | "remove") =>
   });
 
 describe("container runtime", () => {
+  it.live("checks only the Docker client version when selecting an installed runtime", () => {
+    const commands: Array<ReadonlyArray<string>> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      if (!ChildProcess.isStandardCommand(command)) return Effect.die("unexpected piped command");
+      commands.push([command.command, ...command.args]);
+      return Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: Sink.drain,
+          stdout: Stream.empty,
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        }),
+      );
+    });
+    return Effect.gen(function* () {
+      expect(yield* defaultContainerEngineResolver.isInstalled("docker")).toBe(true);
+      expect(commands).toEqual([["docker", "--version"]]);
+    }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+  });
+
   it.live("executes the exact command argv through a bounded process boundary", () =>
     Effect.gen(function* () {
       const runner = yield* makeProcessCommandRunner({
@@ -2772,7 +2802,6 @@ describe("container runtime", () => {
         yield* store.initialize(testStackId, {
           format: "supabase-stack-state-v1",
           identity: {
-            stackId: testStackId,
             projectRoot: root,
             branchContext: "ordinary-workspace",
             stackName: "container-follower",

--- a/packages/stack/src/runtime/database-bootstrap-catalog.integration.test.ts
+++ b/packages/stack/src/runtime/database-bootstrap-catalog.integration.test.ts
@@ -6,12 +6,9 @@ import type { PersistedStackState } from "../state/StackState.ts";
 import { StackPreparationError } from "../public/Errors.ts";
 import { databaseBootstrapPlan } from "./DatabaseBootstrapCatalog.ts";
 
-const stackId = "a".repeat(64);
-
 const stateFrom = (definition: PersistedStackState["definition"]): PersistedStackState => ({
   format: "supabase-stack-state-v1",
   identity: {
-    stackId,
     projectRoot: "/tmp/project",
     branchContext: "ordinary-workspace",
     stackName: "default",

--- a/packages/stack/src/runtime/production-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/production-runtime.integration.test.ts
@@ -76,7 +76,6 @@ const stateFor = (
 ): PersistedStackState => ({
   format: "supabase-stack-state-v1",
   identity: {
-    stackId,
     projectRoot: "/tmp/production-runtime",
     branchContext: "ordinary-workspace",
     stackName: "production-runtime",
@@ -2093,7 +2092,7 @@ describe("production runtime", () => {
     ).pipe(Effect.provide(NodeServices.layer)),
   );
 
-  it.live("ignores obsolete private bindings while retaining requested lazy bindings", () =>
+  it.live("ignores obsolete inspector bindings while retaining requested bindings", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -2106,16 +2105,19 @@ describe("production runtime", () => {
         if (address === null || typeof address === "string")
           return yield* Effect.die("occupied listener has no TCP address");
         const port = yield* Schema.decodeEffect(NetworkPortSchema)(address.port).pipe(Effect.orDie);
-        const previous = yield* compileStack({ projectRoot: root, runtime: { kind: "native" } });
+        const previous = yield* compileStack({
+          projectRoot: root,
+          runtime: { kind: "native" },
+          config: { capabilities: { functions: { settings: { inspector: { mode: "run" } } } } },
+        });
         const disabled = yield* compileStack({
           projectRoot: root,
           runtime: { kind: "native" },
-          config: { capabilities: { mail: { enabled: false } } },
         });
         const requestedLazy = yield* compileStack({
           projectRoot: root,
           runtime: { kind: "native" },
-          config: { capabilities: { mail: { activation: "lazy" } } },
+          config: { capabilities: { functions: { settings: { inspector: { mode: "run" } } } } },
         });
         const secrets = Object.fromEntries(
           disabled.secrets.map((entry) => [
@@ -2131,7 +2133,7 @@ describe("production runtime", () => {
               projectRoot: root,
             },
             definition: previous.definition,
-            privatePorts: [{ workloadId: "mail:mail", binding: "smtp", port }],
+            privatePorts: [{ workloadId: "functions:edge-runtime", binding: "inspector", port }],
             secrets,
           },
         } satisfies { value: PersistedStackState };

--- a/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
+++ b/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
@@ -17,7 +17,6 @@ const withPlatform = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.scoped(effect).pipe(Effect.provide(NodeServices.layer));
 
 const identityFor = (projectRoot: string): PersistedStackState["identity"] => ({
-  stackId,
   projectRoot,
   branchContext: "ordinary-workspace",
   stackName: "runtime-input-owner",

--- a/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
+++ b/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
@@ -58,7 +58,7 @@ const vectorFixture = () =>
     const fs = yield* FileSystem.FileSystem;
     const root = yield* fs.makeTempDirectoryScoped({ prefix: "runtime-input-vector-" });
     const base = yield* compiledState(root, {
-      capabilities: { analytics: { settings: { vector_port: 9001 } } },
+      capabilities: { analytics: { settings: {} } },
     });
     const state: PersistedStackState = {
       ...base,

--- a/packages/stack/src/runtime/workload-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/workload-runtime.integration.test.ts
@@ -34,7 +34,6 @@ const disabledListenerIntents: ListenerIntents = {
 const state: PersistedStackState = {
   format: "supabase-stack-state-v1",
   identity: {
-    stackId: "stack-runtime-spec-test",
     projectRoot: "/tmp/supabase-runtime-spec",
     branchContext: "ordinary-workspace",
     stackName: "runtime-spec",
@@ -168,7 +167,9 @@ describe("workload runtime catalog", () => {
         projectRoot: state.identity.projectRoot,
         runtime: { kind: "native" },
       }).pipe(Effect.provide(NodeServices.layer));
-      const intents = privateBindingIntentsFor(compiled.executionPlan);
+      const intents = privateBindingIntentsFor(compiled.executionPlan, {
+        definition: compiled.definition,
+      });
       expect(intents).toContainEqual({ workloadId: "database:database", binding: "primary" });
       expect(intents).toContainEqual({ workloadId: "mail:mail", binding: "ui" });
       expect(intents).toContainEqual({ workloadId: "mail:mail", binding: "smtp" });
@@ -209,6 +210,28 @@ describe("workload runtime catalog", () => {
         hostPort: 30_018,
         containerPort: 9229,
       });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not reserve disabled pooler or unconfigured inspector bindings", () =>
+    Effect.gen(function* () {
+      const compiled = yield* compileStack({
+        projectRoot: state.identity.projectRoot,
+        runtime: { kind: "native" },
+        config: { capabilities: { pooler: { enabled: false } } },
+      }).pipe(Effect.provide(NodeServices.layer));
+      const configured = { ...state, definition: compiled.definition };
+      const intents = privateBindingIntentsFor(compiled.executionPlan, configured);
+      expect(intents.some(({ workloadId }) => workloadId === "pooler:pooler")).toBe(false);
+      expect(
+        intents.some(
+          ({ workloadId, binding }) =>
+            workloadId === "functions:edge-runtime" && binding === "inspector",
+        ),
+      ).toBe(false);
+      expect(
+        containerResolutionFor(configured, planned("functions:edge-runtime"))?.publications,
+      ).not.toContainEqual(expect.objectContaining({ containerPort: 9229 }));
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -268,7 +291,7 @@ describe("workload runtime catalog", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
-  it.live("compiles pgmeta's primary and admin ports before the Vector companion", () =>
+  it.live("compiles pgmeta's primary port before the Vector companion", () =>
     Effect.gen(function* () {
       const compiled = yield* compileStack({
         projectRoot: state.identity.projectRoot,
@@ -280,12 +303,13 @@ describe("workload runtime catalog", () => {
           },
         },
       }).pipe(Effect.provide(NodeServices.layer));
-      const relevant = privateBindingIntentsFor(compiled.executionPlan).filter(
+      const relevant = privateBindingIntentsFor(compiled.executionPlan, {
+        definition: compiled.definition,
+      }).filter(
         ({ workloadId }) => workloadId === "studio:pgmeta" || workloadId === "analytics:vector",
       );
       expect(relevant).toEqual([
         { workloadId: "studio:pgmeta", binding: "primary" },
-        { workloadId: "studio:pgmeta", binding: "admin" },
         { workloadId: "analytics:vector", binding: "primary" },
       ]);
 
@@ -299,7 +323,7 @@ describe("workload runtime catalog", () => {
       const store = yield* makeStackStateStore({ stateRoot: root });
       yield* store.initialize(stackId, {
         ...state,
-        identity: { ...identity, stackId },
+        identity,
         desiredLifecycle: "running",
         ports: [],
         privatePorts: [],
@@ -312,29 +336,23 @@ describe("workload runtime catalog", () => {
       }).acquire(
         stackId,
         disabledListenerIntents,
-        privateBindingIntentsFor(compiled.executionPlan),
+        privateBindingIntentsFor(compiled.executionPlan, { definition: compiled.definition }),
       );
       const pgmetaPrimary = reservation.privateAssignments.find(
         ({ workloadId, binding }) => workloadId === "studio:pgmeta" && binding === "primary",
       );
-      const pgmetaAdmin = reservation.privateAssignments.find(
-        ({ workloadId, binding }) => workloadId === "studio:pgmeta" && binding === "admin",
-      );
       const vectorPrimary = reservation.privateAssignments.find(
         ({ workloadId, binding }) => workloadId === "analytics:vector" && binding === "primary",
       );
-      if (pgmetaPrimary === undefined || pgmetaAdmin === undefined || vectorPrimary === undefined)
+      if (pgmetaPrimary === undefined || vectorPrimary === undefined)
         throw new Error("Compiled plan did not reserve pgmeta and Vector bindings");
-      expect(pgmetaAdmin.port).not.toBe(pgmetaPrimary.port);
       expect(vectorPrimary.port).not.toBe(pgmetaPrimary.port);
-      expect(vectorPrimary.port).not.toBe(pgmetaAdmin.port);
       const pgmetaResolution = containerResolutionFor(
         { ...state, privatePorts: reservation.privateAssignments },
         planned("studio:pgmeta"),
       );
       expect(pgmetaResolution?.publications).toEqual([
         { address: "127.0.0.1", hostPort: pgmetaPrimary.port, containerPort: 8080 },
-        { address: "127.0.0.1", hostPort: pgmetaAdmin.port, containerPort: 8081 },
       ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
@@ -347,7 +365,6 @@ describe("workload runtime catalog", () => {
       if (spec === undefined) continue;
       const port = 30_000 + index;
       expect(spec.containerPort).toBeGreaterThan(0);
-      expect(spec.env(state, workload, port).SUPABASE_STACK_WORKLOAD).toBe(id);
       expect(spec.readiness.protocol).toMatch(/http|tcp/u);
       expect(spec.args(state, workload, port)).toBeInstanceOf(Array);
       expect(typeof spec.cwd(state, workload)).toBe("string");
@@ -381,9 +398,6 @@ describe("workload runtime catalog", () => {
       });
       const realtime = planned("realtime:realtime");
       expect(runtimeSpecFor(realtime)?.env(state, realtime, 32000).PORT).toBe("32000");
-      expect(
-        runtimeSpecFor(realtime)?.env(state, realtime, 32000).SUPABASE_STACK_PRIVATE_PORT,
-      ).toBe("32000");
       const secondState: PersistedStackState = {
         ...state,
         privatePorts: state.privatePorts.map((assignment) => ({

--- a/packages/stack/src/runtime/workload-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/workload-runtime.integration.test.ts
@@ -123,7 +123,7 @@ describe("workload runtime catalog", () => {
       const storage = planned("storage:storage");
       expect(runtimeSpecFor(storage)?.env(configured, storage, 5000)).toMatchObject({
         FILE_SIZE_LIMIT: "52428800",
-        ENABLE_IMAGE_TRANSFORMATION: "false",
+        ENABLE_IMAGE_TRANSFORMATION: "true",
         S3_PROTOCOL_ENABLED: "true",
         S3_PROTOCOL_ACCESS_KEY_ID: "625729a08b95bf1b7ff351a663f3a23c",
         STORAGE_S3_REGION: "local",
@@ -298,7 +298,7 @@ describe("workload runtime catalog", () => {
         runtime: { kind: "native" },
         config: {
           capabilities: {
-            analytics: { enabled: true, settings: { vector_port: 9001 } },
+            analytics: { enabled: true, settings: {} },
             studio: { enabled: true },
           },
         },

--- a/packages/stack/src/state/Ownership.ts
+++ b/packages/stack/src/state/Ownership.ts
@@ -51,20 +51,19 @@ export class StackRuntimeEnvironment extends Context.Service<
   StackRuntimeEnvironmentValue
 >()("@supabase/stack/StackRuntimeEnvironment") {}
 
-const ControlEndpointSchema = Schema.Union([
-  Schema.Struct({ kind: Schema.Literal("unix"), path: Schema.String }),
-  Schema.Struct({ kind: Schema.Literal("pipe"), name: Schema.String }),
-]);
-
-const OwnerMetadataSchema = Schema.Struct({
+// stackId and endpoint are derived from the identity directory and lease port.
+// Keep them in the in-memory lease value for callers, but do not duplicate them
+// in the durable control document.
+const OwnerMetadataDiskSchema = Schema.Struct({
   format: Schema.Literal(OWNERSHIP_FORMAT),
-  stackId: StackIdSchema,
   ownerSessionId: OwnerSessionIdSchema,
   leasePort: NetworkPortSchema,
-  endpoint: ControlEndpointSchema,
   rpcRelease: Schema.String,
 });
-export type OwnerMetadata = Schema.Schema.Type<typeof OwnerMetadataSchema>;
+export type OwnerMetadata = Schema.Schema.Type<typeof OwnerMetadataDiskSchema> & {
+  readonly stackId: StackId;
+  readonly endpoint: ControlEndpoint;
+};
 
 const OwnerLockSchema = Schema.Struct({
   format: Schema.Literal(OWNER_LOCK_FORMAT),
@@ -241,9 +240,22 @@ const decodeStackId = (value: string): Effect.Effect<StackId, StackStateInvalidE
     Effect.mapError((error) => stateError(`Invalid StackId: ${String(error)}`)),
   );
 
-const metadataFrom = (value: unknown): Effect.Effect<OwnerMetadata, StackStateInvalidError> =>
-  Schema.decodeUnknownEffect(OwnerMetadataSchema)(value, { onExcessProperty: "error" }).pipe(
+const metadataFrom = (
+  value: unknown,
+  stackId: StackId,
+  environment: Pick<StackRuntimeEnvironmentValue, "platform" | "tempRoot">,
+): Effect.Effect<OwnerMetadata, StackStateInvalidError> =>
+  Schema.decodeUnknownEffect(Schema.Record(Schema.String, Schema.Unknown))(value).pipe(
+    Effect.map(({ stackId: _stackId, endpoint: _endpoint, ...disk }) => disk),
+    Effect.flatMap((disk) =>
+      Schema.decodeUnknownEffect(OwnerMetadataDiskSchema)(disk, { onExcessProperty: "error" }),
+    ),
     Effect.mapError((error) => stateError(`Invalid owner metadata: ${String(error)}`)),
+    Effect.map((metadata) => ({
+      ...metadata,
+      stackId,
+      endpoint: controlEndpointFor(stackId, environment, metadata.leasePort),
+    })),
   );
 
 /**
@@ -295,25 +307,7 @@ export const readOwnerMetadata = (
     ).pipe(
       Effect.mapError((error) => stateError(`Unable to parse owner metadata: ${String(error)}`)),
     );
-    const metadata = yield* metadataFrom(parsed);
-    if (metadata.stackId !== validId)
-      return yield* stateError("Owner metadata StackId does not match its directory");
-    const expected = controlEndpointFor(validId, environment, metadata.leasePort);
-    if (metadata.endpoint.kind !== expected.kind)
-      return yield* stateError("Owner metadata endpoint kind does not match this runtime");
-    if (
-      metadata.endpoint.kind === "unix" &&
-      expected.kind === "unix" &&
-      metadata.endpoint.path !== expected.path
-    )
-      return yield* stateError("Owner metadata endpoint does not match its StackId");
-    if (
-      metadata.endpoint.kind === "pipe" &&
-      expected.kind === "pipe" &&
-      metadata.endpoint.name !== expected.name
-    )
-      return yield* stateError("Owner metadata endpoint does not match its StackId");
-    return metadata;
+    return yield* metadataFrom(parsed, validId, environment);
   });
 
 export const ownerLockExists = (
@@ -344,7 +338,7 @@ export const publishOwnership = (
 ): Effect.Effect<void, StackStateInvalidError, FileSystem.FileSystem | Path.Path> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(OwnerMetadataSchema))(
+    const encoded = yield* Schema.encodeEffect(Schema.fromJsonString(OwnerMetadataDiskSchema))(
       lease.metadata,
     ).pipe(
       Effect.mapError((error) => stateError(`Unable to encode owner metadata: ${String(error)}`)),
@@ -638,9 +632,9 @@ export const acquireOwnership = (options: {
           const release = Effect.suspend(() =>
             fs.readFileString(paths.controlMetadata).pipe(
               Effect.flatMap((text) =>
-                Schema.decodeEffect(Schema.fromJsonString(OwnerMetadataSchema))(text).pipe(
+                Schema.decodeEffect(Schema.fromJsonString(OwnerMetadataDiskSchema))(text).pipe(
                   Effect.flatMap((current) =>
-                    current.stackId === validId && current.ownerSessionId === options.ownerSessionId
+                    current.ownerSessionId === options.ownerSessionId
                       ? fs.remove(paths.controlMetadata, { force: true }).pipe(
                           Effect.catchTag("PlatformError", () => Effect.void),
                           Effect.andThen(removeLeaseIfHeld(fs, lockPath, options.ownerSessionId)),

--- a/packages/stack/src/state/StackState.ts
+++ b/packages/stack/src/state/StackState.ts
@@ -32,7 +32,6 @@ import { DesiredStackLifecycleSchema, NetworkPortSchema, PORT_FIELDS } from "../
 export const STACK_STATE_FORMAT = "supabase-stack-state-v1" as const;
 
 const PersistedStackIdentitySchema = Schema.Struct({
-  stackId: Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/)),
   projectRoot: Schema.String,
   branchContext: Schema.String,
   stackName: Schema.String,
@@ -330,11 +329,7 @@ export const PersistedStackStateSchema = stateShape.pipe(
 );
 export type PersistedStackState = Schema.Schema.Type<typeof PersistedStackStateSchema>;
 
-export const toPersistedIdentity = (
-  identity: StackIdentity,
-  stackId: string,
-): PersistedStackIdentity => ({
-  stackId,
+export const toPersistedIdentity = (identity: StackIdentity): PersistedStackIdentity => ({
   projectRoot: identity.projectRoot,
   branchContext: identity.branchContext,
   stackName: identity.stackName,

--- a/packages/stack/src/state/StackStateStore.ts
+++ b/packages/stack/src/state/StackStateStore.ts
@@ -94,6 +94,34 @@ export interface StackStateStore {
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const withoutKeys = (
+  value: Readonly<Record<string, unknown>>,
+  keys: ReadonlyArray<string>,
+): Record<string, unknown> => {
+  const result = { ...value };
+  for (const key of keys) delete result[key];
+  return result;
+};
+
+/** Drops settings removed from the local model when reading older durable state. */
+const normalizeDurableState = (raw: Readonly<Record<string, unknown>>): unknown => {
+  const identity = isRecord(raw.identity) ? withoutKeys(raw.identity, ["stackId"]) : raw.identity;
+  const definition = raw.definition;
+  if (!isRecord(definition) || !isRecord(definition.capabilities)) return { ...raw, identity };
+  const capabilities: Record<string, unknown> = { ...definition.capabilities };
+  const obsolete: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+    ["database", ["network_restrictions", "ssl_enforcement", "vault"]],
+    ["rest", ["auto_expose_new_tables", "tls"]],
+    ["storage", ["analytics"]],
+  ];
+  for (const [capability, keys] of obsolete) {
+    const module = capabilities[capability];
+    if (!isRecord(module) || !isRecord(module.settings)) continue;
+    capabilities[capability] = { ...module, settings: withoutKeys(module.settings, keys) };
+  }
+  return { ...raw, identity, definition: { ...definition, capabilities } };
+};
+
 const stateError = (message: string, cause?: unknown) =>
   new StackStateInvalidError({ message, ...(cause === undefined ? {} : { cause }) });
 
@@ -138,7 +166,7 @@ const decodeState = (
   for (const slot of Object.keys(raw.secrets))
     if (!/^[A-Za-z0-9_.:/-]+$/.test(slot))
       return Effect.fail(stateError(`Persisted secret slot key is invalid: ${slot}`));
-  return Schema.decodeUnknownEffect(PersistedStackStateSchema)(raw, {
+  return Schema.decodeUnknownEffect(PersistedStackStateSchema)(normalizeDurableState(raw), {
     onExcessProperty: "error",
   }).pipe(
     Effect.mapError((error) => stateError(`Invalid persisted stack state: ${String(error)}`)),
@@ -154,13 +182,12 @@ const validateIdentityForStackId = (
   identity: PersistedStackState["identity"],
   stackId: string,
 ): Effect.Effect<void, StackStateInvalidError, Crypto.Crypto> => {
-  const { stackId: persistedStackId, ...tuple } = identity;
-  return deriveStackId(tuple).pipe(
+  return deriveStackId(identity).pipe(
     Effect.mapError((error) =>
       stateError(`Unable to validate persisted identity: ${error.message}`),
     ),
     Effect.flatMap((derived) =>
-      persistedStackId === stackId && derived === stackId
+      derived === stackId
         ? Effect.void
         : Effect.fail(stateError("Persisted identity does not match its StackId directory")),
     ),

--- a/packages/stack/src/state/StackStateStore.ts
+++ b/packages/stack/src/state/StackStateStore.ts
@@ -113,6 +113,7 @@ const normalizeDurableState = (raw: Readonly<Record<string, unknown>>): unknown 
     ["database", ["network_restrictions", "ssl_enforcement", "vault"]],
     ["rest", ["auto_expose_new_tables", "tls"]],
     ["storage", ["analytics"]],
+    ["analytics", ["vector_port"]],
   ];
   for (const [capability, keys] of obsolete) {
     const module = capabilities[capability];

--- a/packages/stack/src/state/ownership.integration.test.ts
+++ b/packages/stack/src/state/ownership.integration.test.ts
@@ -77,9 +77,9 @@ const identity: StackIdentity = {
   stackName: "default",
 };
 
-const stateFor = (stackId: string): PersistedStackState => ({
+const stateFor = (): PersistedStackState => ({
   format: "supabase-stack-state-v1",
-  identity: { ...identity, stackId },
+  identity,
   runtime: { kind: "native" },
   desiredLifecycle: "unconfigured",
   ports: [],
@@ -114,7 +114,7 @@ describe("stack ownership", () => {
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-init-" });
         const stackId = yield* deriveStackId(identity);
         const store = yield* makeStackStateStore({ stateRoot: root });
-        const candidate = stateFor(stackId);
+        const candidate = stateFor();
         const [first, second] = yield* Effect.all(
           [store.initialize(stackId, candidate), store.initialize(stackId, candidate)],
           { concurrency: 2 },
@@ -149,6 +149,12 @@ describe("stack ownership", () => {
           controlEndpointFor(stackId, environment, lease.metadata.leasePort),
         );
         yield* publishOwnership(lease);
+        const paths = yield* resolveStackPaths({ stateRoot: root, stackId });
+        const persisted = yield* Schema.decodeEffect(
+          Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown)),
+        )(yield* fs.readFileString(paths.controlMetadata));
+        expect(persisted).not.toHaveProperty("stackId");
+        expect(persisted).not.toHaveProperty("endpoint");
         expect(yield* readOwnerMetadata(root, stackId, environment)).toEqual(lease.metadata);
 
         const competing = yield* acquireOwnership({
@@ -296,7 +302,7 @@ describe("stack ownership", () => {
     ),
   );
 
-  it.live("fails closed when owner metadata belongs to another identity", () =>
+  it.live("derives control identity and endpoint from the stack directory", () =>
     withPlatform(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -317,12 +323,31 @@ describe("stack ownership", () => {
         yield* publishOwnership(lease);
         const metadataPath = lease.metadataPath;
         const text = yield* fs.readFileString(metadataPath);
-        yield* fs.writeFileString(metadataPath, text.replace(stackId, "b".repeat(64)));
-        const read = yield* readOwnerMetadata(root, stackId, environment).pipe(Effect.exit);
-        expect(errorOf(read)).toBeInstanceOf(StackStateInvalidError);
+        const persisted = yield* Schema.decodeEffect(
+          Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown)),
+        )(text);
+        yield* fs.writeFileString(
+          metadataPath,
+          jsonText({
+            ...persisted,
+            stackId: "b".repeat(64),
+            endpoint: { kind: "unix", path: "/wrong/control.sock" },
+            unexpected: true,
+          }),
+        );
+        const rejected = yield* readOwnerMetadata(root, stackId, environment).pipe(Effect.exit);
+        expect(errorOf(rejected)).toBeInstanceOf(StackStateInvalidError);
+        yield* fs.writeFileString(
+          metadataPath,
+          jsonText({
+            ...persisted,
+            stackId: "b".repeat(64),
+            endpoint: { kind: "unix", path: "/wrong/control.sock" },
+          }),
+        );
+        expect(yield* readOwnerMetadata(root, stackId, environment)).toEqual(lease.metadata);
         yield* lease.release;
-        // A malformed replacement cannot be removed by this stale finalizer.
-        expect(yield* fs.exists(metadataPath)).toBe(true);
+        expect(yield* fs.exists(metadataPath)).toBe(false);
       }),
     ),
   );

--- a/packages/stack/src/state/ports.integration.test.ts
+++ b/packages/stack/src/state/ports.integration.test.ts
@@ -56,7 +56,7 @@ const state = (
   privatePorts: PersistedStackState["privatePorts"] = [],
 ): PersistedStackState => ({
   format: "supabase-stack-state-v1",
-  identity: { ...value, stackId: id },
+  identity: value,
   runtime: { kind: "native" },
   desiredLifecycle: "running",
   ports,

--- a/packages/stack/src/state/state-store.integration.test.ts
+++ b/packages/stack/src/state/state-store.integration.test.ts
@@ -231,6 +231,13 @@ describe("atomic stack state", () => {
                   analytics: { enabled: false },
                 },
               },
+              analytics: {
+                ...encoded.definition?.capabilities.analytics,
+                settings: {
+                  ...encoded.definition?.capabilities.analytics.settings,
+                  vector_port: 9001,
+                },
+              },
             },
           },
         };

--- a/packages/stack/src/state/state-store.integration.test.ts
+++ b/packages/stack/src/state/state-store.integration.test.ts
@@ -33,9 +33,9 @@ const identity = {
   stackName: "default",
 } as const;
 
-const state = (stackId: string, definition?: StackDefinition): PersistedStackState => ({
+const state = (definition?: StackDefinition): PersistedStackState => ({
   format: "supabase-stack-state-v1",
-  identity: { ...identity, stackId },
+  identity,
   runtime: { kind: "native" },
   desiredLifecycle: "stopped",
   definition,
@@ -76,7 +76,7 @@ const completeStateFixture = Effect.gen(function* () {
       },
     },
   });
-  const complete = state(stackId, compiled.definition);
+  const complete = state(compiled.definition);
   yield* store.initialize(stackId, complete);
   const encoded = yield* Schema.encodeEffect(PersistedStackStateSchema)(complete);
   return { fs, path, store, root, stackId, complete, encoded };
@@ -164,8 +164,12 @@ describe("atomic stack state", () => {
   it.live("rejects malformed nested state documents", () =>
     withPlatform(
       Effect.gen(function* () {
-        const { fs, path, store, root, stackId, encoded } = yield* completeStateFixture;
+        const { fs, path, store, root, stackId, complete, encoded } = yield* completeStateFixture;
         const statePath = path.join(root, stackId, "state.json");
+        const persisted = yield* Schema.decodeEffect(
+          Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown)),
+        )(yield* fs.readFileString(statePath));
+        expect(persisted).not.toHaveProperty("identity.stackId");
         const nestedUnknown = {
           ...encoded,
           definition: {
@@ -194,6 +198,51 @@ describe("atomic stack state", () => {
         yield* fs.writeFileString(statePath, yield* jsonText(nestedUnknown));
         const unknownExit = yield* store.read(stackId).pipe(Effect.exit);
         expect(errorOf(unknownExit)).toBeInstanceOf(StackStateInvalidError);
+
+        const oldSnapshot = {
+          ...encoded,
+          identity: { ...encoded.identity, stackId },
+          secrets: { preserved: { policy: "managed", value: "secret-value" } },
+          definition: {
+            ...encoded.definition,
+            capabilities: {
+              ...encoded.definition?.capabilities,
+              database: {
+                ...encoded.definition?.capabilities.database,
+                settings: {
+                  ...encoded.definition?.capabilities.database.settings,
+                  network_restrictions: { enabled: true, allowed_cidrs: ["10.0.0.0/8"] },
+                  ssl_enforcement: { enabled: true },
+                  vault: {},
+                },
+              },
+              rest: {
+                ...encoded.definition?.capabilities.rest,
+                settings: {
+                  ...encoded.definition?.capabilities.rest.settings,
+                  auto_expose_new_tables: true,
+                  tls: { enabled: false },
+                },
+              },
+              storage: {
+                ...encoded.definition?.capabilities.storage,
+                settings: {
+                  ...encoded.definition?.capabilities.storage.settings,
+                  analytics: { enabled: false },
+                },
+              },
+            },
+          },
+        };
+        yield* fs.writeFileString(statePath, yield* jsonText(oldSnapshot));
+        const recovered = yield* store.read(stackId);
+        expect(recovered).toEqual({ ...complete, secrets: oldSnapshot.secrets });
+        if (recovered === undefined) throw new Error("Expected recovered state");
+        yield* store.replace(stackId, recovered);
+        const rewritten = yield* Schema.decodeEffect(Schema.fromJsonString(Schema.Unknown))(
+          yield* fs.readFileString(statePath),
+        );
+        expect(rewritten).toEqual({ ...encoded, secrets: oldSnapshot.secrets });
 
         const missingDefault = {
           ...encoded,
@@ -280,7 +329,7 @@ describe("atomic stack state", () => {
         };
         const stackId = yield* deriveStackId(value);
         const store = yield* makeStackStateStore({ stateRoot: root });
-        const before = { ...state(stackId), identity: { ...value, stackId } };
+        const before = { ...state(), identity: value };
         yield* store.initialize(stackId, before);
         const candidate = {
           ...before,
@@ -325,7 +374,7 @@ describe("atomic stack state", () => {
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-read-race-" });
         const stackId = yield* deriveStackId(identity);
         const store = yield* makeStackStateStore({ stateRoot: root });
-        yield* store.initialize(stackId, state(stackId));
+        yield* store.initialize(stackId, state());
         const statePath = path.join(root, stackId, "state.json");
         const racingFs: FileSystem.FileSystem = {
           ...fs,
@@ -375,16 +424,16 @@ describe("atomic stack state", () => {
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-format-" });
         const store = yield* makeStackStateStore({ stateRoot: root });
         const stackId = yield* deriveStackId(identity);
-        yield* store.initialize(stackId, state(stackId));
+        yield* store.initialize(stackId, state());
         yield* fs.writeFileString(
           path.join(root, stackId, "state.json"),
-          yield* jsonText({ ...state(stackId), format: "supabase-stack-state-v2" }),
+          yield* jsonText({ ...state(), format: "supabase-stack-state-v2" }),
         );
         const unsupported = yield* store.read(stackId).pipe(Effect.exit);
         expect(errorOf(unsupported)).toBeInstanceOf(StackStateFormatUnsupportedError);
         yield* fs.writeFileString(
           path.join(root, stackId, "state.json"),
-          yield* jsonText({ ...state(stackId), format: 1 }),
+          yield* jsonText({ ...state(), format: 1 }),
         );
         const malformed = yield* store.read(stackId).pipe(Effect.exit);
         expect(errorOf(malformed)).toBeInstanceOf(StackStateInvalidError);
@@ -400,7 +449,7 @@ describe("atomic stack state", () => {
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-identity-" });
         const store = yield* makeStackStateStore({ stateRoot: root });
         const stackId = yield* deriveStackId(identity);
-        const original = state(stackId);
+        const original = state();
         const forged = {
           ...original,
           identity: { ...original.identity, projectRoot: "/tmp/forged" },
@@ -420,7 +469,7 @@ describe("atomic stack state", () => {
         });
         const store = yield* makeStackStateStore({ stateRoot: root });
         const stackId = yield* deriveStackId(identity);
-        const oldValue = state(stackId);
+        const oldValue = state();
         const newValue = {
           ...oldValue,
           desiredLifecycle: "running" as const,

--- a/packages/stack/src/supervisor/Ingress.ts
+++ b/packages/stack/src/supervisor/Ingress.ts
@@ -95,16 +95,23 @@ export interface SupervisorIngressOptions {
   >;
 }
 
-const listenerIntents = (input: LifecycleInput): ListenerIntents => ({
-  api: input.definition.listeners.api,
-  database: input.definition.listeners.database,
-  pooler: input.definition.listeners.pooler,
-  studio: input.definition.listeners.studio,
-  mailUi: input.definition.listeners.mailUi,
-  smtp: input.definition.listeners.smtp,
-  pop3: input.definition.listeners.pop3,
-  functionsInspector: input.definition.listeners.functionsInspector,
-});
+const listenerIntents = (input: LifecycleInput): ListenerIntents => {
+  const usable = new Set(input.plan.routes.map(({ listener }) => listener));
+  const select = <K extends keyof ListenerIntents>(field: K): ListenerIntents[K] =>
+    usable.has(field)
+      ? input.definition.listeners[field]
+      : { ...input.definition.listeners[field], enabled: false };
+  return {
+    api: select("api"),
+    database: select("database"),
+    pooler: select("pooler"),
+    studio: select("studio"),
+    mailUi: select("mailUi"),
+    smtp: select("smtp"),
+    pop3: select("pop3"),
+    functionsInspector: select("functionsInspector"),
+  };
+};
 
 const defaultApiMaterial = (
   state: LifecycleInput["state"],
@@ -207,7 +214,11 @@ export const makeSupervisorIngress = (
           if (existing !== undefined) return { ...existing.reservation, fresh: false };
           const reservationScope = Scope.forkUnsafe(ownerScope);
           const reservation = yield* coordinator
-            .acquire(options.stackId, listenerIntents(input), privateBindingIntentsFor(input.plan))
+            .acquire(
+              options.stackId,
+              listenerIntents(input),
+              privateBindingIntentsFor(input.plan, input.state),
+            )
             .pipe(
               Effect.provideContext(options.context),
               Effect.provideService(Scope.Scope, reservationScope),

--- a/packages/stack/src/supervisor/StatusProjection.ts
+++ b/packages/stack/src/supervisor/StatusProjection.ts
@@ -1,11 +1,10 @@
-import { Effect, Schema } from "effect";
+import { Effect } from "effect";
 import {
   CAPABILITY_NAMES,
   type CapabilityName,
   type CapabilityStatus,
 } from "../public/Capability.ts";
-import { StackStateInvalidError } from "../public/Errors.ts";
-import { StackIdSchema } from "../public/StackId.ts";
+import type { StackId } from "../public/StackId.ts";
 import {
   PORT_FIELD_PROTOCOL,
   type ArtifactPreparationStatus,
@@ -75,55 +74,50 @@ const stackLifecycle = (
 };
 
 export const statusFor = (
+  id: StackId,
   state: PersistedStackState,
   observed: ReadonlyArray<ObservedWorkload>,
   active: ReadonlySet<CapabilityName>,
   phase: ActualPhase,
   artifacts: ReadonlyArray<ArtifactPreparationStatus> = [],
-): Effect.Effect<StackStatus, StackStateInvalidError> =>
-  Schema.decodeEffect(StackIdSchema)(state.identity.stackId).pipe(
-    Effect.mapError(
-      (error) =>
-        new StackStateInvalidError({ message: `Invalid persisted StackId: ${String(error)}` }),
-    ),
-    Effect.map((id) => {
-      const definition = state.definition;
-      const capabilities = CAPABILITY_NAMES.map((name) => {
-        const capability = capabilityState(name, state, observed, active, phase);
-        const error = capabilityError(name, observed, capability);
-        return {
-          name,
-          activation:
-            definition?.capabilities[name].activation ?? (name === "database" ? "eager" : "lazy"),
-          state: capability,
-          ...(error === undefined ? {} : { error }),
-        };
-      });
-      const versions: Partial<Record<CapabilityName, string>> = {};
-      if (definition !== undefined)
-        for (const name of CAPABILITY_NAMES) versions[name] = definition.capabilities[name].version;
-      const endpoints = state.ports.reduce<StackStatus["endpoints"]>((result, assignment) => {
-        const protocol = PORT_FIELD_PROTOCOL[assignment.field];
-        const listener = definition?.listeners[assignment.field];
-        return {
-          ...result,
-          [assignment.field]: {
-            protocol,
-            address: listener?.address ?? "127.0.0.1",
-            port: assignment.port,
-            url: `${protocol}://${listener?.address ?? "127.0.0.1"}:${assignment.port}`,
-          },
-        };
-      }, {});
+): Effect.Effect<StackStatus> =>
+  Effect.sync(() => {
+    const definition = state.definition;
+    const capabilities = CAPABILITY_NAMES.map((name) => {
+      const capability = capabilityState(name, state, observed, active, phase);
+      const error = capabilityError(name, observed, capability);
       return {
-        id,
-        lifecycle: stackLifecycle(state, phase),
-        desiredLifecycle: state.desiredLifecycle,
-        runtime: state.runtime,
-        endpoints,
-        versions,
-        capabilities,
-        artifacts,
-      } satisfies StackStatus;
-    }),
-  );
+        name,
+        activation:
+          definition?.capabilities[name].activation ?? (name === "database" ? "eager" : "lazy"),
+        state: capability,
+        ...(error === undefined ? {} : { error }),
+      };
+    });
+    const versions: Partial<Record<CapabilityName, string>> = {};
+    if (definition !== undefined)
+      for (const name of CAPABILITY_NAMES) versions[name] = definition.capabilities[name].version;
+    const endpoints = state.ports.reduce<StackStatus["endpoints"]>((result, assignment) => {
+      const protocol = PORT_FIELD_PROTOCOL[assignment.field];
+      const listener = definition?.listeners[assignment.field];
+      return {
+        ...result,
+        [assignment.field]: {
+          protocol,
+          address: listener?.address ?? "127.0.0.1",
+          port: assignment.port,
+          url: `${protocol}://${listener?.address ?? "127.0.0.1"}:${assignment.port}`,
+        },
+      };
+    }, {});
+    return {
+      id,
+      lifecycle: stackLifecycle(state, phase),
+      desiredLifecycle: state.desiredLifecycle,
+      runtime: state.runtime,
+      endpoints,
+      versions,
+      capabilities,
+      artifacts,
+    } satisfies StackStatus;
+  });

--- a/packages/stack/src/supervisor/Supervisor.ts
+++ b/packages/stack/src/supervisor/Supervisor.ts
@@ -231,6 +231,7 @@ export const makeSupervisor = (
         if (state === undefined)
           return yield* new StackStateInvalidError({ message: "Stack state is missing" });
         const status = yield* statusFor(
+          options.stackId,
           state,
           yield* observedForStatus(),
           yield* Ref.get(active),

--- a/packages/stack/src/supervisor/handles.integration.test.ts
+++ b/packages/stack/src/supervisor/handles.integration.test.ts
@@ -242,7 +242,10 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
   it.live("persists Docker for an omitted container engine without probing", () =>
     withRuntimeRoot((project) =>
       Effect.gen(function* () {
-        const resolver = { resolve: () => Effect.die("resolver must not be called") };
+        const resolver = {
+          isInstalled: () => Effect.die("resolver must not be called"),
+          resolve: () => Effect.die("resolver must not be called"),
+        };
         yield* createStack({ projectRoot: project, runtime: { kind: "container" } }).pipe(
           Effect.provideService(ContainerEngineResolver, resolver),
         );
@@ -253,10 +256,59 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
     ),
   );
 
+  it.live("selects Docker for a new stack when the client is installed", () =>
+    withRuntimeRoot((project) =>
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const resolver = {
+          isInstalled: (kind: "docker" | "podman") =>
+            Effect.sync(() => {
+              calls.push(kind);
+              return true;
+            }),
+          resolve: () => Effect.die("engine construction must not run during create"),
+        };
+        yield* createStack({ projectRoot: project }).pipe(
+          Effect.provideService(ContainerEngineResolver, resolver),
+        );
+        expect(calls).toEqual(["docker"]);
+        expect(
+          (yield* findStack({ projectRoot: project })).pipe(Option.getOrUndefined)?.runtime,
+        ).toEqual({ kind: "container", engine: "docker" });
+      }),
+    ),
+  );
+
+  it.live("selects native for a new stack when the Docker client is absent", () =>
+    withRuntimeRoot((project) =>
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const resolver = {
+          isInstalled: (kind: "docker" | "podman") =>
+            Effect.sync(() => {
+              calls.push(kind);
+              return false;
+            }),
+          resolve: () => Effect.die("engine construction must not run during create"),
+        };
+        yield* createStack({ projectRoot: project }).pipe(
+          Effect.provideService(ContainerEngineResolver, resolver),
+        );
+        expect(calls).toEqual(["docker"]);
+        expect(
+          (yield* findStack({ projectRoot: project })).pipe(Option.getOrUndefined)?.runtime,
+        ).toEqual({ kind: "native" });
+      }),
+    ),
+  );
+
   it.live("persists explicit Podman without probing", () =>
     withRuntimeRoot((project) =>
       Effect.gen(function* () {
-        const resolver = { resolve: () => Effect.die("resolver must not be called") };
+        const resolver = {
+          isInstalled: () => Effect.die("resolver must not be called"),
+          resolve: () => Effect.die("resolver must not be called"),
+        };
         yield* createStack({
           projectRoot: project,
           runtime: { kind: "container", engine: "podman" },
@@ -274,6 +326,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         const calls: string[] = [];
         const dockerCalls: string[] = [];
         const resolver = {
+          isInstalled: () => Effect.succeed(true),
           resolve: (kind: "docker" | "podman") =>
             Effect.succeed(
               kind === "podman"
@@ -300,7 +353,10 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
           projectRoot: project,
           runtime: { kind: "container", engine: "podman" },
         });
-        const resolver = { resolve: () => Effect.die("resolver must not be called") };
+        const resolver = {
+          isInstalled: () => Effect.die("resolver must not be called"),
+          resolve: () => Effect.die("resolver must not be called"),
+        };
         const stack = yield* openStack(created.id).pipe(
           Effect.provideService(ContainerEngineResolver, resolver),
         );
@@ -321,6 +377,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
           runtime: { kind: "container", engine: "podman" },
         }).pipe(
           Effect.provideService(ContainerEngineResolver, {
+            isInstalled: () => Effect.die("resolver must not be called"),
             resolve: () => Effect.die("resolver must not be called"),
           }),
           Effect.exit,
@@ -338,6 +395,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
     withRuntimeRoot((project) =>
       createStack({ projectRoot: project, runtime: { kind: "native" } }).pipe(
         Effect.provideService(ContainerEngineResolver, {
+          isInstalled: () => Effect.die("native stack must not resolve a container engine"),
           resolve: () => Effect.die("native stack must not resolve a container engine"),
         }),
       ),
@@ -365,7 +423,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         const store = yield* makeStackStateStore({ stateRoot: env.stateRoot });
         yield* store.initialize(stackId, {
           format: "supabase-stack-state-v1",
-          identity: { ...identity, stackId },
+          identity,
           runtime: { kind: "native" },
           desiredLifecycle: "stopped",
           ports: [],
@@ -455,7 +513,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         const store = yield* makeStackStateStore({ stateRoot: env.stateRoot });
         yield* store.initialize(stackId, {
           format: "supabase-stack-state-v1",
-          identity: { ...identity, stackId },
+          identity,
           runtime: { kind: "native" },
           desiredLifecycle: "stopped",
           ports: [],

--- a/packages/stack/src/supervisor/handles.integration.test.ts
+++ b/packages/stack/src/supervisor/handles.integration.test.ts
@@ -55,7 +55,10 @@ import {
   StackRuntimeMismatchError,
 } from "../public/Errors.ts";
 import type { ContainerEngine } from "../runtime/ContainerEngine.ts";
-import { ContainerEngineResolver } from "../runtime/ContainerEngineResolver.ts";
+import {
+  ContainerEngineResolver,
+  defaultContainerEngineResolver,
+} from "../runtime/ContainerEngineResolver.ts";
 
 const databaseRelease = catalogReleaseFor("database:database");
 if (databaseRelease === undefined) throw new Error("Missing default database release");
@@ -89,6 +92,10 @@ const withRuntimeRoot = <A, E, R>(effect: (project: string) => Effect.Effect<A, 
       return yield* effect(project).pipe(
         Effect.onExit(() => cleanupOwners),
         Effect.provideService(StackRuntimeEnvironment, runtime),
+        Effect.provideService(ContainerEngineResolver, {
+          isInstalled: () => Effect.succeed(false),
+          resolve: (kind) => defaultContainerEngineResolver.resolve(kind),
+        }),
       );
     }),
   ).pipe(Effect.provide(NodeServices.layer));
@@ -661,7 +668,13 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
           const { Effect } = await import("effect");
           const { NodeServices } = await import("@effect/platform-node");
           const { createStack } = await import(${encodedStackModule});
-          const stack = await Effect.runPromise(Effect.scoped(createStack({ projectRoot: process.argv[1] }).pipe(Effect.provide(NodeServices.layer))));
+          const stack = await Effect.runPromise(
+            Effect.scoped(
+              createStack({ projectRoot: process.argv[1], runtime: { kind: "native" } }).pipe(
+                Effect.provide(NodeServices.layer),
+              ),
+            ),
+          );
           process.stdout.write(stack.id);
         `;
         const spawnCaller = () =>

--- a/packages/stack/src/supervisor/ingress.integration.test.ts
+++ b/packages/stack/src/supervisor/ingress.integration.test.ts
@@ -68,7 +68,6 @@ const makeIngressContext = (prefix: string) =>
 
 const persistedIngressState = (
   identity: StackIdentity,
-  stackId: string,
   compiled: {
     readonly definition: PersistedStackState["definition"];
     readonly executionPlan: ExecutionPlan;
@@ -76,12 +75,14 @@ const persistedIngressState = (
   privatePortBase: number,
 ): PersistedStackState => ({
   format: "supabase-stack-state-v1",
-  identity: { ...identity, stackId },
+  identity,
   runtime: { kind: "native" },
   desiredLifecycle: "running",
   definition: compiled.definition,
   ports: [],
-  privatePorts: privateBindingIntentsFor(compiled.executionPlan).map((binding, index) => ({
+  privatePorts: privateBindingIntentsFor(compiled.executionPlan, {
+    definition: compiled.definition,
+  }).map((binding, index) => ({
     ...binding,
     port: privatePortBase + index,
   })),
@@ -108,6 +109,62 @@ const request = (port: number, path = "/rest/v1/items", method = "GET", host = "
   });
 
 describe("Supervisor ingress", () => {
+  it.live("does not allocate a public listener for a disabled pooler workload", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const crypto = yield* Crypto.Crypto;
+        const context = Context.make(FileSystem.FileSystem, fs).pipe(
+          Context.add(Path.Path, path),
+          Context.add(Crypto.Crypto, crypto),
+        );
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-ingress-pooler-" });
+        const stackIdentity = { ...identity, projectRoot: root };
+        const stackId = yield* deriveStackId(stackIdentity);
+        const compiled = yield* compileStack({
+          projectRoot: root,
+          runtime: { kind: "native" },
+          config: {
+            capabilities: { pooler: { enabled: false } },
+            listeners: { pooler: { enabled: true, port: 55_329 } },
+          },
+        });
+        const store = yield* makeStackStateStore({ stateRoot: root });
+        yield* store.initialize(stackId, {
+          format: "supabase-stack-state-v1",
+          identity: stackIdentity,
+          runtime: { kind: "native" },
+          desiredLifecycle: "running",
+          definition: compiled.definition,
+          ports: [],
+          privatePorts: privateBindingIntentsFor(compiled.executionPlan, {
+            definition: compiled.definition,
+          }).map((binding, index) => ({ ...binding, port: 30_000 + index })),
+          secrets: {},
+        });
+        const ingress = yield* makeSupervisorIngress({
+          stackId,
+          stateRoot: root,
+          store,
+          context,
+          bindPrivate,
+        });
+        const state = yield* store.read(stackId).pipe(Effect.map((value) => value!));
+        yield* ingress.acquire({
+          stackId,
+          state,
+          definition: compiled.definition,
+          secrets: {},
+          plan: compiled.executionPlan,
+        });
+        const acquired = yield* store.read(stackId).pipe(Effect.map((value) => value!));
+        expect(acquired.ports.some(({ field }) => field === "pooler")).toBe(false);
+        expect(acquired.ports.some(({ field }) => field === "api")).toBe(true);
+      }),
+    ),
+  );
+
   it.live("closes reservation scopes after repeated failed acquire attempts", () =>
     run(
       Effect.gen(function* () {
@@ -130,12 +187,14 @@ describe("Supervisor ingress", () => {
         });
         yield* store.initialize(stackId, {
           format: "supabase-stack-state-v1",
-          identity: { ...stackIdentity, stackId },
+          identity: stackIdentity,
           runtime: { kind: "native" },
           desiredLifecycle: "running",
           definition: compiled.definition,
           ports: [],
-          privatePorts: privateBindingIntentsFor(compiled.executionPlan).map((binding, index) => ({
+          privatePorts: privateBindingIntentsFor(compiled.executionPlan, {
+            definition: compiled.definition,
+          }).map((binding, index) => ({
             ...binding,
             port: 30_000 + index,
           })),
@@ -235,10 +294,7 @@ describe("Supervisor ingress", () => {
           },
         });
         const store = yield* makeStackStateStore({ stateRoot: root });
-        yield* store.initialize(
-          stackId,
-          persistedIngressState(stackIdentity, stackId, compiled, 30000),
-        );
+        yield* store.initialize(stackId, persistedIngressState(stackIdentity, compiled, 30000));
         const listenerCloseCount = yield* Ref.make(0);
         const bindHost = (address: string, port: number, field: HostListener["field"]) =>
           bindHostListener(address, port, field).pipe(
@@ -363,7 +419,7 @@ describe("Supervisor ingress", () => {
           },
         });
         const store = yield* makeStackStateStore({ stateRoot: root });
-        const persisted = persistedIngressState(stackIdentity, stackId, compiled, 30_000);
+        const persisted = persistedIngressState(stackIdentity, compiled, 30_000);
         yield* store.initialize(stackId, persisted);
         const binds: Array<{ readonly address: string; readonly field: HostListener["field"] }> =
           [];
@@ -446,13 +502,14 @@ describe("Supervisor ingress", () => {
           identity: {
             ...identity,
             projectRoot: root,
-            stackId,
           },
           runtime: { kind: "native" },
           desiredLifecycle: "running",
           definition: compiled.definition,
           ports: [],
-          privatePorts: privateBindingIntentsFor(compiled.executionPlan).map((binding, index) => ({
+          privatePorts: privateBindingIntentsFor(compiled.executionPlan, {
+            definition: compiled.definition,
+          }).map((binding, index) => ({
             ...binding,
             port: 30100 + index,
           })),
@@ -536,7 +593,7 @@ describe("Supervisor ingress", () => {
           },
         });
         const store = yield* makeStackStateStore({ stateRoot: root });
-        const persisted = persistedIngressState(stackIdentity, stackId, compiled, 30200);
+        const persisted = persistedIngressState(stackIdentity, compiled, 30200);
         yield* store.initialize(stackId, persisted);
         const ingress = yield* makeSupervisorIngress({
           stackId,
@@ -620,7 +677,7 @@ describe("Supervisor ingress", () => {
           },
         });
         const store = yield* makeStackStateStore({ stateRoot: root });
-        const persisted = persistedIngressState(stackIdentity, stackId, compiled, 30300);
+        const persisted = persistedIngressState(stackIdentity, compiled, 30300);
         yield* store.initialize(stackId, persisted);
         const activated: string[] = [];
         const ingress = yield* makeSupervisorIngress({

--- a/packages/stack/src/supervisor/lifecycle.integration.test.ts
+++ b/packages/stack/src/supervisor/lifecycle.integration.test.ts
@@ -94,7 +94,7 @@ const makeFixture = (runtime: StackRuntime = { kind: "native" }) =>
     const store = yield* makeStackStateStore({ stateRoot: root });
     yield* store.initialize(id, {
       format: "supabase-stack-state-v1",
-      identity: { ...identity, stackId: id },
+      identity,
       runtime,
       desiredLifecycle: "unconfigured",
       ports: [],
@@ -374,7 +374,7 @@ describe("durable lifecycle controller", () => {
         expect(yield* fs.exists(`${fixture.root}/${fixture.id}`)).toBe(false);
         const recreated = yield* fixture.store.initialize(fixture.id, {
           format: "supabase-stack-state-v1",
-          identity: { ...identity, stackId: fixture.id },
+          identity,
           runtime: { kind: "native" },
           desiredLifecycle: "unconfigured",
           ports: [],

--- a/packages/stack/src/supervisor/startup-ingress.integration.test.ts
+++ b/packages/stack/src/supervisor/startup-ingress.integration.test.ts
@@ -93,7 +93,7 @@ const makeStartupFixture = () =>
     const store = yield* makeStackStateStore({ stateRoot: root });
     yield* store.initialize(stackId, {
       format: "supabase-stack-state-v1",
-      identity: { ...identity, stackId },
+      identity,
       runtime: { kind: "native" },
       desiredLifecycle: "unconfigured",
       ports: [],

--- a/packages/stack/src/supervisor/supervisor.integration.test.ts
+++ b/packages/stack/src/supervisor/supervisor.integration.test.ts
@@ -184,7 +184,7 @@ const makeFixture = (
           };
     yield* store.initialize(id, {
       format: "supabase-stack-state-v1",
-      identity: { ...identity, stackId: id },
+      identity,
       runtime: fixtureOptions.runtime ?? { kind: "native" },
       desiredLifecycle: "unconfigured",
       ports: [],


### PR DESCRIPTION
Managed stacks can start without `supabase/config.toml`, using defaults without creating a file. Git discovery ignores stray `.git` directories that are not repositories. New stacks select Docker when its client is installed and native otherwise; a stopped Docker daemon still selects Docker, explicit runtime choices are honored, and existing stacks retain their runtime.

Persisted stack state now derives redundant IDs and control endpoints instead of storing them, drops settings and environment variables unused by local services, and reserves only ports needed by active routes and requested workload bindings. Existing saved state remains readable with secrets preserved. Restart preflight checks use the candidate configuration so removed inspector bindings do not block startup.
