### PR TITLE
chore(repo): add an add-compute-runtime skill

### DIFF
--- a/.claude/skills/add-compute-runtime/SKILL.md
+++ b/.claude/skills/add-compute-runtime/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: add-compute-runtime
+description: Add, rename or remove a `supabase compute` runtime — a `--runtime` choice with its own starter files under `shared/compute/stacks/`. Use when a new kind of compute needs its own scaffold, or when a build fails because COMPUTE_RUNTIMES and stacks/ disagree.
+---
+
+# Add a compute runtime
+
+A runtime is two declarations that must agree: an entry in `COMPUTE_RUNTIMES`
+(`apps/cli/src/shared/compute/compute-runtimes.ts`) and a directory of starter
+files under `apps/cli/src/shared/compute/stacks/`. `compute-stacks.macro.ts`
+reads the directory at build time and fails the build when the two disagree, so
+a half-added runtime never ships.
+
+## Pick the class first
+
+- **Catalog** — the platform builds it on a base image it already knows
+  (`node`, `deno`). `push` sends the name as `spec.runtime`.
+- **Context-built** — the starter carries its own `Dockerfile` (`dockerfile`,
+  `actions-runner`). `push` sends no `spec.runtime`; the API never learns the
+  name, and the uploaded context is built as the image it describes.
+
+The class decides whether this is a CLI change at all: a catalog runtime needs
+the Compute API to support the name first, so a runtime you can add CLI-side
+alone is context-built.
+
+## Steps
+
+1. **Declare it.** Add the name to `COMPUTE_RUNTIMES` and a one-line entry to
+   `COMPUTE_RUNTIME_DESCRIPTIONS` — that string is what `--runtime`'s prompt and
+   help show. For a context-built runtime, add it to `CONTEXT_BUILT_RUNTIMES`
+   too; `apiRuntimeFor` and `deployedRuntimeLabel` both read that set, so `push`
+   omits the runtime and `status`/`list` still name it from the config entry.
+
+2. **Write the stack.** One directory under `stacks/<runtime>/`. The macro reads
+   only the files directly inside it — a subdirectory is skipped, so the starter
+   is flat or it is incomplete. Scaffolded files land at mode 0644, so anything
+   the image executes gets its `chmod` in the `Dockerfile`. Files are written
+   verbatim: a `README.md` in the stack is scaffolded into the user's compute
+   directory, which is how a runtime that needs credentials explains itself.
+
+3. **Give it runtime-specific defaults** when the global ones are wrong for it.
+   `defaultExposureFor` is the precedent: a compute that only makes outbound
+   calls records `private` instead of the global `public`. Keep the default that
+   `push` falls back to global — `new` writes the value down, so the per-runtime
+   default only has to be right at scaffold time.
+
+4. **Follow the name through the prose.** The runtime catalog is restated in
+   `packages/config/src/compute.ts` (the published `runtime` description),
+   `stacks/README.md` (the table), and the `SIDE_EFFECTS.md` of any command
+   whose behavior now varies by runtime.
+
+5. **Cover it.** `compute-runtimes.unit.test.ts` for the catalog helpers,
+   `push.integration.test.ts` for the deploy spec the runtime produces — its
+   unknown-runtime test asserts the full offered list, so it fails until you
+   update it — and `new.integration.test.ts` for what the scaffold writes.
+   Fixtures in `compute-stacks.integration.test.ts` derive from
+   `COMPUTE_RUNTIMES`; keep them derived rather than listing runtimes by hand.
+
+6. **Scaffold it for real** before calling it done:
+
+   ```sh
+   SUPABASE_EXPERIMENTAL_COMPUTE=1 pnpm exec bun src/main.ts \
+     compute new demo --runtime <runtime> --workdir "$(mktemp -d)"
+   ```
+
+   Then build what it wrote. A stack that scaffolds but does not build is the
+   failure this step exists to catch.
+
+Done when the scaffold builds, `pnpm check:all` passes from the repo root, and
+the compute unit and integration suites pass.
+
+## Gotchas
+
+- Run the suites through the workspace scripts (`bun --bun vitest`). Plain
+  `pnpm exec vitest` runs them on Node, where every compute test fails to import
+  `@effect/platform-bun`.
+- `knip` strips the `export` from a helper nothing outside the module uses, and
+  `pnpm fix:all` applies that edit — expect it on a predicate you added for
+  readability, and let it happen.

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ coverage/
 .env
 .env.*
 !.env.example
-.claude/
+.claude/*
+# The compute-runtime skill is shared; everything else under .claude/ is local.
+!.claude/skills/
 .agents/.repos/effect-v3
 .repos/slim-services/
 .worktrees/

--- a/apps/cli/src/shared/compute/stacks/actions-runner/README.md
+++ b/apps/cli/src/shared/compute/stacks/actions-runner/README.md
@@ -59,5 +59,9 @@ no online runner queues silently for 24 hours before it fails, so keep
 - No Docker daemon: jobs using `container:`, `services:`, or Docker-based
   actions will fail.
 - Nothing persists between jobs — the workspace is wiped after each one.
-- Self-hosted runners run whatever a workflow tells them to. Do not attach a
-  pool to a public repo where forked pull requests can run against it.
+- Self-hosted runners run whatever a workflow tells them to, and a job runs as
+  the same user as the supervisor, with sudo. Treat the credentials above as
+  readable by every workflow the pool accepts: scope the token to the minimum
+  (Administration: Read and write on just the repos it serves), give each pool
+  its own, and rotate it like any shared secret. Do not attach a pool to a
+  public repo where forked pull requests can run against it.

--- a/apps/cli/src/shared/compute/stacks/actions-runner/entrypoint.sh
+++ b/apps/cli/src/shared/compute/stacks/actions-runner/entrypoint.sh
@@ -61,7 +61,7 @@ b64url() {
 # GitHub App private keys arrive through `supabase secrets` as a single line
 # more often than not, so accept PEM, \n-escaped PEM, or base64-wrapped PEM.
 app_private_key() {
-  local raw="${GITHUB_APP_PRIVATE_KEY:-}"
+  local raw="$github_app_key"
   if [[ "$raw" == *"BEGIN"*"PRIVATE KEY"* ]]; then
     printf '%b\n' "$raw"
   else
@@ -73,7 +73,7 @@ app_jwt() {
   local now header payload signing_input signature
   now="$(date +%s)"
   header="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
-  payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$GITHUB_APP_ID" | b64url)"
+  payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$github_app_id" | b64url)"
   signing_input="${header}.${payload}"
   signature="$(printf '%s' "$signing_input" \
     | openssl dgst -sha256 -sign <(app_private_key) -binary \
@@ -119,14 +119,14 @@ installation_id() {
 # A PAT is used as-is; an App mints a fresh installation token per pass, which
 # keeps every token we hold short-lived.
 github_token() {
-  if [ -n "${GITHUB_PAT:-}" ]; then
-    printf '%s' "$GITHUB_PAT"
+  if [ -n "$github_pat" ]; then
+    printf '%s' "$github_pat"
     return
   fi
 
   local jwt install_id
   jwt="$(app_jwt)"
-  install_id="${GITHUB_APP_INSTALLATION_ID:-}"
+  install_id="$github_app_installation"
   if [ -z "$install_id" ]; then
     install_id="$(installation_id "$jwt")"
   fi
@@ -237,13 +237,22 @@ on_terminate() {
 
 # --- startup checks -----------------------------------------------------
 
+# A job step is a grandchild of this script and inherits its environment, so
+# the credentials are taken out of it here: a shell variable is not exported,
+# which puts the token beyond reach of anything the runner executes.
+github_pat="${GITHUB_PAT:-}"
+github_app_id="${GITHUB_APP_ID:-}"
+github_app_key="${GITHUB_APP_PRIVATE_KEY:-}"
+github_app_installation="${GITHUB_APP_INSTALLATION_ID:-}"
+unset GITHUB_PAT GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY GITHUB_APP_INSTALLATION_ID
+
 [ -n "$GITHUB_OWNER" ] || fail "GITHUB_OWNER is not set. Set it to the org (or user) that owns the runners."
 
-if [ -z "${GITHUB_PAT:-}" ] && [ -z "${GITHUB_APP_ID:-}" ]; then
+if [ -z "$github_pat" ] && [ -z "$github_app_id" ]; then
   fail "No GitHub credentials. Set GITHUB_PAT, or GITHUB_APP_ID plus GITHUB_APP_PRIVATE_KEY."
 fi
 
-if [ -z "${GITHUB_PAT:-}" ] && [ -z "${GITHUB_APP_PRIVATE_KEY:-}" ]; then
+if [ -z "$github_pat" ] && [ -z "$github_app_key" ]; then
   fail "GITHUB_APP_ID is set without GITHUB_APP_PRIVATE_KEY."
 fi
 


### PR DESCRIPTION
Adds `.claude/skills/add-compute-runtime/SKILL.md`, written from actually adding one (`actions-runner`, the base branch of this PR).

A runtime is not one edit. It is two declarations the stack macro cross-checks at build time, a deploy spec whose shape depends on whether the platform builds the runtime on a catalog base image or from the context's own Dockerfile, per-runtime defaults where the global ones are wrong, and the same catalog restated in four pieces of prose. The skill carries that route, plus the things that cost the most time and that no config file confesses: the stack macro reads only the files directly inside `stacks/<runtime>/`, scaffolded files land without the executable bit, and the compute suites only run under Bun.

`.gitignore` gains `!.claude/skills/` so the skill is shared with the repo. Local `.claude/` settings stay ignored — worth a look, since it is the first thing under `.claude/` this repo tracks.

Based on `FUNC-880/compute/self-hosted-runner-runtime` because the skill documents the machinery that branch introduces; retarget to `main` once it merges.