### PR TITLE
fix(cli-go): require word boundary for END in BEGIN ATOMIC bodies

### DIFF
--- a/apps/cli-go/pkg/parser/state.go
+++ b/apps/cli-go/pkg/parser/state.go
@@ -192,18 +192,41 @@ func (s *EscapeState) Next(r rune, data []byte) State {
 type AtomicState struct {
 	prev      State
 	delimiter []byte
+	// pendingEnd tracks a candidate END closer awaiting a trailing
+	// boundary check on the next rune.
+	pendingEnd bool
 }
 
 func (s *AtomicState) Next(r rune, data []byte) State {
+	// A candidate END closes only at a standalone keyword.
+	if s.pendingEnd {
+		if isIdentifierRune(r) {
+			s.pendingEnd = false
+		} else {
+			state := &ReadyState{}
+			return state.Next(r, data)
+		}
+	}
 	// If we are in a quoted state, the current delimiter doesn't count.
 	if curr := s.prev.Next(r, data); curr != nil {
 		s.prev = curr
 	}
 	if _, ok := s.prev.(*ReadyState); ok {
+		if len(data) < len(s.delimiter) {
+			return s
+		}
 		window := data[len(data)-len(s.delimiter):]
 		// Treat delimiter as case insensitive
 		if strings.EqualFold(string(window), string(s.delimiter)) {
-			return &ReadyState{}
+			if !strings.EqualFold(string(s.delimiter), END_ATOMIC) {
+				return &ReadyState{}
+			}
+			if offset := len(data) - len(s.delimiter); offset > 0 {
+				if prev, _ := utf8.DecodeLastRune(data[:offset]); isIdentifierRune(prev) {
+					return s
+				}
+			}
+			s.pendingEnd = true
 		}
 	}
 	return s

--- a/apps/cli-go/pkg/parser/state_test.go
+++ b/apps/cli-go/pkg/parser/state_test.go
@@ -207,4 +207,29 @@ GRANT EXECUTE ON FUNCTION public.atomic_example() TO authenticated;`,
 		}
 		checkSplit(t, sql)
 	})
+
+	t.Run("ignores end in identifiers", func(t *testing.T) {
+		names := []string{
+			"pending",
+			"append",
+			"legend",
+			"ends",
+			"ending",
+			"end_",
+			"PENDING",
+		}
+		for _, name := range names {
+			t.Run(name, func(t *testing.T) {
+				sql := []string{
+					`CREATE OR REPLACE FUNCTION public.probe_splitter() RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+BEGIN ATOMIC
+  SELECT 1 AS ` + name + `;
+END;`,
+				}
+				checkSplit(t, sql)
+			})
+		}
+	})
 }


### PR DESCRIPTION
What changed: AtomicState now treats END as a closer only as a standalone keyword. It checks the preceding rune and defers the trailing check by one rune with pendingEnd. Other delimiters are unchanged. Why: identifiers like pending, append, ends, or end_ contain END as a substring and must not split the statement. Tests: adds ignores end in identifiers cases in state_test.go. Closes #6562