### PR TITLE
fix(stack): preserve native workload exit diagnostics

### DIFF
--- a/packages/stack/src/runtime/NativeRuntime.ts
+++ b/packages/stack/src/runtime/NativeRuntime.ts
@@ -187,7 +187,9 @@ export const makeNativeRuntime = (
               state: resource.stopRequested ? "stopped" : "failed",
               ...(resource.stopRequested
                 ? {}
-                : { error: "Native workload exited before an explicit stop" }),
+                : {
+                    error: `Native workload exited before an explicit stop (code ${String(result.value)})`,
+                  }),
             }
           : {
               ...resource.key,

--- a/packages/stack/src/runtime/native-launcher.ts
+++ b/packages/stack/src/runtime/native-launcher.ts
@@ -228,7 +228,8 @@ export const runNativeLauncher = (): void => {
         return;
       }
       ownerPipe.destroy();
-      if (signal !== null) writeSync(2, `Native workload exited due to signal ${signal}\n`);
+      if (!gracefulForwarded && signal !== null)
+        writeSync(2, `Native workload exited due to signal ${signal}\n`);
       process.exit(code ?? 1);
     });
   }

--- a/packages/stack/src/runtime/native-launcher.ts
+++ b/packages/stack/src/runtime/native-launcher.ts
@@ -5,7 +5,7 @@
 // oxlint-disable-next-line effecttsgo/node-builtin-import
 import { Socket } from "node:net";
 // oxlint-disable-next-line effecttsgo/node-builtin-import
-import { createReadStream, readFileSync } from "node:fs";
+import { createReadStream, readFileSync, writeSync } from "node:fs";
 // oxlint-disable-next-line effecttsgo/node-builtin-import
 import { spawn } from "node:child_process";
 
@@ -220,7 +220,7 @@ export const runNativeLauncher = (): void => {
       stdio: ["ignore", "inherit", "inherit"],
     });
     child.on("error", () => process.exit(127));
-    child.on("exit", (code) => {
+    child.on("exit", (code, signal) => {
       childExited = true;
       if (gracefulTimeout !== undefined) clearTimeout(gracefulTimeout);
       if (ownerLossGraceful) {
@@ -228,6 +228,7 @@ export const runNativeLauncher = (): void => {
         return;
       }
       ownerPipe.destroy();
+      if (signal !== null) writeSync(2, `Native workload exited due to signal ${signal}\n`);
       process.exit(code ?? 1);
     });
   }

--- a/packages/stack/src/runtime/native-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/native-runtime.integration.test.ts
@@ -189,7 +189,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
                 executable: process.execPath,
                 args: [
                   "-e",
-                  `const fs=require("node:fs"); fs.watch(${JSON.stringify(root)}, (_event,name) => { if (name === "trigger") process.exit(1) }); process.stdout.write("watch-ready\\n")`,
+                  `const fs=require("node:fs"); fs.watch(${JSON.stringify(root)}, () => { if (fs.existsSync(${JSON.stringify(triggerPath)})) process.exit(1) }); process.stdout.write("watch-ready\\n")`,
                 ],
               },
             }),
@@ -234,6 +234,37 @@ describe("native runtime", { timeout: 15_000 }, () => {
         const stderr = yield* native.stderr.pipe(Stream.decodeText, Stream.runCollect);
         expect(yield* native.exitCode).toBe(1);
         expect(Array.from(stderr).join("")).toContain(
+          "Native workload exited due to signal SIGTERM",
+        );
+      }),
+    ),
+  );
+
+  it.live("does not report a diagnostic for an explicit native stop", () =>
+    withPlatform(
+      Effect.gen(function* () {
+        const ready = yield* Deferred.make<void>();
+        const native = yield* spawnNativeProcess({
+          executable: process.execPath,
+          args: ["-e", 'process.stdout.write("ready\\n"); setInterval(() => {}, 1000)'],
+        });
+        const stdout = yield* native.stdout.pipe(
+          Stream.decodeText,
+          Stream.splitLines,
+          Stream.runForEach((line) =>
+            line === "ready" ? Deferred.succeed(ready, undefined) : Effect.void,
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        const stderr = yield* Effect.forkChild(
+          native.stderr.pipe(Stream.decodeText, Stream.runCollect),
+          { startImmediately: true },
+        );
+        yield* Deferred.await(ready).pipe(Effect.timeout("3 seconds"));
+        yield* native.kill;
+        const stderrOutput = yield* Fiber.join(stderr);
+        yield* Fiber.join(stdout);
+        expect(Array.from(stderrOutput).join("")).not.toContain(
           "Native workload exited due to signal SIGTERM",
         );
       }),

--- a/packages/stack/src/runtime/native-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/native-runtime.integration.test.ts
@@ -1,9 +1,21 @@
 // oxlint-disable effecttsgo/prefer-schema-over-json -- raw child-process fixture payloads are protocol JSON, not product serialization.
 import { NodeServices, NodeSocket } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Data, Deferred, Effect, Exit, Fiber, FileSystem, Path, Ref, Stream } from "effect";
+import {
+  Cause,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Path,
+  Ref,
+  Schedule,
+  Stream,
+} from "effect";
 import { ChildProcess } from "effect/unstable/process";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- raw process-tree cleanup fixture.
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { LogStoreError, makeLogStore, type LogStore } from "../supervisor/LogStore.ts";
@@ -161,27 +173,69 @@ describe("native runtime", { timeout: 15_000 }, () => {
   it.live("publishes an unexpected native workload exit after readiness", () =>
     withPlatform(
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-native-exit-" });
+        const triggerPath = path.join(root, "trigger");
+        const readySignal = yield* Deferred.make<void>();
+        const logStore = yield* makeLogStore({ path: path.join(root, "logs.json") });
+        const signaledLogStore = signalOnLog(logStore, "watch-ready", readySignal);
         let startedProcess: NativeProcess | undefined;
         const runtime = yield* makeNativeRuntime({
-          resolveProcess: () => Effect.succeed(processPlan(fixtureProcess("native-watch"))),
+          resolveProcess: () =>
+            Effect.succeed({
+              startup: [],
+              main: {
+                executable: process.execPath,
+                args: [
+                  "-e",
+                  `const fs=require("node:fs"); fs.watch(${JSON.stringify(root)}, (_event,name) => { if (name === "trigger") process.exit(1) }); process.stdout.write("watch-ready\\n")`,
+                ],
+              },
+            }),
+          logStore: signaledLogStore,
           waitForReadiness: (_key, _workload, process) =>
             Effect.sync(() => {
               startedProcess = process;
-            }),
+            }).pipe(Effect.andThen(Deferred.await(readySignal))),
         });
         const ready = yield* runtime.start(keyFor("watch"), workload("watch"));
         expect(ready.state).toBe("ready");
         expect(startedProcess).toBeDefined();
-        if (startedProcess !== undefined) {
-          yield* startedProcess.kill;
-          yield* startedProcess.exitCode.pipe(Effect.exit);
-          yield* Effect.yieldNow;
-        }
-        const observed = yield* runtime.observe(stackId);
+        yield* fs.writeFileString(triggerPath, "exit");
+        if (startedProcess !== undefined) yield* startedProcess.exitCode;
+        const observed = yield* runtime.observe(stackId).pipe(
+          Effect.tap(() => Effect.yieldNow),
+          Effect.repeat({
+            until: (values) => values[0]?.state === "failed",
+            schedule: Schedule.forever,
+          }),
+          Effect.timeout("5 seconds"),
+        );
         expect(observed).toEqual([
-          expect.objectContaining({ workloadId: keyFor("watch").workloadId, state: "failed" }),
+          expect.objectContaining({
+            workloadId: keyFor("watch").workloadId,
+            state: "failed",
+            error: "Native workload exited before an explicit stop (code 1)",
+          }),
         ]);
         yield* runtime.remove(keyFor("watch"));
+      }),
+    ),
+  );
+
+  it.live("reports the signal that terminated a native workload", () =>
+    withPlatform(
+      Effect.gen(function* () {
+        const native = yield* spawnNativeProcess({
+          executable: process.execPath,
+          args: ["-e", 'process.kill(process.pid, "SIGTERM")'],
+        });
+        const stderr = yield* native.stderr.pipe(Stream.decodeText, Stream.runCollect);
+        expect(yield* native.exitCode).toBe(1);
+        expect(Array.from(stderr).join("")).toContain(
+          "Native workload exited due to signal SIGTERM",
+        );
       }),
     ),
   );


### PR DESCRIPTION
Native workload failures currently discard the exit code, and the process launcher discards the terminating signal. A Functions process exit therefore appears only as a generic failure followed by a gateway 502.

Preserve the exit code in stack status and write the terminating signal to stderr before the launcher exits. The exit-observation regression uses an explicit readiness handshake and waits for the resulting failed state.

The intermittent native Functions exit reported in [this CI job](https://github.com/supabase/cli/actions/runs/34579231089/job/103198675198?pr=6558) remains under investigation. These diagnostics expose the missing evidence without retrying or masking the failed request.
