### PR TITLE
chore(stack): replace lint suppressions with Effect constructs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,11 @@ notes in `.repos/effect/MIGRATION.md`. Run `pnpm repos:install` if it is absent.
   Effect constructs; do not silence findings with `oxlint-disable`, casts, file
   exclusions, or weaker lint configuration.
 - A suppression is acceptable only for a demonstrated false positive or an unavoidable
-  foreign-library boundary. Limit it to the specific rule and smallest scope, and
-  explain why a compliant implementation is not possible.
+  foreign-library boundary. Before retaining one, inspect the corresponding Effect API
+  and identify the specific missing capability or behavior that prevents replacement;
+  existing Promise-based code, native API usage, or refactoring effort alone do not
+  justify an exception. Limit it to the specific rule and smallest scope, and explain
+  why a compliant implementation is not possible.
 - Passing lint by bypassing its rules does not complete an Effect migration.
 
 ## Commands, validation, and workflows

--- a/apps/cli/src/command-internal/db-bootstrap/shadow-cache.e2e.test.ts
+++ b/apps/cli/src/command-internal/db-bootstrap/shadow-cache.e2e.test.ts
@@ -15,7 +15,7 @@
  * `shadow-cache.unit.test.ts`. Nothing branch-shaped belongs here.
  */
 
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -30,21 +30,22 @@ const DIFF_TIMEOUT_MS = 180_000;
 // filesystem inspection, and fast-failing port-conflict retries.
 const LIFECYCLE_OVERHEAD_MS = 90_000;
 
+const STACK_PORT_ATTEMPT_COUNT = 4;
+const STACK_PORT_BLOCK_SIZE = 32;
+const STACK_PORT_BASE =
+  49152 + ((process.pid * 53) % (16384 - STACK_PORT_ATTEMPT_COUNT * STACK_PORT_BLOCK_SIZE));
+const STACK_PORT_ASSIGNMENT =
+  /^(\s*(?:port|smtp_port|pop3_port|inspector_port|shadow_port) = )\d+$/u;
+
 /**
  * `db diff`'s shadow port. Docker has to bind it, so a test cannot truly reserve it up front —
  * retry on the next candidate (derived from this process's pid, so concurrent runs don't race for
  * one shared port) when the CLI reports a real bind conflict.
  *
- * Fed through `SUPABASE_DB_SHADOW_PORT` rather than rewriting the generated `config.toml`, so the
- * `init` template stays exactly as a user's would be. Not part of the cache key, so retrying on a
- * different port cannot change which tar the run looks for.
+ * The shadow port is not part of the cache key, so retrying on a different port cannot change
+ * which tar the run looks for. Candidates are assigned after the active stack ports below.
  */
 const SHADOW_PORT_CANDIDATE_COUNT = 8;
-const SHADOW_PORT_BASE = 49152 + ((process.pid * 37) % (16384 - SHADOW_PORT_CANDIDATE_COUNT));
-const SHADOW_PORT_CANDIDATES: ReadonlyArray<number> = Array.from(
-  { length: SHADOW_PORT_CANDIDATE_COUNT },
-  (_, index) => SHADOW_PORT_BASE + index,
-);
 
 const DIFF_ARGS = ["db", "diff", "--local", "--use-pg-delta"] as const;
 
@@ -54,6 +55,32 @@ const BASELINE_TAR_PATTERN = /^shadow-baseline-[0-9a-f]{16}\.tar$/u;
 /** Docker's own bind-conflict wording on stderr; only used to decide whether to retry. */
 function isShadowPortConflict(stderr: string): boolean {
   return /port is already allocated|address already in use|Bind for \S+ failed/iu.test(stderr);
+}
+
+function isStackPortConflict(stderr: string): boolean {
+  return /failed to bind host port [^\n]*: address already in use|Bind for \S+ failed: port is already allocated/iu.test(
+    stderr,
+  );
+}
+
+async function assignStackPorts(
+  projectDir: string,
+  attempt: number,
+): Promise<ReadonlyArray<number>> {
+  const configPath = path.join(projectDir, "supabase", "config.toml");
+  const config = await readFile(configPath, "utf8");
+  let index = 0;
+  const base = STACK_PORT_BASE + attempt * STACK_PORT_BLOCK_SIZE;
+  const lines = config.split("\n").map((line) => {
+    const match = STACK_PORT_ASSIGNMENT.exec(line);
+    if (match === null) return line;
+    return `${match[1]}${base + index++}`;
+  });
+  await writeFile(configPath, lines.join("\n"));
+  return Array.from(
+    { length: SHADOW_PORT_CANDIDATE_COUNT },
+    (_, shadowIndex) => base + index + shadowIndex,
+  );
 }
 
 async function baselineTars(cacheDir: string): Promise<ReadonlyArray<string>> {
@@ -84,7 +111,13 @@ describe("shadow baseline cache (e2e, local Docker stack)", () => {
 
   test(
     "publishes a baseline snapshot on the first db diff, then restores it on the second with identical output",
-    { timeout: START_TIMEOUT_MS + 2 * DIFF_TIMEOUT_MS + LIFECYCLE_OVERHEAD_MS },
+    {
+      timeout:
+        STACK_PORT_ATTEMPT_COUNT * START_TIMEOUT_MS +
+        (STACK_PORT_ATTEMPT_COUNT - 1) * CLEANUP_TIMEOUT_MS +
+        2 * DIFF_TIMEOUT_MS +
+        LIFECYCLE_OVERHEAD_MS,
+    },
     async () => {
       projectDir = await mkdtemp(path.join(tmpdir(), "sb-shadow-cache-e2e-"));
       // One temp `SUPABASE_HOME` per test run so both `db diff` processes share the same cache
@@ -100,11 +133,38 @@ describe("shadow baseline cache (e2e, local Docker stack)", () => {
 
       // Exclude the heaviest, least relevant services — `db diff` only needs the local Postgres
       // container reachable, same rationale as stop/status/diff.
-      const start = await runSupabase(
-        ["start", "--exclude", "studio", "--exclude", "logflare", "--exclude", "vector"],
-        { cwd: projectDir, home: home.dir, exitTimeoutMs: START_TIMEOUT_MS },
-      );
+      let start: Awaited<ReturnType<typeof runSupabase>> | undefined;
+      let shadowPortCandidates: ReadonlyArray<number> = [];
+      for (let attempt = 0; attempt < STACK_PORT_ATTEMPT_COUNT; attempt++) {
+        const candidates = await assignStackPorts(projectDir, attempt);
+        const result = await runSupabase(
+          ["start", "--exclude", "studio", "--exclude", "logflare", "--exclude", "vector"],
+          { cwd: projectDir, home: home.dir, exitTimeoutMs: START_TIMEOUT_MS },
+        );
+        start = result;
+        if (result.exitCode === 0) shadowPortCandidates = candidates;
+        if (result.exitCode === 0 || !isStackPortConflict(result.stderr)) break;
+
+        if (attempt === STACK_PORT_ATTEMPT_COUNT - 1) break;
+        const cleanup = await runSupabase(["stop", "--no-backup"], {
+          cwd: projectDir,
+          home: home.dir,
+          exitTimeoutMs: CLEANUP_TIMEOUT_MS,
+        });
+        if (cleanup.exitCode !== 0) {
+          throw new Error(
+            [
+              `Failed to clean up stack after port conflict (exit code ${cleanup.exitCode}).`,
+              `stdout:\n${cleanup.stdout}`,
+              `stderr:\n${cleanup.stderr}`,
+            ].join("\n"),
+          );
+        }
+      }
+      expect(start).toBeDefined();
+      if (start === undefined) return;
       expect(start.exitCode, `stdout:\n${start.stdout}\nstderr:\n${start.stderr}`).toBe(0);
+      expect(shadowPortCandidates).toHaveLength(SHADOW_PORT_CANDIDATE_COUNT);
 
       // Same drift setup as `db/diff/diff.declarative.e2e.test.ts`: create a fresh function
       // directly in the local database so `db diff --local` has real, deterministic SQL to
@@ -133,8 +193,8 @@ as $$ select 1; $$;`,
       let coldTars: ReadonlyArray<string> = [];
       let coldMtimeMs = 0;
 
-      for (const [index, shadowPort] of SHADOW_PORT_CANDIDATES.entries()) {
-        const canRetry = index < SHADOW_PORT_CANDIDATES.length - 1;
+      for (const [index, shadowPort] of shadowPortCandidates.entries()) {
+        const canRetry = index < shadowPortCandidates.length - 1;
         // Each attempt must start from an empty cache, or the previous attempt's tar would make
         // this attempt's first run a warm one.
         await rm(cacheDir, { recursive: true, force: true });

--- a/apps/cli/src/commands/experimental/stack/start/start.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/start/start.integration.test.ts
@@ -93,12 +93,12 @@ function fakeStack(
 ) {
   return {
     id: StackIdSchema.make(id),
-    status: () => Effect.succeed(status(id)),
-    credentials: () => Effect.die("credentials not used in start test"),
+    status: Effect.succeed(status(id)),
+    credentials: Effect.die("credentials not used in start test"),
     prepare: () => Effect.die("prepare not used in start test"),
     start,
-    stop: () => Effect.void,
-    destroy: () => Effect.die("destroy not used in start test"),
+    stop: Effect.void,
+    destroy: Effect.die("destroy not used in start test"),
     logs: () => Effect.die("logs not used in start test"),
     followLogs: () => Stream.empty,
   } satisfies EffectStack;
@@ -375,14 +375,12 @@ describe("stack start targeting", () => {
       ...fakeStack("c".repeat(64), () =>
         Effect.fail(new ContainerEngineError({ message: "Docker is unavailable" })),
       ),
-      stop: () => {
+      stop: Effect.sync(() => {
         stopped = true;
-        return Effect.void;
-      },
-      destroy: () =>
-        Effect.sync(() => {
-          destroyed = true;
-        }),
+      }),
+      destroy: Effect.sync(() => {
+        destroyed = true;
+      }),
     } satisfies EffectStack;
     const setup = handlerLayer({ root, target: { projectRoot: root }, stack });
     return Effect.gen(function* () {
@@ -410,14 +408,12 @@ describe("stack start targeting", () => {
     let destroyed = false;
     const stack = {
       ...fakeStack("f".repeat(64), () => Effect.succeed(status("f".repeat(64)))),
-      stop: () => {
+      stop: Effect.sync(() => {
         stopped = true;
-        return Effect.void;
-      },
-      destroy: () =>
-        Effect.sync(() => {
-          destroyed = true;
-        }),
+      }),
+      destroy: Effect.sync(() => {
+        destroyed = true;
+      }),
     } satisfies EffectStack;
     const setup = handlerLayer({ root, target: { projectRoot: root }, stack });
     return Effect.gen(function* () {
@@ -529,14 +525,12 @@ describe("stack start targeting", () => {
             return yield* Effect.never.pipe(Effect.as(status("7".repeat(64))));
           }),
         ),
-        stop: () => {
+        stop: Effect.sync(() => {
           stopped = true;
-          return Effect.void;
-        },
-        destroy: () =>
-          Effect.sync(() => {
-            destroyed = true;
-          }),
+        }),
+        destroy: Effect.sync(() => {
+          destroyed = true;
+        }),
       } satisfies EffectStack;
       const setup = handlerLayer({ root, target: { projectRoot: root }, stack });
       const fiber = yield* Effect.forkChild(Effect.provide(stackStart(flags()), setup.layer));

--- a/apps/cli/src/commands/experimental/stack/stop/stop.handler.ts
+++ b/apps/cli/src/commands/experimental/stack/stop/stop.handler.ts
@@ -106,7 +106,7 @@ export const stackStop = Effect.fn("experimental.stack.stop")(function* (flags: 
     const target = targetOption.value;
     const stack = yield* stackApi.openStack(target.id).pipe(Effect.mapError(stopError));
     const stopping = yield* output.task(`Stopping stack ${target.id}...`);
-    yield* stack.stop().pipe(
+    yield* stack.stop.pipe(
       Effect.tapError((error) => stopping.fail(error.message)),
       Effect.tap(() => stopping.clear()),
       Effect.mapError(stopError),

--- a/apps/cli/src/commands/experimental/stack/stop/stop.integration.test.ts
+++ b/apps/cli/src/commands/experimental/stack/stop/stop.integration.test.ts
@@ -70,20 +70,22 @@ function setup(opts: {
   const id = opts.found?.id ?? "a".repeat(64);
   const stack = {
     id: StackIdSchema.make(id),
-    status: () => Effect.succeed(status(id)),
-    credentials: () => Effect.die("unused"),
+    status: Effect.succeed(status(id)),
+    credentials: Effect.die("unused"),
     prepare: () => Effect.die("unused"),
     start: () => Effect.die("unused"),
-    stop:
-      opts.stop ??
-      (() =>
-        Effect.sync(() => {
-          state.stopCalls += 1;
-        })),
-    destroy: () =>
-      Effect.sync(() => {
-        state.destroyCalled = true;
-      }),
+    stop: Effect.suspend(() =>
+      (
+        opts.stop ??
+        (() =>
+          Effect.sync(() => {
+            state.stopCalls += 1;
+          }))
+      )(),
+    ),
+    destroy: Effect.sync(() => {
+      state.destroyCalled = true;
+    }),
     logs: () => Effect.die("unused"),
     followLogs: () => Stream.empty,
   } satisfies EffectStack;

--- a/packages/stack/src/control/ControlServer.ts
+++ b/packages/stack/src/control/ControlServer.ts
@@ -13,7 +13,7 @@ import {
   Semaphore,
 } from "effect";
 import { NodeSocket, NodeSocketServer } from "@effect/platform-node";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- FileSystem.stat follows symlinks; control-path validation must reject them.
 import { lstat } from "node:fs/promises";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import { RpcClientError } from "effect/unstable/rpc/RpcClientError";
@@ -536,10 +536,8 @@ export const startControlServer = (
       concurrency: MAINTENANCE_MAX_CONCURRENT_REQUESTS,
     }).pipe(
       Effect.provideService(RpcServer.Protocol, patchedProtocol),
-      // oxlint-disable-next-line effecttsgo/any-unknown-in-error-context
       Effect.provide(StackRpcGroup.toLayer(options.rpcHandlers)),
     );
-    // oxlint-disable-next-line effecttsgo/any-unknown-in-error-context
     yield* Effect.forkScoped(rpcProgram);
     return {
       endpoint: options.endpoint,
@@ -624,17 +622,8 @@ export interface ControlClientOptions extends ControlIdentity {
 }
 
 export interface ControlClient {
-  // oxlint-disable-next-line effecttsgo/lazy-effect -- each call opens a fresh scoped socket.
-  readonly probe: () => Effect.Effect<
-    MaintenanceResponse,
-    Socket.SocketError | MaintenanceProtocolError
-  >;
-  // oxlint-disable-next-line effecttsgo/lazy-effect -- each call opens a fresh scoped socket.
-  readonly stop: () => Effect.Effect<
-    MaintenanceResponse,
-    Socket.SocketError | MaintenanceProtocolError
-  >;
-  // oxlint-disable-next-line effecttsgo/lazy-effect -- each call opens a fresh scoped socket.
+  readonly probe: Effect.Effect<MaintenanceResponse, Socket.SocketError | MaintenanceProtocolError>;
+  readonly stop: Effect.Effect<MaintenanceResponse, Socket.SocketError | MaintenanceProtocolError>;
   /** Connects with an RPC preface and completes when the owner closes the socket. */
   readonly awaitClose: (onOpen?: Effect.Effect<void>) => Effect.Effect<void, Socket.SocketError>;
   readonly rpc: Effect.Effect<StackRpcClient, RpcClientError, Scope.Scope>;
@@ -736,22 +725,23 @@ export const makeControlClient = (
         return yield* wait;
       }),
     );
+  const probe = maintenance("probe").pipe(
+    Effect.timeoutOrElse({
+      duration: MAINTENANCE_REQUEST_DEADLINE_MS,
+      orElse: () =>
+        Effect.fail(
+          new MaintenanceProtocolError({
+            message: "Control request timed out",
+            reason: "transport",
+          }),
+        ),
+    }),
+  );
+  const stop = maintenance("stop");
 
   return {
-    probe: () =>
-      maintenance("probe").pipe(
-        Effect.timeoutOrElse({
-          duration: MAINTENANCE_REQUEST_DEADLINE_MS,
-          orElse: () =>
-            Effect.fail(
-              new MaintenanceProtocolError({
-                message: "Control request timed out",
-                reason: "transport",
-              }),
-            ),
-        }),
-      ),
-    stop: () => maintenance("stop"),
+    probe,
+    stop,
     awaitClose: (onOpen = Effect.void) =>
       Effect.scoped(
         Effect.gen(function* () {

--- a/packages/stack/src/control/control-transport.integration.test.ts
+++ b/packages/stack/src/control/control-transport.integration.test.ts
@@ -340,7 +340,7 @@ describe("control transport", () => {
     withServer(({ endpoint, stackId, ownerSessionId, rebind }) =>
       Effect.gen(function* () {
         expect(yield* rebind).toBe(true);
-        const probe = yield* makeControlClient(endpoint, { stackId, ownerSessionId }).probe();
+        const probe = yield* makeControlClient(endpoint, { stackId, ownerSessionId }).probe;
         expect(probe.ok).toBe(true);
       }),
     ),
@@ -357,7 +357,7 @@ describe("control transport", () => {
           stackId: "a".repeat(64),
           ownerSessionId: "dead-owner",
         });
-        const result = yield* client.stop().pipe(Effect.exit);
+        const result = yield* client.stop.pipe(Effect.exit);
         expect(Exit.isFailure(result)).toBe(true);
         if (Exit.isFailure(result)) {
           const failure = Cause.findErrorOption(result.cause);
@@ -373,7 +373,7 @@ describe("control transport", () => {
       ({ endpoint, stackId, ownerSessionId }) =>
         Effect.gen(function* () {
           const client = makeControlClient(endpoint, { stackId, ownerSessionId });
-          const response = yield* client.stop();
+          const response = yield* client.stop;
           expect(response).toMatchObject({
             ok: false,
             error: { tag: "operation-failed", stackErrorTag: "FutureStackError" },
@@ -536,12 +536,12 @@ describe("control transport", () => {
     withServer(({ endpoint, stackId, ownerSessionId }) =>
       Effect.gen(function* () {
         const client = makeControlClient(endpoint, { stackId, ownerSessionId });
-        const probe = yield* client.probe();
+        const probe = yield* client.probe;
         expect(probe).toMatchObject({ ok: true, op: "probe", stackId, ownerSessionId });
         const rpc = yield* client.rpc;
         const observed = yield* rpc.status(undefined);
         expect(observed.id).toBe(stackId);
-        expect(yield* client.stop()).toEqual({ ok: true, op: "stop" });
+        expect(yield* client.stop).toEqual({ ok: true, op: "stop" });
       }),
     ),
   );
@@ -713,7 +713,7 @@ describe("control transport", () => {
           });
           const stopCompleted = yield* Deferred.make<void>();
           const stopFiber = yield* Effect.forkChild(
-            client.stop().pipe(Effect.ensuring(Deferred.succeed(stopCompleted, undefined))),
+            client.stop.pipe(Effect.ensuring(Deferred.succeed(stopCompleted, undefined))),
           );
           yield* Deferred.await(maintenanceStarted);
           yield* TestClock.adjust("6 seconds");
@@ -745,7 +745,7 @@ describe("control transport", () => {
             stackId,
             ownerSessionId,
           });
-          const stopFiber = yield* Effect.forkChild(client.stop(), { startImmediately: true });
+          const stopFiber = yield* Effect.forkChild(client.stop, { startImmediately: true });
           yield* Deferred.await(completionStarted);
           const response = yield* Fiber.join(stopFiber);
           expect(response).toMatchObject({ ok: true, op: "stop" });

--- a/packages/stack/src/entrypoints/supervisor-node.ts
+++ b/packages/stack/src/entrypoints/supervisor-node.ts
@@ -1,7 +1,7 @@
 import { NodeServices } from "@effect/platform-node";
 import { Crypto, Data, Effect, FileSystem, Path, Schema } from "effect";
 // Node's fd3 readiness channel has no FileSystem abstraction, so it's used directly here.
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- native fd3 process protocol boundary.
 import * as NodeFs from "node:fs";
 import {
   acquireOwnership,

--- a/packages/stack/src/functions/serve-main-bundler.integration.test.ts
+++ b/packages/stack/src/functions/serve-main-bundler.integration.test.ts
@@ -1,53 +1,131 @@
-// oxlint-disable effecttsgo/async-function -- test exercises the Promise-based bundler boundary.
 import { createContext, SourceTextModule } from "node:vm";
-import { describe, expect, it } from "vitest";
+import { Effect, FileSystem, Path } from "effect";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { SignJWT } from "jose";
 import { bundleServeMainTemplate } from "./serve-main-bundler.ts";
 
 describe("stack-owned functions bootstrap", () => {
-  it("produces an executable offline service with the expected runtime contract", async () => {
-    type ServeOptions = {
-      readonly handler: (request: Request) => Promise<Response>;
-      readonly onListen: () => void;
-    };
+  it.live("produces an executable offline service with the expected runtime contract", () =>
+    Effect.gen(function* () {
+      type ServeOptions = {
+        readonly handler: (request: Request) => Promise<Response>;
+        readonly onListen: () => void;
+      };
 
-    let serveOptions: ServeOptions | undefined;
-    const bundled = await bundleServeMainTemplate();
-    const sandbox = {
-      Deno: {
-        env: { get: (_name: string) => undefined, toObject: () => ({}) },
-        errors: {},
-        serve: (options: ServeOptions) => {
-          serveOptions = options;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const run = Effect.runPromiseWith(yield* Effect.context<FileSystem.FileSystem | Path.Path>());
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "stack-bootstrap-" });
+      yield* fs.makeDirectory(path.join(root, "hello"));
+      yield* fs.writeFileString(path.join(root, "hello", "index.ts"), "export default 1");
+      const secret = "bootstrap-test-secret";
+      let serveOptions: ServeOptions | undefined;
+      const bundled = yield* Effect.tryPromise(() => bundleServeMainTemplate());
+      const sandbox = {
+        Deno: {
+          env: {
+            get: (name: string) =>
+              name === "SUPABASE_INTERNAL_FUNCTIONS_ROOT"
+                ? root
+                : name === "SUPABASE_INTERNAL_JWT_SECRET"
+                  ? secret
+                  : undefined,
+            toObject: () => ({}),
+          },
+          lstat: (filename: string) =>
+            run(
+              fs.stat(filename).pipe(
+                Effect.map((info) => ({
+                  isDirectory: info.type === "Directory",
+                  isFile: info.type === "File",
+                  isSymlink: false,
+                })),
+              ),
+            ),
+          realPath: (filename: string) => run(fs.realPath(filename)),
+          errors: {},
+          serve: (options: ServeOptions) => {
+            serveOptions = options;
+          },
         },
-      },
-      EdgeRuntime: { applySupabaseTag: () => undefined },
-      AbortController,
-      Request,
-      Response,
-      URL,
-      console,
-      crypto,
-      setTimeout,
-      clearTimeout,
-      TextEncoder,
-      TextDecoder,
-    };
+        EdgeRuntime: {
+          applySupabaseTag: () => undefined,
+          userWorkers: {
+            create: () => Promise.resolve({ fetch: () => Promise.resolve(new Response("hello")) }),
+          },
+        },
+        AbortController,
+        Request,
+        Response,
+        URL,
+        console,
+        crypto,
+        CryptoKey,
+        Uint8Array,
+        ArrayBuffer,
+        atob,
+        btoa,
+        setTimeout,
+        clearTimeout,
+        TextEncoder,
+        TextDecoder,
+      };
 
-    const module = new SourceTextModule(bundled, {
-      context: createContext(sandbox),
-      identifier: "serve.main.bundle.js",
-    });
-    await module.link(() => {
-      throw new Error("Bundled service unexpectedly imported another module");
-    });
-    await module.evaluate();
+      const module = new SourceTextModule(bundled, {
+        context: createContext(sandbox),
+        identifier: "serve.main.bundle.js",
+      });
+      yield* Effect.tryPromise(() =>
+        module.link(() => {
+          throw new Error("Bundled service unexpectedly imported another module");
+        }),
+      );
+      yield* Effect.tryPromise(() => module.evaluate());
 
-    if (serveOptions === undefined) throw new Error("Bundled service did not register a server");
+      if (serveOptions === undefined)
+        return yield* Effect.die("Bundled service did not register a server");
+      const registered = serveOptions;
 
-    const health = await serveOptions.handler(new Request("http://127.0.0.1/_internal/health"));
-    expect({ status: health.status, body: await health.json() }).toEqual({
-      status: 200,
-      body: { message: "ok" },
-    });
-  });
+      const health = yield* Effect.tryPromise(() =>
+        registered.handler(new Request("http://127.0.0.1/_internal/health")),
+      );
+      const body = yield* Effect.tryPromise(() => health.json());
+      expect({ status: health.status, body }).toEqual({
+        status: 200,
+        body: { message: "ok" },
+      });
+      const token = yield* Effect.tryPromise(() =>
+        new SignJWT({ sub: "bootstrap-test" })
+          .setProtectedHeader({ alg: "HS256" })
+          .sign(new TextEncoder().encode(secret)),
+      );
+      const invoke = (jwt: string) =>
+        Effect.tryPromise(() =>
+          registered.handler(
+            new Request("http://127.0.0.1/hello", {
+              headers: { Authorization: `Bearer ${jwt}` },
+            }),
+          ),
+        );
+      const valid = yield* invoke(token);
+      expect(valid.status).toBe(200);
+      expect(yield* Effect.tryPromise(() => valid.text())).toBe("hello");
+      const wrongToken = yield* Effect.tryPromise(() =>
+        new SignJWT({ sub: "bootstrap-test" })
+          .setProtectedHeader({ alg: "HS256" })
+          .sign(new TextEncoder().encode("wrong-secret")),
+      );
+      const invalidSignature = yield* invoke(wrongToken);
+      expect(invalidSignature.status).toBe(401);
+      expect(yield* Effect.tryPromise(() => invalidSignature.json())).toMatchObject({
+        code: "UNAUTHORIZED_JWT",
+      });
+      const malformed = yield* invoke("invalid");
+      expect(malformed.status).toBe(401);
+      expect(yield* Effect.tryPromise(() => malformed.json())).toMatchObject({
+        code: "UNAUTHORIZED_INVALID_JWT_FORMAT",
+      });
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/packages/stack/src/functions/serve-main-bundler.integration.test.ts
+++ b/packages/stack/src/functions/serve-main-bundler.integration.test.ts
@@ -21,7 +21,7 @@ describe("stack-owned functions bootstrap", () => {
       yield* fs.writeFileString(path.join(root, "hello", "index.ts"), "export default 1");
       const secret = "bootstrap-test-secret";
       let serveOptions: ServeOptions | undefined;
-      const bundled = yield* Effect.tryPromise(() => bundleServeMainTemplate());
+      const bundled = yield* bundleServeMainTemplate;
       const sandbox = {
         Deno: {
           env: {

--- a/packages/stack/src/functions/serve-main-bundler.ts
+++ b/packages/stack/src/functions/serve-main-bundler.ts
@@ -1,27 +1,48 @@
-// oxlint-disable effecttsgo/async-function -- esbuild's public API is Promise-based.
 import { fileURLToPath } from "node:url";
 import { build, stop } from "esbuild";
+import { Data, Effect } from "effect";
+
+class ServeMainBundleError extends Data.TaggedError("ServeMainBundleError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
 
 /** Absolute path to the stack-owned Edge Runtime main service template. */
 export const serveMainEntrypoint = fileURLToPath(new URL("./serve.main.ts", import.meta.url));
 
-/** Produces one offline ES module with jose and path helpers inlined. */
-export async function bundleServeMainTemplate(): Promise<string> {
-  try {
-    const result = await build({
-      entryPoints: [serveMainEntrypoint],
-      bundle: true,
-      format: "esm",
-      platform: "browser",
-      minify: true,
-      write: false,
-      legalComments: "none",
-      logLevel: "silent",
+const bundleServeMainTemplateEffect = Effect.gen(function* () {
+  const result = yield* Effect.tryPromise({
+    try: () =>
+      build({
+        entryPoints: [serveMainEntrypoint],
+        bundle: true,
+        format: "esm",
+        platform: "browser",
+        minify: true,
+        write: false,
+        legalComments: "none",
+        logLevel: "silent",
+      }),
+    catch: (cause) =>
+      new ServeMainBundleError({ message: "Unable to bundle functions bootstrap", cause }),
+  });
+  const output = result.outputFiles[0]?.text;
+  if (output === undefined)
+    return yield* new ServeMainBundleError({
+      message: "esbuild produced no functions bootstrap output",
     });
-    const output = result.outputFiles[0]?.text;
-    if (output === undefined) throw new Error("esbuild produced no functions bootstrap output");
-    return output;
-  } finally {
-    await stop();
-  }
-}
+  return output;
+}).pipe((buildProgram) =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.flatMap(Effect.exit(restore(buildProgram)), (result) =>
+      Effect.tryPromise({
+        try: () => stop(),
+        catch: (cause) => new ServeMainBundleError({ message: "Unable to stop esbuild", cause }),
+      }).pipe(Effect.andThen(result)),
+    ),
+  ),
+);
+
+/** Produces one offline ES module with jose and path helpers inlined. */
+export const bundleServeMainTemplate = (): Promise<string> =>
+  Effect.runPromise(bundleServeMainTemplateEffect);

--- a/packages/stack/src/functions/serve-main-bundler.ts
+++ b/packages/stack/src/functions/serve-main-bundler.ts
@@ -10,7 +10,8 @@ class ServeMainBundleError extends Data.TaggedError("ServeMainBundleError")<{
 /** Absolute path to the stack-owned Edge Runtime main service template. */
 export const serveMainEntrypoint = fileURLToPath(new URL("./serve.main.ts", import.meta.url));
 
-const bundleServeMainTemplateEffect = Effect.gen(function* () {
+/** Produces one offline ES module with jose and path helpers inlined. */
+export const bundleServeMainTemplate = Effect.gen(function* () {
   const result = yield* Effect.tryPromise({
     try: () =>
       build({
@@ -42,7 +43,3 @@ const bundleServeMainTemplateEffect = Effect.gen(function* () {
     ),
   ),
 );
-
-/** Produces one offline ES module with jose and path helpers inlined. */
-export const bundleServeMainTemplate = (): Promise<string> =>
-  Effect.runPromise(bundleServeMainTemplateEffect);

--- a/packages/stack/src/functions/serve-main-resolver.integration.test.ts
+++ b/packages/stack/src/functions/serve-main-resolver.integration.test.ts
@@ -1,39 +1,32 @@
-// oxlint-disable effecttsgo/async-function -- test exercises the Promise-based resolver boundary.
-// oxlint-disable effecttsgo/node-builtin-import -- Node filesystem fixtures own their temporary test root.
-import {
-  mkdtemp,
-  mkdir,
-  readdir,
-  lstat,
-  realpath,
-  rm,
-  symlink,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- FileSystem.stat follows symlinks; the resolver fixture must expose lstat.
+import { lstat } from "node:fs/promises";
+import { NodeServices } from "@effect/platform-node";
+import { Effect, FileSystem, Path } from "effect";
+import { describe, expect, it } from "@effect/vitest";
 import {
   createWorkerServicePathResolver,
   packageJsonContainedFor,
   resolveFunctionConfig,
   type FunctionFileSystem,
+  FunctionFileSystemError,
 } from "./serve-main-resolver.ts";
-
-const nodeFileSystem: FunctionFileSystem = {
-  lstat: async (path) => {
-    const info = await lstat(path);
-    return {
-      isDirectory: info.isDirectory(),
-      isFile: info.isFile(),
-      isSymbolicLink: info.isSymbolicLink(),
-    };
-  },
-  realPath: (path) => realpath(path),
-  readDirectory: async (path) => readdir(path),
-};
-
+const makeNodeFileSystem = (fs: FileSystem.FileSystem): FunctionFileSystem => ({
+  lstat: (path) =>
+    Effect.tryPromise({
+      try: () => lstat(path),
+      catch: (cause) => new FunctionFileSystemError({ cause }),
+    }).pipe(
+      Effect.map((info) => ({
+        isDirectory: info.isDirectory(),
+        isFile: info.isFile(),
+        isSymbolicLink: info.isSymbolicLink(),
+      })),
+    ),
+  realPath: (path) =>
+    fs.realPath(path).pipe(Effect.mapError((cause) => new FunctionFileSystemError({ cause }))),
+  readDirectory: (path) =>
+    fs.readDirectory(path).pipe(Effect.mapError((cause) => new FunctionFileSystemError({ cause }))),
+});
 describe("Edge Runtime worker service paths", () => {
   it("keeps stable identities for functions that share a source directory", () => {
     let nextWorker = 0;
@@ -47,7 +40,6 @@ describe("Edge Runtime worker service paths", () => {
       verifyJWT: true,
     };
     const beta = { ...alpha, entrypointPath: "/functions/shared/beta.ts" };
-
     expect(resolveWorkerPath("alpha", alpha)).toBe("/functions/shared");
     expect(resolveWorkerPath("beta", beta)).toBe("/tmp/supabase-worker-1");
     expect(resolveWorkerPath("alpha", alpha)).toBe("/functions/shared");
@@ -56,34 +48,34 @@ describe("Edge Runtime worker service paths", () => {
     ).toBe("/functions/isolated");
   });
 });
-
 describe("Edge Runtime request-time function resolver", () => {
-  it("resolves current filesystem paths for create/delete", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-"));
-    try {
-      const hello = join(root, "hello");
-      await mkdir(hello, { recursive: true });
-      await writeFile(join(hello, "index.ts"), "export default 1");
-      await writeFile(join(hello, "deno.json"), "{}");
-      const canonicalRoot = await realpath(root);
-
-      const defaults = await resolveFunctionConfig({
+  it.live("resolves current filesystem paths for create/delete", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "stack-functions-resolver-" });
+      const hello = path.join(root, "hello");
+      yield* fs.makeDirectory(hello, { recursive: true });
+      yield* fs.writeFileString(path.join(hello, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(hello, "deno.json"), "{}");
+      const canonicalRoot = yield* fs.realPath(root);
+      const defaults = yield* resolveFunctionConfig({
         root,
         slug: "hello",
         overrides: {},
         fs: nodeFileSystem,
       });
       expect(defaults).toMatchObject({
-        entrypointPath: join(canonicalRoot, "hello", "index.ts"),
-        importMapPath: join(canonicalRoot, "hello", "deno.json"),
+        entrypointPath: path.join(canonicalRoot, "hello", "index.ts"),
+        importMapPath: path.join(canonicalRoot, "hello", "deno.json"),
         verifyJWT: true,
       });
-
-      const created = join(root, "new-function");
-      await mkdir(created);
-      await writeFile(join(created, "index.ts"), "export default 3");
+      const created = path.join(root, "new-function");
+      yield* fs.makeDirectory(created);
+      yield* fs.writeFileString(path.join(created, "index.ts"), "export default 3");
       expect(
-        await resolveFunctionConfig({
+        yield* resolveFunctionConfig({
           root,
           slug: "new-function",
           overrides: {},
@@ -91,26 +83,27 @@ describe("Edge Runtime request-time function resolver", () => {
         }),
       ).toMatchObject({
         verifyJWT: true,
-        entrypointPath: join(canonicalRoot, "new-function", "index.ts"),
+        entrypointPath: path.join(canonicalRoot, "new-function", "index.ts"),
       });
-
-      await unlink(join(hello, "index.ts"));
+      yield* fs.remove(path.join(hello, "index.ts"));
       expect(
-        await resolveFunctionConfig({ root, slug: "hello", overrides: {}, fs: nodeFileSystem }),
+        yield* resolveFunctionConfig({ root, slug: "hello", overrides: {}, fs: nodeFileSystem }),
       ).toBeUndefined();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("discovers a contained package.json for a function without an import map", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-package-discovery-"));
-    try {
-      const hello = join(root, "hello");
-      await mkdir(hello, { recursive: true });
-      await writeFile(join(hello, "index.ts"), "export default 1");
-      await writeFile(join(hello, "package.json"), "{}");
-      const config = await resolveFunctionConfig({
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("discovers a contained package.json for a function without an import map", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-package-discovery-",
+      });
+      const hello = path.join(root, "hello");
+      yield* fs.makeDirectory(hello, { recursive: true });
+      yield* fs.writeFileString(path.join(hello, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(hello, "package.json"), "{}");
+      const config = yield* resolveFunctionConfig({
         root,
         slug: "hello",
         overrides: {},
@@ -118,27 +111,28 @@ describe("Edge Runtime request-time function resolver", () => {
       });
       expect(config).toBeDefined();
       expect(
-        await packageJsonContainedFor({
+        yield* packageJsonContainedFor({
           root,
           config: { ...config!, importMapPath: "" },
           fs: nodeFileSystem,
         }),
       ).toBe(true);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("normalizes persisted empty entrypoint settings to index.ts", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-empty-entrypoint-"));
-    try {
-      const functionRoot = join(root, "hello");
-      await mkdir(functionRoot, { recursive: true });
-      await writeFile(join(functionRoot, "index.ts"), "export default 1");
-      await writeFile(join(functionRoot, "deno.json"), "{}");
-      const canonicalRoot = await realpath(root);
-
-      const config = await resolveFunctionConfig({
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("normalizes persisted empty entrypoint settings to index.ts", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-empty-entrypoint-",
+      });
+      const functionRoot = path.join(root, "hello");
+      yield* fs.makeDirectory(functionRoot, { recursive: true });
+      yield* fs.writeFileString(path.join(functionRoot, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(functionRoot, "deno.json"), "{}");
+      const canonicalRoot = yield* fs.realPath(root);
+      const config = yield* resolveFunctionConfig({
         root,
         slug: "hello",
         overrides: {
@@ -153,15 +147,13 @@ describe("Edge Runtime request-time function resolver", () => {
         },
         fs: nodeFileSystem,
       });
-
       expect(config).toMatchObject({
-        entrypointPath: join(canonicalRoot, "hello", "index.ts"),
-        importMapPath: join(canonicalRoot, "hello", "deno.json"),
+        entrypointPath: path.join(canonicalRoot, "hello", "index.ts"),
+        importMapPath: path.join(canonicalRoot, "hello", "deno.json"),
         verifyJWT: false,
       });
-
-      await writeFile(join(functionRoot, "custom.ts"), "export default 2");
-      const explicit = await resolveFunctionConfig({
+      yield* fs.writeFileString(path.join(functionRoot, "custom.ts"), "export default 2");
+      const explicit = yield* resolveFunctionConfig({
         root,
         slug: "hello",
         overrides: {
@@ -177,48 +169,50 @@ describe("Edge Runtime request-time function resolver", () => {
         },
         fs: nodeFileSystem,
       });
-      expect(explicit?.entrypointPath).toBe(join(canonicalRoot, "hello", "custom.ts"));
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("accepts an absolute entrypoint inside the functions root without a slug directory", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-absolute-entrypoint-"));
-    try {
-      const entrypoint = join(root, "legacy", "index.ts");
-      await mkdir(join(root, "legacy"), { recursive: true });
-      await writeFile(entrypoint, "export default 1");
-
-      await expect(
-        resolveFunctionConfig({
+      expect(explicit?.entrypointPath).toBe(path.join(canonicalRoot, "hello", "custom.ts"));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("accepts an absolute entrypoint inside the functions root without a slug directory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-absolute-entrypoint-",
+      });
+      const entrypoint = path.join(root, "legacy", "index.ts");
+      yield* fs.makeDirectory(path.join(root, "legacy"), { recursive: true });
+      yield* fs.writeFileString(entrypoint, "export default 1");
+      expect(
+        yield* resolveFunctionConfig({
           root,
           slug: "hello",
           overrides: { hello: { entrypointPath: entrypoint } },
           fs: nodeFileSystem,
         }),
-      ).resolves.toMatchObject({
+      ).toMatchObject({
         entrypointPath: entrypoint,
         importMapPath: "",
         verifyJWT: true,
       });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("applies global defaults to newly discovered functions while preserving overrides", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-defaults-"));
-    try {
-      const hello = join(root, "hello");
-      const created = join(root, "created");
-      const canonicalRoot = await realpath(root);
-      await mkdir(hello, { recursive: true });
-      await mkdir(created, { recursive: true });
-      await writeFile(join(hello, "index.ts"), "export default 1");
-      await writeFile(join(created, "index.ts"), "export default 2");
-      await writeFile(join(root, "shared-deno.json"), "{}");
-
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("applies global defaults to newly discovered functions while preserving overrides", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-defaults-",
+      });
+      const hello = path.join(root, "hello");
+      const created = path.join(root, "created");
+      const canonicalRoot = yield* fs.realPath(root);
+      yield* fs.makeDirectory(hello, { recursive: true });
+      yield* fs.makeDirectory(created, { recursive: true });
+      yield* fs.writeFileString(path.join(hello, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(created, "index.ts"), "export default 2");
+      yield* fs.writeFileString(path.join(root, "shared-deno.json"), "{}");
       const defaults = {
         verify_jwt: false,
         import_map_root: "shared-deno.json",
@@ -227,36 +221,36 @@ describe("Edge Runtime request-time function resolver", () => {
         $default: defaults,
         hello: { verify_jwt: true },
       };
-
       expect(
-        await resolveFunctionConfig({ root, slug: "created", overrides, fs: nodeFileSystem }),
+        yield* resolveFunctionConfig({ root, slug: "created", overrides, fs: nodeFileSystem }),
       ).toMatchObject({
         verifyJWT: false,
-        importMapPath: join(canonicalRoot, "shared-deno.json"),
+        importMapPath: path.join(canonicalRoot, "shared-deno.json"),
       });
       expect(
-        await resolveFunctionConfig({ root, slug: "hello", overrides, fs: nodeFileSystem }),
+        yield* resolveFunctionConfig({ root, slug: "hello", overrides, fs: nodeFileSystem }),
       ).toMatchObject({
         verifyJWT: true,
-        importMapPath: join(canonicalRoot, "shared-deno.json"),
+        importMapPath: path.join(canonicalRoot, "shared-deno.json"),
       });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps a closed per-function import map relative to that function", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-import-map-"));
-    try {
-      const hello = join(root, "hello");
-      await mkdir(hello, { recursive: true });
-      await writeFile(join(hello, "index.ts"), "export default 1");
-      await writeFile(join(root, "shared-deno.json"), "{}");
-      await writeFile(join(hello, "custom-deno.json"), "{}");
-
-      const canonicalRoot = await realpath(root);
-      await expect(
-        resolveFunctionConfig({
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("keeps a closed per-function import map relative to that function", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-import-map-",
+      });
+      const hello = path.join(root, "hello");
+      yield* fs.makeDirectory(hello, { recursive: true });
+      yield* fs.writeFileString(path.join(hello, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(root, "shared-deno.json"), "{}");
+      yield* fs.writeFileString(path.join(hello, "custom-deno.json"), "{}");
+      const canonicalRoot = yield* fs.realPath(root);
+      expect(
+        yield* resolveFunctionConfig({
           root,
           slug: "hello",
           overrides: {
@@ -265,45 +259,51 @@ describe("Edge Runtime request-time function resolver", () => {
           },
           fs: nodeFileSystem,
         }),
-      ).resolves.toMatchObject({
-        importMapPath: join(canonicalRoot, "hello", "custom-deno.json"),
+      ).toMatchObject({
+        importMapPath: path.join(canonicalRoot, "hello", "custom-deno.json"),
       });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("accepts a symlinked functions root while enforcing canonical descendants", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-root-link-"));
-    try {
-      const canonical = join(root, "canonical");
-      const configured = join(root, "configured");
-      await mkdir(join(canonical, "hello"), { recursive: true });
-      await writeFile(join(canonical, "hello", "index.ts"), "export default 1");
-      await symlink(canonical, configured, "dir");
-      const found = await resolveFunctionConfig({
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("accepts a symlinked functions root while enforcing canonical descendants", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-root-link-",
+      });
+      const canonical = path.join(root, "canonical");
+      const configured = path.join(root, "configured");
+      yield* fs.makeDirectory(path.join(canonical, "hello"), { recursive: true });
+      yield* fs.writeFileString(path.join(canonical, "hello", "index.ts"), "export default 1");
+      yield* fs.symlink(canonical, configured);
+      const found = yield* resolveFunctionConfig({
         root: configured,
         slug: "hello",
         overrides: {},
         fs: nodeFileSystem,
       });
-      expect(found?.entrypointPath).toBe(join(await realpath(canonical), "hello", "index.ts"));
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("allows package.json discovery under a symlinked functions root", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-package-root-link-"));
-    try {
-      const canonical = join(root, "canonical");
-      const configured = join(root, "configured");
-      const functionRoot = join(canonical, "hello");
-      await mkdir(functionRoot, { recursive: true });
-      await writeFile(join(functionRoot, "index.ts"), "export default 1");
-      await writeFile(join(functionRoot, "package.json"), "{}");
-      await symlink(canonical, configured, "dir");
-      const config = await resolveFunctionConfig({
+      expect(found?.entrypointPath).toBe(
+        path.join(yield* fs.realPath(canonical), "hello", "index.ts"),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("allows package.json discovery under a symlinked functions root", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-package-root-link-",
+      });
+      const canonical = path.join(root, "canonical");
+      const configured = path.join(root, "configured");
+      const functionRoot = path.join(canonical, "hello");
+      yield* fs.makeDirectory(functionRoot, { recursive: true });
+      yield* fs.writeFileString(path.join(functionRoot, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(functionRoot, "package.json"), "{}");
+      yield* fs.symlink(canonical, configured);
+      const config = yield* resolveFunctionConfig({
         root: configured,
         slug: "hello",
         overrides: {},
@@ -311,87 +311,91 @@ describe("Edge Runtime request-time function resolver", () => {
       });
       expect(config).toBeDefined();
       expect(
-        await packageJsonContainedFor({
+        yield* packageJsonContainedFor({
           root: configured,
           config: { ...config!, importMapPath: "" },
           fs: nodeFileSystem,
         }),
       ).toBe(true);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("requires an absolute root and rejects traversal and symlink escapes", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-paths-"));
-    const outside = await mkdtemp(join(tmpdir(), "stack-functions-resolver-outside-"));
-    try {
-      await mkdir(join(root, "safe"));
-      await writeFile(join(root, "safe", "index.ts"), "export default 1");
-      await writeFile(join(outside, "index.ts"), "export default 2");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("requires an absolute root and rejects traversal and symlink escapes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "stack-functions-resolver-paths-" });
+      const outside = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-outside-",
+      });
+      yield* fs.makeDirectory(path.join(root, "safe"));
+      yield* fs.writeFileString(path.join(root, "safe", "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(outside, "index.ts"), "export default 2");
       expect(
-        await resolveFunctionConfig({ root: "", slug: "safe", overrides: {}, fs: nodeFileSystem }),
+        yield* resolveFunctionConfig({ root: "", slug: "safe", overrides: {}, fs: nodeFileSystem }),
       ).toBeUndefined();
       expect(
-        await resolveFunctionConfig({
+        yield* resolveFunctionConfig({
           root,
           slug: "safe",
           overrides: { safe: { entrypoint: "../outside.ts" } },
           fs: nodeFileSystem,
         }),
       ).toBeUndefined();
-
-      await symlink(outside, join(root, "escaped"), "dir");
+      yield* fs.symlink(outside, path.join(root, "escaped"));
       expect(
-        await resolveFunctionConfig({ root, slug: "escaped", overrides: {}, fs: nodeFileSystem }),
+        yield* resolveFunctionConfig({ root, slug: "escaped", overrides: {}, fs: nodeFileSystem }),
       ).toBeUndefined();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-      await rm(outside, { recursive: true, force: true });
-    }
-  });
-
-  it("fails closed when a static wildcard tree contains a symlink", async () => {
-    const root = await mkdtemp(join(tmpdir(), "stack-functions-resolver-static-"));
-    const outside = await mkdtemp(join(tmpdir(), "stack-functions-resolver-static-outside-"));
-    try {
-      const canonicalRoot = await realpath(root);
-      const functionRoot = join(root, "hello");
-      const publicRoot = join(functionRoot, "public");
-      await mkdir(publicRoot, { recursive: true });
-      await writeFile(join(functionRoot, "index.ts"), "export default 1");
-      await writeFile(join(outside, "package.json"), "{}");
-      await symlink(join(outside, "package.json"), join(functionRoot, "package.json"));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("fails closed when a static wildcard tree contains a symlink", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const nodeFileSystem = makeNodeFileSystem(fs);
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-static-",
+      });
+      const outside = yield* fs.makeTempDirectoryScoped({
+        prefix: "stack-functions-resolver-static-outside-",
+      });
+      const canonicalRoot = yield* fs.realPath(root);
+      const functionRoot = path.join(root, "hello");
+      const publicRoot = path.join(functionRoot, "public");
+      yield* fs.makeDirectory(publicRoot, { recursive: true });
+      yield* fs.writeFileString(path.join(functionRoot, "index.ts"), "export default 1");
+      yield* fs.writeFileString(path.join(outside, "package.json"), "{}");
+      yield* fs.symlink(
+        path.join(outside, "package.json"),
+        path.join(functionRoot, "package.json"),
+      );
       const config = {
-        entrypointPath: join(functionRoot, "index.ts"),
+        entrypointPath: path.join(functionRoot, "index.ts"),
         importMapPath: "",
         staticFiles: [],
         verifyJWT: true,
       };
-      expect(await packageJsonContainedFor({ root, config, fs: nodeFileSystem })).toBe(false);
-      await unlink(join(functionRoot, "package.json"));
-      await writeFile(join(publicRoot, "ok.txt"), "ok");
+      expect(yield* packageJsonContainedFor({ root, config, fs: nodeFileSystem })).toBe(false);
+      yield* fs.remove(path.join(functionRoot, "package.json"));
+      yield* fs.writeFileString(path.join(publicRoot, "ok.txt"), "ok");
       expect(
-        await resolveFunctionConfig({
+        yield* resolveFunctionConfig({
           root,
           slug: "hello",
           overrides: { hello: { static_files: ["public/*.txt"] } },
           fs: nodeFileSystem,
         }),
-      ).toMatchObject({ staticFiles: [join(canonicalRoot, "hello", "public", "*.txt")] });
-      await writeFile(join(outside, "secret.txt"), "secret");
-      await symlink(join(outside, "secret.txt"), join(publicRoot, "link.txt"));
+      ).toMatchObject({ staticFiles: [path.join(canonicalRoot, "hello", "public", "*.txt")] });
+      yield* fs.writeFileString(path.join(outside, "secret.txt"), "secret");
+      yield* fs.symlink(path.join(outside, "secret.txt"), path.join(publicRoot, "link.txt"));
       expect(
-        await resolveFunctionConfig({
+        yield* resolveFunctionConfig({
           root,
           slug: "hello",
           overrides: { hello: { static_files: ["public/*.txt"] } },
           fs: nodeFileSystem,
         }),
       ).toBeUndefined();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-      await rm(outside, { recursive: true, force: true });
-    }
-  });
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/packages/stack/src/functions/serve-main-resolver.ts
+++ b/packages/stack/src/functions/serve-main-resolver.ts
@@ -1,4 +1,4 @@
-// oxlint-disable effecttsgo/async-function -- resolver preserves the Edge Runtime Promise callback contract.
+import { Data, Effect } from "effect";
 import { dirname, join } from "./serve-main-deps.ts";
 
 interface FunctionOverride {
@@ -36,9 +36,11 @@ interface FunctionFileInfo {
 
 /** The tiny filesystem surface needed by request-time function discovery. */
 export interface FunctionFileSystem {
-  readonly lstat: (path: string) => Promise<FunctionFileInfo>;
-  readonly realPath: (path: string) => Promise<string>;
-  readonly readDirectory: (path: string) => Promise<ReadonlyArray<string>>;
+  readonly lstat: (path: string) => Effect.Effect<FunctionFileInfo, FunctionFileSystemError>;
+  readonly realPath: (path: string) => Effect.Effect<string, FunctionFileSystemError>;
+  readonly readDirectory: (
+    path: string,
+  ) => Effect.Effect<ReadonlyArray<string>, FunctionFileSystemError>;
 }
 
 const slugPattern = /^[A-Za-z0-9_-]+$/u;
@@ -47,160 +49,157 @@ const globPattern = /[*?[{]/u;
 const contained = (root: string, candidate: string): boolean =>
   candidate === root || candidate.startsWith(`${root.replace(/\/+$/u, "")}/`);
 
-const optionalInfo = async (
+export class FunctionFileSystemError extends Data.TaggedError("FunctionFileSystemError")<{
+  readonly cause: unknown;
+}> {}
+const optionalInfo = (
   fs: FunctionFileSystem,
   path: string,
-): Promise<FunctionFileInfo | undefined> => {
-  try {
-    return await fs.lstat(path);
-  } catch {
-    return undefined;
-  }
-};
+): Effect.Effect<FunctionFileInfo | undefined> =>
+  fs.lstat(path).pipe(Effect.catch(() => Effect.undefined));
 
-const safeRealPath = async (
+const safeRealPath = (
   fs: FunctionFileSystem,
   root: string,
   candidate: string,
-): Promise<boolean> => {
-  try {
-    const [canonicalRoot, canonicalCandidate] = await Promise.all([
-      fs.realPath(root),
-      fs.realPath(candidate),
-    ]);
-    return contained(canonicalRoot, canonicalCandidate);
-  } catch {
-    return false;
-  }
-};
+): Effect.Effect<boolean> =>
+  Effect.all([fs.realPath(root), fs.realPath(candidate)], {
+    concurrency: 2,
+  }).pipe(
+    Effect.map(([canonicalRoot, canonicalCandidate]) =>
+      contained(canonicalRoot, canonicalCandidate),
+    ),
+    Effect.orElseSucceed(() => false),
+  );
 
-/** Rejects symlinks in the complete wildcard search area for this request. */
-const rejectSymlinkDescendants = async (
+const rejectSymlinkDescendants = (
   fs: FunctionFileSystem,
   root: string,
   directory: string,
-): Promise<boolean> => {
-  const info = await optionalInfo(fs, directory);
-  if (info === undefined) return true;
-  if (info.isSymbolicLink || !(await safeRealPath(fs, root, directory))) return false;
-  if (!info.isDirectory) return true;
-  let children: ReadonlyArray<string>;
-  try {
-    children = await fs.readDirectory(directory);
-  } catch {
-    return false;
-  }
-  for (const child of children) {
-    if (!(await rejectSymlinkDescendants(fs, root, join(directory, child)))) return false;
-  }
-  return true;
-};
+): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    const info = yield* optionalInfo(fs, directory);
+    if (info === undefined) return true;
+    if (info.isSymbolicLink || !(yield* safeRealPath(fs, root, directory))) return false;
+    if (!info.isDirectory) return true;
+    const children = yield* fs.readDirectory(directory).pipe(Effect.catch(() => Effect.undefined));
+    if (children === undefined) return false;
+    for (const child of children) {
+      if (!(yield* rejectSymlinkDescendants(fs, root, join(directory, child)))) return false;
+    }
+    return true;
+  });
 
 const relativePath = (base: string, value: string): string =>
   value.length === 0 ? "" : value.startsWith("/") ? value : join(base, value);
 
 /** Resolves one request's persisted override/default against the live functions tree. */
-export const resolveFunctionConfig = async (options: {
+export const resolveFunctionConfig = (options: {
   readonly root: string;
   readonly slug: string;
   readonly overrides: FunctionOverrides;
   readonly fs: FunctionFileSystem;
-}): Promise<FunctionConfig | undefined> => {
-  const { root, slug, overrides, fs } = options;
-  if (!root.startsWith("/") || !slugPattern.test(slug) || slug === "_shared") return undefined;
-  const rootInfo = await optionalInfo(fs, root);
-  // The configured functions root itself may be a symlink; descendants remain
-  // subject to canonical containment and entrypoint symlink rejection below.
-  if (rootInfo === undefined) return undefined;
-  const canonicalRoot = await fs.realPath(root).catch(() => "");
-  if (!canonicalRoot.startsWith("/")) return undefined;
-  const canonicalInfo = await optionalInfo(fs, canonicalRoot);
-  if (canonicalInfo === undefined || !canonicalInfo.isDirectory) return undefined;
-  const globalDefaults = overrides.$default;
-  const functionOverride = overrides[slug];
-  // `$default` cannot be a function slug (the slug schema only accepts letters, digits, `_`,
-  // and `-`), so it's a collision-free global default; the per-function override is spread
-  // last so it always wins.
-  const override = {
-    ...globalDefaults,
-    ...functionOverride,
-  };
-  if (override.enabled === false) return undefined;
-  const functionDirectory = join(canonicalRoot, slug);
-  const rawEntrypoint =
-    override?.entrypointPath && override.entrypointPath.length > 0
-      ? override.entrypointPath
-      : override.entrypoint && override.entrypoint.length > 0
-        ? override.entrypoint
-        : "index.ts";
-  if (!rawEntrypoint.startsWith("/")) {
-    const directoryInfo = await optionalInfo(fs, functionDirectory);
-    if (directoryInfo === undefined || !directoryInfo.isDirectory) return undefined;
-    if (!(await safeRealPath(fs, canonicalRoot, functionDirectory))) return undefined;
-  }
-  const entrypointPath = relativePath(functionDirectory, rawEntrypoint);
-  if (!(await safeRealPath(fs, canonicalRoot, entrypointPath))) return undefined;
-  const entrypointInfo = await optionalInfo(fs, entrypointPath);
-  if (entrypointInfo === undefined || !entrypointInfo.isFile || entrypointInfo.isSymbolicLink)
-    return undefined;
+}): Effect.Effect<FunctionConfig | undefined> =>
+  Effect.gen(function* () {
+    const { root, slug, overrides, fs } = options;
+    if (!root.startsWith("/") || !slugPattern.test(slug) || slug === "_shared") return undefined;
+    const rootInfo = yield* optionalInfo(fs, root);
+    // The configured functions root itself may be a symlink; descendants remain
+    // subject to canonical containment and entrypoint symlink rejection below.
+    if (rootInfo === undefined) return undefined;
+    const canonicalRoot = yield* fs.realPath(root).pipe(Effect.orElseSucceed(() => ""));
+    if (!canonicalRoot.startsWith("/")) return undefined;
+    const canonicalInfo = yield* optionalInfo(fs, canonicalRoot);
+    if (canonicalInfo === undefined || !canonicalInfo.isDirectory) return undefined;
+    const globalDefaults = overrides.$default;
+    const functionOverride = overrides[slug];
+    // `$default` cannot be a function slug (the slug schema only accepts letters, digits, `_`,
+    // and `-`), so it's a collision-free global default; the per-function override is spread
+    // last so it always wins.
+    const override = {
+      ...globalDefaults,
+      ...functionOverride,
+    };
+    if (override.enabled === false) return undefined;
+    const functionDirectory = join(canonicalRoot, slug);
+    const rawEntrypoint =
+      override?.entrypointPath && override.entrypointPath.length > 0
+        ? override.entrypointPath
+        : override.entrypoint && override.entrypoint.length > 0
+          ? override.entrypoint
+          : "index.ts";
+    if (!rawEntrypoint.startsWith("/")) {
+      const directoryInfo = yield* optionalInfo(fs, functionDirectory);
+      if (directoryInfo === undefined || !directoryInfo.isDirectory) return undefined;
+      if (!(yield* safeRealPath(fs, canonicalRoot, functionDirectory))) return undefined;
+    }
+    const entrypointPath = relativePath(functionDirectory, rawEntrypoint);
+    if (!(yield* safeRealPath(fs, canonicalRoot, entrypointPath))) return undefined;
+    const entrypointInfo = yield* optionalInfo(fs, entrypointPath);
+    if (entrypointInfo === undefined || !entrypointInfo.isFile || entrypointInfo.isSymbolicLink)
+      return undefined;
 
-  // Per-function import maps are relative to that function's directory; the reserved global
-  // default is root-relative, so one shared map is reused by every slug.
-  const functionImportMap = functionOverride?.importMapPath ?? functionOverride?.import_map;
-  const globalImportMap = globalDefaults?.importMapRoot ?? globalDefaults?.import_map_root;
-  let importMapPath =
-    functionImportMap !== undefined
-      ? relativePath(functionDirectory, functionImportMap)
-      : globalImportMap !== undefined
-        ? relativePath(canonicalRoot, globalImportMap)
-        : relativePath(functionDirectory, "");
-  if (importMapPath.length > 0) {
-    if (!(await safeRealPath(fs, canonicalRoot, importMapPath))) return undefined;
-    const info = await optionalInfo(fs, importMapPath);
-    if (info === undefined || !info.isFile || info.isSymbolicLink) return undefined;
-  } else {
-    for (const candidate of ["deno.json", "deno.jsonc"]) {
-      const path = join(functionDirectory, candidate);
-      const info = await optionalInfo(fs, path);
-      if (info !== undefined) {
-        if (!info.isFile || info.isSymbolicLink || !(await safeRealPath(fs, canonicalRoot, path)))
-          return undefined;
-        importMapPath = path;
-        break;
+    // Per-function import maps are relative to that function's directory; the reserved global
+    // default is root-relative, so one shared map is reused by every slug.
+    const functionImportMap = functionOverride?.importMapPath ?? functionOverride?.import_map;
+    const globalImportMap = globalDefaults?.importMapRoot ?? globalDefaults?.import_map_root;
+    let importMapPath =
+      functionImportMap !== undefined
+        ? relativePath(functionDirectory, functionImportMap)
+        : globalImportMap !== undefined
+          ? relativePath(canonicalRoot, globalImportMap)
+          : relativePath(functionDirectory, "");
+    if (importMapPath.length > 0) {
+      if (!(yield* safeRealPath(fs, canonicalRoot, importMapPath))) return undefined;
+      const info = yield* optionalInfo(fs, importMapPath);
+      if (info === undefined || !info.isFile || info.isSymbolicLink) return undefined;
+    } else {
+      for (const candidate of ["deno.json", "deno.jsonc"]) {
+        const path = join(functionDirectory, candidate);
+        const info = yield* optionalInfo(fs, path);
+        if (info !== undefined) {
+          if (
+            !info.isFile ||
+            info.isSymbolicLink ||
+            !(yield* safeRealPath(fs, canonicalRoot, path))
+          )
+            return undefined;
+          importMapPath = path;
+          break;
+        }
       }
     }
-  }
 
-  const staticFiles = (override.staticFiles ?? override.static_files ?? []).map((pattern) =>
-    relativePath(functionDirectory, pattern),
-  );
-  for (const pattern of staticFiles) {
-    if (!contained(canonicalRoot, pattern)) return undefined;
-    const wildcardIndex = pattern.search(globPattern);
-    const prefix = wildcardIndex < 0 ? pattern : pattern.slice(0, wildcardIndex);
-    const searchRoot =
-      wildcardIndex < 0
-        ? dirname(pattern)
-        : prefix.slice(0, Math.max(0, prefix.lastIndexOf("/"))) || canonicalRoot;
-    if (!(await rejectSymlinkDescendants(fs, canonicalRoot, searchRoot))) return undefined;
-    if (!globPattern.test(pattern)) {
-      const info = await optionalInfo(fs, pattern);
-      if (
-        info !== undefined &&
-        (!(await safeRealPath(fs, canonicalRoot, pattern)) || info.isSymbolicLink)
-      )
-        return undefined;
+    const staticFiles = (override.staticFiles ?? override.static_files ?? []).map((pattern) =>
+      relativePath(functionDirectory, pattern),
+    );
+    for (const pattern of staticFiles) {
+      if (!contained(canonicalRoot, pattern)) return undefined;
+      const wildcardIndex = pattern.search(globPattern);
+      const prefix = wildcardIndex < 0 ? pattern : pattern.slice(0, wildcardIndex);
+      const searchRoot =
+        wildcardIndex < 0
+          ? dirname(pattern)
+          : prefix.slice(0, Math.max(0, prefix.lastIndexOf("/"))) || canonicalRoot;
+      if (!(yield* rejectSymlinkDescendants(fs, canonicalRoot, searchRoot))) return undefined;
+      if (!globPattern.test(pattern)) {
+        const info = yield* optionalInfo(fs, pattern);
+        if (
+          info !== undefined &&
+          (!(yield* safeRealPath(fs, canonicalRoot, pattern)) || info.isSymbolicLink)
+        )
+          return undefined;
+      }
     }
-  }
 
-  return {
-    entrypointPath,
-    importMapPath,
-    staticFiles,
-    verifyJWT: override.verifyJWT ?? override.verify_jwt ?? true,
-    env: override.env,
-  };
-};
+    return {
+      entrypointPath,
+      importMapPath,
+      staticFiles,
+      verifyJWT: override.verifyJWT ?? override.verify_jwt ?? true,
+      env: override.env,
+    };
+  });
 
 const packageJsonPathFor = (config: FunctionConfig): string =>
   join(dirname(config.entrypointPath), "package.json");
@@ -222,20 +221,24 @@ export const createWorkerServicePathResolver = (makeTempDirectory: () => string)
 };
 
 /** Checks package discovery without allowing a package.json symlink to leave the root. */
-export const packageJsonContainedFor = async (options: {
+export const packageJsonContainedFor = (options: {
   readonly root: string;
   readonly config: FunctionConfig;
   readonly fs: FunctionFileSystem;
-}): Promise<boolean> => {
-  if (!options.root.startsWith("/")) return false;
-  const rootInfo = await optionalInfo(options.fs, options.root);
-  if (rootInfo === undefined || (!rootInfo.isDirectory && !rootInfo.isSymbolicLink)) return false;
-  const canonicalRoot = await options.fs.realPath(options.root).catch(() => "");
-  if (!canonicalRoot.startsWith("/")) return false;
-  const canonicalInfo = await optionalInfo(options.fs, canonicalRoot);
-  if (canonicalInfo === undefined || !canonicalInfo.isDirectory) return false;
-  const packagePath = packageJsonPathFor(options.config);
-  const packageInfo = await optionalInfo(options.fs, packagePath);
-  if (packageInfo === undefined || !packageInfo.isFile || packageInfo.isSymbolicLink) return false;
-  return safeRealPath(options.fs, canonicalRoot, packagePath);
-};
+}): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    if (!options.root.startsWith("/")) return false;
+    const rootInfo = yield* optionalInfo(options.fs, options.root);
+    if (rootInfo === undefined || (!rootInfo.isDirectory && !rootInfo.isSymbolicLink)) return false;
+    const canonicalRoot = yield* options.fs
+      .realPath(options.root)
+      .pipe(Effect.orElseSucceed(() => ""));
+    if (!canonicalRoot.startsWith("/")) return false;
+    const canonicalInfo = yield* optionalInfo(options.fs, canonicalRoot);
+    if (canonicalInfo === undefined || !canonicalInfo.isDirectory) return false;
+    const packagePath = packageJsonPathFor(options.config);
+    const packageInfo = yield* optionalInfo(options.fs, packagePath);
+    if (packageInfo === undefined || !packageInfo.isFile || packageInfo.isSymbolicLink)
+      return false;
+    return yield* safeRealPath(options.fs, canonicalRoot, packagePath);
+  });

--- a/packages/stack/src/functions/serve.main.ts
+++ b/packages/stack/src/functions/serve.main.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-// oxlint-disable effecttsgo/async-function -- standalone Edge Runtime artifact uses Deno async APIs.
-// oxlint-disable effecttsgo/global-console -- standalone artifact emits its user-facing bootstrap logs.
 declare const Deno: any;
 declare const EdgeRuntime: any;
+
+import { Console, Data, Effect, Schema, Stream } from "effect";
 
 import { STATUS_CODE, STATUS_TEXT, toFileUrl } from "./serve-main-deps.ts";
 import {
@@ -11,6 +11,7 @@ import {
   resolveFunctionConfig,
   type FunctionConfig,
   type FunctionFileSystem,
+  FunctionFileSystemError,
   type FunctionOverrides,
 } from "./serve-main-resolver.ts";
 import * as jose from "jose";
@@ -78,7 +79,7 @@ if (Deno.env.get("SUPABASE_INTERNAL_DEBUG") === "true") {
       Object.fromEntries(Object.entries(config).filter(([key]) => key !== "env")),
     ]),
   );
-  console.log("Functions config:", JSON.stringify(debugConfig, null, 2));
+  Effect.runSync(Console.log("Functions config:", JSON.stringify(debugConfig, null, 2)));
 }
 
 const getResponse = (payload: any, status: number, customHeaders = {}) => {
@@ -130,66 +131,86 @@ let localJwks: any = (() => {
     return null;
   }
 })();
-const isValidAsymmetricJWT = async (jwt: string): Promise<{ code: RequestErrors } | null> => {
-  try {
-    if (!localJwks) localJwks = jose.createRemoteJWKSet(JWKS_ENDPOINT);
-    await jose.jwtVerify(jwt, localJwks);
+class BootstrapOperationError extends Data.TaggedError("BootstrapOperationError")<{
+  readonly cause: unknown;
+}> {}
+const foreign = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) => new BootstrapOperationError({ cause }),
+  });
+const isValidAsymmetricJWT = (jwt: string) =>
+  Effect.gen(function* () {
+    if (!localJwks)
+      localJwks = yield* Effect.try({
+        try: () => jose.createRemoteJWKSet(JWKS_ENDPOINT),
+        catch: (cause) => new BootstrapOperationError({ cause }),
+      });
+    yield* foreign(() => jose.jwtVerify(jwt, localJwks));
     return null;
-  } catch {
-    return { code: RequestErrors.InvalidAsymmetricJWT };
-  }
-};
+  }).pipe(Effect.orElseSucceed(() => ({ code: RequestErrors.InvalidAsymmetricJWT })));
 
-export async function verifyHybridJWT(jwtSecret: string, jwksUrl: URL, jwt: string) {
-  try {
-    const algorithm = jose.decodeProtectedHeader(jwt).alg;
+function verifyHybridJWT(jwtSecret: string, jwksUrl: URL, jwt: string) {
+  return Effect.gen(function* () {
+    const algorithm = yield* Effect.try({
+      try: () => jose.decodeProtectedHeader(jwt).alg,
+      catch: (cause) => new BootstrapOperationError({ cause }),
+    });
     if (!algorithm)
       return { code: RequestErrors.InvalidTokenFormat, message: "Invalid JWT format" };
-    if (algorithm === "HS256") {
-      try {
-        await jose.jwtVerify(jwt, new TextEncoder().encode(jwtSecret));
-        return null;
-      } catch {
-        return { code: RequestErrors.InvalidLegacyJWT };
-      }
-    }
-    if (algorithm === "ES256" || algorithm === "RS256") return isValidAsymmetricJWT(jwt);
+    if (algorithm === "HS256")
+      return yield* foreign(() => jose.jwtVerify(jwt, new TextEncoder().encode(jwtSecret))).pipe(
+        Effect.as(null),
+        Effect.orElseSucceed(() => ({ code: RequestErrors.InvalidLegacyJWT })),
+      );
+    if (algorithm === "ES256" || algorithm === "RS256") return yield* isValidAsymmetricJWT(jwt);
     return {
       code: RequestErrors.UnsupportedTokenAlgorithm,
       message: `Unsupported JWT algorithm ${algorithm}`,
     };
-  } catch {
-    return { code: RequestErrors.InvalidTokenFormat, message: "Invalid JWT format" };
-  }
+  }).pipe(
+    Effect.orElseSucceed(() => ({
+      code: RequestErrors.InvalidTokenFormat,
+      message: "Invalid JWT format",
+    })),
+  );
 }
 
 const denoFileSystem: FunctionFileSystem = {
-  lstat: async (path) => {
-    const info = await Deno.lstat(path);
-    return {
-      isDirectory: info.isDirectory,
-      isFile: info.isFile,
-      isSymbolicLink: info.isSymlink,
-    };
-  },
-  realPath: (path) => Deno.realPath(path),
-  readDirectory: async (path) => {
-    const entries: string[] = [];
-    for await (const entry of Deno.readDir(path)) entries.push(entry.name);
-    return entries;
-  },
+  lstat: (path) =>
+    foreign(() => Deno.lstat(path)).pipe(
+      Effect.mapError((cause) => new FunctionFileSystemError({ cause })),
+      Effect.map((info) => ({
+        isDirectory: info.isDirectory,
+        isFile: info.isFile,
+        isSymbolicLink: info.isSymlink,
+      })),
+    ),
+  realPath: (path) =>
+    foreign(() => Deno.realPath(path)).pipe(
+      Effect.mapError((cause) => new FunctionFileSystemError({ cause })),
+    ),
+  readDirectory: (path) =>
+    Stream.fromAsyncIterable(
+      Deno.readDir(path),
+      (cause) => new BootstrapOperationError({ cause }),
+    ).pipe(
+      Stream.map((entry) => entry.name),
+      Stream.runCollect,
+      Effect.mapError((cause) => new FunctionFileSystemError({ cause })),
+    ),
 };
 
-const functionConfig = (slug: string): Promise<FunctionConfig | undefined> =>
+const functionConfig = (slug: string): Effect.Effect<FunctionConfig | undefined> =>
   resolveFunctionConfig({ root: FUNCTIONS_ROOT, slug, overrides: configured, fs: denoFileSystem });
 const workerServicePath = createWorkerServicePathResolver(() =>
   Deno.makeTempDirSync({ prefix: "supabase-worker-" }),
 );
 
-const shouldUsePackageJsonDiscovery = async (config: FunctionConfig): Promise<boolean> => {
-  if (config.importMapPath) return false;
-  return packageJsonContainedFor({ root: FUNCTIONS_ROOT, config, fs: denoFileSystem });
-};
+const shouldUsePackageJsonDiscovery = (config: FunctionConfig): Effect.Effect<boolean> =>
+  config.importMapPath
+    ? Effect.succeed(false)
+    : packageJsonContainedFor({ root: FUNCTIONS_ROOT, config, fs: denoFileSystem });
 
 export function prepareUserRequest(request: Request): Request {
   const url = new URL(request.url);
@@ -202,81 +223,102 @@ export function prepareUserRequest(request: Request): Request {
 }
 
 Deno.serve({
-  handler: async (request: Request) => {
-    const { pathname } = new URL(request.url);
-    if (pathname === "/_internal/health") return getResponse({ message: "ok" }, STATUS_CODE.OK);
-    if (pathname === "/_internal/metric")
-      return Response.json(await EdgeRuntime.getRuntimeMetrics());
-    const functionName = pathname.split("/")[1];
-    if (!functionName) return getResponse("Function not found", STATUS_CODE.NotFound);
-    const config = await functionConfig(functionName);
-    if (!config) return getResponse("Function not found", STATUS_CODE.NotFound);
-    if (request.method !== "OPTIONS" && config.verifyJWT) {
-      const token = getAuthToken(request);
-      if (typeof token !== "string") return getAuthErrorResponse(token);
-      const authFailure = await verifyHybridJWT(JWT_SECRET, JWKS_ENDPOINT, token);
-      if (authFailure) return getAuthErrorResponse(authFailure);
-    }
-    const envVarsObj = {
-      ...Deno.env.toObject(),
-      ...Object.fromEntries(
-        Object.entries(config.env ?? {}).filter(([name]) => !name.startsWith("SUPABASE_")),
-      ),
-      SUPABASE_FUNCTION_SLUG: functionName,
-    };
-    if (SUPABASE_PUBLISHABLE_KEY)
-      envVarsObj.SUPABASE_PUBLISHABLE_KEYS = JSON.stringify({ default: SUPABASE_PUBLISHABLE_KEY });
-    if (SUPABASE_SECRET_KEY)
-      envVarsObj.SUPABASE_SECRET_KEYS = JSON.stringify({ default: SUPABASE_SECRET_KEY });
-    const envVars = Object.entries(envVarsObj).filter(
-      ([name]) => !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_"),
-    );
-    try {
-      const worker = await EdgeRuntime.userWorkers.create({
-        servicePath: workerServicePath(functionName, config),
-        memoryLimitMb: 256,
-        workerTimeoutMs: Number.isFinite(WALLCLOCK_LIMIT_SEC)
-          ? WALLCLOCK_LIMIT_SEC * 1000
-          : 400_000,
-        noModuleCache: true,
-        noNpm: !(await shouldUsePackageJsonDiscovery(config)),
-        importMapPath: config.importMapPath,
-        envVars,
-        forceCreate: true,
-        customModuleRoot: "",
-        cpuTimeSoftLimitMs: 1000,
-        cpuTimeHardLimitMs: 2000,
-        decoratorType: "tc39",
-        maybeEntrypoint: toFileUrl(config.entrypointPath).href,
-        context: { useReadSyncFileAPI: true },
-        staticPatterns: config.staticFiles,
-      });
-      return await worker.fetch(prepareUserRequest(request));
-    } catch (error) {
-      console.error("[functions] worker error", error);
-      for (const [denoError, sbCode] of DENO_SB_ERROR_MAP.entries()) {
-        if (denoError !== undefined && error instanceof denoError)
-          return getResponse(
-            { code: SB_SPECIFIC_ERROR_TEXT[sbCode], message: SB_SPECIFIC_ERROR_REASON[sbCode] },
-            sbCode,
+  handler: (request: Request) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const { pathname } = new URL(request.url);
+        if (pathname === "/_internal/health") return getResponse({ message: "ok" }, STATUS_CODE.OK);
+        if (pathname === "/_internal/metric")
+          return Response.json(yield* foreign(() => EdgeRuntime.getRuntimeMetrics()));
+        const functionName = pathname.split("/")[1];
+        if (!functionName) return getResponse("Function not found", STATUS_CODE.NotFound);
+        const config = yield* functionConfig(functionName);
+        if (!config) return getResponse("Function not found", STATUS_CODE.NotFound);
+        if (request.method !== "OPTIONS" && config.verifyJWT) {
+          const token = getAuthToken(request);
+          if (typeof token !== "string") return getAuthErrorResponse(token);
+          const authFailure = yield* verifyHybridJWT(JWT_SECRET, JWKS_ENDPOINT, token);
+          if (authFailure) return getAuthErrorResponse(authFailure);
+        }
+        const envVarsObj = {
+          ...Deno.env.toObject(),
+          ...Object.fromEntries(
+            Object.entries(config.env ?? {}).filter(([name]) => !name.startsWith("SUPABASE_")),
+          ),
+          SUPABASE_FUNCTION_SLUG: functionName,
+        };
+        if (SUPABASE_PUBLISHABLE_KEY)
+          envVarsObj.SUPABASE_PUBLISHABLE_KEYS = yield* Schema.encodeEffect(
+            Schema.fromJsonString(Schema.Unknown),
+          )({ default: SUPABASE_PUBLISHABLE_KEY });
+        if (SUPABASE_SECRET_KEY)
+          envVarsObj.SUPABASE_SECRET_KEYS = yield* Schema.encodeEffect(
+            Schema.fromJsonString(Schema.Unknown),
+          )({ default: SUPABASE_SECRET_KEY });
+        const envVars = Object.entries(envVarsObj).filter(
+          ([name]) => !EXCLUDED_ENVS.includes(name) && !name.startsWith("SUPABASE_INTERNAL_"),
+        );
+        const noNpm = !(yield* shouldUsePackageJsonDiscovery(config));
+        return yield* Effect.gen(function* () {
+          const worker = yield* foreign(() =>
+            EdgeRuntime.userWorkers.create({
+              servicePath: workerServicePath(functionName, config),
+              memoryLimitMb: 256,
+              workerTimeoutMs: Number.isFinite(WALLCLOCK_LIMIT_SEC)
+                ? WALLCLOCK_LIMIT_SEC * 1000
+                : 400_000,
+              noModuleCache: true,
+              noNpm,
+              importMapPath: config.importMapPath,
+              envVars,
+              forceCreate: true,
+              customModuleRoot: "",
+              cpuTimeSoftLimitMs: 1000,
+              cpuTimeHardLimitMs: 2000,
+              decoratorType: "tc39",
+              maybeEntrypoint: toFileUrl(config.entrypointPath).href,
+              context: { useReadSyncFileAPI: true },
+              staticPatterns: config.staticFiles,
+            }),
           );
-      }
-      return getResponse(
-        {
-          code: STATUS_TEXT[STATUS_CODE.InternalServerError],
-          message: "Request failed due to an internal server error",
-        },
-        STATUS_CODE.InternalServerError,
-      );
-    }
-  },
+          return yield* foreign(() => worker.fetch(prepareUserRequest(request)));
+        }).pipe(
+          Effect.catch((failure) =>
+            Effect.gen(function* () {
+              const error = failure.cause;
+              yield* Console.error("[functions] worker error", error);
+              for (const [denoError, sbCode] of DENO_SB_ERROR_MAP.entries()) {
+                if (denoError !== undefined && error instanceof denoError)
+                  return getResponse(
+                    {
+                      code: SB_SPECIFIC_ERROR_TEXT[sbCode],
+                      message: SB_SPECIFIC_ERROR_REASON[sbCode],
+                    },
+                    sbCode,
+                  );
+              }
+              return getResponse(
+                {
+                  code: STATUS_TEXT[STATUS_CODE.InternalServerError],
+                  message: "Request failed due to an internal server error",
+                },
+                STATUS_CODE.InternalServerError,
+              );
+            }),
+          ),
+        );
+      }),
+      { signal: request.signal },
+    ),
   onListen: () => {
     const names = Object.keys(configured);
     const examples = names
       .slice(0, 5)
       .map((name) => ` - http://127.0.0.1:${HOST_PORT}/functions/v1/${name}`);
-    console.log(
-      `Serving functions on http://127.0.0.1:${HOST_PORT}/functions/v1/<function-name>${examples.length ? `\n${examples.join("\n")}` : ""}\nUsing ${Deno.version.deno}`,
+    Effect.runSync(
+      Console.log(
+        `Serving functions on http://127.0.0.1:${HOST_PORT}/functions/v1/<function-name>${examples.length ? `\n${examples.join("\n")}` : ""}\nUsing ${Deno.version.deno}`,
+      ),
     );
   },
   onError: () =>

--- a/packages/stack/src/gateway/HttpGateway.ts
+++ b/packages/stack/src/gateway/HttpGateway.ts
@@ -1,12 +1,11 @@
 import { Cause, Data, Effect, Exit, FiberSet, Option, Queue, Scope } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import {
   createServer,
   request as proxyRequest,
   type IncomingMessage,
   type Server,
   type ServerResponse,
-  // oxlint-disable-next-line effecttsgo/node-builtin-import
+  // oxlint-disable-next-line effecttsgo/node-builtin-import -- transparent upgrade proxying needs raw handshake bytes; Effect upgrades terminate WebSockets.
 } from "node:http";
 import { Socket } from "node:net";
 import type { Duplex } from "node:stream";

--- a/packages/stack/src/gateway/TcpGateway.ts
+++ b/packages/stack/src/gateway/TcpGateway.ts
@@ -1,6 +1,5 @@
 import { Effect, Exit, FiberSet, Scope } from "effect";
 import { createServer, Socket, type Server } from "node:net";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import type { Duplex } from "node:stream";
 import type { Fiber } from "effect/Fiber";
 import { GatewayActivationError } from "../public/Errors.ts";

--- a/packages/stack/src/gateway/gateway.integration.test.ts
+++ b/packages/stack/src/gateway/gateway.integration.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Option, Queue } from "effect";
 import { GatewayActivationError } from "../public/Errors.ts";
 import { connect as connectNet, createServer, type Server, type Socket } from "node:net";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import {
   Agent,
   type ClientRequest,
@@ -11,7 +10,7 @@ import {
   request as requestHttp,
   type IncomingMessage,
   type ServerResponse,
-  // oxlint-disable-next-line effecttsgo/node-builtin-import
+  // oxlint-disable-next-line effecttsgo/node-builtin-import -- fixture exercises raw HTTP proxy behavior.
 } from "node:http";
 import {
   GatewayRouteNotFoundError,

--- a/packages/stack/src/preparation/SlimServicesSource.ts
+++ b/packages/stack/src/preparation/SlimServicesSource.ts
@@ -1,10 +1,13 @@
-import { Effect, FileSystem, Path, Schema } from "effect";
+import { Effect, FileSystem, Layer, Path, Schema, Stream } from "effect";
+import { NodeStream } from "@effect/platform-node";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientError,
+  HttpClientResponse,
+} from "effect/unstable/http";
 import { createZstdDecompress } from "node:zlib";
 import { createHash } from "node:crypto";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- file-backed streaming avoids archive-sized buffers
-import { createReadStream, createWriteStream } from "node:fs";
-import { Readable, Transform } from "node:stream";
-import { pipeline } from "node:stream/promises";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type { ArtifactRequest, ArtifactSource } from "./ArtifactStore.ts";
 import type { NativeWorkloadArtifact } from "../model/WorkloadCatalog.ts";
@@ -16,7 +19,7 @@ export interface ZstdDecompressor {
   readonly decompress: (
     compressedPath: string,
     outputPath: string,
-  ) => Effect.Effect<void, StackPreparationError>;
+  ) => Effect.Effect<void, StackPreparationError, FileSystem.FileSystem>;
 }
 
 export interface TarBoundary {
@@ -68,102 +71,113 @@ export const systemTarBoundary: TarBoundary = {
         );
     }),
 };
-// oxlint-disable-next-line effecttsgo/global-fetch -- foreign HTTP boundary; production wiring may swap in an Effect HttpClient-backed fetcher.
-const fetcher: Fetcher = (input, init) => globalThis.fetch(input, init);
+const transport = (fetchRequest?: Fetcher) =>
+  fetchRequest === undefined
+    ? FetchHttpClient.layer
+    : Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((request, url, signal) =>
+          Effect.tryPromise({
+            try: () =>
+              fetchRequest(url.href, { signal, method: request.method, headers: request.headers }),
+            catch: (cause) =>
+              new HttpClientError.HttpClientError({
+                reason: new HttpClientError.TransportError({ request, cause }),
+              }),
+          }).pipe(Effect.map((response) => HttpClientResponse.fromWeb(request, response))),
+        ),
+      );
+
+const responseFor = (url: string) =>
+  HttpClient.get(url).pipe(
+    Effect.flatMap((response) =>
+      Effect.gen(function* () {
+        if (response.status < 200 || response.status >= 300)
+          return yield* new StackPreparationError({ message: `HTTP ${response.status}` });
+        return response;
+      }),
+    ),
+  );
 
 const fetchBytes = (
   url: string,
-  request: Fetcher = fetcher,
+  request?: Fetcher,
 ): Effect.Effect<Uint8Array, StackPreparationError> =>
-  Effect.tryPromise({
-    try: (signal) =>
-      request(url, { signal })
-        .then((response) => {
-          if (!response.ok) throw new Error(`HTTP ${response.status}`);
-          return response.arrayBuffer();
-        })
-        .then((bytes) => new Uint8Array(bytes)),
-    catch: (cause) => new StackPreparationError({ message: `Unable to download ${url}`, cause }),
-  });
+  responseFor(url).pipe(
+    Effect.flatMap((response) => response.arrayBuffer),
+    Effect.map((bytes) => new Uint8Array(bytes)),
+    Effect.mapError(
+      (cause) => new StackPreparationError({ message: `Unable to download ${url}`, cause }),
+    ),
+    Effect.provide(transport(request)),
+  );
 
-/** Owned streaming zstd boundary. Cancellation aborts and awaits the exact pipeline. */
 const nodeZstdDecompressor: ZstdDecompressor = {
   decompress: (compressedPath, outputPath) =>
-    Effect.callback<void, StackPreparationError>((resume) => {
-      const controller = new AbortController();
-      const operation = pipeline(
-        createReadStream(compressedPath),
-        createZstdDecompress(),
-        createWriteStream(outputPath, { mode: 0o600 }),
-        { signal: controller.signal },
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      yield* fs.stream(compressedPath).pipe(
+        NodeStream.pipeThroughDuplex({
+          evaluate: () => createZstdDecompress(),
+          onError: (cause) =>
+            new StackPreparationError({
+              message: "Unable to decompress slim-services archive",
+              cause,
+            }),
+        }),
+        Stream.run(fs.sink(outputPath, { mode: 0o600 })),
       );
-      void operation.then(
-        () => resume(Effect.void),
+    }).pipe(
+      Effect.mapError(
         (cause) =>
-          resume(
-            Effect.fail(
-              new StackPreparationError({
-                message: "Unable to decompress slim-services archive",
-                cause,
-              }),
-            ),
-          ),
-      );
-      return Effect.gen(function* () {
-        controller.abort();
-        yield* Effect.promise(() =>
-          operation.then(
-            () => undefined,
-            () => undefined,
-          ),
-        );
-      });
-    }),
+          new StackPreparationError({
+            message: "Unable to decompress slim-services archive",
+            cause,
+          }),
+      ),
+    ),
 };
 
 const downloadToFile = (
   url: string,
   destination: string,
-  request: Fetcher,
+  request: Fetcher | undefined,
   expectedSha256: string,
-): Effect.Effect<void, StackPreparationError> =>
-  Effect.callback<void, StackPreparationError>((resume) => {
-    const controller = new AbortController();
-    // oxlint-disable-next-line effecttsgo/async-function -- foreign pipeline must settle before cancellation cleanup
-    const operation = (async () => {
-      const response = await request(url, { signal: controller.signal });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      if (response.body === null) throw new Error("Response body is empty");
-      const source = Readable.fromWeb(response.body);
-      const hash = createHash("sha256");
-      const digest = new Transform({
-        transform(chunk: Buffer, _encoding, callback) {
-          hash.update(chunk);
-          callback(null, chunk);
-        },
-      });
-      await pipeline(source, digest, createWriteStream(destination, { mode: 0o600 }), {
-        signal: controller.signal,
-      });
-      const actual = hash.digest("hex");
-      if (actual !== expectedSha256.toLowerCase())
-        throw new Error(`expected ${expectedSha256}, got ${actual}`);
-    })();
-    const failure = (cause: unknown) =>
-      resume(
-        Effect.fail(new StackPreparationError({ message: `Unable to download ${url}`, cause })),
-      );
-    void operation.then(() => resume(Effect.void), failure);
-    return Effect.gen(function* () {
-      controller.abort();
-      yield* Effect.promise(() =>
-        operation.then(
-          () => undefined,
-          () => undefined,
-        ),
-      );
+): Effect.Effect<void, StackPreparationError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const response = yield* responseFor(url);
+    const hash = yield* Effect.try({
+      try: () => createHash("sha256"),
+      catch: (cause) =>
+        new StackPreparationError({ message: "Unable to initialize archive digest", cause }),
     });
-  });
+    yield* response.stream.pipe(
+      Stream.tap((chunk) =>
+        Effect.try({
+          try: () => {
+            hash.update(chunk);
+          },
+          catch: (cause) => new StackPreparationError({ message: "Unable to hash archive", cause }),
+        }),
+      ),
+      Stream.run(fs.sink(destination, { mode: 0o600 })),
+    );
+    const actual = yield* Effect.try({
+      try: () => hash.digest("hex"),
+      catch: (cause) =>
+        new StackPreparationError({ message: "Unable to finish archive digest", cause }),
+    });
+    if (actual !== expectedSha256.toLowerCase())
+      return yield* new StackPreparationError({
+        message: `expected ${expectedSha256}, got ${actual}`,
+      });
+  }).pipe(
+    Effect.mapError(
+      (cause) => new StackPreparationError({ message: `Unable to download ${url}`, cause }),
+    ),
+    Effect.provide(transport(request)),
+  );
 
 const checksumFor = (contents: string, archiveName: string): string | undefined =>
   contents
@@ -173,7 +187,7 @@ const checksumFor = (contents: string, archiveName: string): string | undefined 
 
 export const slimServicesChecksum = (
   artifact: NativeWorkloadArtifact,
-  request: Fetcher = fetcher,
+  request?: Fetcher,
 ): Effect.Effect<string, StackPreparationError> =>
   fetchBytes(artifact.checksumUrl, request).pipe(
     Effect.map((bytes) => new TextDecoder().decode(bytes)),
@@ -262,7 +276,7 @@ const validateExtractedTree = (
 
 export const makeSlimServicesSource = (
   resolve: (request: ArtifactRequest) => NativeWorkloadArtifact | undefined,
-  fetchRequest: Fetcher = fetcher,
+  fetchRequest?: Fetcher,
   tarBoundary: TarBoundary = systemTarBoundary,
   decompressor: ZstdDecompressor = nodeZstdDecompressor,
 ): ArtifactSource => {

--- a/packages/stack/src/preparation/slim-services.integration.test.ts
+++ b/packages/stack/src/preparation/slim-services.integration.test.ts
@@ -13,6 +13,12 @@ import {
 import type { NativeWorkloadArtifact } from "../model/WorkloadCatalog.ts";
 import { StackPreparationError } from "../public/Errors.ts";
 
+const waitForAbort = (signal?: AbortSignal | null): Promise<never> =>
+  Effect.runPromise(Effect.never, { signal: signal ?? undefined });
+
+const waitForRelease = (released: Deferred.Deferred<void>): Promise<void> =>
+  Effect.runPromise(Deferred.await(released));
+
 const artifact: NativeWorkloadArtifact = {
   provider: "supabase/slim-services",
   service: "demo",
@@ -271,12 +277,8 @@ describe("slim-services artifact source", () => {
               new Response("0".repeat(64) + "  demo-v1.0.0-linux-amd64.tar.zst\n"),
             );
           signal = init?.signal ?? undefined;
-          // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- signal the test's injected fetch boundary
-          void Effect.runPromise(Deferred.succeed(started, undefined));
-          // oxlint-disable-next-line effecttsgo/new-promise -- fetch fixture intentionally remains pending until abort
-          return new Promise<Response>((_resolve, reject) => {
-            signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
-          });
+          Deferred.doneUnsafe(started, Effect.void);
+          return waitForAbort(signal);
         };
         const fs = yield* FileSystem.FileSystem;
         const destination = yield* fs.makeTempDirectoryScoped({
@@ -357,6 +359,7 @@ describe("slim-services artifact source", () => {
             );
           signal = init?.signal ?? undefined;
           let pulls = 0;
+          const released = Deferred.makeUnsafe<void>();
           const body = new ReadableStream<Uint8Array>({
             pull(controller) {
               pulls += 1;
@@ -364,14 +367,13 @@ describe("slim-services artifact source", () => {
                 controller.enqueue(new Uint8Array([1]));
                 return;
               }
-              // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- signal the stream fixture's external Deferred
-              void Effect.runPromise(Deferred.succeed(started, undefined));
-              // oxlint-disable-next-line effecttsgo/new-promise -- hold the stream pull until cancellation
-              return new Promise<void>(() => undefined);
+              Deferred.doneUnsafe(started, Effect.void);
+              return waitForRelease(released);
             },
             cancel() {
               canceled = true;
               pulls = 99;
+              Deferred.doneUnsafe(released, Effect.void);
             },
           });
           return Promise.resolve(new Response(body));
@@ -406,8 +408,7 @@ describe("slim-services artifact source", () => {
         const decompressor: ZstdDecompressor = {
           decompress: () =>
             Effect.callback((_resume) => {
-              // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- test boundary signal
-              void Effect.runPromise(Deferred.succeed(started, undefined));
+              Deferred.doneUnsafe(started, Effect.void);
               return Effect.sync(() => {
                 destroyed = true;
               });

--- a/packages/stack/src/public/EffectStack.ts
+++ b/packages/stack/src/public/EffectStack.ts
@@ -172,24 +172,15 @@ export interface PrepareStackResult {
 
 export interface EffectStack {
   readonly id: StackId;
-  // Each of these methods opens a fresh scoped RPC invocation per call.
-  // oxlint-disable-next-line effecttsgo/lazy-effect
-  readonly status: () => Effect.Effect<StackStatus, StackStatusError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
-  readonly credentials: () => Effect.Effect<EffectStackCredentials, StackCredentialsError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
+  readonly status: Effect.Effect<StackStatus, StackStatusError>;
+  readonly credentials: Effect.Effect<EffectStackCredentials, StackCredentialsError>;
   readonly prepare: (
     options?: PrepareStackOptions,
   ) => Effect.Effect<PrepareStackResult, PrepareStackError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
   readonly start: (options?: StartStackOptions) => Effect.Effect<StackStatus, StackStartError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
-  readonly stop: () => Effect.Effect<void, StackStopError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
-  readonly destroy: () => Effect.Effect<void, DestroyStackError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
+  readonly stop: Effect.Effect<void, StackStopError>;
+  readonly destroy: Effect.Effect<void, DestroyStackError>;
   readonly logs: (query?: LogQuery) => Effect.Effect<StackLogBatch, StackLogsError>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect
   readonly followLogs: (query?: LogQuery) => Stream.Stream<StackLogEntry, StackLogsError>;
 }
 
@@ -207,7 +198,9 @@ const descriptor = (state: PersistedStackState, id: StackId): StackDescriptor =>
 
 const environment = () =>
   Effect.serviceOption(StackRuntimeEnvironment).pipe(
-    Effect.map(Option.getOrElse(defaultRuntimeEnvironment)),
+    Effect.flatMap((configured) =>
+      Option.isSome(configured) ? Effect.succeed(configured.value) : defaultRuntimeEnvironment,
+    ),
   );
 
 const isCapabilityName = (value: unknown): value is CapabilityName =>
@@ -377,7 +370,7 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
             ownerSessionId: owner.ownerSessionId,
             rpcRelease: owner.rpcRelease,
           });
-          const stop = yield* Effect.exit(client.stop());
+          const stop = yield* Effect.exit(client.stop);
           if (
             Exit.isSuccess(stop) &&
             !stop.value.ok &&
@@ -529,54 +522,59 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
         }),
       ),
     );
-    const destroy = (): Effect.Effect<void, DestroyStackError> =>
+    const destroy: Effect.Effect<void, DestroyStackError> = Effect.suspend(() =>
       options.readPersistedState.pipe(
         Effect.mapError(destroyError),
         Effect.flatMap((state) =>
           Option.isNone(state) ? Effect.fail(stackNotFound()) : destroyAndAwaitOwner,
         ),
-      );
-    const status = (): Effect.Effect<StackStatus, StackStatusError> => {
-      const rpcStatus = invoke((rpc) => rpc.status(undefined), statusError);
-      return rpcStatus.pipe(
-        Effect.catchTag("StackOwnershipConflictError", (ownershipError) =>
-          options.readOfflineState.pipe(
-            Effect.mapError(statusError),
-            Effect.flatMap((state): Effect.Effect<StackStatus, StackStatusError> => {
-              if (Option.isNone(state)) return Effect.fail(stackNotFound());
-              if (isStoppedState(state.value))
-                return statusFor(id, state.value, [], new Set<CapabilityName>(), "stopped");
-              return Effect.fail(
-                new StackOwnershipConflictError({ message: "No Supervisor owns this stack" }),
-              );
-            }),
-            Effect.catchTag("StackOwnershipConflictError", () => Effect.fail(ownershipError)),
-          ),
-        ),
-      );
-    };
-    const credentials = (): Effect.Effect<EffectStackCredentials, StackCredentialsError> =>
-      invoke((rpc) => rpc.credentials(undefined), credentialsError).pipe(
-        Effect.catchTag("StackOwnershipConflictError", (ownershipError) => {
-          const offline: Effect.Effect<never, StackCredentialsError> =
+      ),
+    );
+    const status: Effect.Effect<StackStatus, StackStatusError> = Effect.suspend(
+      (): Effect.Effect<StackStatus, StackStatusError> => {
+        const rpcStatus = invoke((rpc) => rpc.status(undefined), statusError);
+        return rpcStatus.pipe(
+          Effect.catchTag("StackOwnershipConflictError", (ownershipError) =>
             options.readOfflineState.pipe(
-              Effect.mapError(credentialsError),
-              Effect.flatMap((state): Effect.Effect<never, StackCredentialsError> =>
-                Option.isNone(state)
-                  ? Effect.fail(stackNotFound())
-                  : isStoppedState(state.value)
-                    ? Effect.fail(
-                        new StackNotRunningError({
-                          stackId: id,
-                          message: "Stack is not running",
-                        }),
-                      )
-                    : Effect.fail(ownershipError),
-              ),
+              Effect.mapError(statusError),
+              Effect.flatMap((state): Effect.Effect<StackStatus, StackStatusError> => {
+                if (Option.isNone(state)) return Effect.fail(stackNotFound());
+                if (isStoppedState(state.value))
+                  return statusFor(id, state.value, [], new Set<CapabilityName>(), "stopped");
+                return Effect.fail(
+                  new StackOwnershipConflictError({ message: "No Supervisor owns this stack" }),
+                );
+              }),
               Effect.catchTag("StackOwnershipConflictError", () => Effect.fail(ownershipError)),
-            );
-          return offline;
-        }),
+            ),
+          ),
+        );
+      },
+    );
+    const credentials: Effect.Effect<EffectStackCredentials, StackCredentialsError> =
+      Effect.suspend((): Effect.Effect<EffectStackCredentials, StackCredentialsError> =>
+        invoke((rpc) => rpc.credentials(undefined), credentialsError).pipe(
+          Effect.catchTag("StackOwnershipConflictError", (ownershipError) => {
+            const offline: Effect.Effect<never, StackCredentialsError> =
+              options.readOfflineState.pipe(
+                Effect.mapError(credentialsError),
+                Effect.flatMap((state): Effect.Effect<never, StackCredentialsError> =>
+                  Option.isNone(state)
+                    ? Effect.fail(stackNotFound())
+                    : isStoppedState(state.value)
+                      ? Effect.fail(
+                          new StackNotRunningError({
+                            stackId: id,
+                            message: "Stack is not running",
+                          }),
+                        )
+                      : Effect.fail(ownershipError),
+                ),
+                Effect.catchTag("StackOwnershipConflictError", () => Effect.fail(ownershipError)),
+              );
+            return offline;
+          }),
+        ),
       );
     const start = (startOptions?: StartStackOptions) => {
       return invoke(
@@ -608,7 +606,7 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
         // Subscribe to the owner control connection before sending stop so a
         // fast shutdown cannot race the close witness.
         const closeFiber = yield* Effect.forkChild(owner.awaitClose(), { startImmediately: true });
-        const response = yield* owner.stop().pipe(Effect.exit);
+        const response = yield* owner.stop.pipe(Effect.exit);
         if (Exit.isFailure(response)) {
           yield* Fiber.interrupt(closeFiber);
           return yield* Effect.failCause(response.cause);
@@ -633,7 +631,7 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
       Effect.mapError(stopError),
       Effect.flatMap(({ client }) => stopOwner(client)),
     );
-    const stop = () =>
+    const stop: Effect.Effect<void, StackStopError> = Effect.suspend(() =>
       resolveClient(false, "maintenance").pipe(
         Effect.mapError(stopError),
         Effect.flatMap(({ client }) => stopOwner(client)),
@@ -649,7 +647,8 @@ export const makeHandle = (id: StackId, options: HandleDependencies): Effect.Eff
             Effect.catchTag("StackOwnershipConflictError", () => launchAndStop),
           ),
         ),
-      );
+      ),
+    );
     const prepare = (
       prepareOptions?: PrepareStackOptions,
     ): Effect.Effect<PrepareStackResult, PrepareStackError> => options.prepare(prepareOptions);

--- a/packages/stack/src/public/EffectStack.ts
+++ b/packages/stack/src/public/EffectStack.ts
@@ -27,6 +27,7 @@ import { toPersistedIdentity } from "../state/StackState.ts";
 import {
   isMissingStateRemnantError,
   makeStackStateStore,
+  withRegistryLock,
   type StackStateStore,
 } from "../state/StackStateStore.ts";
 import { resolveStackPaths } from "../state/Paths.ts";
@@ -979,15 +980,18 @@ export const createStack = (
     });
     const stackId = yield* deriveStackId(identity);
     const store = yield* makeStackStateStore({ stateRoot: env.stateRoot });
-    const persisted = yield* store
-      .read(stackId)
-      .pipe(
-        Effect.catch((error) =>
-          isMissingStateRemnantError(error)
-            ? Effect.map(Effect.void, () => undefined)
-            : Effect.fail(error),
+    const persisted = yield* withRegistryLock(
+      env.stateRoot,
+      store
+        .read(stackId)
+        .pipe(
+          Effect.catch((error) =>
+            isMissingStateRemnantError(error)
+              ? Effect.map(Effect.void, () => undefined)
+              : Effect.fail(error),
+          ),
         ),
-      );
+    );
     const resolverOption = yield* Effect.serviceOption(ContainerEngineResolver).pipe(
       Effect.map(Option.getOrUndefined),
     );

--- a/packages/stack/src/public/PromiseStack.ts
+++ b/packages/stack/src/public/PromiseStack.ts
@@ -24,9 +24,6 @@ import type { PreparedCapability, PrepareStackResult } from "./EffectStack.ts";
 import { InvalidStackConfigError } from "./Errors.ts";
 import { StackRuntimeEnvironment, type StackRuntimeEnvironmentValue } from "../state/Ownership.ts";
 
-// oxlint-disable effecttsgo/async-function -- Promise facade methods must expose Promise/AsyncIterable APIs.
-// oxlint-disable effecttsgo/any-unknown-in-error-context -- Promise callers receive native rejection values.
-
 /** Recursively replaces Effect `Redacted` leaves with their plain value. */
 type Unredacted<T> =
   T extends Redacted.Redacted<infer Value>
@@ -105,11 +102,11 @@ const adaptStream = <A, E>(stream: Stream.Stream<A, E>): AsyncIterable<A> =>
 
 /** Adapts an already-created Effect handle; exported for facade integration tests. */
 export const adaptEffectStack = (effectStack: EffectStack): PromiseStack => {
-  const invoke = <A>(effect: Effect.Effect<A, unknown>): Promise<A> => Effect.runPromise(effect);
+  const invoke = <A>(effect: Effect.Effect<A, Error>): Promise<A> => Effect.runPromise(effect);
   const withConfig = <A>(
     options: { readonly config?: PromiseStackConfig } | undefined,
-    operation: (config?: StackConfig) => Effect.Effect<A, unknown>,
-  ): Effect.Effect<A, unknown> =>
+    operation: (config?: StackConfig) => Effect.Effect<A, Error>,
+  ): Effect.Effect<A, Error> =>
     Effect.gen(function* () {
       const config =
         options?.config === undefined ? undefined : yield* decodePromiseConfig(options.config);
@@ -117,9 +114,9 @@ export const adaptEffectStack = (effectStack: EffectStack): PromiseStack => {
     });
   return {
     id: effectStack.id,
-    status: () => invoke(effectStack.status()),
+    status: () => invoke(effectStack.status),
     credentials: () =>
-      invoke(effectStack.credentials()).then((value) =>
+      invoke(effectStack.credentials).then((value) =>
         Schema.decodeSync(PromiseStackCredentialsSchema)(unredact(value)),
       ),
     prepare: (options) =>
@@ -146,8 +143,8 @@ export const adaptEffectStack = (effectStack: EffectStack): PromiseStack => {
             : effectStack.start(config === undefined ? {} : { config }),
         ),
       ),
-    stop: () => invoke(effectStack.stop()),
-    destroy: () => invoke(effectStack.destroy()),
+    stop: () => invoke(effectStack.stop),
+    destroy: () => invoke(effectStack.destroy),
     logs: (query) => invoke(effectStack.logs(query)),
     followLogs: (query) => adaptStream(effectStack.followLogs(query)),
   };
@@ -161,13 +158,12 @@ export const makePromiseApi = (
     runtimeEnvironment === undefined
       ? platformLayer
       : Layer.mergeAll(platformLayer, Layer.succeed(StackRuntimeEnvironment, runtimeEnvironment));
-  const run = async <A, E>(effect: Effect.Effect<A, E, RuntimeRequirements>): Promise<A> => {
-    return await Effect.runPromise(effect.pipe(Effect.provide(providedLayer)));
-  };
+  const run = <A, E>(effect: Effect.Effect<A, E, RuntimeRequirements>): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provide(providedLayer)));
 
-  const createOrOpen = async (
-    effect: Effect.Effect<EffectStack, unknown, RuntimeRequirements>,
-  ): Promise<PromiseStack> => adaptEffectStack(await run(effect));
+  const createOrOpen = (
+    effect: Effect.Effect<EffectStack, Error, RuntimeRequirements>,
+  ): Promise<PromiseStack> => run(effect).then(adaptEffectStack);
   return {
     createStack: (options) => createOrOpen(createEffectStack(options)),
     openStack: (id) => createOrOpen(openEffectStack(id)),

--- a/packages/stack/src/public/Testing.ts
+++ b/packages/stack/src/public/Testing.ts
@@ -1,24 +1,37 @@
-// oxlint-disable effecttsgo/async-function -- AsyncDisposable is the public test-resource contract.
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- test resource owns its exact temp directory.
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- test resource builds an isolated root.
-import { dirname, join } from "node:path";
 import { NodeServices } from "@effect/platform-node";
-import { Data } from "effect";
+import { Cause, Data, Effect, Exit, FileSystem, Path } from "effect";
 import { defaultRuntimeEnvironment } from "../supervisor/Launcher.ts";
-import {
-  makePromiseApi,
-  type PromiseStack,
-  type PromiseStackConfig,
-  type PromiseStartStackOptions,
-} from "./PromiseStack.ts";
+import { makePromiseApi, type PromiseStack, type PromiseStackConfig } from "./PromiseStack.ts";
 import type { CreateStackOptions } from "./EffectStack.ts";
 import type { StackRuntimeEnvironmentValue } from "../state/Ownership.ts";
 
 class TestStackReadinessError extends Data.TaggedError("TestStackReadinessError")<{
   readonly message: string;
+  readonly cause?: unknown;
 }> {}
+
+class TestStackOperationError extends Data.TaggedError("TestStackOperationError")<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+const call = <A>(operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) =>
+      new TestStackOperationError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      }),
+  });
+
+const run = <A, E>(program: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromiseExit(program).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    const error = Cause.squash(exit.cause);
+    throw error instanceof TestStackOperationError ? error.cause : error;
+  });
 export interface CreateTestStackOptions {
   readonly config?: PromiseStackConfig;
   readonly name?: string;
@@ -47,26 +60,36 @@ export interface TestStackOperations {
 
 type TestStackOperationsOverrides = Partial<TestStackOperations>;
 
-const createTestProjectRoot = async (): Promise<string> => {
-  const projectsRoot = join(dirname(defaultRuntimeEnvironment().stateRoot), "test-projects");
-  await mkdir(projectsRoot, { recursive: true });
-  return mkdtemp(join(projectsRoot, "supabase-stack-test-"));
-};
+const createTestProjectRoot = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const projectsRoot = path.join(
+    path.dirname((yield* defaultRuntimeEnvironment).stateRoot),
+    "test-projects",
+  );
+  yield* fs.makeDirectory(projectsRoot, { recursive: true });
+  return yield* fs.makeTempDirectory({ directory: projectsRoot, prefix: "supabase-stack-test-" });
+});
 
 const defaultOperations: TestStackOperations = {
-  createRoot: createTestProjectRoot,
+  createRoot: () => run(createTestProjectRoot.pipe(Effect.provide(NodeServices.layer))),
   createStack: (options, environment) =>
     makePromiseApi(NodeServices.layer, environment).createStack(options),
-  removeRoot: (root) => rm(root, { recursive: true, force: true }),
+  removeRoot: (root) =>
+    run(
+      Effect.flatMap(FileSystem.FileSystem, (fs) =>
+        fs.remove(root, { recursive: true, force: true }),
+      ).pipe(Effect.provide(NodeServices.layer)),
+    ),
 };
 
-// Native slim-services artifacts are immutable and expensive to download. Keep one
-// shared cache for test stacks while each stack's state/data roots remain disposable.
-const testArtifactCacheRoot = join(tmpdir(), "supabase-stack-test-artifacts");
-
-const testRuntimeEnvironment = (): StackRuntimeEnvironmentValue => ({
-  ...defaultRuntimeEnvironment(),
-  artifactCacheRoot: testArtifactCacheRoot,
+// Sharing immutable native artifacts keeps disposable test roots inexpensive.
+const testRuntimeEnvironment = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  return {
+    ...(yield* defaultRuntimeEnvironment),
+    artifactCacheRoot: path.join(tmpdir(), "supabase-stack-test-artifacts"),
+  } satisfies StackRuntimeEnvironmentValue;
 });
 
 const validateStartedStatus = (
@@ -129,122 +152,135 @@ const validateStartedStatus = (
     }
     return undefined;
   };
-  if (ready(initial)) return;
+  if (ready(initial)) return Effect.void;
   const failure = terminalFailure(initial);
-  throw (
+  return Effect.fail(
     failure ??
-    new TestStackReadinessError({
-      message: `Stack did not become ready after start (lifecycle ${initial.lifecycle})`,
-    })
+      new TestStackReadinessError({
+        message: `Stack did not become ready after start (lifecycle ${initial.lifecycle})`,
+      }),
   );
 };
 
 const STARTUP_DIAGNOSTIC_LOG_TAIL = 50;
 
-const withStartupDiagnostics = async (stack: PromiseStack, primary: unknown): Promise<Error> => {
-  const [snapshot, recentLogs] = await Promise.all([
-    stack.status().catch(() => undefined),
-    stack.logs({ tail: STARTUP_DIAGNOSTIC_LOG_TAIL }).catch(() => undefined),
-  ]);
-  const capabilityStates =
-    snapshot === undefined
-      ? "unavailable"
-      : snapshot.capabilities
-          .map(
-            ({ name, state, error }) =>
-              `${name}=${state}${error === undefined ? "" : ` (${error})`}`,
-          )
-          .join(", ");
-  const logs =
-    recentLogs === undefined
-      ? "unavailable"
-      : recentLogs.entries
-          .slice(-STARTUP_DIAGNOSTIC_LOG_TAIL)
-          .map(({ source, stream, message }) => `${source}/${stream}: ${message}`)
-          .join("\n") || "none";
-  const reason = primary instanceof Error ? primary.message : String(primary);
-  return new Error(
-    [
-      reason,
-      `lifecycle=${snapshot?.lifecycle ?? "unavailable"}`,
-      `capabilities=${capabilityStates}`,
-      `recent logs:\n${logs}`,
-    ].join("; "),
-    { cause: primary },
-  );
-};
+const withStartupDiagnostics = (
+  stack: PromiseStack,
+  primary: TestStackOperationError | TestStackReadinessError,
+) =>
+  Effect.gen(function* () {
+    const [snapshot, recentLogs] = yield* Effect.all(
+      [
+        call(() => stack.status()).pipe(Effect.catch(() => Effect.undefined)),
+        call(() => stack.logs({ tail: STARTUP_DIAGNOSTIC_LOG_TAIL })).pipe(
+          Effect.catch(() => Effect.undefined),
+        ),
+      ],
+      { concurrency: 2 },
+    );
+    const capabilityStates =
+      snapshot === undefined
+        ? "unavailable"
+        : snapshot.capabilities
+            .map(
+              ({ name, state, error }) =>
+                `${name}=${state}${error === undefined ? "" : ` (${error})`}`,
+            )
+            .join(", ");
+    const logs =
+      recentLogs === undefined
+        ? "unavailable"
+        : recentLogs.entries
+            .slice(-STARTUP_DIAGNOSTIC_LOG_TAIL)
+            .map(({ source, stream, message }) => `${source}/${stream}: ${message}`)
+            .join("\n") || "none";
+    return new TestStackReadinessError({
+      message: [
+        primary.message,
+        `lifecycle=${snapshot?.lifecycle ?? "unavailable"}`,
+        `capabilities=${capabilityStates}`,
+        `recent logs:\n${logs}`,
+      ].join("; "),
+      cause: primary instanceof TestStackOperationError ? primary.cause : primary,
+    });
+  });
 
-const cleanup = async (
+const cleanup = (
   stack: PromiseStack | undefined,
   root: string,
   operations: TestStackOperations,
-  primary?: unknown,
-) => {
-  let failure = primary;
-  let rootCanBeRemoved = true;
-  if (stack !== undefined) {
-    try {
-      await stack.destroy();
-    } catch (error) {
-      rootCanBeRemoved = false;
-      if (failure === undefined) failure = error;
+  primary?: TestStackOperationError | TestStackReadinessError,
+) =>
+  Effect.gen(function* () {
+    if (stack !== undefined) {
+      const failure = yield* call(() => stack.destroy()).pipe(
+        Effect.match({
+          onSuccess: () => undefined,
+          onFailure: (error) => error,
+        }),
+      );
+      // Failed destruction leaves the root available for recovery of durable state.
+      if (failure !== undefined)
+        return yield* new TestStackReadinessError({
+          message: `${(primary ?? failure).message}; retained test stack root ${root}`,
+          cause: primary ?? failure.cause,
+        });
     }
-  }
-  // Retain the exact root when destroy fails because durable/Docker state may remain recoverable.
-  if (rootCanBeRemoved) {
-    try {
-      await operations.removeRoot(root);
-    } catch (error) {
-      if (failure === undefined) failure = error;
-    }
-  }
-  if (!rootCanBeRemoved) {
-    const reason = failure instanceof Error ? failure.message : String(failure);
-    throw new Error(`${reason}; retained test stack root ${root}`, { cause: failure });
-  }
-  if (failure !== undefined) throw failure;
-};
+    yield* call(() => operations.removeRoot(root)).pipe(
+      Effect.mapError((error) => primary ?? error),
+    );
+    if (primary !== undefined) return yield* primary;
+  });
 
 /** Internal seam used by integration tests; the package testing barrel exports only createTestStack. */
-export const createTestStackWith = async (
+export const createTestStackWith = (
   options: CreateTestStackOptions = {},
   operations: TestStackOperations | TestStackOperationsOverrides = defaultOperations,
-): Promise<TestStack> => {
-  const resolvedOperations: TestStackOperations = { ...defaultOperations, ...operations };
-  const projectRoot = await resolvedOperations.createRoot();
-  let stack: PromiseStack | undefined;
-  try {
-    if (options.setupProject !== undefined) await options.setupProject(projectRoot);
-    const runtimeEnvironment = testRuntimeEnvironment();
-    stack = await resolvedOperations.createStack(
-      {
-        projectRoot,
-        name: options.name,
-        runtime: options.runtime,
-      },
-      runtimeEnvironment,
-    );
-    try {
-      const started = await stack.start(
-        options.config === undefined
-          ? undefined
-          : ({ config: options.config } satisfies PromiseStartStackOptions),
+): Promise<TestStack> =>
+  run(
+    Effect.gen(function* () {
+      const resolvedOperations = { ...defaultOperations, ...operations };
+      const projectRoot = yield* call(() => resolvedOperations.createRoot());
+      let stack: PromiseStack | undefined;
+      return yield* Effect.gen(function* () {
+        if (options.setupProject !== undefined) {
+          const setup = options.setupProject;
+          yield* call(() => setup(projectRoot));
+        }
+        const runtimeEnvironment = yield* testRuntimeEnvironment;
+        const resource = yield* call(() =>
+          resolvedOperations.createStack(
+            {
+              projectRoot,
+              name: options.name,
+              runtime: options.runtime,
+            },
+            runtimeEnvironment,
+          ),
+        );
+        stack = resource;
+        yield* call(() =>
+          resource.start(options.config === undefined ? undefined : { config: options.config }),
+        ).pipe(
+          Effect.flatMap((started) => validateStartedStatus(started, options.config)),
+          Effect.catch((error) =>
+            withStartupDiagnostics(resource, error).pipe(Effect.flatMap(Effect.fail)),
+          ),
+        );
+        return {
+          ...resource,
+          stateRoot: runtimeEnvironment.stateRoot,
+          [Symbol.asyncDispose]: () => run(cleanup(resource, projectRoot, resolvedOperations)),
+        } satisfies TestStack;
+      }).pipe(
+        Effect.catch((error) =>
+          cleanup(stack, projectRoot, resolvedOperations, error).pipe(
+            Effect.andThen(Effect.fail(error)),
+          ),
+        ),
       );
-      validateStartedStatus(started, options.config);
-    } catch (error) {
-      throw await withStartupDiagnostics(stack, error);
-    }
-    const resource = stack;
-    return {
-      ...resource,
-      stateRoot: runtimeEnvironment.stateRoot,
-      [Symbol.asyncDispose]: () => cleanup(resource, projectRoot, resolvedOperations),
-    };
-  } catch (error) {
-    await cleanup(stack, projectRoot, resolvedOperations, error);
-    throw error;
-  }
-};
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
 
 /** Creates an isolated managed stack and destroys exactly that identity on disposal. */
 export const createTestStack = (options: CreateTestStackOptions = {}): Promise<TestStack> =>

--- a/packages/stack/src/public/effect-stack.integration.test.ts
+++ b/packages/stack/src/public/effect-stack.integration.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable effecttsgo/prefer-schema-over-json -- malformed caller/state fixtures exercise public validation boundaries.
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import {
@@ -162,7 +161,7 @@ const withRuntimeRoot = <A, E, R>(effect: (project: string) => Effect.Effect<A, 
       );
       const project = path.join(root, "project");
       yield* fs.makeDirectory(project);
-      const defaults = defaultRuntimeEnvironment();
+      const defaults = yield* defaultRuntimeEnvironment;
       const runtime: StackRuntimeEnvironmentValue = {
         ...defaults,
         stateRoot: path.join(root, "managed", "stacks"),
@@ -269,7 +268,7 @@ describe("Effect stack lifecycle handoff", () => {
                 )
               : Effect.succeed(Option.some({ owner: deadOwner, launched: false })),
         });
-        yield* stack.stop();
+        yield* stack.stop;
         expect(yield* Ref.get(launchCalls)).toBe(1);
         expect(yield* Ref.get(liveStopCalls)).toBe(1);
       }).pipe(Effect.provide(NodeServices.layer)),
@@ -328,7 +327,7 @@ describe("Effect stack lifecycle handoff", () => {
         const stack = yield* makeTestHandle(stackId, {
           resolveOwner: () => Effect.succeed(Option.some({ owner, launched: false })),
         });
-        const stopped = yield* stack.stop().pipe(Effect.exit);
+        const stopped = yield* stack.stop.pipe(Effect.exit);
         expect(Exit.isFailure(stopped)).toBe(true);
         if (Exit.isFailure(stopped))
           expect(Option.getOrUndefined(Cause.findErrorOption(stopped.cause))).toBeInstanceOf(
@@ -462,14 +461,14 @@ describe("Effect stack lifecycle handoff", () => {
           { startImmediately: true },
         );
         yield* Deferred.await(followRead);
-        const stopFiber = yield* Effect.forkChild(stack.stop(), { startImmediately: true });
+        const stopFiber = yield* Effect.forkChild(stack.stop, { startImmediately: true });
         yield* Deferred.await(stopped);
         const followed = yield* Fiber.join(followedFiber);
         expect(Array.from(followed)).toEqual([finalAuth]);
         yield* Ref.set(ownerAvailable, false);
         yield* Scope.close(ownerScope, Exit.void);
         yield* Fiber.join(stopFiber);
-        expect((yield* stack.status()).lifecycle).toBe("stopped");
+        expect((yield* stack.status).lifecycle).toBe("stopped");
       }).pipe(Effect.provide(NodeServices.layer)),
     ),
   );
@@ -530,7 +529,6 @@ describe("Effect stack lifecycle handoff", () => {
 
   it.live("delivers final followed entries once and completes after stop", () =>
     withRuntimeRoot((_project) =>
-      // oxlint-disable-next-line effecttsgo/any-unknown-in-error-context -- test-only handle seam
       Effect.gen(function* () {
         const calls = yield* Ref.make(0);
         const entries: [StackLogEntry, StackLogEntry, StackLogEntry, StackLogEntry] = [
@@ -600,13 +598,13 @@ describe("Effect stack lifecycle handoff", () => {
         const env = yield* StackRuntimeEnvironment;
         const stack = yield* createStack({ projectRoot: project });
         expect(yield* readOwnerMetadata(env.stateRoot, stack.id, env)).toBeUndefined();
-        const offline = yield* stack.status();
+        const offline = yield* stack.status;
         expect(offline.lifecycle).toBe("unconfigured");
         expect(offline.capabilities.every(({ state }) => state === "disabled")).toBe(true);
         yield* openStack(stack.id);
         expect(yield* readOwnerMetadata(env.stateRoot, stack.id, env)).toBeUndefined();
-        yield* stack.stop();
-        expect((yield* stack.status()).lifecycle).toBe("unconfigured");
+        yield* stack.stop;
+        expect((yield* stack.status).lifecycle).toBe("unconfigured");
         expect((yield* stack.logs()).entries).toHaveLength(0);
       }),
     ),
@@ -774,9 +772,9 @@ describe("Effect stack lifecycle handoff", () => {
         expect(Exit.isFailure(started)).toBe(true);
         expect(yield* readOwnerMetadata(env.stateRoot, stack.id, env)).toBeUndefined();
         expect(yield* ownerLockExists(env.stateRoot, stack.id)).toBe(false);
-        expect((yield* stack.status()).lifecycle).toBe("stopped");
+        expect((yield* stack.status).lifecycle).toBe("stopped");
         const reopened = yield* openStack(stack.id);
-        expect((yield* reopened.status()).lifecycle).toBe("stopped");
+        expect((yield* reopened.status).lifecycle).toBe("stopped");
       }),
     ),
   );
@@ -792,7 +790,7 @@ describe("Effect stack lifecycle handoff", () => {
           readOfflineState: Effect.fail(ownership),
           readLogs: () => Effect.fail(ownership),
         });
-        const status = yield* stack.status().pipe(Effect.exit);
+        const status = yield* stack.status.pipe(Effect.exit);
         expect(Exit.isFailure(status)).toBe(true);
         const logs = yield* stack.logs().pipe(Effect.exit);
         expect(Exit.isFailure(logs)).toBe(true);
@@ -823,7 +821,7 @@ describe("Effect stack lifecycle handoff", () => {
             new StackOwnershipConflictError({ message: "Owner metadata still exists" }),
           ),
         });
-        const result = yield* stack.status().pipe(Effect.exit);
+        const result = yield* stack.status.pipe(Effect.exit);
         expect(Exit.isFailure(result)).toBe(true);
         if (Exit.isFailure(result)) {
           const error = Option.getOrUndefined(Cause.findErrorOption(result.cause));
@@ -899,7 +897,7 @@ describe("Effect stack lifecycle handoff", () => {
           });
           const assertGuarded = (candidate: EffectStack) =>
             Effect.gen(function* () {
-              expect(Exit.isFailure(yield* candidate.status().pipe(Effect.exit))).toBe(true);
+              expect(Exit.isFailure(yield* candidate.status.pipe(Effect.exit))).toBe(true);
               expect(Exit.isFailure(yield* candidate.logs().pipe(Effect.exit))).toBe(true);
             });
           const lockOnly = yield* openStack(stack.id);
@@ -954,7 +952,7 @@ describe("Effect stack lifecycle handoff", () => {
         const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-effect-stack-cache-" });
         const project = path.join(root, "project");
         yield* fs.makeDirectory(project);
-        const defaults = defaultRuntimeEnvironment();
+        const defaults = yield* defaultRuntimeEnvironment;
         const stateRoot = path.join(root, "managed", "stacks");
         const artifactCacheRoot = path.join(root, "shared-artifacts");
         const configuredEnvironment: StackRuntimeEnvironmentValue = {
@@ -978,10 +976,11 @@ describe("Effect stack lifecycle handoff", () => {
     withRuntimeRoot((project) =>
       Effect.gen(function* () {
         const stack = yield* createStack({ projectRoot: project, runtime: { kind: "native" } });
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- exercise unknown caller input
         const invalid = yield* stack
           .prepare({
-            config: JSON.parse('{"capabilities":{"rest":{"settings":{"unknown":true}}}}'),
+            config: yield* Schema.decodeEffect(Schema.fromJsonString(Schema.Any))(
+              '{"capabilities":{"rest":{"settings":{"unknown":true}}}}',
+            ),
           })
           .pipe(Effect.exit);
         expect(Exit.isFailure(invalid)).toBe(true);
@@ -1009,10 +1008,11 @@ describe("Effect stack lifecycle handoff", () => {
         const env = yield* StackRuntimeEnvironment;
         const stack = yield* createStack({ projectRoot: project });
         const paths = yield* resolveStackPaths({ stateRoot: env.stateRoot, stackId: stack.id });
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- malformed persisted state fixture
         yield* fs.writeFileString(
           paths.stateDocument,
-          JSON.stringify({ format: "supabase-stack-v0" }),
+          yield* Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown))({
+            format: "supabase-stack-v0",
+          }),
         );
 
         const result = yield* stack.prepare().pipe(Effect.exit);
@@ -1036,9 +1036,9 @@ describe("Effect stack lifecycle handoff", () => {
     withRuntimeRoot((project) =>
       Effect.gen(function* () {
         const stack = yield* createStack({ projectRoot: project });
-        yield* stack.destroy();
+        yield* stack.destroy;
 
-        const status = yield* stack.status().pipe(Effect.exit);
+        const status = yield* stack.status.pipe(Effect.exit);
         expect(Exit.isFailure(status)).toBe(true);
         if (Exit.isFailure(status))
           expect(Option.getOrUndefined(Cause.findErrorOption(status.cause))).toBeInstanceOf(
@@ -1059,7 +1059,7 @@ describe("Effect stack lifecycle handoff", () => {
       const stopped = yield* makeTestHandle(stackId, {
         readOfflineState: Effect.succeed(Option.some(stoppedState())),
       });
-      const stoppedResult = yield* stopped.credentials().pipe(Effect.exit);
+      const stoppedResult = yield* stopped.credentials.pipe(Effect.exit);
       expect(Exit.isFailure(stoppedResult)).toBe(true);
       if (Exit.isFailure(stoppedResult)) {
         const error = Cause.findErrorOption(stoppedResult.cause);
@@ -1068,7 +1068,7 @@ describe("Effect stack lifecycle handoff", () => {
       }
 
       const missing = yield* makeTestHandle(stackId);
-      const missingResult = yield* missing.credentials().pipe(Effect.exit);
+      const missingResult = yield* missing.credentials.pipe(Effect.exit);
       expect(Exit.isFailure(missingResult)).toBe(true);
       if (Exit.isFailure(missingResult)) {
         const error = Cause.findErrorOption(missingResult.cause);
@@ -1081,7 +1081,7 @@ describe("Effect stack lifecycle handoff", () => {
           Option.some({ ...stoppedState(), desiredLifecycle: "running" }),
         ),
       });
-      const runningResult = yield* running.credentials().pipe(Effect.exit);
+      const runningResult = yield* running.credentials.pipe(Effect.exit);
       expect(Exit.isFailure(runningResult)).toBe(true);
       if (Exit.isFailure(runningResult)) {
         const error = Cause.findErrorOption(runningResult.cause);
@@ -1097,7 +1097,7 @@ describe("Effect stack lifecycle handoff", () => {
         const fs = yield* FileSystem.FileSystem;
         const env = yield* StackRuntimeEnvironment;
         const stack = yield* createStack({ projectRoot: project });
-        yield* stack.destroy();
+        yield* stack.destroy;
         const paths = yield* resolveStackPaths({ stateRoot: env.stateRoot, stackId: stack.id });
 
         const failed = yield* stack.start().pipe(Effect.exit);
@@ -1284,7 +1284,7 @@ describe("Effect stack lifecycle handoff", () => {
           ...state,
           definition: persisted.definition,
         });
-        const before = yield* stack.status();
+        const before = yield* stack.status;
         const progress: Array<ArtifactPreparationStatus> = [];
         const prepared = yield* stack.prepare({
           config: { capabilities: { rest: { settings: { schemas: ["private"] } } } },
@@ -1306,7 +1306,7 @@ describe("Effect stack lifecycle handoff", () => {
             { workloadId: "rest:rest", capability: "rest", state: "ready" },
           ]),
         );
-        expect(yield* stack.status()).toEqual(before);
+        expect(yield* stack.status).toEqual(before);
       }),
     ),
   );
@@ -1753,7 +1753,7 @@ describe("Effect stack lifecycle handoff", () => {
             ),
           readPersistedState: Effect.succeed(Option.some(stoppedState())),
         });
-        const destroyFiber = yield* Effect.forkChild(stack.destroy(), { startImmediately: true });
+        const destroyFiber = yield* Effect.forkChild(stack.destroy, { startImmediately: true });
         yield* Deferred.await(responseSent);
         yield* Scope.close(ownerScope, Exit.void);
         const destroyed = yield* Fiber.join(destroyFiber).pipe(Effect.exit);
@@ -1785,7 +1785,7 @@ describe("Effect stack lifecycle handoff", () => {
             ),
           readPersistedState: Effect.succeed(Option.some(stoppedState())),
         });
-        const result = yield* stack.destroy().pipe(Effect.exit);
+        const result = yield* stack.destroy.pipe(Effect.exit);
         expect(Exit.isFailure(result)).toBe(true);
         if (Exit.isFailure(result)) {
           const error = Cause.findErrorOption(result.cause);
@@ -1810,7 +1810,7 @@ describe("Effect stack lifecycle handoff", () => {
           }),
         readPersistedState: Effect.succeed(Option.none()),
       });
-      const result = yield* stack.destroy().pipe(Effect.exit);
+      const result = yield* stack.destroy.pipe(Effect.exit);
       expect(Exit.isFailure(result)).toBe(true);
       if (Exit.isFailure(result)) {
         const failure = Cause.findErrorOption(result.cause);
@@ -1829,7 +1829,7 @@ describe("Effect stack lifecycle handoff", () => {
           const fs = yield* FileSystem.FileSystem;
           const env = yield* StackRuntimeEnvironment;
           const stack = yield* createStack({ projectRoot: project, runtime: { kind: "native" } });
-          yield* Effect.addFinalizer(() => stack.destroy().pipe(Effect.ignore));
+          yield* Effect.addFinalizer(() => stack.destroy.pipe(Effect.ignore));
           const store = yield* makeStackStateStore({ stateRoot: env.stateRoot });
           yield* ensureSupervisor({
             stackId: stack.id,
@@ -1853,11 +1853,11 @@ describe("Effect stack lifecycle handoff", () => {
           yield* fs.writeFileString(paths.controlMetadata, incompatibleOwner);
 
           const oldOwner = yield* openStack(stack.id);
-          expect(Exit.isFailure(yield* oldOwner.status().pipe(Effect.exit))).toBe(true);
+          expect(Exit.isFailure(yield* oldOwner.status.pipe(Effect.exit))).toBe(true);
           const ordinaryCreate = yield* createStack({ projectRoot: project });
           expect(ordinaryCreate.id).toBe(stack.id);
           const restarted = yield* openStack(stack.id);
-          yield* Effect.addFinalizer(() => restarted.destroy().pipe(Effect.ignore));
+          yield* Effect.addFinalizer(() => restarted.destroy.pipe(Effect.ignore));
           const directStart = yield* restarted
             .start({ config: lifecycleConfig() })
             .pipe(Effect.exit);
@@ -1868,20 +1868,20 @@ describe("Effect stack lifecycle handoff", () => {
             if (Option.isSome(failure))
               expect(failure.value).toBeInstanceOf(StackUpgradeRequiredError);
           }
-          yield* restarted.stop();
+          yield* restarted.stop;
           const status = yield* restarted.start({ config: lifecycleConfig() });
           const currentOwner = yield* readOwnerMetadata(env.stateRoot, stack.id, env);
           expect(currentOwner?.rpcRelease).toBe(STACK_RPC_RELEASE);
           expect(currentOwner?.ownerSessionId).not.toBe(originalOwner.ownerSessionId);
           expect(status.id).toBe(stack.id);
           expect(status.runtime).toEqual({ kind: "native" });
-          expect((yield* restarted.status()).lifecycle).toBe("running");
-          yield* restarted.stop();
+          expect((yield* restarted.status).lifecycle).toBe("running");
+          yield* restarted.stop;
           expect(yield* readOwnerMetadata(env.stateRoot, stack.id, env)).toBeUndefined();
           expect(yield* ownerLockExists(env.stateRoot, stack.id)).toBe(false);
           const startedAgain = yield* restarted.start({ config: lifecycleConfig() });
           expect(startedAgain.lifecycle).toBe("running");
-          yield* restarted.destroy();
+          yield* restarted.destroy;
         }),
       ),
     240_000,
@@ -2038,8 +2038,8 @@ describe("Effect stack lifecycle handoff", () => {
           const cleanupRecovered = yield* Effect.cached(
             Effect.uninterruptible(
               Effect.gen(function* () {
-                yield* replaced.stop();
-                yield* replaced.destroy();
+                yield* replaced.stop;
+                yield* replaced.destroy;
                 expect(yield* readOwnerMetadata(env.stateRoot, openId, env)).toBeUndefined();
                 expect(yield* ownerLockExists(env.stateRoot, openId)).toBe(false);
               }),
@@ -2074,7 +2074,7 @@ describe("Effect stack lifecycle handoff", () => {
           environment: env,
         });
         const ownerHandle = yield* openStack(stack.id);
-        yield* Effect.addFinalizer(() => ownerHandle.stop().pipe(Effect.ignore));
+        yield* Effect.addFinalizer(() => ownerHandle.stop.pipe(Effect.ignore));
         const owner = yield* readOwnerMetadata(env.stateRoot, stack.id, env);
         const currentOwner = expectPresent(owner, "owner metadata");
         const paths = yield* resolveStackPaths({ stateRoot: env.stateRoot, stackId: stack.id });
@@ -2089,7 +2089,7 @@ describe("Effect stack lifecycle handoff", () => {
           ),
         );
         yield* fs.writeFileString(paths.controlMetadata, incompatibleOwner);
-        yield* ownerHandle.stop();
+        yield* ownerHandle.stop;
         expect(yield* readOwnerMetadata(env.stateRoot, stack.id, env)).toBeUndefined();
         expect(yield* ownerLockExists(env.stateRoot, stack.id)).toBe(false);
       }),
@@ -2149,8 +2149,8 @@ describe("Effect stack lifecycle handoff", () => {
           const stack = yield* makeTestHandle(stackId, {
             resolveOwner: () => Effect.succeed(Option.some({ owner, launched: false })),
           });
-          const status = yield* stack.status().pipe(Effect.exit);
-          const stackCredentials = yield* stack.credentials().pipe(Effect.exit);
+          const status = yield* stack.status.pipe(Effect.exit);
+          const stackCredentials = yield* stack.credentials.pipe(Effect.exit);
           const logs = yield* stack.logs().pipe(Effect.exit);
           const assertUpgrade = (result: Exit.Exit<unknown, StackError>) => {
             expect(Exit.isFailure(result)).toBe(true);
@@ -2170,7 +2170,7 @@ describe("Effect stack lifecycle handoff", () => {
           assertUpgrade(stackCredentials);
           assertUpgrade(logs);
           expect(yield* Ref.get(calls)).toBe(0);
-          yield* stack.stop();
+          yield* stack.stop;
         }).pipe(Effect.provide(NodeServices.layer)),
       ),
   );
@@ -2284,7 +2284,7 @@ describe("Effect stack lifecycle handoff", () => {
           resolveOwner: () => Effect.succeed(Option.some({ owner, launched: true })),
           readPersistedState: Effect.succeed(Option.some(stoppedState())),
         });
-        const destroy = yield* Effect.forkChild(stack.destroy(), { startImmediately: true });
+        const destroy = yield* Effect.forkChild(stack.destroy, { startImmediately: true });
         yield* Deferred.await(destroyEntered);
         yield* Fiber.interrupt(destroy);
         const interrupted = yield* Fiber.join(destroy).pipe(Effect.exit);

--- a/packages/stack/src/public/promise.integration.test.ts
+++ b/packages/stack/src/public/promise.integration.test.ts
@@ -1,14 +1,7 @@
-// oxlint-disable effecttsgo/async-function -- integration test exercises the Promise facade directly.
 import { describe, expect, it } from "@effect/vitest";
 import { NodeServices } from "@effect/platform-node";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- isolated Promise facade state root.
-import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- isolated Promise facade state root.
-import { tmpdir } from "node:os";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- isolated Promise facade state root.
-import { join } from "node:path";
 import { CAPABILITY_NAMES, type CapabilityStatus } from "./Capability.ts";
-import { Effect, Redacted, Stream } from "effect";
+import { Data, Effect, FileSystem, Path, Redacted, Schema, Stream } from "effect";
 import type { EffectStack, PrepareStackOptions, StartStackOptions } from "./EffectStack.ts";
 import type { LogQuery, StackLogEntry } from "./Logs.ts";
 import { StackIdSchema } from "./StackId.ts";
@@ -16,17 +9,20 @@ import type { ArtifactPreparationStatus, StackStatus } from "./Status.ts";
 import { InvalidStackConfigError, StackVersionUnsupportedError } from "./Errors.ts";
 import { adaptEffectStack, makePromiseApi, type PromiseStack } from "./PromiseStack.ts";
 import { compileStack } from "../model/Compiler.ts";
-
+class StreamFixtureError extends Data.TaggedError("StreamFixtureError")<{
+  readonly cause: unknown;
+}> {}
+const malformedConfig = Schema.decodeSync(Schema.fromJsonString(Schema.Any))(
+  '{"capabilities":{"rest":{"settings":{"unknown":true}}}}',
+);
 const stackId = StackIdSchema.make(
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 );
-
 const capabilities: ReadonlyArray<CapabilityStatus> = CAPABILITY_NAMES.map((name) => ({
   name,
   activation: name === "functions" ? "lazy" : "eager",
   state: name === "functions" ? "ready" : "dormant",
 }));
-
 const status: StackStatus = {
   id: stackId,
   lifecycle: "running",
@@ -44,267 +40,288 @@ const status: StackStatus = {
   capabilities,
   artifacts: [],
 };
-
 const effectStack = (): EffectStack =>
   ({
     id: stackId,
-    status: () => Effect.succeed(status),
-    credentials: () =>
-      Effect.succeed({
-        database: { url: Redacted.make("postgres://secret"), password: Redacted.make("db-pass") },
-        api: {
-          publishableKey: "publishable",
-          secretKey: Redacted.make("secret-key"),
-          anonJwt: "anon",
-          serviceRoleJwt: Redacted.make("service-role"),
-        },
-        storage: {
-          endpoint: "http://storage",
-          region: "local",
-          accessKeyId: "access",
-          secretAccessKey: Redacted.make("storage-secret"),
-        },
-      }),
-    prepare: (_options?: PrepareStackOptions) => Effect.succeed({ capabilities: [] }),
-    start: () => Effect.succeed(status),
-    stop: () => Effect.void,
-    destroy: () => Effect.void,
-    logs: () => Effect.succeed({ entries: [], cursor: { opaque: "v1_0" }, running: false }),
-    followLogs: () => Stream.empty,
-  }) satisfies EffectStack;
-
-describe("Promise stack facade", () => {
-  it("prepares a real stack without publishing owner metadata", async () => {
-    const root = await mkdtemp(join(tmpdir(), "supabase-promise-prepare-"));
-    try {
-      const project = join(root, "project");
-      const stateRoot = join(root, "managed", "stacks");
-      await mkdir(project);
-      const api = makePromiseApi(NodeServices.layer, {
-        stateRoot,
-        tempRoot: tmpdir(),
-        platform: "posix",
-      });
-      const stack = await api.createStack({ projectRoot: project, runtime: { kind: "native" } });
-      const statePath = join(stateRoot, stack.id, "state.json");
-      const before = await readFile(statePath, "utf8");
-      await expect(stack.prepare({ capabilities: [] })).resolves.toEqual({ capabilities: [] });
-      expect(await readFile(statePath, "utf8")).toBe(before);
-      expect(await readdir(join(stateRoot, stack.id))).not.toContain("control.json");
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("preserves prepare validation tags", async () => {
-    const root = await mkdtemp(join(tmpdir(), "supabase-promise-prepare-errors-"));
-    try {
-      const project = join(root, "project");
-      await mkdir(project);
-      const api = makePromiseApi(NodeServices.layer, {
-        stateRoot: join(root, "managed", "stacks"),
-        tempRoot: tmpdir(),
-        platform: "posix",
-      });
-      const stack = await api.createStack({ projectRoot: project, runtime: { kind: "native" } });
-      await expect(
-        stack.prepare({
-          config: JSON.parse('{"capabilities":{"rest":{"settings":{"unknown":true}}}}'),
-        }),
-      ).rejects.toBeInstanceOf(InvalidStackConfigError);
-      await expect(
-        stack.prepare({ config: { capabilities: { database: { version: "99" } } } }),
-      ).rejects.toBeInstanceOf(StackVersionUnsupportedError);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("returns log batches and follows from their cursor", async () => {
-    const initial: StackLogEntry = {
-      cursor: { opaque: "v1_0" },
-      timestamp: "2026-01-01T00:00:00.000Z",
-      source: "auth",
-      stream: "stdout",
-      message: "initial",
-    };
-    const followedEntry: StackLogEntry = {
-      ...initial,
-      cursor: { opaque: "v1_1" },
-      message: "followed",
-    };
-    let logsQuery: LogQuery | undefined;
-    let followQuery: LogQuery | undefined;
-    const stack = adaptEffectStack({
-      ...effectStack(),
-      logs: (query) =>
-        Effect.sync(() => {
-          logsQuery = query;
-          return { entries: [initial], cursor: { opaque: "v1_0" }, running: true };
-        }),
-      followLogs: (query) => {
-        followQuery = query;
-        return Stream.succeed(followedEntry);
-      },
-    });
-    const first = await stack.logs({ capabilities: ["auth"], tail: 20 });
-    expect(first.entries).toEqual([initial]);
-    expect(logsQuery).toEqual({ capabilities: ["auth"], tail: 20 });
-    const followed = [];
-    for await (const entry of stack.followLogs({ capabilities: ["auth"], cursor: first.cursor })) {
-      followed.push(entry);
-    }
-    expect(followed).toEqual([followedEntry]);
-    expect(followQuery).toEqual({ capabilities: ["auth"], cursor: { opaque: "v1_0" } });
-  });
-
-  it("unwraps every credential secret without a lifecycle close operation", async () => {
-    const stack: PromiseStack = adaptEffectStack(effectStack());
-
-    await expect(stack.credentials()).resolves.toEqual({
-      database: { url: "postgres://secret", password: "db-pass" },
+    status: Effect.succeed(status),
+    credentials: Effect.succeed({
+      database: { url: Redacted.make("postgres://secret"), password: Redacted.make("db-pass") },
       api: {
         publishableKey: "publishable",
-        secretKey: "secret-key",
+        secretKey: Redacted.make("secret-key"),
         anonJwt: "anon",
-        serviceRoleJwt: "service-role",
+        serviceRoleJwt: Redacted.make("service-role"),
       },
       storage: {
         endpoint: "http://storage",
         region: "local",
         accessKeyId: "access",
-        secretAccessKey: "storage-secret",
+        secretAccessKey: Redacted.make("storage-secret"),
       },
-    });
-    expect(Symbol.asyncDispose in stack).toBe(false);
-  });
-
-  it("cancels an active async stream and witnesses its finalizer", async () => {
-    let finalized = false;
-    const entry: StackLogEntry = {
-      cursor: { opaque: "v1_1" },
-      timestamp: "2026-01-01T00:00:00.000Z",
-      source: "auth",
-      stream: "stdout",
-      message: "active",
-    };
-    const source: EffectStack = {
-      ...effectStack(),
-      followLogs: () =>
-        Stream.make(entry).pipe(
-          Stream.concat(Stream.never),
-          Stream.ensuring(
-            Effect.sync(() => {
-              finalized = true;
-            }),
+    }),
+    prepare: (_options?: PrepareStackOptions) => Effect.succeed({ capabilities: [] }),
+    start: () => Effect.succeed(status),
+    stop: Effect.void,
+    destroy: Effect.void,
+    logs: () => Effect.succeed({ entries: [], cursor: { opaque: "v1_0" }, running: false }),
+    followLogs: () => Stream.empty,
+  }) satisfies EffectStack;
+describe("Promise stack facade", () => {
+  it.live("prepares a real stack without publishing owner metadata", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-promise-prepare-" });
+      const project = path.join(root, "project");
+      const stateRoot = path.join(root, "managed", "stacks");
+      yield* fs.makeDirectory(project);
+      const api = makePromiseApi(NodeServices.layer, {
+        stateRoot,
+        tempRoot: "/tmp",
+        platform: "posix",
+      });
+      const stack = yield* Effect.promise(() =>
+        api.createStack({ projectRoot: project, runtime: { kind: "native" } }),
+      );
+      const statePath = path.join(stateRoot, stack.id, "state.json");
+      const before = yield* fs.readFileString(statePath);
+      yield* Effect.promise(() =>
+        expect(stack.prepare({ capabilities: [] })).resolves.toEqual({ capabilities: [] }),
+      );
+      expect(yield* fs.readFileString(statePath)).toBe(before);
+      expect(yield* fs.readDirectory(path.join(stateRoot, stack.id))).not.toContain("control.json");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("preserves prepare validation tags", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "supabase-promise-prepare-errors-",
+      });
+      const project = path.join(root, "project");
+      yield* fs.makeDirectory(project);
+      const api = makePromiseApi(NodeServices.layer, {
+        stateRoot: path.join(root, "managed", "stacks"),
+        tempRoot: "/tmp",
+        platform: "posix",
+      });
+      const stack = yield* Effect.promise(() =>
+        api.createStack({ projectRoot: project, runtime: { kind: "native" } }),
+      );
+      yield* Effect.promise(() =>
+        expect(
+          stack.prepare({
+            config: malformedConfig,
+          }),
+        ).rejects.toBeInstanceOf(InvalidStackConfigError),
+      );
+      yield* Effect.promise(() =>
+        expect(
+          stack.prepare({ config: { capabilities: { database: { version: "99" } } } }),
+        ).rejects.toBeInstanceOf(StackVersionUnsupportedError),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("returns log batches and follows from their cursor", () =>
+    Effect.gen(function* () {
+      const initial: StackLogEntry = {
+        cursor: { opaque: "v1_0" },
+        timestamp: "2026-01-01T00:00:00.000Z",
+        source: "auth",
+        stream: "stdout",
+        message: "initial",
+      };
+      const followedEntry: StackLogEntry = {
+        ...initial,
+        cursor: { opaque: "v1_1" },
+        message: "followed",
+      };
+      let logsQuery: LogQuery | undefined;
+      let followQuery: LogQuery | undefined;
+      const stack = adaptEffectStack({
+        ...effectStack(),
+        logs: (query) =>
+          Effect.sync(() => {
+            logsQuery = query;
+            return { entries: [initial], cursor: { opaque: "v1_0" }, running: true };
+          }),
+        followLogs: (query) => {
+          followQuery = query;
+          return Stream.succeed(followedEntry);
+        },
+      });
+      const first = yield* Effect.promise(() => stack.logs({ capabilities: ["auth"], tail: 20 }));
+      expect(first.entries).toEqual([initial]);
+      expect(logsQuery).toEqual({ capabilities: ["auth"], tail: 20 });
+      const followed = yield* Stream.fromAsyncIterable(
+        stack.followLogs({ capabilities: ["auth"], cursor: first.cursor }),
+        (cause) => new StreamFixtureError({ cause }),
+      ).pipe(Stream.runCollect);
+      expect(followed).toEqual([followedEntry]);
+      expect(followQuery).toEqual({ capabilities: ["auth"], cursor: { opaque: "v1_0" } });
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("unwraps every credential secret without a lifecycle close operation", () =>
+    Effect.gen(function* () {
+      const stack: PromiseStack = adaptEffectStack(effectStack());
+      yield* Effect.promise(() =>
+        expect(stack.credentials()).resolves.toEqual({
+          database: { url: "postgres://secret", password: "db-pass" },
+          api: {
+            publishableKey: "publishable",
+            secretKey: "secret-key",
+            anonJwt: "anon",
+            serviceRoleJwt: "service-role",
+          },
+          storage: {
+            endpoint: "http://storage",
+            region: "local",
+            accessKeyId: "access",
+            secretAccessKey: "storage-secret",
+          },
+        }),
+      );
+      expect(Symbol.asyncDispose in stack).toBe(false);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("cancels an active async stream and witnesses its finalizer", () =>
+    Effect.gen(function* () {
+      let finalized = false;
+      const entry: StackLogEntry = {
+        cursor: { opaque: "v1_1" },
+        timestamp: "2026-01-01T00:00:00.000Z",
+        source: "auth",
+        stream: "stdout",
+        message: "active",
+      };
+      const source: EffectStack = {
+        ...effectStack(),
+        followLogs: () =>
+          Stream.make(entry).pipe(
+            Stream.concat(Stream.never),
+            Stream.ensuring(
+              Effect.sync(() => {
+                finalized = true;
+              }),
+            ),
           ),
-        ),
-    };
-    const stack = adaptEffectStack(source);
-    const iterator = stack.followLogs()[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toEqual({ done: false, value: entry });
-    await expect(iterator.return?.()).resolves.toMatchObject({ done: true });
-    expect(finalized).toBe(true);
-  });
-
-  it("forwards prepare progress through the Promise facade", async () => {
-    const progress: Array<ArtifactPreparationStatus> = [];
-    const stack = adaptEffectStack({
-      ...effectStack(),
-      prepare: (options?: PrepareStackOptions) =>
-        Effect.sync(() => {
-          options?.onProgress?.({
-            workloadId: "rest:rest",
-            capability: "rest",
-            state: "downloading",
-          });
-          return { capabilities: [] };
+      };
+      const stack = adaptEffectStack(source);
+      const iterator = stack.followLogs()[Symbol.asyncIterator]();
+      yield* Effect.promise(() =>
+        expect(iterator.next()).resolves.toEqual({ done: false, value: entry }),
+      );
+      yield* Effect.promise(() =>
+        expect(iterator.return?.()).resolves.toMatchObject({ done: true }),
+      );
+      expect(finalized).toBe(true);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("forwards prepare progress through the Promise facade", () =>
+    Effect.gen(function* () {
+      const progress: Array<ArtifactPreparationStatus> = [];
+      const stack = adaptEffectStack({
+        ...effectStack(),
+        prepare: (options?: PrepareStackOptions) =>
+          Effect.sync(() => {
+            options?.onProgress?.({
+              workloadId: "rest:rest",
+              capability: "rest",
+              state: "downloading",
+            });
+            return { capabilities: [] };
+          }),
+      });
+      yield* Effect.promise(() =>
+        expect(stack.prepare({ onProgress: (status) => progress.push(status) })).resolves.toEqual({
+          capabilities: [],
         }),
-    });
-
-    await expect(stack.prepare({ onProgress: (status) => progress.push(status) })).resolves.toEqual(
-      {
-        capabilities: [],
-      },
-    );
-    expect(progress).toEqual([
-      { workloadId: "rest:rest", capability: "rest", state: "downloading" },
-    ]);
-  });
-
-  it("completes an empty follower immediately", async () => {
-    const stack = adaptEffectStack(effectStack());
-    const logs = await stack.logs();
-    expect(logs.entries).toHaveLength(0);
-    const logsIterator = stack.followLogs()[Symbol.asyncIterator]();
-    await expect(logsIterator.next()).resolves.toMatchObject({ done: true });
-  });
-
-  it("rejects malformed configs asynchronously with a tagged error", async () => {
-    const stack = adaptEffectStack(effectStack());
-    await expect(
-      stack.start({
-        config: JSON.parse('{"capabilities":{"rest":{"settings":{"unknown":true}}}}'),
-      }),
-    ).rejects.toBeInstanceOf(InvalidStackConfigError);
-  });
-
-  it("redacts nested config secrets for prepare and start", async () => {
-    let preparedConfig: StartStackOptions["config"] | undefined;
-    let startedConfig: StartStackOptions["config"] | undefined;
-    const source: EffectStack = {
-      ...effectStack(),
-      prepare: (options?: PrepareStackOptions) =>
-        Effect.sync(() => {
-          preparedConfig = options?.config;
-          return { capabilities: [] };
-        }),
-      start: (options?: StartStackOptions) =>
-        Effect.sync(() => {
-          startedConfig = options?.config;
-          return status;
-        }),
-    };
-    const stack = adaptEffectStack(source);
-    const config = {
-      capabilities: {
-        storage: { settings: { buckets: { assets: { public: false } } } },
-        auth: { settings: { external: { github: { secret: "github-secret" } } } },
-        functions: {
-          settings: {
-            edge_runtime: { secrets: { EDGE_TOKEN: "edge-secret" } },
-            functions: {
-              hello: { env: { FUNCTION_TOKEN: "function-secret" }, static_files: ["index.html"] },
+      );
+      expect(progress).toEqual([
+        { workloadId: "rest:rest", capability: "rest", state: "downloading" },
+      ]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("completes an empty follower immediately", () =>
+    Effect.gen(function* () {
+      const stack = adaptEffectStack(effectStack());
+      const logs = yield* Effect.promise(() => stack.logs());
+      expect(logs.entries).toHaveLength(0);
+      const logsIterator = stack.followLogs()[Symbol.asyncIterator]();
+      yield* Effect.promise(() =>
+        expect(logsIterator.next()).resolves.toMatchObject({ done: true }),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("rejects malformed configs asynchronously with a tagged error", () =>
+    Effect.gen(function* () {
+      const stack = adaptEffectStack(effectStack());
+      yield* Effect.promise(() =>
+        expect(
+          stack.start({
+            config: malformedConfig,
+          }),
+        ).rejects.toBeInstanceOf(InvalidStackConfigError),
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("redacts nested config secrets for prepare and start", () =>
+    Effect.gen(function* () {
+      let preparedConfig: StartStackOptions["config"] | undefined;
+      let startedConfig: StartStackOptions["config"] | undefined;
+      const source: EffectStack = {
+        ...effectStack(),
+        prepare: (options?: PrepareStackOptions) =>
+          Effect.sync(() => {
+            preparedConfig = options?.config;
+            return { capabilities: [] };
+          }),
+        start: (options?: StartStackOptions) =>
+          Effect.sync(() => {
+            startedConfig = options?.config;
+            return status;
+          }),
+      };
+      const stack = adaptEffectStack(source);
+      const config = {
+        capabilities: {
+          storage: { settings: { buckets: { assets: { public: false } } } },
+          auth: { settings: { external: { github: { secret: "github-secret" } } } },
+          functions: {
+            settings: {
+              edge_runtime: { secrets: { EDGE_TOKEN: "edge-secret" } },
+              functions: {
+                hello: { env: { FUNCTION_TOKEN: "function-secret" }, static_files: ["index.html"] },
+              },
             },
           },
         },
-      },
-    };
-
-    await stack.prepare({ config });
-    await stack.start({ config });
-    for (const value of [preparedConfig, startedConfig]) {
-      const auth = value?.capabilities?.auth;
-      const functions = value?.capabilities?.functions;
-      const authSettings = auth !== undefined && "settings" in auth ? auth.settings : undefined;
-      const functionSettings =
-        functions !== undefined && "settings" in functions ? functions.settings : undefined;
-      expect(Redacted.isRedacted(authSettings?.external?.github?.secret)).toBe(true);
-      expect(Redacted.isRedacted(functionSettings?.edge_runtime?.secrets?.EDGE_TOKEN)).toBe(true);
-      expect(Redacted.isRedacted(functionSettings?.functions?.hello?.env?.FUNCTION_TOKEN)).toBe(
-        true,
-      );
-    }
-    if (startedConfig === undefined) throw new Error("Expected Promise start to capture config");
-    const compiled = await Effect.runPromise(
-      compileStack({
+      };
+      yield* Effect.promise(() => stack.prepare({ config }));
+      yield* Effect.promise(() => stack.start({ config }));
+      for (const value of [preparedConfig, startedConfig]) {
+        const auth = value?.capabilities?.auth;
+        const functions = value?.capabilities?.functions;
+        const authSettings = auth !== undefined && "settings" in auth ? auth.settings : undefined;
+        const functionSettings =
+          functions !== undefined && "settings" in functions ? functions.settings : undefined;
+        expect(Redacted.isRedacted(authSettings?.external?.github?.secret)).toBe(true);
+        expect(Redacted.isRedacted(functionSettings?.edge_runtime?.secrets?.EDGE_TOKEN)).toBe(true);
+        expect(Redacted.isRedacted(functionSettings?.functions?.hello?.env?.FUNCTION_TOKEN)).toBe(
+          true,
+        );
+      }
+      if (startedConfig === undefined)
+        return yield* Effect.die("Expected Promise start to capture config");
+      const compiled = yield* compileStack({
         projectRoot: "/tmp/promise-facade-project",
         runtime: { kind: "native" },
         config: startedConfig,
-      }).pipe(Effect.provide(NodeServices.layer)),
-    );
-    expect(compiled.definition.capabilities.functions.settings.functions_root).toBe(
-      "/tmp/promise-facade-project/supabase/functions",
-    );
-  });
+      }).pipe(Effect.provide(NodeServices.layer));
+      expect(compiled.definition.capabilities.functions.settings.functions_root).toBe(
+        "/tmp/promise-facade-project/supabase/functions",
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/packages/stack/src/public/testing.integration.test.ts
+++ b/packages/stack/src/public/testing.integration.test.ts
@@ -1,20 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Cause, ConfigProvider, Data, Effect, Exit, Path, Stream } from "effect";
 import { homedir, tmpdir } from "node:os";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- this fixture asserts exact root paths.
-import { dirname, join, sep } from "node:path";
+
 import type { PromiseStack } from "./PromiseStack.ts";
 import { createTestStackWith, type TestStackOperations } from "./Testing.ts";
 import { defaultRuntimeEnvironment } from "../supervisor/Launcher.ts";
 import { CAPABILITY_NAMES } from "./Capability.ts";
 import { StackIdSchema } from "./StackId.ts";
 import type { StackStatus } from "./Status.ts";
-
-// oxlint-disable effecttsgo/async-function -- fixtures model the Promise facade's async operations.
+class FixtureError extends Data.TaggedError("FixtureError")<{ readonly cause: unknown }> {}
+const fixturePromise = <A>(thunk: () => A): Promise<A> =>
+  Effect.runPromiseExit(
+    Effect.try({ try: thunk, catch: (cause) => new FixtureError({ cause }) }),
+  ).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    const error = Cause.squash(exit.cause);
+    throw error instanceof FixtureError ? error.cause : error;
+  });
 
 const stackId = StackIdSchema.make(
   "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 );
-
 const status = (
   lifecycle: StackStatus["lifecycle"],
   includeApi = true,
@@ -52,13 +59,8 @@ const status = (
   })),
   artifacts: [],
 });
-
-const stream = <A>(values: ReadonlyArray<A>): AsyncIterable<A> => ({
-  async *[Symbol.asyncIterator]() {
-    yield* values;
-  },
-});
-
+const stream = <A>(values: ReadonlyArray<A>): AsyncIterable<A> =>
+  Stream.toAsyncIterable(Stream.fromIterable(values));
 type FakeStackOptions = {
   readonly failStart?: boolean;
   readonly reachesReadiness?: boolean;
@@ -66,7 +68,6 @@ type FakeStackOptions = {
   readonly functionsState?: "ready" | "dormant" | "stopped";
   readonly failedCapability?: string;
 };
-
 const fakeStack = (events: Array<string>, options: FakeStackOptions = {}): PromiseStack => {
   const {
     failStart = false,
@@ -77,443 +78,497 @@ const fakeStack = (events: Array<string>, options: FakeStackOptions = {}): Promi
   } = options;
   return {
     id: stackId,
-    status: async () =>
-      status(
-        reachesReadiness ? "running" : "stopped",
-        includeApi,
-        functionsState,
-        failedCapability,
+    status: () =>
+      fixturePromise(() =>
+        status(
+          reachesReadiness ? "running" : "stopped",
+          includeApi,
+          functionsState,
+          failedCapability,
+        ),
       ),
-    credentials: async () => ({
-      database: { url: "postgres://test", password: "test" },
-      api: {
-        publishableKey: "publishable",
-        secretKey: "secret",
-        anonJwt: "anon",
-        serviceRoleJwt: "service",
-      },
-      storage: {
-        endpoint: "http://storage",
-        region: "local",
-        accessKeyId: "access",
-        secretAccessKey: "storage",
-      },
-    }),
-    prepare: async () => ({ capabilities: [] }),
-    start: async () => {
-      events.push("start");
-      if (failStart) throw new Error("startup failed");
-      return status(
-        reachesReadiness ? "running" : "stopped",
-        includeApi,
-        functionsState,
-        failedCapability,
-      );
-    },
-    stop: async () => undefined,
-    destroy: async () => {
-      events.push("destroy");
-      if (failStart) throw new Error("destroy failed");
-    },
-    logs: async () => ({ entries: [], cursor: { opaque: "v1_0" }, running: false }),
+    credentials: () =>
+      fixturePromise(() => ({
+        database: { url: "postgres://test", password: "test" },
+        api: {
+          publishableKey: "publishable",
+          secretKey: "secret",
+          anonJwt: "anon",
+          serviceRoleJwt: "service",
+        },
+        storage: {
+          endpoint: "http://storage",
+          region: "local",
+          accessKeyId: "access",
+          secretAccessKey: "storage",
+        },
+      })),
+    prepare: () => fixturePromise(() => ({ capabilities: [] })),
+    start: () =>
+      fixturePromise(() => {
+        events.push("start");
+        if (failStart) throw new Error("startup failed");
+        return status(
+          reachesReadiness ? "running" : "stopped",
+          includeApi,
+          functionsState,
+          failedCapability,
+        );
+      }),
+    stop: () => fixturePromise(() => undefined),
+    destroy: () =>
+      fixturePromise(() => {
+        events.push("destroy");
+        if (failStart) throw new Error("destroy failed");
+      }),
+    logs: () => fixturePromise(() => ({ entries: [], cursor: { opaque: "v1_0" }, running: false })),
     followLogs: () => stream([]),
   };
 };
-
 const setupFixture = (root: string, stackOptions: FakeStackOptions = {}) => {
   const events: Array<string> = [];
   const removed: Array<string> = [];
   const operations: TestStackOperations = {
-    createRoot: async () => root,
-    createStack: async (options) => {
-      events.push(`create:${options.projectRoot}`);
-      return fakeStack(events, stackOptions);
-    },
-    removeRoot: async (removedRoot) => {
-      removed.push(removedRoot);
-    },
+    createRoot: () => fixturePromise(() => root),
+    createStack: (options) =>
+      fixturePromise(() => {
+        events.push(`create:${options.projectRoot}`);
+        return fakeStack(events, stackOptions);
+      }),
+    removeRoot: (removedRoot) =>
+      fixturePromise(() => {
+        removed.push(removedRoot);
+      }),
   };
   return { events, removed, operations };
 };
-
 describe("test stack resource", () => {
-  it("starts automatically and destroys only its owned identity", async () => {
-    const { events, removed, operations } = setupFixture("/tmp/stack-test-owned");
-    const stack = await createTestStackWith({}, operations);
-    await stack[Symbol.asyncDispose]();
-    expect(events).toEqual(["create:/tmp/stack-test-owned", "start", "destroy"]);
-    expect(removed).toEqual(["/tmp/stack-test-owned"]);
-  });
-
-  it("preserves startup failure while retaining the root when destroy fails", async () => {
-    const { events, removed, operations } = setupFixture("/tmp/stack-test-failed", {
-      failStart: true,
-    });
-    await expect(createTestStackWith({}, operations)).rejects.toThrow(
-      /startup failed[\s\S]*retained test stack root \/tmp\/stack-test-failed/,
-    );
-    expect(events).toEqual(["create:/tmp/stack-test-failed", "start", "destroy"]);
-    expect(removed).toEqual([]);
-  });
-
-  it("includes bounded startup diagnostics before cleanup removes a failed stack", async () => {
-    const events: Array<string> = [];
-    const removed: Array<string> = [];
-    const logQueries: Array<Parameters<PromiseStack["logs"]>[0]> = [];
-    const entries = Array.from({ length: 51 }, (_, index) => ({
-      cursor: { opaque: `v1_${(index + 1).toString(36)}` },
-      timestamp: "2026-01-01T00:00:00.000Z",
-      source: "pooler" as const,
-      stream: "stderr" as const,
-      message: index === 50 ? "pooler stderr" : `old-${index}`,
-    }));
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-diagnostics",
-      createStack: async () => ({
-        ...fakeStack(events),
-        start: async () => {
-          events.push("start");
-          throw new Error("startup failed");
-        },
-        status: async () => status("starting"),
-        logs: async (query) => {
-          logQueries.push(query);
-          return { entries, cursor: { opaque: "v1_1" }, running: false };
-        },
-      }),
-      removeRoot: async (root) => {
-        removed.push(root);
-      },
-    };
-
-    let failure: unknown;
-    try {
-      await createTestStackWith({}, operations);
-    } catch (error) {
-      failure = error;
-    }
-    expect(failure).toBeInstanceOf(Error);
-    if (!(failure instanceof Error)) throw new Error("expected startup failure");
-    expect(failure.message).toContain("startup failed");
-    expect(failure.message).toContain("pooler stderr");
-    expect(failure.message).not.toContain("old-0");
-    expect(failure.cause).toEqual(expect.objectContaining({ message: "startup failed" }));
-    expect(logQueries).toEqual([{ tail: 50 }]);
-    expect(events).toEqual(["start", "destroy"]);
-    expect(removed).toEqual(["/tmp/stack-test-diagnostics"]);
-  });
-
-  it("fails and cleans up when start returns before the stack is ready", async () => {
-    const events: Array<string> = [];
-    const removed: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-unready",
-      createStack: async () => ({
-        ...fakeStack(events),
-        start: async () => {
-          events.push("start");
-          return status("starting");
-        },
-      }),
-      removeRoot: async (root) => {
-        removed.push(root);
-      },
-    };
-    await expect(
-      createTestStackWith({ config: { capabilities: { database: {} } } }, operations),
-    ).rejects.toThrow("Stack did not become ready after start (lifecycle starting)");
-    expect(events).toEqual(["start", "destroy"]);
-    expect(removed).toEqual(["/tmp/stack-test-unready"]);
-  });
-
-  it("removes the exact root after disposal", async () => {
-    const events: Array<string> = [];
-    const removed: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-close-failed",
-      createStack: async () => fakeStack(events),
-      removeRoot: async (root) => {
-        removed.push(root);
-      },
-    };
-    const stack = await createTestStackWith({}, operations);
-    await expect(stack[Symbol.asyncDispose]()).resolves.toBeUndefined();
-    expect(events).toEqual(["start", "destroy"]);
-    expect(removed).toEqual(["/tmp/stack-test-close-failed"]);
-  });
-
-  it("does not require disabled Functions or an unconfigured API listener", async () => {
-    const events: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-disabled-surfaces",
-      createStack: async () => fakeStack(events, { includeApi: false, functionsState: "stopped" }),
-      removeRoot: async () => undefined,
-    };
-    const stack = await createTestStackWith(
-      { config: { capabilities: { functions: { enabled: false } } } },
-      operations,
-    );
-    await stack[Symbol.asyncDispose]();
-    expect(events).toEqual(["start", "destroy"]);
-  });
-
-  it("runs setupProject after creating the root and before creating the stack", async () => {
-    const events: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => {
-        events.push("root");
-        return "/tmp/stack-test-setup";
-      },
-      createStack: async (options) => {
-        events.push(`create:${options.projectRoot}`);
-        return fakeStack(events);
-      },
-      removeRoot: async () => {
-        events.push("remove");
-      },
-    };
-    const stack = await createTestStackWith(
-      {
-        setupProject: async (root) => {
-          events.push(`setup:${root}`);
-        },
-      },
-      operations,
-    );
-    await stack[Symbol.asyncDispose]();
-    expect(events).toEqual([
-      "root",
-      "setup:/tmp/stack-test-setup",
-      "create:/tmp/stack-test-setup",
-      "start",
-      "destroy",
-      "remove",
-    ]);
-  });
-
-  it("uses the managed runtime state root without mutating process environment", async () => {
-    const events: Array<string> = [];
-    // oxlint-disable-next-line effecttsgo/process-env -- test-only environment immutability assertion.
-    const originalHome = process.env.SUPABASE_HOME;
-    let environment: Parameters<NonNullable<TestStackOperations["createStack"]>>[1] | undefined;
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-isolated-state",
-      createStack: async (_options, runtimeEnvironment) => {
-        environment = runtimeEnvironment;
-        events.push("create");
-        return fakeStack(events);
-      },
-      removeRoot: async () => undefined,
-    };
-    const stack = await createTestStackWith({}, operations);
-    await stack[Symbol.asyncDispose]();
-    expect(environment?.stateRoot).toBe(defaultRuntimeEnvironment().stateRoot);
-    expect(environment?.artifactCacheRoot).toBe(join(tmpdir(), "supabase-stack-test-artifacts"));
-    expect(environment?.artifactCacheRoot).not.toContain("stack-test-isolated-state");
-    // Compare against the snapshot above to prove no global environment mutation occurred.
-    // oxlint-disable-next-line effecttsgo/process-env -- test-only environment immutability assertion.
-    expect(process.env.SUPABASE_HOME).toBe(originalHome);
-  });
-
-  it("falls back to the OS home when HOME is unavailable", () => {
-    // oxlint-disable-next-line effecttsgo/process-env -- test-only environment matrix.
-    const originalHome = process.env.HOME;
-    // oxlint-disable-next-line effecttsgo/process-env -- test-only environment matrix.
-    const originalSupabaseHome = process.env.SUPABASE_HOME;
-    try {
-      // oxlint-disable-next-line effecttsgo/process-env -- test-only environment matrix.
-      delete process.env.HOME;
-      // oxlint-disable-next-line effecttsgo/process-env -- test-only environment matrix.
-      delete process.env.SUPABASE_HOME;
-      expect(defaultRuntimeEnvironment().stateRoot).toBe(`${homedir()}/.supabase/managed/stacks`);
-    } finally {
-      // oxlint-disable-next-line effecttsgo/process-env -- restore test process environment.
-      if (originalHome === undefined) delete process.env.HOME;
-      else {
-        // oxlint-disable-next-line effecttsgo/process-env -- restore test process environment.
-        process.env.HOME = originalHome;
-      }
-      // oxlint-disable-next-line effecttsgo/process-env -- restore test process environment.
-      if (originalSupabaseHome === undefined) delete process.env.SUPABASE_HOME;
-      else {
-        // oxlint-disable-next-line effecttsgo/process-env -- restore test process environment.
-        process.env.SUPABASE_HOME = originalSupabaseHome;
-      }
-    }
-  });
-
-  it("removes the exact root when setupProject fails", async () => {
-    const events: Array<string> = [];
-    let created = false;
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-setup-failed",
-      createStack: async () => {
-        created = true;
-        return fakeStack(events);
-      },
-      removeRoot: async (root) => {
-        events.push(`remove:${root}`);
-      },
-    };
-    await expect(
-      createTestStackWith(
-        {
-          setupProject: async () => {
-            throw new Error("project setup failed");
+  it.live("starts automatically and destroys only its owned identity", () =>
+    Effect.gen(function* () {
+      const { events, removed, operations } = setupFixture("/tmp/stack-test-owned");
+      const stack = yield* Effect.promise(() => createTestStackWith({}, operations));
+      yield* Effect.promise(() => stack[Symbol.asyncDispose]());
+      expect(events).toEqual(["create:/tmp/stack-test-owned", "start", "destroy"]);
+      expect(removed).toEqual(["/tmp/stack-test-owned"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("preserves startup failure while retaining the root when destroy fails", () =>
+    Effect.gen(function* () {
+      const { events, removed, operations } = setupFixture("/tmp/stack-test-failed", {
+        failStart: true,
+      });
+      yield* Effect.promise(() =>
+        expect(createTestStackWith({}, operations)).rejects.toThrow(
+          /startup failed[\s\S]*retained test stack root \/tmp\/stack-test-failed/,
+        ),
+      );
+      expect(events).toEqual(["create:/tmp/stack-test-failed", "start", "destroy"]);
+      expect(removed).toEqual([]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("includes bounded startup diagnostics before cleanup removes a failed stack", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const removed: Array<string> = [];
+      const logQueries: Array<Parameters<PromiseStack["logs"]>[0]> = [];
+      const entries = Array.from({ length: 51 }, (_, index) => ({
+        cursor: { opaque: `v1_${(index + 1).toString(36)}` },
+        timestamp: "2026-01-01T00:00:00.000Z",
+        source: "pooler" as const,
+        stream: "stderr" as const,
+        message: index === 50 ? "pooler stderr" : `old-${index}`,
+      }));
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-diagnostics"),
+        createStack: () =>
+          fixturePromise(() => ({
+            ...fakeStack(events),
+            start: () =>
+              fixturePromise(() => {
+                events.push("start");
+                throw new Error("startup failed");
+              }),
+            status: () => fixturePromise(() => status("starting")),
+            logs: (query) =>
+              fixturePromise(() => {
+                logQueries.push(query);
+                return { entries, cursor: { opaque: "v1_1" }, running: false };
+              }),
+          })),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removed.push(root);
+          }),
+      };
+      const failure: unknown = yield* Effect.promise(() =>
+        createTestStackWith({}, operations).then(
+          () => undefined,
+          (error: unknown) => error,
+        ),
+      );
+      expect(failure).toBeInstanceOf(Error);
+      if (!(failure instanceof Error)) return yield* Effect.die("expected startup failure");
+      expect(failure.message).toContain("startup failed");
+      expect(failure.message).toContain("pooler stderr");
+      expect(failure.message).not.toContain("old-0");
+      expect(failure.cause).toEqual(expect.objectContaining({ message: "startup failed" }));
+      expect(logQueries).toEqual([{ tail: 50 }]);
+      expect(events).toEqual(["start", "destroy"]);
+      expect(removed).toEqual(["/tmp/stack-test-diagnostics"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("fails and cleans up when start returns before the stack is ready", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const removed: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-unready"),
+        createStack: () =>
+          fixturePromise(() => ({
+            ...fakeStack(events),
+            start: () =>
+              fixturePromise(() => {
+                events.push("start");
+                return status("starting");
+              }),
+          })),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removed.push(root);
+          }),
+      };
+      yield* Effect.promise(() =>
+        expect(
+          createTestStackWith({ config: { capabilities: { database: {} } } }, operations),
+        ).rejects.toThrow("Stack did not become ready after start (lifecycle starting)"),
+      );
+      expect(events).toEqual(["start", "destroy"]);
+      expect(removed).toEqual(["/tmp/stack-test-unready"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("removes the exact root after disposal", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const removed: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-close-failed"),
+        createStack: () => fixturePromise(() => fakeStack(events)),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removed.push(root);
+          }),
+      };
+      const stack = yield* Effect.promise(() => createTestStackWith({}, operations));
+      yield* Effect.promise(() => expect(stack[Symbol.asyncDispose]()).resolves.toBeUndefined());
+      expect(events).toEqual(["start", "destroy"]);
+      expect(removed).toEqual(["/tmp/stack-test-close-failed"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("does not require disabled Functions or an unconfigured API listener", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-disabled-surfaces"),
+        createStack: () =>
+          fixturePromise(() => fakeStack(events, { includeApi: false, functionsState: "stopped" })),
+        removeRoot: () => fixturePromise(() => undefined),
+      };
+      const stack = yield* Effect.promise(() =>
+        createTestStackWith(
+          { config: { capabilities: { functions: { enabled: false } } } },
+          operations,
+        ),
+      );
+      yield* Effect.promise(() => stack[Symbol.asyncDispose]());
+      expect(events).toEqual(["start", "destroy"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("runs setupProject after creating the root and before creating the stack", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () =>
+          fixturePromise(() => {
+            events.push("root");
+            return "/tmp/stack-test-setup";
+          }),
+        createStack: (options) =>
+          fixturePromise(() => {
+            events.push(`create:${options.projectRoot}`);
+            return fakeStack(events);
+          }),
+        removeRoot: () =>
+          fixturePromise(() => {
+            events.push("remove");
+          }),
+      };
+      const stack = yield* Effect.promise(() =>
+        createTestStackWith(
+          {
+            setupProject: (root) =>
+              fixturePromise(() => {
+                events.push(`setup:${root}`);
+              }),
           },
-        },
-        operations,
-      ),
-    ).rejects.toThrow("project setup failed");
-    expect(created).toBe(false);
-    expect(events).toEqual(["remove:/tmp/stack-test-setup-failed"]);
-  });
-
-  it("rejects readiness when a configured capability fails", async () => {
-    const events: Array<string> = [];
-    const removed: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-capability-failed",
-      createStack: async () => fakeStack(events, { failedCapability: "auth" }),
-      removeRoot: async (root) => {
-        removed.push(root);
-      },
-    };
-    await expect(createTestStackWith({}, operations)).rejects.toThrow("auth failed");
-    expect(events).toEqual(["start", "destroy"]);
-    expect(removed).toEqual(["/tmp/stack-test-capability-failed"]);
-  });
-
-  it("rejects readiness when the lifecycle stops before becoming ready", async () => {
-    const events: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-lifecycle-stopped",
-      createStack: async () => ({
-        ...fakeStack(events),
-        start: async () => {
-          events.push("start");
-          return status("stopped");
-        },
-      }),
-      removeRoot: async () => undefined,
-    };
-    await expect(createTestStackWith({}, operations)).rejects.toThrow("stopped");
-    expect(events).toEqual(["start", "destroy"]);
-  });
-
-  it("rejects readiness when the lifecycle starts stopping before becoming ready", async () => {
-    const events: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => "/tmp/stack-test-lifecycle-stopping",
-      createStack: async () => ({
-        ...fakeStack(events),
-        start: async () => {
-          events.push("start");
-          return status("stopping");
-        },
-      }),
-      removeRoot: async () => undefined,
-    };
-    await expect(createTestStackWith({}, operations)).rejects.toThrow("stopping");
-    expect(events).toEqual(["start", "destroy"]);
-  });
-
-  it("uses the managed state root while test stacks overlap", async () => {
-    const roots = ["/tmp/stack-test-shared-a", "/tmp/stack-test-shared-b"];
-    const environments: Array<Parameters<NonNullable<TestStackOperations["createStack"]>>[1]> = [];
-    const removedRoots: Array<string> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => {
-        const root = roots.shift();
-        if (root === undefined) throw new Error("No test root available");
-        return root;
-      },
-      createStack: async (_options, environment) => {
-        environments.push(environment);
-        return fakeStack([]);
-      },
-      removeRoot: async (root) => {
-        removedRoots.push(root);
-      },
-    };
-    const [first, second] = await Promise.all([
-      createTestStackWith({}, operations),
-      createTestStackWith({}, operations),
-    ]);
-    expect(environments.map((environment) => environment?.stateRoot)).toEqual([
-      defaultRuntimeEnvironment().stateRoot,
-      defaultRuntimeEnvironment().stateRoot,
-    ]);
-    await first[Symbol.asyncDispose]();
-    await second[Symbol.asyncDispose]();
-    expect(removedRoots).toEqual(["/tmp/stack-test-shared-a", "/tmp/stack-test-shared-b"]);
-  });
-
-  it("creates auto roots under the managed state root and cleans up the exact root", async () => {
-    let setupRoot: string | undefined;
-    let createdRoot: string | undefined;
-    let removedRoot: string | undefined;
-    const stack = await createTestStackWith(
-      {
-        setupProject: async (root) => {
-          setupRoot = root;
-        },
-      },
-      {
-        createStack: async (options) => {
-          createdRoot = options.projectRoot;
-          return fakeStack([]);
-        },
-        removeRoot: async (root) => {
-          removedRoot = root;
-        },
-      },
-    );
-    const managedRoot = defaultRuntimeEnvironment().stateRoot;
-    const projectsRoot = join(dirname(managedRoot), "test-projects");
-    expect(setupRoot).toBe(createdRoot);
-    expect(createdRoot?.startsWith(`${projectsRoot}${sep}`)).toBe(true);
-    if (!managedRoot.startsWith(`${tmpdir()}${sep}`))
-      expect(createdRoot?.startsWith(`${tmpdir()}${sep}`)).toBe(false);
-    await stack[Symbol.asyncDispose]();
-    expect(removedRoot).toBe(createdRoot);
-  });
-
-  it("retains the project root and managed state when one stack destroy fails", async () => {
-    const roots = ["/tmp/stack-test-retained-a", "/tmp/stack-test-retained-b"];
-    const removedRoots: Array<string> = [];
-    const environments: Array<Parameters<NonNullable<TestStackOperations["createStack"]>>[1]> = [];
-    const operations: TestStackOperations = {
-      createRoot: async () => {
-        const root = roots.shift();
-        if (root === undefined) throw new Error("No test root available");
-        return root;
-      },
-      createStack: async (options, environment) => {
-        environments.push(environment);
-        return {
-          ...fakeStack([]),
-          destroy: async () => {
-            if (options.projectRoot.endsWith("-a")) throw new Error("destroy a failed");
+          operations,
+        ),
+      );
+      yield* Effect.promise(() => stack[Symbol.asyncDispose]());
+      expect(events).toEqual([
+        "root",
+        "setup:/tmp/stack-test-setup",
+        "create:/tmp/stack-test-setup",
+        "start",
+        "destroy",
+        "remove",
+      ]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("uses the managed runtime state root without mutating process environment", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const originalEnvironment = yield* defaultRuntimeEnvironment;
+      let environment: Parameters<NonNullable<TestStackOperations["createStack"]>>[1] | undefined;
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-isolated-state"),
+        createStack: (_options, runtimeEnvironment) =>
+          fixturePromise(() => {
+            environment = runtimeEnvironment;
+            events.push("create");
+            return fakeStack(events);
+          }),
+        removeRoot: () => fixturePromise(() => undefined),
+      };
+      const stack = yield* Effect.promise(() => createTestStackWith({}, operations));
+      yield* Effect.promise(() => stack[Symbol.asyncDispose]());
+      expect(environment?.stateRoot).toBe((yield* defaultRuntimeEnvironment).stateRoot);
+      expect(environment?.artifactCacheRoot).toBe(
+        (yield* Path.Path).join(tmpdir(), "supabase-stack-test-artifacts"),
+      );
+      expect(environment?.artifactCacheRoot).not.toContain("stack-test-isolated-state");
+      // Compare against the snapshot above to prove no global environment mutation occurred.
+      expect(yield* defaultRuntimeEnvironment).toEqual(originalEnvironment);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("falls back to the OS home when HOME is unavailable", () =>
+    Effect.gen(function* () {
+      const environment = yield* defaultRuntimeEnvironment.pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({})),
+      );
+      expect(environment.stateRoot).toBe(`${homedir()}/.supabase/managed/stacks`);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("removes the exact root when setupProject fails", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      let created = false;
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-setup-failed"),
+        createStack: () =>
+          fixturePromise(() => {
+            created = true;
+            return fakeStack(events);
+          }),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            events.push(`remove:${root}`);
+          }),
+      };
+      yield* Effect.promise(() =>
+        expect(
+          createTestStackWith(
+            {
+              setupProject: () =>
+                fixturePromise(() => {
+                  throw new Error("project setup failed");
+                }),
+            },
+            operations,
+          ),
+        ).rejects.toThrow("project setup failed"),
+      );
+      expect(created).toBe(false);
+      expect(events).toEqual(["remove:/tmp/stack-test-setup-failed"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("rejects readiness when a configured capability fails", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const removed: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-capability-failed"),
+        createStack: () => fixturePromise(() => fakeStack(events, { failedCapability: "auth" })),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removed.push(root);
+          }),
+      };
+      yield* Effect.promise(() =>
+        expect(createTestStackWith({}, operations)).rejects.toThrow("auth failed"),
+      );
+      expect(events).toEqual(["start", "destroy"]);
+      expect(removed).toEqual(["/tmp/stack-test-capability-failed"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("rejects readiness when the lifecycle stops before becoming ready", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-lifecycle-stopped"),
+        createStack: () =>
+          fixturePromise(() => ({
+            ...fakeStack(events),
+            start: () =>
+              fixturePromise(() => {
+                events.push("start");
+                return status("stopped");
+              }),
+          })),
+        removeRoot: () => fixturePromise(() => undefined),
+      };
+      yield* Effect.promise(() =>
+        expect(createTestStackWith({}, operations)).rejects.toThrow("stopped"),
+      );
+      expect(events).toEqual(["start", "destroy"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("rejects readiness when the lifecycle starts stopping before becoming ready", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () => fixturePromise(() => "/tmp/stack-test-lifecycle-stopping"),
+        createStack: () =>
+          fixturePromise(() => ({
+            ...fakeStack(events),
+            start: () =>
+              fixturePromise(() => {
+                events.push("start");
+                return status("stopping");
+              }),
+          })),
+        removeRoot: () => fixturePromise(() => undefined),
+      };
+      yield* Effect.promise(() =>
+        expect(createTestStackWith({}, operations)).rejects.toThrow("stopping"),
+      );
+      expect(events).toEqual(["start", "destroy"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("uses the managed state root while test stacks overlap", () =>
+    Effect.gen(function* () {
+      const roots = ["/tmp/stack-test-shared-a", "/tmp/stack-test-shared-b"];
+      const environments: Array<Parameters<NonNullable<TestStackOperations["createStack"]>>[1]> =
+        [];
+      const removedRoots: Array<string> = [];
+      const operations: TestStackOperations = {
+        createRoot: () =>
+          fixturePromise(() => {
+            const root = roots.shift();
+            if (root === undefined) throw new Error("No test root available");
+            return root;
+          }),
+        createStack: (_options, environment) =>
+          fixturePromise(() => {
+            environments.push(environment);
+            return fakeStack([]);
+          }),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removedRoots.push(root);
+          }),
+      };
+      const [first, second] = yield* Effect.promise(() =>
+        Promise.all([createTestStackWith({}, operations), createTestStackWith({}, operations)]),
+      );
+      expect(environments.map((environment) => environment?.stateRoot)).toEqual([
+        (yield* defaultRuntimeEnvironment).stateRoot,
+        (yield* defaultRuntimeEnvironment).stateRoot,
+      ]);
+      yield* Effect.promise(() => first[Symbol.asyncDispose]());
+      yield* Effect.promise(() => second[Symbol.asyncDispose]());
+      expect(removedRoots).toEqual(["/tmp/stack-test-shared-a", "/tmp/stack-test-shared-b"]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("creates auto roots under the managed state root and cleans up the exact root", () =>
+    Effect.gen(function* () {
+      let setupRoot: string | undefined;
+      let createdRoot: string | undefined;
+      let removedRoot: string | undefined;
+      const stack = yield* Effect.promise(() =>
+        createTestStackWith(
+          {
+            setupProject: (root) =>
+              fixturePromise(() => {
+                setupRoot = root;
+              }),
           },
-        };
-      },
-      removeRoot: async (root) => {
-        removedRoots.push(root);
-      },
-    };
-    const [first, second] = await Promise.all([
-      createTestStackWith({}, operations),
-      createTestStackWith({}, operations),
-    ]);
-    await expect(first[Symbol.asyncDispose]()).rejects.toThrow(
-      "destroy a failed; retained test stack root /tmp/stack-test-retained-a",
-    );
-    await second[Symbol.asyncDispose]();
-    expect(removedRoots).toEqual(["/tmp/stack-test-retained-b"]);
-    expect(environments.map((environment) => environment?.stateRoot)).toEqual([
-      defaultRuntimeEnvironment().stateRoot,
-      defaultRuntimeEnvironment().stateRoot,
-    ]);
-  });
+          {
+            createStack: (options) =>
+              fixturePromise(() => {
+                createdRoot = options.projectRoot;
+                return fakeStack([]);
+              }),
+            removeRoot: (root) =>
+              fixturePromise(() => {
+                removedRoot = root;
+              }),
+          },
+        ),
+      );
+      const managedRoot = (yield* defaultRuntimeEnvironment).stateRoot;
+      const { join, dirname, sep } = yield* Path.Path;
+      const projectsRoot = join(dirname(managedRoot), "test-projects");
+      expect(setupRoot).toBe(createdRoot);
+      expect(createdRoot?.startsWith(`${projectsRoot}${sep}`)).toBe(true);
+      if (!managedRoot.startsWith(`${tmpdir()}${sep}`))
+        expect(createdRoot?.startsWith(`${tmpdir()}${sep}`)).toBe(false);
+      yield* Effect.promise(() => stack[Symbol.asyncDispose]());
+      expect(removedRoot).toBe(createdRoot);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+  it.live("retains the project root and managed state when one stack destroy fails", () =>
+    Effect.gen(function* () {
+      const roots = ["/tmp/stack-test-retained-a", "/tmp/stack-test-retained-b"];
+      const removedRoots: Array<string> = [];
+      const environments: Array<Parameters<NonNullable<TestStackOperations["createStack"]>>[1]> =
+        [];
+      const operations: TestStackOperations = {
+        createRoot: () =>
+          fixturePromise(() => {
+            const root = roots.shift();
+            if (root === undefined) throw new Error("No test root available");
+            return root;
+          }),
+        createStack: (options, environment) =>
+          fixturePromise(() => {
+            environments.push(environment);
+            return {
+              ...fakeStack([]),
+              destroy: () =>
+                fixturePromise(() => {
+                  if (options.projectRoot.endsWith("-a")) throw new Error("destroy a failed");
+                }),
+            };
+          }),
+        removeRoot: (root) =>
+          fixturePromise(() => {
+            removedRoots.push(root);
+          }),
+      };
+      const [first, second] = yield* Effect.promise(() =>
+        Promise.all([createTestStackWith({}, operations), createTestStackWith({}, operations)]),
+      );
+      yield* Effect.promise(() =>
+        expect(first[Symbol.asyncDispose]()).rejects.toThrow(
+          "destroy a failed; retained test stack root /tmp/stack-test-retained-a",
+        ),
+      );
+      yield* Effect.promise(() => second[Symbol.asyncDispose]());
+      expect(removedRoots).toEqual(["/tmp/stack-test-retained-b"]);
+      expect(environments.map((environment) => environment?.stateRoot)).toEqual([
+        (yield* defaultRuntimeEnvironment).stateRoot,
+        (yield* defaultRuntimeEnvironment).stateRoot,
+      ]);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 });

--- a/packages/stack/src/public/whole-stack.e2e.test.ts
+++ b/packages/stack/src/public/whole-stack.e2e.test.ts
@@ -25,7 +25,7 @@ import { NodeServices } from "@effect/platform-node";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import { connect as connectTcp } from "node:net";
+import { Socket } from "node:net";
 import { tmpdir } from "node:os";
 
 import { WebSocket } from "ws";
@@ -39,11 +39,16 @@ import type { PromiseStackCredentials } from "./Credentials.ts";
 import type { StackLogEntry } from "./Logs.ts";
 import type { PromiseStackConfig } from "./PromiseStack.ts";
 import type { StackEndpoint, StackStatus } from "./Status.ts";
-const E2E_TIMEOUT_MS = 15 * 60000;
-const REQUEST_TIMEOUT_MS = 60000;
+
+const E2E_TIMEOUT_MS = 15 * 60_000;
+
+const REQUEST_TIMEOUT_MS = 60_000;
+
 const hostRuntime = ManagedRuntime.make(Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer));
 afterAll(() => hostRuntime.dispose());
+
 const { join } = hostRuntime.runSync(Path.Path);
+
 const runNode = <A, E>(
   program: Effect.Effect<
     A,
@@ -51,6 +56,7 @@ const runNode = <A, E>(
     FileSystem.FileSystem | Path.Path | Crypto.Crypto | ChildProcessSpawner.ChildProcessSpawner
   >,
 ) => hostRuntime.runPromise(program);
+
 const execFile = (command: string, args: ReadonlyArray<string>, _options: { encoding: "utf8" }) =>
   runNode(
     Effect.gen(function* () {
@@ -77,16 +83,24 @@ const execFile = (command: string, args: ReadonlyArray<string>, _options: { enco
       return { stdout };
     }).pipe(Effect.scoped),
   );
+
 const withFs = <A, E>(operation: (fs: FileSystem.FileSystem) => Effect.Effect<A, E>) =>
   runNode(Effect.flatMap(FileSystem.FileSystem, operation));
+
 const access = (path: string) => withFs((fs) => fs.access(path));
+
 const mkdir = (path: string, options?: { recursive?: boolean }) =>
   withFs((fs) => fs.makeDirectory(path, options));
+
 const readText = (path: string) => withFs((fs) => fs.readFileString(path));
+
 const readdir = (path: string) => withFs((fs) => fs.readDirectory(path));
+
 const writeFile = (path: string, data: string) => withFs((fs) => fs.writeFileString(path, data));
+
 const rm = (path: string, options: { recursive: boolean; force: boolean }) =>
   withFs((fs) => fs.remove(path, options));
+
 const mkdtemp = (prefix: string) =>
   runNode(
     Effect.gen(function* () {
@@ -98,25 +112,31 @@ const mkdtemp = (prefix: string) =>
       });
     }),
   );
+
 const randomId = () =>
   hostRuntime.runSync(Effect.flatMap(Crypto.Crypto, (crypto) => crypto.randomUUIDv4));
+
 const queryTimestamp = (offset: number) =>
   DateTime.formatIso(DateTime.makeUnsafe(hostRuntime.runSync(Clock.currentTimeMillis) + offset));
+
 const ANALYTICS_QUERY_RETRY_SCHEDULE = Schedule.spaced("1 second").pipe(
   Schedule.upTo({ duration: "3 minutes" }),
 );
+
 const MAILPIT_DELIVERY_RETRY_SCHEDULE = Schedule.spaced("250 millis").pipe(
   Schedule.upTo({ duration: "30 seconds" }),
 );
 // Studio's first lazy request can start four workloads sequentially (4 × 30s).
-const LAZY_STUDIO_ACTIVATION_TIMEOUT_MS = 180000;
+const LAZY_STUDIO_ACTIVATION_TIMEOUT_MS = 180_000;
 // Pooler is activated by the first TCP connection and may take longer than the normal
 // query deadline while its migration and tenant bootstrap processes run.
 const LAZY_POOLER_ACTIVATION_TIMEOUT = "30 seconds";
+
 const ALL_RUNTIME_CASES = [
   { name: "native", runtime: { kind: "native" as const } },
   { name: "Docker", runtime: { kind: "container" as const, engine: "docker" as const } },
 ] as const;
+
 const SELECTED_RUNTIME = Option.getOrUndefined(
   Effect.runSync(Config.option(Config.string("SUPABASE_STACK_E2E_RUNTIME"))),
 );
@@ -126,13 +146,17 @@ if (
   SELECTED_RUNTIME !== "container"
 )
   throw new Error(`Unsupported stack E2E runtime: ${SELECTED_RUNTIME}`);
+
 const RUNTIME_CASES = ALL_RUNTIME_CASES.filter(
   ({ runtime }) => SELECTED_RUNTIME === undefined || runtime.kind === SELECTED_RUNTIME,
 );
+
 const databaseCatalog = catalogEntryFor("database:database");
+
 const NON_DEFAULT_DATABASE_RELEASES = Object.keys(databaseCatalog.releases).filter(
   (version) => version !== databaseCatalog.defaultVersion,
 );
+
 const BASE_WORKLOAD_IDS = [
   "analytics:analytics",
   "analytics:vector",
@@ -148,6 +172,7 @@ const BASE_WORKLOAD_IDS = [
   "studio:pgmeta",
   "studio:studio",
 ] as const;
+
 const OPTIONAL_STORAGE_ANALYTICS_WORKLOAD_IDS = [
   "database:database",
   "analytics:vector",
@@ -155,6 +180,7 @@ const OPTIONAL_STORAGE_ANALYTICS_WORKLOAD_IDS = [
   "storage:imgproxy",
   "storage:storage",
 ] as const;
+
 const ALL_EAGER_WORKLOAD_IDS = [
   "analytics:analytics",
   "analytics:vector",
@@ -170,6 +196,7 @@ const ALL_EAGER_WORKLOAD_IDS = [
   "studio:pgmeta",
   "studio:studio",
 ] as const;
+
 const dockerOwnedResourceCount = async (
   stackId: string,
   kind: "containers" | "networks" | "volumes",
@@ -187,6 +214,7 @@ const dockerOwnedResourceCount = async (
   const result = await execFile("docker", args, { encoding: "utf8" });
   return result.stdout.trim().length === 0 ? 0 : result.stdout.trim().split("\n").length;
 };
+
 const dockerOwnedWorkloadIds = async (stackId: string): Promise<ReadonlyArray<string>> => {
   const listed = await execFile(
     "docker",
@@ -226,11 +254,13 @@ const nativeWorkloadIds = async (stackId: string): Promise<ReadonlyArray<string>
     ),
   ].sort();
 };
+
 const ownedWorkloadIds = async (
   mode: (typeof RUNTIME_CASES)[number],
   stackId: string,
 ): Promise<ReadonlyArray<string>> =>
   mode.runtime.kind === "container" ? dockerOwnedWorkloadIds(stackId) : nativeWorkloadIds(stackId);
+
 const expectOwnedWorkloads = async (
   mode: (typeof RUNTIME_CASES)[number],
   stackId: string,
@@ -238,6 +268,7 @@ const expectOwnedWorkloads = async (
 ): Promise<void> => {
   expect(await ownedWorkloadIds(mode, stackId)).toEqual([...expected].sort());
 };
+
 const supervisorPids = async (stackId: string): Promise<ReadonlyArray<number>> => {
   const result = await execFile("ps", ["-axo", "pid=,command="], { encoding: "utf8" });
   return result.stdout.split("\n").flatMap((line) => {
@@ -251,6 +282,7 @@ const supervisorPids = async (stackId: string): Promise<ReadonlyArray<number>> =
       : [];
   });
 };
+
 const supervisorPid = async (stackId: string): Promise<number> => {
   const matches = await supervisorPids(stackId);
   if (matches.length !== 1)
@@ -259,6 +291,7 @@ const supervisorPid = async (stackId: string): Promise<number> => {
   if (pid === undefined) throw new Error(`Supervisor process for ${stackId} has no PID`);
   return pid;
 };
+
 const nativeDatabaseSharedMemoryId = async (lockPath: string): Promise<number> => {
   const lines = (await readText(lockPath)).split("\n");
   const sharedMemoryId = Number(lines[6]?.trim().split(/\s+/u)[1]);
@@ -266,6 +299,7 @@ const nativeDatabaseSharedMemoryId = async (lockPath: string): Promise<number> =
     throw new Error("Native database lock did not contain a valid shared-memory ID");
   return sharedMemoryId;
 };
+
 const nativeDatabaseSharedMemoryExists = async (
   sharedMemoryId: number,
 ): Promise<boolean | undefined> => {
@@ -285,6 +319,7 @@ const nativeDatabaseSharedMemoryExists = async (
     throw cause;
   }
 };
+
 const waitForProcessExit = (pid: number): Promise<void> => {
   const exited = Effect.try({
     try: () => {
@@ -319,21 +354,26 @@ class E2ERequestError extends Data.TaggedError("E2ERequestError")<{
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
 const websocketDataText = (data: WebSocket.RawData): string => {
   if (typeof data === "string") return data;
   if (Buffer.isBuffer(data)) return data.toString("utf8");
   if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
   return Buffer.concat(data).toString("utf8");
 };
+
 const endpoint = (status: StackStatus, name: keyof StackStatus["endpoints"]): StackEndpoint => {
   const value = status.endpoints[name];
   if (value === undefined) throw new Error(`Expected ${name} listener in stack status`);
   return value;
 };
+
 const capabilityState = (status: StackStatus, name: string): string | undefined =>
   status.capabilities.find((capability) => capability.name === name)?.state;
+
 const expectDefaultLazyState = (status: StackStatus): void => {
   expect(status.lifecycle).toBe("running");
   expect(capabilityState(status, "database")).toBe("ready");
@@ -371,6 +411,7 @@ const activate = async <A>(
   await Effect.runPromise(waitUntilReady);
   return result;
 };
+
 const request = (base: string, path: string, init: RequestInit = {}): Promise<Response> => {
   const url = new URL(path, `${base.replace(/\/$/u, "")}/`);
   const program = Effect.gen(function* () {
@@ -421,13 +462,24 @@ const request = (base: string, path: string, init: RequestInit = {}): Promise<Re
 const connect = (endpoint: StackEndpoint): Promise<void> =>
   Effect.runPromise(
     Effect.callback<void, E2ERequestError>((resume) => {
-      const socket = connectTcp(endpoint.port, endpoint.address);
-      const onConnect = () => resume(Effect.void);
+      const socket = new Socket();
+      let settled = false;
+      const finish = (result: Effect.Effect<void, E2ERequestError>) => {
+        if (settled) return;
+        settled = true;
+        socket.off("connect", onConnect);
+        socket.off("error", onError);
+        socket.destroy();
+        resume(result);
+      };
+      const onConnect = () => finish(Effect.void);
       const onError = (cause: Error) =>
-        resume(Effect.fail(new E2ERequestError({ message: cause.message, cause })));
+        finish(Effect.fail(new E2ERequestError({ message: cause.message, cause })));
       socket.once("connect", onConnect);
       socket.once("error", onError);
+      socket.connect(endpoint.port, endpoint.address);
       return Effect.sync(() => {
+        settled = true;
         socket.off("connect", onConnect);
         socket.off("error", onError);
         socket.destroy();
@@ -443,6 +495,7 @@ const expectEndpointsRefused = async (endpoints: ReadonlyArray<StackEndpoint>): 
     ).rejects.toThrow();
   }
 };
+
 const expectRuntimeInputsAbsent = async (
   stack: Pick<TestStack, "stateRoot" | "id">,
 ): Promise<void> => {
@@ -464,6 +517,7 @@ const expectRuntimeInputsAbsent = async (
     }
   }
 };
+
 const throwCapabilityDiagnostics = async (
   stack: TestStack,
   capabilityName: string,
@@ -499,12 +553,15 @@ const throwCapabilityDiagnostics = async (
     { cause },
   );
 };
+
 const jsonValue = async (response: Response): Promise<unknown> => response.json();
+
 const jsonObject = async (response: Response): Promise<JsonObject> => {
   const value = await jsonValue(response);
   if (!isJsonObject(value)) throw new Error("Expected a JSON object response");
   return Object.fromEntries(Object.entries(value));
 };
+
 const databaseQuery = async (
   url: string,
   statement: string,
@@ -540,6 +597,7 @@ const databaseQuery = async (
     throw new Error(`databaseQuery failed for ${target}: ${statement}`, { cause });
   }
 };
+
 const apiHeaders = (
   credentials: PromiseStackCredentials,
   token: string = credentials.api.anonJwt,
@@ -547,8 +605,10 @@ const apiHeaders = (
   apikey: credentials.api.publishableKey,
   Authorization: `Bearer ${token}`,
 });
+
 const serviceHeaders = (credentials: PromiseStackCredentials): Record<string, string> =>
   apiHeaders(credentials, credentials.api.serviceRoleJwt);
+
 const functionSource = (table: string, marker: string): string => `
 Deno.serve(async () => {
   console.log("${marker}");
@@ -583,33 +643,44 @@ Deno.serve(async () => {
   });
 });
 `;
+
 const waitForSocket = (
   socket: WebSocket,
   predicate: (value: JsonObject) => boolean,
 ): Promise<JsonObject> =>
   Effect.runPromise(
     Effect.callback<JsonObject, E2ERequestError>((resume) => {
+      let settled = false;
+      const finish = (result: Effect.Effect<JsonObject, E2ERequestError>) => {
+        if (settled) return;
+        settled = true;
+        socket.off("message", onMessage);
+        socket.off("error", onError);
+        socket.off("close", onClose);
+        resume(result);
+      };
       const onMessage = (data: WebSocket.RawData) => {
         try {
           const value: unknown = JSON.parse(websocketDataText(data));
           if (isJsonObject(value) && predicate(value))
-            resume(Effect.succeed(Object.fromEntries(Object.entries(value))));
+            finish(Effect.succeed(Object.fromEntries(Object.entries(value))));
         } catch {
           // Realtime can send non-JSON protocol frames.
         }
       };
       const onError = () =>
-        resume(
+        finish(
           Effect.fail(new E2ERequestError({ message: "Realtime WebSocket failed while waiting" })),
         );
       const onClose = () =>
-        resume(
+        finish(
           Effect.fail(new E2ERequestError({ message: "Realtime WebSocket closed while waiting" })),
         );
       socket.on("message", onMessage);
       socket.on("error", onError);
       socket.on("close", onClose);
       return Effect.sync(() => {
+        settled = true;
         socket.off("message", onMessage);
         socket.off("error", onError);
         socket.off("close", onClose);
@@ -624,19 +695,36 @@ const openSocket = (url: string): Promise<WebSocket> =>
         handshakeTimeout: REQUEST_TIMEOUT_MS,
         perMessageDeflate: false,
       });
-      let opened = false;
+      let settled = false;
+      const cleanup = () => {
+        socket.off("open", onOpen);
+        socket.off("error", onError);
+        socket.off("close", cleanup);
+      };
+      const terminate = () => {
+        socket.off("open", onOpen);
+        // Terminating an unfinished handshake emits an error before close.
+        socket.once("close", cleanup);
+        socket.terminate();
+      };
       const onOpen = () => {
-        opened = true;
+        if (settled) return;
+        settled = true;
+        cleanup();
         resume(Effect.succeed(socket));
       };
-      const onError = (cause: Error) =>
+      const onError = (cause: Error) => {
+        if (settled) return;
+        settled = true;
+        terminate();
         resume(Effect.fail(new E2ERequestError({ message: cause.message, cause })));
+      };
       socket.once("open", onOpen);
       socket.once("error", onError);
       return Effect.sync(() => {
-        socket.off("open", onOpen);
-        socket.off("error", onError);
-        if (!opened) socket.terminate();
+        if (settled) return;
+        settled = true;
+        terminate();
       });
     }),
   );
@@ -648,12 +736,14 @@ const makeRealtimeUrl = (api: StackEndpoint, apikey: string): string => {
   url.search = new URLSearchParams({ apikey, vsn: "1.0.0" }).toString();
   return url.toString();
 };
+
 const onePixelPng = Uint8Array.from(
   atob(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   ),
   (character) => character.charCodeAt(0),
 );
+
 const optionalWorkloadConfig = (
   functionSlug: string,
   analyticsApiKey: string,
@@ -665,6 +755,7 @@ const optionalWorkloadConfig = (
   },
   listeners: { smtp: { enabled: true } },
 });
+
 const allEagerConfig = (analyticsApiKey: string): PromiseStackConfig => ({
   capabilities: {
     rest: { activation: "eager" },
@@ -685,6 +776,7 @@ const allEagerConfig = (analyticsApiKey: string): PromiseStackConfig => ({
   },
   listeners: { smtp: { enabled: true } },
 });
+
 const queryAnalyticsMarker = async (
   api: StackEndpoint,
   analyticsApiKey: string,
@@ -742,6 +834,7 @@ type WholeStackScenario = Readonly<{
   studio: StackEndpoint;
   mailUi: StackEndpoint;
 }>;
+
 const arrangeWholeStackDatabase = async (scenario: WholeStackScenario): Promise<void> => {
   const { credentials, markers, table } = scenario;
   await databaseQuery(
@@ -763,6 +856,7 @@ const arrangeWholeStackDatabase = async (scenario: WholeStackScenario): Promise<
   );
   expect(directRows).toEqual([{ id: 1, payload: markers.first }]);
 };
+
 const verifyWholeStackDatabaseLogs = async (stack: TestStack): Promise<void> => {
   expect((await stack.logs({ capabilities: ["database"], tail: 1 })).entries).not.toHaveLength(0);
   const logIterator = stack
@@ -776,6 +870,7 @@ const verifyWholeStackDatabaseLogs = async (stack: TestStack): Promise<void> => 
     await logIterator.return?.();
   }
 };
+
 const exerciseWholeStackRestAndAuth = async (
   scenario: WholeStackScenario,
 ): Promise<{
@@ -820,6 +915,7 @@ const exerciseWholeStackRestAndAuth = async (
   );
   return { restPath, accessToken };
 };
+
 const exerciseWholeStackRealtime = async (
   scenario: WholeStackScenario,
   accessToken: string,
@@ -890,6 +986,7 @@ const exerciseWholeStackRealtime = async (
     await Promise.allSettled(socketWaiters);
   }
 };
+
 const exerciseWholeStackStorage = async (scenario: WholeStackScenario): Promise<void> => {
   const { api, bucket, credentials, stack } = scenario;
   await activate(stack, "storage", async () => {
@@ -909,6 +1006,7 @@ const exerciseWholeStackStorage = async (scenario: WholeStackScenario): Promise<
     expect((await downloaded.arrayBuffer()).byteLength).toBeGreaterThan(0);
   });
 };
+
 const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promise<void> => {
   const { api, credentials, functionSlug, markers, projectRoot, stack, table } = scenario;
   const functionPath = `/functions/v1/${functionSlug}`;
@@ -974,6 +1072,7 @@ const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promis
     await throwCapabilityDiagnostics(stack, "functions", "Functions flow", cause);
   }
 };
+
 const exerciseWholeStackAuxiliary = async (scenario: WholeStackScenario): Promise<URL> => {
   const { api, credentials, mailUi, pooler, stack, studio } = scenario;
   await activate(stack, "mail", async () => {
@@ -1003,6 +1102,7 @@ const exerciseWholeStackAuxiliary = async (scenario: WholeStackScenario): Promis
   expect(poolerRows).toEqual([{ answer: 42 }]);
   return poolerUrl;
 };
+
 const assertWholeStackReady = async (
   scenario: WholeStackScenario,
   status: StackStatus,
@@ -1017,6 +1117,7 @@ const assertWholeStackReady = async (
   }
   await expectOwnedWorkloads(scenario.mode, scenario.stack.id, BASE_WORKLOAD_IDS);
 };
+
 const reactivateWholeStackCapabilities = async (
   scenario: WholeStackScenario,
   restPath: string,
@@ -1058,6 +1159,7 @@ const reactivateWholeStackCapabilities = async (
     });
   });
 };
+
 const restartWholeStackFromPersistedData = async (
   scenario: WholeStackScenario,
   endpointSnapshot: Readonly<Record<string, number | undefined>>,
@@ -1082,6 +1184,7 @@ const restartWholeStackFromPersistedData = async (
   ).toEqual([{ payload: markers.first }]);
   await reactivateWholeStackCapabilities(scenario, restPath, functionPath, poolerUrl);
 };
+
 const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Promise<void> => {
   const identity = randomId().replaceAll("-", "").slice(0, 20).toLowerCase();
   const table = `stack_e2e_${identity}`;

--- a/packages/stack/src/public/whole-stack.e2e.test.ts
+++ b/packages/stack/src/public/whole-stack.e2e.test.ts
@@ -1,21 +1,35 @@
+// oxlint-disable effecttsgo/async-function -- await using scenarios verify the native Promise and AsyncDisposable contracts.
 // This E2E exercises the public Promise facade and real host APIs.
-// oxlint-disable effecttsgo/async-function -- user-facing Promise facade scenario.
-// oxlint-disable effecttsgo/new-promise -- WebSocket event handoff uses the platform Promise API.
-// oxlint-disable effecttsgo/global-fetch -- user-shaped HTTP requests use global fetch.
-// oxlint-disable effecttsgo/global-timers -- timeout guards belong to the host protocol fixtures.
-// oxlint-disable effecttsgo/crypto-random-uuid -- test identities use host randomness.
-// oxlint-disable effecttsgo/global-date -- query windows use host timestamps.
-// oxlint-disable effecttsgo/node-builtin-import -- E2E setup writes a real project with host fs/path APIs.
 import { PgClient } from "@effect/sql-pg";
-import { Data, Effect, Redacted, Schedule, type Duration } from "effect";
-import { execFile as execFileCallback } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import {
+  Cause,
+  Clock,
+  Config,
+  Crypto,
+  Data,
+  DateTime,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Path,
+  Predicate,
+  Redacted,
+  Schedule,
+  Stream,
+  type Duration,
+} from "effect";
+import { NodeServices } from "@effect/platform-node";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+
 import { connect as connectTcp } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { promisify } from "node:util";
+
 import { WebSocket } from "ws";
-import { describe, expect, test } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { createStack, listStacks, type PromiseStack } from "../index.ts";
 import { defaultRuntimeEnvironment } from "../supervisor/Launcher.ts";
 import { createTestStack, type TestStack } from "../testing.ts";
@@ -25,10 +39,69 @@ import type { PromiseStackCredentials } from "./Credentials.ts";
 import type { StackLogEntry } from "./Logs.ts";
 import type { PromiseStackConfig } from "./PromiseStack.ts";
 import type { StackEndpoint, StackStatus } from "./Status.ts";
-
-const E2E_TIMEOUT_MS = 15 * 60_000;
-const REQUEST_TIMEOUT_MS = 60_000;
-const execFile = promisify(execFileCallback);
+const E2E_TIMEOUT_MS = 15 * 60000;
+const REQUEST_TIMEOUT_MS = 60000;
+const hostRuntime = ManagedRuntime.make(Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer));
+afterAll(() => hostRuntime.dispose());
+const { join } = hostRuntime.runSync(Path.Path);
+const runNode = <A, E>(
+  program: Effect.Effect<
+    A,
+    E,
+    FileSystem.FileSystem | Path.Path | Crypto.Crypto | ChildProcessSpawner.ChildProcessSpawner
+  >,
+) => hostRuntime.runPromise(program);
+const execFile = (command: string, args: ReadonlyArray<string>, _options: { encoding: "utf8" }) =>
+  runNode(
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const child = yield* spawner.spawn(ChildProcess.make(command, args));
+      const [stdout, stderr, code] = yield* Effect.all(
+        [
+          child.stdout.pipe(
+            Stream.decodeText(),
+            Stream.runCollect,
+            Effect.map((chunks) => chunks.join("")),
+          ),
+          child.stderr.pipe(
+            Stream.decodeText(),
+            Stream.runCollect,
+            Effect.map((chunks) => chunks.join("")),
+          ),
+          child.exitCode,
+        ],
+        { concurrency: 3 },
+      );
+      if (code !== 0)
+        return yield* new E2ERequestError({ message: `${command} exited ${code}: ${stderr}` });
+      return { stdout };
+    }).pipe(Effect.scoped),
+  );
+const withFs = <A, E>(operation: (fs: FileSystem.FileSystem) => Effect.Effect<A, E>) =>
+  runNode(Effect.flatMap(FileSystem.FileSystem, operation));
+const access = (path: string) => withFs((fs) => fs.access(path));
+const mkdir = (path: string, options?: { recursive?: boolean }) =>
+  withFs((fs) => fs.makeDirectory(path, options));
+const readText = (path: string) => withFs((fs) => fs.readFileString(path));
+const readdir = (path: string) => withFs((fs) => fs.readDirectory(path));
+const writeFile = (path: string, data: string) => withFs((fs) => fs.writeFileString(path, data));
+const rm = (path: string, options: { recursive: boolean; force: boolean }) =>
+  withFs((fs) => fs.remove(path, options));
+const mkdtemp = (prefix: string) =>
+  runNode(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      return yield* fs.makeTempDirectory({
+        directory: path.dirname(prefix),
+        prefix: path.basename(prefix),
+      });
+    }),
+  );
+const randomId = () =>
+  hostRuntime.runSync(Effect.flatMap(Crypto.Crypto, (crypto) => crypto.randomUUIDv4));
+const queryTimestamp = (offset: number) =>
+  DateTime.formatIso(DateTime.makeUnsafe(hostRuntime.runSync(Clock.currentTimeMillis) + offset));
 const ANALYTICS_QUERY_RETRY_SCHEDULE = Schedule.spaced("1 second").pipe(
   Schedule.upTo({ duration: "3 minutes" }),
 );
@@ -36,7 +109,7 @@ const MAILPIT_DELIVERY_RETRY_SCHEDULE = Schedule.spaced("250 millis").pipe(
   Schedule.upTo({ duration: "30 seconds" }),
 );
 // Studio's first lazy request can start four workloads sequentially (4 × 30s).
-const LAZY_STUDIO_ACTIVATION_TIMEOUT_MS = 180_000;
+const LAZY_STUDIO_ACTIVATION_TIMEOUT_MS = 180000;
 // Pooler is activated by the first TCP connection and may take longer than the normal
 // query deadline while its migration and tenant bootstrap processes run.
 const LAZY_POOLER_ACTIVATION_TIMEOUT = "30 seconds";
@@ -44,8 +117,9 @@ const ALL_RUNTIME_CASES = [
   { name: "native", runtime: { kind: "native" as const } },
   { name: "Docker", runtime: { kind: "container" as const, engine: "docker" as const } },
 ] as const;
-// oxlint-disable-next-line effecttsgo/process-env -- selects the CI runtime matrix before an Effect program exists.
-const SELECTED_RUNTIME = process.env["SUPABASE_STACK_E2E_RUNTIME"];
+const SELECTED_RUNTIME = Option.getOrUndefined(
+  Effect.runSync(Config.option(Config.string("SUPABASE_STACK_E2E_RUNTIME"))),
+);
 if (
   SELECTED_RUNTIME !== undefined &&
   SELECTED_RUNTIME !== "native" &&
@@ -96,7 +170,6 @@ const ALL_EAGER_WORKLOAD_IDS = [
   "studio:pgmeta",
   "studio:studio",
 ] as const;
-
 const dockerOwnedResourceCount = async (
   stackId: string,
   kind: "containers" | "networks" | "volumes",
@@ -114,7 +187,6 @@ const dockerOwnedResourceCount = async (
   const result = await execFile("docker", args, { encoding: "utf8" });
   return result.stdout.trim().length === 0 ? 0 : result.stdout.trim().split("\n").length;
 };
-
 const dockerOwnedWorkloadIds = async (stackId: string): Promise<ReadonlyArray<string>> => {
   const listed = await execFile(
     "docker",
@@ -140,7 +212,6 @@ const dockerOwnedWorkloadIds = async (stackId: string): Promise<ReadonlyArray<st
     ),
   ].sort();
 };
-
 /** Native launchers carry the exact stack/workload marker in their command line. */
 const nativeWorkloadIds = async (stackId: string): Promise<ReadonlyArray<string>> => {
   const result = await execFile("ps", ["-axo", "pid=,command="], { encoding: "utf8" });
@@ -155,13 +226,11 @@ const nativeWorkloadIds = async (stackId: string): Promise<ReadonlyArray<string>
     ),
   ].sort();
 };
-
 const ownedWorkloadIds = async (
   mode: (typeof RUNTIME_CASES)[number],
   stackId: string,
 ): Promise<ReadonlyArray<string>> =>
   mode.runtime.kind === "container" ? dockerOwnedWorkloadIds(stackId) : nativeWorkloadIds(stackId);
-
 const expectOwnedWorkloads = async (
   mode: (typeof RUNTIME_CASES)[number],
   stackId: string,
@@ -169,7 +238,6 @@ const expectOwnedWorkloads = async (
 ): Promise<void> => {
   expect(await ownedWorkloadIds(mode, stackId)).toEqual([...expected].sort());
 };
-
 const supervisorPids = async (stackId: string): Promise<ReadonlyArray<number>> => {
   const result = await execFile("ps", ["-axo", "pid=,command="], { encoding: "utf8" });
   return result.stdout.split("\n").flatMap((line) => {
@@ -183,7 +251,6 @@ const supervisorPids = async (stackId: string): Promise<ReadonlyArray<number>> =
       : [];
   });
 };
-
 const supervisorPid = async (stackId: string): Promise<number> => {
   const matches = await supervisorPids(stackId);
   if (matches.length !== 1)
@@ -192,15 +259,13 @@ const supervisorPid = async (stackId: string): Promise<number> => {
   if (pid === undefined) throw new Error(`Supervisor process for ${stackId} has no PID`);
   return pid;
 };
-
 const nativeDatabaseSharedMemoryId = async (lockPath: string): Promise<number> => {
-  const lines = (await readFile(lockPath, "utf8")).split("\n");
+  const lines = (await readText(lockPath)).split("\n");
   const sharedMemoryId = Number(lines[6]?.trim().split(/\s+/u)[1]);
   if (!Number.isSafeInteger(sharedMemoryId) || sharedMemoryId < 0)
     throw new Error("Native database lock did not contain a valid shared-memory ID");
   return sharedMemoryId;
 };
-
 const nativeDatabaseSharedMemoryExists = async (
   sharedMemoryId: number,
 ): Promise<boolean | undefined> => {
@@ -211,12 +276,15 @@ const nativeDatabaseSharedMemoryExists = async (
       .split("\n")
       .some((line) => line.trim().split(/\s+/u)[1] === String(sharedMemoryId));
   } catch (cause) {
-    if (typeof cause === "object" && cause !== null && "code" in cause && cause.code === "ENOENT")
+    if (
+      Predicate.isTagged(cause, "PlatformError") &&
+      "reason" in cause &&
+      Predicate.isTagged(cause.reason, "NotFound")
+    )
       return undefined;
     throw cause;
   }
 };
-
 const waitForProcessExit = (pid: number): Promise<void> => {
   const exited = Effect.try({
     try: () => {
@@ -246,33 +314,26 @@ const waitForProcessExit = (pid: number): Promise<void> => {
     }),
   );
 };
-
 type JsonObject = Record<string, unknown>;
-
 class E2ERequestError extends Data.TaggedError("E2ERequestError")<{
   readonly message: string;
   readonly cause?: unknown;
 }> {}
-
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
-
 const websocketDataText = (data: WebSocket.RawData): string => {
   if (typeof data === "string") return data;
   if (Buffer.isBuffer(data)) return data.toString("utf8");
   if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
   return Buffer.concat(data).toString("utf8");
 };
-
 const endpoint = (status: StackStatus, name: keyof StackStatus["endpoints"]): StackEndpoint => {
   const value = status.endpoints[name];
   if (value === undefined) throw new Error(`Expected ${name} listener in stack status`);
   return value;
 };
-
 const capabilityState = (status: StackStatus, name: string): string | undefined =>
   status.capabilities.find((capability) => capability.name === name)?.state;
-
 const expectDefaultLazyState = (status: StackStatus): void => {
   expect(status.lifecycle).toBe("running");
   expect(capabilityState(status, "database")).toBe("ready");
@@ -288,7 +349,6 @@ const expectDefaultLazyState = (status: StackStatus): void => {
     expect(capabilityState(status, name), `${name} should remain dormant`).toBe("dormant");
   }
 };
-
 /** Wait for one capability transition while subscribing before sending traffic. */
 const activate = async <A>(
   stack: TestStack,
@@ -311,41 +371,69 @@ const activate = async <A>(
   await Effect.runPromise(waitUntilReady);
   return result;
 };
-
-const request = async (base: string, path: string, init: RequestInit = {}): Promise<Response> => {
+const request = (base: string, path: string, init: RequestInit = {}): Promise<Response> => {
   const url = new URL(path, `${base.replace(/\/$/u, "")}/`);
-  const method = init.method ?? "GET";
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      ...init,
-      signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  const program = Effect.gen(function* () {
+    const webRequest = new Request(url.href, init);
+    let outgoing = HttpClientRequest.fromWeb(webRequest);
+    if (webRequest.body !== null) {
+      const bytes = yield* Effect.tryPromise({
+        try: () => webRequest.arrayBuffer(),
+        catch: (cause) => new E2ERequestError({ message: "Unable to read request body", cause }),
+      });
+      outgoing = HttpClientRequest.bodyUint8Array(
+        outgoing,
+        new Uint8Array(bytes),
+        webRequest.headers.get("content-type") ?? undefined,
+      );
+    }
+    const response = yield* HttpClient.execute(outgoing);
+    const body = yield* response.arrayBuffer;
+    if (response.status < 200 || response.status >= 300)
+      return yield* new E2ERequestError({
+        message: `${init.method ?? "GET"} ${url} returned ${response.status}: ${new TextDecoder().decode(body)}`,
+      });
+    return new Response(response.status === 204 || response.status === 205 ? null : body, {
+      status: response.status,
+      headers: response.headers,
     });
-  } catch (cause) {
-    const reason = cause instanceof Error ? cause.message : String(cause);
-    throw new Error(`${method} ${url} failed: ${reason}`, { cause });
-  }
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`${method} ${url} returned ${response.status}: ${body}`);
-  }
-  return response;
+  });
+  return hostRuntime
+    .runPromiseExit(
+      init.signal == null ? program.pipe(Effect.timeout(REQUEST_TIMEOUT_MS)) : program,
+      { signal: init.signal ?? undefined },
+    )
+    .then((exit) => {
+      if (Exit.isSuccess(exit)) return exit.value;
+      const cause: unknown =
+        Cause.hasInterruptsOnly(exit.cause) && init.signal?.aborted
+          ? init.signal.reason
+          : Cause.squash(exit.cause);
+      if (cause instanceof E2ERequestError) throw cause;
+      const reason = cause instanceof Error ? cause.message : String(cause);
+      throw new E2ERequestError({
+        message: `${init.method ?? "GET"} ${url} failed: ${reason}`,
+        cause,
+      });
+    });
 };
 
 const connect = (endpoint: StackEndpoint): Promise<void> =>
-  new Promise((resolve, reject) => {
-    const socket = connectTcp(endpoint.port, endpoint.address);
-    const fail = (cause: unknown) => {
-      socket.destroy();
-      reject(cause instanceof Error ? cause : new Error(String(cause)));
-    };
-    socket.once("connect", () => {
-      socket.destroy();
-      resolve();
-    });
-    socket.once("error", fail);
-    socket.setTimeout(2_000, () => fail(new Error("TCP connection timed out")));
-  });
+  Effect.runPromise(
+    Effect.callback<void, E2ERequestError>((resume) => {
+      const socket = connectTcp(endpoint.port, endpoint.address);
+      const onConnect = () => resume(Effect.void);
+      const onError = (cause: Error) =>
+        resume(Effect.fail(new E2ERequestError({ message: cause.message, cause })));
+      socket.once("connect", onConnect);
+      socket.once("error", onError);
+      return Effect.sync(() => {
+        socket.off("connect", onConnect);
+        socket.off("error", onError);
+        socket.destroy();
+      });
+    }).pipe(Effect.timeout("2 seconds")),
+  );
 
 const expectEndpointsRefused = async (endpoints: ReadonlyArray<StackEndpoint>): Promise<void> => {
   for (const listener of endpoints) {
@@ -355,7 +443,6 @@ const expectEndpointsRefused = async (endpoints: ReadonlyArray<StackEndpoint>): 
     ).rejects.toThrow();
   }
 };
-
 const expectRuntimeInputsAbsent = async (
   stack: Pick<TestStack, "stateRoot" | "id">,
 ): Promise<void> => {
@@ -366,11 +453,17 @@ const expectRuntimeInputsAbsent = async (
     try {
       expect(await readdir(path), `${path} should be empty after cleanup`).toHaveLength(0);
     } catch (cause) {
-      if (!(cause instanceof Error && "code" in cause && cause.code === "ENOENT")) throw cause;
+      if (
+        !(
+          Predicate.isTagged(cause, "PlatformError") &&
+          "reason" in cause &&
+          Predicate.isTagged(cause.reason, "NotFound")
+        )
+      )
+        throw cause;
     }
   }
 };
-
 const throwCapabilityDiagnostics = async (
   stack: TestStack,
   capabilityName: string,
@@ -406,20 +499,19 @@ const throwCapabilityDiagnostics = async (
     { cause },
   );
 };
-
 const jsonValue = async (response: Response): Promise<unknown> => response.json();
-
 const jsonObject = async (response: Response): Promise<JsonObject> => {
   const value = await jsonValue(response);
   if (!isJsonObject(value)) throw new Error("Expected a JSON object response");
   return Object.fromEntries(Object.entries(value));
 };
-
 const databaseQuery = async (
   url: string,
   statement: string,
   parameters: ReadonlyArray<unknown> = [],
-  options: Readonly<{ readonly connectTimeout?: Duration.Input }> = {},
+  options: Readonly<{
+    readonly connectTimeout?: Duration.Input;
+  }> = {},
 ): Promise<ReadonlyArray<object>> => {
   try {
     return await Effect.runPromise(
@@ -448,7 +540,6 @@ const databaseQuery = async (
     throw new Error(`databaseQuery failed for ${target}: ${statement}`, { cause });
   }
 };
-
 const apiHeaders = (
   credentials: PromiseStackCredentials,
   token: string = credentials.api.anonJwt,
@@ -456,10 +547,8 @@ const apiHeaders = (
   apikey: credentials.api.publishableKey,
   Authorization: `Bearer ${token}`,
 });
-
 const serviceHeaders = (credentials: PromiseStackCredentials): Record<string, string> =>
   apiHeaders(credentials, credentials.api.serviceRoleJwt);
-
 const functionSource = (table: string, marker: string): string => `
 Deno.serve(async () => {
   console.log("${marker}");
@@ -494,56 +583,63 @@ Deno.serve(async () => {
   });
 });
 `;
-
 const waitForSocket = (
   socket: WebSocket,
   predicate: (value: JsonObject) => boolean,
 ): Promise<JsonObject> =>
-  new Promise((resolve, reject) => {
-    let settled = false;
-    const cleanup = () => {
-      clearTimeout(timeout);
-      socket.removeListener("message", onMessage);
-      socket.removeListener("error", onError);
-      socket.removeListener("close", onClose);
-    };
-    const finish = (error: Error | undefined, value?: JsonObject) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      if (error === undefined) resolve(value ?? {});
-      else reject(error);
-    };
-    const timeout = setTimeout(
-      () => finish(new Error("Timed out waiting for Realtime message")),
-      REQUEST_TIMEOUT_MS,
-    );
-    const onMessage = (data: WebSocket.RawData) => {
-      try {
-        const value: unknown = JSON.parse(websocketDataText(data));
-        if (!isJsonObject(value)) return;
-        if (!predicate(value)) return;
-        finish(undefined, Object.fromEntries(Object.entries(value)));
-      } catch {
-        // Ignore protocol frames that are not JSON objects.
-      }
-    };
-    const onError = () => finish(new Error("Realtime WebSocket failed while waiting"));
-    const onClose = () => finish(new Error("Realtime WebSocket closed while waiting"));
-    socket.on("message", onMessage);
-    socket.on("error", onError);
-    socket.on("close", onClose);
-  });
+  Effect.runPromise(
+    Effect.callback<JsonObject, E2ERequestError>((resume) => {
+      const onMessage = (data: WebSocket.RawData) => {
+        try {
+          const value: unknown = JSON.parse(websocketDataText(data));
+          if (isJsonObject(value) && predicate(value))
+            resume(Effect.succeed(Object.fromEntries(Object.entries(value))));
+        } catch {
+          // Realtime can send non-JSON protocol frames.
+        }
+      };
+      const onError = () =>
+        resume(
+          Effect.fail(new E2ERequestError({ message: "Realtime WebSocket failed while waiting" })),
+        );
+      const onClose = () =>
+        resume(
+          Effect.fail(new E2ERequestError({ message: "Realtime WebSocket closed while waiting" })),
+        );
+      socket.on("message", onMessage);
+      socket.on("error", onError);
+      socket.on("close", onClose);
+      return Effect.sync(() => {
+        socket.off("message", onMessage);
+        socket.off("error", onError);
+        socket.off("close", onClose);
+      });
+    }).pipe(Effect.timeout(REQUEST_TIMEOUT_MS)),
+  );
 
 const openSocket = (url: string): Promise<WebSocket> =>
-  new Promise((resolve, reject) => {
-    const socket = new WebSocket(url, {
-      handshakeTimeout: REQUEST_TIMEOUT_MS,
-      perMessageDeflate: false,
-    });
-    socket.once("open", () => resolve(socket));
-    socket.once("error", (cause) => reject(cause));
-  });
+  Effect.runPromise(
+    Effect.callback<WebSocket, E2ERequestError>((resume) => {
+      const socket = new WebSocket(url, {
+        handshakeTimeout: REQUEST_TIMEOUT_MS,
+        perMessageDeflate: false,
+      });
+      let opened = false;
+      const onOpen = () => {
+        opened = true;
+        resume(Effect.succeed(socket));
+      };
+      const onError = (cause: Error) =>
+        resume(Effect.fail(new E2ERequestError({ message: cause.message, cause })));
+      socket.once("open", onOpen);
+      socket.once("error", onError);
+      return Effect.sync(() => {
+        socket.off("open", onOpen);
+        socket.off("error", onError);
+        if (!opened) socket.terminate();
+      });
+    }),
+  );
 
 const makeRealtimeUrl = (api: StackEndpoint, apikey: string): string => {
   const url = new URL(api.url);
@@ -552,14 +648,12 @@ const makeRealtimeUrl = (api: StackEndpoint, apikey: string): string => {
   url.search = new URLSearchParams({ apikey, vsn: "1.0.0" }).toString();
   return url.toString();
 };
-
 const onePixelPng = Uint8Array.from(
   atob(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   ),
   (character) => character.charCodeAt(0),
 );
-
 const optionalWorkloadConfig = (
   functionSlug: string,
   analyticsApiKey: string,
@@ -571,7 +665,6 @@ const optionalWorkloadConfig = (
   },
   listeners: { smtp: { enabled: true } },
 });
-
 const allEagerConfig = (analyticsApiKey: string): PromiseStackConfig => ({
   capabilities: {
     rest: { activation: "eager" },
@@ -592,7 +685,6 @@ const allEagerConfig = (analyticsApiKey: string): PromiseStackConfig => ({
   },
   listeners: { smtp: { enabled: true } },
 });
-
 const queryAnalyticsMarker = async (
   api: StackEndpoint,
   analyticsApiKey: string,
@@ -600,8 +692,8 @@ const queryAnalyticsMarker = async (
 ): Promise<number> => {
   const query = new URLSearchParams({
     project: "default",
-    iso_timestamp_start: new Date(Date.now() - 3_600_000).toISOString(),
-    iso_timestamp_end: new Date(Date.now() + 3_600_000).toISOString(),
+    iso_timestamp_start: queryTimestamp(-3_600_000),
+    iso_timestamp_end: queryTimestamp(3_600_000),
     sql:
       "select count(*) as c from postgres_logs where regexp_contains(event_message, '" +
       marker +
@@ -627,10 +719,12 @@ const queryAnalyticsMarker = async (
   });
   return Effect.runPromise(Effect.retry(attempt, { schedule: ANALYTICS_QUERY_RETRY_SCHEDULE }));
 };
-
 type RuntimeCase = (typeof RUNTIME_CASES)[number];
-type WholeStackMarkers = Readonly<{ first: string; second: string; live: string }>;
-
+type WholeStackMarkers = Readonly<{
+  first: string;
+  second: string;
+  live: string;
+}>;
 type WholeStackScenario = Readonly<{
   mode: RuntimeCase;
   stack: TestStack;
@@ -648,7 +742,6 @@ type WholeStackScenario = Readonly<{
   studio: StackEndpoint;
   mailUi: StackEndpoint;
 }>;
-
 const arrangeWholeStackDatabase = async (scenario: WholeStackScenario): Promise<void> => {
   const { credentials, markers, table } = scenario;
   await databaseQuery(
@@ -670,7 +763,6 @@ const arrangeWholeStackDatabase = async (scenario: WholeStackScenario): Promise<
   );
   expect(directRows).toEqual([{ id: 1, payload: markers.first }]);
 };
-
 const verifyWholeStackDatabaseLogs = async (stack: TestStack): Promise<void> => {
   expect((await stack.logs({ capabilities: ["database"], tail: 1 })).entries).not.toHaveLength(0);
   const logIterator = stack
@@ -684,10 +776,12 @@ const verifyWholeStackDatabaseLogs = async (stack: TestStack): Promise<void> => 
     await logIterator.return?.();
   }
 };
-
 const exerciseWholeStackRestAndAuth = async (
   scenario: WholeStackScenario,
-): Promise<{ readonly restPath: string; readonly accessToken: string }> => {
+): Promise<{
+  readonly restPath: string;
+  readonly accessToken: string;
+}> => {
   const { api, credentials, email, identity, password, markers, stack, table } = scenario;
   const restPath = `/rest/v1/${table}?select=id,payload&order=id`;
   const restRows = await activate(stack, "rest", async () =>
@@ -698,7 +792,6 @@ const exerciseWholeStackRestAndAuth = async (
     ),
   );
   expect(restRows).toEqual(expect.arrayContaining([{ id: 1, payload: markers.first }]));
-
   const signup = await activate(stack, "auth", async () =>
     jsonObject(
       await request(api.url, "/auth/v1/signup", {
@@ -711,7 +804,6 @@ const exerciseWholeStackRestAndAuth = async (
   const accessToken = signup.access_token;
   if (typeof accessToken !== "string")
     throw new Error("Auth signup did not return an access token");
-
   const authenticatedInsert = await jsonValue(
     await request(api.url, `/rest/v1/${table}`, {
       method: "POST",
@@ -728,7 +820,6 @@ const exerciseWholeStackRestAndAuth = async (
   );
   return { restPath, accessToken };
 };
-
 const exerciseWholeStackRealtime = async (
   scenario: WholeStackScenario,
   accessToken: string,
@@ -799,7 +890,6 @@ const exerciseWholeStackRealtime = async (
     await Promise.allSettled(socketWaiters);
   }
 };
-
 const exerciseWholeStackStorage = async (scenario: WholeStackScenario): Promise<void> => {
   const { api, bucket, credentials, stack } = scenario;
   await activate(stack, "storage", async () => {
@@ -819,7 +909,6 @@ const exerciseWholeStackStorage = async (scenario: WholeStackScenario): Promise<
     expect((await downloaded.arrayBuffer()).byteLength).toBeGreaterThan(0);
   });
 };
-
 const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promise<void> => {
   const { api, credentials, functionSlug, markers, projectRoot, stack, table } = scenario;
   const functionPath = `/functions/v1/${functionSlug}`;
@@ -837,7 +926,6 @@ const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promis
         rows: expect.arrayContaining([{ id: 1, payload: markers.first }]),
       }),
     );
-
     await writeFile(
       join(projectRoot, "supabase", "functions", functionSlug, "index.ts"),
       functionSource(table, markers.second),
@@ -852,7 +940,6 @@ const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promis
         rows: expect.arrayContaining([{ id: 1, payload: markers.first }]),
       }),
     );
-
     const beforeLiveLogs = await stack.logs({ capabilities: ["functions"] });
     const liveIterator = stack
       .followLogs({ capabilities: ["functions"], cursor: beforeLiveLogs.cursor })
@@ -887,7 +974,6 @@ const exerciseWholeStackFunctions = async (scenario: WholeStackScenario): Promis
     await throwCapabilityDiagnostics(stack, "functions", "Functions flow", cause);
   }
 };
-
 const exerciseWholeStackAuxiliary = async (scenario: WholeStackScenario): Promise<URL> => {
   const { api, credentials, mailUi, pooler, stack, studio } = scenario;
   await activate(stack, "mail", async () => {
@@ -917,7 +1003,6 @@ const exerciseWholeStackAuxiliary = async (scenario: WholeStackScenario): Promis
   expect(poolerRows).toEqual([{ answer: 42 }]);
   return poolerUrl;
 };
-
 const assertWholeStackReady = async (
   scenario: WholeStackScenario,
   status: StackStatus,
@@ -932,7 +1017,6 @@ const assertWholeStackReady = async (
   }
   await expectOwnedWorkloads(scenario.mode, scenario.stack.id, BASE_WORKLOAD_IDS);
 };
-
 const reactivateWholeStackCapabilities = async (
   scenario: WholeStackScenario,
   restPath: string,
@@ -974,7 +1058,6 @@ const reactivateWholeStackCapabilities = async (
     });
   });
 };
-
 const restartWholeStackFromPersistedData = async (
   scenario: WholeStackScenario,
   endpointSnapshot: Readonly<Record<string, number | undefined>>,
@@ -999,9 +1082,8 @@ const restartWholeStackFromPersistedData = async (
   ).toEqual([{ payload: markers.first }]);
   await reactivateWholeStackCapabilities(scenario, restPath, functionPath, poolerUrl);
 };
-
 const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Promise<void> => {
-  const identity = crypto.randomUUID().replaceAll("-", "").slice(0, 20).toLowerCase();
+  const identity = randomId().replaceAll("-", "").slice(0, 20).toLowerCase();
   const table = `stack_e2e_${identity}`;
   const bucket = `stack-e2e-${identity}`;
   const functionSlug = `cross_service_${identity}`;
@@ -1013,7 +1095,6 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
     live: `live-${identity}`,
   };
   let projectRoot = "";
-
   await using stack: TestStack = await createTestStack({
     name: `stack-e2e-${identity}`,
     runtime: mode.runtime,
@@ -1024,13 +1105,11 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
       await writeFile(join(directory, "index.ts"), functionSource(table, markers.first));
     },
   });
-
   const initialRunning = await stack.status();
   expect(initialRunning.runtime).toEqual(mode.runtime);
   expect(projectRoot.length).toBeGreaterThan(0);
   expectDefaultLazyState(initialRunning);
   await expectOwnedWorkloads(mode, stack.id, ["database:database"]);
-
   // Preparation is an explicit cache-only operation. It runs after the helper's
   // initial session is stopped, so the test proves it creates no owner, listener,
   // or workload.
@@ -1061,10 +1140,8 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
   const initialEndpoints = Object.values(initial.endpoints).filter(
     (value): value is StackEndpoint => value !== undefined,
   );
-
   // The warmed capability remains lazy: only its artifact is cached, not its
   // workload. The first request below still performs the normal activation.
-
   const scenario: WholeStackScenario = {
     mode,
     stack,
@@ -1085,20 +1162,16 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
   await arrangeWholeStackDatabase(scenario);
   await verifyWholeStackDatabaseLogs(stack);
   const { restPath, accessToken } = await exerciseWholeStackRestAndAuth(scenario);
-
   await exerciseWholeStackRealtime(scenario, accessToken);
   await exerciseWholeStackStorage(scenario);
-
   // Functions are request-time discovered and call REST through SUPABASE_URL.
   const functionPath = `/functions/v1/${functionSlug}`;
   await exerciseWholeStackFunctions(scenario);
   const poolerUrl = await exerciseWholeStackAuxiliary(scenario);
-
   const ready = await stack.status();
   await assertWholeStackReady(scenario, ready);
   const idempotentStart = await stack.start();
   await assertWholeStackReady(scenario, idempotentStart);
-
   const endpointSnapshot = Object.fromEntries(
     Object.entries(ready.endpoints).map(([name, value]) => [name, value?.port]),
   );
@@ -1111,7 +1184,6 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
     mode.runtime.kind === "container"
       ? await dockerOwnedResourceCount(initial.id, "volumes")
       : undefined;
-
   try {
     await stack.stop();
   } catch (cause) {
@@ -1152,7 +1224,6 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
     expect(await dockerOwnedResourceCount(initial.id, "networks")).toBe(0);
     expect(await dockerOwnedResourceCount(initial.id, "volumes")).toBe(volumesBeforeStop);
   }
-
   await restartWholeStackFromPersistedData(
     scenario,
     endpointSnapshot,
@@ -1160,7 +1231,6 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
     functionPath,
     poolerUrl,
   );
-
   await stack.stop();
   await restartWholeStackFromPersistedData(
     scenario,
@@ -1169,10 +1239,8 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
     functionPath,
     poolerUrl,
   );
-
   const final = await stack.status();
   await assertWholeStackReady(scenario, final);
-
   await stack.stop();
   await expectOwnedWorkloads(mode, stack.id, []);
   const reconfigured = await stack.start({
@@ -1190,20 +1258,19 @@ const runWholeStackScenario = async (mode: (typeof RUNTIME_CASES)[number]): Prom
   expect(endpoint(reconfigured, "api").port).not.toBe(api.port);
   expect(reconfigured.endpoints.studio).toBeUndefined();
 };
-
 describe("managed Supabase stack whole-stack E2E", () => {
   test.skipIf(SELECTED_RUNTIME === "container")(
     "recovers the native database after abrupt Supervisor termination",
     { timeout: E2E_TIMEOUT_MS },
     async () => {
       await using stack: TestStack = await createTestStack({
-        name: `stack-crash-recovery-${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
+        name: `stack-crash-recovery-${randomId().replaceAll("-", "").slice(0, 16)}`,
         runtime: { kind: "native" },
       });
       const before = await stack.status();
       const database = endpoint(before, "database");
       const lockPath = join(stack.stateRoot, stack.id, "data", "database", "postmaster.pid");
-      const databasePid = Number((await readFile(lockPath, "utf8")).split("\n", 1)[0]);
+      const databasePid = Number((await readText(lockPath)).split("\n", 1)[0]);
       if (!Number.isSafeInteger(databasePid) || databasePid <= 0)
         throw new Error("Native database lock did not contain a valid PID");
       const sharedMemoryId = await nativeDatabaseSharedMemoryId(lockPath);
@@ -1215,7 +1282,6 @@ describe("managed Supabase stack whole-stack E2E", () => {
         expect(await nativeDatabaseSharedMemoryExists(sharedMemoryId)).toBe(false);
       await expect(connect(database)).rejects.toThrow();
       await expect(access(lockPath)).rejects.toThrow();
-
       const recovered = await stack.start();
       expectDefaultLazyState(recovered);
       expect(
@@ -1223,7 +1289,6 @@ describe("managed Supabase stack whole-stack E2E", () => {
       ).toEqual([{ value: 1 }]);
     },
   );
-
   for (const mode of RUNTIME_CASES) {
     for (const databaseVersion of NON_DEFAULT_DATABASE_RELEASES) {
       const major = databaseVersion.split(".")[0];
@@ -1232,7 +1297,7 @@ describe("managed Supabase stack whole-stack E2E", () => {
         { timeout: E2E_TIMEOUT_MS },
         async () => {
           await using stack: TestStack = await createTestStack({
-            name: `stack-postgres-${major}-${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
+            name: `stack-postgres-${major}-${randomId().replaceAll("-", "").slice(0, 16)}`,
             runtime: mode.runtime,
             config: { capabilities: { database: { version: major } } },
           });
@@ -1244,12 +1309,11 @@ describe("managed Supabase stack whole-stack E2E", () => {
         },
       );
     }
-
     test(
       `coordinates concurrent isolated stacks in ${mode.name} mode`,
       { timeout: E2E_TIMEOUT_MS },
       async () => {
-        const identity = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+        const identity = randomId().replaceAll("-", "").slice(0, 16);
         const creations = await Promise.allSettled([
           createTestStack({
             name: `stack-concurrent-a-${identity}`,
@@ -1278,14 +1342,12 @@ describe("managed Supabase stack whole-stack E2E", () => {
         const secondStack = secondResult.value;
         await using first: TestStack = firstStack;
         await using second: TestStack = secondStack;
-
         const [firstStatus, secondStatus] = await Promise.all([first.status(), second.status()]);
         expect(firstStatus.lifecycle).toBe("running");
         expect(secondStatus.lifecycle).toBe("running");
         const firstApi = endpoint(firstStatus, "api");
         const secondApi = endpoint(secondStatus, "api");
         expect(firstApi.port).not.toBe(secondApi.port);
-
         const [firstCredentials, secondCredentials] = await Promise.all([
           first.credentials(),
           second.credentials(),
@@ -1330,12 +1392,11 @@ describe("managed Supabase stack whole-stack E2E", () => {
         expect(secondRows).toEqual([{ payload: secondMarker }]);
       },
     );
-
     test(
       `coordinates with an ordinary package stack in ${mode.name} mode`,
       { timeout: E2E_TIMEOUT_MS },
       async () => {
-        const identity = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+        const identity = randomId().replaceAll("-", "").slice(0, 16);
         const ordinaryRoot = await mkdtemp(join(tmpdir(), "supabase-stack-cli-consumer-"));
         let ordinary: PromiseStack | undefined;
         let helper: TestStack | undefined;
@@ -1351,14 +1412,14 @@ describe("managed Supabase stack whole-stack E2E", () => {
             name: `stack-helper-consumer-${identity}`,
             runtime: mode.runtime,
           });
-
           const ordinaryStatus = await ordinary.status();
           const helperStatus = await helper.status();
           expect(ordinaryStatus.lifecycle).toBe("running");
           expect(helperStatus.lifecycle).toBe("running");
-          expect(helper.stateRoot).toBe(defaultRuntimeEnvironment().stateRoot);
+          expect(helper.stateRoot).toBe(
+            (await Effect.runPromise(defaultRuntimeEnvironment)).stateRoot,
+          );
           expect(endpoint(ordinaryStatus, "api").port).not.toBe(endpoint(helperStatus, "api").port);
-
           const scoped = await listStacks({ projectRoot: ordinaryRoot });
           expect(scoped.map(({ id }) => id)).toContain(ordinary.id);
           expect(scoped.map(({ id }) => id)).not.toContain(helper.id);
@@ -1367,7 +1428,6 @@ describe("managed Supabase stack whole-stack E2E", () => {
         } catch (error) {
           primary = error;
         }
-
         const [helperResult, ordinaryResult] = await Promise.allSettled([
           helper === undefined ? Promise.resolve() : helper[Symbol.asyncDispose](),
           ordinary === undefined ? Promise.resolve() : ordinary.destroy(),
@@ -1389,18 +1449,16 @@ describe("managed Supabase stack whole-stack E2E", () => {
         if (cleanupFailure !== undefined) throw cleanupFailure;
       },
     );
-
     test(`supports the complete user flow in ${mode.name} mode`, { timeout: E2E_TIMEOUT_MS }, () =>
       runWholeStackScenario(mode),
     );
-
     test(
       `starts every capability eagerly in ${mode.name} mode`,
       { timeout: E2E_TIMEOUT_MS },
       async () => {
-        const analyticsApiKey = `analytics-key-${crypto.randomUUID()}`;
+        const analyticsApiKey = `analytics-key-${randomId()}`;
         await using stack: TestStack = await createTestStack({
-          name: `stack-eager-${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
+          name: `stack-eager-${randomId().replaceAll("-", "").slice(0, 16)}`,
           runtime: mode.runtime,
           config: allEagerConfig(analyticsApiKey),
           setupProject: async (root) => {
@@ -1414,12 +1472,10 @@ describe("managed Supabase stack whole-stack E2E", () => {
           status.capabilities.map(({ name, state, activation }) => ({ name, state, activation })),
         ).toEqual(CAPABILITY_NAMES.map((name) => ({ name, state: "ready", activation: "eager" })));
         await expectOwnedWorkloads(mode, stack.id, ALL_EAGER_WORKLOAD_IDS);
-
         const credentials = await stack.credentials();
         expect(await databaseQuery(credentials.database.url, "SELECT 1 AS value")).toEqual([
           { value: 1 },
         ]);
-
         await stack.stop();
         const stopped = await stack.status();
         expect(stopped.lifecycle).toBe("stopped");
@@ -1427,12 +1483,11 @@ describe("managed Supabase stack whole-stack E2E", () => {
         await expectOwnedWorkloads(mode, stack.id, []);
       },
     );
-
     test(
       `supports optional image and vector workloads in ${mode.name} mode`,
       { timeout: E2E_TIMEOUT_MS },
       async () => {
-        const identity = crypto.randomUUID().replaceAll("-", "").slice(0, 20).toLowerCase();
+        const identity = randomId().replaceAll("-", "").slice(0, 20).toLowerCase();
         const bucket = `stack-optional-${identity}`;
         const functionSlug = `optional_${identity}`;
         const analyticsApiKey = `analytics-key-${identity}`;
@@ -1443,7 +1498,9 @@ describe("managed Supabase stack whole-stack E2E", () => {
           runtime: mode.runtime,
           config: optionalWorkloadConfig(functionSlug, analyticsApiKey),
           setupProject: async (root) => {
-            await mkdir(join(root, "supabase", "functions", functionSlug), { recursive: true });
+            await mkdir(join(root, "supabase", "functions", functionSlug), {
+              recursive: true,
+            });
             await writeFile(
               join(root, "supabase", "functions", functionSlug, "index.ts"),
               "Deno.serve(() => new Response('ok'))",
@@ -1529,7 +1586,6 @@ describe("managed Supabase stack whole-stack E2E", () => {
       },
     );
   }
-
   for (const mode of RUNTIME_CASES) {
     test(
       `releases owned resources across repeated stop/start cycles in ${mode.name} mode`,
@@ -1538,12 +1594,16 @@ describe("managed Supabase stack whole-stack E2E", () => {
         let stackId: string | undefined;
         let projectRoot = "";
         const snapshots: Array<
-          Readonly<{ containers: number; networks: number; volumes: number }>
+          Readonly<{
+            containers: number;
+            networks: number;
+            volumes: number;
+          }>
         > = [];
         let endpointSnapshot: ReadonlyArray<StackEndpoint> = [];
         {
           await using stack: TestStack = await createTestStack({
-            name: `stack-resource-audit-${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
+            name: `stack-resource-audit-${randomId().replaceAll("-", "").slice(0, 16)}`,
             runtime: mode.runtime,
             setupProject: async (root) => {
               projectRoot = root;

--- a/packages/stack/src/runtime/NativeProcess.ts
+++ b/packages/stack/src/runtime/NativeProcess.ts
@@ -116,6 +116,8 @@ export const spawnNativeProcess = (
   import("effect/unstable/process/ChildProcessSpawner").ChildProcessSpawner | Scope.Scope
 > =>
   Effect.gen(function* () {
+    // Shutdown must precede the spawner's finalizer even when the caller closes in parallel.
+    const processScope = yield* Scope.fork(yield* Scope.Scope, "sequential");
     const launcherArgs =
       identity === undefined
         ? launcher.args
@@ -135,8 +137,7 @@ export const spawnNativeProcess = (
         fd3: { type: "input" },
         fd4: { type: "input" },
       },
-    });
-    yield* Stream.run(Stream.succeed(encodeSpec(spec)), handle.getInputFd(4));
+    }).pipe(Scope.provide(processScope));
     const mapError = <A>(
       effect: Effect.Effect<A, PlatformError>,
     ): Effect.Effect<A, NativeProcessError> =>
@@ -163,16 +164,59 @@ export const spawnNativeProcess = (
       },
       catch: (error) => mapProcessError(error, spec),
     });
+    const signalLauncher = (signal: NodeJS.Signals): Effect.Effect<void, NativeProcessError> =>
+      Effect.try({
+        try: () => {
+          globalThis.process.kill(Number(handle.pid), signal);
+        },
+        catch: (error) => mapProcessError(error, spec),
+      }).pipe(
+        Effect.catch((error) => {
+          const cause = error.cause;
+          return typeof cause === "object" &&
+            cause !== null &&
+            "code" in cause &&
+            cause.code === "ESRCH"
+            ? Effect.void
+            : Effect.fail(error);
+        }),
+      );
+    const killProcess = Effect.gen(function* () {
+      const running = yield* handle.isRunning.pipe(
+        Effect.mapError((error) => mapProcessError(error, spec)),
+      );
+      if (!running) return yield* cleanupProcessGroup;
+      // Record the stop in the launcher before it forwards the signal to the workload.
+      const graceful =
+        globalThis.process.platform === "win32"
+          ? handle
+              .kill({ killSignal: spec.gracefulStopSignal ?? "SIGTERM" })
+              .pipe(Effect.mapError((error) => mapProcessError(error, spec)))
+          : signalLauncher(spec.gracefulStopSignal ?? "SIGTERM").pipe(
+              // Signal termination still completes the wait; group cleanup must follow.
+              Effect.andThen(handle.exitCode.pipe(Effect.catch(() => Effect.void))),
+            );
+      const stopped = yield* graceful.pipe(
+        Effect.timeoutOption(spec.gracefulStopTimeout ?? "2 seconds"),
+      );
+      if (Option.isNone(stopped)) {
+        const stillRunning = yield* handle.isRunning.pipe(
+          Effect.mapError((error) => mapProcessError(error, spec)),
+        );
+        if (stillRunning)
+          yield* handle
+            .kill({ killSignal: "SIGKILL" })
+            .pipe(Effect.mapError((error) => mapProcessError(error, spec)));
+      }
+      if (globalThis.process.platform !== "win32") yield* cleanupProcessGroup;
+    });
+    yield* Scope.addFinalizer(
+      processScope,
+      killProcess.pipe(Effect.catch((error) => Effect.logError(error.message))),
+    );
+    yield* Stream.run(Stream.succeed(encodeSpec(spec)), handle.getInputFd(4));
     const exitCode = yield* Effect.cached(
-      mapError(handle.exitCode).pipe(
-        Effect.tap(
-          () =>
-            // The launcher exits with the workload's code, but its descendants
-            // can keep the detached process group alive. The parent still owns
-            // that exact group, so terminate it after capturing the exit code.
-            cleanupProcessGroup,
-        ),
-      ),
+      mapError(handle.exitCode).pipe(Effect.tap(() => cleanupProcessGroup)),
     );
     return {
       pid: handle.pid,
@@ -180,19 +224,6 @@ export const spawnNativeProcess = (
       stderr: mapStreamError(handle.stderr),
       exitCode,
       isRunning: mapError(handle.isRunning),
-      kill: mapError(
-        Effect.gen(function* () {
-          // NodeChildProcessSpawner owns the exact process group. Its kill
-          // effect sends the signal and waits for the launcher exit event;
-          // bound that wait before forcing the same group.
-          const graceful = yield* handle
-            .kill({ killSignal: spec.gracefulStopSignal ?? "SIGTERM" })
-            .pipe(Effect.timeoutOption(spec.gracefulStopTimeout ?? "2 seconds"));
-          if (Option.isNone(graceful)) {
-            const running = yield* handle.isRunning;
-            if (running) yield* handle.kill({ killSignal: "SIGKILL" });
-          }
-        }),
-      ),
+      kill: killProcess,
     } satisfies NativeProcess;
   }).pipe(Effect.mapError((error) => mapProcessError(error, spec)));

--- a/packages/stack/src/runtime/ProductionRuntime.ts
+++ b/packages/stack/src/runtime/ProductionRuntime.ts
@@ -343,12 +343,17 @@ const bootstrapContent =
   typeof SUPABASE_FUNCTIONS_SERVE_MAIN_TEMPLATE === "string"
     ? Effect.succeed(SUPABASE_FUNCTIONS_SERVE_MAIN_TEMPLATE)
     : Effect.tryPromise({
-        try: () =>
-          import("../functions/serve-main-bundler.ts").then(({ bundleServeMainTemplate }) =>
-            bundleServeMainTemplate(),
-          ),
+        try: () => import("../functions/serve-main-bundler.ts"),
         catch: (cause) => preparationError("Unable to bundle functions bootstrap", cause),
-      });
+      }).pipe(
+        Effect.flatMap(({ bundleServeMainTemplate }) =>
+          bundleServeMainTemplate.pipe(
+            Effect.mapError((cause) =>
+              preparationError("Unable to bundle functions bootstrap", cause),
+            ),
+          ),
+        ),
+      );
 
 const mapDriverError = (
   key: Pick<RuntimeWorkloadKey, "stackId" | "workloadId">,

--- a/packages/stack/src/runtime/ProductionRuntime.ts
+++ b/packages/stack/src/runtime/ProductionRuntime.ts
@@ -1,3 +1,5 @@
+import { NodeHttpClient } from "@effect/platform-node";
+import { HttpClient } from "effect/unstable/http";
 import {
   Cause,
   Context,
@@ -437,18 +439,16 @@ export const makeProductionRuntime = (
     const fetchJson: RuntimeJsonFetcher =
       options.fetchJson ??
       ((url) =>
-        // oxlint-disable effecttsgo/async-function -- production fetch leaf owns AbortSignal.
-        // oxlint-disable effecttsgo/global-fetch-in-effect -- production fetch leaf is the network boundary.
-        Effect.tryPromise({
-          try: async (signal) => {
-            const response = await fetch(url, { signal });
-            if (!response.ok) throw new Error(`HTTP ${response.status}`);
-            return await response.json();
-          },
-          catch: (cause) => preparationError("Unable to fetch Auth OIDC metadata", cause),
-        }));
-    // oxlint-enable effecttsgo/async-function
-    // oxlint-enable effecttsgo/global-fetch-in-effect
+        Effect.gen(function* () {
+          const client = yield* HttpClient.HttpClient;
+          const response = yield* HttpClient.followRedirects(client, 20).get(url);
+          if (response.status < 200 || response.status >= 300)
+            return yield* preparationError(`HTTP ${response.status}`);
+          return yield* response.json;
+        }).pipe(
+          Effect.mapError((cause) => preparationError("Unable to fetch Auth OIDC metadata", cause)),
+          Effect.provide(NodeHttpClient.layerNodeHttp),
+        ));
     const inputOwner = yield* makeRuntimeInputOwner({
       stateRoot: options.stateRoot,
       stackId: options.stackId,

--- a/packages/stack/src/runtime/ReadinessProbe.ts
+++ b/packages/stack/src/runtime/ReadinessProbe.ts
@@ -97,7 +97,6 @@ const httpAttempt = (target: ReadinessTarget) => {
         ? cause
         : runtimeError(target, "Readiness HTTP request failed", cause),
     ),
-    Effect.provide(NodeHttpClient.layerNodeHttp),
   );
 };
 
@@ -157,16 +156,19 @@ export const probeReadiness = (
       options.deadline ?? DEFAULT_READINESS_DEADLINE,
       "Readiness deadline",
     );
-    const attempt = target.mode === "http" ? httpAttempt(target) : tcpAttempt(target);
-    // A zero deadline runs one immediate probe with no retry delay; a positive deadline can
-    // interrupt whichever owned request/socket is still active.
-    if (Duration.isZero(deadline)) return yield* attempt;
-    const schedule =
-      retries === undefined
-        ? Schedule.spaced(retryDelay)
-        : Schedule.spaced(retryDelay).pipe(Schedule.upTo({ times: retries }));
-    yield* Effect.timeoutOrElse(Effect.retry(attempt, schedule), {
-      duration: deadline,
-      orElse: () => Effect.fail(runtimeError(target, "Readiness deadline exceeded")),
-    });
+    const withReadinessBudget = <R>(attempt: Effect.Effect<void, RuntimeDriverError, R>) => {
+      // A zero deadline runs one probe; a positive deadline interrupts the active request/socket.
+      if (Duration.isZero(deadline)) return attempt;
+      const schedule =
+        retries === undefined
+          ? Schedule.spaced(retryDelay)
+          : Schedule.spaced(retryDelay).pipe(Schedule.upTo({ times: retries }));
+      return Effect.timeoutOrElse(Effect.retry(attempt, schedule), {
+        duration: deadline,
+        orElse: () => Effect.fail(runtimeError(target, "Readiness deadline exceeded")),
+      });
+    };
+    return yield* target.mode === "http"
+      ? withReadinessBudget(httpAttempt(target)).pipe(Effect.provide(NodeHttpClient.layerNodeHttp))
+      : withReadinessBudget(tcpAttempt(target));
   });

--- a/packages/stack/src/runtime/ReadinessProbe.ts
+++ b/packages/stack/src/runtime/ReadinessProbe.ts
@@ -1,7 +1,6 @@
-import { Duration, Effect, Option, Schedule } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- Node callback boundary owns cancellation.
-import { request as httpRequest, type IncomingMessage } from "node:http";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- Node callback boundary owns cancellation.
+import { Duration, Effect, Option, Schedule, Stream } from "effect";
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import { HttpClient } from "effect/unstable/http";
 import { Socket } from "node:net";
 import { RuntimeDriverError } from "./RuntimeDriver.ts";
 import { StackPreparationError } from "../public/Errors.ts";
@@ -82,63 +81,25 @@ const decodeDuration = (
   return Effect.succeed(decoded.value);
 };
 
-const httpAttempt = (target: ReadinessTarget): Effect.Effect<void, RuntimeDriverError> =>
-  Effect.callback<void, RuntimeDriverError>((resume) => {
-    let settled = false;
-    let request: ReturnType<typeof httpRequest> | undefined;
-    let response: IncomingMessage | undefined;
-    const cleanup = () => {
-      request?.off("error", onError);
-      if (response !== undefined) {
-        response.off("error", onError);
-        response.off("aborted", onAborted);
-        response.off("end", onEnd);
-      }
-    };
-    const finish = (effect: Effect.Effect<void, RuntimeDriverError>) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resume(effect);
-    };
-    const onError = (cause: Error) =>
-      finish(Effect.fail(runtimeError(target, "Readiness HTTP request failed", cause)));
-    const onAborted = () =>
-      finish(Effect.fail(runtimeError(target, "Readiness HTTP response aborted")));
-    const onEnd = () => {
-      if (response === undefined) return;
-      if ((response.statusCode ?? 500) >= 200 && (response.statusCode ?? 500) < 300)
-        finish(Effect.void);
-      else finish(Effect.fail(runtimeError(target, "Readiness HTTP status was not successful")));
-    };
-    request = httpRequest(
-      {
-        host: target.host,
-        port: target.port,
-        path: target.path ?? "/",
-        method: "GET",
-        headers: target.headers,
-      },
-      (incoming) => {
-        response = incoming;
-        incoming.once("error", onError);
-        incoming.once("aborted", onAborted);
-        incoming.once("end", onEnd);
-        incoming.resume();
-      },
-    );
-    request.once("error", onError);
-    request.end();
-    return Effect.sync(() => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      response?.once("error", () => undefined);
-      response?.destroy();
-      request?.once("error", () => undefined);
-      request?.destroy();
-    });
-  });
+const httpAttempt = (target: ReadinessTarget) => {
+  const host =
+    target.host.includes(":") && !target.host.startsWith("[") ? `[${target.host}]` : target.host;
+  const url = `http://${host}:${target.port}${target.path ?? "/"}`;
+  return Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const response = yield* client.get(url, { headers: target.headers });
+    yield* response.stream.pipe(Stream.runDrain);
+    if (response.status < 200 || response.status >= 300)
+      return yield* runtimeError(target, "Readiness HTTP status was not successful");
+  }).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof RuntimeDriverError
+        ? cause
+        : runtimeError(target, "Readiness HTTP request failed", cause),
+    ),
+    Effect.provide(NodeHttpClient.layerNodeHttp),
+  );
+};
 
 const tcpAttempt = (target: ReadinessTarget): Effect.Effect<void, RuntimeDriverError> =>
   Effect.callback<void, RuntimeDriverError>((resume) => {

--- a/packages/stack/src/runtime/RuntimeInputOwner.ts
+++ b/packages/stack/src/runtime/RuntimeInputOwner.ts
@@ -139,8 +139,12 @@ const resolveFunctionsEdgeRuntimeSecrets = (
     if (name.startsWith("SUPABASE_"))
       return Effect.fail(failure("Functions Edge Runtime secret name is reserved", { name }));
     const value = settingValue(state, raw);
-    // oxlint-disable-next-line no-control-regex
-    if (/[\u0000-\u001f\u007f]/u.test(value))
+    if (
+      [...value].some((character) => {
+        const code = character.codePointAt(0) ?? 0;
+        return code <= 0x1f || code === 0x7f;
+      })
+    )
       return Effect.fail(failure("Functions Edge Runtime secret value is invalid", { name }));
     output[name] = value;
   }

--- a/packages/stack/src/runtime/native-launcher.ts
+++ b/packages/stack/src/runtime/native-launcher.ts
@@ -1,12 +1,10 @@
-// oxlint-disable effecttsgo/process-env -- standalone launcher reads inherited allowlisted variables before Effect starts.
-// oxlint-disable effecttsgo/global-timers -- standalone launcher grace deadline runs before Effect starts.
-// Standalone launcher boundary: this process must remain usable before the
-// Effect runtime exists and therefore talks to the host directly.
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// Standalone launcher boundary: this process owns the host process-group and
+// invokes Effect only for bounded asynchronous lifecycle work.
+import { Config, ConfigProvider, Duration, Effect, Option, Schema } from "effect";
 import { Socket } from "node:net";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- FileSystem cannot adopt inherited fd3/fd4; Bun also requires synchronous fd4 reads.
 import { createReadStream, readFileSync, writeSync } from "node:fs";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- the launcher owns its own process group; platform spawners own child-group shutdown instead.
 import { spawn } from "node:child_process";
 
 interface LaunchSpec {
@@ -18,51 +16,32 @@ interface LaunchSpec {
   readonly gracefulStopTimeoutMs?: number;
 }
 
-const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
-  typeof candidate === "object" && candidate !== null && !Array.isArray(candidate);
+const LaunchSpecSchema = Schema.Struct({
+  executable: Schema.String,
+  args: Schema.optionalKey(Schema.Array(Schema.String)),
+  env: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+  cwd: Schema.optionalKey(Schema.String),
+  gracefulStopSignal: Schema.optionalKey(Schema.Literals(["SIGTERM", "SIGINT"])),
+  gracefulStopTimeoutMs: Schema.optionalKey(
+    Schema.Finite.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0))),
+  ),
+});
+type DecodedLaunchSpec = Schema.Schema.Type<typeof LaunchSpecSchema>;
 
 const decodeSpec = (bytes: Buffer): LaunchSpec | undefined => {
-  try {
-    const value: unknown = JSON.parse(bytes.toString("utf8"));
-    if (!isRecord(value) || typeof value.executable !== "string") return undefined;
-    const args: string[] = [];
-    if (value.args !== undefined) {
-      if (!Array.isArray(value.args)) return undefined;
-      for (const arg of value.args) {
-        if (typeof arg !== "string") return undefined;
-        args.push(arg);
-      }
-    }
-    if (value.cwd !== undefined && typeof value.cwd !== "string") return undefined;
-    let env: Record<string, string> | undefined;
-    if (value.env !== undefined) {
-      if (!isRecord(value.env)) return undefined;
-      env = {};
-      for (const [name, entry] of Object.entries(value.env)) {
-        if (typeof entry !== "string") return undefined;
-        env[name] = entry;
-      }
-    }
-    if (
-      value.gracefulStopSignal !== undefined &&
-      value.gracefulStopSignal !== "SIGTERM" &&
-      value.gracefulStopSignal !== "SIGINT"
-    )
-      return undefined;
-    if (
-      value.gracefulStopTimeoutMs !== undefined &&
-      (typeof value.gracefulStopTimeoutMs !== "number" ||
-        !Number.isFinite(value.gracefulStopTimeoutMs) ||
-        value.gracefulStopTimeoutMs < 0)
-    )
-      return undefined;
-    if ((value.gracefulStopSignal === undefined) !== (value.gracefulStopTimeoutMs === undefined))
-      return undefined;
+  const decoded = Schema.decodeOption(Schema.fromJsonString(LaunchSpecSchema))(
+    bytes.toString("utf8"),
+  );
+  if (Option.isNone(decoded)) return undefined;
+  const value: DecodedLaunchSpec = decoded.value;
+  if ((value.gracefulStopSignal === undefined) !== (value.gracefulStopTimeoutMs === undefined))
+    return undefined;
+  {
     return {
       executable: value.executable,
-      args,
+      args: value.args ?? [],
       cwd: value.cwd,
-      env,
+      env: value.env,
       ...(value.gracefulStopSignal === undefined
         ? {}
         : { gracefulStopSignal: value.gracefulStopSignal }),
@@ -70,8 +49,6 @@ const decodeSpec = (bytes: Buffer): LaunchSpec | undefined => {
         ? {}
         : { gracefulStopTimeoutMs: value.gracefulStopTimeoutMs }),
     };
-  } catch {
-    return undefined;
   }
 };
 
@@ -91,14 +68,15 @@ const inheritedEnvironmentNames = [
   "LC_TIME",
 ] as const;
 
-const inheritedEnvironment = (): NodeJS.ProcessEnv => {
+const inheritedEnvironment = Effect.gen(function* () {
   const environment: NodeJS.ProcessEnv = {};
+  const provider = ConfigProvider.fromEnv();
   for (const name of inheritedEnvironmentNames) {
-    const value = process.env[name];
-    if (value !== undefined) environment[name] = value;
+    const value = yield* Config.option(Config.string(name)).parse(provider);
+    if (Option.isSome(value)) environment[name] = value.value;
   }
   return environment;
-};
+});
 
 /**
  * Runs the standalone native launcher entrypoint.
@@ -112,7 +90,6 @@ export const runNativeLauncher = (): void => {
   let gracefulForwarded = false;
   let ownerLost = false;
   let ownerLossGraceful = false;
-  let gracefulTimeout: ReturnType<typeof setTimeout> | undefined;
   let specGracefulStopSignal: LaunchSpec["gracefulStopSignal"];
   let specGracefulStopTimeoutMs: LaunchSpec["gracefulStopTimeoutMs"];
   let groupTerminated = false;
@@ -175,7 +152,13 @@ export const runNativeLauncher = (): void => {
       return;
     }
     ownerLossGraceful = true;
-    gracefulTimeout = setTimeout(() => terminateGroup("SIGKILL"), specGracefulStopTimeoutMs);
+    // The fiber is process-scoped: the launcher exits on group termination, so
+    // no detached work can outlive this supervisor process.
+    Effect.runFork(
+      Effect.sleep(Duration.millis(specGracefulStopTimeoutMs)).pipe(
+        Effect.andThen(Effect.sync(() => terminateGroup("SIGKILL"))),
+      ),
+    );
   };
 
   // Register the owner pipe before the launch payload: EOF means the owner vanished without
@@ -215,14 +198,13 @@ export const runNativeLauncher = (): void => {
     specGracefulStopTimeoutMs = spec.gracefulStopTimeoutMs;
     child = spawn(spec.executable, [...spec.args], {
       cwd: spec.cwd,
-      env: { ...inheritedEnvironment(), ...spec.env },
+      env: { ...Effect.runSync(inheritedEnvironment), ...spec.env },
       detached: false,
       stdio: ["ignore", "inherit", "inherit"],
     });
     child.on("error", () => process.exit(127));
     child.on("exit", (code, signal) => {
       childExited = true;
-      if (gracefulTimeout !== undefined) clearTimeout(gracefulTimeout);
       if (ownerLossGraceful) {
         terminateGroup("SIGKILL");
         return;

--- a/packages/stack/src/runtime/native-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/native-runtime.integration.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable effecttsgo/prefer-schema-over-json -- raw child-process fixture payloads are protocol JSON, not product serialization.
 import { NodeServices, NodeSocket } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import {
@@ -12,11 +11,10 @@ import {
   Path,
   Ref,
   Schedule,
+  Schema,
   Stream,
 } from "effect";
-import { ChildProcess } from "effect/unstable/process";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- raw process-tree cleanup fixture.
-import { spawnSync } from "node:child_process";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { fileURLToPath } from "node:url";
 import { LogStoreError, makeLogStore, type LogStore } from "../supervisor/LogStore.ts";
 import type { PlannedWorkload } from "../model/ExecutionPlan.ts";
@@ -33,6 +31,8 @@ import {
 } from "./NativeProcess.ts";
 
 const stackId = StackIdSchema.make("d".repeat(64));
+const encodeJson = (value: unknown): string =>
+  Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 
 class ProcessTreeTestError extends Data.TaggedError("ProcessTreeTestError")<{
   readonly message: string;
@@ -535,7 +535,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
           command: process.execPath,
           args: [
             "-e",
-            `process.env.PGPASSWORD="host-secret"; const { runNativeLauncher } = await import(${JSON.stringify(launcherPath)}); runNativeLauncher()`,
+            `process.env.PGPASSWORD="host-secret"; const { runNativeLauncher } = await import(${encodeJson(launcherPath)}); runNativeLauncher()`,
           ],
         };
         const runtime = yield* makeNativeRuntime({
@@ -830,7 +830,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
             if (typeof address === "object" && address !== null) {
               process.stdout.write(\`TARGET_READY \${address.port}\\n\`);
             }
-            const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
+            const child = spawn(process.execPath, ["-e", ${encodeJson(descendantCode)}], {
               stdio: ["ignore", "pipe", "inherit"]
             });
             child.stdout.on("data", (chunk) => {
@@ -840,13 +840,13 @@ describe("native runtime", { timeout: 15_000 }, () => {
         `;
         const ownerCode = `
           const { spawn } = require("node:child_process");
-          const launcherProcess = spawn(${JSON.stringify(targetLauncher.command)}, ${JSON.stringify(targetLauncher.args)}, {
+          const launcherProcess = spawn(${encodeJson(targetLauncher.command)}, ${encodeJson(targetLauncher.args)}, {
             detached: true,
             stdio: ["ignore", "inherit", "inherit", "pipe", "pipe"]
           });
           launcherProcess.stdio[4].end(JSON.stringify({
-            executable: ${JSON.stringify(runtimeCommand)},
-            args: ["-e", ${JSON.stringify(targetCode)}]
+            executable: ${encodeJson(runtimeCommand)},
+            args: ["-e", ${encodeJson(targetCode)}]
           }));
           setInterval(() => {}, 1000);
         `;
@@ -963,7 +963,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
         if (typeof address === "object" && address !== null) {
           process.stdout.write("TARGET_READY " + address.port + "\\n");
         }
-        const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
+            const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
           stdio: ["ignore", "pipe", "inherit"]
         });
         child.stdout.on("data", (chunk) => {
@@ -984,13 +984,13 @@ describe("native runtime", { timeout: 15_000 }, () => {
       const launcherArgs = defaultNativeProcessLauncher().args;
       const ownerCode = `
         const { spawn } = require("node:child_process");
-        const launcherProcess = spawn(${JSON.stringify(process.execPath)}, ${JSON.stringify(launcherArgs)}, {
+          const launcherProcess = spawn(${encodeJson(process.execPath)}, ${encodeJson(launcherArgs)}, {
           detached: true,
           stdio: ["ignore", "inherit", "inherit", "pipe", "pipe"]
         });
-        launcherProcess.stdio[4].end(JSON.stringify({
-          executable: ${JSON.stringify(process.execPath)},
-          args: ["-e", ${JSON.stringify(options.targetCode)}],
+          launcherProcess.stdio[4].end(JSON.stringify({
+            executable: ${encodeJson(process.execPath)},
+            args: ["-e", ${encodeJson(options.targetCode)}],
           gracefulStopSignal: "SIGINT",
           gracefulStopTimeoutMs: ${String(options.gracefulStopTimeoutMs)}
         }));
@@ -1092,7 +1092,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
         `;
           const targetCode = `
           const { spawn } = require("node:child_process");
-          const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
+          const child = spawn(process.execPath, ["-e", ${encodeJson(descendantCode)}], {
             stdio: ["ignore", "pipe", "inherit"]
           });
           child.stdout.on("data", (chunk) => {
@@ -1148,9 +1148,18 @@ describe("native runtime", { timeout: 15_000 }, () => {
           yield* Fiber.interrupt(output);
         }).pipe(
           Effect.ensuring(
-            Effect.sync(() => {
-              if (launcherPid !== undefined && process.platform !== "win32")
-                spawnSync("kill", ["-KILL", `-${launcherPid}`], { stdio: "ignore" });
+            Effect.gen(function* () {
+              if (launcherPid !== undefined && process.platform !== "win32") {
+                const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+                yield* spawner
+                  .exitCode(
+                    ChildProcess.make("kill", ["-KILL", `-${launcherPid}`], {
+                      stdout: "ignore",
+                      stderr: "ignore",
+                    }),
+                  )
+                  .pipe(Effect.ignore);
+              }
             }),
           ),
         );

--- a/packages/stack/src/runtime/native-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/native-runtime.integration.test.ts
@@ -12,6 +12,7 @@ import {
   Ref,
   Schedule,
   Schema,
+  Scope,
   Stream,
 } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -240,35 +241,54 @@ describe("native runtime", { timeout: 15_000 }, () => {
     ),
   );
 
-  it.live("does not report a diagnostic for an explicit native stop", () =>
-    withPlatform(
-      Effect.gen(function* () {
-        const ready = yield* Deferred.make<void>();
-        const native = yield* spawnNativeProcess({
-          executable: process.execPath,
-          args: ["-e", 'process.stdout.write("ready\\n"); setInterval(() => {}, 1000)'],
-        });
-        const stdout = yield* native.stdout.pipe(
-          Stream.decodeText,
-          Stream.splitLines,
-          Stream.runForEach((line) =>
-            line === "ready" ? Deferred.succeed(ready, undefined) : Effect.void,
-          ),
-          Effect.forkChild({ startImmediately: true }),
-        );
-        const stderr = yield* Effect.forkChild(
-          native.stderr.pipe(Stream.decodeText, Stream.runCollect),
-          { startImmediately: true },
-        );
-        yield* Deferred.await(ready).pipe(Effect.timeout("3 seconds"));
-        yield* native.kill;
-        const stderrOutput = yield* Fiber.join(stderr);
-        yield* Fiber.join(stdout);
-        expect(Array.from(stderrOutput).join("")).not.toContain(
-          "Native workload exited due to signal SIGTERM",
-        );
-      }),
-    ),
+  it.live.each([
+    { name: "SIGTERM stops", signal: "SIGTERM", closeScope: false },
+    { name: "SIGINT stops", signal: "SIGINT", closeScope: false },
+    { name: "scope closures", signal: "SIGTERM", closeScope: true },
+  ] as const)(
+    "does not report unexpected exits during concurrent $name",
+    ({ signal, closeScope }) =>
+      withPlatform(
+        Effect.forEach(
+          Array.from({ length: 25 }),
+          () =>
+            Effect.scoped(
+              Effect.gen(function* () {
+                const ready = yield* Deferred.make<void>();
+                const processScope = yield* Effect.acquireRelease(Scope.make("parallel"), (scope) =>
+                  Scope.close(scope, Exit.void),
+                );
+                const native = yield* spawnNativeProcess({
+                  gracefulStopSignal: signal,
+                  executable: process.execPath,
+                  args: ["-e", 'process.stdout.write("ready\\n"); setInterval(() => {}, 1000)'],
+                }).pipe(Effect.provideService(Scope.Scope, processScope));
+                const stdout = yield* native.stdout.pipe(
+                  Stream.decodeText,
+                  Stream.splitLines,
+                  Stream.runForEach((line) =>
+                    line === "ready" ? Deferred.succeed(ready, undefined) : Effect.void,
+                  ),
+                  Effect.forkChild({ startImmediately: true }),
+                );
+                const stderr = yield* Effect.forkChild(
+                  native.stderr.pipe(Stream.decodeText, Stream.runCollect),
+                  { startImmediately: true },
+                );
+                yield* Deferred.await(ready).pipe(Effect.timeout("10 seconds"));
+                yield* closeScope ? Scope.close(processScope, Exit.void) : native.kill;
+                const stderrOutput = yield* Fiber.join(stderr);
+                yield* Fiber.join(stdout);
+                expect(Array.from(stderrOutput).join("")).not.toContain(
+                  "Native workload exited due to signal",
+                );
+                expect(yield* native.isRunning).toBe(false);
+              }),
+            ),
+          { concurrency: 4, discard: true },
+        ),
+      ),
+    { timeout: 60_000 },
   );
 
   it.live("keeps a ready workload after the losing exit observer is interrupted", () =>
@@ -1073,7 +1093,12 @@ describe("native runtime", { timeout: 15_000 }, () => {
     ),
   );
 
-  it.live("terminates descendants after a native workload exits normally", () =>
+  it.live.each([
+    { name: "normal workload exit", mode: "exit" },
+    { name: "a graceful stop", mode: "graceful" },
+    { name: "a forced stop", mode: "forced" },
+    { name: "a scope closing an unresponsive workload", mode: "scope" },
+  ] as const)("terminates descendants after $name", ({ mode }) =>
     withPlatform(
       Effect.gen(function* () {
         let launcherPid: number | undefined;
@@ -1092,22 +1117,27 @@ describe("native runtime", { timeout: 15_000 }, () => {
         `;
           const targetCode = `
           const { spawn } = require("node:child_process");
+          ${mode === "forced" || mode === "scope" ? 'process.on("SIGTERM", () => {});' : ""}
           const child = spawn(process.execPath, ["-e", ${encodeJson(descendantCode)}], {
             stdio: ["ignore", "pipe", "inherit"]
           });
           child.stdout.on("data", (chunk) => {
             process.stdout.write(chunk);
-            if (chunk.toString().includes("DESC_READY ")) {
+            if (${String(mode === "exit")} && chunk.toString().includes("DESC_READY ")) {
               process.stdout.write("DIRECT_EXITING\\n");
               process.exit(0);
             }
           });
           child.on("error", () => process.exit(1));
         `;
+          const processScope = yield* Effect.acquireRelease(Scope.make("parallel"), (scope) =>
+            Scope.close(scope, Exit.void),
+          );
           const native = yield* spawnNativeProcess({
             executable: process.execPath,
             args: ["-e", targetCode],
-          });
+            gracefulStopTimeout: "100 millis",
+          }).pipe(Effect.provideService(Scope.Scope, processScope));
           launcherPid = Number(native.pid);
           const output = yield* native.stdout.pipe(
             Stream.decodeText,
@@ -1131,16 +1161,20 @@ describe("native runtime", { timeout: 15_000 }, () => {
             .runRaw(() => Effect.void, { onOpen: Deferred.succeed(opened, undefined) })
             .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
           yield* Deferred.await(opened).pipe(Effect.timeout("5 seconds"));
-          yield* Deferred.await(workloadExited).pipe(Effect.timeout("5 seconds"));
-          expect(yield* native.exitCode).toBe(0);
+          if (mode === "exit") {
+            yield* Deferred.await(workloadExited).pipe(Effect.timeout("5 seconds"));
+            expect(yield* native.exitCode).toBe(0);
+          } else {
+            yield* mode === "scope" ? Scope.close(processScope, Exit.void) : native.kill;
+            expect(yield* native.isRunning).toBe(false);
+          }
           yield* Fiber.join(closed).pipe(
             Effect.timeoutOrElse({
               duration: "5 seconds",
               orElse: () =>
                 Effect.fail(
                   new ProcessTreeTestError({
-                    message:
-                      "native launcher left descendant listener alive after normal workload exit",
+                    message: `native launcher left descendant listener alive after ${mode}`,
                   }),
                 ),
             }),

--- a/packages/stack/src/runtime/native-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/native-runtime.integration.test.ts
@@ -844,7 +844,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
             detached: true,
             stdio: ["ignore", "inherit", "inherit", "pipe", "pipe"]
           });
-          launcherProcess.stdio[4].end(JSON.stringify({
+        launcherProcess.stdio[4].end(JSON.stringify({
             executable: ${encodeJson(runtimeCommand)},
             args: ["-e", ${encodeJson(targetCode)}]
           }));
@@ -963,7 +963,7 @@ describe("native runtime", { timeout: 15_000 }, () => {
         if (typeof address === "object" && address !== null) {
           process.stdout.write("TARGET_READY " + address.port + "\\n");
         }
-            const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
+        const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantCode)}], {
           stdio: ["ignore", "pipe", "inherit"]
         });
         child.stdout.on("data", (chunk) => {
@@ -984,13 +984,13 @@ describe("native runtime", { timeout: 15_000 }, () => {
       const launcherArgs = defaultNativeProcessLauncher().args;
       const ownerCode = `
         const { spawn } = require("node:child_process");
-          const launcherProcess = spawn(${encodeJson(process.execPath)}, ${encodeJson(launcherArgs)}, {
+        const launcherProcess = spawn(${encodeJson(process.execPath)}, ${encodeJson(launcherArgs)}, {
           detached: true,
           stdio: ["ignore", "inherit", "inherit", "pipe", "pipe"]
         });
-          launcherProcess.stdio[4].end(JSON.stringify({
-            executable: ${encodeJson(process.execPath)},
-            args: ["-e", ${encodeJson(options.targetCode)}],
+        launcherProcess.stdio[4].end(JSON.stringify({
+          executable: ${encodeJson(process.execPath)},
+          args: ["-e", ${encodeJson(options.targetCode)}],
           gracefulStopSignal: "SIGINT",
           gracefulStopTimeoutMs: ${String(options.gracefulStopTimeoutMs)}
         }));

--- a/packages/stack/src/runtime/production-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/production-runtime.integration.test.ts
@@ -26,9 +26,6 @@ import type { StackRuntime } from "../public/Runtime.ts";
 import { NetworkPortSchema } from "../public/Status.ts";
 import type { PersistedStackState } from "../state/StackState.ts";
 import type { StackStateStore } from "../state/StackStateStore.ts";
-
-const encodeJson = (value: unknown): string =>
-  Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 import { resolveSecrets } from "../state/SecretStore.ts";
 import { resolveStackPaths } from "../state/Paths.ts";
 import type { SupervisorIngress } from "../supervisor/Ingress.ts";
@@ -68,6 +65,9 @@ import {
 import type { RuntimeEnvFileOwner } from "./RuntimeEnvFile.ts";
 import { makeRuntimeEnvFileOwner } from "./RuntimeEnvFile.ts";
 import { probeReadiness } from "./ReadinessProbe.ts";
+
+const encodeJson = (value: unknown): string =>
+  Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 
 const stackId = StackIdSchema.make("a".repeat(64));
 

--- a/packages/stack/src/runtime/production-runtime.integration.test.ts
+++ b/packages/stack/src/runtime/production-runtime.integration.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable effecttsgo/prefer-schema-over-json -- generated shell fixtures use protocol JSON quoting, not product serialization.
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import {
@@ -17,9 +16,8 @@ import {
   Stream,
 } from "effect";
 import * as TestClock from "effect/testing/TestClock";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- fixture controls raw HTTP responses and connection failure timing.
 import { createServer, type ServerResponse } from "node:http";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import { createServer as createNetServer } from "node:net";
 import type { StackLogEntry } from "../public/Logs.ts";
 import type { CapabilityName } from "../public/Capability.ts";
@@ -28,6 +26,9 @@ import type { StackRuntime } from "../public/Runtime.ts";
 import { NetworkPortSchema } from "../public/Status.ts";
 import type { PersistedStackState } from "../state/StackState.ts";
 import type { StackStateStore } from "../state/StackStateStore.ts";
+
+const encodeJson = (value: unknown): string =>
+  Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 import { resolveSecrets } from "../state/SecretStore.ts";
 import { resolveStackPaths } from "../state/Paths.ts";
 import type { SupervisorIngress } from "../supervisor/Ingress.ts";
@@ -165,7 +166,7 @@ const writeNativeDatabaseFixture = (
       'const net = require("node:net");',
       "const args = process.argv.slice(1);",
       'const port = Number(args[args.indexOf("-p") + 1]);',
-      `fs.appendFileSync(${JSON.stringify(eventsPath)}, "postgres-start|data=" + process.env.PGDATA + "|user=" + process.env.POSTGRES_USER + "|db=" + process.env.POSTGRES_DB + "|password=" + process.env.POSTGRES_PASSWORD + "|args=" + args.join(" ") + "\\n");`,
+      `fs.appendFileSync(${encodeJson(eventsPath)}, "postgres-start|data=" + process.env.PGDATA + "|user=" + process.env.POSTGRES_USER + "|db=" + process.env.POSTGRES_DB + "|password=" + process.env.POSTGRES_PASSWORD + "|args=" + args.join(" ") + "\\n");`,
       "const server = net.createServer((socket) => socket.end());",
       'server.listen(port, "127.0.0.1");',
       "const stop = () => server.close(() => process.exit(0));",
@@ -176,7 +177,7 @@ const writeNativeDatabaseFixture = (
       main,
       `#!/bin/sh
 set -eu
-exec ${JSON.stringify(process.execPath)} -e ${JSON.stringify(helperScript)} -- "$@"
+exec ${encodeJson(process.execPath)} -e ${encodeJson(helperScript)} -- "$@"
 `,
     );
     yield* fs.chmod(main, 0o755);
@@ -205,7 +206,7 @@ fi
       migrate,
       `#!/bin/sh
 . "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)/.runtime-env.sh"
-printf 'realtime-migrate|RELEASE_DISTRIBUTION=%s\\n' "\${RELEASE_DISTRIBUTION:-missing}" >> ${JSON.stringify(eventsPath)}
+printf 'realtime-migrate|RELEASE_DISTRIBUTION=%s\\n' "\${RELEASE_DISTRIBUTION:-missing}" >> ${encodeJson(eventsPath)}
 `,
     );
     yield* fs.chmod(migrate, 0o755);
@@ -695,6 +696,112 @@ describe("production runtime", () => {
           expect(error?.message).toContain("OIDC discovery request failed");
           expect(error?.cause).toBeInstanceOf(StackPreparationError);
         }
+        yield* runtime.driver.stop({ stackId, workloadId: database.id });
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("follows redirects while resolving Auth OIDC metadata", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({
+          prefix: "supabase-production-oidc-lazy-",
+        });
+        const oidc = createServer((request, response) => {
+          if (request.url === "/.well-known/openid-configuration") {
+            response.writeHead(302, { Location: "/discovery" }).end();
+          } else if (request.url === "/discovery") {
+            response.setHeader("content-type", "application/json");
+            response.end(JSON.stringify({ jwks_uri: `${issuer}/keys` }));
+          } else if (request.url === "/keys") {
+            response.writeHead(302, { Location: "/keys-final" }).end();
+          } else {
+            response.setHeader("content-type", "application/json");
+            response.end(JSON.stringify({ keys: [{ kty: "RSA", n: "n", e: "AQAB" }] }));
+          }
+        });
+        yield* listenForNativeReadiness(oidc);
+        const oidcAddress = oidc.address();
+        if (typeof oidcAddress !== "object" || oidcAddress === null)
+          return yield* Effect.die("OIDC server did not expose an address");
+        const issuer = `http://127.0.0.1:${oidcAddress.port}`;
+        const readinessServer = createNetServer((socket) => socket.end());
+        yield* listenForNativeReadiness(readinessServer);
+        const address = readinessServer.address();
+        if (typeof address !== "object" || address === null)
+          return yield* Effect.die("Database readiness server did not expose an address");
+        const compiled = yield* compileStack({
+          projectRoot: root,
+          runtime: { kind: "container", engine: "docker" },
+          config: {
+            capabilities: {
+              auth: {
+                enabled: true,
+                settings: {
+                  third_party: {
+                    workos: { enabled: true, issuer_url: issuer },
+                  },
+                },
+              },
+            },
+          },
+        });
+        const resolved = yield* resolveSecrets(
+          { declarations: compiled.secrets },
+          undefined,
+          "stopped",
+        );
+        const current = {
+          value: {
+            ...stateFor(resolved.persisted, { kind: "container", engine: "docker" }),
+            identity: {
+              ...stateFor({}).identity,
+              projectRoot: root,
+            },
+            desiredLifecycle: "running" as const,
+            definition: compiled.definition,
+            privatePorts: [
+              { workloadId: "database:database", binding: "primary", port: address.port },
+              { workloadId: "auth:auth", binding: "primary", port: oidcAddress.port },
+            ],
+          },
+        } satisfies { value: PersistedStackState };
+        const database = compiled.executionPlan.workloads.find(
+          ({ id }) => id === "database:database",
+        );
+        const auth = compiled.executionPlan.workloads.find(({ id }) => id === "auth:auth");
+        if (database === undefined || auth === undefined)
+          return yield* Effect.die("Expected database and Auth workloads");
+        const context = yield* Effect.context<FileSystem.FileSystem | Path.Path | Crypto.Crypto>();
+        const runtime = yield* makeProductionRuntime({
+          stateRoot: root,
+          stackId,
+          ownerSessionId: "oidc-lazy",
+          stateStore: stateStoreFor(current),
+          context,
+          ingress,
+          containerEngine: ownerInputContainerEngine([]),
+          artifactPreparer: {
+            prepare: (_runtime, workload) =>
+              Effect.succeed({
+                workloadId: workload.id,
+                capability: workload.capability,
+                version: "test",
+                outcome: "cached" as const,
+                image: workload.selected.kind === "container" ? workload.selected.image : undefined,
+              }),
+          },
+          logStore: memoryLogStore([]),
+          bootstrapDatabase: () => Effect.void,
+        });
+        const databaseReady = yield* runtime.driver.start(
+          { stackId, workloadId: database.id },
+          database,
+        );
+        expect(databaseReady.state).toBe("ready");
+        const authResult = yield* runtime.driver.start({ stackId, workloadId: auth.id }, auth);
+        expect(authResult.state).toBe("ready");
         yield* runtime.driver.stop({ stackId, workloadId: database.id });
       }),
     ).pipe(Effect.provide(NodeServices.layer)),

--- a/packages/stack/src/runtime/readiness-probe.integration.test.ts
+++ b/packages/stack/src/runtime/readiness-probe.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Data, Deferred, Duration, Effect, Exit, Fiber, Option } from "effect";
 import * as TestClock from "effect/testing/TestClock";
-/* oxlint-disable effecttsgo/node-builtin-import -- integration test owns real listeners. */
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- integration test owns a real loopback listener.
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { createServer as createTcpServer, type Server as TcpServer } from "node:net";
 import { StackPreparationError } from "../public/Errors.ts";
@@ -84,8 +84,7 @@ describe("private endpoint readiness probe", () => {
       Effect.gen(function* () {
         const received = yield* Deferred.make<string>();
         const server = createHttpServer((request, response) => {
-          // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- bridge event callback to test signal.
-          Effect.runSync(Deferred.succeed(received, request.headers.host ?? ""));
+          Deferred.doneUnsafe(received, Effect.succeed(request.headers.host ?? ""));
           response.statusCode = request.headers.host === "realtime-dev" ? 200 : 400;
           response.end();
         });
@@ -217,8 +216,7 @@ describe("private endpoint readiness probe", () => {
       Effect.gen(function* () {
         const received = yield* Deferred.make<void>();
         const server = createHttpServer((request) => {
-          // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- bridge event callback to test signal.
-          Effect.runSync(Deferred.succeed(received, undefined));
+          Deferred.doneUnsafe(received, Effect.void);
           request.once("error", () => undefined);
         });
         const port = yield* listenHttp(server, () => undefined);
@@ -237,11 +235,9 @@ describe("private endpoint readiness probe", () => {
         const received = yield* Deferred.make<void>();
         const closed = yield* Deferred.make<void>();
         const server = createHttpServer((request) => {
-          // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- bridge event callback to test signal.
-          Effect.runSync(Deferred.succeed(received, undefined));
+          Deferred.doneUnsafe(received, Effect.void);
           request.once("close", () => {
-            // oxlint-disable-next-line effecttsgo/run-effect-inside-effect -- bridge event callback to test signal.
-            Effect.runSync(Deferred.succeed(closed, undefined));
+            Deferred.doneUnsafe(closed, Effect.void);
           });
         });
         const port = yield* listenHttp(server, () => undefined);

--- a/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
+++ b/packages/stack/src/runtime/runtime-input-owner.integration.test.ts
@@ -1,6 +1,6 @@
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, FileSystem, Option, Path, Redacted } from "effect";
+import { Cause, Effect, Exit, FileSystem, Option, Path, Redacted, Schema } from "effect";
 import { generateKeyPairSync } from "node:crypto";
 import { compileStack, type CompiledStack } from "../model/Compiler.ts";
 import { StackPreparationError } from "../public/Errors.ts";
@@ -12,6 +12,14 @@ import { makeRuntimeInputOwner } from "./RuntimeInputOwner.ts";
 import { resolveContainerResolutionFor } from "./WorkloadRuntimeSpec.ts";
 
 const stackId = StackIdSchema.make("f".repeat(64));
+const jsonSchema = Schema.fromJsonString(Schema.Unknown);
+
+const encodeJson = (value: unknown): string => Schema.encodeSync(jsonSchema)(value);
+const decodeJson = (value: string): unknown => Schema.decodeSync(jsonSchema)(value);
+const decodeJwks = (value: string): { readonly keys: ReadonlyArray<unknown> } =>
+  Schema.decodeUnknownSync(Schema.Struct({ keys: Schema.Array(Schema.Unknown) }))(
+    decodeJson(value),
+  );
 
 const withPlatform = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.scoped(effect).pipe(Effect.provide(NodeServices.layer));
@@ -120,8 +128,7 @@ describe("runtime input owner", () => {
         });
         yield* fs.writeFileString(
           path.join(root, "keys.json"),
-          // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- dynamic JWK fixture JSON
-          JSON.stringify([
+          encodeJson([
             { ...first, alg: "ES256", kid: "ec-key" },
             { ...second, alg: "RS256", kid: "rsa-key" },
           ]),
@@ -162,14 +169,14 @@ describe("runtime input owner", () => {
             ),
         });
         const material = yield* owner.resolve(state, "auth:auth");
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- inspect generated JWT fixture
-        expect(JSON.parse(material.auth?.jwtKeys ?? "[]")).toHaveLength(2);
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- inspect generated JWKS fixture
-        const jwks = JSON.parse(material.auth?.jwks ?? "{}");
+        expect(decodeJson(material.auth?.jwtKeys ?? "[]")).toHaveLength(2);
+        const jwks = decodeJwks(material.auth?.jwks ?? '{"keys":[]}');
         expect(jwks.keys).toHaveLength(3);
-        expect(jwks.keys.every((key: Record<string, unknown>) => !Object.hasOwn(key, "d"))).toBe(
-          true,
-        );
+        expect(
+          jwks.keys.every(
+            (key) => typeof key === "object" && key !== null && !Object.hasOwn(key, "d"),
+          ),
+        ).toBe(true);
       }),
     ),
   );
@@ -185,8 +192,7 @@ describe("runtime input owner", () => {
         });
         yield* fs.writeFileString(
           path.join(root, "keys.json"),
-          // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- dynamic JWK fixture JSON
-          JSON.stringify([
+          encodeJson([
             { ...valid, alg: "ES256" },
             { kty: "EC", alg: "ES256", d: "bad" },
           ]),
@@ -244,8 +250,7 @@ describe("runtime input owner", () => {
           "https://securetoken.google.com/demo/.well-known/openid-configuration",
           "https://issuer.example/keys",
         ]);
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- inspect generated JWKS fixture
-        expect(JSON.parse(material.auth?.jwks ?? "{}").keys).toHaveLength(2);
+        expect(decodeJwks(material.auth?.jwks ?? '{"keys":[]}').keys).toHaveLength(2);
       }),
     ),
   );
@@ -262,8 +267,9 @@ describe("runtime input owner", () => {
           },
         });
         const owner = yield* makeRuntimeInputOwner({ stateRoot: root, stackId });
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- inspect generated JWKS fixture
-        const jwks = JSON.parse((yield* owner.resolve(state, "auth:auth")).auth?.jwks ?? "{}");
+        const jwks = decodeJwks(
+          (yield* owner.resolve(state, "auth:auth")).auth?.jwks ?? '{"keys":[]}',
+        );
         expect(jwks.keys).toEqual([
           {
             kty: "oct",
@@ -494,10 +500,8 @@ describe("runtime input owner", () => {
         const failed = yield* owner.resolve(state, "auth:auth").pipe(Effect.exit);
         const error = errorOf(failed);
         expect(error?.message).toContain("OIDC discovery request failed");
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- assert sanitized diagnostic payload
-        expect(JSON.stringify(error)).not.toContain("secret-token");
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- assert sanitized diagnostic payload
-        expect(JSON.stringify(error)).not.toContain("fragment");
+        expect(encodeJson(error)).not.toContain("secret-token");
+        expect(encodeJson(error)).not.toContain("fragment");
       }),
     ),
   );

--- a/packages/stack/src/state/MaterializedSettings.ts
+++ b/packages/stack/src/state/MaterializedSettings.ts
@@ -1,6 +1,6 @@
 import { CAPABILITY_NAMES, type CapabilityName } from "../public/Capability.ts";
 import type { PersistedStackState } from "./StackState.ts";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { StackStateInvalidError } from "../public/Errors.ts";
 
 /** A plain object in the persisted, materialized settings document. */
@@ -23,8 +23,7 @@ export const settingValue = (state: PersistedStackState, value: unknown): string
   if (Array.isArray(value)) return value.map((entry) => settingValue(state, entry)).join(",");
   if (isRecord(value) && typeof value.slot === "string" && Object.keys(value).length === 1)
     return secret(state, value.slot);
-  // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- dynamic persisted settings are stringified for workload env values
-  return JSON.stringify(value) ?? "";
+  return Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 };
 
 /** Flattens nested materialized settings into environment-style keys. */

--- a/packages/stack/src/state/Ownership.ts
+++ b/packages/stack/src/state/Ownership.ts
@@ -10,8 +10,8 @@ import {
   Schema,
   Scope,
 } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
-import { createServer, type Server } from "node:net";
+import { NodeSocketServer } from "@effect/platform-node";
+import * as Socket from "effect/unstable/socket/Socket";
 import { StackIdSchema, type StackId } from "../public/StackId.ts";
 import { resolveStackPaths } from "./Paths.ts";
 import { StackOwnershipConflictError, StackStateInvalidError } from "../public/Errors.ts";
@@ -104,114 +104,8 @@ export const readOwnerLock = (
     ),
     Effect.catchTag("PlatformError", (error) =>
       Predicate.isTagged(error.reason, "NotFound")
-        ? // oxlint-disable-next-line effecttsgo/effect-succeed-with-void -- this branch carries Option.none as undefined
-          Effect.succeed(undefined)
+        ? Effect.undefined
         : Effect.fail(stateError(`Unable to read owner lock: ${error.message}`)),
-    ),
-  );
-
-const bindLease = (port: number): Effect.Effect<Server, StackStateInvalidError> =>
-  Effect.callback<Server, StackStateInvalidError>((resume) => {
-    const server = createServer({ allowHalfOpen: false }, (socket) => socket.destroy());
-    let settled = false;
-    let canceled = false;
-    const cleanup = () => {
-      server.off("error", onError);
-      server.off("listening", onListening);
-    };
-    const close = () => {
-      if (server.listening) {
-        try {
-          server.close(() => undefined);
-        } catch {
-          // The listener may have failed before a handle was allocated.
-        }
-      }
-    };
-    const onError = (cause: Error & { readonly code?: string }) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      close();
-      if (canceled) return;
-      resume(
-        Effect.fail(
-          new StackStateInvalidError({
-            message: `Unable to acquire owner lease: ${cause.message}`,
-            code: cause.code,
-            cause,
-          }),
-        ),
-      );
-    };
-    const onListening = () => {
-      if (canceled) {
-        settled = true;
-        cleanup();
-        close();
-        return;
-      }
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resume(Effect.succeed(server));
-    };
-    server.once("error", onError);
-    server.once("listening", onListening);
-    try {
-      server.listen({ host: "127.0.0.1", port });
-    } catch (cause) {
-      onError(cause instanceof Error ? cause : new Error(String(cause)));
-    }
-    return Effect.sync(() => {
-      if (!settled) {
-        canceled = true;
-        if (server.listening) close();
-      }
-    });
-  });
-
-const closeBoundServer = (server: Server): Effect.Effect<void> =>
-  Effect.callback<void>((resume) => {
-    if (!server.listening) {
-      resume(Effect.void);
-      return;
-    }
-    let settled = false;
-    const finish = () => {
-      if (!settled) {
-        settled = true;
-        resume(Effect.void);
-      }
-    };
-    try {
-      server.close(finish);
-    } catch {
-      finish();
-    }
-    return Effect.sync(() => {
-      if (!settled) {
-        settled = true;
-        try {
-          server.close(() => undefined);
-        } catch {
-          // The exact listener is already closed or was never allocated.
-        }
-      }
-    });
-  });
-
-const leasePort = (server: Server): Effect.Effect<number, StackStateInvalidError> =>
-  Effect.sync(() => {
-    const address = server.address();
-    if (address === null || typeof address === "string" || !Number.isInteger(address.port))
-      return undefined;
-    return address.port;
-  }).pipe(
-    Effect.flatMap((port) =>
-      port === undefined
-        ? Effect.fail(stateError("Owner lease did not expose a bound port"))
-        : Effect.succeed(port),
     ),
   );
 
@@ -223,13 +117,50 @@ export interface HeldPortLease {
 export const acquirePortLease = (
   port: number,
 ): Effect.Effect<HeldPortLease, StackStateInvalidError> =>
-  Effect.uninterruptible(
+  Effect.uninterruptibleMask((restore) =>
     Effect.gen(function* () {
-      const server = yield* bindLease(port);
-      return yield* leasePort(server).pipe(
-        Effect.map((actualPort) => ({ port: actualPort, close: closeBoundServer(server) })),
-        Effect.onExit((exit) => (Exit.isFailure(exit) ? closeBoundServer(server) : Effect.void)),
-      );
+      const scope = yield* Scope.make();
+      const close = Scope.close(scope, Exit.void);
+      return yield* Effect.gen(function* () {
+        const server = yield* restore(
+          NodeSocketServer.make({ host: "127.0.0.1", port, allowHalfOpen: false }).pipe(
+            Effect.provideService(Scope.Scope, scope),
+            Effect.mapError((error) => {
+              const cause = error.reason.cause;
+              const code =
+                typeof cause === "object" &&
+                cause !== null &&
+                "code" in cause &&
+                typeof cause.code === "string"
+                  ? cause.code
+                  : undefined;
+              return new StackStateInvalidError({
+                message: `Unable to acquire owner lease: ${String(cause)}`,
+                code,
+                cause,
+              });
+            }),
+          ),
+        );
+        if (!Predicate.isTagged(server.address, "TcpAddress"))
+          return yield* stateError("Owner lease did not expose a bound port");
+        yield* Effect.forkIn(
+          server.run((socket) =>
+            socket
+              .run(() => Effect.void, {
+                onOpen: Effect.scoped(
+                  Effect.gen(function* () {
+                    const write = yield* socket.writer;
+                    yield* write(new Socket.CloseEvent());
+                  }),
+                ).pipe(Effect.ignore),
+              })
+              .pipe(Effect.ignore),
+          ),
+          scope,
+        );
+        return { port: server.address.port, close };
+      }).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? close : Effect.void)));
     }),
   );
 

--- a/packages/stack/src/state/SecretStore.ts
+++ b/packages/stack/src/state/SecretStore.ts
@@ -1,5 +1,5 @@
 import { Clock, Crypto, Effect, FileSystem, Path, Redacted, Schema } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- Effect Crypto has no HMAC, private-key import, or asymmetric signing API.
 import { createHmac, createPrivateKey, createSign } from "node:crypto";
 import {
   InvalidJwtSigningMaterialError,

--- a/packages/stack/src/state/StackStateStore.ts
+++ b/packages/stack/src/state/StackStateStore.ts
@@ -10,7 +10,7 @@ import {
   Schedule,
   Schema,
 } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- native rmdir preserves non-recursive recovery semantics.
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- FileSystem.remove cannot atomically remove only an empty directory.
 import { rmdir } from "node:fs/promises";
 import {
   InvalidProjectRootError,
@@ -79,7 +79,7 @@ export interface StackStateStore {
   ) => Effect.Effect<
     void,
     InvalidProjectRootError | StackStateInvalidError,
-    FileSystem.FileSystem | Path.Path
+    FileSystem.FileSystem | Path.Path | Crypto.Crypto
   >;
   /** Removes only an empty runtime-only remnant and its now-empty identity root. */
   readonly recoverRuntimeRemnant: (
@@ -87,7 +87,7 @@ export interface StackStateStore {
   ) => Effect.Effect<
     void,
     InvalidProjectRootError | StackStateInvalidError,
-    FileSystem.FileSystem | Path.Path
+    FileSystem.FileSystem | Path.Path | Crypto.Crypto
   >;
 }
 
@@ -308,10 +308,15 @@ const persistValidatedState = (
 export const withRegistryLock = <A, E, R>(
   stateRoot: string,
   action: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E | StackStateInvalidError, R | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<
+  A,
+  E | StackStateInvalidError,
+  R | FileSystem.FileSystem | Path.Path | Crypto.Crypto
+> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
+    const crypto = yield* Crypto.Crypto;
     const root = path.resolve(stateRoot);
     yield* fs
       .makeDirectory(root, { recursive: true, mode: 0o700 })
@@ -339,12 +344,11 @@ export const withRegistryLock = <A, E, R>(
           ),
         );
         const install = Effect.gen(function* () {
-          const token = yield* Effect.try({
-            // oxlint-disable-next-line effecttsgo/crypto-random-uuid-in-effect -- ephemeral label; ownership is proven by the held lease, not this ID.
-            try: () => globalThis.crypto.randomUUID(),
-            catch: (cause) =>
-              stateError(`Unable to allocate registry lock token: ${String(cause)}`),
-          });
+          const token = yield* crypto.randomUUIDv4.pipe(
+            Effect.mapError((error) =>
+              stateError(`Unable to allocate registry lock token: ${error.message}`),
+            ),
+          );
           const lock: OwnerLock = { format: OWNER_LOCK_FORMAT, token, port: held.port };
           const temporary = yield* writeLockTemp(fs, path, lockPath, lock);
           yield* installLease({ fs, lockPath, temporary, observed: existing }).pipe(
@@ -560,7 +564,7 @@ export const makeStackStateStore = (options: {
     ): Effect.Effect<
       void,
       InvalidProjectRootError | StackStateInvalidError,
-      FileSystem.FileSystem | Path.Path
+      FileSystem.FileSystem | Path.Path | Crypto.Crypto
     > =>
       Effect.gen(function* () {
         const paths = yield* pathsFor(stackId);
@@ -626,7 +630,7 @@ export const makeStackStateStore = (options: {
     ): Effect.Effect<
       void,
       InvalidProjectRootError | StackStateInvalidError,
-      FileSystem.FileSystem | Path.Path
+      FileSystem.FileSystem | Path.Path | Crypto.Crypto
     > => withRegistryLock(options.stateRoot, recoverRuntimeRemnantUnlocked(stackId));
 
     const cleanup = (
@@ -634,7 +638,7 @@ export const makeStackStateStore = (options: {
     ): Effect.Effect<
       void,
       InvalidProjectRootError | StackStateInvalidError,
-      FileSystem.FileSystem | Path.Path
+      FileSystem.FileSystem | Path.Path | Crypto.Crypto
     > =>
       withRegistryLock(
         options.stateRoot,

--- a/packages/stack/src/state/ownership.integration.test.ts
+++ b/packages/stack/src/state/ownership.integration.test.ts
@@ -69,18 +69,29 @@ const observeRejectedPeer = (port: number) =>
   Effect.callback<void, Error>((resume) => {
     const socket = new Socket();
     let connected = false;
+    let settled = false;
+    const finish = (result: Effect.Effect<void, Error>) => {
+      if (settled) return;
+      settled = true;
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      socket.destroy();
+      resume(result);
+    };
     const onConnect = () => {
       connected = true;
     };
-    const onError = (error: Error) => resume(Effect.fail(error));
+    const onError = (error: Error) => finish(Effect.fail(error));
     const onClose = () => {
-      if (connected) resume(Effect.void);
+      if (connected) finish(Effect.void);
     };
     socket.once("connect", onConnect);
     socket.once("error", onError);
     socket.once("close", onClose);
     socket.connect({ host: "127.0.0.1", port });
     return Effect.sync(() => {
+      settled = true;
       socket.off("connect", onConnect);
       socket.off("error", onError);
       socket.off("close", onClose);
@@ -123,6 +134,9 @@ describe("stack ownership", () => {
           return yield* Effect.die("Blocker did not expose a bound port");
         const failed = yield* acquirePortLease(address.port).pipe(Effect.exit);
         expect(Exit.isFailure(failed)).toBe(true);
+        const failure = errorOf(failed);
+        expect(failure).toBeInstanceOf(StackStateInvalidError);
+        expect(failure?.code).toBe("EADDRINUSE");
         yield* closeServer(blocker);
         const lease = yield* acquirePortLease(address.port);
         yield* lease.close;

--- a/packages/stack/src/state/ownership.integration.test.ts
+++ b/packages/stack/src/state/ownership.integration.test.ts
@@ -14,7 +14,7 @@ import {
   Stream,
 } from "effect";
 import { ChildProcess } from "effect/unstable/process";
-import { createServer, type Server } from "node:net";
+import { createServer, Socket, type Server } from "node:net";
 import { deriveStackId, type StackIdentity } from "../identity/Identity.ts";
 import { StackOwnershipConflictError, StackStateInvalidError } from "../public/Errors.ts";
 import {
@@ -65,6 +65,29 @@ const closeServer = (server: Server) =>
     );
   });
 
+const observeRejectedPeer = (port: number) =>
+  Effect.callback<void, Error>((resume) => {
+    const socket = new Socket();
+    let connected = false;
+    const onConnect = () => {
+      connected = true;
+    };
+    const onError = (error: Error) => resume(Effect.fail(error));
+    const onClose = () => {
+      if (connected) resume(Effect.void);
+    };
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+    socket.connect({ host: "127.0.0.1", port });
+    return Effect.sync(() => {
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      socket.destroy();
+    });
+  });
+
 const jsonText = (value: unknown) =>
   Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(value);
 
@@ -104,6 +127,14 @@ describe("stack ownership", () => {
         const lease = yield* acquirePortLease(address.port);
         yield* lease.close;
       }),
+    ),
+  );
+
+  it.live("closes accepted lease peers before lease cleanup completes", () =>
+    withPlatform(
+      Effect.acquireRelease(acquirePortLease(0), (lease) => lease.close).pipe(
+        Effect.flatMap((lease) => observeRejectedPeer(lease.port).pipe(Effect.timeout("1 second"))),
+      ),
     ),
   );
 

--- a/packages/stack/src/state/ports.integration.test.ts
+++ b/packages/stack/src/state/ports.integration.test.ts
@@ -13,7 +13,7 @@ import {
   Schema,
   Scope,
 } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- native server is the listener fixture.
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- HostListener fixtures must supply the native HTTP server that gateways adopt.
 import { createServer as createHttpServer } from "node:http";
 import { deriveStackId, type StackIdentity } from "../identity/Identity.ts";
 import {

--- a/packages/stack/src/state/secrets.integration.test.ts
+++ b/packages/stack/src/state/secrets.integration.test.ts
@@ -1,6 +1,6 @@
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, FileSystem, Option, Path, Redacted } from "effect";
+import { Cause, Effect, Exit, FileSystem, Option, Path, Redacted, Schema } from "effect";
 import * as TestClock from "effect/testing/TestClock";
 import { createHmac, generateKeyPairSync, createVerify } from "node:crypto";
 import {
@@ -17,6 +17,12 @@ import {
 } from "./SecretStore.ts";
 
 const layer = NodeServices.layer;
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+const decodeJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+const decodeJwtPayload = (text: string) =>
+  Schema.decodeUnknownSync(
+    Schema.Struct({ iss: Schema.String, role: Schema.String, exp: Schema.Finite }),
+  )(decodeJson(text));
 const managed = (value?: string): SecretCandidate => ({
   declarations: [
     {
@@ -105,8 +111,7 @@ describe("managed and pass-through secrets", () => {
           present(tokenParts[1], `${slot} payload`),
           "base64url",
         ).toString();
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-        const payload = JSON.parse(payloadText);
+        const payload = decodeJwtPayload(payloadText);
         expect(payload).toMatchObject({
           iss: "supabase-demo",
           role: slot.endsWith("anon_key") ? "anon" : "service_role",
@@ -171,8 +176,7 @@ describe("managed and pass-through secrets", () => {
       };
       yield* fs.writeFileString(
         path.join(root, "keys.json"),
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json -- dynamic JWK fixture JSON
-        JSON.stringify([privateJwk, { kty: "EC", alg: "ES256", d: "invalid" }]),
+        encodeJson([privateJwk, { kty: "EC", alg: "ES256", d: "invalid" }]),
       );
       const failed = yield* resolveSigningKeyMaterial({
         kind: "jwks-file",
@@ -190,8 +194,7 @@ describe("managed and pass-through secrets", () => {
       const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-credentials-" });
       const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
       const privateJwk = { ...privateKey.export({ format: "jwk" }), alg: "ES256", kid: "test-key" };
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      yield* fs.writeFileString(path.join(root, "keys.json"), JSON.stringify([privateJwk]));
+      yield* fs.writeFileString(path.join(root, "keys.json"), encodeJson([privateJwk]));
       const compiled = yield* compileStack({
         projectRoot: root,
         runtime: { kind: "native" },
@@ -210,8 +213,7 @@ describe("managed and pass-through secrets", () => {
       const tokenHeader = present(header, "JWT header");
       const tokenPayload = present(payload, "JWT payload");
       const tokenSignature = present(signature, "JWT signature");
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      expect(JSON.parse(Buffer.from(tokenHeader, "base64url").toString())).toMatchObject({
+      expect(decodeJson(Buffer.from(tokenHeader, "base64url").toString())).toMatchObject({
         alg: "ES256",
         kid: "test-key",
       });
@@ -234,8 +236,7 @@ describe("managed and pass-through secrets", () => {
       const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-credentials-" });
       const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
       const privateJwk = { ...privateKey.export({ format: "jwk" }), alg: "RS256", kid: "rsa-key" };
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      yield* fs.writeFileString(path.join(root, "keys.json"), JSON.stringify([privateJwk]));
+      yield* fs.writeFileString(path.join(root, "keys.json"), encodeJson([privateJwk]));
       const compiled = yield* compileStack({
         projectRoot: root,
         runtime: { kind: "native" },
@@ -254,8 +255,7 @@ describe("managed and pass-through secrets", () => {
       const tokenHeader = present(header, "JWT header");
       const tokenPayload = present(payload, "JWT payload");
       const tokenSignature = present(signature, "JWT signature");
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      expect(JSON.parse(Buffer.from(tokenHeader, "base64url").toString())).toMatchObject({
+      expect(decodeJson(Buffer.from(tokenHeader, "base64url").toString())).toMatchObject({
         alg: "RS256",
         kid: "rsa-key",
       });
@@ -274,8 +274,7 @@ describe("managed and pass-through secrets", () => {
       const root = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-credentials-" });
       const { privateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
       const privateJwk = { ...privateKey.export({ format: "jwk" }), alg: "ES256" };
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      yield* fs.writeFileString(path.join(root, "keys.json"), JSON.stringify([privateJwk]));
+      yield* fs.writeFileString(path.join(root, "keys.json"), encodeJson([privateJwk]));
       const compiled = yield* compileStack({
         projectRoot: root,
         runtime: { kind: "native" },
@@ -292,8 +291,7 @@ describe("managed and pass-through secrets", () => {
       );
       const payloadPart = present(token.split(".")[1], "JWT payload");
       const payloadText = Buffer.from(payloadPart, "base64url").toString();
-      // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-      const payload = JSON.parse(payloadText);
+      const payload = decodeJwtPayload(payloadText);
       expect(payload).toEqual({
         iss: "supabase-demo",
         role: "anon",
@@ -314,11 +312,7 @@ describe("managed and pass-through secrets", () => {
         }),
         alg: "ES256",
       };
-      yield* fs.writeFileString(
-        path.join(root, "public.json"),
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-        JSON.stringify([publicJwk]),
-      );
+      yield* fs.writeFileString(path.join(root, "public.json"), encodeJson([publicJwk]));
       const publicOnly = yield* compileStack({
         projectRoot: root,
         runtime: { kind: "native" },
@@ -380,8 +374,7 @@ describe("managed and pass-through secrets", () => {
       const outside = yield* fs.makeTempDirectoryScoped({ prefix: "supabase-stack-outside-" });
       yield* fs.writeFileString(
         path.join(outside, "private.json"),
-        // oxlint-disable-next-line effecttsgo/prefer-schema-over-json
-        JSON.stringify([{ kty: "EC", alg: "ES256", crv: "P-256", d: "d", x: "x", y: "y" }]),
+        encodeJson([{ kty: "EC", alg: "ES256", crv: "P-256", d: "d", x: "x", y: "y" }]),
       );
       yield* fs.symlink(path.join(outside, "private.json"), path.join(root, "linked.json"));
       const symlinkEscape = yield* compileStack({

--- a/packages/stack/src/supervisor/HostListener.ts
+++ b/packages/stack/src/supervisor/HostListener.ts
@@ -1,9 +1,7 @@
 import { Effect, Queue, Scope } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- pre-adoption HTTP and raw upgrade events must stay queued on the same bound server.
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import { createServer as createNetServer, isIP, type Server as NetServer } from "node:net";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import type { Duplex } from "node:stream";
 import { PortUnavailableError } from "../public/Errors.ts";
 import { PORT_FIELD_PROTOCOL, type PortField } from "../public/Status.ts";

--- a/packages/stack/src/supervisor/Launcher.ts
+++ b/packages/stack/src/supervisor/Launcher.ts
@@ -1,5 +1,6 @@
 import {
   Cause,
+  Config,
   Crypto,
   Effect,
   Exit,
@@ -54,20 +55,30 @@ export const supervisorEntrypointFor = (moduleUrl: string): string => {
   return isBunVirtualPath(sourceEntrypoint) ? SUPERVISOR_DISPATCH_SENTINEL : sourceEntrypoint;
 };
 
-/** Default host values are resolved only at the process composition boundary. */
-export const defaultRuntimeEnvironment = (): StackRuntimeEnvironmentValue => {
-  // oxlint-disable-next-line effecttsgo/process-env -- composition-boundary environment read
-  const home = process.env.SUPABASE_HOME ?? `${process.env.HOME ?? homedir()}/.supabase`;
-  return {
-    stateRoot: `${home}/managed/stacks`,
-    // Keep the POSIX socket root short enough for AF_UNIX path limits.
-    // oxlint-disable-next-line effecttsgo/process-env -- composition-boundary environment read
-    tempRoot: process.platform === "win32" ? (process.env.TEMP ?? "C:\\Windows\\Temp") : "/tmp",
-    platform: process.platform === "win32" ? "windows" : "posix",
-    supervisorCommand: process.execPath,
-    supervisorEntrypoint: supervisorEntrypointFor(import.meta.url),
-  };
-};
+/** Resolves default host values from the active Effect configuration provider. */
+export const defaultRuntimeEnvironment: Effect.Effect<StackRuntimeEnvironmentValue> = Effect.gen(
+  function* () {
+    const optional = (name: string) =>
+      Config.option(Config.string(name)).pipe(Effect.orElseSucceed(() => Option.none<string>()));
+    const configuredHome = yield* optional("SUPABASE_HOME");
+    const configuredUserHome = yield* optional("HOME");
+    const home = Option.getOrElse(
+      configuredHome,
+      () => `${Option.getOrElse(configuredUserHome, homedir)}/.supabase`,
+    );
+    const configuredTemp = yield* optional("TEMP");
+    return {
+      stateRoot: `${home}/managed/stacks`,
+      tempRoot:
+        process.platform === "win32"
+          ? Option.getOrElse(configuredTemp, () => "C:\\Windows\\Temp")
+          : "/tmp",
+      platform: process.platform === "win32" ? "windows" : "posix",
+      supervisorCommand: process.execPath,
+      supervisorEntrypoint: supervisorEntrypointFor(import.meta.url),
+    };
+  },
+);
 
 type ReadinessResult =
   | { readonly kind: "ready"; readonly stackId: StackId; readonly ownerSessionId: string }
@@ -148,9 +159,7 @@ const validateCompatibleOwner = (
     const probeExit = yield* makeControlClient(metadata.endpoint, {
       stackId: options.stackId,
       ownerSessionId: metadata.ownerSessionId,
-    })
-      .probe()
-      .pipe(Effect.exit);
+    }).probe.pipe(Effect.exit);
     if (Exit.isFailure(probeExit)) {
       const failure = Cause.findErrorOption(probeExit.cause);
       if (Option.isSome(failure) && isMaintenanceTransportFailure(failure.value))

--- a/packages/stack/src/supervisor/Lifecycle.ts
+++ b/packages/stack/src/supervisor/Lifecycle.ts
@@ -55,10 +55,8 @@ export interface LifecycleController {
   readonly start: (
     options?: LifecycleStartOptions,
   ) => Effect.Effect<PersistedStackState, StackError, LifecycleRequirements>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect -- fresh effect per call; callers serialize with their own semaphore.
-  readonly stop: () => Effect.Effect<PersistedStackState, StackError, LifecycleRequirements>;
-  // oxlint-disable-next-line effecttsgo/lazy-effect -- fresh effect per call; callers serialize with their own semaphore.
-  readonly destroy: () => Effect.Effect<void, StackError, LifecycleRequirements>;
+  readonly stop: Effect.Effect<PersistedStackState, StackError, LifecycleRequirements>;
+  readonly destroy: Effect.Effect<void, StackError, LifecycleRequirements>;
 }
 
 type LifecycleRequirements = Crypto.Crypto | FileSystem.FileSystem | Path.Path;
@@ -297,27 +295,29 @@ export const makeLifecycleController = (
       });
     };
 
-    const stop = (): Effect.Effect<PersistedStackState, StackError, LifecycleRequirements> =>
-      Effect.gen(function* () {
-        const current = yield* read();
-        if (current.desiredLifecycle === "unconfigured") {
-          // Even an unconfigured stack may have exact runtime remnants from an interrupted
-          // first start. Stop is the explicit retry boundary for that cleanup.
+    const stop: Effect.Effect<PersistedStackState, StackError, LifecycleRequirements> =
+      Effect.suspend(() =>
+        Effect.gen(function* () {
+          const current = yield* read();
+          if (current.desiredLifecycle === "unconfigured") {
+            // Even an unconfigured stack may have exact runtime remnants from an interrupted
+            // first start. Stop is the explicit retry boundary for that cleanup.
+            yield* options.backend.cleanup;
+            return current;
+          }
+          if (current.desiredLifecycle === "destroying")
+            return yield* lifecycleConflict("Stack is being destroyed");
+          const stopped: PersistedStackState =
+            current.desiredLifecycle === "stopped"
+              ? current
+              : { ...current, desiredLifecycle: "stopped" };
+          if (stopped !== current) yield* options.stateStore.replace(options.stackId, stopped);
           yield* options.backend.cleanup;
-          return current;
-        }
-        if (current.desiredLifecycle === "destroying")
-          return yield* lifecycleConflict("Stack is being destroyed");
-        const stopped: PersistedStackState =
-          current.desiredLifecycle === "stopped"
-            ? current
-            : { ...current, desiredLifecycle: "stopped" };
-        if (stopped !== current) yield* options.stateStore.replace(options.stackId, stopped);
-        yield* options.backend.cleanup;
-        return stopped;
-      });
+          return stopped;
+        }),
+      );
 
-    const destroy = (): Effect.Effect<void, StackError, LifecycleRequirements> =>
+    const destroy: Effect.Effect<void, StackError, LifecycleRequirements> = Effect.suspend(() =>
       Effect.gen(function* () {
         const current = yield* read();
         const destroying: PersistedStackState =
@@ -326,7 +326,8 @@ export const makeLifecycleController = (
             : { ...current, desiredLifecycle: "destroying" };
         if (destroying !== current) yield* options.stateStore.replace(options.stackId, destroying);
         yield* destroyRuntime;
-      });
+      }),
+    );
 
     const destroyRuntime: Effect.Effect<void, StackError, LifecycleRequirements> = Effect.gen(
       function* () {

--- a/packages/stack/src/supervisor/Supervisor.ts
+++ b/packages/stack/src/supervisor/Supervisor.ts
@@ -680,9 +680,10 @@ export const makeSupervisor = (
       Effect.gen(function* () {
         const previous = yield* Ref.get(phase);
         yield* Ref.set(phase, "stopping");
-        const result = yield* controller
-          .stop()
-          .pipe(Effect.provideContext(options.context), Effect.exit);
+        const result = yield* controller.stop.pipe(
+          Effect.provideContext(options.context),
+          Effect.exit,
+        );
         if (Exit.isFailure(result)) {
           const state = yield* read().pipe(Effect.orElseSucceed(() => undefined));
           if (state?.desiredLifecycle === "stopped") {
@@ -729,9 +730,10 @@ export const makeSupervisor = (
     const destroyOperation = Effect.gen(function* () {
       const previous = yield* Ref.get(phase);
       yield* Ref.set(phase, "destroying");
-      const result = yield* controller
-        .destroy()
-        .pipe(Effect.provideContext(options.context), Effect.exit);
+      const result = yield* controller.destroy.pipe(
+        Effect.provideContext(options.context),
+        Effect.exit,
+      );
       if (Exit.isFailure(result)) {
         yield* restorePhase(previous);
         return yield* Effect.failCause(result.cause);

--- a/packages/stack/src/supervisor/handles.integration.test.ts
+++ b/packages/stack/src/supervisor/handles.integration.test.ts
@@ -71,7 +71,7 @@ const withRuntimeRoot = <A, E, R>(effect: (project: string) => Effect.Effect<A, 
       const path = yield* Path.Path;
       const project = path.join(root, "project");
       yield* fs.makeDirectory(project);
-      const defaults = defaultRuntimeEnvironment();
+      const defaults = yield* defaultRuntimeEnvironment;
       const runtime: StackRuntimeEnvironmentValue = {
         ...defaults,
         stateRoot: path.join(root, "managed", "stacks"),
@@ -122,7 +122,7 @@ const stopOwner = (id: StackId) =>
         stackId: id,
         ownerSessionId: owner.ownerSessionId,
         rpcRelease: owner.rpcRelease,
-      }).stop(),
+      }).stop,
     );
     const remaining = yield* readOwnerMetadata(env.stateRoot, id, env);
     if (remaining === undefined) {
@@ -367,7 +367,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         const stack = yield* openStack(created.id).pipe(
           Effect.provideService(ContainerEngineResolver, resolver),
         );
-        expect((yield* stack.status()).runtime).toEqual({ kind: "container", engine: "podman" });
+        expect((yield* stack.status).runtime).toEqual({ kind: "container", engine: "podman" });
       }),
     ),
   );
@@ -413,7 +413,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
     withRuntimeRoot((project) =>
       Effect.gen(function* () {
         const stack = yield* createStack({ projectRoot: project });
-        const status = yield* stack.status();
+        const status = yield* stack.status;
         expect(status.lifecycle).toBe("unconfigured");
         expect(status.desiredLifecycle).toBe("unconfigured");
       }),
@@ -592,7 +592,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         }).pipe(Effect.provideService(Scope.Scope, ownerScope));
         const stack = yield* openStack(stackId);
         const destroyFiber = yield* Effect.forkChild(
-          stack.destroy().pipe(Effect.andThen(Deferred.succeed(destroyDone, undefined))),
+          stack.destroy.pipe(Effect.andThen(Deferred.succeed(destroyDone, undefined))),
           { startImmediately: true },
         );
         yield* Deferred.await(destroyStarted);
@@ -616,7 +616,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
           { concurrency: 2 },
         );
         expect(second.id).toBe(first.id);
-        expect((yield* second.status()).lifecycle).toBe("unconfigured");
+        expect((yield* second.status).lifecycle).toBe("unconfigured");
       }),
     ),
   );
@@ -718,7 +718,7 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
         expect(second.code, second.stderr).toBe(0);
         expect(first.id).toBe(second.id);
         const attached = yield* openStack(StackIdSchema.make(first.id));
-        expect((yield* attached.status()).lifecycle).toBe("unconfigured");
+        expect((yield* attached.status).lifecycle).toBe("unconfigured");
       }),
     ),
   );
@@ -729,8 +729,8 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
       withRuntimeRoot((project) =>
         Effect.gen(function* () {
           const stack = yield* createStack({ projectRoot: project });
-          yield* stack.stop();
-          const status = yield* stack.status();
+          yield* stack.stop;
+          const status = yield* stack.status;
           expect(status.lifecycle).toBe("unconfigured");
         }),
       ),

--- a/packages/stack/src/supervisor/handles.integration.test.ts
+++ b/packages/stack/src/supervisor/handles.integration.test.ts
@@ -657,6 +657,65 @@ describe("managed stack handles", { timeout: 30_000 }, () => {
     ),
   );
 
+  it.live("joins stack creation while the first caller is publishing state", () =>
+    withRuntimeRoot((project) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const publicationStarted = yield* Deferred.make<void>();
+        const publish = yield* Deferred.make<void>();
+        const readerEnteredRegistry = yield* Deferred.make<void>();
+        const writerFileSystem: FileSystem.FileSystem = {
+          ...fs,
+          rename: (from, to) =>
+            Effect.gen(function* () {
+              if (to.endsWith("/state.json")) {
+                yield* Deferred.succeed(publicationStarted, undefined);
+                yield* Deferred.await(publish);
+              }
+              yield* fs.rename(from, to);
+            }),
+        };
+        const readerFileSystem: FileSystem.FileSystem = {
+          ...fs,
+          readFileString: (file, encoding) =>
+            fs
+              .readFileString(file, encoding)
+              .pipe(
+                Effect.tap(() =>
+                  file.endsWith("/.stack-registry.lock")
+                    ? Deferred.succeed(readerEnteredRegistry, undefined)
+                    : Effect.void,
+                ),
+              ),
+        };
+        return yield* Effect.gen(function* () {
+          const first = yield* createStack({
+            projectRoot: project,
+            runtime: { kind: "native" },
+          }).pipe(
+            Effect.provideService(FileSystem.FileSystem, writerFileSystem),
+            Effect.forkChild({ startImmediately: true }),
+          );
+          yield* Deferred.await(publicationStarted).pipe(Effect.timeout("10 seconds"));
+          const second = yield* createStack({
+            projectRoot: project,
+            runtime: { kind: "native" },
+          }).pipe(
+            Effect.provideService(FileSystem.FileSystem, readerFileSystem),
+            Effect.forkChild({ startImmediately: true }),
+          );
+          yield* Effect.raceFirst(Fiber.await(second), Deferred.await(readerEnteredRegistry)).pipe(
+            Effect.timeout("10 seconds"),
+          );
+          yield* Deferred.succeed(publish, undefined);
+          const firstHandle = yield* Fiber.join(first);
+          const secondHandle = yield* Fiber.join(second);
+          expect(secondHandle.id).toBe(firstHandle.id);
+        }).pipe(Effect.ensuring(Deferred.succeed(publish, undefined)));
+      }),
+    ),
+  );
+
   it.live("concurrent caller processes share one stack identity after exit", () =>
     withRuntimeRoot((project) =>
       Effect.gen(function* () {

--- a/packages/stack/src/supervisor/host-listener.integration.test.ts
+++ b/packages/stack/src/supervisor/host-listener.integration.test.ts
@@ -1,7 +1,7 @@
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Fiber, Option, Predicate, Queue } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- fixture exercises native listener adoption.
 import { createServer, request as httpRequest, type Server as HttpServer } from "node:http";
 import { connect as connectNet, type Server as NetServer, type Socket } from "node:net";
 import { PortUnavailableError } from "../public/Errors.ts";

--- a/packages/stack/src/supervisor/ingress.integration.test.ts
+++ b/packages/stack/src/supervisor/ingress.integration.test.ts
@@ -1,15 +1,13 @@
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Context, Crypto, Effect, Exit, FileSystem, Option, Path, Ref, Scope } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import {
   createServer as createHttpServer,
   request as requestHttp,
   type IncomingMessage,
   type ServerResponse,
-  // oxlint-disable-next-line effecttsgo/node-builtin-import
+  // oxlint-disable-next-line effecttsgo/node-builtin-import -- ingress protocol fixture.
 } from "node:http";
-// oxlint-disable-next-line effecttsgo/node-builtin-import
 import type { Duplex } from "node:stream";
 import { deriveStackId, type StackIdentity } from "../identity/Identity.ts";
 import { compileStack } from "../model/Compiler.ts";

--- a/packages/stack/src/supervisor/lifecycle.integration.test.ts
+++ b/packages/stack/src/supervisor/lifecycle.integration.test.ts
@@ -149,7 +149,7 @@ describe("durable lifecycle controller", () => {
         const fixture = yield* makeFixture();
         const first = yield* fixture.controller.start({ config: { capabilities: { rest: {} } } });
         fixture.state.calls.length = 0;
-        const second = yield* fixture.controller.stop();
+        const second = yield* fixture.controller.stop;
         expect(second.desiredLifecycle).toBe("stopped");
         fixture.state.calls.length = 0;
         const third = yield* fixture.controller.start();
@@ -275,7 +275,7 @@ describe("durable lifecycle controller", () => {
         yield* fixture.controller.start({ config: original });
         const running = yield* fixture.controller.start({ config: changed }).pipe(Effect.exit);
         expect(errorOf(running)).toBeInstanceOf(StackMustBeStoppedError);
-        yield* fixture.controller.stop();
+        yield* fixture.controller.stop;
         const restarted = yield* fixture.controller.start({ config: changed });
         expect(restarted.desiredLifecycle).toBe("running");
         expect(restarted.secrets).toMatchObject({
@@ -306,14 +306,14 @@ describe("durable lifecycle controller", () => {
         const fixture = yield* makeFixture();
         yield* fixture.controller.start();
         fixture.state.calls.length = 0;
-        const first = yield* fixture.controller.stop();
+        const first = yield* fixture.controller.stop;
         expect(first).toMatchObject({
           desiredLifecycle: "stopped",
           definition: { preparation: "background" },
         });
         expect(fixture.state.calls).toEqual(["cleanup:running"]);
         fixture.state.calls.length = 0;
-        const second = yield* fixture.controller.stop();
+        const second = yield* fixture.controller.stop;
         expect(second).toEqual(first);
         expect(fixture.state.calls).toEqual(["cleanup:running"]);
       }),
@@ -327,12 +327,12 @@ describe("durable lifecycle controller", () => {
         yield* fixture.controller.start();
         fixture.state.calls.length = 0;
         fixture.state.failCleanupOnce = true;
-        const first = yield* fixture.controller.stop().pipe(Effect.exit);
+        const first = yield* fixture.controller.stop.pipe(Effect.exit);
         expect(errorOf(first)).toBeInstanceOf(StackCleanupError);
         const stopped = yield* fixture.store.read(fixture.id);
         expect(stopped?.desiredLifecycle).toBe("stopped");
         fixture.state.calls.length = 0;
-        const second = yield* fixture.controller.stop();
+        const second = yield* fixture.controller.stop;
         expect(second.desiredLifecycle).toBe("stopped");
         expect(fixture.state.calls).toEqual(["cleanup:running"]);
       }),
@@ -344,7 +344,7 @@ describe("durable lifecycle controller", () => {
       Effect.gen(function* () {
         const fixture = yield* makeFixture();
         const first = yield* fixture.controller.start();
-        yield* fixture.controller.stop();
+        yield* fixture.controller.stop;
         fixture.state.calls.length = 0;
         fixture.state.failPreflight = true;
         const exit = yield* fixture.controller
@@ -368,7 +368,7 @@ describe("durable lifecycle controller", () => {
         yield* fs.makeDirectory(`${fixture.root}/${fixture.id}/runtime`, { recursive: true });
         yield* fixture.controller.start();
         fixture.state.calls.length = 0;
-        yield* fixture.controller.destroy();
+        yield* fixture.controller.destroy;
         expect(fixture.state.calls).toEqual(["destroy-data:running"]);
         expect(yield* fixture.store.read(fixture.id)).toBeUndefined();
         expect(yield* fs.exists(`${fixture.root}/${fixture.id}`)).toBe(false);
@@ -393,14 +393,14 @@ describe("durable lifecycle controller", () => {
         yield* fixture.controller.start();
         fixture.state.calls.length = 0;
         fixture.state.failDestroyData = true;
-        const exit = yield* fixture.controller.destroy().pipe(Effect.exit);
+        const exit = yield* fixture.controller.destroy.pipe(Effect.exit);
         expect(errorOf(exit)).toBeInstanceOf(StackCleanupError);
         expect(yield* fixture.store.read(fixture.id)).toMatchObject({
           desiredLifecycle: "destroying",
         });
         expect(fixture.state.calls).toEqual(["destroy-data:running"]);
         fixture.state.failDestroyData = false;
-        yield* fixture.controller.destroy();
+        yield* fixture.controller.destroy;
         expect(yield* fixture.store.read(fixture.id)).toBeUndefined();
       }),
     ),
@@ -410,7 +410,7 @@ describe("durable lifecycle controller", () => {
     run(
       Effect.gen(function* () {
         const fixture = yield* makeFixture();
-        yield* fixture.controller.destroy();
+        yield* fixture.controller.destroy;
         expect(fixture.state.calls).toEqual(["destroy-data:invalid"]);
         expect(yield* fixture.store.read(fixture.id)).toBeUndefined();
       }),
@@ -422,10 +422,10 @@ describe("durable lifecycle controller", () => {
       Effect.gen(function* () {
         const fixture = yield* makeFixture();
         fixture.state.failDestroyDataOnce = true;
-        const first = yield* fixture.controller.destroy().pipe(Effect.exit);
+        const first = yield* fixture.controller.destroy.pipe(Effect.exit);
         expect(errorOf(first)).toBeInstanceOf(StackCleanupError);
         expect((yield* fixture.store.read(fixture.id))?.desiredLifecycle).toBe("destroying");
-        yield* fixture.controller.destroy();
+        yield* fixture.controller.destroy;
         expect(yield* fixture.store.read(fixture.id)).toBeUndefined();
       }),
     ),

--- a/packages/stack/src/supervisor/startup-ingress.integration.test.ts
+++ b/packages/stack/src/supervisor/startup-ingress.integration.test.ts
@@ -12,14 +12,13 @@ import {
   Path,
   Ref,
 } from "effect";
-// oxlint-disable-next-line effecttsgo/node-builtin-import -- native loopback HTTP server is the integration protocol boundary under test.
 import {
   request as requestHttp,
   createServer,
   type ClientRequest,
   type IncomingMessage,
   type ServerResponse,
-  // oxlint-disable-next-line effecttsgo/node-builtin-import -- native loopback HTTP server is the integration protocol boundary under test.
+  // oxlint-disable-next-line effecttsgo/node-builtin-import -- startup ingress protocol fixture.
 } from "node:http";
 import { deriveStackId } from "../identity/Identity.ts";
 import type { StackError } from "../public/Errors.ts";


### PR DESCRIPTION
Replace avoidable Effect lint suppressions across the stack runtime, state handling, downloads, functions bootstrap, and test helpers with native Effect constructs. Stack operations expose reusable Effects, while the public Promise facade keeps its existing method contract.

Remove **109 of the 126 `oxlint-disable` comments** in `packages/stack`; **17 remain**. Preserve cancellation, resource cleanup, HTTP behavior, and failure diagnostics during the migration. Tighten the existing contributor guidance to require concrete evidence before accepting a suppression.

The remaining exceptions cover these specific boundaries:

- **9 native HTTP/server boundaries:** listener adoption and pre-adoption event queues, transparent WebSocket upgrades that preserve raw handshake bytes, and protocol fixtures that control socket or response failures. Effect's higher-level server APIs do not expose all of this behavior; its WebSocket upgrade API terminates the connection rather than transparently proxying it.
- **3 launcher/process boundaries:** inherited fd3/fd4 protocol handling, including synchronous fd4 reads required by Bun, and a launcher that owns its own process group. Effect FileSystem cannot adopt those descriptors, and platform process spawners own child-process groups instead.
- **3 filesystem semantics:** two uses of `lstat` to reject symlinks, which Effect's `FileSystem.stat` follows, and one atomic empty-directory-only removal, which `FileSystem.remove` cannot express.
- **1 cryptographic boundary:** Effect Crypto does not provide HMAC, private-key import, or asymmetric signing APIs required by the secret store.
- **1 native JavaScript lifecycle scenario:** the Promise E2E suite retains its `async-function` suppression to exercise `await using` and `AsyncDisposable` directly. Replacing those scenarios with Effect scopes would stop exercising that language contract.

Each remaining suppression names its rule and explains the required boundary in the source.


Route explicit native stops and scope cleanup through the launcher before signaling workloads, so shutdown cannot race unexpected-exit diagnostics. Isolate the shadow-cache subprocess fixture’s ports and recover from confirmed Docker bind conflicts only after cleaning up its partial stack.

Protect stack creation’s preliminary state read with the registry lock so concurrent callers wait for state publication instead of rejecting an in-progress write as corrupt remnants.
