### PR TITLE
fix(cli): provide stdinLayer to config pull

### DIFF
--- a/apps/cli/src/legacy/commands/config/pull/pull.command.ts
+++ b/apps/cli/src/legacy/commands/config/pull/pull.command.ts
@@ -1,10 +1,11 @@
-import { Option } from "effect";
+import { Layer, Option } from "effect";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { PROJECT_REF_PATTERN } from "../../../config/legacy-project-ref.service.ts";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
 import { LEGACY_GLOBAL_OUTPUT_FORMATS } from "../../../../shared/legacy/global-flags.ts";
+import { stdinLayer } from "../../../../shared/runtime/stdin.layer.ts";
 import { legacyManagementApiRuntimeLayer } from "../../../shared/legacy-management-api-runtime.layer.ts";
 import { withLegacyCommandInstrumentation } from "../../../telemetry/legacy-command-instrumentation.ts";
 import { legacyConfigPull } from "./pull.handler.ts";
@@ -83,5 +84,5 @@ export const legacyConfigPullCommand = Command.make("pull", config).pipe(
     },
   ]),
   Command.withHandler(legacyConfigPullHandler),
-  Command.provide(legacyManagementApiRuntimeLayer(["config", "pull"])),
+  Command.provide(Layer.mergeAll(legacyManagementApiRuntimeLayer(["config", "pull"]), stdinLayer)),
 );

--- a/apps/cli/src/legacy/commands/config/pull/pull.integration.test.ts
+++ b/apps/cli/src/legacy/commands/config/pull/pull.integration.test.ts
@@ -380,6 +380,7 @@ interface SetupOpts {
   readonly projectId?: Option.Option<string>;
   readonly yes?: boolean;
   readonly stdinIsTty?: boolean;
+  readonly pipedAnswers?: ReadonlyArray<string>;
   readonly confirm?: ReadonlyArray<boolean>;
   readonly gitDirty?: boolean;
   readonly gitSpawnFails?: boolean;
@@ -461,7 +462,10 @@ function setup(opts: SetupOpts = {}) {
       tty: mockTty({ stdinIsTty: opts.stdinIsTty ?? false, stdoutIsTty: false }),
       goOutput: opts.goOutput === undefined ? Option.none() : Option.some(opts.goOutput),
     }),
-    mockStdin(opts.stdinIsTty ?? false),
+    mockStdin(
+      opts.stdinIsTty ?? false,
+      opts.pipedAnswers ? `${opts.pipedAnswers.join("\n")}\n` : undefined,
+    ),
     Layer.succeed(LegacyYesFlag, opts.yes ?? false),
     // Listed after `buildLegacyTestRuntime` so it overrides the real spawner
     // BunServices.layer provides (last-wins).
@@ -673,6 +677,40 @@ describe("legacy config pull integration", () => {
         `Apply 1 change(s) to ${join("supabase", "config.toml")}?`,
       );
       expect(out.stdoutText).toContain("not written (declined)");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("honors a piped 'n' decline on non-TTY stdin (no update)", () => {
+    const before = 'project_id = "test"\n[api]\nmax_rows = 500\n';
+    const { layer, out } = setup({
+      toml: before,
+      stdinIsTty: false,
+      pipedAnswers: ["n"],
+    });
+    return Effect.gen(function* () {
+      yield* legacyConfigPull(noFlags);
+      expect(readFileSync(configPath(), "utf8")).toBe(before);
+      expect(out.stderrText).toContain(
+        `Apply 1 change(s) to ${join("supabase", "config.toml")}? [Y/n] n\n`,
+      );
+      expect(out.stdoutText).toContain("not written (declined)");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.live("honors a piped 'y' confirmation on non-TTY stdin", () => {
+    const before = 'project_id = "test"\n[api]\nmax_rows = 500\n';
+    const { layer, out } = setup({
+      toml: before,
+      stdinIsTty: false,
+      pipedAnswers: ["y"],
+    });
+    return Effect.gen(function* () {
+      yield* legacyConfigPull(noFlags);
+      expect(readFileSync(configPath(), "utf8")).not.toBe(before);
+      expect(out.stderrText).toContain(
+        `Apply 1 change(s) to ${join("supabase", "config.toml")}? [Y/n] y\n`,
+      );
+      expect(out.stdoutText).toContain("1 change written.");
     }).pipe(Effect.provide(layer));
   });
 


### PR DESCRIPTION
## TL;DR
Provides `stdinLayer` to `legacyConfigPullCommand` to prevent a panic when reading confirmation from piped stdin.

Was comparing how the legacy commands handle piped input and noticed config pull was the only one not wiring up stdinLayer like the others. Reproduced it locally, crashed exactly as expected, fixed it and added tests.

## Problem
Running `supabase config pull` on non-TTY stdin without `--yes` (e.g. `echo y | supabase config pull`) panics because `stdinLayer` was omitted from the command layer:

```text
Apply 1 change(s) to supabase/config.toml? [Y/n] Service not found: supabase/runtime/Stdin
Try rerunning the command with --debug to troubleshoot the error.
```

With `stdinLayer` merged:
```text
Apply 1 change(s) to supabase/config.toml? [Y/n] y
1 change written.
```

## Solution
* Merge `stdinLayer` into `Command.provide` in `pull.command.ts`, matching `config push`.
* Add non-TTY piped stdin test coverage to `pull.integration.test.ts`.

## Testing
```bash
bun --bun vitest run src/legacy/commands/config/pull/pull.integration.test.ts \
  src/legacy/commands/config/pull/pull.format.unit.test.ts \
  src/legacy/commands/config/pull/pull.plan.unit.test.ts \
  src/legacy/commands/config/pull/pull.scope.unit.test.ts
# 4 test files passed (172 passed)
```

Fixes #6585
