### PR TITLE
fix(cli): handle piped `config pull` input (CLI-2425)

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -68,9 +68,10 @@ Every applicable command must preserve these invariants:
    [profile loader's schema](src/command-internal/profile-load.ts). Both the
    [E2E harness](../../packages/cli-test-helpers/src/harness.ts) and
    [live fixture](tests/helpers/live.ts) depend on file-path mode.
-5. Sibling layers in `Layer.mergeAll` each receive required services explicitly. Any production
-   path that can reach `promptYesNo` provides `stdinLayer`; handler-only tests do not prove this
-   wiring. Production layer changes require a CLI build and a targeted binary smoke test.
+5. Sibling layers in `Layer.mergeAll` each receive required services explicitly. Every production
+   effect graph retaining `promptYesNo`'s `Stdin` requirement provides `stdinLayer`, even when
+   runtime guards avoid its non-TTY branch. Paths that can enter that branch require a CLI build
+   and a targeted piped-input binary test; handler-only tests do not prove this wiring.
 6. Honor both output flags. `-o`/`--output` takes precedence over
    `--output-format`; a new command may reject `--output` with guidance to use
    `--output-format`, as established by `config diff` and `config pull`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -68,8 +68,9 @@ Every applicable command must preserve these invariants:
    [profile loader's schema](src/command-internal/profile-load.ts). Both the
    [E2E harness](../../packages/cli-test-helpers/src/harness.ts) and
    [live fixture](tests/helpers/live.ts) depend on file-path mode.
-5. Sibling layers in `Layer.mergeAll` each receive required services explicitly. Production layer
-   changes require a CLI build and a targeted binary smoke test.
+5. Sibling layers in `Layer.mergeAll` each receive required services explicitly. Any production
+   path that can reach `promptYesNo` provides `stdinLayer`; handler-only tests do not prove this
+   wiring. Production layer changes require a CLI build and a targeted binary smoke test.
 6. Honor both output flags. `-o`/`--output` takes precedence over
    `--output-format`; a new command may reject `--output` with guidance to use
    `--output-format`, as established by `config diff` and `config pull`.

--- a/apps/cli/src/commands/config/pull/pull.command.ts
+++ b/apps/cli/src/commands/config/pull/pull.command.ts
@@ -1,9 +1,10 @@
-import { Option } from "effect";
+import { Layer, Option } from "effect";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { Command, Flag } from "effect/unstable/cli";
 
 import { PROJECT_REF_PATTERN } from "../../../config/project-ref.service.ts";
 import { withJsonErrorHandling } from "../../../shared/output/json-error-handling.ts";
+import { stdinLayer } from "../../../shared/runtime/stdin.layer.ts";
 import { GLOBAL_OUTPUT_FORMATS } from "../../../command-internal/global-flags.ts";
 import { managementApiRuntimeLayer } from "../../../command-internal/management-api-runtime.layer.ts";
 import { withCommandTelemetry } from "../../../telemetry/command-telemetry.ts";
@@ -75,5 +76,5 @@ export const configPullCommand = Command.make("pull", config).pipe(
     },
   ]),
   Command.withHandler(configPullHandler),
-  Command.provide(managementApiRuntimeLayer(["config", "pull"])),
+  Command.provide(Layer.mergeAll(managementApiRuntimeLayer(["config", "pull"]), stdinLayer)),
 );

--- a/apps/cli/src/commands/config/pull/pull.e2e.test.ts
+++ b/apps/cli/src/commands/config/pull/pull.e2e.test.ts
@@ -81,7 +81,9 @@ describe("config pull CLI surface", () => {
       );
 
       expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
-      expect(stderr).toContain(`Apply 1 change(s) to supabase/config.toml? [Y/n] n\n`);
+      expect(stderr).toContain(
+        `Apply 1 change(s) to ${join("supabase", "config.toml")}? [Y/n] n\n`,
+      );
       expect(stdout).toContain("not written (declined)");
       expect(await readFile(configPath, "utf8")).toBe(before);
     } finally {

--- a/apps/cli/src/commands/config/pull/pull.e2e.test.ts
+++ b/apps/cli/src/commands/config/pull/pull.e2e.test.ts
@@ -1,13 +1,15 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { runSupabase } from "../../../../tests/helpers/cli.ts";
+import { v2ProjectConfigResponse } from "../../../../tests/helpers/config-fixtures.ts";
 
 // A fake-but-well-formed token bypasses the eager SUPABASE_ACCESS_TOKEN check, so the run
 // reaches this command's own handler instead of failing generically first.
 const TEST_TOKEN = "sbp_" + "a".repeat(40);
+const TEST_REF = "abcdefghijklmnopqrst";
 
 describe("config pull CLI surface", () => {
   test("plain `config pull` parses — no boolean flag is accidentally required", async () => {
@@ -30,6 +32,60 @@ describe("config pull CLI surface", () => {
         "failed to read supabase/config.toml or supabase/config.json: file not found. Run `supabase init` to create one.",
       );
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("reads a piped confirmation through the production command layer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "supabase-config-pull-piped-e2e-"));
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (request.method === "GET" && url.pathname === `/v2/projects/${TEST_REF}/config`) {
+          return Response.json(v2ProjectConfigResponse({ ref: TEST_REF }));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const configDir = join(cwd, "supabase");
+      const configPath = join(configDir, "config.toml");
+      const profilePath = join(cwd, "profile.yaml");
+      const before = `project_id = "${TEST_REF}"\n[api]\nmax_rows = 500\n`;
+      await mkdir(configDir, { recursive: true });
+      await writeFile(configPath, before);
+      await writeFile(
+        profilePath,
+        [
+          "name: config-pull-piped-e2e",
+          `api_url: ${JSON.stringify(server.url.origin)}`,
+          `dashboard_url: ${JSON.stringify(server.url.origin)}`,
+          'project_host: "example.invalid"',
+          "",
+        ].join("\n"),
+      );
+
+      const { exitCode, stdout, stderr } = await runSupabase(
+        ["config", "pull", "--project-ref", TEST_REF],
+        {
+          cwd,
+          stdin: "n\n",
+          env: {
+            SUPABASE_ACCESS_TOKEN: TEST_TOKEN,
+            SUPABASE_PROFILE: profilePath,
+            SUPABASE_WORKDIR: cwd,
+          },
+        },
+      );
+
+      expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+      expect(stderr).toContain(`Apply 1 change(s) to supabase/config.toml? [Y/n] n\n`);
+      expect(stdout).toContain("not written (declined)");
+      expect(await readFile(configPath, "utf8")).toBe(before);
+    } finally {
+      await server.stop(true);
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/apps/cli/src/commands/experimental/stack/destroy/destroy.command.ts
+++ b/apps/cli/src/commands/experimental/stack/destroy/destroy.command.ts
@@ -1,6 +1,7 @@
 import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 import { withJsonErrorHandling } from "../../../../shared/output/json-error-handling.ts";
+import { stdinLayer } from "../../../../shared/runtime/stdin.layer.ts";
 import { withCommandTelemetry } from "../../../../telemetry/command-telemetry.ts";
 import { stackDestroy } from "./destroy.handler.ts";
 
@@ -31,4 +32,5 @@ export const stackDestroyCommand = Command.make("destroy", config).pipe(
   Command.withHandler((flags) =>
     stackDestroy(flags).pipe(withCommandTelemetry({ flags, config }), withJsonErrorHandling),
   ),
+  Command.provide(stdinLayer),
 );

--- a/apps/cli/src/commands/experimental/stack/destroy/destroy.e2e.test.ts
+++ b/apps/cli/src/commands/experimental/stack/destroy/destroy.e2e.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+
+import { runSupabase } from "../../../../../tests/helpers/cli.ts";
+
+describe("stack destroy CLI surface", () => {
+  test("rejects an invalid stack id through the compiled command wiring", () =>
+    runSupabase(["--experimental", "stack", "destroy", "--yes", "--stack-id", "invalid"]).then(
+      ({ exitCode, stdout, stderr }) => {
+        expect(exitCode, `${stdout}\n${stderr}`).not.toBe(0);
+        expect(`${stdout}\n${stderr}`).toContain("--stack-id must be a lowercase SHA-256 stack id");
+      },
+    ));
+});

--- a/apps/cli/src/commands/start/start.command.ts
+++ b/apps/cli/src/commands/start/start.command.ts
@@ -3,6 +3,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import type * as CliCommand from "effect/unstable/cli/Command";
 
 import { commandRuntimeLayer } from "../../shared/runtime/command-runtime.layer.ts";
+import { stdinLayer } from "../../shared/runtime/stdin.layer.ts";
 import { withJsonErrorHandling } from "../../shared/output/json-error-handling.ts";
 import { httpClientLayer } from "../../auth/http-debug.layer.ts";
 import { commandSettingsLayer } from "../../config/command-settings.layer.ts";
@@ -63,4 +64,5 @@ export const startCommand = Command.make("start", config).pipe(
     start(flags).pipe(withCommandTelemetry({ flags }), withJsonErrorHandling),
   ),
   Command.provide(startRuntimeLayer),
+  Command.provide(stdinLayer),
 );

--- a/apps/cli/src/shared/cli/run.ts
+++ b/apps/cli/src/shared/cli/run.ts
@@ -44,7 +44,6 @@ import { ttyLayer } from "../runtime/tty.layer.ts";
 import { CommandRuntime } from "../runtime/command-runtime.service.ts";
 import { ProcessControl } from "../runtime/process-control.service.ts";
 import type { RuntimeInfo } from "../runtime/runtime-info.service.ts";
-import type { Stdin } from "../runtime/stdin.service.ts";
 import type { Tty } from "../runtime/tty.service.ts";
 import type { Analytics } from "../telemetry/analytics.service.ts";
 import { aiToolLayer } from "../telemetry/ai-tool.layer.ts";
@@ -90,7 +89,6 @@ export type AllowedRunCliServices =
   | TelemetryRuntime
   | Tty
   | CommandPlatformApiFactory
-  | Stdin
   | "effect/unstable/cli/GlobalFlag/linked"
   | "effect/unstable/cli/GlobalFlag/local";
 


### PR DESCRIPTION
## TL;DR

Prevents `supabase config pull` from crashing when confirmation input is piped
the command could reach `promptYesNo` without providing `stdinLayer`

which is now fixed by:
Providing `stdinLayer` at the command boundary and covering the piped input path with a binary regression test.

## Ref:

- closes https://github.com/supabase/cli/issues/6585